### PR TITLE
fix(cli): disable default show help when user input error cmd

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -48,21 +48,20 @@ export async function start() {
     .options("verbose", {
       description: "Print additional information.",
       boolean: true,
-      default: false
+      default: false,
     })
     .options("debug", {
       description: "Print diagnostic information.",
       boolean: true,
-      default: false
+      default: false,
     })
     .demandCommand()
     .scriptName(constants.cliName)
     .help()
     .strict()
+    .showHelpOnFail(false, "Specify --help for available options")
     .alias("help", "h")
     .alias("v", "version")
     .version(getVersion())
-    .epilogue(
-      "For more information about the Teams Toolkit - https://aka.ms/teamsfx-learn."
-    ).argv;
+    .epilogue("For more information about the Teams Toolkit - https://aka.ms/teamsfx-learn.").argv;
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/72644308/123573851-55253200-d801-11eb-8f66-27635a2a9a91.png)

related task: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/9823359