### PR TITLE
fix(env-checker): update the behavior when learn more link clicked

### DIFF
--- a/packages/vscode-extension/src/debug/depsChecker/vscodeAdapter.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/vscodeAdapter.ts
@@ -55,6 +55,7 @@ export class VSCodeAdapter implements IDepsAdapter {
       return true;
     } else if (input == learnMoreButton) {
       await openUrl(link);
+      return await this.displayContinueWithLearnMore(message, link);
     }
 
     return false;
@@ -63,7 +64,7 @@ export class VSCodeAdapter implements IDepsAdapter {
   public async displayLearnMore(message: string, link: string): Promise<boolean> {
     return await this.displayWarningMessage(message, Messages.learnMoreButtonText, async () => {
       await openUrl(link);
-      return Promise.resolve(false);
+      return await this.displayLearnMore(message, link);
     });
   }
 


### PR DESCRIPTION
If `Learn more` button clicked in the pop-up notification window, the link will be opened automatically and the notification window will be **kept there**.

work item: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/9943712/