### PR TITLE
fix(env-checker): config set to off does not disable env checker

### DIFF
--- a/packages/cli/src/cmds/preview/depsChecker/cliAdapter.ts
+++ b/packages/cli/src/cmds/preview/depsChecker/cliAdapter.ts
@@ -13,6 +13,7 @@ export class CLIAdapter implements IDepsAdapter {
   private readonly downloadIndicatorInterval = 1000; // same as vscode-dotnet-runtime
   private readonly _telemetry: IDepsTelemetry;
   private readonly _hasBackend: boolean;
+  private static ConfigEnabledValue = "on";
 
   constructor(hasBackend: boolean, telemetry: IDepsTelemetry) {
     this._hasBackend = hasBackend;
@@ -113,7 +114,7 @@ export class CLIAdapter implements IDepsAdapter {
     const config = result.value;
 
     if (key in config) {
-      return config[key];
+      return config[key] === CLIAdapter.ConfigEnabledValue;
     } else {
       return true;
     }

--- a/packages/cli/src/cmds/preview/depsChecker/cliAdapter.ts
+++ b/packages/cli/src/cmds/preview/depsChecker/cliAdapter.ts
@@ -7,13 +7,12 @@ import { DepsCheckerEvent, Messages } from "./common";
 import { IDepsAdapter, IDepsTelemetry } from "./checker";
 import CLIUIInstance from "../../../userInteraction";
 import cliLogger from "../../../commonlib/log";
-import { CliConfigOptions, UserSettings } from "../../../userSetttings";
+import { CliConfigEnvChecker, CliConfigOptions, UserSettings } from "../../../userSetttings";
 
 export class CLIAdapter implements IDepsAdapter {
   private readonly downloadIndicatorInterval = 1000; // same as vscode-dotnet-runtime
   private readonly _telemetry: IDepsTelemetry;
   private readonly _hasBackend: boolean;
-  private static ConfigEnabledValue = "on";
 
   constructor(hasBackend: boolean, telemetry: IDepsTelemetry) {
     this._hasBackend = hasBackend;
@@ -114,7 +113,7 @@ export class CLIAdapter implements IDepsAdapter {
     const config = result.value;
 
     if (key in config) {
-      return config[key] === CLIAdapter.ConfigEnabledValue;
+      return config[key] === CliConfigEnvChecker.On;
     } else {
       return true;
     }

--- a/packages/cli/src/userSetttings.ts
+++ b/packages/cli/src/userSetttings.ts
@@ -23,6 +23,11 @@ export enum CliConfigTelemetry {
   Off = "off",
 }
 
+export enum CliConfigEnvChecker {
+  On = "on",
+  Off = "off",
+}
+
 export class UserSettings {
   public static getUserSettingsFile(): string {
     const homeDir = os.homedir();


### PR DESCRIPTION
We should check whether the config value equals to the string literal "on", instead of checking for truthy values.

Test result (set validate-dotnet-sdk to off and uninstall dotnet-sdk)
![image](https://user-images.githubusercontent.com/9698542/126293253-71d4c0be-8d05-409a-a197-d1e287915f08.png)

![image](https://user-images.githubusercontent.com/9698542/126293701-153efa96-b17b-4b0e-8a9e-7f860de4e9d2.png)
