### PR TITLE
fix: simple auth cannot run with .net 5 only

### DIFF
--- a/packages/simpleauth/src/TeamsFxSimpleAuth/runtimeconfig.template.json
+++ b/packages/simpleauth/src/TeamsFxSimpleAuth/runtimeconfig.template.json
@@ -1,0 +1,3 @@
+{
+  "rollForward": "Major"
+}


### PR DESCRIPTION
Set rollForward to `Major` which roll forward to lowest higher major version, and lowest minor version, if requested major version is missing.