### PR TITLE
fix(spfx): disable spfx chat tab

### DIFF
--- a/packages/fx-core/templates/plugins/resource/spfx/solution/manifest.json
+++ b/packages/fx-core/templates/plugins/resource/spfx/solution/manifest.json
@@ -38,8 +38,7 @@
             "configurationUrl": "https://{teamSiteDomain}{teamSitePath}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest={teamSitePath}/_layouts/15/teamshostedapp.aspx%3FopenPropertyPane=true%26teams%26componentId=<%= componentId %>%26forceLocale={locale}",
             "canUpdateConfiguration": true,
             "scopes": [
-                "team",
-                "groupchat"
+                "team"
             ]
         }
     ],


### PR DESCRIPTION
related task: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/10241958
![image](https://user-images.githubusercontent.com/72644308/123612152-e19d1800-d834-11eb-9f73-e3a5372e861a.png)
"Add to a chat" has been removed.