### PR TITLE
feat(function): register required RPs for function app in provision step

### DIFF
--- a/packages/fx-core/src/plugins/resource/function/constants.ts
+++ b/packages/fx-core/src/plugins/resource/function/constants.ts
@@ -171,6 +171,7 @@ export class AzureInfo {
     `https://${functionAppName}.scm.azurewebsites.net/api/zipdeploy`;
   public static readonly runFromPackageSettingKey = "WEBSITE_RUN_FROM_PACKAGE";
   public static readonly runFromPackageEnabled = "1";
+  public static readonly requiredResourceProviders = ["Microsoft.Web", "Microsoft.Storage"];
 }
 
 export class Commands {

--- a/packages/fx-core/src/plugins/resource/function/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/function/plugin.ts
@@ -404,7 +404,7 @@ export class FunctionPluginImpl {
         StepGroup.ProvisionStepGroup,
         ProvisionSteps.registerResourceProviders,
         async () =>
-          await AzureLib.registerResourceProviders(
+          await AzureLib.ensureResourceProviders(
             providerClient,
             AzureInfo.requiredResourceProviders
           )

--- a/packages/fx-core/src/plugins/resource/function/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/function/plugin.ts
@@ -29,8 +29,10 @@ import {
   runWithErrorCatchAndThrow,
   FunctionNameConflictError,
   FetchConfigError,
+  RegisterResourceProviderError,
 } from "./resources/errors";
 import {
+  AzureInfo,
   DefaultProvisionConfigs,
   DefaultValues,
   DependentPluginInfo,
@@ -389,16 +391,18 @@ export class FunctionPluginImpl {
     );
     const nodeVersion = await this.getValidNodeVersion(ctx);
 
-    const resourceManagementClientContext = await runWithErrorCatchAndThrow(
-      new InitAzureSDKError(),
-      () => AzureClientFactory.getResourceManagementClientContext(credential, subscriptionId)
+    Logger.info(
+      `Registering resource providers: ${AzureInfo.requiredResourceProviders.join(",")}.`
+    );
+    const providerClient = await runWithErrorCatchAndThrow(new InitAzureSDKError(), () =>
+      AzureClientFactory.getResourceProviderClient(credential, subscriptionId)
     );
     await runWithErrorCatchAndThrow(
-      new ProvisionError(""),
+      new RegisterResourceProviderError(),
       async () =>
-        await AzureLib.registerResourceProvider(
-          resourceManagementClientContext,
-          "Microsoft.Storage"
+        await AzureLib.registerResourceProviders(
+          providerClient,
+          AzureInfo.requiredResourceProviders
         )
     );
 

--- a/packages/fx-core/src/plugins/resource/function/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/function/plugin.ts
@@ -389,6 +389,19 @@ export class FunctionPluginImpl {
     );
     const nodeVersion = await this.getValidNodeVersion(ctx);
 
+    const resourceManagementClientContext = await runWithErrorCatchAndThrow(
+      new InitAzureSDKError(),
+      () => AzureClientFactory.getResourceManagementClientContext(credential, subscriptionId)
+    );
+    await runWithErrorCatchAndThrow(
+      new ProvisionError(""),
+      async () =>
+        await AzureLib.registerResourceProvider(
+          resourceManagementClientContext,
+          "Microsoft.Storage"
+        )
+    );
+
     const storageManagementClient: StorageManagementClient = await runWithErrorCatchAndThrow(
       new InitAzureSDKError(),
       () => AzureClientFactory.getStorageManagementClient(credential, subscriptionId)

--- a/packages/fx-core/src/plugins/resource/function/resources/errors.ts
+++ b/packages/fx-core/src/plugins/resource/function/resources/errors.ts
@@ -3,7 +3,7 @@
 import * as path from "path";
 import { ConfigFolderName, SystemError, UserError } from "@microsoft/teamsfx-api";
 
-import { FunctionPluginPathInfo as PathInfo } from "../constants";
+import { AzureInfo, FunctionPluginPathInfo as PathInfo } from "../constants";
 import { Logger } from "../utils/logger";
 
 export enum ErrorType {
@@ -30,6 +30,9 @@ const tips = {
   retryRequestForZip:
     "If the template zip file was broken, retry the command to download a new one.",
   checkFunctionExtVersion: `Check function extension version and ${PathInfo.solutionFolderName}${path.sep}${PathInfo.functionExtensionsFileName}.`,
+  registerRequiredRP: `Register ${AzureInfo.requiredResourceProviders.join(
+    ","
+  )} resource provider for your subscription manually.`,
 };
 
 export class FunctionPluginError extends Error {
@@ -129,6 +132,18 @@ export class UnzipError extends FunctionPluginError {
       tips.checkPathAccess,
       tips.retryRequestForZip,
     ]);
+  }
+}
+
+// TODO: help link for the error
+export class RegisterResourceProviderError extends FunctionPluginError {
+  constructor() {
+    super(
+      ErrorType.User,
+      "RegisterResourceProviderError",
+      "Failed to register required resource provider for function app.",
+      [tips.registerRequiredRP, tips.checkLog]
+    );
   }
 }
 
@@ -237,7 +252,12 @@ export class UploadZipError extends FunctionPluginError {
 
 export class UnknownFallbackError extends FunctionPluginError {
   constructor() {
-    super(ErrorType.System, "UnknownFallbackError", "Trigger fallback caused by unknown reason.", []);
+    super(
+      ErrorType.System,
+      "UnknownFallbackError",
+      "Trigger fallback caused by unknown reason.",
+      []
+    );
   }
 }
 

--- a/packages/fx-core/src/plugins/resource/function/resources/message.ts
+++ b/packages/fx-core/src/plugins/resource/function/resources/message.ts
@@ -38,6 +38,11 @@ export class InfoMessages {
   public static readonly generateFunctionAppName = (name: string) =>
     `Using function app name: ${name}.`;
 
+  public static readonly ensureResourceProviders = (namespaces: string[], subscriptionId: string) =>
+    `Registering required resource providers ${namespaces.join(
+      ","
+    )} for subscription ${subscriptionId}...`;
+
   public static readonly checkResource = (
     resourceType: string,
     resourceName: string,

--- a/packages/fx-core/src/plugins/resource/function/resources/steps.ts
+++ b/packages/fx-core/src/plugins/resource/function/resources/steps.ts
@@ -9,6 +9,7 @@ export enum ScaffoldSteps {
 }
 
 export enum ProvisionSteps {
+  registerResourceProviders = "Registering required resource providers.",
   ensureStorageAccount = "Setting up storage account.",
   getConnectionString = "Retrieving connection string.",
   ensureAppServicePlans = "Setting up Azure App Services plan.",

--- a/packages/fx-core/src/plugins/resource/function/utils/azure-client.ts
+++ b/packages/fx-core/src/plugins/resource/function/utils/azure-client.ts
@@ -40,11 +40,11 @@ export class AzureClientFactory {
     return new ResourceManagementClient(credentials, subscriptionId);
   }
 
-  public static getResourceManagementClientContext(
+  public static getResourceProviderClient(
     credentials: TokenCredentialsBase,
     subscriptionId: string
-  ): ResourceManagementClientContext {
-    return new ResourceManagementClientContext(credentials, subscriptionId);
+  ): Providers {
+    return new Providers(new ResourceManagementClientContext(credentials, subscriptionId));
   }
 }
 
@@ -71,12 +71,11 @@ export class AzureLib {
     return res.body;
   }
 
-  public static async registerResourceProvider(
-    client: ResourceManagementClientContext,
-    providerNamespace: string
-  ): Promise<Provider> {
-    const provider = new Providers(client);
-    return await provider.register(providerNamespace);
+  public static async registerResourceProviders(
+    client: Providers,
+    providerNamespaces: string[]
+  ): Promise<Provider[]> {
+    return Promise.all(providerNamespaces.map((namespace) => client.register(namespace)));
   }
 
   private static async ensureResource<T>(

--- a/packages/fx-core/src/plugins/resource/function/utils/azure-client.ts
+++ b/packages/fx-core/src/plugins/resource/function/utils/azure-client.ts
@@ -1,12 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { ResourceManagementClient, ResourceManagementModels } from "@azure/arm-resources";
+import {
+  Providers,
+  ResourceManagementClient,
+  ResourceManagementClientContext,
+  ResourceManagementModels,
+} from "@azure/arm-resources";
 import { StorageManagementClient, StorageManagementModels } from "@azure/arm-storage";
 import { TokenCredentialsBase } from "@azure/ms-rest-nodeauth";
 import { WebSiteManagementClient, WebSiteManagementModels } from "@azure/arm-appservice";
 
 import { InfoMessages } from "../resources/message";
 import { Logger } from "./logger";
+import { Provider } from "@azure/arm-resources/esm/models";
 
 export class AzureClientFactory {
   /* TODO: we wrap the constructor to function and further discuss whether we should make it singleton.
@@ -33,6 +39,13 @@ export class AzureClientFactory {
   ): ResourceManagementClient {
     return new ResourceManagementClient(credentials, subscriptionId);
   }
+
+  public static getResourceManagementClientContext(
+    credentials: TokenCredentialsBase,
+    subscriptionId: string
+  ): ResourceManagementClientContext {
+    return new ResourceManagementClientContext(credentials, subscriptionId);
+  }
 }
 
 type Site = WebSiteManagementModels.Site;
@@ -56,6 +69,14 @@ export class AzureLib {
       resourceGroupName
     );
     return res.body;
+  }
+
+  public static async registerResourceProvider(
+    client: ResourceManagementClientContext,
+    providerNamespace: string
+  ): Promise<Provider> {
+    const provider = new Providers(client);
+    return await provider.register(providerNamespace);
   }
 
   private static async ensureResource<T>(

--- a/packages/fx-core/tests/plugins/resource/function/unit/azure-client.test.ts
+++ b/packages/fx-core/tests/plugins/resource/function/unit/azure-client.test.ts
@@ -24,6 +24,38 @@ const resourceGroupName = "ut";
 
 describe(FunctionPluginInfo.pluginName, async () => {
   describe("Azure Client Test", async () => {
+    it("Test ensureResourceProvider with existence", async () => {
+      // Arrange
+      const item: any = { registrationState: "Registered" };
+      const namespace = ["ut"];
+      const client: any = {
+        get: (namespace: string) => item,
+        register: (namespace: string) => item,
+      };
+
+      // Act
+      const res = await AzureLib.ensureResourceProviders(client, namespace);
+
+      // Assert
+      chai.assert.deepEqual(res, [item]);
+    });
+
+    it("Test ensureResourceProvider", async () => {
+      // Arrange
+      const item: any = { registrationState: "Unregistered" };
+      const namespace = ["ut"];
+      const client: any = {
+        get: (namespace: string) => item,
+        register: (namespace: string) => item,
+      };
+
+      // Act
+      const res = await AzureLib.ensureResourceProviders(client, namespace);
+
+      // Assert
+      chai.assert.deepEqual(res, [item]);
+    });
+
     it("Test ensureAppServicePlans with existence", async () => {
       // Arrange
       const item: any = { name: "ut" };

--- a/packages/fx-core/tests/plugins/resource/function/unit/provision.test.ts
+++ b/packages/fx-core/tests/plugins/resource/function/unit/provision.test.ts
@@ -93,7 +93,7 @@ const context: any = {
     }),
   },
   root: __dirname,
-  answers: {platform: Platform.VSCode}
+  answers: { platform: Platform.VSCode },
 };
 
 describe(FunctionPluginInfo.pluginName, () => {
@@ -121,6 +121,7 @@ describe(FunctionPluginInfo.pluginName, () => {
       sinon.stub(AzureLib, "getConnectionString").resolves("ut connection string");
       sinon.stub(AzureLib, "ensureFunctionApp").resolves(functionApp);
       sinon.stub(AzureLib, "findFunctionApp").resolves(functionApp);
+      sinon.stub(AzureLib, "findResourceProvider").resolves({} as any);
       sinon.stub(AzureClientFactory, "getWebSiteManagementClient").returns({
         webApps: {
           updateAuthSettings: () => undefined,


### PR DESCRIPTION
Have tested below scenario and all get expected result.

<body lang=EN-US style='tab-interval:.5in;word-wrap:break-word'>
<!--StartFragment-->

  | User can create resource but is not granted to register   resource provider | User have full permission to the subs
-- | -- | --
Required RPs have been registered | Pass | Pass
Required RPs are in Unregistering, Registering or   Unregistered status. | Failed with   RegisterResourceProviderError | Pass

<!--EndFragment-->
</body>
