### PR TITLE
feat(env-checker): [part-3] add telemetry implementation in CLI env checker

### DIFF
--- a/packages/cli/src/cmds/preview/depsChecker/cliAdapter.ts
+++ b/packages/cli/src/cmds/preview/depsChecker/cliAdapter.ts
@@ -1,14 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import * as path from "path";
 import { DepsCheckerEvent, Messages } from "./common";
 import { IDepsAdapter, IDepsTelemetry } from "./checker";
-import { cliEnvCheckerLogger as logger } from "./cliLogger";
-import { cliTelemetry } from "./cliTelemetry";
-import DialogManagerInstance from "../../../userInterface";
 import CLIUIInstance from "../../../userInteraction";
 
 export class CLIAdapter implements IDepsAdapter {
-  private readonly configurationPrefix = "fx-extension";
-  private readonly downloadIndicatorInterval = 1000; // same as vscode-dotnet-runtime
   private readonly validateDotnetSdkKey = "validateDotnetSdk";
   private readonly validateFuncCoreToolsKey = "validateFuncCoreTools";
   private readonly validateNodeVersionKey = "validateNode";

--- a/packages/cli/src/telemetry/cliTelemetryEvents.ts
+++ b/packages/cli/src/telemetry/cliTelemetryEvents.ts
@@ -69,6 +69,8 @@ export enum TelemetryProperty {
   PreviewNpmInstallNpmVersion = "preview-npm-install-npm-version",
   PreviewNpmInstallErrorMessage = "preview-npm-install-error-message",
   PreviewServiceName = "preview-service-name",
+  PreviewOSArch = "preview-os-arch",
+  PreviewOSRelease = "preview-os-release",
 }
 
 export enum TelemetrySuccess {


### PR DESCRIPTION
The telemetry implemenation is similar to the extension's, with just slight differences replacing `ExtTelemetry` with `cliTelemtry`

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/10338893/