### PR TITLE
fix(apim): validate the openapi document when load the document

### DIFF
--- a/packages/fx-core/package.json
+++ b/packages/fx-core/package.json
@@ -17,6 +17,7 @@
     "test:identity": "nyc mocha --no-timeouts --require ts-node/register \"tests/plugins/resource/identity/**/*.test.ts\"",
     "test:appstudio": "nyc mocha --no-timeouts --require ts-node/register \"tests/plugins/resource/appstudio/**/*.test.ts\"",
     "test:spfx": "nyc mocha --no-timeouts --require ts-node/register \"tests/plugins/resource/spfx/**/*.test.ts\"",
+    "test:apim": "nyc mocha --no-timeouts --require ts-node/register \"tests/plugins/resource/apim/**/*.test.ts\"",
     "test:unit": "nyc mocha --no-timeouts --require ts-node/register \"tests/**/*.test.ts\"",
     "test:solution": "nyc mocha --no-timeouts --require ts-node/register \"tests/plugins/solution/*.test.ts\"",
     "test:core": "nyc mocha --no-timeouts --require ts-node/register \"tests/core/*.test.ts\"",

--- a/packages/fx-core/src/plugins/resource/apim/error.ts
+++ b/packages/fx-core/src/plugins/resource/apim/error.ts
@@ -30,6 +30,22 @@ export const InvalidOpenApiDocument: IApimPluginError = {
   helpLink: ProjectConstants.helpLink,
 };
 
+export const EmptyTitleInOpenApiDocument: IApimPluginError = {
+  type: ErrorType.User,
+  code: "EmptyTitleInOpenApiDocument",
+  message: (filePath: string) =>
+    `The property 'title' cannot be empty in the OpenApi document '${filePath}'.`,
+  helpLink: ProjectConstants.helpLink,
+};
+
+export const EmptyVersionInOpenApiDocument: IApimPluginError = {
+  type: ErrorType.User,
+  code: "EmptyVersionInOpenApiDocument",
+  message: (filePath: string) =>
+    `The property 'version' cannot be empty in the OpenApi document '${filePath}'.`,
+  helpLink: ProjectConstants.helpLink,
+};
+
 export const InvalidAadObjectId: IApimPluginError = {
   type: ErrorType.User,
   code: "InvalidAadObjectId",

--- a/packages/fx-core/tests/plugins/resource/apim/data/openApiProcessor/errorSpec/title-empty.json
+++ b/packages/fx-core/tests/plugins/resource/apim/data/openApiProcessor/errorSpec/title-empty.json
@@ -3,5 +3,6 @@
   "info": {
     "title": "",
     "version": "v1"
-  }
+  },
+  "paths": {}
 }

--- a/packages/fx-core/tests/plugins/resource/apim/data/openApiProcessor/errorSpec/title-undefined.yaml
+++ b/packages/fx-core/tests/plugins/resource/apim/data/openApiProcessor/errorSpec/title-undefined.yaml
@@ -1,3 +1,23 @@
 openapi: 3.0.1
 info:
   version: v1
+paths:
+  "/users/{id}":
+    get:
+      summary: GetUsers
+      description: Get all users.
+      operationId: getUsers
+      parameters:
+        - name: id
+          in: path
+          description: user id
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: The user information.
+          content:
+            application/json:
+              schema:
+                type: integer

--- a/packages/fx-core/tests/plugins/resource/apim/data/openApiProcessor/errorSpec/version-empty.yaml
+++ b/packages/fx-core/tests/plugins/resource/apim/data/openApiProcessor/errorSpec/version-empty.yaml
@@ -2,3 +2,23 @@ openapi: 3.0.1
 info:
   title: test title
   version: ""
+paths:
+  "/users/{id}":
+    get:
+      summary: GetUsers
+      description: Get all users.
+      operationId: getUsers
+      parameters:
+        - name: id
+          in: path
+          description: user id
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: The user information.
+          content:
+            application/json:
+              schema:
+                type: integer

--- a/packages/fx-core/tests/plugins/resource/apim/data/openApiProcessor/errorSpec/version-undefined.json
+++ b/packages/fx-core/tests/plugins/resource/apim/data/openApiProcessor/errorSpec/version-undefined.json
@@ -2,5 +2,6 @@
   "openapi": "3.0.1",
   "info": {
     "title": "test title"
-  }
+  },
+  "paths": {}
 }

