### PR TITLE
refactor(apim): refactor apim plugin according to core refactor

### DIFF
--- a/packages/fx-core/src/plugins/resource/apim/answer.ts
+++ b/packages/fx-core/src/plugins/resource/apim/answer.ts
@@ -39,46 +39,57 @@ export function buildAnswer(ctx: PluginContext): IAnswer {
   }
 }
 
-export class VSCodeAnswer implements IAnswer {
-  private answer: Inputs;
+class BaseAnswer {
+  protected answer: Inputs;
   constructor(answer: Inputs) {
     this.answer = answer;
   }
+
+  protected getOptionItem(questionName: string): OptionItem {
+    return this.answer[questionName] as OptionItem;
+  }
+
+  protected getString(questionName: string): string {
+    return this.answer[questionName] as string;
+  }
+}
+
+export class VSCodeAnswer extends BaseAnswer implements IAnswer {
+  constructor(answer: Inputs) {
+    super(answer);
+  }
+
   get resourceGroupName(): string | undefined {
-    const apimService = (this.answer[QuestionConstants.VSCode.Apim.questionName] as OptionItem)
-      .data as IApimServiceResource;
+    const apimService = this.getOptionItem(QuestionConstants.VSCode.Apim.questionName)
+      ?.data as IApimServiceResource;
     return apimService?.resourceGroupName;
   }
   get apimServiceName(): string | undefined {
-    const apimService = (this.answer[QuestionConstants.VSCode.Apim.questionName] as OptionItem)
+    const apimService = this.getOptionItem(QuestionConstants.VSCode.Apim.questionName)
       ?.data as IApimServiceResource;
     return apimService?.serviceName;
   }
   get apiDocumentPath(): string | undefined {
-    return (this.answer[QuestionConstants.VSCode.OpenApiDocument.questionName] as OptionItem)
-      ?.label;
+    return this.getOptionItem(QuestionConstants.VSCode.OpenApiDocument.questionName)?.label;
   }
   get openApiDocumentSpec(): OpenAPI.Document | undefined {
-    const openApiDocument = (this.answer[
+    const openApiDocument = this.getOptionItem(
       QuestionConstants.VSCode.OpenApiDocument.questionName
-    ] as OptionItem)?.data as IOpenApiDocument;
+    )?.data as IOpenApiDocument;
     return openApiDocument?.spec as OpenAPI.Document;
   }
   get apiPrefix(): string | undefined {
-    return this.answer[QuestionConstants.VSCode.ApiPrefix.questionName] as string;
+    return this.getString(QuestionConstants.VSCode.ApiPrefix.questionName);
   }
   get apiId(): string | undefined {
-    const api = (this.answer[QuestionConstants.VSCode.ApiVersion.questionName] as OptionItem)
+    const api = this.getOptionItem(QuestionConstants.VSCode.ApiVersion.questionName)
       ?.data as ApiContract;
     return api?.name;
   }
   get versionIdentity(): string | undefined {
-    const api = (this.answer[QuestionConstants.VSCode.ApiVersion.questionName] as OptionItem)
+    const api = this.getOptionItem(QuestionConstants.VSCode.ApiVersion.questionName)
       ?.data as ApiContract;
-    return (
-      api?.apiVersion ??
-      (this.answer[QuestionConstants.VSCode.NewApiVersion.questionName] as string)
-    );
+    return api?.apiVersion ?? this.getString(QuestionConstants.VSCode.NewApiVersion.questionName);
   }
 
   save(lifecycle: PluginLifeCycle, apimConfig: IApimPluginConfig): void {
@@ -95,29 +106,28 @@ export class VSCodeAnswer implements IAnswer {
   }
 }
 
-export class CLIAnswer implements IAnswer {
-  private answer: Inputs;
+export class CLIAnswer extends BaseAnswer implements IAnswer {
   constructor(answer: Inputs) {
-    this.answer = answer;
+    super(answer);
   }
 
   get resourceGroupName(): string | undefined {
-    return this.answer[QuestionConstants.CLI.ApimResourceGroup.questionName] as string;
+    return this.getString(QuestionConstants.CLI.ApimResourceGroup.questionName);
   }
   get apimServiceName(): string | undefined {
-    return this.answer[QuestionConstants.CLI.ApimServiceName.questionName] as string;
+    return this.getString(QuestionConstants.CLI.ApimServiceName.questionName);
   }
   get apiDocumentPath(): string | undefined {
-    return this.answer[QuestionConstants.CLI.OpenApiDocument.questionName] as string;
+    return this.getString(QuestionConstants.CLI.OpenApiDocument.questionName);
   }
   get apiPrefix(): string | undefined {
-    return this.answer[QuestionConstants.CLI.ApiPrefix.questionName] as string;
+    return this.getString(QuestionConstants.CLI.ApiPrefix.questionName);
   }
   get apiId(): string | undefined {
-    return this.answer[QuestionConstants.CLI.ApiId.questionName] as string;
+    return this.getString(QuestionConstants.CLI.ApiId.questionName);
   }
   get versionIdentity(): string | undefined {
-    return this.answer[QuestionConstants.CLI.ApiVersion.questionName] as string;
+    return this.getString(QuestionConstants.CLI.ApiVersion.questionName);
   }
 
   save(lifecycle: PluginLifeCycle, apimConfig: IApimPluginConfig): void {

--- a/packages/fx-core/src/plugins/resource/apim/answer.ts
+++ b/packages/fx-core/src/plugins/resource/apim/answer.ts
@@ -27,36 +27,36 @@ export interface IAnswer {
   ): Promise<void>;
 }
 
-export function buildAnswer(ctx: PluginContext): IAnswer {
-  const answers = AssertNotEmpty("ctx.answers", ctx.answers);
-  switch (answers.platform) {
+export function buildAnswer(inputs: Inputs | undefined): IAnswer {
+  inputs = AssertNotEmpty("inputs", inputs);
+  switch (inputs.platform) {
     case Platform.VSCode:
-      return new VSCodeAnswer(answers);
+      return new VSCodeAnswer(inputs);
     case Platform.CLI:
-      return new CLIAnswer(answers);
+      return new CLIAnswer(inputs);
     default:
       throw BuildError(NotImplemented);
   }
 }
 
 class BaseAnswer {
-  protected answer: Inputs;
-  constructor(answer: Inputs) {
-    this.answer = answer;
+  protected inputs: Inputs;
+  constructor(inputs: Inputs) {
+    this.inputs = inputs;
   }
 
   protected getOptionItem(questionName: string): OptionItem {
-    return this.answer[questionName] as OptionItem;
+    return this.inputs[questionName] as OptionItem;
   }
 
   protected getString(questionName: string): string {
-    return this.answer[questionName] as string;
+    return this.inputs[questionName] as string;
   }
 }
 
 export class VSCodeAnswer extends BaseAnswer implements IAnswer {
-  constructor(answer: Inputs) {
-    super(answer);
+  constructor(inputs: Inputs) {
+    super(inputs);
   }
 
   get resourceGroupName(): string | undefined {
@@ -107,8 +107,8 @@ export class VSCodeAnswer extends BaseAnswer implements IAnswer {
 }
 
 export class CLIAnswer extends BaseAnswer implements IAnswer {
-  constructor(answer: Inputs) {
-    super(answer);
+  constructor(inputs: Inputs) {
+    super(inputs);
   }
 
   get resourceGroupName(): string | undefined {

--- a/packages/fx-core/src/plugins/resource/apim/config.ts
+++ b/packages/fx-core/src/plugins/resource/apim/config.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { ConfigValue, ReadonlySolutionConfig } from "@microsoft/teamsfx-api";
+import { PluginConfig, ReadonlySolutionConfig } from "@microsoft/teamsfx-api";
 import {
   TeamsToolkitComponent,
   ComponentRetryOperations,
@@ -54,8 +54,8 @@ export interface ISolutionConfig {
 
 export class ApimPluginConfig implements IApimPluginConfig {
   // TODO update @microsoft/teamsfx-api to the latest version
-  private readonly config: Map<string, ConfigValue>;
-  constructor(config: Map<string, ConfigValue>) {
+  private readonly config: PluginConfig;
+  constructor(config: PluginConfig) {
     this.config = config;
   }
 
@@ -133,12 +133,9 @@ export class ApimPluginConfig implements IApimPluginConfig {
   }
 
   private getValue(key: string, namingRule?: INamingRule): string | undefined {
-    const value = this.config.get(key);
-    if (typeof value !== "string" && typeof value !== "undefined") {
-      throw BuildError(InvalidPropertyType, key, "string");
-    }
+    const value = this.config.getString(key);
 
-    if (namingRule && typeof value === "string") {
+    if (namingRule && value) {
       const message = NamingRules.validate(value, namingRule);
       if (message) {
         throw BuildError(InvalidConfigValue, TeamsToolkitComponent.ApimPlugin, key, message);

--- a/packages/fx-core/src/plugins/resource/apim/constants.ts
+++ b/packages/fx-core/src/plugins/resource/apim/constants.ts
@@ -36,7 +36,6 @@ export class QuestionConstants {
   public static readonly VSCode = class {
     public static readonly Apim = class {
       public static readonly questionName: string = "vsc-apim-service";
-      public static readonly funcName: string = "apim-service-option";
       public static readonly description: string = "Select API Management service";
       public static readonly createNewApimOption: string = "+ Create a new API Management service";
     };
@@ -52,12 +51,10 @@ export class QuestionConstants {
     public static readonly ExistingOpenApiDocument = class {
       // Same to OpenApiDocument.questionName
       public static readonly questionName: string = "vsc-open-api-document";
-      public static readonly funcName: string = "existing-open-api-document-option";
     };
 
     public static readonly ApiPrefix = class {
       public static readonly questionName: string = "vsc-api-prefix";
-      public static readonly funcName: string = "api-prefix-default-value";
       public static readonly description: string = "Input the API name prefix.";
       public static readonly prompt: string =
         "The unique name of the API will be '{api-prefix}-{resource-suffix}-{api-version}'.";
@@ -65,14 +62,12 @@ export class QuestionConstants {
 
     public static readonly ApiVersion = class {
       public static readonly questionName: string = "vsc-api-version";
-      public static readonly funcName: string = "api-version-option";
       public static readonly description: string = "Select an API version.";
       public static readonly createNewApiVersionOption: string = "+ Create a new API version";
     };
 
     public static readonly NewApiVersion = class {
       public static readonly questionName: string = "vsc-new-api-version";
-      public static readonly funcName: string = "new-api-version-default-value";
       public static readonly description: string = "Input the API version.";
     };
   };

--- a/packages/fx-core/src/plugins/resource/apim/constants.ts
+++ b/packages/fx-core/src/plugins/resource/apim/constants.ts
@@ -256,6 +256,7 @@ export enum PluginLifeCycle {
   Provision = "provision",
   PostProvision = "post-provision",
   Deploy = "deploy",
+  GetQuestionsForUserTask = "get-questions-for-user-task",
 }
 
 export enum ProgressStep {
@@ -273,6 +274,7 @@ export const PluginLifeCycleToProgressStep: { [key in PluginLifeCycle]: Progress
   [PluginLifeCycle.Provision]: ProgressStep.Provision,
   [PluginLifeCycle.PostProvision]: ProgressStep.PostProvision,
   [PluginLifeCycle.Deploy]: ProgressStep.Deploy,
+  [PluginLifeCycle.GetQuestionsForUserTask]: ProgressStep.None,
 };
 
 export const ProgressMessages: { [key in ProgressStep]: { [step: string]: string } } = {

--- a/packages/fx-core/src/plugins/resource/apim/index.ts
+++ b/packages/fx-core/src/plugins/resource/apim/index.ts
@@ -143,7 +143,7 @@ async function _getQuestionsForUserTask(
   const apimConfig = new ApimPluginConfig(ctx.config);
   const questionManager = await Factory.buildQuestionManager(ctx, solutionConfig);
   if (func.method === "addResource") {
-    return await questionManager.update(ctx, apimConfig);
+    return await questionManager.addResource(ctx, apimConfig);
   }
   return undefined;
 }
@@ -157,7 +157,7 @@ async function _callFunc(ctx: PluginContext, progressBar: ProgressBar, func: Fun
 async function _scaffold(ctx: PluginContext, progressBar: ProgressBar): Promise<void> {
   const solutionConfig = new SolutionConfig(ctx.configOfOtherPlugins);
   const apimConfig = new ApimPluginConfig(ctx.config);
-  const answer = buildAnswer(ctx);
+  const answer = buildAnswer(ctx.answers);
   const scaffoldManager = await Factory.buildScaffoldManager(ctx, solutionConfig);
 
   const appName = AssertNotEmpty("projectSettings.appName", ctx?.projectSettings?.appName);
@@ -228,7 +228,7 @@ async function _deploy(ctx: PluginContext, progressBar: ProgressBar): Promise<vo
   const solutionConfig = new SolutionConfig(ctx.configOfOtherPlugins);
   const apimConfig = new ApimPluginConfig(ctx.config);
   const functionConfig = new FunctionPluginConfig(ctx.configOfOtherPlugins);
-  const answer = buildAnswer(ctx);
+  const answer = buildAnswer(ctx.answers);
 
   if (answer.validate) {
     await answer.validate(PluginLifeCycle.Deploy, apimConfig, ctx.root);

--- a/packages/fx-core/src/plugins/resource/apim/index.ts
+++ b/packages/fx-core/src/plugins/resource/apim/index.ts
@@ -38,12 +38,17 @@ export class ApimPlugin implements Plugin {
   ): Promise<Result<QTreeNode | undefined, FxError>> {
     return await this.executeWithFxError(PluginLifeCycle.GetQuestions, _getQuestions, ctx, stage);
   }
-  
+
   public async getQuestionsForUserTask(
     func: Func,
     ctx: PluginContext
   ): Promise<Result<QTreeNode | undefined, FxError>> {
-    return await this.executeWithFxError(PluginLifeCycle.GetQuestions, _getQuestionsForUserTask, ctx, func);
+    return await this.executeWithFxError(
+      PluginLifeCycle.GetQuestions,
+      _getQuestionsForUserTask,
+      ctx,
+      func
+    );
   }
 
   public async callFunc(func: Func, ctx: PluginContext): Promise<Result<any, FxError>> {
@@ -122,15 +127,12 @@ async function _getQuestions(
   const apimConfig = new ApimPluginConfig(ctx.config);
   const questionManager = await Factory.buildQuestionManager(ctx, solutionConfig);
   switch (stage) {
-    case Stage.update:
-      return await questionManager.update(ctx, apimConfig);
     case Stage.deploy:
       return await questionManager.deploy(ctx, apimConfig);
     default:
       return undefined;
   }
 }
-
 
 async function _getQuestionsForUserTask(
   ctx: PluginContext,
@@ -140,7 +142,7 @@ async function _getQuestionsForUserTask(
   const solutionConfig = new SolutionConfig(ctx.configOfOtherPlugins);
   const apimConfig = new ApimPluginConfig(ctx.config);
   const questionManager = await Factory.buildQuestionManager(ctx, solutionConfig);
-  if(func.method === "addResource"){
+  if (func.method === "addResource") {
     return await questionManager.update(ctx, apimConfig);
   }
   return undefined;
@@ -161,10 +163,10 @@ async function _scaffold(ctx: PluginContext, progressBar: ProgressBar): Promise<
   const appName = AssertNotEmpty("projectSettings.appName", ctx?.projectSettings?.appName);
 
   if (answer.validate) {
-    await answer.validate(Stage.update, apimConfig, ctx.root);
+    await answer.validate(PluginLifeCycle.Scaffold, apimConfig, ctx.root);
   }
 
-  answer.save(Stage.update, apimConfig);
+  answer.save(PluginLifeCycle.Scaffold, apimConfig);
 
   await progressBar.next(ProgressStep.Scaffold, ProgressMessages[ProgressStep.Scaffold].Scaffold);
   await scaffoldManager.scaffold(appName, ctx.root);
@@ -229,10 +231,10 @@ async function _deploy(ctx: PluginContext, progressBar: ProgressBar): Promise<vo
   const answer = buildAnswer(ctx);
 
   if (answer.validate) {
-    await answer.validate(Stage.deploy, apimConfig, ctx.root);
+    await answer.validate(PluginLifeCycle.Deploy, apimConfig, ctx.root);
   }
 
-  answer.save(Stage.deploy, apimConfig);
+  answer.save(PluginLifeCycle.Deploy, apimConfig);
 
   const apimManager = await Factory.buildApimManager(ctx, solutionConfig);
 

--- a/packages/fx-core/src/plugins/resource/apim/index.ts
+++ b/packages/fx-core/src/plugins/resource/apim/index.ts
@@ -44,7 +44,7 @@ export class ApimPlugin implements Plugin {
     ctx: PluginContext
   ): Promise<Result<QTreeNode | undefined, FxError>> {
     return await this.executeWithFxError(
-      PluginLifeCycle.GetQuestions,
+      PluginLifeCycle.GetQuestionsForUserTask,
       _getQuestionsForUserTask,
       ctx,
       func

--- a/packages/fx-core/src/plugins/resource/apim/managers/questionManager.ts
+++ b/packages/fx-core/src/plugins/resource/apim/managers/questionManager.ts
@@ -8,7 +8,7 @@ import * as CLI from "../questions/cliQuestion";
 
 export interface IQuestionManager {
   callFunc(func: Func, ctx: PluginContext): Promise<any>;
-  update(ctx: PluginContext, apimConfig?: IApimPluginConfig): Promise<QTreeNode>;
+  addResource(ctx: PluginContext, apimConfig?: IApimPluginConfig): Promise<QTreeNode>;
   deploy(ctx: PluginContext, apimConfig?: IApimPluginConfig): Promise<QTreeNode>;
 }
 
@@ -40,7 +40,7 @@ export class VscQuestionManager implements IQuestionManager {
     throw BuildError(NotImplemented);
   }
 
-  async update(ctx: PluginContext, apimConfig: IApimPluginConfig): Promise<QTreeNode> {
+  async addResource(ctx: PluginContext, apimConfig: IApimPluginConfig): Promise<QTreeNode> {
     const rootNode = new QTreeNode({
       type: "group",
     });
@@ -48,7 +48,7 @@ export class VscQuestionManager implements IQuestionManager {
       return rootNode;
     }
 
-    const question = this.apimServiceQuestion.getQuestion(ctx);
+    const question = this.apimServiceQuestion.getQuestion();
     const apimServiceNode = new QTreeNode(question);
     rootNode.addChild(apimServiceNode);
     return rootNode;
@@ -71,7 +71,7 @@ export class VscQuestionManager implements IQuestionManager {
     rootNode.addChild(documentNode);
 
     if (!apimConfig.apiPrefix) {
-      const apiPrefixQuestion = this.apiPrefixQuestion.getQuestion(ctx);
+      const apiPrefixQuestion = this.apiPrefixQuestion.getQuestion();
       const apiPrefixQuestionNode = new QTreeNode(apiPrefixQuestion);
       documentNode.addChild(apiPrefixQuestionNode);
     }
@@ -80,7 +80,7 @@ export class VscQuestionManager implements IQuestionManager {
     const versionQuestionNode = new QTreeNode(versionQuestion);
     documentNode.addChild(versionQuestionNode);
 
-    const newVersionQuestion = this.newApiVersionQuestion.getQuestion(ctx);
+    const newVersionQuestion = this.newApiVersionQuestion.getQuestion();
     const newVersionQuestionNode = new QTreeNode(newVersionQuestion);
     newVersionQuestionNode.condition = this.newApiVersionQuestion.condition();
     versionQuestionNode.addChild(newVersionQuestionNode);
@@ -113,7 +113,7 @@ export class CliQuestionManager implements IQuestionManager {
     throw BuildError(NotImplemented);
   }
 
-  async update(ctx: PluginContext): Promise<QTreeNode> {
+  async addResource(ctx: PluginContext): Promise<QTreeNode> {
     const rootNode = new QTreeNode({
       type: "group",
     });

--- a/packages/fx-core/src/plugins/resource/apim/managers/questionManager.ts
+++ b/packages/fx-core/src/plugins/resource/apim/managers/questionManager.ts
@@ -3,7 +3,6 @@
 import { Func, PluginContext, QTreeNode } from "@microsoft/teamsfx-api";
 import { BuildError, NotImplemented } from "../error";
 import { IApimPluginConfig } from "../config";
-import { IQuestionService } from "../questions/question";
 import * as VSCode from "../questions/vscodeQuestion";
 import * as CLI from "../questions/cliQuestion";
 
@@ -38,24 +37,6 @@ export class VscQuestionManager implements IQuestionManager {
   }
 
   async callFunc(func: Func, ctx: PluginContext): Promise<any> {
-    const questionServices: IQuestionService[] = [
-      this.apimServiceQuestion,
-      this.openApiDocumentQuestion,
-      this.apiPrefixQuestion,
-      this.apiVersionQuestion,
-      this.newApiVersionQuestion,
-      this.existingOpenApiDocumentFunc,
-    ];
-    for (const questionService of questionServices) {
-      if (
-        questionService.funcName &&
-        questionService.executeFunc &&
-        questionService.funcName === func.method
-      ) {
-        return await questionService.executeFunc(ctx);
-      }
-    }
-
     throw BuildError(NotImplemented);
   }
 

--- a/packages/fx-core/src/plugins/resource/apim/questions/question.ts
+++ b/packages/fx-core/src/plugins/resource/apim/questions/question.ts
@@ -13,12 +13,6 @@ export interface IQuestionService {
   // Control whether the question is displayed to the user.
   condition?(parentAnswerPath: string): { target?: string } & ValidationSchema;
 
-  // Define the method name
-  funcName?: string;
-
-  // Generate the options / default value / answer of the question.
-  executeFunc?(ctx: PluginContext): Promise<string | OptionItem | OptionItem[]>;
-
   // Generate the question
   getQuestion(ctx: PluginContext): Question;
 }

--- a/packages/fx-core/src/plugins/resource/apim/questions/vscodeQuestion.ts
+++ b/packages/fx-core/src/plugins/resource/apim/questions/vscodeQuestion.ts
@@ -28,7 +28,6 @@ import { Lazy } from "../utils/commonUtils";
 
 export class ApimServiceQuestion extends BaseQuestionService implements IQuestionService {
   private readonly lazyApimService: Lazy<ApimService>;
-  public readonly funcName = QuestionConstants.VSCode.Apim.funcName;
 
   constructor(
     lazyApimService: Lazy<ApimService>,
@@ -39,7 +38,26 @@ export class ApimServiceQuestion extends BaseQuestionService implements IQuestio
     this.lazyApimService = lazyApimService;
   }
 
-  public async executeFunc(ctx: PluginContext): Promise<OptionItem[]> {
+  public getQuestion(ctx: PluginContext): SingleSelectQuestion {
+    return {
+      type: "singleSelect",
+      name: QuestionConstants.VSCode.Apim.questionName,
+      title: QuestionConstants.VSCode.Apim.description,
+      staticOptions: [
+        {
+          id: QuestionConstants.VSCode.Apim.createNewApimOption,
+          label: QuestionConstants.VSCode.Apim.createNewApimOption,
+        },
+      ],
+      dynamicOptions: async (inputs: Inputs): Promise<OptionItem[]> => {
+        return this.getDynamicOptions();
+      },
+      returnObject: true,
+      skipSingleOption: false,
+    };
+  }
+
+  private async getDynamicOptions(): Promise<OptionItem[]> {
     const apimService: ApimService = await this.lazyApimService.getValue();
     const apimServiceList = await apimService.listService();
     const existingOptions = apimServiceList.map((apimService) => {
@@ -56,28 +74,10 @@ export class ApimServiceQuestion extends BaseQuestionService implements IQuestio
     };
     return [newOption, ...existingOptions];
   }
-
-  public getQuestion(ctx: PluginContext): SingleSelectQuestion {
-    return {
-      type: "singleSelect",
-      name: QuestionConstants.VSCode.Apim.questionName,
-      title: QuestionConstants.VSCode.Apim.description,
-      staticOptions: [{
-        id: QuestionConstants.VSCode.Apim.createNewApimOption,
-        label: QuestionConstants.VSCode.Apim.createNewApimOption,
-      }],
-      dynamicOptions: async (inputs: Inputs) : Promise< OptionItem[] > => {
-         return this.executeFunc(ctx);
-      },
-      returnObject: true,
-      skipSingleOption: false,
-    };
-  }
 }
 
 export class OpenApiDocumentQuestion extends BaseQuestionService implements IQuestionService {
   private readonly openApiProcessor: OpenApiProcessor;
-  public readonly funcName = QuestionConstants.VSCode.OpenApiDocument.funcName;
 
   constructor(
     openApiProcessor: OpenApiProcessor,
@@ -88,9 +88,23 @@ export class OpenApiDocumentQuestion extends BaseQuestionService implements IQue
     this.openApiProcessor = openApiProcessor;
   }
 
-  public async executeFunc(ctx: PluginContext): Promise<OptionItem[]> {
+  public getQuestion(ctx: PluginContext): SingleSelectQuestion {
+    return {
+      type: "singleSelect",
+      name: QuestionConstants.VSCode.OpenApiDocument.questionName,
+      title: QuestionConstants.VSCode.OpenApiDocument.description,
+      staticOptions: [],
+      dynamicOptions: async (inputs: Inputs): Promise<OptionItem[]> => {
+        return this.getDynamicOptions(ctx.root);
+      },
+      returnObject: true,
+      skipSingleOption: false,
+    };
+  }
+
+  private async getDynamicOptions(root: string): Promise<OptionItem[]> {
     const filePath2OpenApiMap = await this.openApiProcessor.listOpenApiDocument(
-      ctx.root,
+      root,
       QuestionConstants.VSCode.OpenApiDocument.excludeFolders,
       QuestionConstants.VSCode.OpenApiDocument.openApiDocumentFileExtensions
     );
@@ -103,25 +117,10 @@ export class OpenApiDocumentQuestion extends BaseQuestionService implements IQue
     filePath2OpenApiMap.forEach((value, key) => result.push({ id: key, label: key, data: value }));
     return result;
   }
-
-  public getQuestion(ctx: PluginContext): SingleSelectQuestion {
-    return {
-      type: "singleSelect",
-      name: QuestionConstants.VSCode.OpenApiDocument.questionName,
-      title: QuestionConstants.VSCode.OpenApiDocument.description,
-      staticOptions: [],
-      dynamicOptions: async (inputs: Inputs) : Promise< OptionItem[] > => {
-        return this.executeFunc(ctx);
-      },
-      returnObject: true,
-      skipSingleOption: false,
-    };
-  }
 }
 
 export class ExistingOpenApiDocumentFunc extends BaseQuestionService implements IQuestionService {
   private readonly openApiProcessor: OpenApiProcessor;
-  public readonly funcName = QuestionConstants.VSCode.ExistingOpenApiDocument.funcName;
 
   constructor(
     openApiProcessor: OpenApiProcessor,
@@ -132,46 +131,30 @@ export class ExistingOpenApiDocumentFunc extends BaseQuestionService implements 
     this.openApiProcessor = openApiProcessor;
   }
 
-  public async executeFunc(ctx: PluginContext): Promise<OptionItem> {
-    const apimConfig = new ApimPluginConfig(ctx.config);
-    const openApiDocumentPath = AssertConfigNotEmpty(
-      TeamsToolkitComponent.ApimPlugin,
-      ApimPluginConfigKeys.apiDocumentPath,
-      apimConfig.apiDocumentPath
-    );
-    const openApiDocument = await this.openApiProcessor.loadOpenApiDocument(
-      openApiDocumentPath,
-      ctx.root
-    );
-    return { id: openApiDocumentPath, label: openApiDocumentPath, data: openApiDocument };
-  }
-
   public getQuestion(ctx: PluginContext): FuncQuestion {
     return {
       type: "func",
       name: QuestionConstants.VSCode.ExistingOpenApiDocument.questionName,
-      func: async (inputs: Inputs) :  Promise< OptionItem > => {
-        return this.executeFunc(ctx);
-      }
+      func: async (inputs: Inputs): Promise<OptionItem> => {
+        const apimConfig = new ApimPluginConfig(ctx.config);
+        const openApiDocumentPath = AssertConfigNotEmpty(
+          TeamsToolkitComponent.ApimPlugin,
+          ApimPluginConfigKeys.apiDocumentPath,
+          apimConfig.apiDocumentPath
+        );
+        const openApiDocument = await this.openApiProcessor.loadOpenApiDocument(
+          openApiDocumentPath,
+          ctx.root
+        );
+        return { id: openApiDocumentPath, label: openApiDocumentPath, data: openApiDocument };
+      },
     };
   }
 }
 
 export class ApiPrefixQuestion extends BaseQuestionService implements IQuestionService {
-  public readonly funcName = QuestionConstants.VSCode.ApiPrefix.funcName;
-
   constructor(telemetryReporter?: TelemetryReporter, logger?: LogProvider) {
     super(telemetryReporter, logger);
-  }
-
-  public async executeFunc(ctx: PluginContext): Promise<string> {
-    const apiTitle = buildAnswer(ctx)?.openApiDocumentSpec?.info.title;
-    let apiPrefix: string | undefined;
-    if (apiTitle) {
-      apiPrefix = NamingRules.apiPrefix.sanitize(apiTitle);
-    }
-
-    return apiPrefix ? apiPrefix : ApimDefaultValues.apiPrefix;
   }
 
   public getQuestion(ctx: PluginContext): TextInputQuestion {
@@ -180,8 +163,14 @@ export class ApiPrefixQuestion extends BaseQuestionService implements IQuestionS
       name: QuestionConstants.VSCode.ApiPrefix.questionName,
       title: QuestionConstants.VSCode.ApiPrefix.description,
       prompt: QuestionConstants.VSCode.ApiPrefix.prompt,
-      default: async (inputs: Inputs): Promise< string > => {
-        return this.executeFunc(ctx);
+      default: async (inputs: Inputs): Promise<string> => {
+        const apiTitle = buildAnswer(ctx)?.openApiDocumentSpec?.info.title;
+        let apiPrefix: string | undefined;
+        if (apiTitle) {
+          apiPrefix = NamingRules.apiPrefix.sanitize(apiTitle);
+        }
+
+        return apiPrefix ? apiPrefix : ApimDefaultValues.apiPrefix;
       },
       validation: {
         validFunc: (input: string, previousInputs?: Inputs): string | undefined =>
@@ -193,7 +182,6 @@ export class ApiPrefixQuestion extends BaseQuestionService implements IQuestionS
 
 export class ApiVersionQuestion extends BaseQuestionService implements IQuestionService {
   private readonly lazyApimService: Lazy<ApimService>;
-  public readonly funcName = QuestionConstants.VSCode.ApiVersion.funcName;
 
   constructor(
     lazyApimService: Lazy<ApimService>,
@@ -204,7 +192,7 @@ export class ApiVersionQuestion extends BaseQuestionService implements IQuestion
     this.lazyApimService = lazyApimService;
   }
 
-  public async executeFunc(ctx: PluginContext): Promise<OptionItem[]> {
+  private async getDynamicOptions(ctx: PluginContext): Promise<OptionItem[]> {
     const apimService = await this.lazyApimService.getValue();
     const apimConfig = new ApimPluginConfig(ctx.config);
     const solutionConfig = new SolutionConfig(ctx.configOfOtherPlugins);
@@ -249,9 +237,9 @@ export class ApiVersionQuestion extends BaseQuestionService implements IQuestion
       type: "singleSelect",
       name: QuestionConstants.VSCode.ApiVersion.questionName,
       title: QuestionConstants.VSCode.ApiVersion.description,
-      staticOptions:[],
-      dynamicOptions: async (inputs: Inputs) : Promise< OptionItem[] > => {
-        return this.executeFunc(ctx);
+      staticOptions: [],
+      dynamicOptions: async (inputs: Inputs): Promise<OptionItem[]> => {
+        return this.getDynamicOptions(ctx);
       },
       returnObject: true,
       skipSingleOption: false,
@@ -260,8 +248,6 @@ export class ApiVersionQuestion extends BaseQuestionService implements IQuestion
 }
 
 export class NewApiVersionQuestion extends BaseQuestionService implements IQuestionService {
-  public readonly funcName = QuestionConstants.VSCode.NewApiVersion.funcName;
-
   constructor(telemetryReporter?: TelemetryReporter, logger?: LogProvider) {
     super(telemetryReporter, logger);
   }
@@ -272,23 +258,19 @@ export class NewApiVersionQuestion extends BaseQuestionService implements IQuest
     };
   }
 
-  public async executeFunc(ctx: PluginContext): Promise<string> {
-    const apiVersion = buildAnswer(ctx)?.openApiDocumentSpec?.info.version;
-    let versionIdentity: string | undefined;
-    if (apiVersion) {
-      versionIdentity = NamingRules.versionIdentity.sanitize(apiVersion);
-    }
-
-    return versionIdentity ? versionIdentity : ApimDefaultValues.apiVersion;
-  }
-
   public getQuestion(ctx: PluginContext): TextInputQuestion {
     return {
       type: "text",
       name: QuestionConstants.VSCode.NewApiVersion.questionName,
       title: QuestionConstants.VSCode.NewApiVersion.description,
       default: async (inputs: Inputs): Promise<string> => {
-        return this.executeFunc(ctx);
+        const apiVersion = buildAnswer(ctx)?.openApiDocumentSpec?.info.version;
+        let versionIdentity: string | undefined;
+        if (apiVersion) {
+          versionIdentity = NamingRules.versionIdentity.sanitize(apiVersion);
+        }
+
+        return versionIdentity ? versionIdentity : ApimDefaultValues.apiVersion;
       },
       validation: {
         validFunc: (input: string, previousInputs?: Inputs): string | undefined =>

--- a/packages/fx-core/tests/plugins/resource/apim/config.test.ts
+++ b/packages/fx-core/tests/plugins/resource/apim/config.test.ts
@@ -52,6 +52,10 @@ describe("config", () => {
       [ApimPluginConfigKeys.serviceName]: 1,
     });
 
+    if (!configContent) {
+      throw Error("Empty test input");
+    }
+
     const apimPluginConfig = new ApimPluginConfig(configContent);
     it("Undefined property", () => {
       chai.expect(apimPluginConfig.apiPath).to.equal(undefined);
@@ -59,7 +63,9 @@ describe("config", () => {
     it("Error type property", () => {
       chai
         .expect(() => apimPluginConfig.serviceName)
-        .to.throw("Property 'serviceName' is not type 'string'");
+        .to.throw(
+          "Project configuration 'serviceName' of 'fx-resource-apim' is invalid. The value can contain only letters, numbers and hyphens. The first character must be a letter and last character must be a letter or a number."
+        );
     });
     it("Property with value", () => {
       chai.expect(apimPluginConfig.resourceGroupName).to.equal("test-resource-group-name");

--- a/packages/fx-core/tests/plugins/resource/apim/config.test.ts
+++ b/packages/fx-core/tests/plugins/resource/apim/config.test.ts
@@ -8,7 +8,12 @@ import {
   SolutionConfigKeys,
 } from "../../../../src/plugins/resource/apim/constants";
 import { ApimPluginConfig, SolutionConfig } from "../../../../src/plugins/resource/apim/config";
-import { ConfigValue, PluginIdentity, ReadonlyPluginConfig } from "@microsoft/teamsfx-api";
+import {
+  ConfigMap,
+  ConfigValue,
+  PluginIdentity,
+  ReadonlyPluginConfig,
+} from "@microsoft/teamsfx-api";
 
 describe("config", () => {
   describe("SolutionConfig", () => {
@@ -42,10 +47,10 @@ describe("config", () => {
   });
 
   describe("ApimPluginConfig", () => {
-    const configContent = new Map<string, ConfigValue>([
-      [ApimPluginConfigKeys.resourceGroupName, "test-resource-group-name"],
-      [ApimPluginConfigKeys.serviceName, 1],
-    ]);
+    const configContent = ConfigMap.fromJSON({
+      [ApimPluginConfigKeys.resourceGroupName]: "test-resource-group-name",
+      [ApimPluginConfigKeys.serviceName]: 1,
+    });
 
     const apimPluginConfig = new ApimPluginConfig(configContent);
     it("Undefined property", () => {


### PR DESCRIPTION
Refactor APIM plugin according to the changes of teamsfx-api.
1. Use `input` instead of `answer` in the question model
2. Use `LocalFunc` instead of `callFunc` in the question model
3. Remove the usage of `Stage.update`
4. Add lifecycle `GetQuestionsForUserTask`