### PR TITLE
test(env-checker): use vscode-test to run env-checker test cases

### DIFF
--- a/.github/workflows/env-checker-ci-pr.yml
+++ b/.github/workflows/env-checker-ci-pr.yml
@@ -35,7 +35,7 @@ jobs:
       ## Details about this issue: https://github.com/npm/cli/wiki/%22cb()-never-called%3F--I'm-having-the-same-problem!%22
       ### tl;dr: This error is not one thing, but a category of errors. It means "something broke and we didn't have a way to catch it". We will always need a lot of detail to reproduce an error like this, or we cannot ever fix it. Every instance is unique, and your cb() never called is nothing like any other.
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
+        os: [windows-latest, macos-11, ubuntu-latest]
         node-version: [14]
         func-version: [none]
         dotnet-version: [none]
@@ -49,12 +49,12 @@ jobs:
           fetch-depth: 0
 
       - name: Uninstalling .NET on Windows
-        if: ${{ matrix.os == 'windows-latest' }}
+        if: ${{ runner.os == 'Windows' }}
         run: |
           powershell -NoProfile -Command ./.github/env-checker/uninstall-dotnet.ps1
 
       - name: Uninstalling .NET on macOS or Ubuntu
-        if: ${{ matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest' }}
+        if: ${{ runner.os == 'macOS' || runner.os == 'Linux' }}
         run: |
           ./.github/env-checker/uninstall-dotnet.sh
 
@@ -64,12 +64,12 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Setup Azure Functions Core Tools For Linux
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.func-version != 'none' }}
+        if: ${{ runner.os == 'Linux' && matrix.func-version != 'none' }}
         run: |
           sudo npm install --unsafe-perm -g azure-functions-core-tools@${{ matrix.func-version }}
 
       - name: Setup Azure Functions Core Tools For Windows and macOS
-        if: ${{ matrix.os != 'ubuntu-latest' && matrix.func-version != 'none' }}
+        if: ${{ runner.os != 'Linux' && matrix.func-version != 'none' }}
         run: |
           npm install -g azure-functions-core-tools@${{ matrix.func-version }}
 

--- a/.github/workflows/env-checker-ci-pr.yml
+++ b/.github/workflows/env-checker-ci-pr.yml
@@ -91,7 +91,16 @@ jobs:
             npm install
             npx lerna bootstrap --concurrency 1
 
+      ## In headless Linux CI machines xvfb is required to run VS Code
+      ## https://code.visualstudio.com/api/working-with-extensions/continuous-integration#github-actions
+      - name: Integration Test with xvfb
+        working-directory: ./packages/vscode-extension
+        if: runner.os == 'Linux'
+        run: |
+          xvfb-run -a npm run test:env-checker
+
       - name: Integration Test
         working-directory: ./packages/vscode-extension
+        if: runner.os != 'Linux'
         run: |
           npm run test:env-checker

--- a/.github/workflows/env-checker-ci-schedule.yml
+++ b/.github/workflows/env-checker-ci-schedule.yml
@@ -17,8 +17,9 @@ jobs:
       ##
       ## Details about this issue: https://github.com/npm/cli/wiki/%22cb()-never-called%3F--I'm-having-the-same-problem!%22
       ### tl;dr: This error is not one thing, but a category of errors. It means "something broke and we didn't have a way to catch it". We will always need a lot of detail to reproduce an error like this, or we cannot ever fix it. Every instance is unique, and your cb() never called is nothing like any other.
+      # macos-latest is 10.15. We need to test 11 as well.
       matrix: # TODO: add more versions and cases where Node.js do not exist
-        os: [windows-latest, macos-latest, ubuntu-latest]
+        os: [windows-latest, macos-latest, macos-11, ubuntu-latest]
         node-version: [10, 12, 14]
         func-version: [none]
         dotnet-version: [none, 3.1.x, 5.0.x]
@@ -32,12 +33,12 @@ jobs:
           fetch-depth: 0
 
       - name: Uninstalling .NET on Windows
