### PR TITLE
fix: revert 'explicitly using bash to execute dotnet-install.sh' script

### DIFF
--- a/packages/fx-core/src/plugins/resource/function/utils/depsChecker/dotnetChecker.ts
+++ b/packages/fx-core/src/plugins/resource/function/utils/depsChecker/dotnetChecker.ts
@@ -212,11 +212,10 @@ export class DotnetChecker implements IDepsChecker {
   ): Promise<void> {
     const installCommand: string = await DotnetChecker.getInstallCommand(version, installDir);
     const windowsFullCommand = `powershell.exe -NoProfile -ExecutionPolicy unrestricted -Command "& { [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12 ; & ${installCommand} }`;
-    const unixFullCommand = `bash ${installCommand}`;
 
     try {
       const start = performance.now();
-      const { stdout, stderr } = await exec(isWindows() ? windowsFullCommand : unixFullCommand, {
+      const { stdout, stderr } = await exec(isWindows() ? windowsFullCommand : installCommand, {
         cwd: process.cwd(),
         maxBuffer: DotnetChecker.maxBuffer,
         timeout: DotnetChecker.timeout,

--- a/packages/vscode-extension/src/debug/depsChecker/dotnetChecker.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/dotnetChecker.ts
@@ -212,11 +212,10 @@ export class DotnetChecker implements IDepsChecker {
   ): Promise<void> {
     const installCommand: string = await DotnetChecker.getInstallCommand(version, installDir);
     const windowsFullCommand = `powershell.exe -NoProfile -ExecutionPolicy unrestricted -Command "& { [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12 ; & ${installCommand} }`;
-    const unixFullCommand = `bash ${installCommand}`;
 
     try {
       const start = performance.now();
-      const { stdout, stderr } = await exec(isWindows() ? windowsFullCommand : unixFullCommand, {
+      const { stdout, stderr } = await exec(isWindows() ? windowsFullCommand : installCommand, {
         cwd: process.cwd(),
         maxBuffer: DotnetChecker.maxBuffer,
         timeout: DotnetChecker.timeout,


### PR DESCRIPTION
- Fix syntax error for bash script