### PR TITLE
fix(env-checker): fix dotnet-not-installed error message for Linux in function plugin

### DIFF
--- a/packages/fx-core/src/plugins/resource/function/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/function/plugin.ts
@@ -833,7 +833,7 @@ export class FunctionPluginImpl {
           // TODO: handle linux installation
           if (!(await funcPluginAdapter.handleDotnetForLinux(ctx, dotnetChecker))) {
             // NOTE: this is a temporary fix for Linux, to make the error message more readable.
-            const message = await funcPluginAdapter.generateMsg(Messages.linuxDepsNotFound, [dotnetChecker]);
+            const message = await funcPluginAdapter.generateMsg(Messages.linuxDepsNotFoundHelpLinkMessage, [dotnetChecker]);
             funcPluginAdapter.handleDotnetError(
               new DepsCheckerError(message, dotnetManualInstallHelpLink)
             );

--- a/packages/fx-core/src/plugins/resource/function/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/function/plugin.ts
@@ -832,8 +832,10 @@ export class FunctionPluginImpl {
         if (isLinux()) {
           // TODO: handle linux installation
           if (!(await funcPluginAdapter.handleDotnetForLinux(ctx, dotnetChecker))) {
+            // NOTE: this is a temporary fix for Linux, to make the error message more readable.
+            const message = await funcPluginAdapter.generateMsg(Messages.linuxDepsNotFound, [dotnetChecker]);
             funcPluginAdapter.handleDotnetError(
-              new DepsCheckerError(Messages.defaultErrorMessage, dotnetManualInstallHelpLink)
+              new DepsCheckerError(message, dotnetManualInstallHelpLink)
             );
           }
           return;

--- a/packages/fx-core/src/plugins/resource/function/utils/depsChecker/common.ts
+++ b/packages/fx-core/src/plugins/resource/function/utils/depsChecker/common.ts
@@ -88,6 +88,11 @@ Click "Install" to install @InstallPackages.`,
 Teams Toolkit requires these dependencies. 
 
 Click "Continue" to continue.`,
+
+  linuxDepsNotFoundHelpLinkMessage: `Cannot find @SupportedPackages.
+
+Teams Toolkit requires these dependencies.`,
+
 };
 
 export enum DepsCheckerEvent {

--- a/packages/fx-core/src/plugins/resource/function/utils/depsChecker/funcPluginAdapter.ts
+++ b/packages/fx-core/src/plugins/resource/function/utils/depsChecker/funcPluginAdapter.ts
@@ -95,7 +95,7 @@ class FuncPluginAdapter implements IDepsAdapter {
   }
 
   public async handleDotnetForLinux(ctx: PluginContext, checker: IDepsChecker): Promise<boolean> {
-    const confirmMessage = await this.generateMsg([checker]);
+    const confirmMessage = await this.generateMsg(Messages.linuxDepsNotFound, [checker]);
     return this.displayContinueWithLearnMoreLink(ctx, confirmMessage, dotnetManualInstallHelpLink);
   }
 
@@ -131,7 +131,7 @@ class FuncPluginAdapter implements IDepsAdapter {
     return userSelected === Messages.continueButtonText;
   }
 
-  private async generateMsg(checkers: Array<IDepsChecker>): Promise<string> {
+  public async generateMsg(messageTemplate: string, checkers: Array<IDepsChecker>): Promise<string> {
     const supportedPackages = [];
     for (const checker of checkers) {
       const info = await checker.getDepsInfo();
@@ -140,7 +140,7 @@ class FuncPluginAdapter implements IDepsAdapter {
       supportedPackages.push(supportedPackage);
     }
     const supportedMessage = supportedPackages.join(" and ");
-    return Messages.linuxDepsNotFound.replace("@SupportedPackages", supportedMessage);
+    return messageTemplate.replace("@SupportedPackages", supportedMessage);
   }
 }
 

--- a/packages/vscode-extension/src/debug/depsChecker/common.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/common.ts
@@ -94,6 +94,11 @@ Teams Toolkit requires these dependencies.
 Click "Continue" to continue.
 
 (If you just installed @SupportedPackages, restart Visual Studio Code for the change to take effect.)`,
+
+  linuxDepsNotFoundHelpLinkMessage: `Cannot find @SupportedPackages.
+
+Teams Toolkit requires these dependencies.`,
+
 };
 
 export enum DepsCheckerEvent {


### PR DESCRIPTION
- Also tell the user the missing dependencies in the finall error message

## Test result
### Linux CLI
![image](https://user-images.githubusercontent.com/9698542/118461921-bd77f280-b730-11eb-816d-fc742c04400c.png)
** Note that a browser will automatically pop up to open the help link.

### Linux Toolkit
A popup dialog will show up and we also output the error message to output channel
![image](https://user-images.githubusercontent.com/9698542/118463739-b225c680-b732-11eb-81a6-5bb0b2a21ca1.png)


### WSL

![image](https://user-images.githubusercontent.com/9698542/118462621-75a59b00-b731-11eb-993d-98d5f2c78f90.png)
The URL is not automatically opened in browser compared to Linux and Windows. But the user can copy and paste the link to a browser to open the URL manually.

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/9950544?src=WorkItemMention&src-action=artifact_link