### PR TITLE
chore(ut): add basic ut cases for operations

### DIFF
--- a/packages/github-actions/teams-toolkit-cicd/__tests__/operations.test.ts
+++ b/packages/github-actions/teams-toolkit-cicd/__tests__/operations.test.ts
@@ -1,0 +1,116 @@
+import * as fs from 'fs-extra'
+import mock from 'mock-fs'
+import {Operations} from '../src/operations'
+import {BaseError} from '../src/base-error'
+import * as path from 'path'
+import CommandUtil from '../src/utils/exec'
+
+const projectRoot = '/home/test/'
+
+describe('Test BuildTeamsApp', () => {
+  beforeEach(() => {
+    mock({
+      '/home/test': {
+        '.fx': {
+          'env.default.json': JSON.stringify({})
+        }
+      }
+    })
+  })
+  afterEach(() => {
+    mock.restore()
+  })
+  test('[BuildTeamsApp] LanguageError', async () => {
+    expect.assertions(1)
+    // Arrange
+    // Act & Assert
+    try {
+      await Operations.BuildTeamsApp(projectRoot, ['tabs'])
+    } catch (error) {
+      expect(error).toBeInstanceOf(BaseError)
+    }
+  })
+
+  test('[BuildTeamsApp] Happy path', async () => {
+    expect.assertions(0)
+    // Arrange
+    await fs.writeJson(path.join(projectRoot, '.fx', 'env.default.json'), {
+      solution: {
+        programmingLanguage: 'javascript'
+      }
+    })
+
+    // Act & Assert
+    try {
+      await Operations.BuildTeamsApp(projectRoot, ['tabs'])
+    } catch (error) {
+      console.log(error)
+      expect(true).toBeFalsy() // Should not reach here.
+    }
+  })
+})
+
+describe('Test ProvisionHostingEnvironment', () => {
+  test('[ProvisionHostingEnvironment] Happy path', async () => {
+    // Arrange
+    CommandUtil.Execute = jest.fn().mockReturnValue(0)
+
+    // Act
+    const ret = await Operations.ProvisionHostingEnvironment(projectRoot)
+
+    // Assert
+    expect(ret).toBe(0)
+  })
+})
+
+describe('Test DeployToHostingEnvironment', () => {
+  test('[DeployToHostingEnvironment] Happy path', async () => {
+    // Arrange
+    CommandUtil.Execute = jest.fn().mockReturnValue(0)
+
+    // Act
+    const ret = await Operations.DeployToHostingEnvironment(projectRoot)
+
+    // Assert
+    expect(ret).toBe(0)
+  })
+})
+
+describe('Test PackTeamsApp', () => {
+  test('[PackTeamsApp] Happy path', async () => {
+    // Arrange
+    CommandUtil.Execute = jest.fn().mockReturnValue(0)
+
+    // Act
+    const ret = await Operations.PackTeamsApp(projectRoot)
+
+    // Assert
+    expect(ret).toBe(0)
+  })
+})
+
+describe('Test ValidateTeamsAppManifest', () => {
+  test('[ValidateTeamsAppManifest] Happy path', async () => {
+    // Arrange
+    CommandUtil.Execute = jest.fn().mockReturnValue(0)
+
+    // Act
+    const ret = await Operations.ValidateTeamsAppManifest(projectRoot)
+
+    // Assert
+    expect(ret).toBe(0)
+  })
+})
+
+describe('Test PublishTeamsApp', () => {
+  test('[PublishTeamsApp] Happy path', async () => {
+    // Arrange
+    CommandUtil.Execute = jest.fn().mockReturnValue(0)
+
+    // Act
+    const ret = await Operations.PublishTeamsApp(projectRoot)
+
+    // Assert
+    expect(ret).toBe(0)
+  })
+})

--- a/packages/github-actions/teams-toolkit-cicd/__tests__/operations.test.ts
+++ b/packages/github-actions/teams-toolkit-cicd/__tests__/operations.test.ts
@@ -44,7 +44,6 @@ describe('Test BuildTeamsApp', () => {
     try {
       await Operations.BuildTeamsApp(projectRoot, ['tabs'])
     } catch (error) {
-      console.log(error)
       expect(true).toBeFalsy() // Should not reach here.
     }
   })

