### PR TITLE
fix(cli-preview): merge process.env when starting services

### DIFF
--- a/packages/cli/src/cmds/preview/commonUtils.ts
+++ b/packages/cli/src/cmds/preview/commonUtils.ts
@@ -162,16 +162,12 @@ export async function getPortsInUse(
 export function mergeProcessEnv(
   env: { [key: string]: string | undefined } | undefined
 ): { [key: string]: string | undefined } | undefined {
-  const processEnv = process.env;
   if (env === undefined) {
     return process.env;
   }
-  const keys = Object.keys(env);
-  for (const key of Object.keys(processEnv)) {
-    const existing = keys.some((k) => k === key);
-    if (!existing) {
-      env[key] = processEnv[key];
-    }
+  const result = Object.assign({}, process.env);
+  for (const key of Object.keys(env)) {
+    result[key] = env[key];
   }
-  return env;
+  return result;
 }

--- a/packages/cli/src/cmds/preview/commonUtils.ts
+++ b/packages/cli/src/cmds/preview/commonUtils.ts
@@ -158,3 +158,20 @@ export async function getPortsInUse(
   }
   return portsInUse;
 }
+
+export function mergeProcessEnv(
+  env: { [key: string]: string | undefined } | undefined
+): { [key: string]: string | undefined } | undefined {
+  const processEnv = process.env;
+  if (env === undefined) {
+    return process.env;
+  }
+  const keys = Object.keys(env);
+  for (const key of Object.keys(processEnv)) {
+    const existing = keys.some((k) => k === key);
+    if (!existing) {
+      env[key] = processEnv[key];
+    }
+  }
+  return env;
+}

--- a/packages/cli/src/cmds/preview/preview.ts
+++ b/packages/cli/src/cmds/preview/preview.ts
@@ -379,7 +379,7 @@ export default class Preview extends YargsCommand {
       const env = await commonUtils.getFrontendLocalEnv(workspaceFolder);
       frontendStartTask = new Task(constants.frontendStartCommand, {
         cwd: frontendRoot,
-        env,
+        env: commonUtils.mergeProcessEnv(env),
       });
     }
 
@@ -389,7 +389,7 @@ export default class Preview extends YargsCommand {
       const env = await commonUtils.getAuthLocalEnv(workspaceFolder);
       authStartTask = new Task(constants.authStartCommand, {
         cwd,
-        env,
+        env: commonUtils.mergeProcessEnv(env),
       });
     }
 
@@ -397,17 +397,19 @@ export default class Preview extends YargsCommand {
     let backendWatchTask: Task | undefined;
     if (backendRoot !== undefined) {
       const env = await commonUtils.getBackendLocalEnv(workspaceFolder);
+      const mergedEnv = commonUtils.mergeProcessEnv(env);
       const command =
         programmingLanguage === constants.ProgrammingLanguage.typescript
           ? constants.backendStartTsCommand
           : constants.backendStartJsCommand;
       backendStartTask = new Task(command, {
         cwd: backendRoot,
-        env,
+        env: mergedEnv,
       });
       if (programmingLanguage === constants.ProgrammingLanguage.typescript) {
         backendWatchTask = new Task(constants.backendWatchCommand, {
           cwd: backendRoot,
+          env: mergedEnv,
         });
       }
     }
@@ -421,7 +423,7 @@ export default class Preview extends YargsCommand {
       const env = await commonUtils.getBotLocalEnv(workspaceFolder);
       botStartTask = new Task(command, {
         cwd: botRoot,
-        env,
+        env: commonUtils.mergeProcessEnv(env),
       });
     }
 


### PR DESCRIPTION
merge process.env when starting services, otherwise there will be an error on macos: `env: node: No such file or directory` or `/bin/sh: dotnet: command not found`