### PR TITLE
fix: add query param to app studio calls

### DIFF
--- a/packages/fx-core/src/plugins/resource/aad/appStudio.ts
+++ b/packages/fx-core/src/plugins/resource/aad/appStudio.ts
@@ -109,6 +109,10 @@ export namespace AppStudio {
       baseURL: baseUrl,
     });
     instance.defaults.headers.common["Authorization"] = `Bearer ${appStudioToken}`;
+    instance.interceptors.request.use(function (config) {
+      config.params = { teamstoolkit: true, ...config.params };
+      return config;
+    });
     return instance;
   }
 }

--- a/packages/fx-core/src/plugins/resource/appstudio/appStudio.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/appStudio.ts
@@ -28,6 +28,10 @@ export namespace AppStudioClient {
       baseURL: baseUrl,
     });
     instance.defaults.headers.common["Authorization"] = `Bearer ${appStudioToken}`;
+    instance.interceptors.request.use(function (config) {
+      config.params = { teamstoolkit: true, ...config.params };
+      return config;
+    });
     return instance;
   }
 

--- a/packages/fx-core/src/plugins/resource/bot/appStudio/appStudio.ts
+++ b/packages/fx-core/src/plugins/resource/bot/appStudio/appStudio.ts
@@ -21,7 +21,7 @@ export class AppStudio {
       throw new SomethingMissingError(ConfigNames.APPSTUDIO_TOKEN);
     }
 
-    return axios.create({
+    const instance = axios.create({
       headers: {
         post: {
           Authorization: `Bearer ${accessToken}`,
@@ -31,6 +31,11 @@ export class AppStudio {
         },
       },
     });
+    instance.interceptors.request.use(function (config) {
+      config.params = { teamstoolkit: true, ...config.params };
+      return config;
+    });
+    return instance;
   }
 
   public static async createAADAppV2(


### PR DESCRIPTION
Add a query parameter to app studio calls, to let dev portal's telemetry know how many calls are from Teams toolkit.

Related bug: 10386504

![image](https://user-images.githubusercontent.com/71362691/126453061-ec5d716e-65dd-40ca-b214-132a28bafb0f.png)
