### PR TITLE
fix(env-checker): correct the bookmark within help link

### DIFF
--- a/docs/vscode-extension/envchecker-help.md
+++ b/docs/vscode-extension/envchecker-help.md
@@ -63,7 +63,7 @@ And **the latest version of Node.js LTS v14** would be recommended to be install
 ### Mitigation
 Please refer to [the guide](#how-to-install-nodejs) to install `Node.js`.
 
-## FailToInstallDotnet
+## <a name="functionDepsCheckerfailtoinstalldotnet"></a>FailToInstallDotnet
 ### Notification Message
 > Failed to install .NET Core SDK (v3.1), please install it manually and restart all your Visual Studio Code instances.
 
@@ -73,14 +73,14 @@ It might be caused by timeout issue (longer than 3 minutes), the process to inst
 * Retry the operation (local debugging or Function app deployment).
 * Please refer to [the guide](#how-to-install-net-sdk) to install `.NET SDK` manually.
 
-## DotnetNotFound 
+## <a name="functionDepsCheckerdotnetnotfound"></a>DotnetNotFound
 ### Notification Message
 > (Linux only) The toolkit cannot find `.NET 5` or `.NET Core 3.1` on your machine. As a fundamental runtime context for Teams app, these dependencies are required. Please install the required dependencies manually.
 
 ### Mitigation
 Please refer to [the guide](#how-to-install-net-sdk) to install `.NET SDK` manually.
 
-## DotnetNotSupportTargetVersion
+## <a name="functionDepsCheckerdotnetnotsupporttargetversion"></a>DotnetNotSupportTargetVersion
 ### Notification Message
 > NETSDK1045: The current .NET SDK does not support 'newer version' as a target.
 
@@ -100,6 +100,6 @@ To open your user and workspace settings, use the following Visual Studio Code m
 
 ![envchecker-settings](../images/vscode-extension/envchecker/envchecker-settings.png)
 
-## Report issues 
+## <a name="functionDepsCheckerreport-issues"></a>Report issues 
 
 If above FAQs can't solve your problem, please click [here](https://github.com/OfficeDev/Teamsfx/issues/new) to submit an issue on GitHub and attach the log from Visual Studio Code output channel named "Teams Toolkit".

--- a/packages/fx-core/src/plugins/resource/function/utils/depsChecker/funcPluginAdapter.ts
+++ b/packages/fx-core/src/plugins/resource/function/utils/depsChecker/funcPluginAdapter.ts
@@ -13,7 +13,7 @@ import {
   QuestionType,
   returnUserError,
 } from "@microsoft/teamsfx-api";
-import { Messages, dotnetManualInstallHelpLink } from "./common";
+import { Messages, dotnetManualInstallHelpLink, defaultHelpLink } from "./common";
 import { IDepsAdapter, IDepsChecker } from "./checker";
 import { getResourceFolder } from "../../../../..";
 
@@ -81,14 +81,17 @@ class FuncPluginAdapter implements IDepsAdapter {
   }
 
   public handleDotnetError(error: Error): void {
+    const source = "functionDepsChecker";
+    const defaultAnchor = "report-issues";
     if (error instanceof DepsCheckerError) {
-      throw returnUserError(error, "function", "DepsCheckerError", error.helpLink, error);
+      const [helpLink, anchor] = this.splitHelpLink(error.helpLink);
+      throw returnUserError(error, source, anchor || defaultAnchor, helpLink, error);
     } else {
       throw returnUserError(
         new Error(Messages.defaultErrorMessage),
-        "function",
-        "DepsCheckerError",
-        dotnetManualInstallHelpLink,
+        source,
+        defaultAnchor,
+        defaultHelpLink,
         error
       );
     }
@@ -141,6 +144,15 @@ class FuncPluginAdapter implements IDepsAdapter {
     }
     const supportedMessage = supportedPackages.join(" and ");
     return Messages.linuxDepsNotFound.replace("@SupportedPackages", supportedMessage);
+  }
+
+  private splitHelpLink(link: string): [string, string] {
+    const lastAnchor = link.lastIndexOf("#");
+    if (lastAnchor !== -1) {
+      return [link.slice(0, lastAnchor), link.slice(lastAnchor + 1)];
+    } else {
+      return [link, ""];
+    }
   }
 }
 


### PR DESCRIPTION
work item: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/9922768

![image](https://user-images.githubusercontent.com/15644078/118477705-8e1db180-b741-11eb-924e-cf4cfe0ea7a8.png)

Here's the help link with bookmark: 

https://aka.ms/teamsfx-envchecker-help#functionDepsCheckerdotnetnotfound 

=> 

Preview the doc in the personal branch: https://github.com/OfficeDev/TeamsFx/blob/qinezh/fix-1/docs/vscode-extension/envchecker-help.md#functionDepsCheckerdotnetnotfound

The pattern to generate bookmark in function plugin would be: `functionDepsChecker` + `${original_bookmark}`