### PR TITLE
fix(function): avoid to configure function app twice in second run

### DIFF
--- a/packages/fx-core/src/plugins/resource/function/enums.ts
+++ b/packages/fx-core/src/plugins/resource/function/enums.ts
@@ -30,6 +30,7 @@ export enum FunctionConfigKey {
   /* Intermediate  */
   functionName = "functionName",
   skipDeploy = "skipDeploy",
+  site = "site",
 }
 
 export enum QuestionKey {

--- a/packages/fx-core/src/plugins/resource/function/ops/provision.ts
+++ b/packages/fx-core/src/plugins/resource/function/ops/provision.ts
@@ -75,7 +75,15 @@ export class FunctionProvision {
       },
     };
 
-    return AzureLib.ensureFunctionApp(client, resourceGroupName, functionAppName, siteEnvelope);
+    const site = await AzureLib.ensureFunctionApp(client, resourceGroupName, functionAppName, siteEnvelope);
+
+    // The ensureFunctionApp may return a site found on Azure,
+    // we need to return a site with updated settings for post provision.
+    settings.forEach(pair => {
+      pair.name && pair.value && this.pushAppSettings(site, pair.name, pair.value);
+    });
+
+    return site;
   }
 
   // TODO: Extend to support multiple language and versions.
@@ -97,7 +105,7 @@ export class FunctionProvision {
   }
 
   // Push AppSettings when it is not included.
-  private static pushAppSettings(
+  public static pushAppSettings(
     site: Site,
     newName: string,
     newValue: string,

--- a/packages/fx-core/src/plugins/resource/function/resources/steps.ts
+++ b/packages/fx-core/src/plugins/resource/function/resources/steps.ts
@@ -16,7 +16,6 @@ export enum ProvisionSteps {
 }
 
 export enum PostProvisionSteps {
-  findFunctionApp = "Retrieving settings.",
   updateFunctionSettings = "Updating settings.",
   updateFunctionAuthSettings = "Updating auth settings.",
 }

--- a/packages/fx-core/src/plugins/resource/function/utils/azure-client.ts
+++ b/packages/fx-core/src/plugins/resource/function/utils/azure-client.ts
@@ -148,8 +148,9 @@ export class AzureLib {
     functionAppName: string,
     siteEnvelope: Site
   ): Promise<Site> {
-    return this.ensureResource<Site>(() =>
-      client.webApps.createOrUpdate(resourceGroupName, functionAppName, siteEnvelope)
+    return this.ensureResource<Site>(
+      () => client.webApps.createOrUpdate(resourceGroupName, functionAppName, siteEnvelope),
+      () => this.findFunctionApp(client, resourceGroupName, functionAppName)
     );
   }
 }


### PR DESCRIPTION
An issue is that function app's settings will be updated at provision and post-provision.
So there is an intermediate stage during the provision. If user stop the process in the stage at second run, the env will break.

To avoid, in this PR, we don't update in the provision stage at second run.
We pass the setting to post stage, and update the app settings only in post provision.
