### PR TITLE
chore(env-checker): remove the config to disable func tool checker

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -397,11 +397,6 @@
             "description": "Ensure Node.js is installed.",
             "default": true
           },
-          "fx-extension.validateFuncCoreTools": {
-            "type": "boolean",
-            "description": "Ensure Azure Functions Core Tools is installed.",
-            "default": true
-          },
           "fx-extension.validateDotnetSdk": {
             "type": "boolean",
             "description": "Ensure .NET SDK is installed.",


### PR DESCRIPTION
Remove the config to avoid confusion to customers, as the func tool will be installed as a npm dev dependency now.