### PR TITLE
fix: update status when play video

### DIFF
--- a/packages/vscode-extension/src/controls/QuickStart.tsx
+++ b/packages/vscode-extension/src/controls/QuickStart.tsx
@@ -270,6 +270,7 @@ export default class QuickStart extends React.Component<any, any> {
                   className="capabilitiesVideo"
                   controls
                   disablePictureInPicture
+                  onPlay={this.onWatchVideo}
                 >
                   <source src="https://aka.ms/teamsfx-video"></source>
                 </video>
@@ -279,6 +280,7 @@ export default class QuickStart extends React.Component<any, any> {
                     className="watchOnBrowser"
                     href="https://aka.ms/teamsfx-video"
                     target="_blank"
+                    onClick={this.onWatchVideo}
                   >
                     Watch on browser
                   </a>


### PR DESCRIPTION
Update status when user click `Play` in the video, or click `Watch in the browser`.