### PR TITLE
feat(extension): unify no-open or invalid project errors

### DIFF
--- a/packages/fx-core/src/common/tools.ts
+++ b/packages/fx-core/src/common/tools.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 import { exec } from "child_process";
 import * as fs from "fs-extra";
-import { ConfigMap, Dict, Json, UserError } from "@microsoft/teamsfx-api";
+import { ConfigFolderName, ConfigMap, Dict, Json, UserError } from "@microsoft/teamsfx-api";
 import { promisify } from "util";
 import axios from "axios";
 import AdmZip from "adm-zip";
@@ -256,4 +256,19 @@ export function isUserCancelError(error: Error): boolean {
     errorName === getStrings().solution.CancelProvision ||
     errorName === "UserCancel"
   );
+}
+
+export function isValidProject(workspacePath?: string): boolean {
+  if (!workspacePath) return false;
+  const checklist: string[] = [
+    path.join(workspacePath, `.${ConfigFolderName}`, "settings.json"),
+    path.join(workspacePath, `.${ConfigFolderName}`, "env.default.json"),
+    path.join(workspacePath, `.${ConfigFolderName}`, "manifest.source.json"),
+  ];
+  for (const fp of checklist) {
+    if (!fs.pathExistsSync(fp)) {
+      return false;
+    }
+  }
+  return true;
 }

--- a/packages/fx-core/src/core/error.ts
+++ b/packages/fx-core/src/core/error.ts
@@ -54,13 +54,17 @@ export function EnvNotExist(param: any): UserError {
   );
 }
 
