### PR TITLE
feat: Use core getQuestions to get CLI help param

### DIFF
--- a/packages/cli/src/cmds/capability.ts
+++ b/packages/cli/src/cmds/capability.ts
@@ -6,24 +6,24 @@
 import * as path from "path";
 import { Argv, Options } from "yargs";
 
-import { ConfigMap, err, FxError, ok, Result } from "@microsoft/teamsfx-api";
+import { err, FxError, ok, Result } from "@microsoft/teamsfx-api";
 
 import activate from "../activate";
-import * as constants from "../constants";
-import { getParamJson, getSystemInputs } from "../utils";
+import { getSystemInputs } from "../utils";
 import { YargsCommand } from "../yargsCommand";
 import CliTelemetry from "../telemetry/cliTelemetry";
 import { TelemetryEvent, TelemetryProperty, TelemetrySuccess } from "../telemetry/cliTelemetryEvents";
 import CLIUIInstance from "../userInteraction";
+import { HelpParamGenerator } from "../helpParamGenerator";
 
 export class CapabilityAddTab extends YargsCommand {
   public readonly commandHead = `tab`;
   public readonly command = `${this.commandHead}`;
   public readonly description = "Add a tab.";
-  public readonly paramPath = constants.capabilityAddTabParamPath;
-  public readonly params: { [_: string]: Options } = getParamJson(this.paramPath);
+  public params: { [_: string]: Options } = {};
 
   public builder(yargs: Argv): Argv<any> {
+    this.params = HelpParamGenerator.getYargsParamForHelp("addCapability-Tab");
     return yargs.options(this.params);
   }
 
@@ -31,7 +31,7 @@ export class CapabilityAddTab extends YargsCommand {
     const rootFolder = path.resolve(args.folder || "./");
     CliTelemetry.withRootFolder(rootFolder).sendTelemetryEvent(TelemetryEvent.AddCapStart);
 
-    CLIUIInstance.updatePresetAnswers(args);
+    CLIUIInstance.updatePresetAnswers(this.params, args);
 
     const result = await activate(rootFolder);
     if (result.isErr()) {
@@ -70,10 +70,9 @@ export class CapabilityAddBot extends YargsCommand {
   public readonly commandHead = `bot`;
   public readonly command = `${this.commandHead}`;
   public readonly description = "Add a bot.";
-  public readonly paramPath = constants.capabilityAddBotParamPath;
-  public readonly params: { [_: string]: Options } = getParamJson(this.paramPath);
-
+  public params: { [_: string]: Options } = {};
   public builder(yargs: Argv): Argv<any> {
+    this.params = HelpParamGenerator.getYargsParamForHelp("addCapability-Bot");
     return yargs.options(this.params);
   }
 
@@ -81,7 +80,7 @@ export class CapabilityAddBot extends YargsCommand {
     const rootFolder = path.resolve(args.folder || "./");
     CliTelemetry.withRootFolder(rootFolder).sendTelemetryEvent(TelemetryEvent.AddCapStart);
 
-    CLIUIInstance.updatePresetAnswers(args);
+    CLIUIInstance.updatePresetAnswers(this.params, args);
 
     const result = await activate(rootFolder);
     if (result.isErr()) {
@@ -95,8 +94,6 @@ export class CapabilityAddBot extends YargsCommand {
       namespace: "fx-solution-azure",
       method: "addCapability"
     };
-
-    const answers = new ConfigMap();
 
     const core = result.value;
     {
@@ -121,10 +118,10 @@ export class CapabilityAddMessageExtension extends YargsCommand {
   public readonly commandHead = `messaging-extension`;
   public readonly command = `${this.commandHead}`;
   public readonly description = "Add Messaging Extensions.";
-  public readonly paramPath = constants.capabilityAddMessageExtensionParamPath;
-  public readonly params: { [_: string]: Options } = getParamJson(this.paramPath);
+  public params: { [_: string]: Options } = {};
 
   public builder(yargs: Argv): Argv<any> {
+    this.params = HelpParamGenerator.getYargsParamForHelp("addCapability-MessagingExtension");
     return yargs.options(this.params);
   }
 
@@ -132,7 +129,7 @@ export class CapabilityAddMessageExtension extends YargsCommand {
     const rootFolder = path.resolve(args.folder || "./");
     CliTelemetry.withRootFolder(rootFolder).sendTelemetryEvent(TelemetryEvent.AddCapStart);
 
-    CLIUIInstance.updatePresetAnswers(args);
+    CLIUIInstance.updatePresetAnswers(this.params, args);
 
     const result = await activate(rootFolder);
     if (result.isErr()) {
@@ -146,8 +143,6 @@ export class CapabilityAddMessageExtension extends YargsCommand {
       namespace: "fx-solution-azure",
       method: "addCapability"
     };
-
-    const answers = new ConfigMap();
 
     const core = result.value;
     {

--- a/packages/cli/src/cmds/init.ts
+++ b/packages/cli/src/cmds/init.ts
@@ -19,7 +19,7 @@ export default class Init extends YargsCommand {
   public readonly command = `${this.commandHead}`;
   public readonly description = "Add Teams support to an existing Blazor application.";
 
-  public readonly params: { [_: string]: Options } = {
+  public params: { [_: string]: Options } = {
     "app-name": {
       type: "string",
       description: "Application name.",

--- a/packages/cli/src/cmds/provision.ts
+++ b/packages/cli/src/cmds/provision.ts
@@ -6,15 +6,16 @@
 import path from "path";
 import { Argv, Options } from "yargs";
 
-import { FxError, err, ok, Result } from "@microsoft/teamsfx-api";
+import { FxError, err, ok, Result, Stage } from "@microsoft/teamsfx-api";
 
 import activate from "../activate";
 import * as constants from "../constants";
-import { getParamJson, getSystemInputs, setSubscriptionId } from "../utils";
+import { getSystemInputs, setSubscriptionId } from "../utils";
 import { YargsCommand } from "../yargsCommand";
 import CliTelemetry from "../telemetry/cliTelemetry";
 import { TelemetryEvent, TelemetryProperty, TelemetrySuccess } from "../telemetry/cliTelemetryEvents";
 import CLIUIInstance from "../userInteraction";
+import { HelpParamGenerator } from "../helpParamGenerator";
 
 export default class Provision extends YargsCommand {
   public readonly commandHead = `provision`;
@@ -22,9 +23,10 @@ export default class Provision extends YargsCommand {
   public readonly description = "Provision the cloud resources in the current application.";
   public readonly paramPath = constants.provisionParamPath;
 
-  public readonly params: { [_: string]: Options } = getParamJson(this.paramPath);
+  public params: { [_: string]: Options } = {};
 
   public builder(yargs: Argv): Argv<any> {
+    this.params = HelpParamGenerator.getYargsParamForHelp(Stage.provision);
     return yargs.version(false).options(this.params);
   }
 
@@ -32,7 +34,7 @@ export default class Provision extends YargsCommand {
     const rootFolder = path.resolve(args.folder || "./");
     CliTelemetry.withRootFolder(rootFolder).sendTelemetryEvent(TelemetryEvent.ProvisionStart);
 
-    CLIUIInstance.updatePresetAnswers(args);
+    CLIUIInstance.updatePresetAnswers(this.params, args);
 
     {
       const result = await setSubscriptionId(args.subscription, rootFolder);

--- a/packages/cli/src/cmds/publish.ts
+++ b/packages/cli/src/cmds/publish.ts
@@ -4,14 +4,14 @@
 "use strict";
 
 import { Argv, Options } from "yargs";
-import * as path from "path";
-import { FxError, err, ok, Result, Platform, Func } from "@microsoft/teamsfx-api";
+import { FxError, err, ok, Result, Platform, Func, Stage } from "@microsoft/teamsfx-api";
 import activate from "../activate";
 import * as constants from "../constants";
 import { YargsCommand } from "../yargsCommand";
-import { argsToInputs, getParamJson } from "../utils";
+import { argsToInputs } from "../utils";
 import CliTelemetry from "../telemetry/cliTelemetry";
 import { TelemetryEvent, TelemetryProperty, TelemetrySuccess } from "../telemetry/cliTelemetryEvents";
+import { HelpParamGenerator } from "../helpParamGenerator";
 
 export default class Publish extends YargsCommand {
   public readonly commandHead = `publish`;
@@ -19,9 +19,10 @@ export default class Publish extends YargsCommand {
   public readonly description = "Publish the app to Teams.";
   public readonly paramPath = constants.publishParamPath;
 
-  public readonly params: { [_: string]: Options } = getParamJson(this.paramPath);
+  public params: { [_: string]: Options } = {};
 
   public builder(yargs: Argv): Argv<any> {
+    this.params = HelpParamGenerator.getYargsParamForHelp(Stage.publish);
     return yargs.version(false).options(this.params);
   }
 
@@ -50,7 +51,7 @@ export default class Publish extends YargsCommand {
     }
 
     const core = result.value;
-    if (answers[manifestFolderParamName]) {
+    if (answers[manifestFolderParamName] && answers["teams-app-id"]) {
       answers.platform = Platform.VS;
       const func: Func = {
         namespace: "fx-solution-azure",

--- a/packages/cli/src/cmds/resource.ts
+++ b/packages/cli/src/cmds/resource.ts
@@ -10,12 +10,13 @@ import { err, FxError, ok, Result, LogLevel } from "@microsoft/teamsfx-api";
 
 import activate from "../activate";
 import * as constants from "../constants";
-import { getParamJson, getSystemInputs, readConfigs, setSubscriptionId } from "../utils";
+import { getSystemInputs, readConfigs, setSubscriptionId } from "../utils";
 import { YargsCommand } from "../yargsCommand";
 import CliTelemetry from "../telemetry/cliTelemetry";
 import { TelemetryEvent, TelemetryProperty, TelemetrySuccess } from "../telemetry/cliTelemetryEvents";
 import CLIUIInstance from "../userInteraction";
 import CLILogProvider from "../commonlib/log";
+import { HelpParamGenerator } from "../helpParamGenerator";
 
 export class ResourceAdd extends YargsCommand {
   public readonly commandHead = `add`;
@@ -41,10 +42,10 @@ export class ResourceAddSql extends YargsCommand {
   public readonly commandHead = `azure-sql`;
   public readonly command = `${this.commandHead}`;
   public readonly description = "Add a new SQL database.";
-  public readonly paramPath = constants.resourceAddSqlParamPath;
-  public readonly params: { [_: string]: Options } = getParamJson(this.paramPath);
+  public params: { [_: string]: Options } = {};
 
   public builder(yargs: Argv): Argv<any> {
+    this.params = HelpParamGenerator.getYargsParamForHelp("addResource-sql");
     return yargs.options(this.params);
   }
 
@@ -54,7 +55,7 @@ export class ResourceAddSql extends YargsCommand {
       [TelemetryProperty.Resources]: this.commandHead
     });
 
-    CLIUIInstance.updatePresetAnswers(args);
+    CLIUIInstance.updatePresetAnswers(this.params, args);
 
     const result = await activate(rootFolder);
     if (result.isErr()) {
@@ -93,10 +94,10 @@ export class ResourceAddApim extends YargsCommand {
   public readonly commandHead = `azure-apim`;
   public readonly command = `${this.commandHead}`;
   public readonly description = "Add a new API Managment service instance.";
-  public readonly paramPath = constants.resourceAddApimParamPath;
-  public readonly params: { [_: string]: Options } = getParamJson(this.paramPath);
+  public params: { [_: string]: Options } = {};
 
   public builder(yargs: Argv): Argv<any> {
+    this.params = HelpParamGenerator.getYargsParamForHelp("addResource-apim");
     return yargs.options(this.params);
   }
 
@@ -112,7 +113,7 @@ export class ResourceAddApim extends YargsCommand {
       [TelemetryProperty.Resources]: this.commandHead
     });
 
-    CLIUIInstance.updatePresetAnswers(args);
+    CLIUIInstance.updatePresetAnswers(this.params, args);
 
     {
       const result = await setSubscriptionId(args.subscription, rootFolder);
@@ -160,10 +161,10 @@ export class ResourceAddFunction extends YargsCommand {
   public readonly commandHead = `azure-function`;
   public readonly command = `${this.commandHead}`;
   public readonly description = "Add a new function app.";
-  public readonly paramPath = constants.resourceAddFunctionParamPath;
-  public readonly params: { [_: string]: Options } = getParamJson(this.paramPath);
+  public params: { [_: string]: Options } = {};
 
   public builder(yargs: Argv): Argv<any> {
+    this.params = HelpParamGenerator.getYargsParamForHelp("addResource-function");
     return yargs.options(this.params);
   }
 
@@ -173,7 +174,7 @@ export class ResourceAddFunction extends YargsCommand {
       [TelemetryProperty.Resources]: this.commandHead
     });
 
-    CLIUIInstance.updatePresetAnswers(args);
+    CLIUIInstance.updatePresetAnswers(this.params, args);
 
     const result = await activate(rootFolder);
     if (result.isErr()) {
@@ -232,9 +233,10 @@ export class ResourceShowFunction extends YargsCommand {
   public readonly command = `${this.commandHead}`;
   public readonly description = "Azure Functions details";
   public readonly paramPath = constants.resourceShowFunctionParamPath;
-  public readonly params: { [_: string]: Options } = getParamJson(this.paramPath);
+  public params: { [_: string]: Options } = {};
 
   public builder(yargs: Argv): Argv<any> {
+    this.params = HelpParamGenerator.getYargsParamForHelp("ResourceShowFunction");
     return yargs.options(this.params);
   }
 
@@ -261,9 +263,10 @@ export class ResourceShowSQL extends YargsCommand {
   public readonly command = `${this.commandHead}`;
   public readonly description = "Azure SQL details";
   public readonly paramPath = constants.resourceShowSQLParamPath;
-  public readonly params: { [_: string]: Options } = getParamJson(this.paramPath);
+  public params: { [_: string]: Options } = {};
 
   public builder(yargs: Argv): Argv<any> {
+    this.params = HelpParamGenerator.getYargsParamForHelp("ResourceShowSQL");
     return yargs.options(this.params);
   }
 
@@ -290,9 +293,10 @@ export class ResourceShowApim extends YargsCommand {
   public readonly command = `${this.commandHead}`;
   public readonly description = "Azure APIM details";
   public readonly paramPath = constants.resourceShowApimParamPath;
-  public readonly params: { [_: string]: Options } = getParamJson(this.paramPath);
+  public params: { [_: string]: Options } = {};
 
   public builder(yargs: Argv): Argv<any> {
+    this.params = HelpParamGenerator.getYargsParamForHelp("ResourceShowApim");
     return yargs.options(this.params);
   }
 
@@ -319,9 +323,10 @@ export class ResourceList extends YargsCommand {
   public readonly command = `${this.commandHead}`;
   public readonly description = "List all of the resources in the current application";
   public readonly paramPath = constants.resourceListParamPath;
-  public readonly params: { [_: string]: Options } = getParamJson(this.paramPath);
+  public params: { [_: string]: Options } = {};
 
   public builder(yargs: Argv): Argv<any> {
+    this.params = HelpParamGenerator.getYargsParamForHelp("ResourceList");
     return yargs.options(this.params);
   }
 

--- a/packages/cli/src/helpParamGenerator.ts
+++ b/packages/cli/src/helpParamGenerator.ts
@@ -1,0 +1,188 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+"use strict";
+
+import { Result, FxError, err, ok, Inputs, Tools, Stage, Platform, QTreeNode, Question, isAutoSkipSelect, SingleSelectQuestion, MultiSelectQuestion, OptionItem } from "@microsoft/teamsfx-api";
+
+import { FxCore } from "@microsoft/teamsfx-core";
+import AzureAccountManager from "./commonlib/azureLogin";
+import AppStudioTokenProvider from "./commonlib/appStudioLogin";
+import GraphTokenProvider from "./commonlib/graphLogin";
+import CLILogProvider from "./commonlib/log";
+import DialogManagerInstance from "./userInterface";
+import { CliTelemetry } from "./telemetry/cliTelemetry";
+import CLIUIInstance from "./userInteraction";
+import { flattenNodes, getSingleOptionString, toYargsOptions } from "./utils";
+import { Options } from "yargs";
+
+const rootFolderNode = new QTreeNode({
+  type: "folder",
+  name: "folder",
+  title: "Select root folder of the project",
+  default: "./",
+});
+
+export class HelpParamGenerator {
+  private static core: FxCore | undefined;
+  private static questionsMap: Map<string, QTreeNode> = new Map<string, QTreeNode>();
+  public static async activate(): Promise<Result<FxCore, FxError>> {
+    const tools: Tools = {
+      logProvider: CLILogProvider,
+      tokenProvider: {
+        azureAccountProvider: AzureAccountManager,
+        graphTokenProvider: GraphTokenProvider,
+        appStudioToken: AppStudioTokenProvider
+      },
+      telemetryReporter: CliTelemetry.getReporter(),
+      dialog: DialogManagerInstance,
+      ui: CLIUIInstance
+    };
+    const core: FxCore = new FxCore(tools);
+    return ok(core);
+  }
+
+  public static setCore(core: FxCore) {
+    HelpParamGenerator.core = core;
+  }
+
+  private static getSystemInputs(projectPath?: string, platform?: Platform): Inputs {
+    const systemInputs: Inputs = {
+      platform: platform === undefined ? Platform.CLI_HELP : platform, 
+      projectPath: projectPath
+    };
+    return systemInputs;
+  }
+
+  private static setQuestionNodes(stage: string, questions: QTreeNode | undefined) {
+    if (questions) {
+      HelpParamGenerator.questionsMap.set(stage, questions);
+    }
+  }
+
+  private static async getQuestionsForUserTask(stage: string, systemInput: Inputs, core: FxCore) {
+    const func = {
+      namespace: "fx-solution-azure",
+      method: stage
+    };
+    const result = await core.getQuestionsForUserTask(func, systemInput);
+    if (result.isErr()) {
+      return err(result.error);
+    }
+    else {
+      HelpParamGenerator.setQuestionNodes(stage, result.value);
+    }
+    return ok(undefined);
+  }
+
+  private static getQuestionRootNodeForHelp(stage: string): QTreeNode | undefined {
+    if (HelpParamGenerator.questionsMap.has(stage)) {
+      return HelpParamGenerator.questionsMap.get(stage);
+    }
+    return undefined;
+  }
+
+  public static async initializeQuestionsForHelp(): Promise<Result<undefined, FxError>> {
+    const result = await HelpParamGenerator.activate();
+    if (result.isErr()) {
+      return err(result.error);
+    }
+    const core = result.value;
+    const systemInput = HelpParamGenerator.getSystemInputs();
+    for (const stage in Stage) {
+      let result;
+      if(stage === Stage.publish){
+        result = await core.getQuestions(stage as Stage, HelpParamGenerator.getSystemInputs("",Platform.VS));
+      }
+      else{
+        result = await core.getQuestions(stage as Stage, systemInput);
+      }
+      if (result.isErr()) {
+        return err(result.error);
+      }
+      else {
+        HelpParamGenerator.setQuestionNodes(stage, result.value);
+      }
+    }
+    const userTasks = ["addCapability","addResource"];
+    for (const userTask of userTasks )
+    {
+      const result = await HelpParamGenerator.getQuestionsForUserTask(userTask, systemInput, core);
+      if (result.isErr()) {
+        return err(result.error);
+      }
+    }
+
+    return ok(undefined);
+  }
+
+  public static getYargsParamForHelp(stage: string): { [_: string]: Options } {
+    let resourceName: string | undefined;
+    let capabilityName: string | undefined;
+    if (stage.startsWith("addResource")) {
+      resourceName = stage.split("-")[1];
+      stage = "addResource";
+    }
+    else if (stage.startsWith("addCapability")) {
+      capabilityName = stage.split("-")[1];
+      stage = "addCapability";
+    }
+    const root = HelpParamGenerator.getQuestionRootNodeForHelp(stage);
+    let nodes: QTreeNode[] = [];
+    if (resourceName && root?.children) {
+      // Do CLI map for resource add
+      const mustHaveNodes = root.children.filter(node => (node.condition as any).minItems === 1);
+      const resourcesNodes = root.children.filter(node => (node.condition as any).contains === resourceName)[0];
+      (root.data as any).default = [resourceName];
+      (root.data as any).hide = true;
+      root.children = undefined;
+      nodes = [root].concat(mustHaveNodes).concat(resourcesNodes ? flattenNodes(resourcesNodes) : []);
+    }
+    else if (capabilityName && root?.children){
+      // Do CLI map for capability add 
+      const capabilityNodes = root.children.filter(node => ((node.condition as any).containsAny as string[]).includes(capabilityName as string))[0];
+      (root.data as any).default = [capabilityName];
+      (root.data as any).hide = true;
+      root.children = undefined;
+      nodes = [root].concat(capabilityNodes ? flattenNodes(capabilityNodes) : []);
+    }
+    else if (root) {
+      nodes = flattenNodes(root);
+    }
+
+    // hide VS param for publish.
+    if (stage === Stage.publish){
+      for (const node of nodes) {
+        (node.data as any).hide = true;
+      }
+    }
+
+    // Add folder node
+    if (stage !== Stage.create) {
+      nodes = nodes.concat([rootFolderNode]);
+    }
+    // Set default folder value for create stage
+    else {
+      for (const node of nodes) {
+        if (node.data.name === "folder") {
+          (node.data as any).default = "./";
+        }
+      }
+    }
+
+    const nodesWithoutGroup = nodes.filter((node) => node.data.type !== "group");
+    const params: { [_: string]: Options } = {};
+    nodesWithoutGroup.forEach((node) => {
+      const data = node.data as Question;
+      if (isAutoSkipSelect(data) && data.type != "func") {
+        // set the only option to default value so yargs will auto fill it.
+        data.default = getSingleOptionString(data as SingleSelectQuestion | MultiSelectQuestion);
+        (data as any).hide = true;
+      }
+      params[data.name] = toYargsOptions(data);
+    });
+
+    return params;
+  }
+}
+

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,6 +9,7 @@ import yargs from "yargs";
 
 import { commands } from "./cmds";
 import * as constants from "./constants";
+import { HelpParamGenerator } from "./helpParamGenerator";
 
 /**
  * Registers cli and partner commands with yargs.
@@ -38,7 +39,8 @@ function getVersion(): string {
 /**
  * Starts the CLI process.
  */
-export function start() {
+export async function start() {
+  await HelpParamGenerator.initializeQuestionsForHelp();
   register(yargs);
   yargs
     .options("verbose", {

--- a/packages/cli/src/userInteraction.ts
+++ b/packages/cli/src/userInteraction.ts
@@ -38,6 +38,7 @@ import {
 import CLILogProvider from "./commonlib/log";
 import { NotValidInputValue, UnknownError } from "./error";
 import { sleep } from "./utils";
+import { Options } from "yargs";
 
 /// TODO: input can be undefined
 type ValidationType<T> = (input: T) => string | boolean | Promise<string | boolean>;
@@ -57,9 +58,11 @@ export class CLIUserInteraction implements UserInteraction {
     this.presetAnswers.set(key, value);
   }
 
-  public updatePresetAnswers(answers: { [key: string]: any}) {
+  public updatePresetAnswers(question: { [_: string]: Options },answers: { [key: string]: any}) {
     for (const key in answers) {
-      this.updatePresetAnswer(key, answers[key]);
+      if(key in question){
+        this.updatePresetAnswer(key, answers[key]);
+      }
     }
   }
 

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -231,8 +231,7 @@ export function getTeamsAppId(rootfolder: string | undefined): any {
 export function getSystemInputs(projectPath?: string):Inputs{
   const systemInputs:Inputs = {
     platform: Platform.CLI,
-    projectPath: projectPath,
-    featureFlag: true
+    projectPath: projectPath
   };
   return systemInputs;
 }

--- a/packages/fx-core/src/common/tools.ts
+++ b/packages/fx-core/src/common/tools.ts
@@ -10,7 +10,7 @@ import * as path from "path";
 import { getResourceFolder } from "..";
 import { fakeServer } from "sinon";
 import { PluginNames } from "../plugins";
-import { AzureResourceApim, AzureResourceFunction, AzureResourceSQL, BotOptionItem, HostTypeOptionSPFx, MessageExtensionItem, TabOptionItem } from "../plugins/solution/fx-solution/question";
+import { AzureResourceApim, AzureResourceFunction, AzureResourceSQL, AzureSolutionQuestionNames, BotOptionItem, HostTypeOptionSPFx, MessageExtensionItem, TabOptionItem } from "../plugins/solution/fx-solution/question";
 
 const execAsync = promisify(exec);
 
@@ -380,7 +380,7 @@ export async function askSubscription(azureAccountProvider:AzureAccountProvider,
         }
       ); 
       const askRes = await ui.selectOption({
-        name: "asksub",
+        name: AzureSolutionQuestionNames.AskSub,
         title: "Select a subscription",
         options: options,
         returnObject: true

--- a/packages/fx-core/src/plugins/resource/apim/factory.ts
+++ b/packages/fx-core/src/plugins/resource/apim/factory.ts
@@ -139,6 +139,7 @@ export class Factory {
           existingOpenApiDocumentFunc
         );
       case Platform.CLI:
+      case Platform.CLI_HELP:
         const cliApimServiceNameQuestion = new CLI.ApimServiceNameQuestion();
         const cliApimResourceGroupQuestion = new CLI.ApimResourceGroupQuestion();
         const cliOpenApiDocumentQuestion = new CLI.OpenApiDocumentQuestion();

--- a/packages/fx-core/src/plugins/resource/appstudio/index.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/index.ts
@@ -53,7 +53,7 @@ export class AppStudioPlugin implements Plugin {
           title: "Please input the teams app id in App Studio",
         });
         appStudioQuestions.addChild(remoteTeamsAppId);
-      } else {
+      } else if (ctx.answers?.platform === Platform.VSCode){
         const buildOrPublish = new QTreeNode({
           name: Constants.BUILD_OR_PUBLISH_QUESTION,
           type: "singleSelect",
@@ -154,7 +154,7 @@ export class AppStudioPlugin implements Plugin {
   public async publish(ctx: PluginContext): Promise<Result<string | undefined, FxError>> {
     TelemetryUtils.init(ctx);
     TelemetryUtils.sendStartEvent(TelemetryEventName.publish);
-    if (ctx.answers?.platform !== Platform.VS) {
+    if (ctx.answers?.platform === Platform.VSCode) {
       const answer = ctx.answers![Constants.BUILD_OR_PUBLISH_QUESTION] as string;
       if (answer === manuallySubmitOption.id) {
         const appDirectory = `${ctx.root}/.${ConfigFolderName}`;

--- a/packages/fx-core/src/plugins/resource/sql/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/sql/plugin.ts
@@ -78,37 +78,21 @@ export class SqlPluginImpl {
       const sqlNode = new QTreeNode({
         type: "group",
       });
+      if (ctx.answers?.platform === Platform.CLI_HELP) {
+        sqlNode.addChild(new QTreeNode(adminNameQuestion));
+        sqlNode.addChild(new QTreeNode(adminPasswordQuestion));
+        sqlNode.addChild(new QTreeNode(confirmPasswordQuestion));
+        sqlNode.addChild(skipAddingUserQuestion);
+        return ok(sqlNode);
+      }
       this.init(ctx);
       if (this.config.azureSubscriptionId) {
-        // ctx.logProvider?.info(Message.checkSql);
         const managementClient: ManagementClient = new ManagementClient(ctx, this.config);
         await managementClient.init();
         this.config.existSql = await managementClient.existAzureSQL();
       }
 
       if (!this.config.existSql) {
-        adminNameQuestion.validation = {
-          validFunc: async (input: string, previousInputs?: Inputs) : Promise<string | undefined> => {
-            const res = sqlUserNameValidator(input as string);
-            return res;
-          }
-        };
-        adminPasswordQuestion.validation = {
-          validFunc: async (input: string, previousInputs?: Inputs) : Promise<string | undefined> => {
-            const password = input as string;
-            const name = previousInputs![Constants.questionKey.adminName] as string;
-            const res = sqlPasswordValidatorGenerator(name)(password);
-            return res;
-          }
-        };
-        confirmPasswordQuestion.validation = {
-          validFunc: async (input: string, previousInputs?: Inputs) : Promise<string | undefined> => {
-            const confirm = input as string;
-            const password = previousInputs![Constants.questionKey.adminPassword] as string;
-            const res = sqlConfirmPasswordValidatorGenerator(password)(confirm);
-            return res;
-          }
-        };
         sqlNode.addChild(new QTreeNode(adminNameQuestion));
         sqlNode.addChild(new QTreeNode(adminPasswordQuestion));
         sqlNode.addChild(new QTreeNode(confirmPasswordQuestion));
@@ -117,7 +101,6 @@ export class SqlPluginImpl {
       if (ctx.answers?.platform === Platform.CLI) {
         sqlNode.addChild(skipAddingUserQuestion);
       }
-      // ctx.logProvider?.info(Message.endGetQuestions);
       return ok(sqlNode);
     }
     return ok(undefined);

--- a/packages/fx-core/src/plugins/resource/sql/questions.ts
+++ b/packages/fx-core/src/plugins/resource/sql/questions.ts
@@ -1,26 +1,49 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { QTreeNode, TextInputQuestion } from "@microsoft/teamsfx-api";
+import { Inputs, QTreeNode, TextInputQuestion } from "@microsoft/teamsfx-api";
 import { Constants } from "./constants";
+import { sqlConfirmPasswordValidatorGenerator, sqlPasswordValidatorGenerator, sqlUserNameValidator } from "./utils/checkInput";
 
 export const adminNameQuestion: TextInputQuestion = {
   name: Constants.questionKey.adminName,
   title: Constants.userQuestion.adminName,
-  type: "text"
+  type: "text",
+  validation: {
+    validFunc: async (input: string, previousInputs?: Inputs): Promise<string | undefined> => {
+      const res = sqlUserNameValidator(input as string);
+      return res;
+    }
+  }
 };
 
 export const adminPasswordQuestion: TextInputQuestion = {
   name: Constants.questionKey.adminPassword,
   title: Constants.userQuestion.adminPassword,
   type: "text",
-  password: true
+  password: true,
+  validation: {
+    validFunc: async (input: string, previousInputs?: Inputs): Promise<string | undefined> => {
+      const password = input as string;
+      const name = previousInputs![Constants.questionKey.adminName] as string;
+      const res = sqlPasswordValidatorGenerator(name)(password);
+      return res;
+    }
+  }
 };
 
 export const confirmPasswordQuestion: TextInputQuestion = {
   name: Constants.questionKey.confirmPassword,
   title: Constants.userQuestion.confirmPassword,
   type: "text",
-  password: true
+  password: true,
+  validation: {
+    validFunc: async (input: string, previousInputs?: Inputs): Promise<string | undefined> => {
+      const confirm = input as string;
+      const password = previousInputs![Constants.questionKey.adminPassword] as string;
+      const res = sqlConfirmPasswordValidatorGenerator(password)(confirm);
+      return res;
+    }
+  }
 };
 
 export const skipAddingUserQuestion = new QTreeNode({

--- a/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
@@ -1387,7 +1387,7 @@ export class TeamsAppSolution implements Solution {
       else {
         pluginsToProvision = this.allPlugins;
       }
-      
+      node.addChild(new QTreeNode(AskSubscriptionQuestion));
       for (const plugin of pluginsToProvision) {
         if (plugin.getQuestions) {
           const pluginCtx = getPluginContext(ctx, plugin.name, manifest);


### PR DESCRIPTION
1. Initialize core and get questions for help param of all the stage at the begining.
2. Switch all the cmd(except init) builder to use params from core.
3. Reorganize all the runCommand() to be consistent.
4. Fix updatePresetAnswers(): use questions/params to set the answer instead of the yargs args.

Plugin Change:
1. Add APIM getQuestions() for CLI_HELP platform @XiaofuHuang 
2. Add SQL getQuestions() for CLI_HELP platform @xzf0587 
3. Change publish getQuestions().(remove build-or-publish for CLI platform) @nliu-ms 

Core Change:
1. Add subscription question node in provision stage. @jayzhang  @LongOddCode  @1yefuwang1 