### PR TITLE
feat(frontend): refine sending telemetry

### DIFF
--- a/packages/fx-core/src/plugins/resource/frontend/constants.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/constants.ts
@@ -28,7 +28,7 @@ export class Constants {
 }
 
 export class FrontendPluginInfo {
-    static PluginName = "Tab Frontend plugin";
+    static PluginName = "frontend";
     static DisplayName = "Tab Frontend";
     static ShortName = "FE";
     static IssueLink = ""; // TODO: default issue link
@@ -111,8 +111,6 @@ export class TelemetryEvent {
 
     static readonly PreDeploy = "pre-deploy";
     static readonly Deploy = "deploy";
-
-    static readonly postLocalDebug = "post-local-debug";
 }
 
 export class TelemetryKey {
@@ -120,6 +118,7 @@ export class TelemetryKey {
     static readonly Success = "success";
     static readonly ErrorType = "error-type";
     static readonly ErrorMessage = "error-message";
+    static readonly ErrorCode = "error-code";
 }
 
 export class TelemetryValue {

--- a/packages/fx-core/src/plugins/resource/frontend/constants.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/constants.ts
@@ -28,7 +28,7 @@ export class Constants {
 }
 
 export class FrontendPluginInfo {
-    static PluginName = "frontend";
+    static PluginName = "fx-resource-frontend-hosting";
     static DisplayName = "Tab Frontend";
     static ShortName = "FE";
     static IssueLink = ""; // TODO: default issue link

--- a/packages/fx-core/src/plugins/resource/frontend/index.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/index.ts
@@ -66,7 +66,7 @@ export class FrontendPlugin implements Plugin {
         fn: () => Promise<TeamsFxResult>,
     ): Promise<TeamsFxResult> {
         try {
-            telemetryHelper.sendSuccessEvent(ctx, stage + TelemetryEvent.startSuffix);
+            telemetryHelper.sendStartEvent(ctx, stage);
             const result = await fn();
             telemetryHelper.sendSuccessEvent(ctx, stage);
             return result;

--- a/packages/fx-core/src/plugins/resource/frontend/index.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/index.ts
@@ -83,6 +83,7 @@ export class FrontendPlugin implements Plugin {
             }
 
             if (e instanceof UserError || e instanceof SystemError) {
+                telemetryHelper.sendErrorEvent(ctx, stage, e);
                 return err(e);
             }
 

--- a/packages/fx-core/src/plugins/resource/frontend/ops/scaffold.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/ops/scaffold.ts
@@ -18,7 +18,6 @@ import { Logger } from "../utils/logger";
 import { Messages } from "../resources/messages";
 import { PluginContext } from "@microsoft/teamsfx-api";
 import { Utils } from "../utils";
-import { telemetryHelper } from "../utils/telemetry-helper";
 import { TemplateInfo, TemplateVariable } from "../resources/templateInfo";
 
 export type Manifest = {
@@ -98,7 +97,6 @@ export class FrontendScaffold {
             );
             return await FrontendScaffold.fetchZipFromUrl(templateUrl);
         } catch (e) {
-            telemetryHelper.sendErrorEvent(ctx, Messages.FailedFetchTemplate(), e);
             Logger.warning(Messages.FailedFetchTemplate());
             return FrontendScaffold.getTemplateZipFromLocal(templateInfo);
         }

--- a/packages/fx-core/src/plugins/resource/frontend/utils/telemetry-helper.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/utils/telemetry-helper.ts
@@ -33,6 +33,7 @@ export class telemetryHelper {
             properties[TelemetryKey.ErrorType] = TelemetryValue.UserError;
         }
         properties[TelemetryKey.ErrorMessage] = e.message;
+        properties[TelemetryKey.ErrorCode] = e.name;
 
         ctx.telemetryReporter?.sendTelemetryEvent(eventName, properties, measurements);
     }

--- a/packages/fx-core/src/plugins/resource/frontend/utils/telemetry-helper.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/utils/telemetry-helper.ts
@@ -1,10 +1,21 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { FrontendPluginInfo, TelemetryKey, TelemetryValue } from "../constants";
+import { FrontendPluginInfo, TelemetryEvent, TelemetryKey, TelemetryValue } from "../constants";
 import { PluginContext, SystemError, UserError } from "@microsoft/teamsfx-api";
 
 export class telemetryHelper {
+
+    static sendStartEvent(
+        ctx: PluginContext,
+        eventName: string,
+        properties: { [key: string]: string } = {},
+        measurements: { [key: string]: number } = {},
+    ): void {
+        properties[TelemetryKey.Component] = FrontendPluginInfo.PluginName;
+        ctx.telemetryReporter?.sendTelemetryEvent(eventName + TelemetryEvent.startSuffix, properties, measurements);
+    }
+
     static sendSuccessEvent(
         ctx: PluginContext,
         eventName: string,


### PR DESCRIPTION
1. start event doesn't need `success` property
2. error event need contains `error-code`, `error-message` and `error-type`
3. Plugin must send telemetry for api: [pre,post] [scaffold, provision, deploy], get question and local debug don't need to send telemetry. We can offline discuss if our plugin need more telemetry for our own business. 