### PR TITLE
Align CLI options to Extension options (#659)

### DIFF
--- a/packages/cli/resource/newParam.json
+++ b/packages/cli/resource/newParam.json
@@ -6,13 +6,13 @@
         "option": [
             {
                 "id": "yes",
-                "label": "Build your own Teams app from scratch",
-                "detail": "Define your own Teams app."
+                "label": "Create a new Teams app",
+                "detail": "Create a new Teams app"
             },
             {
                 "id": "no",
-                "label": "Choose from Samples",
-                "detail": "Quickly get started with the basic Teams app concepts and code structures."
+                "label": "Start from a sample",
+                "detail": "Use an existing sample as a starting point for your new application."
             }
         ],
         "default": "yes",

--- a/packages/cli/src/question/question.ts
+++ b/packages/cli/src/question/question.ts
@@ -189,6 +189,18 @@ export async function visitInteractively(
   if (node.data.type !== NodeType.group) {
     if (!isAutoSkipSelect(node.data)) {
       answers = await inquirer.prompt([toInquirerQuestion(node.data, answers, remoteFuncValidator)], answers);
+      // convert the option.label to option.id
+      if ("option" in node.data) {
+        const option = node.data.option;
+        if (option instanceof Array && option.length > 0 && typeof option[0] !== "string") {
+          const tmpAns = answers[node.data.name];
+          if (tmpAns instanceof Array) {
+            answers[node.data.name] = tmpAns.map(label => (option as OptionItem[]).find(op => label === op.label)?.id);
+          } else {
+            answers[node.data.name] = (option as OptionItem[]).find(op => tmpAns === op.label)?.id;
+          }
+        }
+      }
     }
     else {
       answers[node.data.name] = getSingleOption(node.data as (SingleSelectQuestion | MultiSelectQuestion));

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -57,7 +57,7 @@ export function getChoicesFromQTNodeQuestion(data: Question, interactive = false
       return option as string[];
     } else {
       if (interactive) {
-        return (option as OptionItem[]).map(op => op.id);
+        return (option as OptionItem[]).map(op => op.label);
       } else {
         return (option as OptionItem[]).map(op => op.cliName ? op.cliName : op.id);
       }


### PR DESCRIPTION
Same critical fix to P0 bug with #659 
* Update strings to match extension
* fix: use option.lable instead of id when run CLI interactively

Co-authored-by: Zhiyu You <zhiyou@microsoft.com>