### PR TITLE
fix: differentiate vs and cli platform

### DIFF
--- a/packages/fx-core/src/plugins/resource/appstudio/index.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/index.ts
@@ -17,7 +17,7 @@ export class AppStudioPlugin implements Plugin {
         });
 
         if (stage === Stage.publish) {
-            if (ctx.platform !== Platform.VSCode) {
+            if (ctx.platform === Platform.VS) {
                 const appPath = new QTreeNode({
                     type: NodeType.folder,
                     name: Constants.PUBLISH_PATH_QUESTION,


### PR DESCRIPTION
for vs platform, get teams app id and manifest from answers;
for vsc/cli platform, get teams app id and manifest from context