### PR TITLE
fix(bot): align me capability value

### DIFF
--- a/packages/fx-core/src/plugins/resource/bot/enums/pluginActRoles.ts
+++ b/packages/fx-core/src/plugins/resource/bot/enums/pluginActRoles.ts
@@ -1,4 +1,4 @@
 export enum PluginActRoles {
-    Bot = "Bot",
-    MessageExtension = "MessageExtension"
+  Bot = "Bot",
+  MessageExtension = "MessagingExtension",
 }


### PR DESCRIPTION
1. bot plugin get capabilities selected from solution's config in context.
2. solution change capability value from MessageExtension to MessagingExtension.
3. bot plugin checks if users selected me by value MessageExtension, so cause the bug.

Better way is to provide a common enum for these capability values in fx-core, but not existing for now.

to fix bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/9924015