### PR TITLE
feat: support ansi color for logprovider info

### DIFF
--- a/packages/api/src/utils/log.ts
+++ b/packages/api/src/utils/log.ts
@@ -56,6 +56,12 @@ export interface LogProvider {
     info(message: string): Promise<boolean>;
 
     /**
+     * Use to record info information
+     * @param message Information of log event
+     */
+    info(message: Array<{content: string, color: Colors}>): Promise<boolean>;
+
+    /**
      * Use to record warning information
      * @param message Information of log event
      */
@@ -72,4 +78,38 @@ export interface LogProvider {
      * @param message Information of log event
      */
     fatal(message: string): Promise<boolean>;
+}
+
+/**
+ * Colors for CLI output message
+ */
+export enum Colors {
+    /**
+     * Primary text color
+     */
+    BRIGHT_WHITE = 0,
+    /**
+     * Secondary text color
+     */
+    WHITE = 1,
+    /**
+     * Important text color
+     */
+    BRIGHT_MAGENTA = 2,
+    /**
+     * Success message indicator
+     */
+    BRIGHT_GREEN = 3,
+    /**
+     * Warning message indicator
+     */
+    BRIGHT_YELLOW = 4,
+    /**
+     * Error message indicator
+     */
+    BRIGHT_RED = 5,
+    /**
+     * Hyperlink
+     */
+    BRIGHT_CYAN = 6
 }

--- a/packages/api/tests/log.test.ts
+++ b/packages/api/tests/log.test.ts
@@ -13,7 +13,7 @@ class TestLogProvider implements LogProvider {
     async debug({}: string): Promise<boolean> {
         return true;
     }
-    async info({}: string): Promise<boolean> {
+    async info({}: string | Array<any>): Promise<boolean> {
         return true;
     }
     async warning({}: string): Promise<boolean> {
@@ -37,7 +37,7 @@ class TestLogProvider2 implements LogProvider {
     async debug({}: string): Promise<boolean> {
         return false;
     }
-    async info({}: string): Promise<boolean> {
+    async info({}: string | Array<any>): Promise<boolean> {
         return false;
     }
     async warning({}: string): Promise<boolean> {

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -2120,11 +2120,6 @@
       "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
       "dev": true
     },
-    "colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
-    },
     "combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -99,7 +99,7 @@
     "async-mutex": "^0.3.1",
     "axios": "^0.21.1",
     "azure-arm-resource": "^3.1.1-preview",
-    "colors": "^1.4.0",
+    "chalk": "^4.1.0",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "fs-extra": "^9.1.0",

--- a/packages/cli/src/commonlib/azureLogin.ts
+++ b/packages/cli/src/commonlib/azureLogin.ts
@@ -3,7 +3,6 @@
 
 "use strict";
 
-import colors from "colors";
 import { TokenCredential } from "@azure/core-auth";
 import { TokenCredentialsBase, DeviceTokenCredentials } from "@azure/ms-rest-nodeauth";
 import {

--- a/packages/cli/src/commonlib/codeFlowLogin.ts
+++ b/packages/cli/src/commonlib/codeFlowLogin.ts
@@ -14,7 +14,6 @@ import { AddressInfo } from "net";
 import { accountPath, UTF8 } from "./cacheAccess";
 import open from "open";
 import { azureLoginMessage, env, m365LoginMessage, MFACode } from "./common/constant";
-import colors from "colors";
 import * as constants from "../constants";
 import CliTelemetry from "../telemetry/cliTelemetry";
 import {

--- a/packages/cli/src/commonlib/codeFlowTenantLogin.ts
+++ b/packages/cli/src/commonlib/codeFlowTenantLogin.ts
@@ -14,7 +14,6 @@ import { AddressInfo } from "net";
 import { accountPath, UTF8 } from "./cacheAccess";
 import open from "open";
 import { azureLoginMessage, changeLoginTenantMessage, env, m365LoginMessage, MFACode } from "./common/constant";
-import colors from "colors";
 import * as constants from "../constants";
 
 class ErrorMessage {

--- a/packages/cli/src/commonlib/log.ts
+++ b/packages/cli/src/commonlib/log.ts
@@ -3,13 +3,12 @@
 
 "use strict";
 
-import colors from "colors";
-
-import { LogLevel, LogProvider } from "@microsoft/teamsfx-api";
+import { LogLevel, LogProvider, Colors } from "@microsoft/teamsfx-api";
 
 import { CLILogLevel } from "../constants";
+import { getColorizedString } from "./../utils";
+import chalk from "chalk";
 
-colors.white.green.yellow.red;
 
 export class CLILogProvider implements LogProvider {
   private static instance: CLILogProvider;
@@ -44,7 +43,16 @@ export class CLILogProvider implements LogProvider {
     return this.log(LogLevel.Debug, message);
   }
 
-  info(message: string): Promise<boolean> {
+  info(message: Array<{content: string, color: Colors}>): Promise<boolean>;
+  
+  info(message: string): Promise<boolean>;
+
+  info(message: string | Array<{content: string, color: Colors}>): Promise<boolean> {
+    if (message instanceof Array) {
+      message = getColorizedString(message);
+    } else {
+      message = this.white(message);
+    }
     return this.log(LogLevel.Info, message);
   }
 
@@ -62,35 +70,35 @@ export class CLILogProvider implements LogProvider {
 
   white(msg: string): string {
     if (process.stdout.isTTY) {
-      return msg.white;
+      return chalk.whiteBright(msg);
     }
     return msg;
   }
 
   green(msg: string): string {
     if (process.stdout.isTTY) {
-      return msg.green;
+      return chalk.greenBright(msg);
     }
     return msg;
   }
 
   yellow(msg: string): string {
     if (process.stderr.isTTY) {
-      return msg.yellow;
+      return chalk.yellowBright(msg);
     }
     return msg;
   }
 
   red(msg: string): string {
     if (process.stderr.isTTY) {
-      return msg.red;
+      return chalk.redBright(msg);
     }
     return msg;
   }
 
   linkColor(msg: string): string {
     if (process.stdout.isTTY) {
-      return msg.cyan.underline;
+      return chalk.cyanBright.underline(msg);
     }
     return msg;
   }
@@ -112,7 +120,7 @@ export class CLILogProvider implements LogProvider {
           CLILogProvider.logLevel === CLILogLevel.debug ||
           CLILogProvider.logLevel === CLILogLevel.verbose
         ) {
-          console.info(this.white(message));
+          console.info(message);
         }
         break;
       case LogLevel.Warning:

--- a/packages/cli/src/commonlib/log.ts
+++ b/packages/cli/src/commonlib/log.ts
@@ -51,9 +51,13 @@ export class CLILogProvider implements LogProvider {
     if (message instanceof Array) {
       message = getColorizedString(message);
     } else {
-      message = this.white(message);
+      message = chalk.whiteBright(message);
     }
     return this.log(LogLevel.Info, message);
+  }
+
+  white(msg: string): string {
+    return chalk.whiteBright(msg);
   }
 
   warning(message: string): Promise<boolean> {
@@ -68,51 +72,20 @@ export class CLILogProvider implements LogProvider {
     return this.log(LogLevel.Fatal, message);
   }
 
-  white(msg: string): string {
-    if (process.stdout.isTTY) {
-      return chalk.whiteBright(msg);
-    }
-    return msg;
-  }
-
-  green(msg: string): string {
-    if (process.stdout.isTTY) {
-      return chalk.greenBright(msg);
-    }
-    return msg;
-  }
-
-  yellow(msg: string): string {
-    if (process.stderr.isTTY) {
-      return chalk.yellowBright(msg);
-    }
-    return msg;
-  }
-
-  red(msg: string): string {
-    if (process.stderr.isTTY) {
-      return chalk.redBright(msg);
-    }
-    return msg;
-  }
-
   linkColor(msg: string): string {
-    if (process.stdout.isTTY) {
-      return chalk.cyanBright.underline(msg);
-    }
-    return msg;
+    return chalk.cyanBright.underline(msg);
   }
 
   async log(logLevel: LogLevel, message: string): Promise<boolean> {
     switch (logLevel) {
       case LogLevel.Trace:
         if (CLILogProvider.logLevel === CLILogLevel.debug) {
-          console.trace(this.white(message));
+          console.trace(chalk.whiteBright(message));
         }
         break;
       case LogLevel.Debug:
         if (CLILogProvider.logLevel === CLILogLevel.debug) {
-          console.debug(this.white(message));
+          console.debug(chalk.whiteBright(message));
         }
         break;
       case LogLevel.Info:
@@ -125,12 +98,12 @@ export class CLILogProvider implements LogProvider {
         break;
       case LogLevel.Warning:
         if (CLILogProvider.logLevel !== CLILogLevel.error) {
-          console.warn(this.yellow(message));
+          console.warn(chalk.yellowBright(message));
         }
         break;
       case LogLevel.Error:
       case LogLevel.Fatal:
-        console.error(this.red(message));
+        console.error(chalk.redBright(message));
         break;
     }
     return true;
@@ -142,17 +115,17 @@ export class CLILogProvider implements LogProvider {
       case LogLevel.Debug:
       case LogLevel.Info:
         if (white) {
-          console.info(this.white(message));
+          console.info(chalk.whiteBright(message));
         } else {
-          console.info(this.green(message));
+          console.info(chalk.greenBright(message));
         }
         break;
       case LogLevel.Warning:
-        console.warn(this.yellow(message));
+        console.warn(chalk.yellowBright(message));
         break;
       case LogLevel.Error:
       case LogLevel.Fatal:
-        console.error(this.red(message));
+        console.error(chalk.redBright(message));
         break;
     }
   }

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -229,30 +229,26 @@ export function getTeamsAppId(rootfolder: string | undefined): any {
 }
 
 export function getColorizedString(message: Array<{content: string, color: Colors}>): string {
-  // Only TTY support ANSI color
-  if (process.stdout.isTTY) {
-    const colorizedMessage = message.map(item => {
-      switch(item.color) {
-        case Colors.BRIGHT_WHITE:
-          return chalk.whiteBright(item.content);
-        case Colors.WHITE:
-          return chalk.white(item.content);
-        case Colors.BRIGHT_MAGENTA:
-          return chalk.magentaBright(item.content);
-        case Colors.BRIGHT_GREEN:
-          return chalk.greenBright(item.content);
-        case Colors.BRIGHT_RED:
-          return chalk.redBright(item.content);
-        case Colors.BRIGHT_YELLOW:
-          return chalk.yellowBright(item.content);
-        case Colors.BRIGHT_CYAN:
-          return chalk.cyanBright.underline(item.content);
-        default:
-          return ""
-      }
-    }).join("");
-    return colorizedMessage;
-  } else {
-    return message.map(x => x.content).join("");
-  }
+  // Color support is automatically detected by chalk
+  const colorizedMessage = message.map(item => {
+    switch(item.color) {
+      case Colors.BRIGHT_WHITE:
+        return chalk.whiteBright(item.content);
+      case Colors.WHITE:
+        return chalk.white(item.content);
+      case Colors.BRIGHT_MAGENTA:
+        return chalk.magentaBright(item.content);
+      case Colors.BRIGHT_GREEN:
+        return chalk.greenBright(item.content);
+      case Colors.BRIGHT_RED:
+        return chalk.redBright(item.content);
+      case Colors.BRIGHT_YELLOW:
+        return chalk.yellowBright(item.content);
+      case Colors.BRIGHT_CYAN:
+        return chalk.cyanBright.underline(item.content);
+      default:
+        return item.content;
+    }
+  }).join("");
+  return colorizedMessage;
 }

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -6,6 +6,7 @@
 import fs from "fs-extra";
 import path from "path";
 import { Options } from "yargs";
+import chalk from "chalk";
 
 import {
   NodeType,
@@ -22,6 +23,7 @@ import {
   getSingleOption,
   SingleSelectQuestion,
   MultiSelectQuestion,
+  Colors
 } from "@microsoft/teamsfx-api";
 
 import { ConfigNotFoundError, ReadFileError } from "./error";
@@ -224,4 +226,41 @@ export function getTeamsAppId(rootfolder: string | undefined): any {
   }
 
   return undefined;
+}
+
+export function getColorizedString(message: Array<{content: string, color: Colors}>): string {
+  // Only TTY support ANSI color
+  if (process.stdout.isTTY) {
+    let colorizedMessage = "";
+    (message as Array<{content: string, color: Colors}>).map(function(item) {
+      switch(item.color) {
+        case Colors.BRIGHT_WHITE:
+          colorizedMessage = colorizedMessage + chalk.whiteBright(item.content);
+          break;
+        case Colors.WHITE:
+          colorizedMessage = colorizedMessage + chalk.white(item.content);
+          break;
+        case Colors.BRIGHT_MAGENTA:
+          colorizedMessage = colorizedMessage + chalk.magentaBright(item.content);
+          break;
+        case Colors.BRIGHT_GREEN:
+          colorizedMessage = colorizedMessage + chalk.greenBright(item.content);
+          break;
+        case Colors.BRIGHT_RED:
+          colorizedMessage = colorizedMessage + chalk.redBright(item.content);
+          break;
+        case Colors.BRIGHT_YELLOW:
+          colorizedMessage = colorizedMessage + chalk.yellowBright(item.content);
+          break;
+        case Colors.BRIGHT_CYAN:
+          colorizedMessage = colorizedMessage + chalk.cyanBright.underline(item.content);
+          break;
+        default:
+          break;
+      }
+    });
+    return colorizedMessage;
+  } else {
+    return message.map(x => x.content).join("");
+  }
 }

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -231,34 +231,26 @@ export function getTeamsAppId(rootfolder: string | undefined): any {
 export function getColorizedString(message: Array<{content: string, color: Colors}>): string {
   // Only TTY support ANSI color
   if (process.stdout.isTTY) {
-    let colorizedMessage = "";
-    (message as Array<{content: string, color: Colors}>).map(function(item) {
+    const colorizedMessage = message.map(item => {
       switch(item.color) {
         case Colors.BRIGHT_WHITE:
-          colorizedMessage = colorizedMessage + chalk.whiteBright(item.content);
-          break;
+          return chalk.whiteBright(item.content);
         case Colors.WHITE:
-          colorizedMessage = colorizedMessage + chalk.white(item.content);
-          break;
+          return chalk.white(item.content);
         case Colors.BRIGHT_MAGENTA:
-          colorizedMessage = colorizedMessage + chalk.magentaBright(item.content);
-          break;
+          return chalk.magentaBright(item.content);
         case Colors.BRIGHT_GREEN:
-          colorizedMessage = colorizedMessage + chalk.greenBright(item.content);
-          break;
+          return chalk.greenBright(item.content);
         case Colors.BRIGHT_RED:
-          colorizedMessage = colorizedMessage + chalk.redBright(item.content);
-          break;
+          return chalk.redBright(item.content);
         case Colors.BRIGHT_YELLOW:
-          colorizedMessage = colorizedMessage + chalk.yellowBright(item.content);
-          break;
+          return chalk.yellowBright(item.content);
         case Colors.BRIGHT_CYAN:
-          colorizedMessage = colorizedMessage + chalk.cyanBright.underline(item.content);
-          break;
+          return chalk.cyanBright.underline(item.content);
         default:
-          break;
+          return ""
       }
-    });
+    }).join("");
     return colorizedMessage;
   } else {
     return message.map(x => x.content).join("");

--- a/packages/fx-core/src/plugins/resource/appstudio/index.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/index.ts
@@ -19,6 +19,7 @@ import {
   QuestionType,
   SystemError,
   UserError,
+  Colors
 } from "@microsoft/teamsfx-api";
 import { AppStudioPluginImpl } from "./plugin";
 import { Constants } from "./constants";
@@ -128,13 +129,19 @@ export class AppStudioPlugin implements Plugin {
         appDirectory,
         manifestString
       );
-      const builtSuccess = `Teams Package ${appPackagePath} built successfully!`;
       await ctx.dialog?.communicate(
         new DialogMsg(DialogType.Show, {
-          description: builtSuccess,
+          description: `Teams Package ${appPackagePath} built successfully!`,
           level: MsgLevel.Info,
         })
       );
+      const builtSuccess = [
+        { content: "(√)Done: ", color: Colors.BRIGHT_GREEN },
+        { content: "Teams Package ", color: Colors.BRIGHT_WHITE },
+        { content: appPackagePath, color: Colors.BRIGHT_MAGENTA },
+        { content: " built successfully!", color: Colors.BRIGHT_WHITE }
+      ]
+      ctx.logProvider?.info(builtSuccess);
       const properties: { [key: string]: string } = {};
       properties[TelemetryPropertyKey.buildOnly] = "true";
       TelemetryUtils.sendSuccessEvent(TelemetryEventName.buildTeamsPackage, properties);

--- a/packages/fx-core/tests/plugins/resource/aad/helper.ts
+++ b/packages/fx-core/tests/plugins/resource/aad/helper.ts
@@ -32,7 +32,7 @@ const mockLogProvider: LogProvider = {
     console.log(message);
     return true;
   },
-  async info(message: string): Promise<boolean> {
+  async info(message: string | Array<any>): Promise<boolean> {
     console.log("Log info");
     console.log(message);
     return true;

--- a/packages/fx-core/tests/plugins/resource/bot/unit/utils.ts
+++ b/packages/fx-core/tests/plugins/resource/bot/unit/utils.ts
@@ -50,7 +50,7 @@ export function generateFakeServiceClientCredentials(): ServiceClientCredentials
 
 export function generateFakeLogProvider(): LogProvider {
   return {
-    info: (message: string) => {
+    info: (message: string | Array<any>) => {
       return Promise.resolve(true);
     },
     log: (logLevel: LogLevel, message: string) => {

--- a/packages/fx-core/tests/plugins/resource/frontend/helper.ts
+++ b/packages/fx-core/tests/plugins/resource/frontend/helper.ts
@@ -63,7 +63,7 @@ export class TestHelper {
     async debug(message: string): Promise<boolean> {
       return true;
     },
-    async info(message: string): Promise<boolean> {
+    async info(message: string | Array<any>): Promise<boolean> {
       return true;
     },
     async warning(message: string): Promise<boolean> {

--- a/packages/vscode-extension/src/commonlib/log.ts
+++ b/packages/vscode-extension/src/commonlib/log.ts
@@ -3,7 +3,7 @@
 
 "use strict";
 
-import { LogLevel, LogProvider } from "@microsoft/teamsfx-api";
+import { LogLevel, LogProvider, Colors } from "@microsoft/teamsfx-api";
 import * as vscode from "vscode";
 
 const outputChannelDisplayName = "Teams Toolkit";
@@ -37,7 +37,15 @@ export class VsCodeLogProvider implements LogProvider {
     return this.log(LogLevel.Debug, message);
   }
 
-  info(message: string): Promise<boolean> {
+  info(message: Array<{content: string, color: Colors}>): Promise<boolean>;
+  
+  info(message: string): Promise<boolean>;
+
+  info(message: string | Array<{content: string, color: Colors}>): Promise<boolean> {
+    // VSCode output channel is not TTY, does not support ANSI color
+    if (message instanceof Array) {
+      message = message.map(x => x.content).join("");
+    }
     return this.log(LogLevel.Info, message);
   }
 


### PR DESCRIPTION
1) Support color for LogProvider.info, others like error/warning will have default color.
2) Replace colors with chalk package.

E.g. CLI:
![image](https://user-images.githubusercontent.com/71362691/121472993-92618580-c9f4-11eb-873b-a2968ae656ac.png)

VSCode output channel (default color):
![image](https://user-images.githubusercontent.com/71362691/121473088-b755f880-c9f4-11eb-82a9-ca943cc2f310.png)
