### PR TITLE
refactor(function): rename telemetryHelper and make ctx static

### DIFF
--- a/packages/fx-core/src/plugins/resource/function/index.ts
+++ b/packages/fx-core/src/plugins/resource/function/index.ts
@@ -7,7 +7,6 @@ import {
   PluginContext,
   QTreeNode,
   Result,
-  Stage,
   SystemError,
   UserError,
   err,
@@ -26,7 +25,7 @@ import { FunctionPluginImpl } from "./plugin";
 import { FxResult, FunctionPluginResultFactory as ResultFactory } from "./result";
 import { FunctionEvent } from "./enums";
 import { Logger } from "./utils/logger";
-import { telemetryHelper } from "./utils/telemetry-helper";
+import { TelemetryHelper } from "./utils/telemetry-helper";
 
 // This layer tries to provide a uniform exception handling for function plugin.
 export class FunctionPlugin implements Plugin {
@@ -135,14 +134,14 @@ export class FunctionPlugin implements Plugin {
     sendTelemetry = true
   ): Promise<FxResult> {
     try {
-      sendTelemetry && telemetryHelper.sendStartEvent(ctx, event);
+      sendTelemetry && TelemetryHelper.sendStartEvent(ctx, event);
       const res: FxResult = await fn();
-      sendTelemetry && telemetryHelper.sendResultEvent(ctx, event, res);
+      sendTelemetry && TelemetryHelper.sendResultEvent(ctx, event, res);
       return res;
     } catch (e) {
       if (e instanceof UserError || e instanceof SystemError) {
         const res = err(e);
-        sendTelemetry && telemetryHelper.sendResultEvent(ctx, event, res);
+        sendTelemetry && TelemetryHelper.sendResultEvent(ctx, event, res);
         return res;
       }
 
@@ -151,14 +150,14 @@ export class FunctionPlugin implements Plugin {
           e.errorType === ErrorType.User
             ? ResultFactory.UserError(e.getMessage(), e.code, undefined, e, e.stack)
             : ResultFactory.SystemError(e.getMessage(), e.code, undefined, e, e.stack);
-        sendTelemetry && telemetryHelper.sendResultEvent(ctx, event, res);
+        sendTelemetry && TelemetryHelper.sendResultEvent(ctx, event, res);
         return res;
       }
 
       const UnhandledErrorCode = "UnhandledError";
       /* Never send unhandled error message for privacy concern. */
       sendTelemetry &&
-        telemetryHelper.sendResultEvent(
+        TelemetryHelper.sendResultEvent(
           ctx,
           event,
           ResultFactory.SystemError("Got an unhandled error", UnhandledErrorCode)

--- a/packages/fx-core/src/plugins/resource/function/ops/deploy.ts
+++ b/packages/fx-core/src/plugins/resource/function/ops/deploy.ts
@@ -111,7 +111,7 @@ export class FunctionDeploy {
     }
 
     const binPath = path.join(componentPath, FunctionPluginPathInfo.functionExtensionsFolderName);
-    const telemetry = new FuncPluginTelemetry(ctx);
+    const telemetry = new FuncPluginTelemetry();
     const dotnetChecker = new DotnetChecker(
       new FuncPluginAdapter(ctx, telemetry),
       funcPluginLogger,

--- a/packages/fx-core/src/plugins/resource/function/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/function/plugin.ts
@@ -827,7 +827,7 @@ export class FunctionPluginImpl {
 
   private async handleDotnetChecker(ctx: PluginContext): Promise<void> {
     try {
-      const telemetry = new FuncPluginTelemetry(ctx);
+      const telemetry = new FuncPluginTelemetry();
       const funcPluginAdapter = new FuncPluginAdapter(ctx, telemetry);
       await step(StepGroup.PreDeployStepGroup, PreDeploySteps.dotnetInstall, async () => {
         const dotnetChecker = new DotnetChecker(
@@ -886,7 +886,7 @@ export class FunctionPluginImpl {
             await FunctionDeploy.installFuncExtensions(ctx, workingPath, functionLanguage);
           } catch (error) {
             // wrap the original error to UserError so the extensibility model will pop-up a dialog correctly
-            const telemetry = new FuncPluginTelemetry(ctx);
+            const telemetry = new FuncPluginTelemetry();
             new FuncPluginAdapter(ctx, telemetry).handleDotnetError(error);
           }
         })

--- a/packages/fx-core/src/plugins/resource/function/utils/depsChecker/funcPluginTelemetry.ts
+++ b/packages/fx-core/src/plugins/resource/function/utils/depsChecker/funcPluginTelemetry.ts
@@ -7,7 +7,7 @@ import { performance } from "perf_hooks";
 import { PluginContext, SystemError, UserError } from "@microsoft/teamsfx-api";
 import { IDepsTelemetry } from "./checker";
 import { DepsCheckerEvent, TelemetryMessurement } from "./common";
-import { telemetryHelper } from "../telemetry-helper";
+import { TelemetryHelper } from "../telemetry-helper";
 import { TelemetryKey } from "../../enums";
 
 export class FuncPluginTelemetry implements IDepsTelemetry {
@@ -30,7 +30,7 @@ export class FuncPluginTelemetry implements IDepsTelemetry {
     if (timecost) {
       measurements[TelemetryMessurement.completionTime] = timecost;
     }
-    telemetryHelper.sendSuccessEvent(this._ctx, eventName, FuncPluginTelemetry.getCommonProps(), measurements);
+    TelemetryHelper.sendSuccessEvent(this._ctx, eventName, FuncPluginTelemetry.getCommonProps(), measurements);
   }
 
   public async sendEventWithDuration(
@@ -47,12 +47,12 @@ export class FuncPluginTelemetry implements IDepsTelemetry {
       measurements[TelemetryMessurement.completionTime] = timecost;
     }
 
-    telemetryHelper.sendSuccessEvent(this._ctx, eventName, FuncPluginTelemetry.getCommonProps(), measurements);
+    TelemetryHelper.sendSuccessEvent(this._ctx, eventName, FuncPluginTelemetry.getCommonProps(), measurements);
   }
 
   public sendUserErrorEvent(eventName: DepsCheckerEvent, errorMessage: string): void {
     const error = new UserError(eventName, errorMessage, this._source);
-    telemetryHelper.sendErrorEvent(this._ctx, eventName, error, FuncPluginTelemetry.getCommonProps());
+    TelemetryHelper.sendErrorEvent(this._ctx, eventName, error, FuncPluginTelemetry.getCommonProps());
   }
 
   public sendSystemErrorEvent(
@@ -66,6 +66,6 @@ export class FuncPluginTelemetry implements IDepsTelemetry {
       this._source,
       errorStack
     );
-    telemetryHelper.sendErrorEvent(this._ctx, eventName, error, FuncPluginTelemetry.getCommonProps());
+    TelemetryHelper.sendErrorEvent(this._ctx, eventName, error, FuncPluginTelemetry.getCommonProps());
   }
 }

--- a/packages/fx-core/src/plugins/resource/function/utils/depsChecker/funcPluginTelemetry.ts
+++ b/packages/fx-core/src/plugins/resource/function/utils/depsChecker/funcPluginTelemetry.ts
@@ -12,11 +12,6 @@ import { TelemetryKey } from "../../enums";
 
 export class FuncPluginTelemetry implements IDepsTelemetry {
   private readonly _source = "func-envchecker";
-  private readonly _ctx: PluginContext;
-
-  constructor(ctx: PluginContext) {
-    this._ctx = ctx;
-  }
 
   private static getCommonProps(): { [key: string]: string } {
     const properties: { [key: string]: string; } = {};
@@ -30,7 +25,7 @@ export class FuncPluginTelemetry implements IDepsTelemetry {
     if (timecost) {
       measurements[TelemetryMessurement.completionTime] = timecost;
     }
-    TelemetryHelper.sendSuccessEvent(this._ctx, eventName, FuncPluginTelemetry.getCommonProps(), measurements);
+    TelemetryHelper.sendSuccessEvent(eventName, FuncPluginTelemetry.getCommonProps(), measurements);
   }
 
   public async sendEventWithDuration(
@@ -47,12 +42,12 @@ export class FuncPluginTelemetry implements IDepsTelemetry {
       measurements[TelemetryMessurement.completionTime] = timecost;
     }
 
-    TelemetryHelper.sendSuccessEvent(this._ctx, eventName, FuncPluginTelemetry.getCommonProps(), measurements);
+    TelemetryHelper.sendSuccessEvent(eventName, FuncPluginTelemetry.getCommonProps(), measurements);
   }
 
   public sendUserErrorEvent(eventName: DepsCheckerEvent, errorMessage: string): void {
     const error = new UserError(eventName, errorMessage, this._source);
-    TelemetryHelper.sendErrorEvent(this._ctx, eventName, error, FuncPluginTelemetry.getCommonProps());
+    TelemetryHelper.sendErrorEvent(eventName, error, FuncPluginTelemetry.getCommonProps());
   }
 
   public sendSystemErrorEvent(
@@ -66,6 +61,6 @@ export class FuncPluginTelemetry implements IDepsTelemetry {
       this._source,
       errorStack
     );
-    TelemetryHelper.sendErrorEvent(this._ctx, eventName, error, FuncPluginTelemetry.getCommonProps());
+    TelemetryHelper.sendErrorEvent(eventName, error, FuncPluginTelemetry.getCommonProps());
   }
 }

--- a/packages/fx-core/src/plugins/resource/function/utils/telemetry-helper.ts
+++ b/packages/fx-core/src/plugins/resource/function/utils/telemetry-helper.ts
@@ -8,7 +8,7 @@ import { FxResult } from "../result";
 import { FunctionEvent, TelemetryKey, TelemetryValue } from "../enums";
 import { DepsCheckerEvent } from "./depsChecker/common";
 
-export class telemetryHelper {
+export class TelemetryHelper {
   static fillCommonProperty(ctx: PluginContext, properties: { [key: string]: string }) {
     properties[TelemetryKey.Component] = FunctionPluginInfo.pluginName;
     properties[TelemetryKey.AppId] =


### PR DESCRIPTION
1. rename `telemetryHelper` to `TelemetryHelper`
2. make ctx static to avoid broadcast