### PR TITLE
fix: update wording 'teamsfx' to 'teams' on quick start page

### DIFF
--- a/packages/vscode-extension/src/controls/QuickStart.tsx
+++ b/packages/vscode-extension/src/controls/QuickStart.tsx
@@ -122,8 +122,8 @@ export default class QuickStart extends React.Component<any, any> {
               return (
                 <GetStartedAction
                   title={`Explore Teams Toolkit commands`}
-                  content={`Open Command Palette (${shortcut}) and type ‘Teamsfx’ to find all relevant commands. `}
-                  actionText="Display TeamsFx commands"
+                  content={`Open Command Palette (${shortcut}) and type ‘Teams’ to find all relevant commands. `}
+                  actionText="Display Teams commands"
                   onAction={this.displayCommands}
                   secondaryActionText="Next"
                   onSecondaryAction={() => {


### PR DESCRIPTION
Screenshot:
before:
![image](https://user-images.githubusercontent.com/73154171/119302786-46de7600-bc97-11eb-9f72-51f148acc348.png)
after:
![image](https://user-images.githubusercontent.com/73154171/119302754-37f7c380-bc97-11eb-93eb-d6d79ea5666e.png)

ADO:
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/9881529
