### PR TITLE
fix(env-checker): add error popup for backend extension install

### DIFF
--- a/packages/fx-core/src/plugins/resource/function/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/function/plugin.ts
@@ -426,11 +426,7 @@ export class FunctionPluginImpl {
         // NOTE: make sure this step is before using `dotnet` command if you refactor this code.
         await this.handleDotnetChecker(ctx);
 
-        await runWithErrorCatchAndThrow(new InstallTeamsfxBindingError(), async () =>
-            await step(StepGroup.PreDeployStepGroup, PreDeploySteps.installTeamsfxBinding, async () =>
-                FunctionDeploy.installFuncExtensions(workingPath, functionLanguage)
-            )
-        );
+        await this.handleBackendExtensionsInstall(workingPath, functionLanguage)
 
         await runWithErrorCatchAndThrow(new InstallNpmPackageError(), async () =>
             await step(StepGroup.PreDeployStepGroup, PreDeploySteps.npmPrepare, async () =>
@@ -604,5 +600,16 @@ export class FunctionPluginImpl {
         } finally {
             funcPluginLogger.cleanup();
         }
+    }
+
+    private async handleBackendExtensionsInstall(workingPath: string, functionLanguage: FunctionLanguage): Promise<void> {
+        await step(StepGroup.PreDeployStepGroup, PreDeploySteps.installTeamsfxBinding, async () => {
+            try {
+                await FunctionDeploy.installFuncExtensions(workingPath, functionLanguage)
+            } catch (error) {
+                // wrap the original error to UserError so the extensibility model will pop-up a dialog correctly
+                funcPluginAdapter.handleDotnetError(error);
+            }
+        });
     }
 }


### PR DESCRIPTION
- Also handle the DepsChecker error for BackendExtensionInstaller in function plugin to correctly pop-up dialog

If the user only has .NET SDK 2.1 and a global.json, an error will popup like this
![image](https://user-images.githubusercontent.com/9698542/117782765-85763880-b274-11eb-8e0f-50bdce5a7947.png)


https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/9902032/