### PR TITLE
feat(local-debug): use npx nodemon to start bot

### DIFF
--- a/packages/vscode-extension/src/debug/teamsfxTaskProvider.ts
+++ b/packages/vscode-extension/src/debug/teamsfxTaskProvider.ts
@@ -178,7 +178,7 @@ export class TeamsfxTaskProvider implements vscode.TaskProvider {
   ): Promise<vscode.Task> {
     const command: string = constants.botStartCommand;
     definition = definition || { type: TeamsfxTaskProvider.type, command };
-    const commandLine = "nodemon --inspect=9239 index.js";
+    const commandLine = "npx nodemon --inspect=9239 index.js";
     const env = await commonUtils.getBotLocalEnv();
     const options: vscode.ShellExecutionOptions = {
       cwd: projectRoot,


### PR DESCRIPTION
use npx nodemon to start bot.