### PR TITLE
fix: differentiate local debug and remote teams app name

### DIFF
--- a/packages/fx-core/src/plugins/solution/fx-solution/appstudio/appstudio.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/appstudio/appstudio.ts
@@ -320,6 +320,7 @@ export namespace AppStudio {
         appName?: string,
         version?: string,
         botId?: string,
+        appNameSuffix?: string
     ): [IAppDefinition, TeamsAppManifest] {
         if (appName) {
             manifest = replaceConfigValue(manifest, "appName", appName);
@@ -341,7 +342,14 @@ export namespace AppStudio {
             updatedManifest.validDomains?.push(domain);
         }
 
-        return [convertToAppDefinition(updatedManifest, ignoreIcon), updatedManifest];
+        // For local debug teams app, the app name will have a suffix to differentiate from remote teams app
+        const appDefinition = convertToAppDefinition(updatedManifest, ignoreIcon);
+        if (appNameSuffix) {
+            appDefinition.shortName = appDefinition.shortName + appNameSuffix;
+            appDefinition.appName = appDefinition.shortName;
+        }
+
+        return [appDefinition, updatedManifest];
     }
 
     export function convertToAppDefinition(appManifest: TeamsAppManifest, ignoreIcon: boolean): IAppDefinition {

--- a/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
@@ -1477,6 +1477,7 @@ export class TeamsAppSolution implements Solution {
             manifest.name.short,
             manifest.version,
             botId,
+            "-local-debug"
         );
 
         const localTeamsAppID = ctx.config.get(GLOBAL_CONFIG)?.getString(LOCAL_DEBUG_TEAMS_APP_ID);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/71362691/117408400-7759ac80-af42-11eb-9861-f526654acd3c.png)
