### PR TITLE
feat(frontend): Add help link for some user errors

### DIFF
--- a/packages/fx-core/src/plugins/resource/frontend/constants.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/constants.ts
@@ -31,7 +31,7 @@ export class FrontendPluginInfo {
   static DisplayName = "Tab Frontend";
   static ShortName = "FE";
   static IssueLink = "https://github.com/OfficeDev/TeamsFx/issues/new";
-  static HelpLink = ""; // TODO: default help link
+  static HelpLink = "https://aka.ms/teamsfx-fe-help";
 }
 
 export class Commands {

--- a/packages/fx-core/src/plugins/resource/frontend/error-factory.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/error-factory.ts
@@ -18,7 +18,6 @@ export class ErrorFactory {
     stack?: string,
     helpLink?: string
   ): FxError {
-    helpLink ??= this.helpLink;
     return new UserError(name, message, this.source, stack, helpLink, innerError);
   }
 
@@ -27,9 +26,8 @@ export class ErrorFactory {
     message: string,
     innerError?: any,
     stack?: string,
-    issueLink?: string
+    issueLink = this.issueLink
   ): FxError {
-    issueLink ??= this.issueLink;
     return new SystemError(name, message, this.source, stack, issueLink, innerError);
   }
 }

--- a/packages/fx-core/src/plugins/resource/frontend/index.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/index.ts
@@ -81,7 +81,7 @@ export class FrontendPlugin implements Plugin {
       if (e instanceof FrontendPluginError) {
         const error =
           e.errorType === ErrorType.User
-            ? ErrorFactory.UserError(e.code, e.getMessage())
+            ? ErrorFactory.UserError(e.code, e.getMessage(), undefined, undefined, e.helpLink)
             : ErrorFactory.SystemError(
                 e.code,
                 e.getMessage(),

--- a/packages/fx-core/src/plugins/resource/frontend/resources/errors.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/resources/errors.ts
@@ -37,14 +37,22 @@ export class FrontendPluginError extends Error {
   public message: string;
   public suggestions: string[];
   public errorType: ErrorType;
+  public helpLink?: string;
   public innerError?: Error;
 
-  constructor(errorType: ErrorType, code: string, message: string, suggestions: string[]) {
+  constructor(
+    errorType: ErrorType,
+    code: string,
+    message: string,
+    suggestions: string[],
+    helpLink?: string
+  ) {
     super(message);
     this.code = code;
     this.message = message;
     this.suggestions = suggestions;
     this.errorType = errorType;
+    this.helpLink = helpLink;
   }
 
   getMessage(): string {

--- a/packages/fx-core/src/plugins/resource/frontend/resources/errors.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/resources/errors.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Constants, FrontendPathInfo } from "../constants";
+import { Constants, FrontendPathInfo, FrontendPluginInfo } from "../constants";
 import { Logger } from "../utils/logger";
 import path from "path";
 
@@ -129,7 +129,8 @@ export class StaticWebsiteDisabledError extends FrontendPluginError {
       ErrorType.User,
       "StaticWebsiteDisableError",
       "Static website hosting feature is disabled for Azure Storage Account.",
-      [tips.reProvision]
+      [tips.reProvision],
+      FrontendPluginInfo.HelpLink
     );
   }
 }
@@ -172,7 +173,8 @@ export class EnableStaticWebsiteError extends FrontendPluginError {
       ErrorType.User,
       "EnableStaticWebsiteError",
       "Failed to enable static website feature for Azure Storage Account.",
-      [tips.checkSystemTime, tips.checkStoragePermissions]
+      [tips.checkSystemTime, tips.checkStoragePermissions],
+      FrontendPluginInfo.HelpLink
     );
   }
 }


### PR DESCRIPTION
Found some EnableStaticWebsiteError and StaticWebsiteDisableError for frontend plugin, add a help document to tell user how to deal with these.