### PR TITLE
fix: azure initialize status

### DIFF
--- a/packages/vscode-extension/src/commonlib/azureLogin.ts
+++ b/packages/vscode-extension/src/commonlib/azureLogin.ts
@@ -343,10 +343,10 @@ export class AzureAccountManager extends login implements AzureAccountProvider {
     AzureAccountManager.currentStatus = azureAccount.status;
     azureAccount.onStatusChanged(async (event) => {
       if(AzureAccountManager.currentStatus === "Initializing") {
-        AzureAccountManager.currentStatus = azureAccount.status;
+        AzureAccountManager.currentStatus = event;
         return;
       }
-      AzureAccountManager.currentStatus = azureAccount.status;
+      AzureAccountManager.currentStatus = event;
       if (event === loggedOut) {
         if (AzureAccountManager.statusChange !== undefined) {
           await AzureAccountManager.statusChange(signedOut, undefined, undefined);

--- a/packages/vscode-extension/src/commonlib/azureLogin.ts
+++ b/packages/vscode-extension/src/commonlib/azureLogin.ts
@@ -29,6 +29,7 @@ export class AzureAccountManager extends login implements AzureAccountProvider {
   private static instance: AzureAccountManager;
   private static subscriptionId: string | undefined;
   private static tenantId: string | undefined;
+  private static currentStatus: string | undefined;
 
   private static statusChange?: (
     status: string,
@@ -339,9 +340,13 @@ export class AzureAccountManager extends login implements AzureAccountProvider {
   async addStatusChangeEvent() {
     const azureAccount: AzureAccount =
       vscode.extensions.getExtension<AzureAccount>("ms-vscode.azure-account")!.exports;
-    // wait for Azure Account extension initialize
-    await azureAccount.waitForSubscriptions();
+    AzureAccountManager.currentStatus = azureAccount.status;
     azureAccount.onStatusChanged(async (event) => {
+      if(AzureAccountManager.currentStatus === "Initializing") {
+        AzureAccountManager.currentStatus = azureAccount.status;
+        return;
+      }
+      AzureAccountManager.currentStatus = azureAccount.status;
       if (event === loggedOut) {
         if (AzureAccountManager.statusChange !== undefined) {
           await AzureAccountManager.statusChange(signedOut, undefined, undefined);

--- a/packages/vscode-extension/src/commonlib/azureLogin.ts
+++ b/packages/vscode-extension/src/commonlib/azureLogin.ts
@@ -339,6 +339,8 @@ export class AzureAccountManager extends login implements AzureAccountProvider {
   async addStatusChangeEvent() {
     const azureAccount: AzureAccount =
       vscode.extensions.getExtension<AzureAccount>("ms-vscode.azure-account")!.exports;
+    // wait for Azure Account extension initialize
+    await azureAccount.waitForSubscriptions();
     azureAccount.onStatusChanged(async (event) => {
       if (event === loggedOut) {
         if (AzureAccountManager.statusChange !== undefined) {


### PR DESCRIPTION
1. Fix Azure notify status when first open Vs Code and not signed in.  (This is because Azure Account will be ready after toolkit extension starts.)


Bug: When open new VsCode and do not sign in Azure after treeView move from core to extension.
https://dev.azure.com/msazure/Microsoft%20Teams%20Extensibility/_workitems/edit/10192921/