-        if: ${{ matrix.os == 'windows-latest' }}
+        if: ${{ runner.os == 'Windows' }}
         run: |
           powershell -NoProfile -Command ./.github/env-checker/uninstall-dotnet.ps1
 
       - name: Uninstalling .NET on macOS or Ubuntu
-        if: ${{ matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest' }}
+        if: ${{ runner.os == 'macOS' || runner.os == 'Linux' }}
         run: |
           ./.github/env-checker/uninstall-dotnet.sh
 
@@ -47,12 +48,12 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Setup Azure Functions Core Tools For Linux
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.func-version != 'none' }}
+        if: ${{ runner.os == 'Linux' && matrix.func-version != 'none' }}
         run: |
           sudo npm install --unsafe-perm -g azure-functions-core-tools@${{ matrix.func-version }}
 
       - name: Setup Azure Functions Core Tools For Windows and macOS
-        if: ${{ matrix.os != 'ubuntu-latest' && matrix.func-version != 'none' }}
+        if: ${{ runner.os != 'Linux' && matrix.func-version != 'none' }}
         run: |
           npm install -g azure-functions-core-tools@${{ matrix.func-version }}
 

--- a/.github/workflows/env-checker-ci-schedule.yml
+++ b/.github/workflows/env-checker-ci-schedule.yml
@@ -75,7 +75,16 @@ jobs:
             npm install
             npx lerna bootstrap --concurrency 1
 
+      ## In headless Linux CI machines xvfb is required to run VS Code
+      ## https://code.visualstudio.com/api/working-with-extensions/continuous-integration#github-actions
+      - name: Integration Test with xvfb
+        working-directory: ./packages/vscode-extension
+        if: runner.os == 'Linux'
+        run: |
+          xvfb-run -a npm run test:env-checker
+
       - name: Integration Test
         working-directory: ./packages/vscode-extension
+        if: runner.os != 'Linux'
         run: |
           npm run test:env-checker

--- a/.github/workflows/env-checker-ci-schedule.yml
+++ b/.github/workflows/env-checker-ci-schedule.yml
@@ -2,8 +2,8 @@ name: Environment Checker Integration Test Schedule Run
 
 on:
   schedule:
-    # Runs everyday 00:00 UTC
-    - cron:  '0 0 * * *'
+    # Runs everyday 15:42 China Time. Avoid start of hour because these are high load times.
+    - cron:  '42 7 * * *'
   workflow_dispatch: # Manual trigger
 
 jobs:

--- a/packages/vscode-extension/.vscode/launch.json
+++ b/packages/vscode-extension/.vscode/launch.json
@@ -41,13 +41,16 @@
       "preLaunchTask": "npm: test-watch"
     },
     {
-      "name": "Environment Checker Tests",
-      "type": "node",
+      "name": "Extension Tests (Environment Checker)",
+      "type": "extensionHost",
       "request": "launch",
-      "program": "${workspaceFolder}/node_modules/mocha/bin/mocha",
-      "args": ["--ui", "tdd", "./out/test/suite/envChecker/cases/**/*.js", "--timeout", "180000"],
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}",
+        "--extensionTestsPath=${workspaceFolder}/out/test/suite/envChecker/index"
+      ],
       "outFiles": ["${workspaceFolder}/out/src/**/*.js", "${workspaceFolder}/out/test/**/*.js"],
-      "preLaunchTask": "npm: test-watch"
+      "preLaunchTask": "npm: test-watch",
+      "sourceMaps": true
     }
   ]
 }

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -456,7 +456,7 @@
     "test:unit": "echo 'to be implementd'",
     "test:integration": "echo 'to be implementd'",
     "test:e2e": "echo 'to be implementd'",
