### PR TITLE
fix(env-checker): update to 'Continue anyway' to reduce confusion

### DIFF
--- a/packages/fx-core/src/plugins/resource/function/utils/depsChecker/common.ts
+++ b/packages/fx-core/src/plugins/resource/function/utils/depsChecker/common.ts
@@ -46,7 +46,7 @@ export const dotnetNotSupportTargetVersionHelpLink = `${defaultHelpLink}#dotnetn
 
 export const Messages = {
   learnMoreButtonText: "Learn more",
-  continueButtonText: "Continue",
+  continueButtonText: "Continue anyway",
 
   defaultErrorMessage: "Install the required dependencies manually.",
 
@@ -68,13 +68,13 @@ export const Messages = {
 
   NodeNotFound: `Cannot find Node.js.
 
-Teams Toolkit requires Node.js; the recommended version is v12.
+Teams Toolkit requires Node.js; the recommended version is v14.
 
 Click "Learn more" to learn how to install the Node.js.`,
   NodeNotSupported: `Node.js (@CurrentVersion) is not in the supported version list (@SupportedVersions).
 
 Click "Learn more" to learn more about the supported Node.js versions.
-Click "Continue" to continue local debugging.`,
+Click "Continue anyway" to continue local debugging.`,
 
   dotnetNotFound: `Cannot find @NameVersion. For the details why .NET SDK is needed, refer to ${dotnetExplanationHelpLink}`,
   depsNotFound: `Cannot find @SupportedPackages.
@@ -85,14 +85,13 @@ Click "Install" to install @InstallPackages.`,
 
   linuxDepsNotFound: `Cannot find @SupportedPackages.
 
-Teams Toolkit requires these dependencies. 
+Teams Toolkit requires these dependencies.
 
-Click "Continue" to continue.`,
+Click "Continue anyway" to continue.`,
 
   linuxDepsNotFoundHelpLinkMessage: `Cannot find @SupportedPackages.
 
 Teams Toolkit requires these dependencies.`,
-
 };
 
 export enum DepsCheckerEvent {

--- a/packages/fx-core/src/plugins/resource/function/utils/depsChecker/funcPluginAdapter.ts
+++ b/packages/fx-core/src/plugins/resource/function/utils/depsChecker/funcPluginAdapter.ts
@@ -129,12 +129,17 @@ class FuncPluginAdapter implements IDepsAdapter {
           description: link,
         })
       );
+
+      return this.displayContinueWithLearnMoreLink(ctx, message, link);
     }
 
     return userSelected === Messages.continueButtonText;
   }
 
-  public async generateMsg(messageTemplate: string, checkers: Array<IDepsChecker>): Promise<string> {
+  public async generateMsg(
+    messageTemplate: string,
+    checkers: Array<IDepsChecker>
+  ): Promise<string> {
     const supportedPackages = [];
     for (const checker of checkers) {
       const info = await checker.getDepsInfo();

--- a/packages/vscode-extension/src/debug/depsChecker/common.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/common.ts
@@ -46,7 +46,7 @@ export const dotnetNotSupportTargetVersionHelpLink = `${defaultHelpLink}#dotnetn
 
 export const Messages = {
   learnMoreButtonText: "Learn more",
-  continueButtonText: "Continue",
+  continueButtonText: "Continue anyway",
 
   defaultErrorMessage: "Install the required dependencies manually.",
 
@@ -76,7 +76,7 @@ Click "Learn more" to learn how to install the Node.js.
   NodeNotSupported: `Node.js (@CurrentVersion) is not in the supported version list (@SupportedVersions).
 
 Click "Learn more" to learn more about the supported Node.js versions.
-Click "Continue" to continue local debugging.
+Click "Continue anyway" to continue local debugging.
 
 (If you just installed Node.js (@SupportedVersions), restart Visual Studio Code for the change to take effect.)`,
 
@@ -91,14 +91,13 @@ Click "Install" to install @InstallPackages.`,
 
 Teams Toolkit requires these dependencies. 
 
-Click "Continue" to continue.
+Click "Continue anyway" to continue.
 
 (If you just installed @SupportedPackages, restart Visual Studio Code for the change to take effect.)`,
 
   linuxDepsNotFoundHelpLinkMessage: `Cannot find @SupportedPackages.
 
 Teams Toolkit requires these dependencies.`,
-
 };
 
 export enum DepsCheckerEvent {


### PR DESCRIPTION
**work item**: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/9951344/
**Summary**: Update the text of `Continue` button with `Continue anyway`.

Here's the snapshot:

teamsfx-cli (WSL): deploy function app when .NET SDK is not installed:

![image](https://user-images.githubusercontent.com/15644078/118596667-413be880-b7de-11eb-8b59-b0de80b9dacb.png)

Teams Toolkit (WSL): local debug when .NET SDK is not installed:

![image](https://user-images.githubusercontent.com/15644078/118596842-7d6f4900-b7de-11eb-92bc-f8be7d15ed68.png)

