### PR TITLE
fix(env-checker): disable env-checker in function plugin for CLI

### DIFF
--- a/docs/vscode-extension/envchecker-help.md
+++ b/docs/vscode-extension/envchecker-help.md
@@ -100,6 +100,14 @@ To open your user and workspace settings, use the following Visual Studio Code m
 
 ![envchecker-settings](../images/vscode-extension/envchecker/envchecker-settings.png)
 
+## BackendExtensionsInstallFailed
+### Notification Message
+> Failed to run backend extension install.
+
+### Mitigation
+* Retry Function app deployment.
+* If you are using TeamsFX CLI, check whether .NET Core version (`.NET 5` or `.NET Core 3.1`) is installed. If not, refer to [the guide](#how-to-install-net-sdk) to install `.NET SDK` manually.
+
 ## Report issues 
 
 If above FAQs can't solve your problem, please click [here](https://github.com/OfficeDev/Teamsfx/issues/new) to submit an issue on GitHub and attach the log from Visual Studio Code output channel named "Teams Toolkit".

--- a/packages/fx-core/src/plugins/resource/function/index.ts
+++ b/packages/fx-core/src/plugins/resource/function/index.ts
@@ -108,7 +108,7 @@ export class FunctionPlugin implements Plugin {
 
   public async preDeploy(ctx: PluginContext): Promise<FxResult> {
     Logger.setLogger(ctx.logProvider);
-    funcPluginAdapter.setFeatureFlag(ctx.answers);
+    funcPluginAdapter.setFeatureFlag(ctx);
     await StepHelperFactory.preDeployStepHelper.start(
       Object.entries(PreDeploySteps).length,
       ctx.dialog
@@ -122,7 +122,7 @@ export class FunctionPlugin implements Plugin {
 
   public async deploy(ctx: PluginContext): Promise<FxResult> {
     Logger.setLogger(ctx.logProvider);
-    funcPluginAdapter.setFeatureFlag(ctx.answers);
+    funcPluginAdapter.setFeatureFlag(ctx);
     await StepHelperFactory.deployStepHelper.start(Object.entries(DeploySteps).length, ctx.dialog);
     const res = await this.runWithErrorWrapper(ctx, LifeCycle.deploy, () =>
       this.functionPluginImpl.deploy(ctx)

--- a/packages/fx-core/src/plugins/resource/function/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/function/plugin.ts
@@ -820,7 +820,7 @@ export class FunctionPluginImpl {
           funcPluginTelemetry
         );
         try {
-          if (await dotnetChecker.isInstalled()) {
+          if (!await dotnetChecker.isEnabled() || await dotnetChecker.isInstalled()) {
             return;
           }
         } catch (error) {

--- a/packages/fx-core/src/plugins/resource/function/utils/depsChecker/backendExtensionsInstall.ts
+++ b/packages/fx-core/src/plugins/resource/function/utils/depsChecker/backendExtensionsInstall.ts
@@ -8,7 +8,7 @@
 // and run the scripts (tools/depsChecker/copyfiles.sh or tools/depsChecker/copyfiles.ps1 according to your OS)
 // to copy you changes to function plugin.
 
-import { defaultHelpLink, dotnetNotSupportTargetVersionHelpLink } from "./common";
+import { backendExtensionsInstallFailedHelpLink, defaultHelpLink, dotnetNotSupportTargetVersionHelpLink } from "./common";
 import { DotnetChecker } from "./dotnetChecker";
 import { BackendExtensionsInstallError } from "./errors";
 import { cpUtils } from "./cpUtils";
@@ -80,7 +80,7 @@ export class BackendExtensionsInstaller {
       }
       throw new BackendExtensionsInstallError(
         `Failed to run backend extension install: error = '${error}'`,
-        defaultHelpLink
+        backendExtensionsInstallFailedHelpLink
       );
     } finally {
       this._logger.cleanup();

--- a/packages/fx-core/src/plugins/resource/function/utils/depsChecker/common.ts
+++ b/packages/fx-core/src/plugins/resource/function/utils/depsChecker/common.ts
@@ -43,6 +43,7 @@ export const dotnetExplanationHelpLink = `${defaultHelpLink}#overall`;
 export const dotnetFailToInstallHelpLink = `${defaultHelpLink}#failtoinstalldotnet`;
 export const dotnetManualInstallHelpLink = `${defaultHelpLink}#dotnetnotfound`;
 export const dotnetNotSupportTargetVersionHelpLink = `${defaultHelpLink}#dotnetnotsupporttargetversion`;
+export const backendExtensionsInstallFailedHelpLink = `${defaultHelpLink}#backendextensionsinstallfailed`;
 
 export const Messages = {
   learnMoreButtonText: "Learn more",

--- a/packages/fx-core/src/plugins/resource/function/utils/depsChecker/funcPluginAdapter.ts
+++ b/packages/fx-core/src/plugins/resource/function/utils/depsChecker/funcPluginAdapter.ts
@@ -9,6 +9,7 @@ import {
   ConfigMap,
   DialogMsg,
   DialogType,
+  Platform,
   PluginContext,
   QuestionType,
   returnUserError,
@@ -76,8 +77,13 @@ class FuncPluginAdapter implements IDepsAdapter {
     throw new Error("Method not implemented.");
   }
 
-  public setFeatureFlag(answers?: ConfigMap): void {
-    this.enabled = answers?.getBoolean(this.answerKey) || false;
+  public setFeatureFlag(ctx?: PluginContext): void {
+    // NOTE: only enable env checker for vscode extension according to the design
+    if (ctx?.platform === Platform.VSCode) {
+      this.enabled = ctx?.answers?.getBoolean(this.answerKey) || false;
+    } else {
+      this.enabled = false;
+    }
   }
 
   public handleDotnetError(error: Error): void {

--- a/packages/vscode-extension/src/debug/depsChecker/backendExtensionsInstall.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/backendExtensionsInstall.ts
@@ -8,7 +8,7 @@
 // and run the scripts (tools/depsChecker/copyfiles.sh or tools/depsChecker/copyfiles.ps1 according to your OS)
 // to copy you changes to function plugin.
 
-import { defaultHelpLink, dotnetNotSupportTargetVersionHelpLink } from "./common";
+import { backendExtensionsInstallFailedHelpLink, defaultHelpLink, dotnetNotSupportTargetVersionHelpLink } from "./common";
 import { DotnetChecker } from "./dotnetChecker";
 import { BackendExtensionsInstallError } from "./errors";
 import { cpUtils } from "./cpUtils";
@@ -80,7 +80,7 @@ export class BackendExtensionsInstaller {
       }
       throw new BackendExtensionsInstallError(
         `Failed to run backend extension install: error = '${error}'`,
-        defaultHelpLink
+        backendExtensionsInstallFailedHelpLink
       );
     } finally {
       this._logger.cleanup();

--- a/packages/vscode-extension/src/debug/depsChecker/common.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/common.ts
@@ -43,6 +43,7 @@ export const dotnetExplanationHelpLink = `${defaultHelpLink}#overall`;
 export const dotnetFailToInstallHelpLink = `${defaultHelpLink}#failtoinstalldotnet`;
 export const dotnetManualInstallHelpLink = `${defaultHelpLink}#dotnetnotfound`;
 export const dotnetNotSupportTargetVersionHelpLink = `${defaultHelpLink}#dotnetnotsupporttargetversion`;
+export const backendExtensionsInstallFailedHelpLink = `${defaultHelpLink}#backendextensionsinstallfailed`;
 
 export const Messages = {
   learnMoreButtonText: "Learn more",


### PR DESCRIPTION
- Fix the bug "env checker feature flag is not checked in function plugin"
- Disable the env checker feature flag for CLI

## Test result

### Windows with .NET SDK 5.0

The deployment process can succeed using the globally installed .NET SDK

```
[TeamsfxCLI] Preparing function app for deployment: [0/3] Prepare task.
[TeamsfxCLI] Preparing function app for deployment: [1/3] Installing .NET Core SDK if needed.
[TeamsfxCLI] Preparing function app for deployment: [2/3] Installing TeamsFX Binding.
[TeamsfxCLI] Preparing function app for deployment: [3/3] Preparing JS files.
...
```

### Windows without .NET SDK

When using CLI, if .NET SDK is not installed, it will fail in the process of "backend extension install".

```
[TeamsfxCLI] Preparing function app for deployment: [2/3] Installing TeamsFX Binding.
[Function Plugin] Debug 2021-05-17T06:20:56.061Z: get dotnet path failed, error: 'Error: ENOENT: no such file or directory, open 'C:\Users\aochengwang\.fx\dotnet.json''
Debug 2021-05-17T06:20:56.063Z: Running command: "dotnet build extensions.csproj -o C:\Users\aochengwang\projects\aochengapp534\api\bin --ignore-failed-sources", options = '{"cwd":"C:\\Users\\aochengwang\\projects\\aochengapp534\\api","shell":false}'
Debug 2021-05-17T06:20:56.064Z: Failed to run command 'dotnet build extensions.csproj -o C:\Users\aochengwang\projects\aochengapp534\api\bin --ignore-failed-sources': cmdOutputIncludingStderr: '', error: Error: spawn dotnet ENOENT
[Function Plugin] Failed to run backend extension install: error = 'Error: spawn dotnet ENOENT'
[function.DepsCheckerError]: Failed to run backend extension install: error = 'Error: spawn dotnet ENOENT'
Get help from https://aka.ms/teamsfx-envchecker-help#backendextensionsinstallfailed#functionDepsCheckerError
```

## WSL
### WSL with .NET SDK 5.0

The deployment process can succeed using the globally installed .NET SDK

```
[TeamsfxCLI] Preparing function app for deployment: [0/3] Prepare task.
[TeamsfxCLI] Preparing function app for deployment: [1/3] Installing .NET Core SDK if needed.
[TeamsfxCLI] Preparing function app for deployment: [2/3] Installing TeamsFX Binding.
[TeamsfxCLI] Preparing function app for deployment: [3/3] Preparing JS files.
```

### WSL without .NET SDK
```
[TeamsfxCLI] Preparing function app for deployment: [2/3] Installing TeamsFX Binding.
[Function Plugin] Debug 2021-05-17T06:28:19.620Z: Running command: "/usr/share/dotnet/dotnet build extensions.csproj -o /home/alexwang/Teamsfx/aochengapp535/api/bin --ignore-failed-sources", options = '{"cwd":"/home/alexwang/Teamsfx/aochengapp535/api","shell":false}'
Debug 2021-05-17T06:28:19.620Z: Failed to run command '/usr/share/dotnet/dotnet build extensions.csproj -o /home/alexwang/Teamsfx/aochengapp535/api/bin --ignore-failed-sources': cmdOutputIncludingStderr: '', error: Error: spawn /usr/share/dotnet/dotnet ENOENT
[Function Plugin] Failed to run backend extension install: error = 'Error: spawn /usr/share/dotnet/dotnet ENOENT'
[function.DepsCheckerError]: Failed to run backend extension install: error = 'Error: spawn /usr/share/dotnet/dotnet ENOENT'
Get help from https://aka.ms/teamsfx-envchecker-help#backendextensionsinstallfailed#functionDepsCheckerError
```

## Known Issues
- If the user does not have global .NET SDK, backend extension installation (it runs "dotnet build") will fail with an error message "Failed to run backend extension install" and provide a help link to let the user checker possible reasons manually
- The help link anchor is not correct due to [known issue](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/9922768/)


https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/9950544?src=WorkItemMention&src-action=artifact_link