### PR TITLE
refactor(env-checker): introduce the node checker for azure and spfx repectively

### DIFF
--- a/docs/vscode-extension/envchecker-help.md
+++ b/docs/vscode-extension/envchecker-help.md
@@ -14,6 +14,12 @@ As the TeamsFx project is implemented by `Node.js`, it's required to install the
 
 **NOTE**: Please restart all your Visual Studio Code instances after the installation is finished.
 
+## Current installed Node.js is not in the supported version list (SPFx hosting)
+
+ When `SPFx` is selected as the hosting type, only LTS versions (v10, v12 and v14) of Node.js are supported by TeamsFx currently, please make sure the installed Node.js meets this requirement. In addition, **Node v14 (LTS)** would be recommended to be installed.
+
+**NOTE**: Please restart all your Visual Studio Code instances after the installation is finished.
+
 ## Why .NET SDK is needed?
 
 The `.NET SDK` is used to

--- a/packages/vscode-extension/src/debug/depsChecker/azureNodeChecker.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/azureNodeChecker.ts
@@ -1,0 +1,8 @@
+import { nodeNotFoundHelpLink, nodeNotSupportedForAzureHelpLink } from "./common";
+import { NodeChecker } from "./nodeChecker";
+
+export class AzureNodeChecker extends NodeChecker {
+    protected readonly _nodeNotFoundHelpLink = nodeNotFoundHelpLink;
+    protected readonly _nodeNotSupportedHelpLink = nodeNotSupportedForAzureHelpLink;
+    protected readonly _supportedVersions = ["10", "12", "14"];
+}

--- a/packages/vscode-extension/src/debug/depsChecker/checker.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/checker.ts
@@ -9,7 +9,7 @@
 // to copy you changes to function plugin.
 
 import { isLinux, Messages, defaultHelpLink, DepsCheckerEvent, dotnetManualInstallHelpLink } from "./common";
