### PR TITLE
fix: move login loglevel error for cli

### DIFF
--- a/packages/cli/src/commonlib/appStudioLogin.ts
+++ b/packages/cli/src/commonlib/appStudioLogin.ts
@@ -34,7 +34,7 @@ const config = {
         CLILogProvider.log(4 - loglevel, message);
       },
       piiLoggingEnabled: false,
-      logLevel: LogLevel.Verbose
+      logLevel: LogLevel.Error
     }
   },
   cache: {

--- a/packages/cli/src/commonlib/azureLogin.ts
+++ b/packages/cli/src/commonlib/azureLogin.ts
@@ -42,7 +42,7 @@ const config = {
         CLILogProvider.log(4 - loglevel, message);
       },
       piiLoggingEnabled: false,
-      logLevel: LogLevel.Verbose
+      logLevel: LogLevel.Error
     }
   },
   cache: {

--- a/packages/cli/src/commonlib/graphLogin.ts
+++ b/packages/cli/src/commonlib/graphLogin.ts
@@ -26,7 +26,7 @@ const config = {
         CLILogProvider.log(4 - loglevel, message);
       },
       piiLoggingEnabled: false,
-      logLevel: LogLevel.Verbose
+      logLevel: LogLevel.Error
     }
   }
   // TODO: add this back after graph change to 7ea7c24c-b1f6-4a20-9d11-9ae12e9e7ac0 first party app


### PR DESCRIPTION
Set CLI login loglevel to Error, which is the same as vscode extension.