-export function NotSupportedProjectType(): UserError {
-  return returnUserError(
-    new Error(`Project type not supported`),
-    CoreSource,
-    CoreErrorNames.NotSupportedProjectType
-  );
-}
+export const NoProjectOpenedError = new UserError(
+  "NoProjectOpened",
+  "No project opened, you can create a new project or open an existing one.",
+  CoreSource
+);
+
+export const InvalidProjectError = new UserError(
+  "InvalidProject",
+  "The project type is invalid",
+  CoreSource
+);
 
 export function DownloadSampleFail(): SystemError {
   return returnUserError(

--- a/packages/fx-core/src/core/index.ts
+++ b/packages/fx-core/src/core/index.ts
@@ -1140,7 +1140,8 @@ export class CoreProxy implements Core {
     try {
       // check if this project is supported
       if (checkAndConfig) {
-        const supported = isValidProject(this.coreImpl.ctx.root);
+        const workspacePath = answers?.getString("workspacePath");
+        const supported = isValidProject(workspacePath);
         if (!supported) {
           return notSupportedRes;
         }

--- a/packages/vscode-extension/src/commandsTreeViewProvider.ts
+++ b/packages/vscode-extension/src/commandsTreeViewProvider.ts
@@ -6,8 +6,8 @@ import * as path from "path";
 import { ext } from "./extensionVariables";
 import { TreeItem, TreeCategory, Result, FxError, ok } from "@microsoft/teamsfx-api";
 import * as StringResources from "./resources/Strings.json";
-import { getWorkspacePath, isValidProject } from "./handlers";
-import { isValidShade } from "@fluentui/react";
+import { getWorkspacePath } from "./handlers";
+import { isValidProject } from "@microsoft/teamsfx-core";
 
 class TreeViewManager {
   private static instance: TreeViewManager;
@@ -64,7 +64,7 @@ class TreeViewManager {
     const accountProvider = new CommandsTreeViewProvider([]);
     disposables.push(vscode.window.registerTreeDataProvider("teamsfx-accounts", accountProvider));
 
-    const projectTreeViewCommand = isValidProject()
+    const projectTreeViewCommand = isValidProject(getWorkspacePath())
       ? [
           new TreeViewCommand(
             StringResources.vsc.commandsTreeViewProvider.createProjectTitle,

--- a/packages/vscode-extension/src/commandsTreeViewProvider.ts
+++ b/packages/vscode-extension/src/commandsTreeViewProvider.ts
@@ -6,6 +6,8 @@ import * as path from "path";
 import { ext } from "./extensionVariables";
 import { TreeItem, TreeCategory, Result, FxError, ok } from "@microsoft/teamsfx-api";
 import * as StringResources from "./resources/Strings.json";
+import { getWorkspacePath, isValidProject } from "./handlers";
+import { isValidShade } from "@fluentui/react";
 
 class TreeViewManager {
   private static instance: TreeViewManager;
@@ -52,7 +54,7 @@ class TreeViewManager {
         TreeCategory.GettingStarted,
         undefined,
         "book_16"
-      ),
+      )
     ];
     const getStartedProvider = new CommandsTreeViewProvider(getStartTreeViewCommand);
     disposables.push(
@@ -62,89 +64,102 @@ class TreeViewManager {
     const accountProvider = new CommandsTreeViewProvider([]);
     disposables.push(vscode.window.registerTreeDataProvider("teamsfx-accounts", accountProvider));
 
-    const projectTreeViewCommand = [
-      new TreeViewCommand(
-        StringResources.vsc.commandsTreeViewProvider.createProjectTitle,
-        StringResources.vsc.commandsTreeViewProvider.createProjectDescription,
-        "fx-extension.create",
-        vscode.TreeItemCollapsibleState.None,
-        undefined,
-        undefined,
-        "createProject"
-      ),
-      new TreeViewCommand(
-        StringResources.vsc.commandsTreeViewProvider.addCapabilitiesTitle,
-        StringResources.vsc.commandsTreeViewProvider.addCapabilitiesDescription,
-        "fx-extension.addCapability",
-        vscode.TreeItemCollapsibleState.None,
-        undefined,
-        undefined,
-        "addCapability"
-      ),
-      new TreeViewCommand(
-        StringResources.vsc.commandsTreeViewProvider.addResourcesTitle,
-        StringResources.vsc.commandsTreeViewProvider.addResourcesDescription,
-        "fx-extension.update",
-        vscode.TreeItemCollapsibleState.None,
-        undefined,
-        undefined,
-        "addResources"
-      ),
-      new TreeViewCommand(
-        StringResources.vsc.commandsTreeViewProvider.manifestEditorTitle,
-        StringResources.vsc.commandsTreeViewProvider.manifestEditorDescription,
-        "fx-extension.openManifest",
-        vscode.TreeItemCollapsibleState.None,
-        undefined,
-        undefined,
-        "manifestEditor"
-      ),
-      new TreeViewCommand(
-        StringResources.vsc.commandsTreeViewProvider.validateManifestTitle,
-        StringResources.vsc.commandsTreeViewProvider.validateManifestDescription,
-        "fx-extension.validateManifest",
-        vscode.TreeItemCollapsibleState.None,
-        undefined,
-        undefined,
-        "validatemanifest"
-      ),
-      new TreeViewCommand(
-        StringResources.vsc.commandsTreeViewProvider.buildPackageTitle,
-        StringResources.vsc.commandsTreeViewProvider.buildPackageDescription,
-        "fx-extension.build",
-        vscode.TreeItemCollapsibleState.None,
-        undefined,
-        undefined,
-        "build"
-      ),
-      new TreeViewCommand(
-        StringResources.vsc.commandsTreeViewProvider.provisionTitle,
-        StringResources.vsc.commandsTreeViewProvider.provisionDescription,
-        "fx-extension.provision",
-        vscode.TreeItemCollapsibleState.None,
-        undefined,
-        undefined,
-        "provision"
-      ),
-      new TreeViewCommand(
-        StringResources.vsc.commandsTreeViewProvider.deployTitle,
-        StringResources.vsc.commandsTreeViewProvider.deployDescription,
-        "fx-extension.deploy",
-        vscode.TreeItemCollapsibleState.None,
-        undefined,
-        undefined,
-        "deploy"
-      ),
-      new TreeViewCommand(
-        StringResources.vsc.commandsTreeViewProvider.publishTitle,
-        StringResources.vsc.commandsTreeViewProvider.publishDescription,
-        "fx-extension.publish",
-        vscode.TreeItemCollapsibleState.None,
-        undefined,
-        undefined,
-        "publish"
-      ),
-    ];
+    const projectTreeViewCommand = isValidProject()
+      ? [
+          new TreeViewCommand(
+            StringResources.vsc.commandsTreeViewProvider.createProjectTitle,
+            StringResources.vsc.commandsTreeViewProvider.createProjectDescription,
+            "fx-extension.create",
+            vscode.TreeItemCollapsibleState.None,
+            undefined,
+            undefined,
+            "createProject"
+          ),
+          new TreeViewCommand(
+            StringResources.vsc.commandsTreeViewProvider.addCapabilitiesTitle,
+            StringResources.vsc.commandsTreeViewProvider.addCapabilitiesDescription,
+            "fx-extension.addCapability",
+            vscode.TreeItemCollapsibleState.None,
+            undefined,
+            undefined,
+            "addCapability"
+          ),
+          new TreeViewCommand(
+            StringResources.vsc.commandsTreeViewProvider.addResourcesTitle,
+            StringResources.vsc.commandsTreeViewProvider.addResourcesDescription,
+            "fx-extension.update",
+            vscode.TreeItemCollapsibleState.None,
+            undefined,
+            undefined,
+            "addResources"
+          ),
+          new TreeViewCommand(
+            StringResources.vsc.commandsTreeViewProvider.manifestEditorTitle,
+            StringResources.vsc.commandsTreeViewProvider.manifestEditorDescription,
+            "fx-extension.openManifest",
+            vscode.TreeItemCollapsibleState.None,
+            undefined,
+            undefined,
+            "manifestEditor"
+          ),
+          new TreeViewCommand(
+            StringResources.vsc.commandsTreeViewProvider.validateManifestTitle,
+            StringResources.vsc.commandsTreeViewProvider.validateManifestDescription,
+            "fx-extension.validateManifest",
+            vscode.TreeItemCollapsibleState.None,
+            undefined,
+            undefined,
+            "validatemanifest"
+          ),
+          new TreeViewCommand(
+            StringResources.vsc.commandsTreeViewProvider.buildPackageTitle,
+            StringResources.vsc.commandsTreeViewProvider.buildPackageDescription,
+            "fx-extension.build",
+            vscode.TreeItemCollapsibleState.None,
+            undefined,
+            undefined,
+            "build"
+          ),
+          new TreeViewCommand(
+            StringResources.vsc.commandsTreeViewProvider.provisionTitle,
+            StringResources.vsc.commandsTreeViewProvider.provisionDescription,
+            "fx-extension.provision",
+            vscode.TreeItemCollapsibleState.None,
+            undefined,
+            undefined,
+            "provision"
+          ),
+          new TreeViewCommand(
+            StringResources.vsc.commandsTreeViewProvider.deployTitle,
+            StringResources.vsc.commandsTreeViewProvider.deployDescription,
+            "fx-extension.deploy",
+            vscode.TreeItemCollapsibleState.None,
+            undefined,
+            undefined,
+            "deploy"
+          ),
+          new TreeViewCommand(
+            StringResources.vsc.commandsTreeViewProvider.publishTitle,
+            StringResources.vsc.commandsTreeViewProvider.publishDescription,
+            "fx-extension.publish",
+            vscode.TreeItemCollapsibleState.None,
+            undefined,
+            undefined,
+            "publish"
+          )
+        ]
+      : [
+          new TreeViewCommand(
+            StringResources.vsc.commandsTreeViewProvider.createProjectTitle,
+            StringResources.vsc.commandsTreeViewProvider.createProjectDescription,
+            "fx-extension.create",
+            vscode.TreeItemCollapsibleState.None,
+            undefined,
+            undefined,
+            "createProject"
+          )
+        ];
+
     const projectProvider = new CommandsTreeViewProvider(projectTreeViewCommand);
     disposables.push(vscode.window.registerTreeDataProvider("teamsfx-project", projectProvider));
 
@@ -158,7 +173,7 @@ class TreeViewManager {
         undefined,
         undefined,
         "appManagement"
-      ),
+      )
       // new TreeViewCommand(
       //   StringResources.vsc.commandsTreeViewProvider.appManagementTitle,
       //   StringResources.vsc.commandsTreeViewProvider.appManagementDescription,
@@ -192,7 +207,7 @@ class TreeViewManager {
         TreeCategory.Feedback,
         undefined,
         "reportIssues"
-      ),
+      )
     ];
     const feedbackProvider = new CommandsTreeViewProvider(feedbackTreeViewCommand);
     disposables.push(vscode.window.registerTreeDataProvider("teamsfx-feedback", feedbackProvider));
@@ -221,10 +236,11 @@ export default TreeViewManager.getInstance();
 
 export class CommandsTreeViewProvider implements vscode.TreeDataProvider<TreeViewCommand> {
   public static readonly TreeViewFlag = "TreeView";
-  private _onDidChangeTreeData: vscode.EventEmitter<TreeViewCommand | undefined | void> =
-    new vscode.EventEmitter<TreeViewCommand | undefined | void>();
-  readonly onDidChangeTreeData: vscode.Event<TreeViewCommand | undefined | void> =
-    this._onDidChangeTreeData.event;
+  private _onDidChangeTreeData: vscode.EventEmitter<
+    TreeViewCommand | undefined | void
+  > = new vscode.EventEmitter<TreeViewCommand | undefined | void>();
+  readonly onDidChangeTreeData: vscode.Event<TreeViewCommand | undefined | void> = this
+    ._onDidChangeTreeData.event;
 
   private commands: TreeViewCommand[] = [];
   private disposableMap: Map<string, vscode.Disposable> = new Map();
@@ -440,7 +456,7 @@ export class TreeViewCommand extends vscode.TreeItem {
       this.command = {
         title: label,
         command: commandId,
-        arguments: [[CommandsTreeViewProvider.TreeViewFlag]],
+        arguments: [[CommandsTreeViewProvider.TreeViewFlag]]
       };
     }
   }

--- a/packages/vscode-extension/src/error.ts
+++ b/packages/vscode-extension/src/error.ts
@@ -15,15 +15,3 @@ export enum ExtensionErrors {
   UnknownSubscription = "UnknownSubscription",
   PortAlreadyInUse = "PortAlreadyInUse"
 }
-
-export const NoProjectOpenedError = new UserError(
-  "NoProjectOpened",
-  "No project opened, you can create a new project or open an existing one.",
-  ExtensionSource
-);
-
-export const InvalidProject = new UserError(
-  "InvalidProject",
-  "The project type is invalid",
-  ExtensionSource
-);

--- a/packages/vscode-extension/src/error.ts
+++ b/packages/vscode-extension/src/error.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { UserError } from "@microsoft/teamsfx-api";
+
 export const ExtensionSource = "Ext";
 
 export enum ExtensionErrors {
@@ -13,3 +15,15 @@ export enum ExtensionErrors {
   UnknownSubscription = "UnknownSubscription",
   PortAlreadyInUse = "PortAlreadyInUse"
 }
+
+export const NoProjectOpenedError = new UserError(
+  "NoProjectOpened",
+  "No project opened, you can create a new project or open an existing one.",
+  ExtensionSource
+);
+
+export const InvalidProject = new UserError(
+  "InvalidProject",
+  "The project type is invalid",
+  ExtensionSource
+);

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -287,9 +287,9 @@ export async function runCommand(stage: Stage): Promise<Result<null, FxError>> {
   let result: Result<null, FxError> = ok(null);
 
   try {
+    const workspacePath = getWorkspacePath();
     // 1. check concurrent lock
     if (stage !== Stage.create) {
-      const workspacePath = getWorkspacePath();
       if (workspacePath === undefined) {
         result = err(NoProjectOpenedError);
         await processResult(eventName, result);
@@ -329,6 +329,7 @@ export async function runCommand(stage: Stage): Promise<Result<null, FxError>> {
     const answers = new ConfigMap();
     answers.set("stage", stage);
     answers.set("platform", Platform.VSCode);
+    answers.set("workspacePath", workspacePath);
 
     // 4. getQuestions
     const qres = await core.getQuestions(stage, Platform.VSCode);
@@ -455,6 +456,7 @@ async function runUserTask(func: Func, eventName: string): Promise<Result<null, 
     const answers = new ConfigMap();
     answers.set("task", eventName);
     answers.set("platform", Platform.VSCode);
+    answers.set("workspacePath", workspacePath);
 
     // 4. getQuestions
     const qres = await core.getQuestionsForUserTask(func, Platform.VSCode);


### PR DESCRIPTION
fix: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/9901474


## For command pallet:

When no project opened:
![image](https://user-images.githubusercontent.com/1658418/118291998-c5564d80-b50a-11eb-9c82-fe4acf709e37.png)

When invalid project opened:
![image](https://user-images.githubusercontent.com/1658418/118292104-ddc66800-b50a-11eb-8e60-7c773f7cca0e.png)

## For treeview:

When no project opened or invalid project opened, only one command is shown:
![image](https://user-images.githubusercontent.com/1658418/118291935-b4a5d780-b50a-11eb-8fb1-0ce8b9e4998e.png)

When valid project opened:
![image](https://user-images.githubusercontent.com/1658418/118292164-edde4780-b50a-11eb-8122-6937a00d5e11.png)

