### PR TITLE
fix(env checker): remove func-core-tool v2 from supported list

### DIFF
--- a/packages/cli/src/cmds/preview/depsChecker/funcToolChecker.ts
+++ b/packages/cli/src/cmds/preview/depsChecker/funcToolChecker.ts
@@ -20,7 +20,7 @@ const funcPackageName = "azure-functions-core-tools";
 const funcToolName = "Azure Function Core Tool";
 
 const installVersion = FuncVersion.v3;
-const supportedVersions = [FuncVersion.v2, FuncVersion.v3];
+const supportedVersions = [FuncVersion.v3];
 const displayFuncName = `${funcToolName} (v${FuncVersion.v3})`;
 
 const timeout = 5 * 60 * 1000;

--- a/packages/vscode-extension/src/debug/depsChecker/funcToolChecker.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/funcToolChecker.ts
@@ -20,7 +20,7 @@ const funcPackageName = "azure-functions-core-tools";
 const funcToolName = "Azure Function Core Tool";
 
 const installVersion = FuncVersion.v3;
-const supportedVersions = [FuncVersion.v2, FuncVersion.v3];
+const supportedVersions = [FuncVersion.v3];
 const displayFuncName = `${funcToolName} (v${FuncVersion.v3})`;
 
 const timeout = 5 * 60 * 1000;


### PR DESCRIPTION
[bug](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/10357266)