### PR TITLE
chore(bot): use template lib in fxcore

### DIFF
--- a/packages/fx-core/src/plugins/resource/bot/utils/templateManifest.ts
+++ b/packages/fx-core/src/plugins/resource/bot/utils/templateManifest.ts
@@ -8,23 +8,7 @@ import { DownloadConstants, TemplateProjectsConstants } from "../constants";
 import { DownloadError, TemplateProjectNotFoundError } from "../errors";
 import { Logger } from "../logger";
 import * as utils from "../utils/common";
-
-export const templatesVersion = "0.1.*";
-export const tagPrefix = "templates@";
-export const preRelease = process.env.TEAMSFX_TEMPLATE_PRERELEASE || "";
-export const tagListURL =
-    "https://github.com/OfficeDev/TeamsFx/releases/download/template-tag-list/template-tags.txt";
-
-export function selectTag(tags: string[]): string | undefined {
-    const versionPattern = preRelease ? `0.0.0-${preRelease}` : templatesVersion;
-    const versionList = tags.map((tag: string) => tag.replace(tagPrefix, ""));
-    const selectedVersion = semver.maxSatisfying(versionList, versionPattern);
-    return selectedVersion ? (tagPrefix + selectedVersion) : undefined;
-}
-
-export const templateURL = (tag: string, templateName: string): string =>
-    `https://github.com/OfficeDev/TeamsFx/releases/download/${tag}/${templateName}.zip`;
-
+import { selectTag, tagListURL, templateURL } from "../../../../common/templates";
 
 export class TemplateManifest {
     public tags: string[] = [];


### PR DESCRIPTION
Use common templates config/lib from fx-core.

Sorry for: Didn't realize the code is from fx-core which is a common place.