### PR TITLE
feat(cli-preview): add browser option to preview command

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -170,6 +170,15 @@
         "uuid": "^8.3.0"
       },
       "dependencies": {
+        "open": {
+          "version": "7.4.2",
+          "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+          "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+          "requires": {
+            "is-docker": "^2.0.0",
+            "is-wsl": "^2.1.1"
+          }
+        },
         "tslib": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
@@ -2598,6 +2607,11 @@
       "requires": {
         "clone": "^1.0.2"
       }
+    },
+    "define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -5396,12 +5410,13 @@
       }
     },
     "open": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
-      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.2.1.tgz",
+      "integrity": "sha512-rXILpcQlkF/QuFez2BJDf3GsqpjGKbkUUToAIGo9A0Q6ZkoSGogZJulrUdwRkrAsoQvoZsrjCYt8+zblOk7JQQ==",
       "requires": {
-        "is-docker": "^2.0.0",
-        "is-wsl": "^2.1.1"
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
       }
     },
     "optionator": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -114,7 +114,7 @@
     "md5": "^2.3.0",
     "ms-rest-azure": "^3.0.0",
     "node-machine-id": "^1.1.12",
-    "open": "^7.3.1",
+    "open": "^8.2.1",
     "tedious": "^9.2.1",
     "tree-kill": "^1.2.2",
     "underscore": "^1.12.1",

--- a/packages/cli/src/cmds/preview/constants.ts
+++ b/packages/cli/src/cmds/preview/constants.ts
@@ -3,6 +3,12 @@
 
 "use strict";
 
+export enum Browser {
+  chrome = "chrome",
+  edge = "edge",
+  default = "default",
+}
+
 export const sideloadingUrl =
   "https://teams.microsoft.com/l/app/${teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}";
 export const teamsAppIdPlaceholder = "${teamsAppId}";

--- a/packages/cli/src/cmds/preview/errors.ts
+++ b/packages/cli/src/cmds/preview/errors.ts
@@ -7,6 +7,7 @@ import { FxError, returnUserError, UserError } from "@microsoft/teamsfx-api";
 import * as util from "util";
 
 import * as constants from "../../constants";
+import { Browser } from "./constants";
 
 export function WorkspaceNotSupported(workspaceFolder: string): UserError {
   return returnUserError(
@@ -79,6 +80,14 @@ export function PreviewWithoutProvision(): UserError {
     new Error("Provision and deploy commands are required before preview from remote."),
     constants.cliSource,
     "PreviewWithoutProvision"
+  );
+}
+
+export function OpeningBrowserFailed(browser: Browser): UserError {
+  return returnUserError(
+    new Error(`Failed to open ${browser} browser. Check if ${browser} exists on your system.`),
+    constants.cliSource,
+    "OpeningBrowserFailed"
   );
 }
 

--- a/packages/cli/src/telemetry/cliTelemetryEvents.ts
+++ b/packages/cli/src/telemetry/cliTelemetryEvents.ts
@@ -63,6 +63,7 @@ export enum TelemetryProperty {
   InternalAlias = "internal-alias",
   PreviewAppId = "preview-appid",
   PreviewType = "preview-type",
+  PreviewBrowser = "preview-browser",
   PreviewNpmInstallName = "preview-npm-install-name",
   PreviewNpmInstallExitCode = "preview-npm-install-exit-code",
   PreviewNpmInstallNodeVersion = "preview-npm-install-node-version",


### PR DESCRIPTION
To fix: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/10318744

@Alive-Fish @jiayi-ruan Please help review, thanks:
1. `package.json` and `package-lock.json`: upgrade `open` version to use `open.apps` for browser selection
2. `src/telemetry/cliTelemetryEvents.ts`: add `preview-browser` telemetry property