### PR TITLE
fix: fix spelling error for CLI version string

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -33,7 +33,7 @@ function getVersionString(): string {
   version += json.version;
   version += "\n";
 
-  version += "build with ";
+  version += "built with ";
   const dirs = readdirSync(path.join(__dirname + "/../node_modules"));
   const api = dirs.find((dir) => dir === "fx-api");
   json = JSON.parse(readFileSync(path.join(__dirname, "/../node_modules/" + api + "/package.json"), "utf8"));


### PR DESCRIPTION
Fix spelling error for CLI version string.

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/9803072