-import { DepsCheckerError, NodeNotFoundError, NotSupportedNodeError } from "./errors";
+import { DepsCheckerError, NodeNotFoundError, NodeNotSupportedError } from "./errors";
 
 export interface IDepsChecker {
   isEnabled(): Promise<boolean>;
@@ -136,10 +136,10 @@ export class DepsChecker {
   }
 
   private async handleError(error: Error): Promise<boolean> {
-    if (error instanceof NotSupportedNodeError) {
+    if (error instanceof NodeNotSupportedError) {
       return await this._adapter.displayContinueWithLearnMore(
         error.message,
-        (error as NotSupportedNodeError).helpLink
+        (error as NodeNotSupportedError).helpLink
       );
     } else if (error instanceof NodeNotFoundError) {
       return await this._adapter.displayLearnMore(

--- a/packages/vscode-extension/src/debug/depsChecker/common.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/common.ts
@@ -36,7 +36,8 @@ export function isLinux(): boolean {
 export const defaultHelpLink = "https://aka.ms/teamsfx-envchecker-help";
 
 export const nodeNotFoundHelpLink = `${defaultHelpLink}#the-toolkit-cannot-find-nodejs-on-your-machine`;
-export const nodeNotSupportedHelpLink = `${defaultHelpLink}#current-installed-nodejs-is-not-in-the-supported-version-list`;
+export const nodeNotSupportedForAzureHelpLink = `${defaultHelpLink}#current-installed-nodejs-is-not-in-the-supported-version-list-azure-hosting`;
+export const nodeNotSupportedForSPFxHelpLink = `${defaultHelpLink}#current-installed-nodejs-is-not-in-the-supported-version-list-spfx-hosting`;
 
 export const dotnetExplanationHelpLink = `${defaultHelpLink}#why-net-sdk-is-needed`;
 export const dotnetFailToInstallHelpLink = `${defaultHelpLink}#failed-to-install-net-core-sdk-v31`;

--- a/packages/vscode-extension/src/debug/depsChecker/errors.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/errors.ts
@@ -27,11 +27,11 @@ export class NodeNotFoundError extends DepsCheckerError {
   }
 }
 
-export class NotSupportedNodeError extends DepsCheckerError {
+export class NodeNotSupportedError extends DepsCheckerError {
   constructor(message: string, helpLink: string) {
     super(message, helpLink);
 
-    Object.setPrototypeOf(this, NotSupportedNodeError.prototype);
+    Object.setPrototypeOf(this, NodeNotSupportedError.prototype);
   }
 }
 

--- a/packages/vscode-extension/src/debug/depsChecker/spfxNodeChecker.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/spfxNodeChecker.ts
@@ -1,0 +1,8 @@
+import { nodeNotFoundHelpLink, nodeNotSupportedForSPFxHelpLink } from "./common";
+import { NodeChecker } from "./nodeChecker";
+
+export class SPFxNodeChecker extends NodeChecker {
+    protected readonly _nodeNotFoundHelpLink = nodeNotFoundHelpLink;
+    protected readonly _nodeNotSupportedHelpLink = nodeNotSupportedForSPFxHelpLink;
+    protected readonly _supportedVersions: string[] = ["10", "12", "14"];
+}

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -57,9 +57,7 @@ import * as vscode from "vscode";
 import { VsCodeUI, VS_CODE_UI } from "./qm/vsc_ui";
 import { DepsChecker } from "./debug/depsChecker/checker";
 import { BackendExtensionsInstaller } from "./debug/depsChecker/backendExtensionsInstall";
-import { FuncToolChecker } from "./debug/depsChecker/funcToolChecker";
 import { DotnetChecker } from "./debug/depsChecker/dotnetChecker";
-import { NodeChecker, AzureSupportedNodeVersions } from "./debug/depsChecker/nodeChecker";
 import * as util from "util";
 import * as StringResources from "./resources/Strings.json";
 import { vscodeAdapter } from "./debug/depsChecker/vscodeAdapter";
@@ -67,6 +65,8 @@ import { vscodeLogger } from "./debug/depsChecker/vscodeLogger";
 import { vscodeTelemetry } from "./debug/depsChecker/vscodeTelemetry";
 import { PanelType } from "./controls/PanelType";
 import { signedIn, signedOut } from "./commonlib/common/constant";
+import { AzureNodeChecker } from "./debug/depsChecker/azureNodeChecker";
+import { SPFxNodeChecker } from "./debug/depsChecker/spfxNodeChecker";
 
 export let core: CoreProxy;
 const runningTasks = new Set<string>(); // to control state of task execution
@@ -391,7 +391,7 @@ async function runUserTask(func: Func, eventName:string): Promise<Result<null, F
     const answers = new ConfigMap();
     answers.set("task", eventName);
     answers.set("platform", Platform.VSCode);
-    
+
     // 4. getQuestions
     const qres = await core.getQuestionsForUserTask(func, Platform.VSCode);
     if (qres.isErr()) {
@@ -511,25 +511,28 @@ export async function addCapabilityHandler(): Promise<Result<null, FxError>> {
 }
 
 /**
- * check & install required dependencies during local debug.
+ * check & install required dependencies during local debug when selected hosting type is Azure.
  */
 export async function validateDependenciesHandler(): Promise<void> {
-  const depsChecker = new DepsChecker(vscodeLogger, vscodeAdapter, [
-    new NodeChecker(AzureSupportedNodeVersions, vscodeAdapter, vscodeLogger, vscodeTelemetry), 
-    new DotnetChecker(vscodeAdapter, vscodeLogger, vscodeTelemetry)]);
-  const shouldContinue = await depsChecker.resolve();
-  if (!shouldContinue) {
-    // TODO: better mechanism to stop the tasks and debug session.
-    throw new Error("debug stopped.");
-  }
+  const nodeChecker = new AzureNodeChecker(vscodeAdapter, vscodeLogger, vscodeTelemetry);
+  const dotnetChecker = new DotnetChecker(vscodeAdapter, vscodeLogger, vscodeTelemetry);
+  const depsChecker = new DepsChecker(vscodeLogger, vscodeAdapter, [nodeChecker, dotnetChecker]);
+  await validateDependenciesCore(depsChecker);
 }
 
-const spfxNodeSupportVersion = ["10", "12", "14"];
+/**
+ * check & install required dependencies during local debug when selected hosting type is SPFx.
+ */
 export async function validateSpfxDependenciesHandler(): Promise<void> {
-  const depsChecker = new DepsChecker(vscodeLogger, vscodeAdapter, [
-    new NodeChecker(spfxNodeSupportVersion, vscodeAdapter, vscodeLogger, vscodeTelemetry)]);
+  const nodeChecker = new SPFxNodeChecker(vscodeAdapter, vscodeLogger, vscodeTelemetry);
+  const depsChecker = new DepsChecker(vscodeLogger, vscodeAdapter, [nodeChecker]);
+  await validateDependenciesCore(depsChecker);
+}
+
+async function validateDependenciesCore(depsChecker: DepsChecker): Promise<void> {
   const shouldContinue = await depsChecker.resolve();
   if (!shouldContinue) {
+    await debug.stopDebugging();
     // TODO: better mechanism to stop the tasks and debug session.
     throw new Error("debug stopped.");
   }

--- a/packages/vscode-extension/test/suite/envChecker/cases/all.ts
+++ b/packages/vscode-extension/test/suite/envChecker/cases/all.ts
@@ -12,6 +12,7 @@ import { TestLogger } from "../adapters/testLogger";
 import { TestTelemetry } from "../adapters/testTelemetry";
 import { commandExistsInPath } from "../utils/common";
 import { isLinux } from "../../../../src/debug/depsChecker/common";
+import { AzureNodeChecker } from "../../../../src/debug/depsChecker/azureNodeChecker";
 
 const azureSupportedNodeVersions = ["10", "12", "14"];
 
@@ -31,7 +32,7 @@ function createTestChecker(
   );
   const logger = new TestLogger();
   const telemetry = new TestTelemetry();
-  const nodeChecker = new NodeChecker(azureSupportedNodeVersions, testAdapter, logger, telemetry);
+  const nodeChecker = new AzureNodeChecker(testAdapter, logger, telemetry);
   const dotnetChecker = new DotnetChecker(testAdapter, logger, telemetry);
   const depsChecker = new DepsChecker(logger, testAdapter, [dotnetChecker]);
 

--- a/packages/vscode-extension/test/suite/envChecker/cases/node.ts
+++ b/packages/vscode-extension/test/suite/envChecker/cases/node.ts
@@ -10,6 +10,7 @@ import { TestLogger } from "../adapters/testLogger";
 import { TestTelemetry } from "../adapters/testTelemetry";
 import { ConfigFolderName } from "fx-api";
 import { isLinux } from "../../../../src/utils/commonUtils";
+import { AzureNodeChecker } from "../../../../src/debug/depsChecker/azureNodeChecker";
 
 const azureSupportedNodeVersions = ["10", "12", "14"];
 
@@ -28,7 +29,7 @@ function createTestChecker(
     nodeCheckerEnabled
   );
   const logger = new TestLogger();
-  const nodeChecker = new NodeChecker(azureSupportedNodeVersions, testAdapter, logger, new TestTelemetry());
+  const nodeChecker = new AzureNodeChecker(testAdapter, logger, new TestTelemetry());
   const depsChecker = new DepsChecker(logger, testAdapter, [nodeChecker]);
 
   return [depsChecker, nodeChecker];


### PR DESCRIPTION
Refactor to add:
* AzureNodeChecker
* SPFxNodeChecker

So the node checker for Azure and SPFx can customize its supported versions and help links.