### PR TITLE
fix: use common link instead of internal link for azure portal

### DIFF
--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -637,7 +637,7 @@ export async function openM365AccountHandler() {
 }
 
 export async function openAzureAccountHandler() {
-  return env.openExternal(Uri.parse("https://ms.portal.azure.com/"));
+  return env.openExternal(Uri.parse("https://portal.azure.com/"));
 }
 
 // TODO: remove this once welcome page is ready


### PR DESCRIPTION
As https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/9835985 noted, the ms.portal.azure.com is only for MS internal only