### PR TITLE
feat: update comment to avoid from diversity break

### DIFF
--- a/packages/vscode-extension/src/controls/webviewPanel.ts
+++ b/packages/vscode-extension/src/controls/webviewPanel.ts
@@ -204,7 +204,7 @@ export class WebviewPanel {
     const scriptPathOnDisk = vscode.Uri.file(path.join(this.extensionPath, "out/src", "client.js"));
     const scriptUri = scriptPathOnDisk.with({ scheme: "vscode-resource" });
 
-    // Use a nonce to whitelist which scripts can be run
+    // Use a nonce to to only allow specific scripts to be run
     const nonce = this.getNonce();
 
     return `<!DOCTYPE html>


### PR DESCRIPTION
The wording 'whitelist' breaks diversity rule. Change the string.