### PR TITLE
fix(bot): save config when exceptions occur

### DIFF
--- a/packages/fx-core/src/plugins/resource/bot/index.ts
+++ b/packages/fx-core/src/plugins/resource/bot/index.ts
@@ -158,6 +158,7 @@ export class TeamsBot implements Plugin {
       return res;
     } catch (e) {
       await ProgressBarFactory.closeProgressBar(); // Close all progress bars.
+      this.teamsBotImpl.config.saveConfigIntoContext(context); // Save config when exceptions occur.
 
       if (e instanceof UserError || e instanceof SystemError) {
         const res = err(e);


### PR DESCRIPTION
Didn't save config when exceptions will cause inconsistent behaviors.

to fix bug: https://dev.azure.com/msazure/Microsoft%20Teams%20Extensibility/_workitems/edit/9986090
