### PR TITLE
fix(env-checker): cli config get returns incorrect undefined value

### DIFF
--- a/packages/cli/src/cmds/config.ts
+++ b/packages/cli/src/cmds/config.ts
@@ -114,21 +114,21 @@ export class ConfigGet extends YargsCommand {
       case CliConfigOptions.EnvCheckerValidateDotnetSdk:
         CLILogProvider.necessaryLog(
           LogLevel.Info,
-          JSON.stringify(config.envCheckerValidateDotnetSdk, null, 2),
+          JSON.stringify(config[CliConfigOptions.EnvCheckerValidateDotnetSdk], null, 2),
           true
         );
         return ok(null);
       case CliConfigOptions.EnvCheckerValidateFuncCoreTools:
         CLILogProvider.necessaryLog(
           LogLevel.Info,
-          JSON.stringify(config.EnvCheckerValidateFuncCoreTools, null, 2),
+          JSON.stringify(config[CliConfigOptions.EnvCheckerValidateFuncCoreTools], null, 2),
           true
         );
         return ok(null);
       case CliConfigOptions.EnvCheckerValidateNode:
         CLILogProvider.necessaryLog(
           LogLevel.Info,
-          JSON.stringify(config.EnvCheckerValidateNode, null, 2),
+          JSON.stringify(config[CliConfigOptions.EnvCheckerValidateNode], null, 2),
           true
         );
         return ok(null);


### PR DESCRIPTION
Originally, the config value of `validate-dotnet-sdk` will fail to be printed because a wrong key is specified.
![image](https://user-images.githubusercontent.com/9698542/126275388-b927ebef-03b9-4a42-b07f-e9d24b04d166.png)

After the fix:
![image](https://user-images.githubusercontent.com/9698542/126275512-0ba3a5cb-9e9f-4d44-9f75-25b2f68e5157.png)
