### PR TITLE
fix: update subscription after sub auto selected

### DIFF
--- a/packages/fx-core/src/core/index.ts
+++ b/packages/fx-core/src/core/index.ts
@@ -509,6 +509,8 @@ class CoreImpl implements Core {
 
             if (subscriptions.length === 1) {
               this.setSubscription(subscriptions[0]);
+              selectSubLabel = subscriptions[0].subscriptionName;
+              icon = "subscriptionSelected";
             }
           } else {
             selectSubLabel = activeSubscription.subscriptionName;


### PR DESCRIPTION
Issue:
Subscription name not updated to sidebar after login with one sub
Reproducible steps:
1. login using account A
2. select subscription Sa under account A
3. sign out
4. sign in using another account B(which has only one subscription under this account)
5. subscription is auto selected but sidebar not updated
ADO:
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/9997487