### PR TITLE
fix: add confirm & progress bar for sample clone

### DIFF
--- a/packages/cli/resource/newParam.json
+++ b/packages/cli/resource/newParam.json
@@ -291,7 +291,7 @@
                     },
                     {
                         "id": "todo-list-SPFx",
-                        "label": "To Do List2",
+                        "label": "Todo List with SPFx",
                         "detail": "Todo List with SPFx is a Todo List for individual user to manage his/her personal to-do items in the format of an app installed on Teams client.",
                         "data": "https://github.com/HuihuiWu-Microsoft/TeamsFx-Samples/archive/refs/heads/main.zip"
                     },

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -68,7 +68,7 @@ export const templates: {
     sampleAppUrl: "https://github.com/HuihuiWu-Microsoft/TeamsFx-Samples/archive/refs/heads/main.zip"
   },
   {
-    title: "To Do List2",
+    title: "Todo List with SPFx",
     sampleAppName: "todo-list-SPFx",
     description: "Todo List with SPFx is a Todo List for individual user to manage his/her personal to-do items in the format of an app installed on Teams client.",
     sampleAppUrl: "https://github.com/HuihuiWu-Microsoft/TeamsFx-Samples/archive/refs/heads/main.zip"

--- a/packages/fx-core/src/core/error.ts
+++ b/packages/fx-core/src/core/error.ts
@@ -48,3 +48,7 @@ export function EnvNotExist(param: any): UserError {
 export function NotSupportedProjectType(): UserError {
     return returnUserError(new Error(`Project type not supported`), CoreSource, CoreErrorNames.NotSupportedProjectType);
 }
+
+export function DownloadSampleFail(): SystemError {
+    return returnUserError(new Error("Failed to clone sample app"), CoreSource, CoreErrorNames.DownloadSampleFail);
+}

--- a/packages/fx-core/src/core/question.ts
+++ b/packages/fx-core/src/core/question.ts
@@ -96,7 +96,7 @@ export const SampleSelect: SingleSelectQuestion = {
         data: "https://github.com/HuihuiWu-Microsoft/TeamsFx-Samples/archive/refs/heads/main.zip"
     },{
         id:"todo-list-SPFx",
-        label: "To Do List2",
+        label: "Todo List with SPFx",
         detail: "Todo List with SPFx is a Todo List for individual user to manage his/her personal to-do items in the format of an app installed on Teams client.",
         data: "https://github.com/HuihuiWu-Microsoft/TeamsFx-Samples/archive/refs/heads/main.zip"
     },{


### PR DESCRIPTION
1. rename "To Do List2" to "Todo List with SPFx"
2. add progress bar for sample clone in webview trigger.
3. add confirm button for sample clone in command palate & tree view trigger. 
 (Note: here the confirm comes after all the answers collected , different in webview(confirm first, then select folder).
Bug opened:https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/9912386)

related task:
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/9902864
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/9888172