### PR TITLE
fix: detect vscode for remote environment

### DIFF
--- a/packages/api/src/constants.ts
+++ b/packages/api/src/constants.ts
@@ -2,47 +2,46 @@
 // Licensed under the MIT license.
 "use strict";
 
-
 export const ConfigFolderName = "fx";
 export const ProductName = "teamsfx";
 
-export enum Platform
-{
-    VSCode = "vsc",
-    VS = "vs",
-    CLI = "cli"
+export enum Platform {
+  VSCode = "vsc",
+  VS = "vs",
+  CLI = "cli",
 }
 
-export enum VsCodeEnv
-{
-    local = "local",
-    codespaceBrowser = "codespaceBrowser",
-    codespaceVsCode = "codespaceVsCode",
-    remoteContainer = "remoteContainer"
-}
- 
-export enum Task
-{
-    create = "create",
-    update = "update",
-    debug = "debug",
-    provision = "provision",
-    deploy = "deploy",
-    publish = "publish",
-    userTask = "userTask"
+export enum VsCodeEnv {
+  local = "local",
+  codespaceBrowser = "codespaceBrowser",
+  codespaceVsCode = "codespaceVsCode",
+  remote = "remote",
 }
 
-export enum Stage
-{
-    create = "create",
-    update = "update",
-    debug = "debug",
-    provision = "provision",
-    deploy = "deploy",
-    publish = "publish",
-    userTask = "userTask"
+export enum Task {
+  create = "create",
+  update = "update",
+  debug = "debug",
+  provision = "provision",
+  deploy = "deploy",
+  publish = "publish",
+  userTask = "userTask",
 }
 
-export type PredefinedTask = Task.create|Task.update|Task.debug|Task.provision|Task.deploy|Task.publish;
- 
+export enum Stage {
+  create = "create",
+  update = "update",
+  debug = "debug",
+  provision = "provision",
+  deploy = "deploy",
+  publish = "publish",
+  userTask = "userTask",
+}
 
+export type PredefinedTask =
+  | Task.create
+  | Task.update
+  | Task.debug
+  | Task.provision
+  | Task.deploy
+  | Task.publish;

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -12,7 +12,7 @@ import {
   env,
   ViewColumn,
   debug,
-  QuickPickItem
+  QuickPickItem,
 } from "vscode";
 import {
   Result,
@@ -34,7 +34,7 @@ import {
   InputResult,
   InputResultType,
   VsCodeEnv,
-  AppStudioTokenProvider
+  AppStudioTokenProvider,
 } from "@microsoft/teamsfx-api";
 import { CoreProxy } from "@microsoft/teamsfx-core";
 import DialogManagerInstance from "./userInterface";
@@ -54,7 +54,7 @@ import {
   TelemetryProperty,
   TelemetryTiggerFrom,
   TelemetrySuccess,
-  AccountType
+  AccountType,
 } from "./telemetry/extTelemetryEvents";
 import * as commonUtils from "./debug/commonUtils";
 import { ExtensionErrors, ExtensionSource } from "./error";
@@ -210,7 +210,7 @@ export async function activate(): Promise<Result<null, FxError>> {
       source: ExtensionSource,
       message: e.message,
       stack: e.stack,
-      timestamp: new Date()
+      timestamp: new Date(),
     };
     showError(FxError);
     return err(FxError);
@@ -236,14 +236,14 @@ export async function validateManifestHandler(args?: any[]): Promise<Result<null
 
   const func: Func = {
     namespace: "fx-solution-azure",
-    method: "validateManifest"
+    method: "validateManifest",
   };
   const result = await core.executeUserTask(func);
   if (result.isErr()) {
     ExtTelemetry.sendTelemetryErrorEvent(TelemetryEvent.ValidateManifest, result.error);
   } else {
     ExtTelemetry.sendTelemetryEvent(TelemetryEvent.ValidateManifest, {
-      [TelemetryProperty.Success]: TelemetrySuccess.Yes
+      [TelemetryProperty.Success]: TelemetrySuccess.Yes,
     });
   }
 
@@ -255,14 +255,14 @@ export async function buildPackageHandler(args?: any[]): Promise<Result<null, Fx
 
   const func: Func = {
     namespace: "fx-solution-azure",
-    method: "buildPackage"
+    method: "buildPackage",
   };
   const result = await core.executeUserTask(func);
   if (result.isErr()) {
     ExtTelemetry.sendTelemetryErrorEvent(TelemetryEvent.Build, result.error);
   } else {
     ExtTelemetry.sendTelemetryEvent(TelemetryEvent.Build, {
-      [TelemetryProperty.Success]: TelemetrySuccess.Yes
+      [TelemetryProperty.Success]: TelemetrySuccess.Yes,
     });
   }
 
@@ -284,7 +284,7 @@ export async function publishHandler(args?: any[]): Promise<Result<null, FxError
   return await runCommand(Stage.publish);
 }
 
-const coreExeceutor: RemoteFuncExecutor = async function(
+const coreExeceutor: RemoteFuncExecutor = async function (
   func: Func,
   answers: Inputs | ConfigMap
 ): Promise<Result<unknown, FxError>> {
@@ -369,7 +369,7 @@ export async function runCommand(stage: Stage): Promise<Result<null, FxError>> {
       runningTasks.delete(stage);
       if (eventName) {
         ExtTelemetry.sendTelemetryEvent(eventName, {
-          [TelemetryProperty.Success]: TelemetrySuccess.No
+          [TelemetryProperty.Success]: TelemetrySuccess.No,
         });
       }
       return await provisionHandler();
@@ -395,8 +395,10 @@ export function detectVsCodeEnv(): VsCodeEnv {
     // Codespaces browser-based editor will return UIKind.Web for uiKind
     if (vscode.env.uiKind === vscode.UIKind.Web) {
       return VsCodeEnv.codespaceBrowser;
-    } else {
+    } else if (vscode.env.remoteName === "codespaces") {
       return VsCodeEnv.codespaceVsCode;
+    } else {
+      return VsCodeEnv.remote;
     }
   } else {
     // running locally
@@ -503,7 +505,7 @@ async function processResult(eventName: string | undefined, result: Result<null,
   } else {
     if (eventName) {
       ExtTelemetry.sendTelemetryEvent(eventName, {
-        [TelemetryProperty.Success]: TelemetrySuccess.Yes
+        [TelemetryProperty.Success]: TelemetrySuccess.Yes,
       });
     }
   }
@@ -542,7 +544,7 @@ export async function updateAADHandler(args: any[]): Promise<Result<null, FxErro
   ExtTelemetry.sendTelemetryEvent(TelemetryEvent.UpdateAadStart, getTriggerFromProperty(args));
   const func: Func = {
     namespace: "fx-solution-azure/fx-resource-aad-app-for-teams",
-    method: "aadUpdatePermission"
+    method: "aadUpdatePermission",
   };
   return await runUserTask(func, TelemetryEvent.UpdateAad);
 }
@@ -551,7 +553,7 @@ export async function addCapabilityHandler(args: any[]): Promise<Result<null, Fx
   ExtTelemetry.sendTelemetryEvent(TelemetryEvent.AddCapStart, getTriggerFromProperty(args));
   const func: Func = {
     namespace: "fx-solution-azure",
-    method: "addCapability"
+    method: "addCapability",
   };
   return await runUserTask(func, TelemetryEvent.AddCap);
 }
@@ -698,7 +700,7 @@ function getTriggerFromProperty(args?: any[]) {
   return {
     [TelemetryProperty.TriggerFrom]: isFromTreeView
       ? TelemetryTiggerFrom.TreeView
-      : TelemetryTiggerFrom.CommandPalette
+      : TelemetryTiggerFrom.CommandPalette,
   };
 }
 
@@ -775,7 +777,7 @@ export async function openManifestHandler(args?: any[]): Promise<Result<null, Fx
         window.showTextDocument(document);
       });
       ExtTelemetry.sendTelemetryEvent(TelemetryEvent.OpenManifestEditor, {
-        [TelemetryProperty.Success]: TelemetrySuccess.Yes
+        [TelemetryProperty.Success]: TelemetrySuccess.Yes,
       });
       return ok(null);
     } else {
@@ -783,7 +785,7 @@ export async function openManifestHandler(args?: any[]): Promise<Result<null, Fx
         name: "FileNotFound",
         source: ExtensionSource,
         message: util.format(StringResources.vsc.handlers.fileNotFound, manifestFile),
-        timestamp: new Date()
+        timestamp: new Date(),
       };
       showError(FxError);
       ExtTelemetry.sendTelemetryErrorEvent(TelemetryEvent.OpenManifestEditor, FxError);
@@ -794,7 +796,7 @@ export async function openManifestHandler(args?: any[]): Promise<Result<null, Fx
       name: "NoWorkspace",
       source: ExtensionSource,
       message: StringResources.vsc.handlers.noOpenWorkspace,
-      timestamp: new Date()
+      timestamp: new Date(),
     };
     showError(FxError);
     ExtTelemetry.sendTelemetryErrorEvent(TelemetryEvent.OpenManifestEditor, FxError);
@@ -864,7 +866,7 @@ export async function showError(e: FxError) {
       title: StringResources.vsc.handlers.getHelp,
       run: async (): Promise<void> => {
         commands.executeCommand("vscode.open", Uri.parse(`${e.helpLink}#${e.source}${e.name}`));
-      }
+      },
     };
 
     const button = await window.showErrorMessage(`[${errorCode}]: ${e.message}`, help);
