### PR TITLE
feat(local-debug): improve the timing to switch active terminal

### DIFF
--- a/packages/vscode-extension/src/debug/teamsfxTaskHandler.ts
+++ b/packages/vscode-extension/src/debug/teamsfxTaskHandler.ts
@@ -57,6 +57,16 @@ function isTeamsfxTask(task: vscode.Task): boolean {
   return false;
 }
 
+function displayTerminal(taskName: string): boolean {
+  const terminal = vscode.window.terminals.find(t => t.name === taskName);
+  if (terminal !== undefined && terminal !== vscode.window.activeTerminal) {
+    terminal.show(true);
+    return true;
+  }
+
+  return false;
+}
+
 function onDidStartTaskProcessHandler(event: vscode.TaskProcessStartEvent): void {
   if (ext.workspaceUri && isWorkspaceSupported(ext.workspaceUri.fsPath)) {
     const task = event.execution.task;
@@ -73,21 +83,24 @@ function onDidStartTaskProcessHandler(event: vscode.TaskProcessStartEvent): void
 
 function onDidEndTaskProcessHandler(event: vscode.TaskProcessEndEvent): void {
   const task = event.execution.task;
+  const activeTerminal = vscode.window.activeTerminal;
+
   if (task.scope !== undefined && isTeamsfxTask(task)) {
     allRunningTeamsfxTasks.delete({ source: task.source, name: task.name, scope: task.scope });
   } else if (isNpmInstallTask(task)) {
     activeNpmInstallTasks.delete(task.name);
-    // when the task in the active terminal is ended.
-    // TODO: only when the task is ended successfully.
-    if (vscode.window.activeTerminal?.name === task.name) {
+
+    if (activeTerminal?.name === task.name && event.exitCode === 0) {
+      // when the task in active terminal is ended successfully.
       for (const hiddenTaskName of activeNpmInstallTasks) {
-        // show the first hiden terminal.
-        const hiddenTerminal = vscode.window.terminals.find(t => t.name === hiddenTaskName);
-        if (hiddenTerminal !== undefined) {
-          hiddenTerminal.show(true);
+        // display the first hidden terminal.
+        if (displayTerminal(hiddenTaskName)) {
           return;
         }
       }
+    } else if (activeTerminal?.name !== task.name && event.exitCode !== 0) {
+      // when the task in hidden terminal failed to execute.
+      displayTerminal(task.name);
     }
   }
 }


### PR DESCRIPTION
Improve the timing to switch active terminal for npm-install tasks:
* when the task in **active** terminal is ended **successfully**, switch terminal to show the hidden running task.
* when the task in **hidden** terminal **failed** to execute, switch terminal to show the hidden failure task.

----
Assumed there're two npm-install tasks running in parallel:
1. frontend npm install (active terminal)
2. backend npm install (hidden terminal)

**scenario 1**: task-1 completed successfully, task-2 is still running.
**behavior**: the terminal for task-2 will be displayed.

**scenario 2**: task-1 is still running, task-2 is failed to executed.
**behavior**: the terminal for task-2 will be displayed.

**scenario 3**: task-1 is failed to executed, task-2 is still running.
**behavior**: nothing changes.

**scenario 4**: task-1 is failed to executed, then task-2 is failed to executed either.
**behavior**: the terminal for task-2 will be displayed after task-2 is failed. (so user can be aware of both of the failure tasks.)

----

related PR: https://github.com/OfficeDev/TeamsFx/pull/1189