### PR TITLE
fix(cli-preview): terminate background tasks when error occurs

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -6702,6 +6702,11 @@
         "punycode": "^2.1.1"
       }
     },
+    "tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="
+    },
     "ts-loader": {
       "version": "9.2.3",
       "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.2.3.tgz",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -112,6 +112,7 @@
     "node-machine-id": "^1.1.12",
     "open": "^7.3.1",
     "tedious": "^9.2.1",
+    "tree-kill": "^1.2.2",
     "underscore": "^1.12.1",
     "yargs": "^16.2.0"
   },

--- a/packages/cli/src/cmds/preview/commonUtils.ts
+++ b/packages/cli/src/cmds/preview/commonUtils.ts
@@ -38,7 +38,9 @@ export function createTaskStopCb(
     } else {
       const error = TaskFailed(taskTitle);
       cliLogger.necessaryLog(LogLevel.Error, `${error.source}.${error.name}: ${error.message}`);
-      cliLogger.necessaryLog(LogLevel.Info, result.stderr[result.stderr.length - 1], true);
+      if (result.stderr.length > 0) {
+        cliLogger.necessaryLog(LogLevel.Info, result.stderr[result.stderr.length - 1], true);
+      }
       return error;
     }
   };
@@ -100,7 +102,7 @@ export async function getBotLocalEnv(
 }
 
 async function detectPortListeningImpl(port: number, host: string): Promise<boolean> {
-  return new Promise<boolean>((resolve, reject) => {
+  return new Promise<boolean>((resolve) => {
     try {
       const server = net.createServer();
       server

--- a/packages/cli/src/cmds/preview/task.ts
+++ b/packages/cli/src/cmds/preview/task.ts
@@ -3,8 +3,9 @@
 
 "use strict";
 
-import { spawn, SpawnOptions } from "child_process";
+import { ChildProcess, spawn, SpawnOptions } from "child_process";
 import { err, FxError, ok, Result } from "@microsoft/teamsfx-api";
+import treeKill from "tree-kill";
 
 interface TaskOptions {
   cwd?: string;
@@ -21,6 +22,9 @@ export interface TaskResult {
 export class Task {
   private command: string;
   private options: TaskOptions;
+
+  private resolved = false;
+  private task: ChildProcess | undefined;
 
   constructor(command: string, options: TaskOptions) {
     this.command = command;
@@ -40,24 +44,24 @@ export class Task {
       cwd: this.options.cwd,
       env: this.options.env,
     };
-    const task = spawn(this.command, spawnOptions);
+    this.task = spawn(this.command, spawnOptions);
     const stdout: string[] = [];
     const stderr: string[] = [];
-    return new Promise((resolve, reject) => {
-      task.stdout?.on("data", (data) => {
+    return new Promise((resolve) => {
+      this.task?.stdout?.on("data", (data) => {
         // TODO: log
         stdout.push(data.toString());
       });
-      task.stderr?.on("data", (data) => {
+      this.task?.stderr?.on("data", (data) => {
         // TODO: log
         stderr.push(data.toString());
       });
-      task.on("exit", async () => {
+      this.task?.on("exit", async () => {
         const result: TaskResult = {
-          success: task.exitCode === 0,
+          success: this.task?.exitCode === 0,
           stdout: stdout,
           stderr: stderr,
-          exitCode: task.exitCode,
+          exitCode: this.task?.exitCode === undefined ? null : this.task?.exitCode,
         };
         const error = await stopCallback(result);
         if (error) {
@@ -83,18 +87,17 @@ export class Task {
       cwd: this.options.cwd,
       env: this.options.env,
     };
-    const task = spawn(this.command, spawnOptions);
+    this.task = spawn(this.command, spawnOptions);
     const stdout: string[] = [];
     const stderr: string[] = [];
-    let success = false;
-    return new Promise((resolve, reject) => {
-      task.stdout?.on("data", async (data) => {
+    return new Promise((resolve) => {
+      this.task?.stdout?.on("data", async (data) => {
         // TODO: log
         stdout.push(data.toString());
-        if (!success) {
+        if (!this.resolved) {
           const match = pattern.test(data.toString());
           if (match) {
-            success = true;
+            this.resolved = true;
             const result: TaskResult = {
               success: true,
               stdout: stdout,
@@ -110,25 +113,49 @@ export class Task {
           }
         }
       });
-      task.stderr?.on("data", (data) => {
+      this.task?.stderr?.on("data", (data) => {
         // TODO: log
         stderr.push(data.toString());
       });
 
-      task.on("exit", async () => {
-        const result: TaskResult = {
-          success: false,
-          stdout: stdout,
-          stderr: stderr,
-          exitCode: task.exitCode,
-        };
-        const error = await stopCallback(result);
-        if (error) {
-          resolve(err(error));
-        } else {
-          resolve(ok(result));
+      this.task?.on("exit", async () => {
+        if (!this.resolved) {
+          this.resolved = true;
+          const result: TaskResult = {
+            success: false,
+            stdout: stdout,
+            stderr: stderr,
+            exitCode: this.task?.exitCode === undefined ? null : this.task?.exitCode,
+          };
+          const error = await stopCallback(result);
+          if (error) {
+            resolve(err(error));
+          } else {
+            resolve(ok(result));
+          }
         }
       });
+    });
+  }
+
+  public async terminate(): Promise<void> {
+    return new Promise((resolve) => {
+      if (this.task?.exitCode) {
+        resolve();
+      }
+      const pid = this.task?.pid;
+      if (pid === undefined) {
+        resolve();
+      } else {
+        treeKill(pid, (error) => {
+          if (error) {
+            // ignore any error
+            resolve();
+          } else {
+            resolve();
+          }
+        });
+      }
     });
   }
 }


### PR DESCRIPTION
use `tree-kill` to terminate background tasks when error occurs.