--- a/packages/github-actions/teams-toolkit-cicd/package.json
+++ b/packages/github-actions/teams-toolkit-cicd/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.15",
+    "@types/mock-fs": "^4.13.1",
     "@types/node": "^14.14.9",
     "@typescript-eslint/parser": "^4.8.1",
     "@vercel/ncc": "^0.25.1",
@@ -41,6 +42,7 @@
     "jest": "^26.6.3",
     "jest-circus": "^26.6.3",
     "js-yaml": "^3.14.0",
+    "mock-fs": "^5.0.0",
     "prettier": "2.2.1",
     "ts-jest": "^26.4.4",
     "typescript": "^4.1.3"

--- a/packages/github-actions/teams-toolkit-cicd/src/operations.ts
+++ b/packages/github-actions/teams-toolkit-cicd/src/operations.ts
@@ -1,5 +1,5 @@
 import * as path from 'path'
-import {Execute} from './utils/exec'
+import {CommandUtil} from './utils/exec'
 import {Commands, Pathes, Miscs, ActionOutputs} from './constant'
 import {ProgrammingLanguage} from './enums/programmingLanguages'
 import * as fs from 'fs-extra'
@@ -28,7 +28,7 @@ export class Operations {
       const commands = buildMapQuerier.query(cap, lang)
       if (await fs.pathExists(capPath)) {
         for (const command of commands) {
-          await Execute(command, capPath)
+          await CommandUtil.Execute(command, capPath)
         }
       }
     })
@@ -39,7 +39,7 @@ export class Operations {
   static async ProvisionHostingEnvironment(
     projectRoot: string
   ): Promise<number> {
-    const ret = await Execute(
+    const ret = await CommandUtil.Execute(
       Commands.TeamsfxProvision(process.env.TEST_SUBSCRIPTION_ID!),
       projectRoot
     )
@@ -57,7 +57,7 @@ export class Operations {
   static async DeployToHostingEnvironment(
     projectRoot: string
   ): Promise<number> {
-    const ret = await Execute(Commands.TeamsfxDeploy, projectRoot)
+    const ret = await CommandUtil.Execute(Commands.TeamsfxDeploy, projectRoot)
 
     const packageSolutionPath = path.join(
       projectRoot,
@@ -82,7 +82,7 @@ export class Operations {
   }
 
   static async PackTeamsApp(projectRoot: string): Promise<number> {
-    const ret = await Execute(Commands.TeamsfxBuild, projectRoot)
+    const ret = await CommandUtil.Execute(Commands.TeamsfxBuild, projectRoot)
     if (ret === 0) {
       core.setOutput(
         ActionOutputs.PackageZipPath,
@@ -93,10 +93,10 @@ export class Operations {
   }
 
   static async ValidateTeamsAppManifest(projectRoot: string): Promise<number> {
-    return await Execute(Commands.TeamsfxValidate, projectRoot)
+    return await CommandUtil.Execute(Commands.TeamsfxValidate, projectRoot)
   }
 
   static async PublishTeamsApp(projectRoot: string): Promise<number> {
-    return await Execute(Commands.TeamsfxPublish, projectRoot)
+    return await CommandUtil.Execute(Commands.TeamsfxPublish, projectRoot)
   }
 }

--- a/packages/github-actions/teams-toolkit-cicd/src/utils/exec.ts
+++ b/packages/github-actions/teams-toolkit-cicd/src/utils/exec.ts
@@ -1,7 +1,11 @@
 import * as exec from '@actions/exec'
-
-export async function Execute(cmd: string, workdir: string): Promise<number> {
-  return await exec.exec(cmd, undefined, {
-    cwd: workdir
-  })
+// eslint-disable-next-line @typescript-eslint/no-extraneous-class
+export class CommandUtil {
+  static async Execute(cmd: string, workdir: string): Promise<number> {
+    return await exec.exec(cmd, undefined, {
+      cwd: workdir
+    })
+  }
 }
+
+export default CommandUtil


### PR DESCRIPTION
Add basic ut cases for operations.ts.

1. make Execute as a module.
2. add basic ut cases.
3. mock fs by mock-fs.

target for the action feature branch.

to finish https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/10298211