### PR TITLE
chore: fix pack bug

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -126,7 +126,7 @@ jobs:
       - name: version change
         id: version-change
         run: |
-          echo "::set-output name=CHANGED::$(git tag --points-at HEAD)"
+          echo "::set-output name=CHANGED::$(git tag --points-at HEAD | xargs)"
 
       - name: update cli ai key
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (github.event.inputs.preid == 'stable'||github.event.inputs.preid == 'rc') }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -122,6 +122,11 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && github.event.inputs.preid == 'stable' }}
         run: |
           npx lerna version --no-private --conventional-commits --conventional-graduate --no-changelog --yes
+      
+      - name: version change
+        id: version-change
+        run: |
+          echo "::set-output name=CHANGED::$(git tag --points-at HEAD)"
 
       - name: update cli ai key
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && (github.event.inputs.preid == 'stable'||github.event.inputs.preid == 'rc') }}
@@ -170,19 +175,8 @@ jobs:
             VERSION=`ls *.vsix | awk -F '.vsix' '{print $1}'`
             echo "::set-output name=VERSION::$VERSION"
 
-      - name: check whether vscode extension changed or not
-        id: extension-checker
-        working-directory: ./packages/vscode-extension
-        run: |
-          if git diff HEAD^ package.json | grep version;
-          then
-            echo "::set-output name=CHANGED::true"
-          else
-            echo "::set-output name=CHANGED::false"
-          fi
-
       - name: release VSCode extension to github
-        if: ${{ steps.extension-checker.outputs.CHANGED == 'true' }}
+        if: ${{ contains(steps.version-change.outputs.CHANGED, 'ms-teams-vscode-extension@') }}
         uses: marvinpinto/action-automatic-releases@latest
         with:
           repo_token: ${{ secrets.CD_PAT }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -128,7 +128,7 @@ jobs:
               targetpct=$(echo '${{ needs.target-branch-test.outputs.coverages }}' | jq .\"$i\".lines.pct) 
               sourcepct=$(echo '${{ needs.source-branch-test.outputs.coverages }}' | jq .\"$i\".lines.pct) 
               if (( ${sourcepct%.*} < ${targetpct%.*})); then
-                printf "==========================================================================="
+                printf "===========================================================================\n"
                 printf "test coverage has dropped: [package]%s [target]%s, [source]%s.\n" $i $targetpct $sourcepct
                 printf "if you didn't mofify %s, please rebase the target branch and rerun.\n" $i
                 printf "==========================================================================="


### PR DESCRIPTION
before publish npm package, there will be a update AI key commit, so So it turns out that there will be errors by judging ^HEAD package.json version.
It's better to judge the version change by last commits with local tags, if changed, means lerna version tags on last commits, so there need to release visx to GitHub