### PR TITLE
fix(cli): make cli case insensitive for param name and option value

### DIFF
--- a/packages/cli/src/cmds/new.ts
+++ b/packages/cli/src/cmds/new.ts
@@ -11,23 +11,13 @@ import { Argv, Options } from "yargs";
 import * as uuid from "uuid";
 import { glob } from "glob";
 
-import {
-  FxError,
-  err,
-  ok,
-  Result,
-  Question,
-  LogLevel,
-  Stage,
-} from "@microsoft/teamsfx-api";
+import { FxError, err, ok, Result, Question, LogLevel, Stage } from "@microsoft/teamsfx-api";
 
-import activate  from "../activate";
+import activate from "../activate";
 import * as constants from "../constants";
 import { NotFoundInputedFolder, SampleAppDownloadFailed, ProjectFolderExist } from "../error";
 import { YargsCommand } from "../yargsCommand";
-import {
-  getSystemInputs,
-} from "../utils";
+import { getSystemInputs } from "../utils";
 import CliTelemetry from "../telemetry/cliTelemetry";
 import {
   TelemetryEvent,
@@ -110,7 +100,7 @@ class NewTemplete extends YargsCommand {
     this.subCommands.forEach((cmd) => {
       yargs.command(cmd.command, cmd.description, cmd.builder.bind(cmd), cmd.handler.bind(cmd));
     });
-    const templatesNames = constants.templates.map((t) => t.sampleAppName);
+    const templatesNames = constants.templates.map((t) => t.sampleAppName.toLowerCase());
     yargs
       .positional("template-name", {
         description: "Enter the template name",
@@ -135,7 +125,9 @@ class NewTemplete extends YargsCommand {
     }
     CliTelemetry.sendTelemetryEvent(TelemetryEvent.DownloadSampleStart);
     const templateName = args["template-name"] as string;
-    const template = constants.templates.find((t) => t.sampleAppName === templateName)!;
+    const template = constants.templates.find(
+      (t) => t.sampleAppName.toLowerCase() === templateName
+    )!;
 
     const sampleAppFolder = path.resolve(folder, template.sampleAppName);
     if ((await fs.pathExists(sampleAppFolder)) && (await fs.readdir(sampleAppFolder)).length > 0) {
@@ -147,9 +139,9 @@ class NewTemplete extends YargsCommand {
     await this.downloadSampleHook(templateName, sampleAppFolder);
     CLILogProvider.necessaryLog(
       LogLevel.Info,
-      `Downloaded the '${CLILogProvider.white(template.sampleAppName)}' sample to '${CLILogProvider.white(
-        sampleAppFolder
-      )}'.`
+      `Downloaded the '${CLILogProvider.white(
+        template.sampleAppName
+      )}' sample to '${CLILogProvider.white(sampleAppFolder)}'.`
     );
 
     CliTelemetry.sendTelemetryEvent(TelemetryEvent.DownloadSample, {
@@ -197,12 +189,14 @@ class NewTemplete extends YargsCommand {
       const originalId = "c314487b-f51c-474d-823e-a2c3ec82b1ff";
       const componentId = uuid.v4();
       glob.glob(`${sampleAppPath}/**/*.json`, { nodir: true, dot: true }, async (err, files) => {
-        await Promise.all(files.map(async (file) => {
-          let content = (await fs.readFile(file)).toString();
-          const reg = new RegExp(originalId, "g");
-          content = content.replace(reg, componentId);
-          await fs.writeFile(file, content);
-        }));
+        await Promise.all(
+          files.map(async (file) => {
+            let content = (await fs.readFile(file)).toString();
+            const reg = new RegExp(originalId, "g");
+            content = content.replace(reg, componentId);
+            await fs.writeFile(file, content);
+          })
+        );
       });
     }
   }
@@ -221,7 +215,11 @@ class NewTempleteList extends YargsCommand {
     [argName: string]: string | string[];
   }): Promise<Result<null, FxError>> {
     CLILogProvider.necessaryLog(LogLevel.Info, `The following are sample apps:`);
-    CLILogProvider.necessaryLog(LogLevel.Info, JSON.stringify(constants.templates, undefined, 4), true);
+    CLILogProvider.necessaryLog(
+      LogLevel.Info,
+      JSON.stringify(constants.templates, undefined, 4),
+      true
+    );
     CLILogProvider.necessaryLog(
       LogLevel.Info,
       `Use the command ${CLILogProvider.white(

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -107,3 +107,10 @@ export enum CLILogLevel {
 
 export const sqlPasswordQustionName = "sql-password";
 export const sqlPasswordConfirmQuestionName = "sql-confirm-password";
+export const booleanParamNames = new Set<string>([
+  "verbose",
+  "version",
+  "interactive",
+  "local",
+  "remote",
+]);

--- a/packages/cli/src/error.ts
+++ b/packages/cli/src/error.ts
@@ -14,6 +14,8 @@ import {
   OptionItem,
   MultiSelectQuestion,
   SingleSelectQuestion,
+  SingleSelectConfig,
+  MultiSelectConfig,
   StaticOptions,
 } from "@microsoft/teamsfx-api";
 
@@ -36,13 +38,13 @@ export function CannotDeployPlugin(pluginName: string): UserError {
 }
 
 export function NotValidOptionValue(
-  question: MultiSelectQuestion | SingleSelectQuestion,
+  question: MultiSelectQuestion | SingleSelectQuestion | SingleSelectConfig | MultiSelectConfig,
   options: StaticOptions
 ): UserError {
   if (options instanceof Array && options.length > 0 && typeof options[0] !== "string") {
     options = (options as OptionItem[]).map((op) => op.id);
   }
-  throw NotValidInputValue(question.name, `This question only supports [${options}] options`);
+  return NotValidInputValue(question.name, `This question only supports [${options}] options`);
 }
 
 export function NotValidInputValue(inputName: string, msg: string): UserError {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,6 +11,7 @@ import { commands } from "./cmds";
 import * as constants from "./constants";
 import { registerPrompts } from "./prompts";
 import { HelpParamGenerator } from "./helpParamGenerator";
+import { lowerCaseMiddleWare } from "./utils";
 
 /**
  * Registers cli and partner commands with yargs.
@@ -45,6 +46,7 @@ export async function start() {
   await HelpParamGenerator.initializeQuestionsForHelp();
   register(yargs);
   yargs
+    .middleware(lowerCaseMiddleWare, true)
     .options("verbose", {
       description: "Print additional information.",
       boolean: true,
@@ -64,5 +66,9 @@ export async function start() {
     .alias("v", "version")
     .version(getVersion())
     .wrap(Math.min(100, yargs.terminalWidth()))
+    // disable camel case expansion since we suppose all the cli name are lower case.
+    .parserConfiguration({
+      "camel-case-expansion": false,
+    })
     .epilogue("For more information about the Teams Toolkit - https://aka.ms/teamsfx-learn.").argv;
 }

--- a/packages/cli/src/userInteraction.ts
+++ b/packages/cli/src/userInteraction.ts
@@ -40,7 +40,12 @@ import {
 } from "@microsoft/teamsfx-api";
 
 import CLILogProvider from "./commonlib/log";
-import { EmptySubConfigOptions, NotValidInputValue, UnknownError } from "./error";
+import {
+  EmptySubConfigOptions,
+  NotValidInputValue,
+  NotValidOptionValue,
+  UnknownError,
+} from "./error";
 import { sleep, getColorizedString } from "./utils";
 import { ChoiceOptions } from "./prompts";
 import { ProgressHandler } from "./progressHandler";
@@ -319,14 +324,18 @@ export class CLIUserInteraction implements UserInteraction {
             : (choices as ChoiceOptions[]).map((choice) => choice.name),
           result.value
         );
-        const anwser = config.options[index];
-        if (config.returnObject) {
-          resolve(ok({ type: "success", result: anwser }));
+        if (index < 0) {
+          resolve(err(NotValidOptionValue(config, config.options)));
         } else {
-          if (typeof anwser === "string") {
+          const anwser = config.options[index];
+          if (config.returnObject) {
             resolve(ok({ type: "success", result: anwser }));
           } else {
-            resolve(ok({ type: "success", result: anwser.id }));
+            if (typeof anwser === "string") {
+              resolve(ok({ type: "success", result: anwser }));
+            } else {
+              resolve(ok({ type: "success", result: anwser.id }));
+            }
           }
         }
       } else {
@@ -355,6 +364,12 @@ export class CLIUserInteraction implements UserInteraction {
             : (choices as ChoiceOptions[]).map((choice) => choice.name),
           result.value
         );
+        for (const index of indexes) {
+          if (index < 0) {
+            resolve(err(NotValidOptionValue(config, config.options)));
+            return;
+          }
+        }
         const anwers = this.getSubArray(config.options as any[], indexes);
         if (config.returnObject) {
           resolve(ok({ type: "success", result: anwers }));


### PR DESCRIPTION
Main fix: Make cli case insensitive for param name and option value
Related task: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/9721031
Notice there are some known issues due to yargs framework limitation:
1. command , subcommand and positional param doesn't support case insensitive. 
2. If user input multi value for a multi-select param and the param name is not lowercase, it will throw error. like:
![image](https://user-images.githubusercontent.com/72644308/124239963-d4419f80-db4c-11eb-875b-7ac0df60052a.png)

while other cases are supported, like:
![image](https://user-images.githubusercontent.com/72644308/124240006-e3285200-db4c-11eb-985a-76b5b7e6697c.png)
![image](https://user-images.githubusercontent.com/72644308/124240095-fb986c80-db4c-11eb-8363-1fbe68d42e39.png)

Other fix:
1. Fix bug: when the given option value is not aligned with the dynamic option value, throw error
2. Hide "samples" and "scratch" param in "teamsfx new -h" view because of duplication of the "teamsfx new template -h"
