### PR TITLE
refactor(frontend): make frontend plugin stateless

### DIFF
--- a/packages/fx-core/src/plugins/resource/frontend/configs.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/configs.ts
@@ -12,9 +12,7 @@ import {
 import { Utils } from "./utils";
 
 export class FrontendConfig {
-  appName: string;
   subscriptionId: string;
-  resourceNameSuffix: string;
   resourceGroupName: string;
   location: string;
   storageName: string;
@@ -23,19 +21,15 @@ export class FrontendConfig {
   localPath?: string;
 
   private constructor(
-    appName: string,
     subscriptionId: string,
     resourceGroupName: string,
     location: string,
-    resourceNameSuffix: string,
     storageName: string,
     credentials: TokenCredentialsBase
   ) {
-    this.appName = appName;
     this.subscriptionId = subscriptionId;
     this.resourceGroupName = resourceGroupName;
     this.location = location;
-    this.resourceNameSuffix = resourceNameSuffix;
     this.storageName = storageName;
     this.credentials = credentials;
   }
@@ -79,11 +73,9 @@ export class FrontendConfig {
     }
 
     return new FrontendConfig(
-      appName,
       subscriptionId,
       resourceGroupName,
       location,
-      resourceNameSuffix,
       storageName,
       credentials
     );

--- a/packages/fx-core/src/plugins/resource/frontend/configs.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/configs.ts
@@ -19,7 +19,7 @@ export class FrontendConfig {
   credentials: TokenCredentialsBase;
 
   endpoint?: string;
-  hostname?: string;
+  domain?: string;
 
   private constructor(
     subscriptionId: string,
@@ -83,10 +83,16 @@ export class FrontendConfig {
   }
 
   public syncToPluginContext(ctx: PluginContext): void {
-    FrontendConfig.setConfigIfNotExists(ctx, FrontendConfigInfo.Endpoint, this.endpoint);
-    FrontendConfig.setConfigIfNotExists(ctx, FrontendConfigInfo.Hostname, this.hostname);
-    FrontendConfig.setConfigIfNotExists(ctx, FrontendConfigInfo.StorageName, this.storageName);
+    Object.entries(this)
+      .filter((kv) => FrontendConfig.persistentConfigList.find((x: string) => x === kv[0]))
+      .forEach((kv) => {
+        if (kv[1]) {
+          FrontendConfig.setConfigIfNotExists(ctx, kv[0], kv[1]);
+        }
+      });
   }
+
+  private static persistentConfigList = Object.entries(FrontendConfigInfo).map((kv) => kv[1]);
 
   private static getConfig<T>(key: string, configs?: ReadonlyPluginConfig): T {
     const value = configs?.get(key) as T;

--- a/packages/fx-core/src/plugins/resource/frontend/configs.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/configs.ts
@@ -84,7 +84,7 @@ export class FrontendConfig {
 
   public syncToPluginContext(ctx: PluginContext): void {
     Object.entries(this)
-      .filter((kv) => FrontendConfig.persistentConfigList.find((x: string) => x === kv[0]))
+      .filter((kv) => FrontendConfig.persistentConfigList.includes(kv[0]))
       .forEach((kv) => {
         if (kv[1]) {
           FrontendConfig.setConfigIfNotExists(ctx, kv[0], kv[1]);
@@ -92,7 +92,7 @@ export class FrontendConfig {
       });
   }
 
-  private static persistentConfigList = Object.entries(FrontendConfigInfo).map((kv) => kv[1]);
+  private static persistentConfigList = Object.values(FrontendConfigInfo);
 
   private static getConfig<T>(key: string, configs?: ReadonlyPluginConfig): T {
     const value = configs?.get(key) as T;

--- a/packages/fx-core/src/plugins/resource/frontend/configs.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/configs.ts
@@ -18,7 +18,8 @@ export class FrontendConfig {
   storageName: string;
   credentials: TokenCredentialsBase;
 
-  localPath?: string;
+  endpoint?: string;
+  hostname?: string;
 
   private constructor(
     subscriptionId: string,
@@ -81,11 +82,24 @@ export class FrontendConfig {
     );
   }
 
+  public syncToPluginContext(ctx: PluginContext): void {
+    FrontendConfig.setConfigIfNotExists(ctx, FrontendConfigInfo.Endpoint, this.endpoint);
+    FrontendConfig.setConfigIfNotExists(ctx, FrontendConfigInfo.Hostname, this.hostname);
+    FrontendConfig.setConfigIfNotExists(ctx, FrontendConfigInfo.StorageName, this.storageName);
+  }
+
   private static getConfig<T>(key: string, configs?: ReadonlyPluginConfig): T {
     const value = configs?.get(key) as T;
     if (!value) {
       throw new InvalidConfigError(key);
     }
     return value;
+  }
+
+  private static setConfigIfNotExists(ctx: PluginContext, key: string, value: unknown): void {
+    if (ctx.config.get(key)) {
+      return;
+    }
+    ctx.config.set(key, value);
   }
 }

--- a/packages/fx-core/src/plugins/resource/frontend/constants.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/constants.ts
@@ -53,8 +53,7 @@ export class EnvironmentVariables {
 
 export class FrontendPathInfo {
   static WorkingDir = "tabs";
-  static TemplateDir = path.join("templates", "plugins", "resource", "frontend");
-  static RootDir = path.join(__dirname, "..", "..", "..", "..");
+  static TemplateDir = path.join("plugins", "resource", "frontend");
   static TemplateFileExt = ".tpl";
   static TemplatePackageExt = ".zip";
   static BuildFolderName = "build";

--- a/packages/fx-core/src/plugins/resource/frontend/constants.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/constants.ts
@@ -34,8 +34,6 @@ export class FrontendPluginInfo {
   static ShortName = "FE";
   static IssueLink = "https://github.com/OfficeDev/TeamsFx/issues/new";
   static HelpLink = ""; // TODO: default help link
-  static readonly templateManifestURL =
-    "https://github.com/henzhang-ms/Teams-Templates/releases/latest/download/manifest.json";
 }
 
 export class Commands {
@@ -95,9 +93,7 @@ export class DependentPluginInfo {
 export class FrontendConfigInfo {
   static readonly StorageName = "storageName";
   static readonly Endpoint = "endpoint";
-  static readonly Hostname = "domain";
-  static readonly StaticTab = "staticTabs";
-  static readonly ConfigurableTab = "configurableTabs";
+  static readonly Domain = "domain";
 }
 
 export class TelemetryEvent {

--- a/packages/fx-core/src/plugins/resource/frontend/index.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/index.ts
@@ -1,18 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 import { FrontendPluginImpl } from "./plugin";
-import {
-  Plugin,
-  PluginContext,
-  ok,
-  err,
-  SystemError,
-  UserError,
-  Stage,
-  QTreeNode,
-  Result,
-  FxError,
-} from "@microsoft/teamsfx-api";
+import { Plugin, PluginContext, err, SystemError, UserError } from "@microsoft/teamsfx-api";
 
 import { ErrorFactory, TeamsFxResult } from "./error-factory";
 import {
@@ -28,13 +17,6 @@ import { telemetryHelper } from "./utils/telemetry-helper";
 
 export class FrontendPlugin implements Plugin {
   frontendPluginImpl = new FrontendPluginImpl();
-
-  public async getQuestions(
-    stage: Stage,
-    ctx: PluginContext
-  ): Promise<Result<QTreeNode | undefined, FxError>> {
-    return this.frontendPluginImpl.getQuestions(stage, ctx);
-  }
 
   public async scaffold(ctx: PluginContext): Promise<TeamsFxResult> {
     Logger.setLogger(ctx.logProvider);
@@ -76,14 +58,6 @@ export class FrontendPlugin implements Plugin {
     return this.runWithErrorHandling(ctx, TelemetryEvent.Deploy, () =>
       this.frontendPluginImpl.deploy(ctx)
     );
-  }
-
-  public async localDebug(ctx: PluginContext): Promise<TeamsFxResult> {
-    return ok(undefined);
-  }
-
-  public async postLocalDebug(ctx: PluginContext): Promise<TeamsFxResult> {
-    return ok(undefined);
   }
 
   private async runWithErrorHandling(

--- a/packages/fx-core/src/plugins/resource/frontend/ops/scaffold.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/ops/scaffold.ts
@@ -79,7 +79,7 @@ export class FrontendScaffold {
   }
 
   public static getTemplateZipFromLocal(templateInfo: TemplateInfo): AdmZip {
-    const templatePath = templateInfo.localTemplatePath; //path.resolve(FrontendPathInfo.RootDir, );
+    const templatePath = templateInfo.localTemplatePath;
     return new AdmZip(templatePath);
   }
 

--- a/packages/fx-core/src/plugins/resource/frontend/ops/scaffold.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/ops/scaffold.ts
@@ -88,7 +88,6 @@ export class FrontendScaffold {
     templateInfo: TemplateInfo
   ): Promise<AdmZip> {
     try {
-      // Temporarily hard code template language as JavaScript
       const templateUrl = await FrontendScaffold.getTemplateURL(
         tagListURL,
         templateInfo.localTemplateBaseName

--- a/packages/fx-core/src/plugins/resource/frontend/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/plugin.ts
@@ -123,7 +123,7 @@ export class FrontendPluginImpl {
       }
       return new CreateStorageAccountError();
     };
-    const endpoint = await runWithErrorCatchAndWrap(
+    config.endpoint = await runWithErrorCatchAndWrap(
       createStorageErrorWrapper,
       async () => await client.createStorageAccount()
     );
@@ -134,10 +134,8 @@ export class FrontendPluginImpl {
       async () => await client.enableStaticWebsite()
     );
 
-    const hostname = new URL(endpoint).hostname;
-    this.setConfigIfNotExists(ctx, FrontendConfigInfo.Endpoint, endpoint);
-    this.setConfigIfNotExists(ctx, FrontendConfigInfo.Hostname, hostname);
-    this.setConfigIfNotExists(ctx, FrontendConfigInfo.StorageName, config.storageName);
+    config.hostname = new URL(config.endpoint).hostname;
+    config.syncToPluginContext(ctx);
 
     await ProgressHelper.endProvisionProgress();
     Logger.info(Messages.EndProvision(PluginInfo.DisplayName));

--- a/packages/fx-core/src/plugins/resource/frontend/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/plugin.ts
@@ -134,7 +134,7 @@ export class FrontendPluginImpl {
       async () => await client.enableStaticWebsite()
     );
 
-    config.hostname = new URL(config.endpoint).hostname;
+    config.domain = new URL(config.endpoint).hostname;
     config.syncToPluginContext(ctx);
 
     await ProgressHelper.endProvisionProgress();

--- a/packages/fx-core/src/plugins/resource/frontend/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/plugin.ts
@@ -49,9 +49,6 @@ import {
 import { TemplateInfo } from "./resources/templateInfo";
 
 export class FrontendPluginImpl {
-  config?: FrontendConfig;
-  azureStorageClient?: AzureStorageClient;
-
   private setConfigIfNotExists(ctx: PluginContext, key: string, value: unknown): void {
     if (ctx.config.get(key)) {
       return;
@@ -91,30 +88,27 @@ export class FrontendPluginImpl {
   public async preProvision(ctx: PluginContext): Promise<TeamsFxResult> {
     Logger.info(Messages.StartPreProvision(PluginInfo.DisplayName));
 
-    this.config = await FrontendConfig.fromPluginContext(ctx);
-    this.azureStorageClient = new AzureStorageClient(this.config);
+    const config = await FrontendConfig.fromPluginContext(ctx);
+    const azureStorageClient = new AzureStorageClient(config);
 
     const resourceGroupExists: boolean = await runWithErrorCatchAndThrow(
       new CheckResourceGroupError(),
-      async () => await this.azureStorageClient!.doesResourceGroupExists()
+      async () => await azureStorageClient.doesResourceGroupExists()
     );
     if (!resourceGroupExists) {
       throw new NoResourceGroupError();
     }
 
     Logger.info(Messages.EndPreProvision(PluginInfo.DisplayName));
-    return ok(this.config);
+    return ok(undefined);
   }
 
   public async provision(ctx: PluginContext): Promise<TeamsFxResult> {
     Logger.info(Messages.StartProvision(PluginInfo.DisplayName));
     const progressHandler = await ProgressHelper.startProvisionProgressHandler(ctx);
 
-    const client = this.azureStorageClient;
-    const storageName = this.config?.storageName;
-    if (!storageName || !client) {
-      throw new NoPreStepError();
-    }
+    const config = await FrontendConfig.fromPluginContext(ctx);
+    const client = new AzureStorageClient(config);
 
     await progressHandler?.next(ProvisionSteps.CreateStorage);
     const createStorageErrorWrapper = (innerError: any) => {
@@ -143,11 +137,11 @@ export class FrontendPluginImpl {
     const hostname = new URL(endpoint).hostname;
     this.setConfigIfNotExists(ctx, FrontendConfigInfo.Endpoint, endpoint);
     this.setConfigIfNotExists(ctx, FrontendConfigInfo.Hostname, hostname);
-    this.setConfigIfNotExists(ctx, FrontendConfigInfo.StorageName, storageName);
+    this.setConfigIfNotExists(ctx, FrontendConfigInfo.StorageName, config.storageName);
 
     await ProgressHelper.endProvisionProgress();
     Logger.info(Messages.EndProvision(PluginInfo.DisplayName));
-    return ok(this.config);
+    return ok(undefined);
   }
 
   public async postProvision(ctx: PluginContext): Promise<TeamsFxResult> {
@@ -187,21 +181,21 @@ export class FrontendPluginImpl {
       );
     }
 
-    return ok(this.config);
+    return ok(undefined);
   }
 
   public async preDeploy(ctx: PluginContext): Promise<TeamsFxResult> {
     Logger.info(Messages.StartPreDeploy(PluginInfo.DisplayName));
     const progressHandler = await ProgressHelper.createPreDeployProgressHandler(ctx);
 
-    this.config = await FrontendConfig.fromPluginContext(ctx);
-    this.azureStorageClient = new AzureStorageClient(this.config);
+    const config = await FrontendConfig.fromPluginContext(ctx);
+    const client = new AzureStorageClient(config);
 
     await progressHandler?.next(PreDeploySteps.CheckStorage);
 
     const resourceGroupExists: boolean = await runWithErrorCatchAndThrow(
       new CheckResourceGroupError(),
-      async () => await this.azureStorageClient!.doesResourceGroupExists()
+      async () => await client.doesResourceGroupExists()
     );
     if (!resourceGroupExists) {
       throw new NoResourceGroupError();
@@ -209,7 +203,7 @@ export class FrontendPluginImpl {
 
     const storageExists: boolean = await runWithErrorCatchAndThrow(
       new CheckStorageError(),
-      async () => await this.azureStorageClient!.doesStorageAccountExists()
+      async () => await client.doesStorageAccountExists()
     );
     if (!storageExists) {
       throw new NoStorageError();
@@ -217,7 +211,7 @@ export class FrontendPluginImpl {
 
     const storageAvailable: boolean | undefined = await runWithErrorCatchAndThrow(
       new CheckStorageError(),
-      async () => await this.azureStorageClient!.isStorageStaticWebsiteEnabled()
+      async () => await client.isStorageStaticWebsiteEnabled()
     );
     if (!storageAvailable) {
       throw new StaticWebsiteDisabledError();
@@ -225,17 +219,15 @@ export class FrontendPluginImpl {
 
     ProgressHelper.endPreDeployProgress();
     Logger.info(Messages.EndPreDeploy(PluginInfo.DisplayName));
-    return ok(this.config);
+    return ok(undefined);
   }
 
   public async deploy(ctx: PluginContext): Promise<TeamsFxResult> {
     Logger.info(Messages.StartDeploy(PluginInfo.DisplayName));
     await ProgressHelper.startDeployProgressHandler(ctx);
 
-    const client = this.azureStorageClient;
-    if (!client) {
-      throw new NoPreStepError();
-    }
+    const config = await FrontendConfig.fromPluginContext(ctx);
+    const client = new AzureStorageClient(config);
 
     const componentPath: string = path.join(ctx.root, FrontendPathInfo.WorkingDir);
 
@@ -244,6 +236,6 @@ export class FrontendPluginImpl {
 
     await ProgressHelper.endDeployProgress();
     Logger.info(Messages.EndDeploy(PluginInfo.DisplayName));
-    return ok(this.config);
+    return ok(undefined);
   }
 }

--- a/packages/fx-core/src/plugins/resource/frontend/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/plugin.ts
@@ -1,14 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import {
-  PluginContext,
-  ok,
-  QTreeNode,
-  NodeType,
-  Stage,
-  Result,
-  FxError,
-} from "@microsoft/teamsfx-api";
+import { PluginContext, ok } from "@microsoft/teamsfx-api";
 import path from "path";
 
 import { AzureStorageClient } from "./clients";
@@ -65,14 +57,6 @@ export class FrontendPluginImpl {
       return;
     }
     ctx.config.set(key, value);
-  }
-
-  public getQuestions(stage: Stage, _ctx: PluginContext): Result<QTreeNode | undefined, FxError> {
-    const res = new QTreeNode({
-      type: NodeType.group,
-    });
-
-    return ok(res);
   }
 
   public async scaffold(ctx: PluginContext): Promise<TeamsFxResult> {
@@ -246,7 +230,7 @@ export class FrontendPluginImpl {
 
   public async deploy(ctx: PluginContext): Promise<TeamsFxResult> {
     Logger.info(Messages.StartDeploy(PluginInfo.DisplayName));
-    const progressHandler = await ProgressHelper.startDeployProgressHandler(ctx);
+    await ProgressHelper.startDeployProgressHandler(ctx);
 
     const client = this.azureStorageClient;
     if (!client) {

--- a/packages/fx-core/src/plugins/resource/frontend/resources/messages.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/resources/messages.ts
@@ -12,7 +12,7 @@ export class Messages {
   static readonly ProgressScaffold = "Scaffolding Tab frontend project.";
   static readonly ProgressCreateStorage = "Creating Azure Storage account.";
   static readonly ProgressConfigure = "Configuring.";
-  static readonly ProgressNPMInstall = 'Running "npm install" for Tab frontend project.';
+  static readonly ProgressNPMInstall = `Running "npm install" for Tab frontend project.`;
   static readonly ProgressBuild = "Building Tab frontend project.";
   static readonly ProgressCheckStorage = "Checking Azure Storage account availability.";
   static readonly ProgressGetSrcAndDest = "Retrieving deployment source and destination.";

--- a/packages/fx-core/src/plugins/resource/frontend/resources/templateInfo.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/resources/templateInfo.ts
@@ -13,8 +13,8 @@ export interface TemplateVariable {
 }
 
 export class TabLanguage {
-  static readonly JavaScript = "JavaScript";
-  static readonly TypeScript = "TypeScript";
+  static readonly JavaScript = "javascript";
+  static readonly TypeScript = "typescript";
 }
 
 export class Scenario {
@@ -55,19 +55,17 @@ export class TemplateInfo {
     this.localTemplateBaseName = [this.group, this.language, this.scenario].join(".");
     this.localTemplatePath = path.join(
       getTemplatesFolder(),
-      "plugins",
-      "resource",
-      "frontend",
+      FrontendPathInfo.TemplateDir,
       this.localTemplateBaseName + FrontendPathInfo.TemplatePackageExt
     );
   }
 
   private validateTabLanguage(language: string): string {
-    if (language.toLowerCase() === TabLanguage.JavaScript.toLowerCase()) {
+    if (language.toLowerCase() === TabLanguage.JavaScript) {
       return "js";
     }
 
-    if (language.toLowerCase() === TabLanguage.TypeScript.toLowerCase()) {
+    if (language.toLowerCase() === TabLanguage.TypeScript) {
       return "ts";
     }
 

--- a/packages/fx-core/tests/plugins/resource/frontend/helper.ts
+++ b/packages/fx-core/tests/plugins/resource/frontend/helper.ts
@@ -147,19 +147,6 @@ export class TestHelper {
     return new AzureStorageClient(config);
   }
 
-  static async initializedFrontendPlugin(
-    frontendPlugin: FrontendPlugin,
-    pluginContext: PluginContext
-  ): Promise<FrontendPlugin> {
-    const config = await TestHelper.getFakeFrontendConfig(pluginContext);
-    frontendPlugin.frontendPluginImpl.config = config;
-
-    frontendPlugin.frontendPluginImpl.azureStorageClient =
-      await TestHelper.getFakeAzureStorageClient(pluginContext);
-
-    return frontendPlugin;
-  }
-
   static candidateTag = templates.tagPrefix + templates.templatesVersion.replace(/\*/g, "0");
   static targetTag = templates.tagPrefix + templates.templatesVersion.replace(/\*/g, "1");
   static templateCompose = "a.b.c";

--- a/packages/fx-core/tests/plugins/resource/frontend/unit/index.test.ts
+++ b/packages/fx-core/tests/plugins/resource/frontend/unit/index.test.ts
@@ -51,10 +51,7 @@ describe("frontendPlugin", () => {
 
     beforeEach(async () => {
       pluginContext = TestHelper.getFakePluginContext();
-      frontendPlugin = await TestHelper.initializedFrontendPlugin(
-        new FrontendPlugin(),
-        pluginContext
-      );
+      frontendPlugin = new FrontendPlugin();
     });
 
     afterEach(() => {
@@ -78,10 +75,7 @@ describe("frontendPlugin", () => {
 
     beforeEach(async () => {
       pluginContext = TestHelper.getFakePluginContext();
-      frontendPlugin = await TestHelper.initializedFrontendPlugin(
-        new FrontendPlugin(),
-        pluginContext
-      );
+      frontendPlugin = new FrontendPlugin();
     });
 
     afterEach(() => {
@@ -96,9 +90,6 @@ describe("frontendPlugin", () => {
       );
 
       chai.assert.isTrue(result.isOk());
-      result.map((config) => {
-        chai.assert.isTrue(/^[a-z0-9]{1,16}fe[a-z0-9]{6}$/.test(config.storageName!));
-      });
     });
 
     it("resource group not exists", async () => {
@@ -119,10 +110,7 @@ describe("frontendPlugin", () => {
 
     beforeEach(async () => {
       pluginContext = TestHelper.getFakePluginContext();
-      frontendPlugin = await TestHelper.initializedFrontendPlugin(
-        new FrontendPlugin(),
-        pluginContext
-      );
+      frontendPlugin = new FrontendPlugin();
 
       createStorageAccountStub = sinon
         .stub(StorageAccounts.prototype, "create")
@@ -187,10 +175,7 @@ describe("frontendPlugin", () => {
     beforeEach(async () => {
       pluginContext = TestHelper.getFakePluginContext();
       pluginContext.config.set(FrontendConfigInfo.Endpoint, TestHelper.storageEndpoint);
-      frontendPlugin = await TestHelper.initializedFrontendPlugin(
-        new FrontendPlugin(),
-        pluginContext
-      );
+      frontendPlugin = new FrontendPlugin();
     });
 
     afterEach(() => {
@@ -216,7 +201,6 @@ describe("frontendPlugin", () => {
     beforeEach(async () => {
       frontendPlugin = new FrontendPlugin();
       pluginContext = TestHelper.getFakePluginContext();
-      frontendPlugin = await TestHelper.initializedFrontendPlugin(frontendPlugin, pluginContext);
 
       staticWebsiteEnabledStub = sinon
         .stub(AzureStorageClient.prototype, "isStorageStaticWebsiteEnabled")
@@ -262,7 +246,6 @@ describe("frontendPlugin", () => {
     beforeEach(async () => {
       frontendPlugin = new FrontendPlugin();
       pluginContext = TestHelper.getFakePluginContext();
-      frontendPlugin = await TestHelper.initializedFrontendPlugin(frontendPlugin, pluginContext);
       sinon.stub(AzureStorageClient.prototype, "getContainer").resolves({} as any);
       sinon.stub(AzureStorageClient.prototype, "deleteAllBlobs").resolves();
       sinon.stub(AzureStorageClient.prototype, "uploadFiles").resolves();
@@ -280,14 +263,6 @@ describe("frontendPlugin", () => {
     it("happy path", async () => {
       const result = await frontendPlugin.deploy(pluginContext);
       chai.assert.isTrue(result.isOk());
-    });
-
-    it("no deployment parameters", async () => {
-      frontendPlugin = new FrontendPlugin();
-
-      const result = await frontendPlugin.deploy(pluginContext);
-
-      assertError(result, new NoPreStepError().code);
     });
 
     it("local path does not exists", async () => {

--- a/packages/fx-core/tests/plugins/resource/frontend/unit/index.test.ts
+++ b/packages/fx-core/tests/plugins/resource/frontend/unit/index.test.ts
@@ -123,7 +123,7 @@ describe("frontendPlugin", () => {
     });
 
     it("happy path", async () => {
-      const hostname = new URL(TestHelper.storageEndpoint).hostname;
+      const domain = new URL(TestHelper.storageEndpoint).hostname;
 
       const result = await frontendPlugin.provision(pluginContext);
 
@@ -132,7 +132,7 @@ describe("frontendPlugin", () => {
         pluginContext.config.get(FrontendConfigInfo.Endpoint),
         TestHelper.storageEndpoint
       );
-      chai.assert.equal(pluginContext.config.get(FrontendConfigInfo.Hostname), hostname);
+      chai.assert.equal(pluginContext.config.get(FrontendConfigInfo.Domain), domain);
     });
 
     it("Create storage throw error", async () => {

--- a/packages/fx-core/tests/plugins/resource/frontend/unit/scaffold.test.ts
+++ b/packages/fx-core/tests/plugins/resource/frontend/unit/scaffold.test.ts
@@ -70,9 +70,8 @@ describe("FrontendScaffold", () => {
   describe("getTemplateZip", () => {
     before(() => {
       const config: any = {};
-      config[
-        path.join(getTemplatesFolder(), "plugins", "resource", "frontend", `tab.js.default.zip`)
-      ] = new AdmZip().toBuffer();
+      config[path.join(getTemplatesFolder(), FrontendPathInfo.TemplateDir, `tab.js.default.zip`)] =
+        new AdmZip().toBuffer();
       mock(config);
     });
 


### PR DESCRIPTION
1. Make frontend plugin stateless.
2. Remove useless codes and comments.
3. Sync config to context, make it easier to add new persistent configs.