### PR TITLE
fix: update margin on sample gallery page according to UX

### DIFF
--- a/packages/vscode-extension/src/controls/SampleGallery.scss
+++ b/packages/vscode-extension/src/controls/SampleGallery.scss
@@ -1,5 +1,5 @@
 .sample-gallery {
-  margin: 52px 20px;
+  margin: 100px 20px;
 
   .section {
     display: flex;


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/9922655/?fullScreen=false&triage=true

In this bug, 
For #1, fix in this pr
For #2, already fixed
For #3, I don't think this is needed and not sure how to implement, confirmed with UX, not needed so far.