### PR TITLE
chore(bot): remove dependency of local fallback zips in ut

### DIFF
--- a/packages/fx-core/tests/plugins/resource/bot/unit/languageStrategy.test.ts
+++ b/packages/fx-core/tests/plugins/resource/bot/unit/languageStrategy.test.ts
@@ -31,10 +31,15 @@ describe("Language Strategy", () => {
       sinon.stub(LanguageStrategy, "getTemplateProjectZipUrl").resolves("");
 
       // Act
-      const zip = await LanguageStrategy.getTemplateProjectZip(programmingLanguage, group_name);
+      try {
+        await LanguageStrategy.getTemplateProjectZip(programmingLanguage, group_name);
+      } catch (e) {
+        chai.assert.isTrue(e instanceof PluginError);
+        return;
+      }
 
       // Assert
-      chai.assert.isNotNull(zip);
+      chai.assert.fail(Messages.ShouldNotReachHere);
     });
   });
 


### PR DESCRIPTION
adjust ut case 
    since local fallback zips will be packed dynamically.

Use mock-fs to mock local zips, so it has nothing to do with the real local fallback zips.

to finish work item: https://dev.azure.com/msazure/Microsoft%20Teams%20Extensibility/_workitems/edit/9942214