### PR TITLE
refactor(function): normalize suffix when generate service name

### DIFF
--- a/packages/fx-core/src/plugins/resource/function/constants.ts
+++ b/packages/fx-core/src/plugins/resource/function/constants.ts
@@ -165,8 +165,8 @@ export class DefaultProvisionConfigs {
 }
 
 export class AzureInfo {
-  public static readonly storageAccountNameLenMax: number = 24;
-  public static readonly functionAppNameLenMax: number = 32;
+  public static readonly resourceNameLenMax: number = 24;
+  public static readonly suffixLenMax: number = 12;
   public static readonly zipDeployURL = (functionAppName: string) =>
     `https://${functionAppName}.scm.azurewebsites.net/api/zipdeploy`;
   public static readonly runFromPackageSettingKey = "WEBSITE_RUN_FROM_PACKAGE";

--- a/packages/fx-core/src/plugins/resource/function/ops/provision.ts
+++ b/packages/fx-core/src/plugins/resource/function/ops/provision.ts
@@ -19,13 +19,17 @@ type NameValuePair = WebSiteManagementModels.NameValuePair;
 type SiteAuthSettings = WebSiteManagementModels.SiteAuthSettings;
 
 export class FunctionNaming {
-  private static concatName(appName: string, mergedSuffix: string, limit: number): string {
-    const suffix: string = mergedSuffix.substr(0, limit);
-    const paddingLength: number = AzureInfo.storageAccountNameLenMax - suffix.length;
-    const normalizedAppName = appName
-      .replace(RegularExpr.allCharToBeSkippedInName, "")
+  private static normalize(raw: string): string {
+    return raw
+      .replace(RegularExpr.allCharToBeSkippedInName, CommonConstants.emptyString)
       .toLowerCase();
-    return normalizedAppName.substr(0, paddingLength) + suffix;
+  }
+
+  private static concatName(appName: string, mergedSuffix: string): string {
+    const suffix = this.normalize(mergedSuffix).substr(0, AzureInfo.suffixLenMax);
+    const paddingLength = AzureInfo.resourceNameLenMax - suffix.length;
+    const normalizedAppName = this.normalize(appName).substr(0, paddingLength);
+    return normalizedAppName + suffix;
   }
 
   public static generateStorageAccountName(
@@ -34,7 +38,7 @@ export class FunctionNaming {
     identSuffix: string
   ): string {
     const mergedSuffix: string = classSuffix + identSuffix;
-    return this.concatName(appName, mergedSuffix, AzureInfo.storageAccountNameLenMax);
+    return this.concatName(appName, mergedSuffix);
   }
 
   public static generateFunctionAppName(
@@ -43,7 +47,7 @@ export class FunctionNaming {
     identSuffix: string
   ): string {
     const mergedSuffix: string = classSuffix + identSuffix;
-    return this.concatName(appName, mergedSuffix, AzureInfo.functionAppNameLenMax);
+    return this.concatName(appName, mergedSuffix);
   }
 }
 
@@ -75,11 +79,16 @@ export class FunctionProvision {
       },
     };
 
-    const site = await AzureLib.ensureFunctionApp(client, resourceGroupName, functionAppName, siteEnvelope);
+    const site = await AzureLib.ensureFunctionApp(
+      client,
+      resourceGroupName,
+      functionAppName,
+      siteEnvelope
+    );
 
     // The ensureFunctionApp may return a site found on Azure,
     // we need to return a site with updated settings for post provision.
-    settings.forEach(pair => {
+    settings.forEach((pair) => {
       pair.name && pair.value && this.pushAppSettings(site, pair.name, pair.value);
     });
 


### PR DESCRIPTION
1. Normalize suffix when generating resource name. it is not a bug in current stage because suffix and resource name are generated in same lifecycle, user has no chance to inject. In case it becomes a bug someday, let's refine it.
2. Unify the max length of function app name and storage name because there is no benefit to separate them. Unification makes it simpler.