### PR TITLE
fix(solution): wording when no sub was found

### DIFF
--- a/packages/fx-core/src/plugins/solution/fx-solution/commonQuestions.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/commonQuestions.ts
@@ -58,7 +58,7 @@ export async function askSubscription(
   if (subscriptions.length === 0) {
     return err(
       returnUserError(
-        new Error("Failed to find a subscription."),
+        new Error("No Azure Subscription found for your account."),
         "Solution",
         SolutionError.NoSubscriptionFound
       )


### PR DESCRIPTION
fixes https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_sprints/taskboard/Teams%20Extensibility%20E2E%20Team/Microsoft%20Teams%20Extensibility/CY21-6.1?workitem=10107295