### PR TITLE
fix(env-checker): fix ENOENT error when run dotnet-install script with execFile

### DIFF
--- a/packages/fx-core/src/plugins/resource/function/utils/depsChecker/dotnetChecker.ts
+++ b/packages/fx-core/src/plugins/resource/function/utils/depsChecker/dotnetChecker.ts
@@ -394,7 +394,7 @@ export class DotnetChecker implements IDepsChecker {
   ): Promise<string[]> {
     const command = [
       // path.join does not prepend '.'
-      [".", this.getDotnetInstallScriptName()].join(path.sep),
+      this.getDotnetInstallScriptPath(),
       "-InstallDir",
       isWindows() ? DotnetChecker.escapeFilePath(dotnetInstallDir) : dotnetInstallDir,
       "-Channel",

--- a/packages/fx-core/src/plugins/resource/function/utils/depsChecker/dotnetChecker.ts
+++ b/packages/fx-core/src/plugins/resource/function/utils/depsChecker/dotnetChecker.ts
@@ -393,7 +393,6 @@ export class DotnetChecker implements IDepsChecker {
     dotnetInstallDir: string
   ): Promise<string[]> {
     const command = [
-      // path.join does not prepend '.'
       this.getDotnetInstallScriptPath(),
       "-InstallDir",
       isWindows() ? DotnetChecker.escapeFilePath(dotnetInstallDir) : dotnetInstallDir,

--- a/packages/vscode-extension/src/debug/depsChecker/dotnetChecker.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/dotnetChecker.ts
@@ -394,7 +394,7 @@ export class DotnetChecker implements IDepsChecker {
   ): Promise<string[]> {
     const command = [
       // path.join does not prepend '.'
-      [".", this.getDotnetInstallScriptName()].join(path.sep),
+      this.getDotnetInstallScriptPath(),
       "-InstallDir",
       isWindows() ? DotnetChecker.escapeFilePath(dotnetInstallDir) : dotnetInstallDir,
       "-Channel",

--- a/packages/vscode-extension/src/debug/depsChecker/dotnetChecker.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/dotnetChecker.ts
@@ -393,7 +393,6 @@ export class DotnetChecker implements IDepsChecker {
     dotnetInstallDir: string
   ): Promise<string[]> {
     const command = [
-      // path.join does not prepend '.'
       this.getDotnetInstallScriptPath(),
       "-InstallDir",
       isWindows() ? DotnetChecker.escapeFilePath(dotnetInstallDir) : dotnetInstallDir,


### PR DESCRIPTION
- When using relative PATH in execFile, it will throw ENOENT on macOS 11.2.3. Changed to absolute path to workaround this issue
## Tests:
Run local debug without .NET SDK

### macOS:
#### Output Channel
![image](https://user-images.githubusercontent.com/9698542/117922700-73080780-b325-11eb-8da3-4829f4e5ac7a.png)
#### Final result
![image](https://user-images.githubusercontent.com/9698542/117922793-93d05d00-b325-11eb-9754-2435657c1918.png)

### Windows
#### Output Channel
![image](https://user-images.githubusercontent.com/9698542/117923067-080b0080-b326-11eb-9b22-9ecef55f2b2c.png)
#### Final result
![image](https://user-images.githubusercontent.com/9698542/117923277-57e9c780-b326-11eb-9813-b6c29b545c6f.png)

### Linux
Linux is not affected because we won't install .NET SDK on Linux