### PR TITLE
fix(local-debug): kill tasks via SIGTERM rather than SIGINT

### DIFF
--- a/packages/vscode-extension/src/debug/teamsfxTaskHandler.ts
+++ b/packages/vscode-extension/src/debug/teamsfxTaskHandler.ts
@@ -105,7 +105,7 @@ function onDidStartDebugSessionHandler(event: vscode.DebugSession): void {
 export function terminateAllRunningTeamsfxTasks(): void {
   for (const task of allRunningTeamsfxTasks) {
     try {
-      process.kill(task[1], "SIGINT");
+      process.kill(task[1], "SIGTERM");
     } catch (e) {
       // ignore and keep killing others
     }


### PR DESCRIPTION
To fix: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/9999085/.

For linux/wsl, if the default shell is not bash, the root process of shell execution tasks will be the shell process. However, kill the tasks via SIGINT will not terminate the shell process, causing the tasks not terminated when stop debugging.