### PR TITLE
fix: download sample app to same folder will overwrite

### DIFF
--- a/packages/fx-core/src/core/index.ts
+++ b/packages/fx-core/src/core/index.ts
@@ -278,6 +278,21 @@ class CoreImpl implements Core {
         if (answer === "Clone") {
           const url = samples.data as string;
           const sampleId = samples.id;
+
+          const sampleAppPath = path.join(folder, sampleId);
+          if (
+            (await fs.pathExists(sampleAppPath)) &&
+            (await fs.readdir(sampleAppPath)).length > 0
+          ) {
+            return err(
+              new UserError(
+                error.CoreErrorNames.ProjectFolderExist,
+                `Path ${sampleAppPath} alreay exists. Select a different folder.`,
+                error.CoreSource
+              )
+            );
+          }
+
           const progress = this.ctx.dialog.createProgressBar("Fetch sample app", 2);
           progress.start();
           try {

--- a/packages/vscode-extension/src/controls/webviewPanel.ts
+++ b/packages/vscode-extension/src/controls/webviewPanel.ts
@@ -87,6 +87,16 @@ export class WebviewPanel {
                 title: "Select folder to clone the sample app",
               });
               if (folder !== undefined) {
+                const sampleAppPath = path.join(folder[0].fsPath, msg.data.appFolder);
+                if (
+                  (await fs.pathExists(sampleAppPath)) &&
+                  (await fs.readdir(sampleAppPath)).length > 0
+                ) {
+                  vscode.window.showErrorMessage(
+                    `Path ${sampleAppPath} alreay exists. Select a different folder.`
+                  );
+                  return;
+                }
                 const dialogManager = DialogManager.getInstance();
                 const progress = dialogManager.createProgressBar("Fetch sample app", 2);
                 progress.start();
@@ -102,7 +112,7 @@ export class WebviewPanel {
                     );
                     vscode.commands.executeCommand(
                       "vscode.openFolder",
-                      vscode.Uri.file(path.join(folder[0].fsPath, msg.data.appFolder))
+                      vscode.Uri.file(sampleAppPath)
                     );
                   } else {
                     vscode.window.showErrorMessage("Failed to clone sample app");


### PR DESCRIPTION
ADO: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/9921766
Screenshot: 
![sampleappoverwrite](https://user-images.githubusercontent.com/73154171/118439105-edff6280-b717-11eb-836a-7f52fc9dc608.gif)
