### PR TITLE
fix(apim): install swagger-jsdoc in version 6

### DIFF
--- a/packages/fx-core/templates/plugins/resource/apim/README.md
+++ b/packages/fx-core/templates/plugins/resource/apim/README.md
@@ -55,7 +55,7 @@ Update the Open API document under the `openapi` folder. We support both yaml an
 
 ### Recommended way 1: Using npm package swagger-jsdoc
 
-- Run command: `npm install -g swagger-jsdoc`.
+- Install the stable version of swagger-jsdoc. Run command: `npm install -g swagger-jsdoc@6`.
 - Annotating source code. Read [more](https://github.com/Surnet/swagger-jsdoc/) about how to use swagger-jsdoc to annotate the source code. Below is a sample annotation.
   - API annotation
     ```js


### PR DESCRIPTION
The swagger-jsdoc pre-release version 7.0.0-rc.6 does not work. Change the document and recommend user to install version 6.

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/9986060