### PR TITLE
test(env-checker): add retry to the "lerna bootstrap" stage to workaround "cb() never called" bug of npm

### DIFF
--- a/.github/workflows/env-checker-ci-pr.yml
+++ b/.github/workflows/env-checker-ci-pr.yml
@@ -76,10 +76,17 @@ jobs:
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
 
-      - name: Setup project
-        run: |
-          npm install
-          npx lerna bootstrap --concurrency 1
+      # https://github.com/marketplace/actions/retry-step
+      - name: Setup project with Retry
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 3
+          on_retry_command: git clean -fXd .
+          command: |
+            npm install
+            npx lerna bootstrap --concurrency 1
 
       - name: Integration Test
         working-directory: ./packages/vscode-extension

--- a/.github/workflows/env-checker-ci-schedule.yml
+++ b/.github/workflows/env-checker-ci-schedule.yml
@@ -62,10 +62,17 @@ jobs:
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
 
-      - name: Setup project
-        run: |
-          npm install
-          npx lerna bootstrap --concurrency 1
+      # https://github.com/marketplace/actions/retry-step
+      - name: Setup project with Retry
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 3
+          on_retry_command: git clean -fXd .
+          command: |
+            npm install
+            npx lerna bootstrap --concurrency 1
 
       - name: Integration Test
         working-directory: ./packages/vscode-extension


### PR DESCRIPTION
- Retry 3 times with a timeout of 5min for 'lerna bootstrap' stage