### PR TITLE
[WIP] fix: avoid BadGateway error

### DIFF
--- a/packages/fx-core/src/plugins/resource/appstudio/appStudio.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/appStudio.ts
@@ -86,6 +86,14 @@ export namespace AppStudioClient {
             
             if (response && response.data) {
                 if (response.data.error) {
+                    // To avoid App Studio BadGateway error
+                    // The app is actually published to app catalog.
+                    if (response.data.error.code === "BadGateway") {
+                        const appDefinition = await getAppByTeamsAppId(teamsAppId, appStudioToken);
+                        if (appDefinition) {
+                            return appDefinition.teamsAppId;
+                        }
+                    }
                     throw AppStudioResultFactory.SystemError(
                         AppStudioError.TeamsAppPublishFailedError.name,
                         AppStudioError.TeamsAppPublishFailedError.message(teamsAppId),


### PR DESCRIPTION
Check if the app is successfully published to app catalog. If so, ignore the badgateway error.