### PR TITLE
fix: add appid to localdebug telemetry

### DIFF
--- a/packages/fx-core/src/plugins/resource/localdebug/util/telemetry.ts
+++ b/packages/fx-core/src/plugins/resource/localdebug/util/telemetry.ts
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 import { PluginContext, SystemError, UserError } from "@microsoft/teamsfx-api";
-import { LocalDebugPluginInfo } from "../constants";
+import { LocalDebugPluginInfo, SolutionPlugin } from "../constants";
 
 enum TelemetryPropertyKey {
     component = "component",
+    appId = "appid",
     success = "success",
     errorType = "error-type",
     errorCode = "error-code",
@@ -26,9 +27,11 @@ export enum TelemetryEventName {
 
 export class TelemetryUtils {
     static ctx: PluginContext;
+    static localAppId: string | undefined;
 
     public static init(ctx: PluginContext) {
         TelemetryUtils.ctx = ctx;
+        TelemetryUtils.localAppId = ctx.configOfOtherPlugins.get(SolutionPlugin.Name)?.get(SolutionPlugin.LocalTeamsAppId) as string;
     }
 
     public static sendStartEvent(
@@ -40,6 +43,9 @@ export class TelemetryUtils {
             properties = {};
         }
         properties[TelemetryPropertyKey.component] = LocalDebugPluginInfo.pluginName;
+        if (TelemetryUtils.localAppId) {
+            properties[TelemetryPropertyKey.appId] = TelemetryUtils.localAppId;
+        }
         TelemetryUtils.ctx.telemetryReporter?.sendTelemetryEvent(`${LocalDebugPluginInfo.pluginName}/${eventName}-start`, properties, measurements);
     }
 
@@ -53,6 +59,9 @@ export class TelemetryUtils {
             properties = {};
         }
         properties[TelemetryPropertyKey.component] = LocalDebugPluginInfo.pluginName;
+        if (TelemetryUtils.localAppId) {
+            properties[TelemetryPropertyKey.appId] = TelemetryUtils.localAppId;
+        }
         properties[TelemetryPropertyKey.success] = TelemetryPropertyValue.success;
         TelemetryUtils.ctx.telemetryReporter?.sendTelemetryErrorEvent(`${LocalDebugPluginInfo.pluginName}/${eventName}`, properties, measurements, errorProps);
     }
@@ -68,6 +77,9 @@ export class TelemetryUtils {
             properties = {};
         }
         properties[TelemetryPropertyKey.component] = LocalDebugPluginInfo.pluginName;
+        if (TelemetryUtils.localAppId) {
+            properties[TelemetryPropertyKey.appId] = TelemetryUtils.localAppId;
+        }
         properties[TelemetryPropertyKey.success] = TelemetryPropertyValue.failure;
         if (err instanceof SystemError) {
             properties[TelemetryPropertyKey.errorType] = TelemetryPropertyValue.systemError;

--- a/packages/fx-core/src/plugins/resource/localdebug/util/telemetry.ts
+++ b/packages/fx-core/src/plugins/resource/localdebug/util/telemetry.ts
@@ -31,7 +31,7 @@ export class TelemetryUtils {
 
     public static init(ctx: PluginContext) {
         TelemetryUtils.ctx = ctx;
-        TelemetryUtils.localAppId = ctx.configOfOtherPlugins.get(SolutionPlugin.Name)?.get(SolutionPlugin.LocalTeamsAppId) as string;
+        TelemetryUtils.localAppId = ctx.configOfOtherPlugins?.get(SolutionPlugin.Name)?.get(SolutionPlugin.LocalTeamsAppId) as string;
     }
 
     public static sendStartEvent(


### PR DESCRIPTION
According to the latest telemetry doc, add `appid` to property. For local debug, use local app id as value.