### PR TITLE
feat(local-debug): show message once react starts before browser started

### DIFF
--- a/packages/vscode-extension/src/debug/teamsfxTaskHandler.ts
+++ b/packages/vscode-extension/src/debug/teamsfxTaskHandler.ts
@@ -79,7 +79,7 @@ function onDidStartTaskProcessHandler(event: vscode.TaskProcessStartEvent): void
       );
       // NOTE: trigger task via "Terminal -> Run Task..." will not enter this flow since the task name will be "teamsfx: frontend start"
       if (task.name === constants.frontendStartCommand) {
-        vscode.window.showInformationMessage(StringResources.vsc.localDebug.waitForBrowserStarted);
+        vscode.window.showInformationMessage(StringResources.vsc.localDebug.waitForBrowserToStart);
       }
     } else if (isNpmInstallTask(task)) {
       activeNpmInstallTasks.add(task.name);

--- a/packages/vscode-extension/src/debug/teamsfxTaskHandler.ts
+++ b/packages/vscode-extension/src/debug/teamsfxTaskHandler.ts
@@ -9,6 +9,8 @@ import { ext } from "../extensionVariables";
 import { ExtTelemetry } from "../telemetry/extTelemetry";
 import { TelemetryEvent, TelemetryProperty } from "../telemetry/extTelemetryEvents";
 import { isWorkspaceSupported, getTeamsAppId } from "../utils/commonUtils";
+import * as constants from "./constants";
+import * as StringResources from "../resources/Strings.json";
 
 interface IRunningTeamsfxTask {
   source: string;
@@ -75,6 +77,10 @@ function onDidStartTaskProcessHandler(event: vscode.TaskProcessStartEvent): void
         { source: task.source, name: task.name, scope: task.scope },
         event.processId
       );
+      // NOTE: trigger task via "Terminal -> Run Task..." will not enter this flow since the task name will be "teamsfx: frontend start"
+      if (task.name === constants.frontendStartCommand) {
+        vscode.window.showInformationMessage(StringResources.vsc.localDebug.waitForBrowserStarted);
+      }
     } else if (isNpmInstallTask(task)) {
       activeNpmInstallTasks.add(task.name);
     }

--- a/packages/vscode-extension/src/resources/Strings.json
+++ b/packages/vscode-extension/src/resources/Strings.json
@@ -107,7 +107,8 @@
     },
     "localDebug": {
       "portAlreadyInUse": "Port: %s is already in use. Close this port and try again.",
-      "portsAlreadyInUse": "Ports: %s are already in use. Close these ports and try again."
+      "portsAlreadyInUse": "Ports: %s are already in use. Close these ports and try again.",
+      "waitForBrowserStarted": "Please wait while the toolkit is starting your browser..."
     },
     "survey": {
       "takeSurvey": {

--- a/packages/vscode-extension/src/resources/Strings.json
+++ b/packages/vscode-extension/src/resources/Strings.json
@@ -108,7 +108,7 @@
     "localDebug": {
       "portAlreadyInUse": "Port: %s is already in use. Close this port and try again.",
       "portsAlreadyInUse": "Ports: %s are already in use. Close these ports and try again.",
-      "waitForBrowserStarted": "Please wait while the toolkit is starting your browser..."
+      "waitForBrowserToStart": "Please wait while the toolkit is starting your browser..."
     },
     "survey": {
       "takeSurvey": {


### PR DESCRIPTION
show information message once react starts before browser started, telling user to wait for the browser to start.

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/9712275

Preview:
![image](https://user-images.githubusercontent.com/37978464/120137841-c627f880-c207-11eb-967d-c5bd54faa41b.png)
