### PR TITLE
fix: remove space character at the end of command - Create New Project in vscode extension

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -219,7 +219,7 @@
       },
       {
         "command": "fx-extension.create",
-        "title": "Teams: Create New Project "
+        "title": "Teams: Create New Project"
       },
       {
         "command": "fx-extension.update",


### PR DESCRIPTION
fix: Remove the space character at the end of command - Create New Project in vscode extension