### PR TITLE
fix(cli-preview): disable cli preview

### DIFF
--- a/packages/cli/src/cmds/index.ts
+++ b/packages/cli/src/cmds/index.ts
@@ -29,5 +29,5 @@ export const commands: YargsCommand[] = [
   new Validate(),
   new Publish(),
   new Config(),
-  new Preview(),
+  // new Preview(),
 ];


### PR DESCRIPTION
Disabled preview command as env checker for CLI is not ready.

![image](https://user-images.githubusercontent.com/15644078/125013803-14e66f00-e09f-11eb-8f78-56f83ce1222c.png)
