### PR TITLE
fix: local debug not break without local.env file

### DIFF
--- a/packages/fx-core/src/plugins/resource/localdebug/index.ts
+++ b/packages/fx-core/src/plugins/resource/localdebug/index.ts
@@ -169,7 +169,7 @@ export class LocalDebugPlugin implements Plugin {
             const includeBot = ctx.configOfOtherPlugins.has(BotPlugin.Name);
 
             const localEnvProvider = new LocalEnvProvider(ctx.root);
-            const localEnvs = await localEnvProvider.loadLocalEnv();
+            const localEnvs = await localEnvProvider.loadLocalEnv(includeFrontend, includeBackend, includeBot);
 
             // configs
             const localDebugConfigs = ctx.config;

--- a/packages/fx-core/src/plugins/resource/localdebug/localEnv.ts
+++ b/packages/fx-core/src/plugins/resource/localdebug/localEnv.ts
@@ -15,8 +15,12 @@ export class LocalEnvProvider {
         this.localEnvFilePath = `${workspaceFolder}/.${ConfigFolderName}/local.env`;
     }
 
-    public async loadLocalEnv(): Promise<{ [name: string]: string }> {
-        return dotenv.parse(await fs.readFile(this.localEnvFilePath));
+    public async loadLocalEnv(includeFrontend: boolean, includeBackend: boolean, includeBot: boolean): Promise<{ [name: string]: string }> {
+        if (await fs.pathExists(this.localEnvFilePath)) {
+            return dotenv.parse(await fs.readFile(this.localEnvFilePath));
+        } else {
+            return this.initialLocalEnvs(includeFrontend, includeBackend, includeBot);
+        }
     }
 
     public async saveLocalEnv(envs: { [name: string]: string } | undefined): Promise<void> {

--- a/packages/fx-core/tests/plugins/resource/localdebug/unit/localEnv.test.ts
+++ b/packages/fx-core/tests/plugins/resource/localdebug/unit/localEnv.test.ts
@@ -28,7 +28,7 @@ describe("LocalEnvProvider", ()=> {
             fs.createFileSync(testFilePath);
             fs.writeFileSync(testFilePath, testContent);
 
-            const envs = await localEnvProvider.loadLocalEnv();
+            const envs = await localEnvProvider.loadLocalEnv(true, false, false);
 
             chai.assert.isDefined(envs);
             chai.assert.equal(Object.keys(envs).length, 2);
@@ -39,7 +39,7 @@ describe("LocalEnvProvider", ()=> {
         it("empty file", async () => {
             fs.createFileSync(testFilePath);
 
-            const envs = await localEnvProvider.loadLocalEnv();
+            const envs = await localEnvProvider.loadLocalEnv(true, false, false);
 
             chai.assert.isDefined(envs);
             chai.assert.equal(Object.keys(envs).length, 0);
@@ -52,9 +52,24 @@ describe("LocalEnvProvider", ()=> {
             };
             await localEnvProvider.saveLocalEnv(expectedEnvs);
 
-            const actualEnvs = await localEnvProvider.loadLocalEnv();
+            const actualEnvs = await localEnvProvider.loadLocalEnv(true, false, false);
 
             chai.assert.deepEqual(actualEnvs, expectedEnvs);
+        });
+
+        it("no env file", async () => {
+            const actualEnvs = await localEnvProvider.loadLocalEnv(true, true, true);
+
+            chai.assert.isDefined(actualEnvs);
+            const actualEntries = Object.entries(actualEnvs);
+            const expectedKeys = Object.values(LocalEnvFrontendKeys)
+                .concat(Object.values(LocalEnvAuthKeys)
+                .concat(Object.values(LocalEnvBackendKeys)))
+                .concat(Object.values(LocalEnvBotKeys));
+            chai.assert.equal(actualEntries.length, expectedKeys.length);
+            for (const key of expectedKeys) {
+                chai.assert.isDefined(actualEnvs[key]);
+            }
         });
     });
 


### PR DESCRIPTION
If `local.env` file is missing/removed, local debug still can run (generate new one).