### PR TITLE
feat(env-checker): add telemetry for node checker

### DIFF
--- a/packages/fx-core/src/plugins/resource/function/utils/depsChecker/common.ts
+++ b/packages/fx-core/src/plugins/resource/function/utils/depsChecker/common.ts
@@ -35,13 +35,13 @@ export function isLinux(): boolean {
 // help links
 export const defaultHelpLink = "https://aka.ms/teamsfx-envchecker-help";
 
-export const nodeNotFoundHelpLink = `${defaultHelpLink}#the-toolkit-cannot-find-nodejs-on-your-machine`;
-export const nodeNotSupportedForAzureHelpLink = `${defaultHelpLink}#current-installed-nodejs-is-not-in-the-supported-version-list-azure-hosting`;
-export const nodeNotSupportedForSPFxHelpLink = `${defaultHelpLink}#current-installed-nodejs-is-not-in-the-supported-version-list-spfx-hosting`;
+export const nodeNotFoundHelpLink = `${defaultHelpLink}#nodenotfound`;
+export const nodeNotSupportedForAzureHelpLink = `${defaultHelpLink}#nodenotsupportedazure-hosting`;
+export const nodeNotSupportedForSPFxHelpLink = `${defaultHelpLink}#nodenotsupportedspfx-hosting`;
 
-export const dotnetExplanationHelpLink = `${defaultHelpLink}#why-net-sdk-is-needed`;
-export const dotnetFailToInstallHelpLink = `${defaultHelpLink}#failed-to-install-net-core-sdk-v31`;
-export const dotnetManualInstallHelpLink = `${defaultHelpLink}#linux-only-the-toolkit-cannot-find-net-5-or-net-core-31-on-your-machine-please-install-it-manually`;
+export const dotnetExplanationHelpLink = `${defaultHelpLink}#overall`;
+export const dotnetFailToInstallHelpLink = `${defaultHelpLink}#failtoinstalldotnet`;
+export const dotnetManualInstallHelpLink = `${defaultHelpLink}#dotnetnotfound`;
 
 export const Messages = {
   learnMoreButtonText: "Learn more",
@@ -50,7 +50,7 @@ export const Messages = {
   defaultErrorMessage: "Please install the required dependencies manually.",
 
   // since FuncToolChecker is disabled and azure functions core tools will be installed as devDependencies now,
-  // below messages won't be displayed to end user.
+  // below messages related to FuncToolChecker won't be displayed to end user.
   startInstallFunctionCoreTool: `Downloading and installing @NameVersion.`,
   finishInstallFunctionCoreTool: `Successfully installed @NameVersion.`,
   needReplaceWithFuncCoreToolV3: `You must replace with @NameVersion to debug your local functions.`,
@@ -86,7 +86,7 @@ Click "Install" to install @InstallPackages.`,
 
   linuxDepsNotFound: `The toolkit cannot find @SupportedPackages on your machine.
 
-As a fundamental runtime context for Teams app, these dependencies are required.
+As a fundamental runtime context for Teams app, these dependencies are required. 
 
 Please install the required dependencies manually.
 
@@ -94,6 +94,8 @@ Click "Continue" to continue.`
 };
 
 export enum DepsCheckerEvent {
+  // since FuncToolChecker is disabled and azure functions core tools will be installed as devDependencies now,
+  // below events related to FuncToolChecker won't be displayed to end user.
   funcCheck = "func-check",
   funcCheckSkipped = "func-check-skipped",
   funcInstall = "func-install",
@@ -110,7 +112,11 @@ export enum DepsCheckerEvent {
   dotnetInstallError = "dotnet-install-error",
   dotnetInstallScriptCompleted = "dotnet-install-script-completed",
   dotnetInstallScriptError = "dotnet-install-script-error",
-  dotnetValidationError = "dotnet-validation-error"
+  dotnetValidationError = "dotnet-validation-error",
+
+  nodeNotFound = "node-not-found",
+  nodeNotSupportedForAzure = "node-not-supported-for-azure",
+  nodeNotSupportedForSPFx = "node-not-supported-for-spfx"
 }
 
 export enum TelemtryMessages {

--- a/packages/vscode-extension/src/debug/depsChecker/azureNodeChecker.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/azureNodeChecker.ts
@@ -1,8 +1,9 @@
-import { nodeNotFoundHelpLink, nodeNotSupportedForAzureHelpLink } from "./common";
+import { DepsCheckerEvent, nodeNotFoundHelpLink, nodeNotSupportedForAzureHelpLink } from "./common";
 import { NodeChecker } from "./nodeChecker";
 
 export class AzureNodeChecker extends NodeChecker {
+    protected readonly _supportedVersions = ["10", "12", "14"];
     protected readonly _nodeNotFoundHelpLink = nodeNotFoundHelpLink;
     protected readonly _nodeNotSupportedHelpLink = nodeNotSupportedForAzureHelpLink;
-    protected readonly _supportedVersions = ["10", "12", "14"];
+    protected readonly _nodeNotSupportedEvent = DepsCheckerEvent.nodeNotSupportedForAzure;
 }

--- a/packages/vscode-extension/src/debug/depsChecker/common.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/common.ts
@@ -50,7 +50,7 @@ export const Messages = {
   defaultErrorMessage: "Please install the required dependencies manually.",
 
   // since FuncToolChecker is disabled and azure functions core tools will be installed as devDependencies now,
-  // below messages won't be displayed to end user.
+  // below messages related to FuncToolChecker won't be displayed to end user.
   startInstallFunctionCoreTool: `Downloading and installing @NameVersion.`,
   finishInstallFunctionCoreTool: `Successfully installed @NameVersion.`,
   needReplaceWithFuncCoreToolV3: `You must replace with @NameVersion to debug your local functions.`,
@@ -94,6 +94,8 @@ Click "Continue" to continue.`
 };
 
 export enum DepsCheckerEvent {
+  // since FuncToolChecker is disabled and azure functions core tools will be installed as devDependencies now,
+  // below events related to FuncToolChecker won't be displayed to end user.
   funcCheck = "func-check",
   funcCheckSkipped = "func-check-skipped",
   funcInstall = "func-install",
@@ -110,7 +112,11 @@ export enum DepsCheckerEvent {
   dotnetInstallError = "dotnet-install-error",
   dotnetInstallScriptCompleted = "dotnet-install-script-completed",
   dotnetInstallScriptError = "dotnet-install-script-error",
-  dotnetValidationError = "dotnet-validation-error"
+  dotnetValidationError = "dotnet-validation-error",
+
+  nodeNotFound = "node-not-found",
+  nodeNotSupportedForAzure = "node-not-supported-for-azure",
+  nodeNotSupportedForSPFx = "node-not-supported-for-spfx"
 }
 
 export enum TelemtryMessages {

--- a/packages/vscode-extension/src/debug/depsChecker/spfxNodeChecker.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/spfxNodeChecker.ts
@@ -1,8 +1,9 @@
-import { nodeNotFoundHelpLink, nodeNotSupportedForSPFxHelpLink } from "./common";
+import { DepsCheckerEvent, nodeNotFoundHelpLink, nodeNotSupportedForSPFxHelpLink } from "./common";
 import { NodeChecker } from "./nodeChecker";
 
 export class SPFxNodeChecker extends NodeChecker {
+    protected readonly _supportedVersions: string[] = ["10", "12", "14"];
     protected readonly _nodeNotFoundHelpLink = nodeNotFoundHelpLink;
     protected readonly _nodeNotSupportedHelpLink = nodeNotSupportedForSPFxHelpLink;
-    protected readonly _supportedVersions: string[] = ["10", "12", "14"];
+    protected readonly _nodeNotSupportedEvent = DepsCheckerEvent.nodeNotSupportedForSPFx;
 }


### PR DESCRIPTION
1. Add telemetry event for node checker in common.ts. 
2. Sync the common.ts in function plugin.
3. Send telemetry if node can't be found or node not supported.