--- a/packages/fx-core/tests/plugins/resource/apim/openApiProcessor.test.ts
+++ b/packages/fx-core/tests/plugins/resource/apim/openApiProcessor.test.ts
@@ -6,6 +6,8 @@ import chaiAsPromised from "chai-as-promised";
 import path from "path";
 import { OpenApiProcessor } from "../../../../src/plugins/resource/apim/utils/openApiProcessor";
 import {
+  EmptyTitleInOpenApiDocument,
+  EmptyVersionInOpenApiDocument,
   InvalidFunctionEndpoint,
   InvalidOpenApiDocument,
 } from "../../../../src/plugins/resource/apim/error";
@@ -15,29 +17,32 @@ chai.use(chaiAsPromised);
 const testDataBaseFolder = "./tests/plugins/resource/apim/data/openApiProcessor";
 describe("OpenApiProcessor", () => {
   describe("#loadOpenApiDocument()", () => {
-    const testInput: { message: string; filePath: string; schemaVersion: OpenApiSchemaVersion }[] =
-      [
-        {
-          message: "v3 json file",
-          filePath: `${testDataBaseFolder}/openapi-user.json`,
-          schemaVersion: OpenApiSchemaVersion.V3,
-        },
-        {
-          message: "v3 yaml file",
-          filePath: `${testDataBaseFolder}/openapi-user.yaml`,
-          schemaVersion: OpenApiSchemaVersion.V3,
-        },
-        {
-          message: "v2 json file",
-          filePath: `${testDataBaseFolder}/swagger-user.json`,
-          schemaVersion: OpenApiSchemaVersion.V2,
-        },
-        {
-          message: "v2 yaml file",
-          filePath: `${testDataBaseFolder}/swagger-user.yaml`,
-          schemaVersion: OpenApiSchemaVersion.V2,
-        },
-      ];
+    const testInput: {
+      message: string;
+      filePath: string;
+      schemaVersion: OpenApiSchemaVersion;
+    }[] = [
+      {
+        message: "v3 json file",
+        filePath: `${testDataBaseFolder}/openapi-user.json`,
+        schemaVersion: OpenApiSchemaVersion.V3,
+      },
+      {
+        message: "v3 yaml file",
+        filePath: `${testDataBaseFolder}/openapi-user.yaml`,
+        schemaVersion: OpenApiSchemaVersion.V3,
+      },
+      {
+        message: "v2 json file",
+        filePath: `${testDataBaseFolder}/swagger-user.json`,
+        schemaVersion: OpenApiSchemaVersion.V2,
+      },
+      {
+        message: "v2 yaml file",
+        filePath: `${testDataBaseFolder}/swagger-user.yaml`,
+        schemaVersion: OpenApiSchemaVersion.V2,
+      },
+    ];
 
     testInput.forEach((input) => {
       it(input.message, async () => {
@@ -84,7 +89,9 @@ describe("OpenApiProcessor", () => {
       {
         message: "title empty",
         filePath: `${testDataBaseFolder}/errorSpec/title-empty.json`,
-        error: InvalidOpenApiDocument.message(`${testDataBaseFolder}/errorSpec/title-empty.json`),
+        error: EmptyTitleInOpenApiDocument.message(
+          `${testDataBaseFolder}/errorSpec/title-empty.json`
+        ),
       },
       {
         message: "title undefined",
@@ -96,7 +103,9 @@ describe("OpenApiProcessor", () => {
       {
         message: "version empty",
         filePath: `${testDataBaseFolder}/errorSpec/version-empty.yaml`,
-        error: InvalidOpenApiDocument.message(`${testDataBaseFolder}/errorSpec/version-empty.yaml`),
+        error: EmptyVersionInOpenApiDocument.message(
+          `${testDataBaseFolder}/errorSpec/version-empty.yaml`
+        ),
       },
       {
         message: "version undefined",


### PR DESCRIPTION
Validate the Open API document when loading the document

Fix the bugs when the Open API document is invalid.
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/10117377/
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/10126313/