### PR TITLE
fix(cli): set background color for the rest of the line

### DIFF
--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -298,5 +298,5 @@ export function getColorizedString(message: Array<{ content: string; color: Colo
       }
     })
     .join("");
-  return colorizedMessage + "\u00A0\u001B[K";
+  return colorizedMessage + (process.stdout.isTTY ? "\u00A0\u001B[K" : "");
 }

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -298,5 +298,5 @@ export function getColorizedString(message: Array<{ content: string; color: Colo
       }
     })
     .join("");
-  return colorizedMessage + "\u00A0";
+  return colorizedMessage + "\u00A0\u001B[K";
 }


### PR DESCRIPTION
When the output `scrolling the window`, the rest of the line will be filled with color of the first character.

![image](https://user-images.githubusercontent.com/71362691/125245512-3d7e9b00-e323-11eb-9410-8cfc6b4b3eb1.png)


Reference: https://stackoverflow.com/a/53741857/16437100