### PR TITLE
Application name instead of project name

### DIFF
--- a/packages/cli/resource/newParam.json
+++ b/packages/cli/resource/newParam.json
@@ -266,7 +266,7 @@
                     "data": {
                         "type": "text",
                         "name": "app-name",
-                        "title": "Project name"
+                        "title": "Application name"
                     }
                 }
             ]

--- a/packages/fx-core/src/core/question.ts
+++ b/packages/fx-core/src/core/question.ts
@@ -20,7 +20,7 @@ export const ProjectNamePattern:string = "^[a-zA-Z][\\da-zA-Z]+$";
 export const QuestionAppName: TextInputQuestion = {
     type: NodeType.text,
     name: CoreQuestionNames.AppName,
-    title: "Project name",
+    title: "Application name",
     validation: {
         validFunc: async (appName: string, answer?: ConfigMap): Promise<string|undefined> => {
             const folder = answer?.getString(CoreQuestionNames.Foler);
@@ -30,11 +30,11 @@ export const QuestionAppName: TextInputQuestion = {
             };
             const validateResult = jsonschema.validate(appName, schema);
             if (validateResult.errors && validateResult.errors.length > 0) {
-                return `project name doesn't match pattern: ${schema.pattern}`;
+                return "Application name must start with a letter and can only contain letters and digits.";
             }
             const projectPath = path.resolve(folder, appName);
             const exists = await fs.pathExists(projectPath);
-            if (exists) return `Project path already exists:${projectPath}, please change a different project name.`;
+            if (exists) return `Path exists: ${projectPath}. Select a different Application name.`;
             return undefined;
         }
     },


### PR DESCRIPTION
Make project wizard use application name instead of project name. Clean up the error around invalid application name. Fixes https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/9910926