### PR TITLE
fix(env-checker): workaround for the ps execution policy issue

### DIFF
--- a/packages/vscode-extension/src/debug/depsChecker/funcToolChecker.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/funcToolChecker.ts
@@ -136,7 +136,9 @@ async function getFuncPSScriptPath(): Promise<string> {
     const output = await cpUtils.executeCommand(
       undefined,
       logger,
-      undefined,
+      {
+        shell: "cmd.exe"
+      },
       "where",
       "func",
     );


### PR DESCRIPTION
work item: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/9654301

Workaround: remove func.ps1 if the Azure Function Core Tools is installed by us via npm.