### PR TITLE
fix: remove faq plus sample app in extension sample gallery page

### DIFF
--- a/packages/fx-core/src/core/question.ts
+++ b/packages/fx-core/src/core/question.ts
@@ -93,12 +93,6 @@ export const SampleSelect: SingleSelectQuestion = {
   title: "Start from a sample",
   option: [
     {
-      id: "in-meeting-app",
-      label: "In-meeting App",
-      detail: "A template for apps using only in the context of a Teams meeting",
-      data: "https://github.com/OfficeDev/TeamsFx-Samples/archive/refs/heads/main.zip",
-    },
-    {
       id: "todo-list-with-Azure-backend",
       label: "Todo List with backend on Azure",
       detail: "Todo List app with Azure Function backend and Azure SQL database",
@@ -114,6 +108,12 @@ export const SampleSelect: SingleSelectQuestion = {
       id: "share-now",
       label: "Share Now",
       detail: "Knowledge sharing app contains a Tab and a Message Extension",
+      data: "https://github.com/OfficeDev/TeamsFx-Samples/archive/refs/heads/main.zip",
+    },
+    {
+      id: "in-meeting-app",
+      label: "In-meeting App",
+      detail: "A template for apps using only in the context of a Teams meeting",
       data: "https://github.com/OfficeDev/TeamsFx-Samples/archive/refs/heads/main.zip",
     },
   ],

--- a/packages/vscode-extension/src/controls/SampleGallery.tsx
+++ b/packages/vscode-extension/src/controls/SampleGallery.tsx
@@ -64,14 +64,6 @@ export default class SampleGallery extends React.Component<any, any> {
             sampleAppUrl="https://github.com/OfficeDev/TeamsFx-Samples/archive/refs/heads/main.zip"
           />
           <SampleAppCard
-            image={FAQPlus}
-            tags={["Easy QnA", "Bot", "JS"]}
-            title="FAQ Plus"
-            description="FAQ Plus is a conversational Q&A bot providing an easy way to answer frequently asked questions by users. One can ask a question and the bot responds with information in the knowledge base. If the answer is not in the knowledge base, the bot submits the question to a pre-configured team of experts who help provide support."
-            sampleAppFolder="faq-plus"
-            sampleAppUrl="https://github.com/OfficeDev/TeamsFx-Samples/archive/refs/heads/main.zip"
-          />
-          <SampleAppCard
             image={InMeetingApp}
             tags={["Meeting extension", "JS"]}
             title="In-meeting App"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/73154171/118589803-b6ee8700-b7d3-11eb-88f5-e714a132760a.png)
