### PR TITLE
fix: sidebar not updated when sign out from Azure extension

### DIFF
--- a/packages/fx-core/src/core/index.ts
+++ b/packages/fx-core/src/core/index.ts
@@ -732,6 +732,14 @@ class CoreImpl implements Core {
                 contextValue: "signinAzure",
               },
             ]);
+
+            this.ctx.treeProvider?.remove([
+              {
+                commandId: "fx-extension.selectSubscription",
+                label: "",
+                parent: "fx-extension.signinAzure"
+              }
+            ]);
           }
 
           return Promise.resolve();


### PR DESCRIPTION
Issue:
Sign out from Azure extension command palette, the sidebar is not updated

ADO:
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/9881584

Screenshot:
before:
![signoutfromazure_before](https://user-images.githubusercontent.com/73154171/119313163-d0954000-bca5-11eb-8e01-45400b524dcb.gif)


after:
![signoutfromazure](https://user-images.githubusercontent.com/73154171/119312820-6d0b1280-bca5-11eb-98b7-77ee640b34b6.gif)
