### PR TITLE
chore(credscan): add suppression file for credential scan task

### DIFF
--- a/.azure-pipelines/CredScanSuppressions.json
+++ b/.azure-pipelines/CredScanSuppressions.json
@@ -1,0 +1,25 @@
+{
+    "tool": "Credential Scanner",
+    "suppressions": [
+        {
+             "file": "packages\\function-extension\tests\\TestAssets\\FunctionAppJS\\localSettingsJson\\emptyClientId_local.settings.json",
+            "_justification": "Fake credentials used for unit tests."
+        },
+        {
+             "file": "packages\\function-extension\tests\\TestAssets\\FunctionAppJS\\localSettingsJson\\main_local.settings.json",
+            "_justification": "Fake credentials used for unit tests."
+        },
+        {
+            "placeholder": "M365_CLIENT_SECRET",
+            "_justification": "This is the secret place holder used by TeamsFx project."
+        },
+        {
+            "placeholder": "SQL_USERNAME",
+            "_justification": "This is the secret place holder used by TeamsFx project."
+        },
+        {
+            "placeholder": "publishingPassword",
+            "_justification": "This is the secret place holder used by TeamsFx project."
+        }
+    ]
+}


### PR DESCRIPTION
To eliminate some false alarms for the credential scan task, we can add a suppression file to whitelist some test files or terms for security. See https://strikecommunity.azurewebsites.net/articles/4127/local-suppression-usage-examples.html for how to configure rules in a suppression file.