### PR TITLE
fix(vsc): auto show teamsfx treeview at first time

### DIFF
--- a/packages/vscode-extension/src/controls/openWelcomePage.ts
+++ b/packages/vscode-extension/src/controls/openWelcomePage.ts
@@ -15,4 +15,5 @@ export async function openWelcomePageAfterExtensionInstallation(): Promise<void>
   // Let's show!
   await ext.context.globalState.update(welcomePageKey, true);
   vscode.commands.executeCommand("fx-extension.openWelcome");
+  vscode.commands.executeCommand("workbench.view.extension.teamsfx");
 }


### PR DESCRIPTION
ADO: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_sprints/taskboard/Teams%20Extensibility%20E2E%20Team/Microsoft%20Teams%20Extensibility/cy21-6.2?workitem=10209884
![Animation2](https://user-images.githubusercontent.com/26411726/123040101-c772cc80-d425-11eb-8496-5dbf282d5725.gif)
