### PR TITLE
fix(solution): ask subscription failed if the subscription is existing in the configuration

### DIFF
--- a/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
@@ -1605,8 +1605,8 @@ export class TeamsAppSolution implements Solution {
                         return err(result.error);
                     }
                     ctx.config.get(GLOBAL_CONFIG)?.set("subscriptionId", result.value);
-                    return ok(null);
                 }
+                return ok(null);
             }
         }
         return err(


### PR DESCRIPTION
Bug: ask subscription failed if the subscription is existing in the configuration