### PR TITLE
chore(env-checker): add os-info to env-checker telemetry in extension

### DIFF
--- a/packages/vscode-extension/src/debug/depsChecker/vscodeTelemetry.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/vscodeTelemetry.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import * as os from "os";
 import { performance } from "perf_hooks";
 import { SystemError, UserError } from "@microsoft/teamsfx-api";
 import { TelemetryProperty } from "../../telemetry/extTelemetryEvents";
@@ -12,9 +13,7 @@ export class VSCodeTelemetry implements IDepsTelemetry {
   private readonly _telemetryComponentType = "extension:debug:envchecker";
 
   public sendEvent(eventName: DepsCheckerEvent, timecost?: number): void {
-    const properties: { [p: string]: string } = {
-      [TelemetryProperty.Component]: this._telemetryComponentType,
-    };
+    const properties = this.getBaseProperties();
 
     const measurements: { [p: string]: number } = {};
     if (timecost) {
@@ -37,9 +36,7 @@ export class VSCodeTelemetry implements IDepsTelemetry {
 
   public sendUserErrorEvent(eventName: DepsCheckerEvent, errorMessage: string): void {
     const error = new UserError(eventName, errorMessage, this._telemetryComponentType);
-    ExtTelemetry.sendTelemetryErrorEvent(eventName, error, {
-      [TelemetryProperty.Component]: this._telemetryComponentType,
-    });
+    ExtTelemetry.sendTelemetryErrorEvent(eventName, error, this.getBaseProperties());
   }
 
   public sendSystemErrorEvent(
@@ -53,9 +50,15 @@ export class VSCodeTelemetry implements IDepsTelemetry {
       this._telemetryComponentType,
       errorStack
     );
-    ExtTelemetry.sendTelemetryErrorEvent(eventName, error, {
+    ExtTelemetry.sendTelemetryErrorEvent(eventName, error, this.getBaseProperties());
+  }
+
+  private getBaseProperties(): { [p: string]: string } {
+    return {
       [TelemetryProperty.Component]: this._telemetryComponentType,
-    });
+      [TelemetryProperty.OSArch]: os.arch(),
+      [TelemetryProperty.OSRelease]: os.release(),
+    };
   }
 }
 

--- a/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
@@ -77,6 +77,8 @@ export enum TelemetryProperty {
   DebugAppId = "debug-appid",
   Internal = "internal",
   InternalAlias = "internal-alias",
+  OSArch = "os-arch",
+  OSRelease = "os-release",
 }
 
 export enum TelemetrySuccess {


### PR DESCRIPTION
- Add os.arch and os.release to telemetry properties.
- To detect some platforms:
    - os.arch == "arm64" for M1 macOS.
    - os.release contains "WSL" from Windows Subsystem for Linux. [From an official source](https://github.com/microsoft/WSL/issues/423#issuecomment-221627364). Example: `5.4.72-microsoft-standard-WSL2`

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_queries/query/2ef235af-bf64-4e1e-a595-f548ae6371d8/