### PR TITLE
chore(CI): Temporarily remove CI action on MacOS

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest]
         node-version: [14]
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Temporarily remove CI action on MacOS because of its bad availability.