### PR TITLE
fix(apim): change the appName used in apim plugin

### DIFF
--- a/packages/fx-core/src/plugins/resource/apim/index.ts
+++ b/packages/fx-core/src/plugins/resource/apim/index.ts
@@ -13,7 +13,7 @@ import {
   Stage,
   Func,
 } from "@microsoft/teamsfx-api";
-import { BuildError, UnhandledError } from "./error";
+import { AssertNotEmpty, BuildError, UnhandledError } from "./error";
 import { Telemetry } from "./utils/telemetry";
 import { AadPluginConfig, ApimPluginConfig, FunctionPluginConfig, SolutionConfig } from "./config";
 import {
@@ -136,6 +136,8 @@ async function _scaffold(ctx: PluginContext, progressBar: ProgressBar): Promise<
   const answer = buildAnswer(ctx);
   const scaffoldManager = await Factory.buildScaffoldManager(ctx, solutionConfig);
 
+  const appName = AssertNotEmpty("projectSettings.appName", ctx?.projectSettings?.appName);
+
   if (answer.validate) {
     await answer.validate(Stage.update, apimConfig, ctx.root);
   }
@@ -143,7 +145,7 @@ async function _scaffold(ctx: PluginContext, progressBar: ProgressBar): Promise<
   answer.save(Stage.update, apimConfig);
 
   await progressBar.next(ProgressStep.Scaffold, ProgressMessages[ProgressStep.Scaffold].Scaffold);
-  await scaffoldManager.scaffold(ctx.app.name.short, ctx.root);
+  await scaffoldManager.scaffold(appName, ctx.root);
 }
 
 async function _provision(ctx: PluginContext, progressBar: ProgressBar): Promise<void> {
@@ -153,17 +155,19 @@ async function _provision(ctx: PluginContext, progressBar: ProgressBar): Promise
   const apimManager = await Factory.buildApimManager(ctx, solutionConfig);
   const aadManager = await Factory.buildAadManager(ctx);
 
+  const appName = AssertNotEmpty("projectSettings.appName", ctx?.projectSettings?.appName);
+
   await progressBar.next(
     ProgressStep.Provision,
     ProgressMessages[ProgressStep.Provision].CreateApim
   );
-  await apimManager.provision(apimConfig, solutionConfig, ctx.app.name.short);
+  await apimManager.provision(apimConfig, solutionConfig, appName);
 
   await progressBar.next(
     ProgressStep.Provision,
     ProgressMessages[ProgressStep.Provision].CreateAad
   );
-  await aadManager.provision(apimConfig, ctx.app.name.short);
+  await aadManager.provision(apimConfig, appName);
 }
 
 async function _postProvision(ctx: PluginContext, progressBar: ProgressBar): Promise<void> {
@@ -175,6 +179,8 @@ async function _postProvision(ctx: PluginContext, progressBar: ProgressBar): Pro
   const aadManager = await Factory.buildAadManager(ctx);
   const teamsAppAadManager = await Factory.buildTeamsAppAadManager(ctx);
 
+  const appName = AssertNotEmpty("projectSettings.appName", ctx?.projectSettings?.appName);
+
   await progressBar.next(
     ProgressStep.PostProvision,
     ProgressMessages[ProgressStep.PostProvision].ConfigClientAad
@@ -185,7 +191,7 @@ async function _postProvision(ctx: PluginContext, progressBar: ProgressBar): Pro
     ProgressStep.PostProvision,
     ProgressMessages[ProgressStep.PostProvision].ConfigApim
   );
-  await apimManager.postProvision(apimConfig, solutionConfig, aadConfig, ctx.app.name.short);
+  await apimManager.postProvision(apimConfig, solutionConfig, aadConfig, appName);
 
   await progressBar.next(
     ProgressStep.PostProvision,

--- a/packages/fx-core/src/plugins/resource/apim/utils/namingRules.ts
+++ b/packages/fx-core/src/plugins/resource/apim/utils/namingRules.ts
@@ -49,7 +49,8 @@ export class NamingRules {
     maxLength: 50,
     validPattern: ValidationConstants.serviceIdValidPattern,
     sanitize(appName: string, suffix: string): string {
-      return `${NamingRules.short(appName, 48 - suffix.length)}am${suffix}`;
+      const sanitizedAppName = NamingRules.sanitizeId(appName, false, false);
+      return `${NamingRules.short(sanitizedAppName, 48 - suffix.length)}am${suffix}`;
     },
   };
 
@@ -58,7 +59,8 @@ export class NamingRules {
     maxLength: ValidationConstants.defaultMaxLength,
     validPattern: ValidationConstants.defaultValidPattern,
     sanitize(appName: string, suffix: string): string {
-      return `${NamingRules.short(appName, 80 - suffix.length - 9)}-${suffix}-product`;
+      const sanitizedAppName = NamingRules.sanitizeId(appName, false, false);
+      return `${NamingRules.short(sanitizedAppName, 80 - suffix.length - 9)}-${suffix}-product`;
     },
   };
 
@@ -67,7 +69,8 @@ export class NamingRules {
     maxLength: ValidationConstants.defaultMaxLength,
     validPattern: ValidationConstants.defaultValidPattern,
     sanitize(appName: string, suffix: string): string {
-      return `${NamingRules.short(appName, 80 - suffix.length - 8)}-${suffix}-server`;
+      const sanitizedAppName = NamingRules.sanitizeId(appName, false, false);
+      return `${NamingRules.short(sanitizedAppName, 80 - suffix.length - 8)}-${suffix}-server`;
     },
   };
 


### PR DESCRIPTION
The user often change the app name in manifest.json, so use the app name in settings.json