### PR TITLE
fix: await flush CLI telemetry before exit

### DIFF
--- a/packages/cli/.vscode/launch.json
+++ b/packages/cli/.vscode/launch.json
@@ -21,6 +21,25 @@
         "${workspaceFolder}/../fx-core/build/**/*.js",
         "${workspaceFolder}/../api/build/**/*.js"
       ]
+    },
+    {
+      "type": "pwa-node",
+      "request": "launch",
+      "name": "Launch provision command (non-interactive)",
+      "skipFiles": ["<node_internals>/**"],
+      "program": "${workspaceFolder}/cli.js",
+      "args": ["provision", "--folder", "../../../teams/app001"],
+      "outFiles": [
+        "${workspaceFolder}/lib/**/*.js",
+        "${workspaceFolder}/../fx-core/build/**/*.js",
+        "${workspaceFolder}/../api/build/**/*.js"
+      ],
+      "resolveSourceMapLocations": [
+        "${workspaceFolder}/lib/**/*.js",
+        "${workspaceFolder}/../fx-core/build/**/*.js",
+        "${workspaceFolder}/../api/build/**/*.js"
+      ],
+      "console": "integratedTerminal"
     }
   ]
 }

--- a/packages/cli/src/commonlib/telemetry.ts
+++ b/packages/cli/src/commonlib/telemetry.ts
@@ -53,7 +53,7 @@ export class CliTelemetryReporter implements TelemetryReporter {
     this.reporter.sendTelemetryException(error, properties, measurements);
   }
 
-  flush(): void {
-    this.reporter.flush();
+  async flush(): Promise<void> {
+    await this.reporter.flush();
   }
 }

--- a/packages/cli/src/telemetry/cliTelemetry.ts
+++ b/packages/cli/src/telemetry/cliTelemetry.ts
@@ -105,8 +105,8 @@ export class CliTelemetry {
     CliTelemetry.reporter.withRootFolder(CliTelemetry.rootFolder).sendTelemetryException(error, properties, measurements);
   }
 
-  public flush(): void {
-    CliTelemetry.reporter.flush();
+  public async flush(): Promise<void> {
+    await CliTelemetry.reporter.flush();
   }
 }
 

--- a/packages/cli/src/telemetry/telemetryReporter.ts
+++ b/packages/cli/src/telemetry/telemetryReporter.ts
@@ -235,7 +235,6 @@ export default class TelemetryReporter {
       if (this.appInsightsClient) {
         this.appInsightsClient.flush({
           callback: () => {
-            this.appInsightsClient = undefined;
             resolve(void 0);
           },
         });

--- a/packages/cli/src/yargsCommand.ts
+++ b/packages/cli/src/yargsCommand.ts
@@ -89,10 +89,10 @@ export abstract class YargsCommand {
         CLILogProvider.necessaryLog(LogLevel.Error, FxError.stack || "undefined");
       }
 
-      CliTelemetryInstance.flush();
+      await CliTelemetryInstance.flush();
       exit(-1, FxError);
     }
 
-    CliTelemetryInstance.flush();
+    await CliTelemetryInstance.flush();
   }
 }


### PR DESCRIPTION
fix: await flush CLI telemetry before exit

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/10057991