@@ -876,7 +878,7 @@ export async function showError(e: FxError) {
       title: StringResources.vsc.handlers.reportIssue,
       run: async (): Promise<void> => {
         commands.executeCommand("vscode.open", Uri.parse(`${path}${param}`));
-      }
+      },
     };
 
     const button = await window.showErrorMessage(`[${errorCode}]: ${e.message}`, issue);
@@ -890,25 +892,25 @@ export async function cmpAccountsHandler() {
   const signInAzureOption: VscQuickPickItem = {
     id: "signInAzure",
     label: "Sign in to Azure",
-    function: () => signInAzure()
+    function: () => signInAzure(),
   };
 
   const signOutAzureOption: VscQuickPickItem = {
     id: "signOutAzure",
     label: "Sign out of Azure: ",
-    function: () => signOutAzure(false)
+    function: () => signOutAzure(false),
   };
 
   const signInM365Option: VscQuickPickItem = {
     id: "signinM365",
     label: "Sign in to M365",
-    function: () => signInM365()
+    function: () => signInM365(),
   };
 
   const signOutM365Option: VscQuickPickItem = {
     id: "signOutM365",
     label: "Sign out of M365: ",
-    function: () => signOutM365(false)
+    function: () => signOutM365(false),
   };
 
   //TODO: hide subscription list until core or api expose the get subscription list API
@@ -963,7 +965,7 @@ export async function signOutAzure(isFromTreeView: boolean) {
     [TelemetryProperty.TriggerFrom]: isFromTreeView
       ? TelemetryTiggerFrom.TreeView
       : TelemetryTiggerFrom.CommandPalette,
-    [TelemetryProperty.AccountType]: AccountType.Azure
+    [TelemetryProperty.AccountType]: AccountType.Azure,
   });
   const result = await AzureAccountManager.signout();
   if (result) {
@@ -971,15 +973,15 @@ export async function signOutAzure(isFromTreeView: boolean) {
       {
         commandId: "fx-extension.signinAzure",
         label: StringResources.vsc.handlers.signInAzure,
-        contextValue: "signinAzure"
-      }
+        contextValue: "signinAzure",
+      },
     ]);
     await TreeViewManagerInstance.getTreeView("teamsfx-accounts")!.remove([
       {
         commandId: "fx-extension.selectSubscription",
         label: "",
-        parent: "fx-extension.signinAzure"
-      }
+        parent: "fx-extension.signinAzure",
+      },
     ]);
   }
 }
@@ -989,7 +991,7 @@ export async function signOutM365(isFromTreeView: boolean) {
     [TelemetryProperty.TriggerFrom]: isFromTreeView
       ? TelemetryTiggerFrom.TreeView
       : TelemetryTiggerFrom.CommandPalette,
-    [TelemetryProperty.AccountType]: AccountType.M365
+    [TelemetryProperty.AccountType]: AccountType.M365,
   });
   let appstudioLogin: AppStudioTokenProvider = AppStudioTokenInstance;
   const vscodeEnv = detectVsCodeEnv();
@@ -1002,8 +1004,8 @@ export async function signOutM365(isFromTreeView: boolean) {
       {
         commandId: "fx-extension.signinM365",
         label: StringResources.vsc.handlers.signIn365,
-        contextValue: "signinM365"
-      }
+        contextValue: "signinM365",
+      },
     ]);
   }
 }


### PR DESCRIPTION
If user is running the Teams Toolkit in VS Code Remote environment (WSL/SSH/Container), the `VscEnv` will be detected as "remote", rather than "CodeSpace".