### PR TITLE
chore: update CI pipeline to be triggered by push event on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - release
   pull_request:
     branches:
       - main


### PR DESCRIPTION
update CI pipeline to be triggered by push event on main branch, then new CI build will be triggered after PRs merge.