### PR TITLE
feat(env-checker): add telemetry event for learn more/continue/cancel buttons

### DIFF
--- a/packages/fx-core/src/plugins/resource/function/ops/deploy.ts
+++ b/packages/fx-core/src/plugins/resource/function/ops/deploy.ts
@@ -111,10 +111,11 @@ export class FunctionDeploy {
     }
 
     const binPath = path.join(componentPath, FunctionPluginPathInfo.functionExtensionsFolderName);
+    const telemetry = new FuncPluginTelemetry(ctx);
     const dotnetChecker = new DotnetChecker(
-      new FuncPluginAdapter(ctx),
+      new FuncPluginAdapter(ctx, telemetry),
       funcPluginLogger,
-      new FuncPluginTelemetry(ctx)
+      telemetry,
     );
     const backendExtensionsInstaller = new BackendExtensionsInstaller(
       dotnetChecker,

--- a/packages/fx-core/src/plugins/resource/function/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/function/plugin.ts
@@ -801,12 +801,13 @@ export class FunctionPluginImpl {
 
   private async handleDotnetChecker(ctx: PluginContext): Promise<void> {
     try {
-      const funcPluginAdapter = new FuncPluginAdapter(ctx);
+      const telemetry = new FuncPluginTelemetry(ctx);
+      const funcPluginAdapter = new FuncPluginAdapter(ctx, telemetry);
       await step(StepGroup.PreDeployStepGroup, PreDeploySteps.dotnetInstall, async () => {
         const dotnetChecker = new DotnetChecker(
           funcPluginAdapter,
           funcPluginLogger,
-          new FuncPluginTelemetry(ctx)
+          telemetry,
         );
         try {
           if (!(await dotnetChecker.isEnabled()) || await dotnetChecker.isInstalled()) {
@@ -859,7 +860,8 @@ export class FunctionPluginImpl {
             await FunctionDeploy.installFuncExtensions(ctx, workingPath, functionLanguage);
           } catch (error) {
             // wrap the original error to UserError so the extensibility model will pop-up a dialog correctly
-            new FuncPluginAdapter(ctx).handleDotnetError(error);
+            const telemetry = new FuncPluginTelemetry(ctx);
+            new FuncPluginAdapter(ctx, telemetry).handleDotnetError(error);
           }
         })
     );

--- a/packages/fx-core/src/plugins/resource/function/utils/depsChecker/common.ts
+++ b/packages/fx-core/src/plugins/resource/function/utils/depsChecker/common.ts
@@ -106,6 +106,10 @@ export enum DepsCheckerEvent {
   dotnetInstallScriptError = "dotnet-install-script-error",
   dotnetValidationError = "dotnet-validation-error",
 
+  clickLearnMore = "env-checker-click-learn-more",
+  clickContinue = "env-checker-click-continue",
+  clickCancel = "env-checker-click-cancel",
+
   nodeNotFound = "node-not-found",
   nodeNotSupportedForAzure = "node-not-supported-for-azure",
   nodeNotSupportedForSPFx = "node-not-supported-for-spfx",

--- a/packages/vscode-extension/src/debug/depsChecker/common.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/common.ts
@@ -111,6 +111,7 @@ export enum DepsCheckerEvent {
   dotnetInstallScriptCompleted = "dotnet-install-script-completed",
   dotnetInstallScriptError = "dotnet-install-script-error",
   dotnetValidationError = "dotnet-validation-error",
+  dotnetSearchDotnetSdks = "dotnet-search-dotnet-sdks",
 
   clickLearnMore = "env-checker-click-learn-more",
   clickContinue = "env-checker-click-continue",
@@ -127,6 +128,7 @@ export enum TelemtryMessages {
   NPMNotFound = "npm is not found.",
   failedToExecDotnetScript = "failed to exec dotnet script.",
   failedToValidateDotnet = "failed to validate dotnet.",
+  failedToSearchDotnetSdks = "failed to search dotnet sdks.",
 }
 
 export enum TelemetryMessurement {

--- a/packages/vscode-extension/src/debug/depsChecker/common.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/common.ts
@@ -112,6 +112,10 @@ export enum DepsCheckerEvent {
   dotnetInstallScriptError = "dotnet-install-script-error",
   dotnetValidationError = "dotnet-validation-error",
 
+  clickLearnMore = "env-checker-click-learn-more",
+  clickContinue = "env-checker-click-continue",
+  clickCancel = "env-checker-click-cancel",
+
   nodeNotFound = "node-not-found",
   nodeNotSupportedForAzure = "node-not-supported-for-azure",
   nodeNotSupportedForSPFx = "node-not-supported-for-spfx",

--- a/packages/vscode-extension/src/debug/depsChecker/dotnetChecker.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/dotnetChecker.ts
@@ -366,8 +366,12 @@ export class DotnetChecker implements IDepsChecker {
         }
       });
     } catch (error) {
-      await this._logger.debug(
-        `Failed to search dotnet sdk by dotnetPath = ${dotnetExecPath}, error = '${error}'`
+      const errorMessage = `Failed to search dotnet sdk by dotnetPath = '${dotnetExecPath}', error = '${error}'`;
+      await this._logger.debug(errorMessage);
+      this._telemetry.sendSystemErrorEvent(
+        DepsCheckerEvent.dotnetSearchDotnetSdks,
+        TelemtryMessages.failedToSearchDotnetSdks,
+        errorMessage,
       );
     }
     return sdks;

--- a/packages/vscode-extension/src/debug/depsChecker/vscodeAdapter.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/vscodeAdapter.ts
@@ -57,7 +57,6 @@ export class VSCodeAdapter implements IDepsAdapter {
       continueButton
     );
 
-
     if (input === continueButton) {
       this._telemetry.sendEvent(DepsCheckerEvent.clickContinue);
       return true;

--- a/packages/vscode-extension/src/debug/depsChecker/vscodeAdapter.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/vscodeAdapter.ts
@@ -1,9 +1,10 @@
 import * as path from "path";
 import { window, workspace, WorkspaceConfiguration, MessageItem, commands, Uri } from "vscode";
-import { Messages } from "./common";
-import { IDepsAdapter } from "./checker";
+import { DepsCheckerEvent, Messages } from "./common";
+import { IDepsAdapter, IDepsTelemetry } from "./checker";
 import { hasTeamsfxBackend } from "../commonUtils";
 import { vscodeLogger as logger } from "./vscodeLogger";
+import { vscodeTelemetry } from "./vscodeTelemetry";
 
 export class VSCodeAdapter implements IDepsAdapter {
   private readonly configurationPrefix = "fx-extension";
@@ -11,6 +12,11 @@ export class VSCodeAdapter implements IDepsAdapter {
   private readonly validateDotnetSdkKey = "validateDotnetSdk";
   private readonly validateFuncCoreToolsKey = "validateFuncCoreTools";
   private readonly validateNodeVersionKey = "validateNode";
+  private readonly _telemetry: IDepsTelemetry
+
+  constructor(telemetry: IDepsTelemetry) {
+    this._telemetry = telemetry;
+  }
 
   public hasTeamsfxBackend(): Promise<boolean> {
     return hasTeamsfxBackend();
@@ -51,13 +57,17 @@ export class VSCodeAdapter implements IDepsAdapter {
       continueButton
     );
 
+
     if (input === continueButton) {
+      this._telemetry.sendEvent(DepsCheckerEvent.clickContinue);
       return true;
     } else if (input == learnMoreButton) {
+      this._telemetry.sendEvent(DepsCheckerEvent.clickLearnMore);
       await VSCodeAdapter.openUrl(link);
       return await this.displayContinueWithLearnMore(message, link);
     }
 
+    this._telemetry.sendEvent(DepsCheckerEvent.clickCancel);
     return false;
   }
 
@@ -76,10 +86,12 @@ export class VSCodeAdapter implements IDepsAdapter {
     const button: MessageItem = { title: buttonText };
     const input = await window.showWarningMessage(message, { modal: true }, button);
     if (input === button) {
+      this._telemetry.sendEvent(DepsCheckerEvent.clickLearnMore);
       return await action();
     }
 
     // click cancel button
+    this._telemetry.sendEvent(DepsCheckerEvent.clickCancel);
     return false;
   }
 
@@ -103,4 +115,4 @@ export class VSCodeAdapter implements IDepsAdapter {
   }
 }
 
-export const vscodeAdapter = new VSCodeAdapter();
+export const vscodeAdapter = new VSCodeAdapter(vscodeTelemetry);


### PR DESCRIPTION
- Add telemetry events for clicking "Learn More", "Continue" and "Cancel" buttons. One event for each button.
- Also add in function plugin
- Add error event for searchDotnetSdks()


### Test result:
![image](https://user-images.githubusercontent.com/9698542/121133938-7d0a2100-c865-11eb-9102-b4b86fbcadad.png)


https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/10036370/