### PR TITLE
fix: add app id to local debug telemetry

### DIFF
--- a/packages/vscode-extension/src/debug/commonUtils.ts
+++ b/packages/vscode-extension/src/debug/commonUtils.ts
@@ -226,3 +226,17 @@ export function getTeamsAppTenantId(): string | undefined {
 
   return undefined;
 }
+
+export function getLocalTeamsAppId(): string | undefined {
+  if (ext.workspaceUri) {
+    const ws = ext.workspaceUri.fsPath;
+    if (isWorkspaceSupported(ws)) {
+      const env = getActiveEnv();
+      const envJsonPath = path.join(ws, `.${ConfigFolderName}/env.${env}.json`);
+      const envJson = JSON.parse(fs.readFileSync(envJsonPath, "utf8"));
+      return envJson.solution.localDebugTeamsAppId;
+    }
+  }
+
+  return undefined;
+}

--- a/packages/vscode-extension/src/debug/teamsfxTaskHandler.ts
+++ b/packages/vscode-extension/src/debug/teamsfxTaskHandler.ts
@@ -4,6 +4,7 @@
 import { ProductName } from "@microsoft/teamsfx-api";
 import * as vscode from "vscode";
 
+import { getLocalTeamsAppId } from "./commonUtils";
 import { ext } from "../extensionVariables";
 import { ExtTelemetry } from "../telemetry/extTelemetry";
 import { TelemetryEvent, TelemetryProperty } from "../telemetry/extTelemetryEvents";
@@ -79,17 +80,18 @@ function onDidStartDebugSessionHandler(event: vscode.DebugSession): void {
       // send f5 event telemetry
       try {
         const remoteAppId = getTeamsAppId() as string;
+        const localAppId = getLocalTeamsAppId() as string;
+        const isRemote =
+          (debugConfig.url as string) &&
+          remoteAppId &&
+          (debugConfig.url as string).includes(remoteAppId);
         ExtTelemetry.sendTelemetryEvent(TelemetryEvent.DebugStart, {
           [TelemetryProperty.DebugSessionId]: event.id,
           [TelemetryProperty.DebugType]: debugConfig.type,
           [TelemetryProperty.DebugRequest]: debugConfig.request,
           [TelemetryProperty.DebugPort]: debugConfig.port + "",
-          [TelemetryProperty.DebugRemote]:
-            (debugConfig.url as string) &&
-            remoteAppId &&
-            (debugConfig.url as string).includes(remoteAppId)
-              ? "true"
-              : "false",
+          [TelemetryProperty.DebugRemote]: isRemote ? "true" : "false",
+          [TelemetryProperty.DebugAppId]: isRemote ? remoteAppId : localAppId,
         });
       } catch {
         // ignore telemetry error

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -608,7 +608,10 @@ export async function backendExtensionsInstallHandler(): Promise<void> {
  */
 export async function preDebugCheckHandler(): Promise<void> {
   try {
-    ExtTelemetry.sendTelemetryEvent(TelemetryEvent.DebugPreCheck);
+    const localAppId = commonUtils.getLocalTeamsAppId() as string;
+    ExtTelemetry.sendTelemetryEvent(TelemetryEvent.DebugPreCheck, {
+      [TelemetryProperty.DebugAppId]: localAppId,
+    });
   } catch {
     // ignore telemetry error
   }
@@ -617,7 +620,10 @@ export async function preDebugCheckHandler(): Promise<void> {
   result = await runCommand(Stage.debug);
   if (result.isErr()) {
     try {
-      ExtTelemetry.sendTelemetryErrorEvent(TelemetryEvent.DebugPreCheck, result.error);
+      const localAppId = commonUtils.getLocalTeamsAppId() as string;
+      ExtTelemetry.sendTelemetryErrorEvent(TelemetryEvent.DebugPreCheck, result.error, {
+        [TelemetryProperty.DebugAppId]: localAppId,
+      });
     } finally {
       // ignore telemetry error
       terminateAllRunningTeamsfxTasks();

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -644,7 +644,10 @@ export async function preDebugCheckHandler(): Promise<void> {
     }
     const error = new UserError(ExtensionErrors.PortAlreadyInUse, message, ExtensionSource);
     try {
-      ExtTelemetry.sendTelemetryErrorEvent(TelemetryEvent.DebugPreCheck, error);
+      const localAppId = commonUtils.getLocalTeamsAppId() as string;
+      ExtTelemetry.sendTelemetryErrorEvent(TelemetryEvent.DebugPreCheck, error, {
+        [TelemetryProperty.DebugAppId]: localAppId,
+      });
     } finally {
       // ignore telemetry error
       window.showErrorMessage(message);

--- a/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
@@ -74,8 +74,9 @@ export enum TelemetryProperty {
   DebugRequest = "request",
   DebugPort = "port",
   DebugRemote = "remote",
+  DebugAppId = "debug-appid",
   Internal = "internal",
-  InternalAlias = "internal-alias"
+  InternalAlias = "internal-alias",
 }
 
 export enum TelemetrySuccess {


### PR DESCRIPTION
Add teams app id as `debug-appid` to local debug related telemetries:
- `debug-precheck` event records local teams app id if exist.
- `debug-start` event records local teams app id for local debug, and remote teams app id for remote launch.