### PR TITLE
fix: do not show LastModifiedTime if it's undefined

### DIFF
--- a/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
@@ -92,11 +92,15 @@ export class AppStudioPluginImpl {
             if (ctx.platform === Platform.VS) {
                 executePublishUpdate = true;
             } else {
+                let description = `The app ${existApp.displayName} has already been submitted to tenant App Catalog.\nStatus: ${existApp.publishingState}\n`;
+                if (existApp.lastModifiedDateTime) {
+                    description = description + `Last Modified: ${existApp.lastModifiedDateTime?.toString()}\n`;
+                }
+                description = description + "Do you want to submit a new update?";
                 executePublishUpdate = (await ctx.dialog?.communicate(new DialogMsg(
                     DialogType.Ask,
                     {
-                        description: `The app ${existApp.displayName} has already been submitted to tenant App Catalog.\nStatus: ${existApp.publishingState}\n`+
-                                    `Last Modified: ${existApp.lastModifiedDateTime?.toString()}.\nDo you want to submit a new update?`,
+                        description: description,
                         type: QuestionType.Confirm,
                         options: ["Confirm"]
                     }


### PR DESCRIPTION
When the user submit the app, and the admin approved it. The lastModifiedTime of this record will be null. We will hide LastModifiedTime in this case.

![image](https://user-images.githubusercontent.com/71362691/117622792-9d32bb80-b1a5-11eb-9671-5242a87eb423.png)
