### PR TITLE
fix(env-checker): Handle the corner case of global broken .NET SDK

### DIFF
--- a/packages/vscode-extension/src/debug/depsChecker/dotnetChecker.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/dotnetChecker.ts
@@ -288,7 +288,7 @@ export class DotnetChecker implements IDepsChecker {
       const installedVersions = dotnetSdks
         .map((sdk) => DotnetChecker.parseDotnetVersion(sdk.version))
         .filter((version) => version !== null) as string[];
-      return this.isDotnetVersionsInstalled(installedVersions);
+      return this.isDotnetVersionsInstalled(installedVersions) && (await this.validateWithHelloWorld());
     } catch (error) {
       const errorMessage = `validate private install failed, error = '${error}'`;
       this._telemetry.sendSystemErrorEvent(
@@ -421,8 +421,7 @@ export class DotnetChecker implements IDepsChecker {
   }
 
   private async validate(): Promise<boolean> {
-    const isInstallationValid =
-      (await this.isDotnetInstalledCorrectly()) && (await this.validateWithHelloWorld());
+    const isInstallationValid = await this.isDotnetInstalledCorrectly();
     if (!isInstallationValid) {
       this._telemetry.sendEvent(DepsCheckerEvent.dotnetValidationError);
       await DotnetChecker.cleanup();


### PR DESCRIPTION
If the user has a global broken .NET SDK, we will pop up this error dialog to let user install .NET SDK manually. The popup help link is this: https://github.com/OfficeDev/TeamsFx/blob/main/docs/vscode-extension/envchecker-help.md#failtoinstalldotnet

## Windows:
![image](https://user-images.githubusercontent.com/9698542/118105080-8b078600-b40e-11eb-80c5-1615cf9b6c6e.png)

## macOS

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/9923279