### PR TITLE
feat(frontend): Add Azure error code to error message and send for telemetry

### DIFF
--- a/packages/fx-core/src/plugins/resource/frontend/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/plugin.ts
@@ -120,7 +120,7 @@ export class FrontendPluginImpl {
       ) {
         return new StorageAccountAlreadyTakenError();
       }
-      return new CreateStorageAccountError();
+      return new CreateStorageAccountError(innerError.code);
     };
     config.endpoint = await runWithErrorCatchAndWrap(
       createStorageErrorWrapper,

--- a/packages/fx-core/src/plugins/resource/frontend/resources/errors.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/resources/errors.ts
@@ -146,11 +146,13 @@ export class StorageAccountAlreadyTakenError extends FrontendPluginError {
 }
 
 export class CreateStorageAccountError extends FrontendPluginError {
-  constructor(innerErrorCode: string) {
+  constructor(innerErrorCode?: string) {
     super(
       ErrorType.User,
       "CreateStorageAccountError",
-      `Failed to create Azure Storage Account, Azure error code: ${innerErrorCode}.`,
+      `Failed to create Azure Storage Account${
+        innerErrorCode ? `, Azure error code: ${innerErrorCode}` : ""
+      }.`,
       [tips.checkLog]
     );
   }

--- a/packages/fx-core/src/plugins/resource/frontend/resources/errors.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/resources/errors.ts
@@ -146,10 +146,13 @@ export class StorageAccountAlreadyTakenError extends FrontendPluginError {
 }
 
 export class CreateStorageAccountError extends FrontendPluginError {
-  constructor() {
-    super(ErrorType.User, "CreateStorageAccountError", "Failed to create Azure Storage Account.", [
-      tips.checkLog,
-    ]);
+  constructor(innerErrorCode: string) {
+    super(
+      ErrorType.User,
+      "CreateStorageAccountError",
+      `Failed to create Azure Storage Account, Azure error code: ${innerErrorCode}.`,
+      [tips.checkLog]
+    );
   }
 }
 


### PR DESCRIPTION
There are many CreateStorageAccountError in telemetry but we don't know why. Add Azure error code to error message and the error message will be added to telemetry, which may help us know what's happening.