### PR TITLE
fix(local-debug): set skipNgrok, trustDevCert to default value if undefined

### DIFF
--- a/packages/fx-core/src/plugins/resource/localdebug/index.ts
+++ b/packages/fx-core/src/plugins/resource/localdebug/index.ts
@@ -196,7 +196,7 @@ export class LocalDebugPlugin implements Plugin {
       (pluginName) => pluginName === FunctionPlugin.Name
     );
     const includeBot = selectedPlugins?.some((pluginName) => pluginName === BotPlugin.Name);
-    const skipNgrok = ctx.config?.get(LocalDebugConfigKeys.SkipNgrok) as string;
+    let skipNgrok = ctx.config?.get(LocalDebugConfigKeys.SkipNgrok) as string;
 
     const telemetryProperties = {
       platform: ctx.platform as string,
@@ -243,6 +243,10 @@ export class LocalDebugPlugin implements Plugin {
       }
 
       if (includeBot) {
+        if (skipNgrok === undefined) {
+          skipNgrok = "false";
+          ctx.config.set(LocalDebugConfigKeys.SkipNgrok, skipNgrok);
+        }
         if (skipNgrok?.trim().toLowerCase() === "true") {
           const localBotEndpoint = ctx.config.get(LocalDebugConfigKeys.LocalBotEndpoint) as string;
           if (localBotEndpoint === undefined) {
@@ -286,7 +290,7 @@ export class LocalDebugPlugin implements Plugin {
       (pluginName) => pluginName === FunctionPlugin.Name
     );
     const includeBot = selectedPlugins?.some((pluginName) => pluginName === BotPlugin.Name);
-    const trustDevCert = ctx.config?.get(
+    let trustDevCert = ctx.config?.get(
       LocalDebugConfigKeys.TrustDevelopmentCertificate
     ) as string;
 
@@ -381,8 +385,11 @@ export class LocalDebugPlugin implements Plugin {
 
         // local certificate
         try {
-          const needTrust =
-            trustDevCert === undefined || trustDevCert.trim().toLowerCase() === "true";
+          if (trustDevCert === undefined) {
+            trustDevCert = "true";
+            ctx.config.set(LocalDebugConfigKeys.TrustDevelopmentCertificate, trustDevCert);
+          }
+          const needTrust = trustDevCert.trim().toLowerCase() === "true";
           const certManager = new LocalCertificateManager(ctx);
           const localCert = await certManager.setupCertificate(needTrust);
           if (localCert) {


### PR DESCRIPTION
set `skipNgrok` and `trustDevCert` to default value if they are undefined on `localDebug` and `postLocalDebug`.

To fix: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/9941264