### PR TITLE
chore: add interfaces for ARM support

### DIFF
--- a/packages/fx-core/src/plugins/solution/fx-solution/arm.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/arm.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { FxError, Result, PluginContext } from "@microsoft/teamsfx-api";
+
+// WIP: Put the interfaces here temporary to unblock development, they will be moved to the V2 teamsfx-api in the future.
+export interface ArmResourcePlugin {
+  scaffoldArmTemplate: (ctx: PluginContext) => Promise<Result<ScaffoldArmTemplateResult, FxError>>;
+}
+
+export interface BicepOrchestrationTemplate {
+  Content: string;
+}
+
+export interface BicepOrchestrationParameterTemplate extends BicepOrchestrationTemplate {
+  ParameterFile: string;
+}
+
+export interface BicepOrchestrationResourceTemplate extends BicepOrchestrationTemplate {
+  Outputs: { [OutputName: string]: string };
+}
+
+export interface BicepModule {
+  Content: string;
+}
+
+export interface BicepOrchestration {
+  ParameterTemplate: BicepOrchestrationParameterTemplate;
+  VariableTemplate: BicepOrchestrationTemplate;
+  ResourceTemplate: BicepOrchestrationResourceTemplate;
+  OutputTemplate: BicepOrchestrationTemplate;
+}
+
+export interface ScaffoldArmTemplateResult {
+  Modules: { [moduleFileName: string]: BicepModule };
+  Orchestration: BicepOrchestration;
+}


### PR DESCRIPTION
WIP: this PR adds required interfaces for ARM support implementation. It's a temporary solution to unblock ARM feature development, so I didn't evolve the folder structure for fx-core to provide a better place for them. The interfaces will be moved to the V2 teamsfx-api in the future.