### PR TITLE
docs(README): correct the documentation link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This repository contains the following packages:
 <br>
 
 ## Getting Started
-To start a Teams project with TeamsFx, see the Prerequisites section of [the documentation](https://aka.ms/teamsfx-install).
+To start a Teams project with TeamsFx, see the Prerequisites section of [the documentation](https://aka.ms/teamsfx-docs).
 
 ## Contributing
 


### PR DESCRIPTION
Correct the aka short link to point to the right documentation page: #1271