### PR TITLE
fix(bot): bot name conflicts

### DIFF
--- a/packages/fx-core/src/plugins/resource/bot/appStudio/appStudio.ts
+++ b/packages/fx-core/src/plugins/resource/bot/appStudio/appStudio.ts
@@ -4,7 +4,7 @@ import { IAADDefinition } from "./interfaces/IAADDefinition";
 
 import { AxiosInstance, default as axios } from "axios";
 import {
-  CallAppStudioError,
+  AADAppCheckingError,
   ConfigUpdatingError,
   ProvisionError,
   SomethingMissingError,
@@ -96,7 +96,7 @@ export class AppStudio {
         axiosInstance.get(`${AppStudio.baseUrl}/api/aadapp/v2/${objectId}`)
       );
     } catch (e) {
-      throw new CallAppStudioError(LifecycleFuncNames.CHECK_AAD_APP, e);
+      throw new AADAppCheckingError(e);
     }
 
     if (!response || !response.data) {

--- a/packages/fx-core/src/plugins/resource/bot/azureOps.ts
+++ b/packages/fx-core/src/plugins/resource/bot/azureOps.ts
@@ -11,13 +11,12 @@ import {
   MessageEndpointUpdatingError,
   MissingSubscriptionRegistrationError,
   FreeServerFarmsQuotaError,
-  BotNameRegisteredError,
+  InvalidBotDataError,
 } from "./errors";
 import { CommonStrings, ConfigNames } from "./resources/strings";
 import * as utils from "./utils/common";
 import { default as axios } from "axios";
 import { ErrorMessagesForChecking } from "./constants";
-import { Messages } from "./resources/messages";
 
 export class AzureOperations {
   public static async CreateBotChannelRegistration(
@@ -40,11 +39,8 @@ export class AzureOperations {
     } catch (e) {
       if (e.code === "MissingSubscriptionRegistration") {
         throw new MissingSubscriptionRegistrationError();
-      } else if (
-        e.code === "InvalidBotData" &&
-        e.message.includes(Messages.BotNameAlreadyRegistered)
-      ) {
-        throw new BotNameRegisteredError();
+      } else if (e.code === "InvalidBotData") {
+        throw new InvalidBotDataError(e);
       } else {
         throw new ProvisionError(CommonStrings.BOT_CHANNEL_REGISTRATION, e);
       }

--- a/packages/fx-core/src/plugins/resource/bot/azureOps.ts
+++ b/packages/fx-core/src/plugins/resource/bot/azureOps.ts
@@ -11,11 +11,13 @@ import {
   MessageEndpointUpdatingError,
   MissingSubscriptionRegistrationError,
   FreeServerFarmsQuotaError,
+  BotNameRegisteredError,
 } from "./errors";
 import { CommonStrings, ConfigNames } from "./resources/strings";
 import * as utils from "./utils/common";
 import { default as axios } from "axios";
 import { ErrorMessagesForChecking } from "./constants";
+import { Messages } from "./resources/messages";
 
 export class AzureOperations {
   public static async CreateBotChannelRegistration(
@@ -38,6 +40,11 @@ export class AzureOperations {
     } catch (e) {
       if (e.code === "MissingSubscriptionRegistration") {
         throw new MissingSubscriptionRegistrationError();
+      } else if (
+        e.code === "InvalidBotData" &&
+        e.message.includes(Messages.BotNameAlreadyRegistered)
+      ) {
+        throw new BotNameRegisteredError();
       } else {
         throw new ProvisionError(CommonStrings.BOT_CHANNEL_REGISTRATION, e);
       }

--- a/packages/fx-core/src/plugins/resource/bot/constants.ts
+++ b/packages/fx-core/src/plugins/resource/bot/constants.ts
@@ -135,7 +135,7 @@ export class ErrorNames {
   public static readonly MISSING_SUBSCRIPTION_REGISTRATION_ERROR =
     "MissingSubscriptionRegistrationError";
   public static readonly FREE_SERVER_FARMS_QUOTA_ERROR = "FreeServerFarmsQuotaError";
-  public static readonly BOT_NAME_REGISTERED_ERROR = "BotNameRegisteredError";
+  public static readonly INVALID_BOT_DATA_ERROR = "InvalidBotDataError";
 }
 
 export class Links {

--- a/packages/fx-core/src/plugins/resource/bot/constants.ts
+++ b/packages/fx-core/src/plugins/resource/bot/constants.ts
@@ -135,6 +135,7 @@ export class ErrorNames {
   public static readonly MISSING_SUBSCRIPTION_REGISTRATION_ERROR =
     "MissingSubscriptionRegistrationError";
   public static readonly FREE_SERVER_FARMS_QUOTA_ERROR = "FreeServerFarmsQuotaError";
+  public static readonly BOT_NAME_REGISTERED_ERROR = "BotNameRegisteredError";
 }
 
 export class Links {

--- a/packages/fx-core/src/plugins/resource/bot/errors.ts
+++ b/packages/fx-core/src/plugins/resource/bot/errors.ts
@@ -237,3 +237,15 @@ export class FreeServerFarmsQuotaError extends PluginError {
     );
   }
 }
+
+export class BotNameRegisteredError extends PluginError {
+  constructor(innerError?: Error) {
+    super(
+      ErrorType.User,
+      ErrorNames.BOT_NAME_REGISTERED_ERROR,
+      Messages.BotNameAlreadyRegistered,
+      [Messages.DeleteExistingBotChannelRegistration, Messages.DeleteBotAfterAzureAccountSwitching],
+      innerError
+    );
+  }
+}

--- a/packages/fx-core/src/plugins/resource/bot/errors.ts
+++ b/packages/fx-core/src/plugins/resource/bot/errors.ts
@@ -42,7 +42,7 @@ export class PluginError extends Error {
 
 export class PreconditionError extends PluginError {
   constructor(message: string, suggestions: string[]) {
-    super(ErrorType.System, ErrorNames.PRECONDITION_ERROR, message, suggestions);
+    super(ErrorType.User, ErrorNames.PRECONDITION_ERROR, message, suggestions);
   }
 }
 
@@ -71,12 +71,12 @@ export class UserInputsError extends PluginError {
   }
 }
 
-export class CallAppStudioError extends PluginError {
-  constructor(apiName: string, innerError?: Error) {
+export class AADAppCheckingError extends PluginError {
+  constructor(innerError?: Error) {
     super(
       ErrorType.System,
       ErrorNames.CALL_APPSTUDIO_API_ERROR,
-      Messages.FailToCallAppStudio(apiName),
+      Messages.FailToCallAppStudioForCheckingAADApp,
       [Messages.RetryTheCurrentStep],
       innerError
     );
@@ -86,10 +86,10 @@ export class CallAppStudioError extends PluginError {
 export class ClientCreationError extends PluginError {
   constructor(clientName: string, innerError?: Error) {
     super(
-      ErrorType.System,
+      ErrorType.User,
       ErrorNames.CLIENT_CREATION_ERROR,
       Messages.FailToCreateSomeClient(clientName),
-      [Messages.RetryTheCurrentStep],
+      [Messages.CheckOutputLogAndTryToFix, Messages.RetryTheCurrentStep],
       innerError
     );
   }
@@ -98,10 +98,10 @@ export class ClientCreationError extends PluginError {
 export class ProvisionError extends PluginError {
   constructor(resource: string, innerError?: Error) {
     super(
-      ErrorType.System,
+      ErrorType.User,
       ErrorNames.PROVISION_ERROR,
       Messages.FailToProvisionSomeResource(resource),
-      [Messages.RetryTheCurrentStep],
+      [Messages.CheckOutputLogAndTryToFix, Messages.RetryTheCurrentStep],
       innerError
     );
   }
@@ -123,10 +123,10 @@ export class MissingSubscriptionRegistrationError extends PluginError {
 export class ConfigUpdatingError extends PluginError {
   constructor(configName: string, innerError?: Error) {
     super(
-      ErrorType.System,
+      ErrorType.User,
       ErrorNames.CONFIG_UPDATING_ERROR,
       Messages.FailToUpdateConfigs(configName),
-      [Messages.RetryTheCurrentStep],
+      [Messages.CheckOutputLogAndTryToFix, Messages.RetryTheCurrentStep],
       innerError
     );
   }
@@ -157,10 +157,10 @@ export class PackDirExistenceError extends PluginError {
 export class ListPublishingCredentialsError extends PluginError {
   constructor(innerError?: Error) {
     super(
-      ErrorType.System,
+      ErrorType.User,
       ErrorNames.LIST_PUBLISHING_CREDENTIALS_ERROR,
       Messages.FailToListPublishingCredentials,
-      [Messages.RetryTheCurrentStep],
+      [Messages.CheckOutputLogAndTryToFix, Messages.RetryTheCurrentStep],
       innerError
     );
   }
@@ -169,10 +169,10 @@ export class ListPublishingCredentialsError extends PluginError {
 export class ZipDeployError extends PluginError {
   constructor(innerError?: Error) {
     super(
-      ErrorType.System,
+      ErrorType.User,
       ErrorNames.ZIP_DEPLOY_ERROR,
       Messages.FailToDoZipDeploy,
-      ["Please retry the deploy command."],
+      [Messages.CheckOutputLogAndTryToFix, Messages.RetryTheCurrentStep],
       innerError
     );
   }
@@ -181,10 +181,10 @@ export class ZipDeployError extends PluginError {
 export class MessageEndpointUpdatingError extends PluginError {
   constructor(endpoint: string, innerError?: Error) {
     super(
-      ErrorType.System,
+      ErrorType.User,
       ErrorNames.MSG_ENDPOINT_UPDATING_ERROR,
       Messages.FailToUpdateMessageEndpoint(endpoint),
-      [Messages.RetryTheCurrentStep],
+      [Messages.CheckOutputLogAndTryToFix, Messages.RetryTheCurrentStep],
       innerError
     );
   }
@@ -193,7 +193,7 @@ export class MessageEndpointUpdatingError extends PluginError {
 export class DownloadError extends PluginError {
   constructor(url: string, innerError?: Error) {
     super(
-      ErrorType.System,
+      ErrorType.User,
       ErrorNames.DOWNLOAD_ERROR,
       Messages.FailToDownloadFrom(url),
       ["Please check your network status and retry."],
@@ -205,7 +205,7 @@ export class DownloadError extends PluginError {
 export class TemplateProjectNotFoundError extends PluginError {
   constructor() {
     super(
-      ErrorType.System,
+      ErrorType.User,
       ErrorNames.TEMPLATE_PROJECT_NOT_FOUND_ERROR,
       Messages.SomethingIsNotFound("Template project for scaffold"),
       [Messages.RetryTheCurrentStep]
@@ -214,11 +214,11 @@ export class TemplateProjectNotFoundError extends PluginError {
 }
 
 export class CommandExecutionError extends PluginError {
-  constructor(cmd: string, message: string, innerError?: Error) {
+  constructor(cmd: string, innerError?: Error) {
     super(
-      ErrorType.System,
+      ErrorType.User,
       ErrorNames.COMMAND_EXECUTION_ERROR,
-      Messages.CommandFailWithMessage(cmd, message),
+      Messages.CommandExecutionFailed(cmd),
       [Messages.CheckCommandOutputAndTryToFixIt, Messages.RetryTheCurrentStep],
       innerError
     );

--- a/packages/fx-core/src/plugins/resource/bot/errors.ts
+++ b/packages/fx-core/src/plugins/resource/bot/errors.ts
@@ -238,12 +238,12 @@ export class FreeServerFarmsQuotaError extends PluginError {
   }
 }
 
-export class BotNameRegisteredError extends PluginError {
-  constructor(innerError?: Error) {
+export class InvalidBotDataError extends PluginError {
+  constructor(innerError: Error) {
     super(
       ErrorType.User,
-      ErrorNames.BOT_NAME_REGISTERED_ERROR,
-      Messages.BotNameAlreadyRegistered,
+      ErrorNames.INVALID_BOT_DATA_ERROR,
+      innerError.message,
       [Messages.DeleteExistingBotChannelRegistration, Messages.DeleteBotAfterAzureAccountSwitching],
       innerError
     );

--- a/packages/fx-core/src/plugins/resource/bot/languageStrategy.ts
+++ b/packages/fx-core/src/plugins/resource/bot/languageStrategy.ts
@@ -94,11 +94,7 @@ export class LanguageStrategy {
         await utils.execute("npm install", packDir);
         await utils.execute("npm run build", packDir);
       } catch (e) {
-        throw new CommandExecutionError(
-          `${Commands.NPM_INSTALL},${Commands.NPM_BUILD}`,
-          e.message,
-          e
-        );
+        throw new CommandExecutionError(`${Commands.NPM_INSTALL},${Commands.NPM_BUILD}`, e);
       }
     }
 
@@ -107,7 +103,7 @@ export class LanguageStrategy {
         // fail to npm install @microsoft/teamsfx on azure web app, so pack it locally.
         await utils.execute("npm install @microsoft/teamsfx", packDir);
       } catch (e) {
-        throw new CommandExecutionError(`${Commands.NPM_INSTALL}`, e.message, e);
+        throw new CommandExecutionError(`${Commands.NPM_INSTALL}`, e);
       }
     }
   }

--- a/packages/fx-core/src/plugins/resource/bot/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/bot/plugin.ts
@@ -401,6 +401,9 @@ export class TeamsBotImpl {
           `Before running this bot, please manually update bot's message endpoint(${this.config.provision.siteEndpoint}${CommonStrings.MESSAGE_ENDPOINT_SUFFIX}). Click 'Get Help' button for more details.`,
           Links.UPDATE_MESSAGE_ENDPOINT
         );
+        Logger.info(
+          `Please manually update bot's message endpoint(${this.config.provision.siteEndpoint}${CommonStrings.MESSAGE_ENDPOINT_SUFFIX}).`
+        );
         break;
       }
     }

--- a/packages/fx-core/src/plugins/resource/bot/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/bot/plugin.ts
@@ -398,11 +398,15 @@ export class TeamsBotImpl {
         // Remind end developers to update message endpoint manually.
         await DialogUtils.showAndHelp(
           context,
-          `Before running this bot, please manually update bot's message endpoint(${this.config.provision.siteEndpoint}${CommonStrings.MESSAGE_ENDPOINT_SUFFIX}). Click 'Get Help' button for more details.`,
+          Messages.RemindUsersToUpdateMessageEndpoint(
+            `${this.config.provision.siteEndpoint}${CommonStrings.MESSAGE_ENDPOINT_SUFFIX}`
+          ),
           Links.UPDATE_MESSAGE_ENDPOINT
         );
         Logger.info(
-          `Please manually update bot's message endpoint(${this.config.provision.siteEndpoint}${CommonStrings.MESSAGE_ENDPOINT_SUFFIX}).`
+          Messages.RemindUsersToUpdateMessageEndpoint(
+            `${this.config.provision.siteEndpoint}${CommonStrings.MESSAGE_ENDPOINT_SUFFIX}`
+          )
         );
         break;
       }

--- a/packages/fx-core/src/plugins/resource/bot/resources/messages.ts
+++ b/packages/fx-core/src/plugins/resource/bot/resources/messages.ts
@@ -3,7 +3,7 @@
 
 export class Messages {
   public static readonly SomethingIsInvalidWithValue = (something: string, value: string): string =>
-    `'${something}' is invalid with '${value}'.`;
+    `'${something}' is invalid with value '${value}'.`;
   public static readonly InputValidValueForSomething = (something: string): string =>
     `Please select valid values for '${something}'.`;
   public static readonly SomethingIsMissing = (something: string): string =>
@@ -32,12 +32,12 @@ export class Messages {
     "Please click 'Get Help' button for more details.";
   public static readonly ClickIssueButtonToReportIssue =
     "Please click 'Report Issue' button to report the issue.";
-  public static readonly CommandFailWithMessage = (command: string, message: string): string =>
-    `Run '${command}' failed with message: ${message}`;
+  public static readonly CommandExecutionFailed = (command: string): string =>
+    `Run '${command}' failed.`;
   public static readonly DoSthBeforeSth = (sth: string, beforeSth: string): string =>
     `Perform command '${sth}' before '${beforeSth}'.`;
-  public static readonly FailToCallAppStudio = (apiName: string): string =>
-    `Failed to execute '${apiName}'.`;
+  public static readonly FailToCallAppStudioForCheckingAADApp =
+    "Failed to call app studio's api to check aad app's existence.";
   public static readonly SuccessfullyRetrievedTemplateZip = (zipUrl: string): string =>
     `Successfully retrieved zip package from ${zipUrl}.`;
   public static readonly FallingBackToUseLocalTemplateZip =
@@ -113,4 +113,6 @@ export class Messages {
     "Please delete existing azure bot channel registrations.";
   public static readonly DeleteBotAfterAzureAccountSwitching =
     "If azure account is switched, don't forget to delete azure bot channel registration under the previous account.";
+  public static readonly CheckOutputLogAndTryToFix =
+    "Please check log in output channel and try to fix this issue.";
 }

--- a/packages/fx-core/src/plugins/resource/bot/resources/messages.ts
+++ b/packages/fx-core/src/plugins/resource/bot/resources/messages.ts
@@ -33,11 +33,11 @@ export class Messages {
   public static readonly ClickIssueButtonToReportIssue =
     "Please click 'Report Issue' button to report the issue.";
   public static readonly CommandExecutionFailed = (command: string): string =>
-    `Run '${command}' failed.`;
+    `Failed to run '${command}'.`;
   public static readonly DoSthBeforeSth = (sth: string, beforeSth: string): string =>
     `Perform command '${sth}' before '${beforeSth}'.`;
   public static readonly FailToCallAppStudioForCheckingAADApp =
-    "Failed to call app studio's api to check aad app's existence.";
+    "Failed to call App Studio's api to check AAD application's existence.";
   public static readonly SuccessfullyRetrievedTemplateZip = (zipUrl: string): string =>
     `Successfully retrieved zip package from ${zipUrl}.`;
   public static readonly FallingBackToUseLocalTemplateZip =
@@ -96,8 +96,8 @@ export class Messages {
     "The subscription didn't register to use namespace 'Microsoft.BotService'.";
   public static readonly MaxFreeAppServicePlanIsTen =
     "The maximum number of Free App Service Plan allowed in a Subscription is 10.";
-  public static readonly BotNameAlreadyRegistered =
-    "The bot name is already registered to another bot application.";
+  public static readonly RemindUsersToUpdateMessageEndpoint = (messageEndpoint: string): string =>
+    `Before running this bot, please manually update bot's message endpoint(${messageEndpoint}). Click 'Get Help' button for more details.`;
 
   // Suggestions
   public static readonly RetryTheCurrentStep = "Please retry the current step.";

--- a/packages/fx-core/src/plugins/resource/bot/resources/messages.ts
+++ b/packages/fx-core/src/plugins/resource/bot/resources/messages.ts
@@ -96,6 +96,8 @@ export class Messages {
     "The subscription didn't register to use namespace 'Microsoft.BotService'.";
   public static readonly MaxFreeAppServicePlanIsTen =
     "The maximum number of Free App Service Plan allowed in a Subscription is 10.";
+  public static readonly BotNameAlreadyRegistered =
+    "The bot name is already registered to another bot application.";
 
   // Suggestions
   public static readonly RetryTheCurrentStep = "Please retry the current step.";
@@ -107,4 +109,8 @@ export class Messages {
   public static readonly RecreateTheProject = "Please recreate the project.";
   public static readonly CheckCommandOutputAndTryToFixIt =
     "Please check the command output and try to fix it.";
+  public static readonly DeleteExistingBotChannelRegistration =
+    "Please delete existing azure bot channel registrations.";
+  public static readonly DeleteBotAfterAzureAccountSwitching =
+    "If azure account is switched, don't forget to delete azure bot channel registration under the previous account.";
 }

--- a/packages/fx-core/tests/plugins/resource/bot/unit/errors.test.ts
+++ b/packages/fx-core/tests/plugins/resource/bot/unit/errors.test.ts
@@ -7,7 +7,7 @@ import {
   PluginError,
   ErrorType,
   UserInputsError,
-  CallAppStudioError,
+  AADAppCheckingError,
   ConfigUpdatingError,
   ConfigValidationError,
   PackDirExistenceError,
@@ -46,13 +46,11 @@ describe("Test Errors", () => {
     });
   });
 
-  describe("CallAppStudioError", () => {
+  describe("AADAppCheckingError", () => {
     it("Happy Path", () => {
       // Arrange
-      const apiName = "genPassword";
-
       // Act
-      const myError = new CallAppStudioError(apiName);
+      const myError = new AADAppCheckingError();
 
       // Assert
       chai.assert.isTrue(myError instanceof PluginError);
@@ -70,7 +68,7 @@ describe("Test Errors", () => {
 
       // Assert
       chai.assert.isTrue(myError instanceof PluginError);
-      chai.assert.isTrue(myError.errorType === ErrorType.System);
+      chai.assert.isTrue(myError.errorType === ErrorType.User);
     });
   });
 


### PR DESCRIPTION
1. add specific error message for bot name conflicts, and, remind users to clear resources in previous azure account.
2. align user error principle: If users can possibly recover by themselves, then it should be a user error.
3. refine wording for some errors.
4. remove CommandExecutionError message from low-level Error object, instead, using the message made by bot plugin, to avoid long low-level Error.message.
5. Log message endpoint to be updated manually.

to fix bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/9959194


Explanations for the screenshot below:
Since solution and plugins both need to throw error, to reduce duplicated error. Solution will throw an overall error if help link is not set. Plugins will throw a specific error if help link is present.

![image](https://user-images.githubusercontent.com/1803943/118752352-8111d700-b895-11eb-897b-49a0bebc84e5.png)
