### PR TITLE
test(env-checker): fix skip condition for existing .NET SDK test case

### DIFF
--- a/packages/vscode-extension/test/suite/envChecker/cases/dotnet.ts
+++ b/packages/vscode-extension/test/suite/envChecker/cases/dotnet.ts
@@ -97,7 +97,7 @@ suite("DotnetChecker E2E Test - first run", async () => {
   });
 
   test(".NET SDK is not installed and the user homedir contains special characters", async function (this: Mocha.Context) {
-    if (isLinux() && !(await commandExistsInPath(dotnetUtils.dotnetCommand))) {
+    if (isLinux() || (await commandExistsInPath(dotnetUtils.dotnetCommand))) {
       this.skip();
     }
 

--- a/packages/vscode-extension/test/suite/envChecker/utils/dotnet.ts
+++ b/packages/vscode-extension/test/suite/envChecker/utils/dotnet.ts
@@ -103,8 +103,10 @@ export async function withDotnet(
     await dotnetChecker["runDotnetInstallScript"](version, installDir);
     const dotnetExecPath = DotnetChecker["getDotnetExecPathFromDotnetInstallationDir"](installDir);
 
-    if (!await hasDotnetVersion(dotnetExecPath, version)) {
-      throw new Error(`Failed to install .NET SDK version '${version}' for testing, dotnetExecPath = '${dotnetExecPath}'`);
+    if (!(await hasDotnetVersion(dotnetExecPath, version))) {
+      throw new Error(
+        `Failed to install .NET SDK version '${version}' for testing, dotnetExecPath = '${dotnetExecPath}'`
+      );
     }
 
     if (addToPath) {


### PR DESCRIPTION
There is a bug causing a env-checker test case to fail when .NET SDK is installed on macOS or Windows. The PR triggered CI won't fail because this case is not covered in the PR triggered test. The schedule CI failed because of this bug.

This PR fixes:
- The skip condition is wrong. This description of this test case states that it is for cases where .NET SDK is installed.


[The failed schedule CI](https://github.com/OfficeDev/TeamsFx/actions/runs/894663114)

[The manually triggered successful CI after this fix](https://github.com/OfficeDev/TeamsFx/actions/runs/894846410)