### PR TITLE
fix(localdebug): Do not change run icon display status when opening a new editor

### DIFF
--- a/packages/vscode-extension/src/debug/runIconHandler.ts
+++ b/packages/vscode-extension/src/debug/runIconHandler.ts
@@ -30,3 +30,7 @@ function enableRunIcon(): void {
   const validProject = ext.workspaceUri && isValidProject(ext.workspaceUri.fsPath);
   vscode.commands.executeCommand("setContext", "fx-extension.runIconActive", validProject);
 }
+
+export function disableRunIcon(): void {
+  vscode.commands.executeCommand("setContext", "fx-extension.runIconActive", false);
+}

--- a/packages/vscode-extension/src/debug/runIconHandler.ts
+++ b/packages/vscode-extension/src/debug/runIconHandler.ts
@@ -5,10 +5,10 @@ import { ExtensionErrors, ExtensionSource } from "../error";
 import * as vscode from "vscode";
 import * as StringResources from "../resources/Strings.json";
 
-export async function selectAndDebug(args?: any[]): Promise<Result<null, FxError>> {
+export async function selectAndDebug(): Promise<Result<null, FxError>> {
   if (ext.workspaceUri && isValidProject(ext.workspaceUri.fsPath)) {
-    vscode.commands.executeCommand("workbench.view.debug");
-    vscode.commands.executeCommand("workbench.action.debug.selectandstart");
+    await vscode.commands.executeCommand("workbench.view.debug");
+    await vscode.commands.executeCommand("workbench.action.debug.selectandstart");
     return ok(null);
   } else {
     const error = returnUserError(
@@ -22,7 +22,6 @@ export async function selectAndDebug(args?: any[]): Promise<Result<null, FxError
 }
 
 export function registerRunIcon(): void {
-  ext.context.subscriptions.push(vscode.workspace.onDidOpenTextDocument(enableRunIcon));
   ext.context.subscriptions.push(vscode.workspace.onDidChangeWorkspaceFolders(enableRunIcon));
   enableRunIcon();
 }

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -16,7 +16,7 @@ import * as StringResources from "./resources/Strings.json";
 import { openWelcomePageAfterExtensionInstallation } from "./controls/openWelcomePage";
 import { VsCodeUI } from "./qm/vsc_ui";
 import { exp } from "./exp";
-import { registerRunIcon } from "./debug/runIconHandler";
+import { disableRunIcon, registerRunIcon } from "./debug/runIconHandler";
 
 export let VS_CODE_UI: VsCodeUI;
 
@@ -215,4 +215,5 @@ export async function activate(context: vscode.ExtensionContext) {
 // this method is called when your extension is deactivated
 export function deactivate() {
   handlers.cmdHdlDisposeTreeView();
+  disableRunIcon();
 }


### PR DESCRIPTION
1. Do not change run icon display status when opening a new editor
2. Make sure `workbench.view.debug` finished before `workbench.action.debug.selectandstart`