### PR TITLE
fix(tab): prevent creating credentials for each render

### DIFF
--- a/templates/tab/js/default/src/components/sample/Welcome.jsx
+++ b/templates/tab/js/default/src/components/sample/Welcome.jsx
@@ -39,10 +39,10 @@ export function Welcome(props) {
   });
 
   const { isInTeams } = useTeamsFx();
-  const credential = new TeamsUserCredential();
-  const userProfile = useData(async () =>
-    isInTeams ? await credential.getUserInfo() : undefined
-  )?.data;
+  const userProfile = useData(async () => {
+    const credential = new TeamsUserCredential();
+    return isInTeams ? await credential.getUserInfo() : undefined;
+  })?.data;
   const userName = userProfile ? userProfile.displayName : "";
   return (
     <div className="welcome page">

--- a/templates/tab/js/default/src/components/sample/lib/useGraph.js
+++ b/templates/tab/js/default/src/components/sample/lib/useGraph.js
@@ -1,14 +1,12 @@
-import { useRef } from "react";
 import { useData } from "./useData";
 import { TeamsUserCredential, createMicrosoftGraphClient } from "@microsoft/teamsfx";
 
 export function useGraph(asyncFunc, options) {
-  const credential = useRef(new TeamsUserCredential());
-
   const { scope } = { scope: ["User.Read"], ...options };
   const initial = useData(async () => {
     try {
-      const graph = createMicrosoftGraphClient(credential.current, scope);
+      const credential = new TeamsUserCredential();
+      const graph = createMicrosoftGraphClient(credential, scope);
       return await asyncFunc(graph);
     } catch (err) {
       if (err.code.includes("UiRequiredError")) {
@@ -21,8 +19,9 @@ export function useGraph(asyncFunc, options) {
 
   const { data, error, loading, reload } = useData(
     async () => {
-      await credential.current.login(scope);
-      const graph = createMicrosoftGraphClient(credential.current, scope);
+      const credential = new TeamsUserCredential();
+      await credential.login(scope);
+      const graph = createMicrosoftGraphClient(credential, scope);
       return await asyncFunc(graph);
     },
     { auto: false }

--- a/templates/tab/ts/default/src/components/sample/Welcome.tsx
+++ b/templates/tab/ts/default/src/components/sample/Welcome.tsx
@@ -39,10 +39,10 @@ export function Welcome(props: { showFunction?: boolean; environment?: string })
   });
 
   const { isInTeams } = useTeamsFx();
-  const credential = new TeamsUserCredential();
-  const userProfile = useData(async () =>
-    isInTeams ? await credential.getUserInfo() : undefined
-  )?.data;
+  const userProfile = useData(async () => {
+    const credential = new TeamsUserCredential();
+    return isInTeams ? await credential.getUserInfo() : undefined;
+  })?.data;
   const userName = userProfile ? userProfile.displayName : "";
   return (
     <div className="welcome page">

--- a/templates/tab/ts/default/src/components/sample/lib/useGraph.ts
+++ b/templates/tab/ts/default/src/components/sample/lib/useGraph.ts
@@ -1,4 +1,3 @@
-import { useRef } from "react";
 import { useData } from "./useData";
 import { TeamsUserCredential, createMicrosoftGraphClient } from "@microsoft/teamsfx";
 import { Client } from "@microsoft/microsoft-graph-client";
@@ -7,12 +6,11 @@ export function useGraph<T>(
   asyncFunc: (graph: Client) => Promise<T>,
   options?: { scope: string | string[] }
 ) {
-  const credential = useRef(new TeamsUserCredential());
-
   const { scope } = { scope: ["User.Read"], ...options };
   const initial = useData(async () => {
     try {
-      const graph = createMicrosoftGraphClient(credential.current, scope);
+      const credential = new TeamsUserCredential();
+      const graph = createMicrosoftGraphClient(credential, scope);
       return await asyncFunc(graph);
     } catch (err) {
       if (err.code.includes("UiRequiredError")) {
@@ -25,8 +23,9 @@ export function useGraph<T>(
 
   const { data, error, loading, reload } = useData(
     async () => {
-      await credential.current.login(scope);
-      const graph = createMicrosoftGraphClient(credential.current, scope);
+      const credential = new TeamsUserCredential();
+      await credential.login(scope);
+      const graph = createMicrosoftGraphClient(credential, scope);
       return await asyncFunc(graph);
     },
     { auto: false }


### PR DESCRIPTION
Duplicated log messages were shown in console since we new credentials for each react render.