### PR TITLE
fix(env-checker): fix the error message

### DIFF
--- a/packages/fx-core/src/plugins/resource/function/utils/depsChecker/dotnetChecker.ts
+++ b/packages/fx-core/src/plugins/resource/function/utils/depsChecker/dotnetChecker.ts
@@ -235,9 +235,9 @@ export class DotnetChecker implements IDepsChecker {
     try {
       const start = performance.now();
       fs.chmodSync(this.getDotnetInstallScriptPath(), "755");
-      const { stdout, stderr } = await execFile(command[0], command.splice(1), options);
+      const { stdout, stderr } = await execFile(command[0], command.slice(1), options);
       await this._logger.debug(
-        `Finished running dotnet-install script, command = '${command}', options = '${JSON.stringify(
+        `Finished running dotnet-install script, command = '${command.join(" ")}', options = '${JSON.stringify(
           options
         )}', stdout = '${stdout}', stderr = '${stderr}'`
       );
@@ -265,7 +265,9 @@ export class DotnetChecker implements IDepsChecker {
         `${Messages.failToInstallDotnet.split("@NameVersion").join(installedNameWithVersion)} ${
           Messages.dotnetInstallErrorCode
         }, ` +
-        `command = '${command}', options = '${options}', error = '${error}', stdout = '${error.stdout}', stderr = '${error.stderr}'`;
+        `command = '${command.join(" ")}', options = '${JSON.stringify(
+          options
+        )}', error = '${error}', stdout = '${error.stdout}', stderr = '${error.stderr}'`;
 
       this._telemetry.sendSystemErrorEvent(
         DepsCheckerEvent.dotnetInstallScriptError,

--- a/packages/vscode-extension/src/debug/depsChecker/dotnetChecker.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/dotnetChecker.ts
@@ -185,7 +185,7 @@ export class DotnetChecker implements IDepsChecker {
       await DotnetChecker.persistDotnetExecPath(dotnetExecPath);
       await this._logger.debug(`[end] write dotnet path to config`);
       await this._logger.info(
-          Messages.finishInstallDotnet.replace("@NameVersion", installedNameWithVersion)
+        Messages.finishInstallDotnet.replace("@NameVersion", installedNameWithVersion)
       );
     } catch (error) {
       await this._logger.error(
@@ -235,9 +235,9 @@ export class DotnetChecker implements IDepsChecker {
     try {
       const start = performance.now();
       fs.chmodSync(this.getDotnetInstallScriptPath(), "755");
-      const { stdout, stderr } = await execFile(command[0], command.splice(1), options);
+      const { stdout, stderr } = await execFile(command[0], command.slice(1), options);
       await this._logger.debug(
-        `Finished running dotnet-install script, command = '${command}', options = '${JSON.stringify(
+        `Finished running dotnet-install script, command = '${command.join(" ")}', options = '${JSON.stringify(
           options
         )}', stdout = '${stdout}', stderr = '${stderr}'`
       );
@@ -265,7 +265,9 @@ export class DotnetChecker implements IDepsChecker {
         `${Messages.failToInstallDotnet.split("@NameVersion").join(installedNameWithVersion)} ${
           Messages.dotnetInstallErrorCode
         }, ` +
-        `command = '${command}', options = '${options}', error = '${error}', stdout = '${error.stdout}', stderr = '${error.stderr}'`;
+        `command = '${command.join(" ")}', options = '${JSON.stringify(
+          options
+        )}', error = '${error}', stdout = '${error.stdout}', stderr = '${error.stderr}'`;
 
       this._telemetry.sendSystemErrorEvent(
         DepsCheckerEvent.dotnetInstallScriptError,
@@ -461,9 +463,9 @@ export class DotnetChecker implements IDepsChecker {
       return actual.includes(expected);
     } catch (error) {
       this._telemetry.sendSystemErrorEvent(
-          DepsCheckerEvent.dotnetValidationError,
-          TelemtryMessages.failedToValidateDotnet,
-          error
+        DepsCheckerEvent.dotnetValidationError,
+        TelemtryMessages.failedToValidateDotnet,
+        error
       );
       await this._logger.debug(
         `Failed to run hello world, dotnetPath = ${dotnetPath}, expected output = ${expected}, actual output = ${actual}, error = ${error}`


### PR DESCRIPTION
1. fix `options` is an object without being serialized in error message.
2. fix `command` has been changed after running `command.splice(1)`
