### PR TITLE
Fix: fix app-not-found by adding account hint

### DIFF
--- a/packages/fx-core/src/plugins/resource/localdebug/launch.ts
+++ b/packages/fx-core/src/plugins/resource/localdebug/launch.ts
@@ -57,7 +57,7 @@ export function generateConfigurations(includeFrontend: boolean, includeBackend:
             name: "Launch Remote (Edge)",
             type: LaunchBrowser.edge,
             request: "launch",
-            url: "https://teams.microsoft.com/l/app/${teamsAppId}?installAppPackage=true",
+            url: "https://teams.microsoft.com/l/app/${teamsAppId}?installAppPackage=true&${account-hint}",
             presentation: {
                 group: "remote",
                 order: edgeOrder,
@@ -67,7 +67,7 @@ export function generateConfigurations(includeFrontend: boolean, includeBackend:
             name: "Launch Remote (Chrome)",
             type: LaunchBrowser.chrome,
             request: "launch",
-            url: "https://teams.microsoft.com/l/app/${teamsAppId}?installAppPackage=true",
+            url: "https://teams.microsoft.com/l/app/${teamsAppId}?installAppPackage=true&${account-hint}",
             presentation: {
                 group: "remote",
                 order: chromeOrder,

--- a/packages/fx-core/src/plugins/resource/localdebug/launch.ts
+++ b/packages/fx-core/src/plugins/resource/localdebug/launch.ts
@@ -57,7 +57,7 @@ export function generateConfigurations(includeFrontend: boolean, includeBackend:
             name: "Launch Remote (Edge)",
             type: LaunchBrowser.edge,
             request: "launch",
-            url: "https://teams.microsoft.com/_#/l/app/${teamsAppId}?installAppPackage=true",
+            url: "https://teams.microsoft.com/l/app/${teamsAppId}?installAppPackage=true",
             presentation: {
                 group: "remote",
                 order: edgeOrder,
@@ -67,7 +67,7 @@ export function generateConfigurations(includeFrontend: boolean, includeBackend:
             name: "Launch Remote (Chrome)",
             type: LaunchBrowser.chrome,
             request: "launch",
-            url: "https://teams.microsoft.com/_#/l/app/${teamsAppId}?installAppPackage=true",
+            url: "https://teams.microsoft.com/l/app/${teamsAppId}?installAppPackage=true",
             presentation: {
                 group: "remote",
                 order: chromeOrder,
@@ -84,7 +84,7 @@ export function generateConfigurations(includeFrontend: boolean, includeBackend:
                     name: "Start and Attach to Frontend (Edge)",
                     type: LaunchBrowser.edge,
                     request: "launch",
-                    url: "https://teams.microsoft.com/_#/l/app/${localTeamsAppId}?installAppPackage=true",
+                    url: "https://teams.microsoft.com/l/app/${localTeamsAppId}?installAppPackage=true&${account-hint}",
                     preLaunchTask: "Start Frontend",
                     cascadeTerminateToConfigurations: ["Start and Attach to Backend"],
                     presentation: {
@@ -96,7 +96,7 @@ export function generateConfigurations(includeFrontend: boolean, includeBackend:
                     name: "Start and Attach to Frontend (Chrome)",
                     type: LaunchBrowser.chrome,
                     request: "launch",
-                    url: "https://teams.microsoft.com/_#/l/app/${localTeamsAppId}?installAppPackage=true",
+                    url: "https://teams.microsoft.com/l/app/${localTeamsAppId}?installAppPackage=true&${account-hint}",
                     preLaunchTask: "Start Frontend",
                     cascadeTerminateToConfigurations: ["Start and Attach to Backend"],
                     presentation: {
@@ -124,7 +124,7 @@ export function generateConfigurations(includeFrontend: boolean, includeBackend:
                     name: "Start and Attach to Frontend (Edge)",
                     type: LaunchBrowser.edge,
                     request: "launch",
-                    url: "https://teams.microsoft.com/_#/l/app/${localTeamsAppId}?installAppPackage=true",
+                    url: "https://teams.microsoft.com/l/app/${localTeamsAppId}?installAppPackage=true&${account-hint}",
                     preLaunchTask: "Start Frontend",
                     presentation: {
                         group: "all",
@@ -135,7 +135,7 @@ export function generateConfigurations(includeFrontend: boolean, includeBackend:
                     name: "Start and Attach to Frontend (Chrome)",
                     type: LaunchBrowser.chrome,
                     request: "launch",
-                    url: "https://teams.microsoft.com/_#/l/app/${localTeamsAppId}?installAppPackage=true",
+                    url: "https://teams.microsoft.com/l/app/${localTeamsAppId}?installAppPackage=true&${account-hint}",
                     preLaunchTask: "Start Frontend",
                     presentation: {
                         group: "all",
@@ -153,7 +153,7 @@ export function generateConfigurations(includeFrontend: boolean, includeBackend:
                 name: "Launch Bot (Edge)",
                 type: LaunchBrowser.edge,
                 request: "launch",
-                url: "https://teams.microsoft.com/_#/l/app/${localTeamsAppId}?installAppPackage=true",
+                url: "https://teams.microsoft.com/l/app/${localTeamsAppId}?installAppPackage=true&${account-hint}",
                 cascadeTerminateToConfigurations: ["Start and Attach to Bot"],
                 presentation: {
                     group: "all",
@@ -164,7 +164,7 @@ export function generateConfigurations(includeFrontend: boolean, includeBackend:
                 name: "Launch Bot (Chrome)",
                 type: LaunchBrowser.chrome,
                 request: "launch",
-                url: "https://teams.microsoft.com/_#/l/app/${localTeamsAppId}?installAppPackage=true",
+                url: "https://teams.microsoft.com/l/app/${localTeamsAppId}?installAppPackage=true&${account-hint}",
                 cascadeTerminateToConfigurations: ["Start and Attach to Bot"],
                 presentation: {
                     group: "all",
@@ -193,7 +193,7 @@ export function generateConfigurations(includeFrontend: boolean, includeBackend:
                 name: "Start and Attach to Frontend (Edge)",
                 type: LaunchBrowser.edge,
                 request: "launch",
-                url: "https://teams.microsoft.com/_#/l/app/${localTeamsAppId}?installAppPackage=true",
+                url: "https://teams.microsoft.com/l/app/${localTeamsAppId}?installAppPackage=true&${account-hint}",
                 preLaunchTask: "Start Frontend",
                 cascadeTerminateToConfigurations: includeBackend ? ["Start and Attach to Bot", "Start and Attach to Backend"]: ["Start and Attach to Bot"],
                 presentation: {
@@ -205,7 +205,7 @@ export function generateConfigurations(includeFrontend: boolean, includeBackend:
                 name: "Start and Attach to Frontend (Chrome)",
                 type: LaunchBrowser.chrome,
                 request: "launch",
-                url: "https://teams.microsoft.com/_#/l/app/${localTeamsAppId}?installAppPackage=true",
+                url: "https://teams.microsoft.com/l/app/${localTeamsAppId}?installAppPackage=true&${account-hint}",
                 preLaunchTask: "Start Frontend",
                 cascadeTerminateToConfigurations: includeBackend ? ["Start and Attach to Bot", "Start and Attach to Backend"]: ["Start and Attach to Bot"],
                 presentation: {

--- a/packages/vscode-extension/src/debug/commonUtils.ts
+++ b/packages/vscode-extension/src/debug/commonUtils.ts
@@ -9,6 +9,8 @@ import * as constants from "./constants";
 import { ConfigFolderName, Func } from "@microsoft/teamsfx-api";
 import { core, showError } from "../handlers";
 import * as net from "net";
+import { ext } from "../extensionVariables";
+import { getActiveEnv, isWorkspaceSupported } from "../utils/commonUtils";
 
 export async function getProjectRoot(
   folderPath: string,
@@ -178,4 +180,18 @@ export async function detectPortListening(port: number, hosts: string[]): Promis
     }
   }
   return false;
+}
+
+export function getTeamsAppTenantId(): string | undefined {
+  if (ext.workspaceUri) {
+    const ws = ext.workspaceUri.fsPath;
+    if (isWorkspaceSupported(ws)) {
+      const env = getActiveEnv();
+      const envJsonPath = path.join(ws, `.${ConfigFolderName}/env.${env}.json`);
+      const envJson = JSON.parse(fs.readFileSync(envJsonPath, "utf8"));
+      return envJson.solution.teamsAppTenantId;
+    }
+  }
+
+  return undefined;
 }

--- a/packages/vscode-extension/src/debug/teamsfxDebugProvider.ts
+++ b/packages/vscode-extension/src/debug/teamsfxDebugProvider.ts
@@ -3,6 +3,7 @@
 
 import * as vscode from "vscode";
 
+import AppStudioTokenInstance from "../commonlib/appStudioLogin";
 import * as commonUtils from "./commonUtils";
 import { core, showError } from "../handlers";
 import { Func } from "@microsoft/teamsfx-api";
@@ -42,6 +43,29 @@ export class TeamsfxDebugProvider implements vscode.DebugConfigurationProvider {
           teamsAppId as string
         );
 
+        if (isLocalSideloadingConfiguration) {
+          // fill account hint for local only
+          const accountHintPlaceholder = "${account-hint}";
+          let tenantId = undefined, loginHint = undefined;
+          try {
+            const tokenObject = await AppStudioTokenInstance.getJsonObject(false);
+            tenantId = tokenObject?.tid;
+            loginHint = tokenObject?.upn;
+          } catch {
+            // ignore error
+          }
+          if (tenantId && loginHint) {
+            debugConfiguration.url = (debugConfiguration.url as string).replace(
+              accountHintPlaceholder,
+              `appTenantId=${tenantId}&login_hint=${loginHint}`
+            );
+          } else {
+            debugConfiguration.url = (debugConfiguration.url as string).replace(
+              accountHintPlaceholder,
+              ""
+            );
+          }
+        }
       }
     } catch (err) {
       // TODO(kuojianlu): add log and telemetry

--- a/packages/vscode-extension/src/debug/teamsfxDebugProvider.ts
+++ b/packages/vscode-extension/src/debug/teamsfxDebugProvider.ts
@@ -50,9 +50,16 @@ export class TeamsfxDebugProvider implements vscode.DebugConfigurationProvider {
         if (isaccountHintConfiguration) {
           let tenantId = undefined, loginHint = undefined;
           try {
-            const tokenObject = await AppStudioTokenInstance.getJsonObject(false);
-            tenantId = tokenObject?.tid;
-            loginHint = tokenObject?.upn;
+            const tokenObject = (await AppStudioTokenInstance.getStatus())?.accountInfo;
+            if (tokenObject) {
+              // user signed in
+              tenantId = tokenObject.tid;
+              loginHint = tokenObject.upn;
+            } else {
+              // no signed user
+              tenantId = commonUtils.getTeamsAppTenantId();
+              loginHint = "login_your_m365_account"; // a workaround that user has the chance to login
+            }
           } catch {
             // ignore error
           }

--- a/packages/vscode-extension/src/debug/teamsfxDebugProvider.ts
+++ b/packages/vscode-extension/src/debug/teamsfxDebugProvider.ts
@@ -43,9 +43,11 @@ export class TeamsfxDebugProvider implements vscode.DebugConfigurationProvider {
           teamsAppId as string
         );
 
-        if (isLocalSideloadingConfiguration) {
-          // fill account hint for local only
-          const accountHintPlaceholder = "${account-hint}";
+        const accountHintPlaceholder = "${account-hint}";
+        const isaccountHintConfiguration: boolean = (debugConfiguration.url as string).includes(
+          accountHintPlaceholder
+        );
+        if (isaccountHintConfiguration) {
           let tenantId = undefined, loginHint = undefined;
           try {
             const tokenObject = await AppStudioTokenInstance.getJsonObject(false);


### PR DESCRIPTION
Use `https://teams.microsoft.com/l/app/${teamsAppId}?installAppPackage=true&appTenantId=${tenantId}&login_hint=${userAccount}` as launch url to navigate user to login the correct account.

This could fix the app not found issue for local and remote debug, but:
- `login_hint` cannot be empty. So, when remote debug and no signed user, use "login_your_m365_account" as login hint - at least user has the chance to login another account.
- This will always show a Teams app selection page as following:
  ![image](https://user-images.githubusercontent.com/7642967/118082267-71a31180-b3ef-11eb-9e08-1ed0c71433ee.png)