-    "test:env-checker": "npm run compile && npm run copy-test-files && npx mocha --require source-map-support/register --ui tdd \"./out/test/suite/envChecker/cases/**/*.js\" --timeout 180000",
+    "test:env-checker": "npm run compile && npm run copy-test-files && node out/test/runEnvCheckerTest.js",
     "check-format": "prettier --list-different --config .prettierrc.json --ignore-path .prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "format": "prettier --write --config .prettierrc.json --ignore-path .prettierignore \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "lint:fix": "eslint --config .eslintrc.js package.json src test --ext .ts --fix --fix-type [problem,suggestion]",

--- a/packages/vscode-extension/test/runEnvCheckerTest.ts
+++ b/packages/vscode-extension/test/runEnvCheckerTest.ts
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as path from "path";
+
+import { runTests } from "vscode-test";
+
+// This file is mostly copied from this tutorial
+// https://code.visualstudio.com/api/working-with-extensions/testing-extension
+async function main() {
+  try {
+    // The folder containing the Extension Manifest package.json
+    // Passed to `--extensionDevelopmentPath`
+    const extensionDevelopmentPath = path.resolve(__dirname, "../..");
+
+    // The path to the extension test script
+    // Passed to --extensionTestsPath
+    const extensionTestsPath = path.resolve(__dirname, "./suite/envChecker/index");
+
+    // Download VS Code, unzip it and run the integration test
+    await runTests({ extensionDevelopmentPath, extensionTestsPath });
+  } catch (err) {
+    console.error("Failed to run tests");
+    process.exit(1);
+  }
+}
+
+main();

--- a/packages/vscode-extension/test/suite/envChecker/index.ts
+++ b/packages/vscode-extension/test/suite/envChecker/index.ts
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as path from "path";
+import * as Mocha from "mocha";
+import * as glob from "glob";
+import * as util from "util";
+
+// This file is mostly copied from this tutorial
+// https://code.visualstudio.com/api/working-with-extensions/testing-extension
+export function run(): Promise<void> {
+  // Create the mocha test
+  const options: Mocha.MochaOptions = {
+    ui: "tdd",
+    timeout: 5 * 60 * 1000, // 5 minute timeout
+    color: true,
+  };
+
+  // NOTE: this equals to running "mocha --require source-map-support/register" to make the error stack trace more readable.
+  //  the latest @types/mocha does not have this options because @types/mocha is not up-to-date.
+  // However, mocha js package has this options: https://mochajs.org/api/mocha#Mocha
+  (options as any).require = ["source-map-support/register"];
+
+  console.log(`Mocha options: ${JSON.stringify(options, undefined, 2)}`);
+  const mocha = new Mocha(options);
+
+  const testsRoot = path.resolve(__dirname, ".");
+  return new Promise((resolve, reject) => {
+    glob("./cases/**.js", { cwd: testsRoot }, (err, files) => {
+      // Add files to the test suite
+      files.forEach((f) => mocha.addFile(path.resolve(testsRoot, f)));
+
+      try {
+        mocha.run((failures) => {
+          if (failures > 0) {
+            reject(new Error(`${failures} tests failed.`));
+          } else {
+            resolve();
+          }
+        });
+      } catch (err) {
+        console.error(err);
+        reject(err);
+      }
+    });
+  });
+}


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/9769204/

Some bugs are not reproducible with standalone mocha tests. Use vscode-test to run the env-checker test cases in vscode context. This is more realistic to the actual user environment than launching the tests with mocha.

- add test script and test runner script for vscode-test
- add an entry in the extension's `launch.json` to support debugging the test cases
- modify GitHub action config to support vscode-test
- add macOS 11 as an test environment in schedule test

** tradeoff: using vscode-test will slightly decrease the performance. (e.g. Windows test 4min -> 5min)

## Test

- Schedule test passed: https://github.com/OfficeDev/TeamsFx/actions/runs/873636003
- Revert the commit that fixes the "ENOENT" bug and manually run the test in GitHub action, the original bug can be reproduced now 
https://github.com/OfficeDev/TeamsFx/runs/2661893898?check_suite_focus=true#step:11:463


