### PR TITLE
refactor(env-checker): [part-4] refactor feature flags with async functions to support cli senarios

### DIFF
--- a/packages/cli/src/cmds/preview/depsChecker/checker.ts
+++ b/packages/cli/src/cmds/preview/depsChecker/checker.ts
@@ -35,9 +35,9 @@ export interface IDepsAdapter {
   showOutputChannel: () => void;
 
   hasTeamsfxBackend(): Promise<boolean>;
-  dotnetCheckerEnabled(): boolean;
-  funcToolCheckerEnabled(): boolean;
-  nodeCheckerEnabled(): boolean;
+  dotnetCheckerEnabled(): Promise<boolean>;
+  funcToolCheckerEnabled(): Promise<boolean>;
+  nodeCheckerEnabled(): Promise<boolean>;
   runWithProgressIndicator(callback: () => Promise<void>): Promise<void>;
   getResourceDir(): string;
 }

--- a/packages/cli/src/cmds/preview/depsChecker/cliAdapter.ts
+++ b/packages/cli/src/cmds/preview/depsChecker/cliAdapter.ts
@@ -24,16 +24,19 @@ export class CLIAdapter implements IDepsAdapter {
     return Promise.resolve(this._hasBackend);
   }
 
-  public dotnetCheckerEnabled(): boolean {
-    return this.checkerEnabled(this.validateDotnetSdkKey);
+  public dotnetCheckerEnabled(): Promise<boolean> {
+    // TODO: implement me
+    throw new Error("not implemented");
   }
 
-  public funcToolCheckerEnabled(): boolean {
-    return this.checkerEnabled(this.validateFuncCoreToolsKey);
+  public funcToolCheckerEnabled(): Promise<boolean> {
+    // TODO: implement me
+    throw new Error("not implemented");
   }
 
-  public nodeCheckerEnabled(): boolean {
-    return this.checkerEnabled(this.validateNodeVersionKey);
+  public nodeCheckerEnabled(): Promise<boolean> {
+    // TODO: implement me
+    throw new Error("not implemented");
   }
 
   public async runWithProgressIndicator(callback: () => Promise<void>): Promise<void> {
@@ -98,11 +101,6 @@ export class CLIAdapter implements IDepsAdapter {
 
   public getResourceDir(): string {
     return path.resolve(__dirname, "resource");
-  }
-
-  private checkerEnabled(key: string): boolean {
-    // TODO: retrieve from CLI config
-    return true;
   }
 
   private static async openUrl(url: string): Promise<void> {

--- a/packages/cli/src/cmds/preview/depsChecker/dotnetChecker.ts
+++ b/packages/cli/src/cmds/preview/depsChecker/dotnetChecker.ts
@@ -72,12 +72,12 @@ export class DotnetChecker implements IDepsChecker {
     };
   }
 
-  public isEnabled(): Promise<boolean> {
-    const enabled = this._adapter.dotnetCheckerEnabled();
+  public async isEnabled(): Promise<boolean> {
+    const enabled = await this._adapter.dotnetCheckerEnabled();
     if (!enabled) {
       this._telemetry.sendEvent(DepsCheckerEvent.dotnetCheckSkipped);
     }
-    return Promise.resolve(enabled);
+    return enabled;
   }
 
   public async isInstalled(): Promise<boolean> {

--- a/packages/cli/src/cmds/preview/depsChecker/funcToolChecker.ts
+++ b/packages/cli/src/cmds/preview/depsChecker/funcToolChecker.ts
@@ -48,7 +48,7 @@ export class FuncToolChecker implements IDepsChecker {
   public async isEnabled(): Promise<boolean> {
     // only for function api
     const hasBackend = await this._adapter.hasTeamsfxBackend();
-    const checkerEnabled = this._adapter.funcToolCheckerEnabled();
+    const checkerEnabled = await this._adapter.funcToolCheckerEnabled();
 
     if (!checkerEnabled) {
       this._telemetry.sendEvent(DepsCheckerEvent.funcCheckSkipped);

--- a/packages/cli/src/cmds/preview/depsChecker/nodeChecker.ts
+++ b/packages/cli/src/cmds/preview/depsChecker/nodeChecker.ts
@@ -31,7 +31,7 @@ export abstract class NodeChecker implements IDepsChecker {
   }
 
   public isEnabled(): Promise<boolean> {
-    return Promise.resolve(this._adapter.nodeCheckerEnabled());
+    return this._adapter.nodeCheckerEnabled();
   }
 
   public async isInstalled(): Promise<boolean> {

--- a/packages/fx-core/src/plugins/resource/function/utils/depsChecker/checker.ts
+++ b/packages/fx-core/src/plugins/resource/function/utils/depsChecker/checker.ts
@@ -35,9 +35,9 @@ export interface IDepsAdapter {
   showOutputChannel: () => void;
 
   hasTeamsfxBackend(): Promise<boolean>;
-  dotnetCheckerEnabled(): boolean;
-  funcToolCheckerEnabled(): boolean;
-  nodeCheckerEnabled(): boolean;
+  dotnetCheckerEnabled(): Promise<boolean>;
+  funcToolCheckerEnabled(): Promise<boolean>;
+  nodeCheckerEnabled(): Promise<boolean>;
   runWithProgressIndicator(callback: () => Promise<void>): Promise<void>;
   getResourceDir(): string;
 }
@@ -157,27 +157,28 @@ export class DepsChecker {
       supportedPackages.push(supportedPackage);
     }
     const supportedMessage = supportedPackages.join(" and ");
-    return Messages.linuxDepsNotFound.replace("@SupportedPackages", supportedMessage);
+    return Messages.linuxDepsNotFound.split("@SupportedPackages").join(supportedMessage);
   }
 
   private async handleError(error: Error): Promise<boolean> {
+    return DepsChecker.handleErrorWithDisplay(error, this._adapter);
+  }
+
+  public static async handleErrorWithDisplay(
+    error: Error,
+    adapter: IDepsAdapter
+  ): Promise<boolean> {
     if (error instanceof NodeNotSupportedError) {
-      return await this._adapter.displayContinueWithLearnMore(
+      return await adapter.displayContinueWithLearnMore(
         error.message,
         (error as NodeNotSupportedError).helpLink
       );
     } else if (error instanceof NodeNotFoundError) {
-      return await this._adapter.displayLearnMore(
-        error.message,
-        (error as NodeNotFoundError).helpLink
-      );
+      return await adapter.displayLearnMore(error.message, (error as NodeNotFoundError).helpLink);
     } else if (error instanceof DepsCheckerError) {
-      return await this._adapter.displayLearnMore(
-        error.message,
-        (error as DepsCheckerError).helpLink
-      );
+      return await adapter.displayLearnMore(error.message, (error as DepsCheckerError).helpLink);
     } else {
-      return await this._adapter.displayLearnMore(Messages.defaultErrorMessage, defaultHelpLink);
+      return await adapter.displayLearnMore(Messages.defaultErrorMessage, defaultHelpLink);
     }
   }
 }

--- a/packages/fx-core/src/plugins/resource/function/utils/depsChecker/dotnetChecker.ts
+++ b/packages/fx-core/src/plugins/resource/function/utils/depsChecker/dotnetChecker.ts
@@ -72,12 +72,12 @@ export class DotnetChecker implements IDepsChecker {
     };
   }
 
-  public isEnabled(): Promise<boolean> {
-    const enabled = this._adapter.dotnetCheckerEnabled();
+  public async isEnabled(): Promise<boolean> {
+    const enabled = await this._adapter.dotnetCheckerEnabled();
     if (!enabled) {
       this._telemetry.sendEvent(DepsCheckerEvent.dotnetCheckSkipped);
     }
-    return Promise.resolve(enabled);
+    return enabled;
   }
 
   public async isInstalled(): Promise<boolean> {
@@ -368,8 +368,12 @@ export class DotnetChecker implements IDepsChecker {
         }
       });
     } catch (error) {
-      await this._logger.debug(
-        `Failed to search dotnet sdk by dotnetPath = ${dotnetExecPath}, error = '${error}'`
+      const errorMessage = `Failed to search dotnet sdk by dotnetPath = '${dotnetExecPath}', error = '${error}'`;
+      await this._logger.debug(errorMessage);
+      this._telemetry.sendSystemErrorEvent(
+        DepsCheckerEvent.dotnetSearchDotnetSdks,
+        TelemtryMessages.failedToSearchDotnetSdks,
+        errorMessage
       );
     }
     return sdks;

--- a/packages/fx-core/src/plugins/resource/function/utils/depsChecker/funcPluginAdapter.ts
+++ b/packages/fx-core/src/plugins/resource/function/utils/depsChecker/funcPluginAdapter.ts
@@ -52,12 +52,12 @@ export class FuncPluginAdapter implements IDepsAdapter {
     return path.resolve(path.join(getResourceFolder(), "plugins", "resource", "function"));
   }
 
-  public dotnetCheckerEnabled(): boolean {
+  public dotnetCheckerEnabled(): Promise<boolean> {
     let enabled = true;
     if (this._ctx.answers && this._ctx.answers[this.dotnetSettingKey] !== undefined) {
       enabled = (<boolean>this._ctx.answers[this.dotnetSettingKey]) as boolean;
     }
-    return enabled;
+    return Promise.resolve(enabled);
   }
 
   public async runWithProgressIndicator(callback: () => Promise<void>): Promise<void> {
@@ -78,10 +78,10 @@ export class FuncPluginAdapter implements IDepsAdapter {
   public hasTeamsfxBackend(): Promise<boolean> {
     throw new Error("Method not implemented.");
   }
-  public funcToolCheckerEnabled(): boolean {
+  public funcToolCheckerEnabled(): Promise<boolean> {
     throw new Error("Method not implemented.");
   }
-  public nodeCheckerEnabled(): boolean {
+  public nodeCheckerEnabled(): Promise<boolean> {
     throw new Error("Method not implemented.");
   }
 

--- a/packages/vscode-extension/src/debug/depsChecker/checker.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/checker.ts
@@ -35,9 +35,9 @@ export interface IDepsAdapter {
   showOutputChannel: () => void;
 
   hasTeamsfxBackend(): Promise<boolean>;
-  dotnetCheckerEnabled(): boolean;
-  funcToolCheckerEnabled(): boolean;
-  nodeCheckerEnabled(): boolean;
+  dotnetCheckerEnabled(): Promise<boolean>;
+  funcToolCheckerEnabled(): Promise<boolean>;
+  nodeCheckerEnabled(): Promise<boolean>;
   runWithProgressIndicator(callback: () => Promise<void>): Promise<void>;
   getResourceDir(): string;
 }

--- a/packages/vscode-extension/src/debug/depsChecker/dotnetChecker.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/dotnetChecker.ts
@@ -72,12 +72,12 @@ export class DotnetChecker implements IDepsChecker {
     };
   }
 
-  public isEnabled(): Promise<boolean> {
-    const enabled = this._adapter.dotnetCheckerEnabled();
+  public async isEnabled(): Promise<boolean> {
+    const enabled = await this._adapter.dotnetCheckerEnabled();
     if (!enabled) {
       this._telemetry.sendEvent(DepsCheckerEvent.dotnetCheckSkipped);
     }
-    return Promise.resolve(enabled);
+    return enabled;
   }
 
   public async isInstalled(): Promise<boolean> {

--- a/packages/vscode-extension/src/debug/depsChecker/funcToolChecker.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/funcToolChecker.ts
@@ -48,7 +48,7 @@ export class FuncToolChecker implements IDepsChecker {
   public async isEnabled(): Promise<boolean> {
     // only for function api
     const hasBackend = await this._adapter.hasTeamsfxBackend();
-    const checkerEnabled = this._adapter.funcToolCheckerEnabled();
+    const checkerEnabled = await this._adapter.funcToolCheckerEnabled();
 
     if (!checkerEnabled) {
       this._telemetry.sendEvent(DepsCheckerEvent.funcCheckSkipped);

--- a/packages/vscode-extension/src/debug/depsChecker/nodeChecker.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/nodeChecker.ts
@@ -31,7 +31,7 @@ export abstract class NodeChecker implements IDepsChecker {
   }
 
   public isEnabled(): Promise<boolean> {
-    return Promise.resolve(this._adapter.nodeCheckerEnabled());
+    return this._adapter.nodeCheckerEnabled();
   }
 
   public async isInstalled(): Promise<boolean> {

--- a/packages/vscode-extension/src/debug/depsChecker/vscodeAdapter.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/vscodeAdapter.ts
@@ -12,7 +12,7 @@ export class VSCodeAdapter implements IDepsAdapter {
   private readonly validateDotnetSdkKey = "validateDotnetSdk";
   private readonly validateFuncCoreToolsKey = "validateFuncCoreTools";
   private readonly validateNodeVersionKey = "validateNode";
-  private readonly _telemetry: IDepsTelemetry
+  private readonly _telemetry: IDepsTelemetry;
 
   constructor(telemetry: IDepsTelemetry) {
     this._telemetry = telemetry;
@@ -22,16 +22,16 @@ export class VSCodeAdapter implements IDepsAdapter {
     return hasTeamsfxBackend();
   }
 
-  public dotnetCheckerEnabled(): boolean {
-    return this.checkerEnabled(this.validateDotnetSdkKey);
+  public dotnetCheckerEnabled(): Promise<boolean> {
+    return Promise.resolve(this.checkerEnabled(this.validateDotnetSdkKey));
   }
 
-  public funcToolCheckerEnabled(): boolean {
-    return this.checkerEnabled(this.validateFuncCoreToolsKey);
+  public funcToolCheckerEnabled(): Promise<boolean> {
+    return Promise.resolve(this.checkerEnabled(this.validateFuncCoreToolsKey));
   }
 
-  public nodeCheckerEnabled(): boolean {
-    return this.checkerEnabled(this.validateNodeVersionKey);
+  public nodeCheckerEnabled(): Promise<boolean> {
+    return Promise.resolve(this.checkerEnabled(this.validateNodeVersionKey));
   }
 
   public async runWithProgressIndicator(callback: () => Promise<void>): Promise<void> {

--- a/packages/vscode-extension/test/suite/envChecker/adapters/testAdapter.ts
+++ b/packages/vscode-extension/test/suite/envChecker/adapters/testAdapter.ts
@@ -104,16 +104,16 @@ export class TestAdapter implements IDepsAdapter {
     return Promise.resolve(this._hasTeamsfxBackend);
   }
 
-  dotnetCheckerEnabled(): boolean {
-    return this._dotnetCheckerEnabled;
+  dotnetCheckerEnabled(): Promise<boolean> {
+    return Promise.resolve(this._dotnetCheckerEnabled);
   }
 
-  funcToolCheckerEnabled(): boolean {
-    return this._funcToolCheckerEnabled;
+  funcToolCheckerEnabled(): Promise<boolean> {
+    return Promise.resolve(this._funcToolCheckerEnabled);
   }
 
-  nodeCheckerEnabled(): boolean {
-    return this._nodeCheckerEnabled;
+  nodeCheckerEnabled(): Promise<boolean> {
+    return Promise.resolve(this._nodeCheckerEnabled);
   }
 
   runWithProgressIndicator(callback: () => Promise<void>): Promise<void> {


### PR DESCRIPTION
- Refactor `xxxEnabled()` function to async function, because retrieving config requires async function calls which won't work with normal functions.
- There are two commits, the first of which is refactoring and the other is just copying files.

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/10338893/