### PR TITLE
fix: start vsc will be asked to login Azure

### DIFF
--- a/packages/fx-core/src/core/index.ts
+++ b/packages/fx-core/src/core/index.ts
@@ -651,14 +651,6 @@ class CoreImpl implements Core {
         return ok(null);
       };
 
-      let azureAccountLabel = "Sign in to Azure";
-      let azureAccountContextValue = "signinAzure";
-      const token = await this.ctx.azureAccountProvider?.getAccountCredentialAsync();
-      if (token !== undefined) {
-        azureAccountLabel = (token as any).username ? (token as any).username : "";
-        azureAccountContextValue = "signedinAzure";
-      }
-
       this.ctx.appStudioToken?.setStatusChangeMap(
         "tree-view",
         (
@@ -767,12 +759,12 @@ class CoreImpl implements Core {
         },
         {
           commandId: "fx-extension.signinAzure",
-          label: azureAccountLabel,
+          label: "Sign in to Azure",
           callback: async (args?: any[]) => {
             return signinAzureCallback(supported, args);
           },
           parent: TreeCategory.Account,
-          contextValue: azureAccountContextValue,
+          contextValue: "signinAzure",
           subTreeItems: [],
           icon: "azure",
           tooltip: {


### PR DESCRIPTION
The bug is due to the change from sync call to async call, since sync call is removed and setStatusMap will auto fire, so there's no need to get initial status manually.

ADO: 10068005