### PR TITLE
test(env-checker): add backend extension install nuget test cases

### DIFF
--- a/packages/vscode-extension/test/suite/envChecker/cases/all.ts
+++ b/packages/vscode-extension/test/suite/envChecker/cases/all.ts
@@ -12,15 +12,13 @@ import { DepsChecker } from "../../../../src/debug/depsChecker/checker";
 import { TestAdapter } from "../adapters/testAdapter";
 import { logger } from "../adapters/testLogger";
 import { TestTelemetry } from "../adapters/testTelemetry";
-import { commandExistsInPath, createTmpDir, isNonEmptyDir } from "../utils/common";
+import { commandExistsInPath, isNonEmptyDir } from "../utils/common";
+import { azureSupportedNodeVersions } from "../utils/node";
+import { testCsprojFileName, testOutputDirName } from "../utils/backendExtensionsInstaller";
 import { isLinux } from "../../../../src/debug/depsChecker/common";
 import { AzureNodeChecker } from "../../../../src/debug/depsChecker/azureNodeChecker";
 import { BackendExtensionsInstaller } from "../../../../src/debug/depsChecker/backendExtensionsInstall";
 chai.use(chaiAsPromised);
-
-const azureSupportedNodeVersions = ["10", "12", "14"];
-const testCsprojFileName = "extensions.csproj";
-const testOutputDirName = "bin";
 
 function createTestChecker(
   hasTeamsfxBackend: boolean,

--- a/packages/vscode-extension/test/suite/envChecker/cases/backendExtensionsInstaller.ts
+++ b/packages/vscode-extension/test/suite/envChecker/cases/backendExtensionsInstaller.ts
@@ -1,0 +1,120 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as path from "path";
+import * as chai from "chai";
+import * as dotnetUtils from "../utils/dotnet";
+import * as chaiAsPromised from "chai-as-promised";
+import { DotnetChecker } from "../../../../src/debug/depsChecker/dotnetChecker";
+import { TestAdapter } from "../adapters/testAdapter";
+import { logger } from "../adapters/testLogger";
+import { TestTelemetry } from "../adapters/testTelemetry";
+import { isNonEmptyDir } from "../utils/common";
+import {
+  addDotnetNugetSource,
+  createDotnetNugetConfig,
+  listDotnetNugetSource,
+  testCsprojFileName,
+  testOutputDirName,
+} from "../utils/backendExtensionsInstaller";
+import { BackendExtensionsInstaller } from "../../../../src/debug/depsChecker/backendExtensionsInstall";
+chai.use(chaiAsPromised);
+
+function createTestBackendExtensionsInstaller(): [DotnetChecker, BackendExtensionsInstaller] {
+  const testAdapter = new TestAdapter(true, false, true);
+  const telemetry = new TestTelemetry();
+  const dotnetChecker = new DotnetChecker(testAdapter, logger, telemetry);
+  const backendExtensionsInstaller = new BackendExtensionsInstaller(dotnetChecker, logger);
+  return [dotnetChecker, backendExtensionsInstaller];
+}
+
+suite("Backend extensions installer E2E test", async () => {
+  // setup a backend project dir with extensions.csproj
+  let backendProjectDir: string;
+  let backendOutputPath: string;
+  let cleanupProjectDir: () => void;
+  setup(async function (this: Mocha.Context) {
+    [backendProjectDir, cleanupProjectDir] = await dotnetUtils.createTmpBackendProjectDir(
+      testCsprojFileName
+    );
+    backendOutputPath = path.resolve(backendProjectDir, testOutputDirName);
+
+    await dotnetUtils.cleanup();
+  });
+
+  test("Backend extensions install when .NET SDK is installed", async function (this: Mocha.Context) {
+    // make sure .NET SDK are installed
+    if (
+      !(await dotnetUtils.hasAnyDotnetVersions(
+        dotnetUtils.dotnetCommand,
+        dotnetUtils.dotnetSupportedVersions
+      ))
+    ) {
+      this.skip();
+    }
+
+    const [dotnetChecker, backendExtensionsInstaller] = createTestBackendExtensionsInstaller();
+    chai.assert.isTrue(await dotnetChecker.isInstalled());
+    const dotnetExecPath = await dotnetChecker.getDotnetExecPath();
+    chai.assert.isNotNull(dotnetExecPath);
+    chai.assert.isTrue(
+      await dotnetUtils.hasAnyDotnetVersions(dotnetExecPath!, dotnetUtils.dotnetSupportedVersions)
+    );
+
+    // setup nuget config to prevent affecting the tester's local environment
+    await createDotnetNugetConfig(dotnetExecPath, backendProjectDir);
+
+    chai.assert.isFalse(await isNonEmptyDir(backendOutputPath));
+    await backendExtensionsInstaller.install(
+      backendProjectDir,
+      testCsprojFileName,
+      testOutputDirName
+    );
+    chai.assert.isTrue(await isNonEmptyDir(backendOutputPath));
+  });
+
+  test("Broken NuGet sources", async function (this: Mocha.Context) {
+    // make sure .NET SDK are installed
+    if (
+      !(await dotnetUtils.hasAnyDotnetVersions(
+        dotnetUtils.dotnetCommand,
+        dotnetUtils.dotnetSupportedVersions
+      ))
+    ) {
+      this.skip();
+    }
+
+    const [dotnetChecker, backendExtensionsInstaller] = createTestBackendExtensionsInstaller();
+    chai.assert.isTrue(await dotnetChecker.isInstalled());
+    const dotnetExecPath = await dotnetChecker.getDotnetExecPath();
+    chai.assert.isNotNull(dotnetExecPath);
+    chai.assert.isTrue(
+      await dotnetUtils.hasAnyDotnetVersions(dotnetExecPath!, dotnetUtils.dotnetSupportedVersions)
+    );
+
+    // setup nuget config to prevent affecting the tester's local environment
+    await createDotnetNugetConfig(dotnetExecPath, backendProjectDir);
+    // setup a broken nuget source
+    await addDotnetNugetSource(
+      dotnetExecPath,
+      backendProjectDir,
+      "fail",
+      "https://this.does.not.exist"
+    );
+    // log the output of list nuget source
+    await listDotnetNugetSource(dotnetExecPath, backendProjectDir);
+
+    chai.assert.isFalse(await isNonEmptyDir(backendOutputPath));
+    await backendExtensionsInstaller.install(
+      backendProjectDir,
+      testCsprojFileName,
+      testOutputDirName
+    );
+    chai.assert.isTrue(await isNonEmptyDir(backendOutputPath));
+  });
+
+  teardown(async function (this: Mocha.Context) {
+    await dotnetUtils.cleanup();
+    cleanupProjectDir();
+  });
+});

--- a/packages/vscode-extension/test/suite/envChecker/utils/backendExtensionsInstaller.ts
+++ b/packages/vscode-extension/test/suite/envChecker/utils/backendExtensionsInstaller.ts
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { cpUtils } from "../../../../src/debug/depsChecker/cpUtils";
+import { logger } from "../adapters/testLogger";
+
+export const testCsprojFileName = "extensions.csproj";
+export const testOutputDirName = "bin";
+
+export async function createDotnetNugetConfig(dotnetExecPath: string, dir: string): Promise<void> {
+  await cpUtils.executeCommand(
+    undefined,
+    logger,
+    { cwd: dir },
+    dotnetExecPath,
+    "new",
+    "nugetConfig"
+  );
+}
+
+export async function addDotnetNugetSource(
+  dotnetExecPath: string,
+  dir: string,
+  name: string,
+  nugetSource: string
+) {
+  await cpUtils.executeCommand(
+    undefined,
+    logger,
+    { cwd: dir },
+    dotnetExecPath,
+    "nuget",
+    "add",
+    "source",
+    "-n",
+    name,
+    nugetSource
+  );
+}
+
+export async function listDotnetNugetSource(dotnetExecPath: string, dir: string): Promise<string> {
+  return await cpUtils.executeCommand(
+    undefined,
+    logger,
+    { cwd: dir },
+    dotnetExecPath,
+    "nuget",
+    "list",
+    "source"
+  );
+}

--- a/packages/vscode-extension/test/suite/envChecker/utils/node.ts
+++ b/packages/vscode-extension/test/suite/envChecker/utils/node.ts
@@ -3,6 +3,8 @@
 
 import { cpUtils } from "../../../../src/debug/depsChecker/cpUtils";
 
+export const azureSupportedNodeVersions = ["10", "12", "14"];
+
 export async function getNodeVersion(): Promise<string | null> {
   const nodeVersionRegex = /v(?<major_version>\d+)\.(?<minor_version>\d+)\.(?<patch_version>\d+)/gm;
   try {


### PR DESCRIPTION
Add standalone test cases for backend extension installer.

Add 2 test cases:
- Run BackendExtensionInstaller when .NET SDK is installed
- Run BackendExtensionInstaller when the user has some broken nuget source in the global .NET SDK.

---

ADO task: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/9769204/