### PR TITLE
fix(aad): show detail error message in pop up window

### DIFF
--- a/packages/fx-core/src/plugins/resource/aad/errors.ts
+++ b/packages/fx-core/src/plugins/resource/aad/errors.ts
@@ -3,7 +3,6 @@
 
 import { ConfigKeys, Plugins } from "./constants";
 
-const referLogMessage = "Please refer to the log for detailed information.";
 const referHelpLink = "Please refer to the help link for further steps.";
 const aadHelpLink = "https://aka.ms/teamsfx-aad-help";
 
@@ -39,32 +38,28 @@ export const GetSkipAppConfigError: AadError = {
 
 export const CreateAppError: AadError = {
   name: "AadCreateAppError",
-  message: () => `Failed to create an app in Azure Active Directory. ${referLogMessage}`,
+  message: () => `Failed to create an app in Azure Active Directory.`,
 };
 
 export const CreateSecretError: AadError = {
   name: "AadCreateSecretError",
-  message: () =>
-    `Failed to create an application secret in Azure Active Directory. ${referLogMessage}`,
+  message: () => `Failed to create an application secret in Azure Active Directory.`,
 };
 
 export const UpdateRedirectUriError: AadError = {
   name: "UpdateRedirectUriError",
-  message: () =>
-    `Failed to update application redirect URI in Azure Active Directory. ${referLogMessage}`,
+  message: () => `Failed to update application redirect URI in Azure Active Directory.`,
 };
 
 export const UpdateAppIdUriError: AadError = {
   name: "UpdateAppIdUriError",
-  message: () =>
-    `Failed to update Application ID URI in Azure Active Directory. ${referLogMessage} ${referHelpLink}`,
+  message: () => `Failed to update Application ID URI in Azure Active Directory. ${referHelpLink}`,
   helpLink: aadHelpLink,
 };
 
 export const UpdatePermissionError: AadError = {
   name: "AadUpdatePermissionError",
-  message: () =>
-    `Failed to update application permission in Azure Active Directory. ${referLogMessage}`,
+  message: () => `Failed to update application permission in Azure Active Directory.`,
 };
 
 export const AppIdUriInvalidError: AadError = {

--- a/packages/fx-core/src/plugins/resource/aad/index.ts
+++ b/packages/fx-core/src/plugins/resource/aad/index.ts
@@ -79,6 +79,7 @@ export class AadAppForTeamsPlugin implements Plugin {
         if (e.innerError.response?.data?.errorMessage) {
           errorMessage += ` Reason: ${e.innerError.response?.data?.errorMessage}`;
         }
+        e.message = errorMessage;
       }
       ctx.logProvider?.error(errorMessage);
       TelemetryUtils.init(ctx);


### PR DESCRIPTION
show detail message in pop up window;
remove "Please refer to the log for detailed information" from error message;

Previous pop up winodw:
![image](https://user-images.githubusercontent.com/63089166/124410443-09343900-dd7d-11eb-8c82-16e97b164fcd.png)
Now:
![image](https://user-images.githubusercontent.com/63089166/124410449-0cc7c000-dd7d-11eb-8e29-8a5e0fc10c0a.png)
