### PR TITLE
test(env-checker): add validation after installing .NET SDK for testing

### DIFF
--- a/packages/vscode-extension/test/suite/envChecker/utils/dotnet.ts
+++ b/packages/vscode-extension/test/suite/envChecker/utils/dotnet.ts
@@ -104,6 +104,10 @@ export async function withDotnet(
     await dotnetChecker["runDotnetInstallScript"](version, installDir);
     const dotnetExecPath = DotnetChecker["getDotnetExecPathFromDotnetInstallationDir"](installDir);
 
+    if (!await hasDotnetVersion(dotnetExecPath, version)) {
+      throw new Error(`Failed to install .NET SDK version '${version}' for testing, dotnetExecPath = '${dotnetExecPath}'`);
+    }
+
     if (addToPath) {
       process.env.PATH =
         path.resolve(dotnetExecPath, "..") + (isWindows() ? ";" : ":") + process.env.PATH;


### PR DESCRIPTION
As you can see in this PR GitHub Action error report: https://github.com/OfficeDev/TeamsFx/runs/2691126542?check_suite_focus=true

This error output is kind of confusing. The actual reason is the change in this PR breaks the install logic on Linux/macOS. But from the error message, it is hard to determine the actual reason. 

```
  2) DotnetChecker E2E Test - second run
       Invalid dotnet.json file and .NET SDK installed:
     Error: ENOENT: no such file or directory, lstat '/this'
  	at Object.realpathSync (fs.js:1728:7)
  	at Object.realpathSync (electron/js2c/asar_bundle.js:5:4607)
  	at Object.assertPathEqual (out/test/suite/envChecker/utils/common.js:37:26)
  	at Context.<anonymous> (out/test/suite/envChecker/cases/dotnet.js:282:26)
  	at Generator.next (<anonymous>)
  	at fulfilled (out/test/suite/envChecker/cases/dotnet.js:7:58)
```


So add an validation step after installing .NET SDK for testing to fail early.