### PR TITLE
feat: display teams toolkit command in quick start

### DIFF
--- a/packages/vscode-extension/src/controls/Commands.ts
+++ b/packages/vscode-extension/src/controls/Commands.ts
@@ -5,7 +5,7 @@ export enum Commands {
   OpenExternalLink = "open-external-link",
   CloneSampleApp = "clone-sample-app",
   DisplayCommandPalette = "display-command-palette",
-  DisplayCliCommands = "display-cli-commands",
+  DisplayCommands = "display-commands",
   SigninM365 = "sign-in-m365",
   SigninAzure = "sign-in-azure",
   CreateNewProject = "create-new-project",

--- a/packages/vscode-extension/src/controls/QuickStart.tsx
+++ b/packages/vscode-extension/src/controls/QuickStart.tsx
@@ -92,7 +92,7 @@ export default class QuickStart extends React.Component<any, any>{
                                 title={`Explore Teams Toolkit commands`}
                                 content={`Open Command Palette (${shortcut}) and type ‘Teamsfx’ to find all relevant commands. `}
                                 actionText="Display TeamsFx commands"
-                                onAction={this.displayCliCommands}
+                                onAction={this.displayCommands}
                                 secondaryActionText="Next"
                                 onSecondaryAction={() => { this.onNextStep(curStep); }}
                                 expanded={this.state.currentStep === curStep}
@@ -265,10 +265,10 @@ export default class QuickStart extends React.Component<any, any>{
         });
     }
 
-    displayCliCommands = () => {
+    displayCommands = () => {
         vscode.postMessage({
-            command: Commands.DisplayCliCommands,
-            data: "teamsfx --help"
+            command: Commands.DisplayCommands,
+            data: "Teams"
         });
 
         let done = this.state.stepsDone;

--- a/packages/vscode-extension/src/controls/webviewPanel.ts
+++ b/packages/vscode-extension/src/controls/webviewPanel.ts
@@ -92,10 +92,8 @@ export class WebviewPanel {
             break;
           case Commands.DisplayCommandPalette:
             break;
-          case Commands.DisplayCliCommands:
-            const terminal = vscode.window.activeTerminal ? vscode.window.activeTerminal : vscode.window.createTerminal("Teams toolkit", "C: \\Windows\\System32\\cmd.exe");
-            terminal.show();
-            terminal.sendText(msg.data);
+          case Commands.DisplayCommands:
+            vscode.commands.executeCommand("workbench.action.quickOpen", `>${msg.data}`);
             break;
           case Commands.SigninM365:
             await AppStudioTokenInstance.getJsonObject(false);


### PR DESCRIPTION
Display teams toolkit commands instead of cli commands according to UX change