### PR TITLE
test: add telemetry and progress handler's unit tests

### DIFF
--- a/packages/cli/.nycrc
+++ b/packages/cli/.nycrc
@@ -7,7 +7,8 @@
   ],
   "exclude": [
     "src/cmds/preview/depsChecker/**/*",
-    "src/cmds/preview/preview.ts"
+    "src/cmds/preview/preview.ts",
+    "src/index.ts"
   ],
   "reporter": [
     "text",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,7 +22,7 @@
     "test:e2e:parallel": "mocha --no-timeouts --parallel --require ts-node/register \"tests/e2e/**/*.tests.ts\"",
     "test:e2e:smoke": "mocha --no-timeouts --require ts-node/register \"tests/e2e/smoke/*.tests.ts\"",
     "test:e2e:others": "mocha --no-timeouts --require ts-node/register \"tests/e2e/{,!(smoke)}/*.tests.ts\"",
-    "test:unit": "nyc mocha --no-timeouts --require ts-node/register \"tests/unit/**/*.tests.ts\"",
+    "test:unit": "nyc mocha --require ts-node/register \"tests/unit/**/*.tests.ts\"",
     "check-format": "prettier --list-different --config .prettierrc.json --ignore-path .prettierignore \"{src,tests}/**/*.ts\" \"*.{js,json}\"",
     "format": "prettier --write --config .prettierrc.json --ignore-path .prettierignore \"{src,tests}/**/*.ts\" \"*.{js,json}\"",
     "lint:fix": "eslint \"src/**/*.ts\" \"tests/**/*.ts\" --fix",

--- a/packages/cli/tests/unit/cmds/new.tests.ts
+++ b/packages/cli/tests/unit/cmds/new.tests.ts
@@ -124,7 +124,7 @@ describe("New Command Tests", function () {
       }
     });
 
-    it("Folder not exists", async () => {
+    it("Folder not exists", async function () {
       this.timeout(5000);
       const folder = path.join(TestFolder, sampleAppName);
       deleteFolderIfExists(folder);

--- a/packages/cli/tests/unit/progressHandler.tests.ts
+++ b/packages/cli/tests/unit/progressHandler.tests.ts
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import sinon from "sinon";
+import { LogLevel } from "@microsoft/teamsfx-api";
+
+import { ProgressHandler } from "../../src/progressHandler";
+import Logger from "../../src/commonlib/log";
+import * as constants from "../../src/constants";
+import { expect } from "./utils";
+
+describe("Progress Handler", function () {
+  const sandbox = sinon.createSandbox();
+  let levels: LogLevel[] = [];
+  let msgs: string[] = [];
+
+  before(() => {
+    sandbox.stub(Logger, "necessaryLog").callsFake((level: LogLevel, message: string) => {
+      levels.push(level);
+      msgs.push(message);
+    });
+  });
+
+  after(() => {
+    sandbox.restore();
+  });
+
+  afterEach(() => {
+    levels = [];
+    msgs = [];
+  });
+
+  it("start", async () => {
+    const handler = new ProgressHandler("Test", 1);
+    await handler.start("start");
+    expect(levels).deep.equals([LogLevel.Info]);
+    expect(msgs).deep.equals([`[${constants.cliSource}] Test: [0/1] start`]);
+  });
+
+  it("next", async () => {
+    const handler = new ProgressHandler("Test", 1);
+    await handler.next("step 1");
+    expect(levels).deep.equals([LogLevel.Info]);
+    expect(msgs).deep.equals([`[${constants.cliSource}] Test: [1/1] step 1`]);
+  });
+
+  it("end", async () => {
+    const handler = new ProgressHandler("Test", 1);
+    handler["currentStep"] = 10;
+    await handler.end();
+    expect(handler["currentStep"]).equals(0);
+  });
+});

--- a/packages/cli/tests/unit/telemetry/cliTelemetry.tests.ts
+++ b/packages/cli/tests/unit/telemetry/cliTelemetry.tests.ts
@@ -1,0 +1,122 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { ok, returnSystemError, returnUserError } from "@microsoft/teamsfx-api";
+import sinon from "sinon";
+
+import Telemetry, { CliTelemetry } from "../../../src/telemetry/cliTelemetry";
+import { CliTelemetryReporter } from "../../../src/commonlib/telemetry";
+import { UserSettings } from "../../../src/userSetttings";
+import { expect } from "../utils";
+import {
+  TelemetryComponentType,
+  TelemetryErrorType,
+  TelemetryProperty,
+  TelemetrySuccess,
+} from "../../../src/telemetry/cliTelemetryEvents";
+import * as Utils from "../../../src/utils";
+
+describe("Telemetry", function () {
+  const sandbox = sinon.createSandbox();
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("setReporter", () => {
+    sandbox.stub(UserSettings, "getTelemetrySetting").returns(ok(false));
+    const reporter = new CliTelemetryReporter("real", "real", "real", "real");
+    CliTelemetry.setReporter(reporter);
+  });
+
+  it("getReporter", () => {
+    sandbox.stub(UserSettings, "getTelemetrySetting").returns(ok(false));
+    const reporter = new CliTelemetryReporter("real", "real", "real", "real");
+    CliTelemetry.setReporter(reporter);
+    expect(CliTelemetry.getReporter()["reporter"]);
+  });
+
+  it("withRootFolder", () => {
+    Telemetry.withRootFolder("real");
+    expect(CliTelemetry["rootFolder"]).equals("real");
+  });
+
+  it("sendTelemetryEvent", () => {
+    sandbox.stub(UserSettings, "getTelemetrySetting").returns(ok(false));
+    sandbox.stub(Utils, "getTeamsAppId").returns(undefined);
+    sandbox
+      .stub(CliTelemetryReporter.prototype, "sendTelemetryEvent")
+      .callsFake((eventName: string, properties?: any) => {
+        expect(eventName).equals("eventName");
+        expect(properties[TelemetryProperty.Component]).equals(TelemetryComponentType);
+        expect(properties[TelemetryProperty.AppId]).equals(undefined);
+      });
+    const reporter = new CliTelemetryReporter("real", "real", "real", "real");
+    CliTelemetry.setReporter(reporter);
+    Telemetry.sendTelemetryEvent("eventName");
+  });
+
+  describe("sendTelemetryEvent", () => {
+    const sandbox = sinon.createSandbox();
+
+    before(() => {
+      sandbox.stub(UserSettings, "getTelemetrySetting").returns(ok(false));
+      sandbox.stub(Utils, "getTeamsAppId").returns(undefined);
+      sandbox
+        .stub(CliTelemetryReporter.prototype, "sendTelemetryErrorEvent")
+        .callsFake((eventName: string, properties?: any) => {
+          expect(properties[TelemetryProperty.Component]).equals(TelemetryComponentType);
+          expect(properties[TelemetryProperty.AppId]).equals(undefined);
+          expect(properties[TelemetryProperty.Success]).equals(TelemetrySuccess.No);
+          if (eventName === "UserError") {
+            expect(properties[TelemetryProperty.ErrorType]).equals(TelemetryErrorType.UserError);
+            expect(properties[TelemetryProperty.ErrorCode]).equals("ut.user");
+            expect(properties[TelemetryProperty.ErrorMessage]).equals("UserError");
+          } else {
+            expect(properties[TelemetryProperty.ErrorType]).equals(TelemetryErrorType.SystemError);
+            expect(properties[TelemetryProperty.ErrorCode]).equals("ut.system");
+            expect(properties[TelemetryProperty.ErrorMessage]).equals("SystemError");
+          }
+        });
+      const reporter = new CliTelemetryReporter("real", "real", "real", "real");
+      CliTelemetry.setReporter(reporter);
+    });
+
+    after(() => {
+      sandbox.restore();
+    });
+
+    it("UserError", () => {
+      const userError = returnUserError(new Error("UserError"), "ut", "user");
+      Telemetry.sendTelemetryErrorEvent("UserError", userError);
+    });
+
+    it("SystemError", () => {
+      const systemError = returnSystemError(new Error("SystemError"), "ut", "system");
+      Telemetry.sendTelemetryErrorEvent("SystemError", systemError);
+    });
+  });
+
+  it("sendTelemetryException", () => {
+    sandbox.stub(UserSettings, "getTelemetrySetting").returns(ok(false));
+    sandbox.stub(Utils, "getTeamsAppId").returns(undefined);
+    sandbox
+      .stub(CliTelemetryReporter.prototype, "sendTelemetryException")
+      .callsFake((error: Error, properties?: any) => {
+        expect(error.message).equals("exception");
+        expect(properties[TelemetryProperty.Component]).equals(TelemetryComponentType);
+        expect(properties[TelemetryProperty.AppId]).equals(undefined);
+      });
+    const reporter = new CliTelemetryReporter("real", "real", "real", "real");
+    CliTelemetry.setReporter(reporter);
+    Telemetry.sendTelemetryException(new Error("exception"));
+  });
+
+  it("flush", async () => {
+    sandbox.stub(CliTelemetryReporter.prototype, "flush");
+    sandbox.stub(UserSettings, "getTelemetrySetting").returns(ok(false));
+    const reporter = new CliTelemetryReporter("real", "real", "real", "real");
+    CliTelemetry.setReporter(reporter);
+    await Telemetry.flush();
+  });
+});

--- a/packages/cli/tests/unit/telemetry/telemetryReporter.tests.ts
+++ b/packages/cli/tests/unit/telemetry/telemetryReporter.tests.ts
@@ -1,0 +1,154 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { ok } from "@microsoft/teamsfx-api";
+import sinon from "sinon";
+import { TelemetryClient } from "applicationinsights";
+
+import Reporter from "../../../src/telemetry/telemetryReporter";
+import { UserSettings } from "../../../src/userSetttings";
+import { expect } from "../utils";
+import Logger from "../../../src/commonlib/log";
+
+describe("Telemetry Reporter", function () {
+  const sandbox = sinon.createSandbox();
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe("updateUserOptIn", () => {
+    const sandbox = sinon.createSandbox();
+
+    before(() => {
+      sandbox
+        .stub(UserSettings, "getTelemetrySetting")
+        .onFirstCall()
+        .returns(ok(false))
+        .onSecondCall()
+        .returns(ok(true));
+      sandbox.stub(Reporter.prototype, <any>"createAppInsightsClient");
+    });
+
+    after(() => {
+      sandbox.restore();
+    });
+
+    it("telemetry false", () => {
+      const reporter = new Reporter("real", "real", "real", "real");
+      expect(reporter["userOptIn"]).to.be.false;
+    });
+
+    it("telemetry true", () => {
+      const reporter = new Reporter("real", "real", "real", "real");
+      expect(reporter["userOptIn"]).to.be.true;
+    });
+  });
+
+  it("getCommonProperties", () => {
+    sandbox.stub(UserSettings, "getTelemetrySetting").returns(ok(false));
+    const reporter = new Reporter("real", "real", "real", "real");
+    const properties = reporter["getCommonProperties"]();
+    expect(Object.keys(properties)).deep.equals([
+      "common.os",
+      "common.platformversion",
+      "common.cliversion",
+      "common.machineid",
+    ]);
+  });
+
+  it("cloneAndChange", () => {
+    sandbox.stub(UserSettings, "getTelemetrySetting").returns(ok(false));
+    const reporter = new Reporter("real", "real", "real", "real");
+    const obj = {
+      a: "aa",
+      b: "bb",
+    };
+    const change = (key: string, val: string) => [key, val].join(",");
+    const properties = reporter["cloneAndChange"](obj, change);
+    expect(properties).deep.equals({
+      a: "a,aa",
+      b: "b,bb",
+    });
+    expect(obj).deep.equals({
+      a: "aa",
+      b: "bb",
+    });
+  });
+
+  describe("anonymizeFilePaths", () => {
+    const sandbox = sinon.createSandbox();
+
+    before(() => {
+      sandbox.stub(UserSettings, "getTelemetrySetting").returns(ok(false));
+    });
+
+    after(() => {
+      sandbox.restore();
+    });
+
+    it("No stack", () => {
+      const reporter = new Reporter("real", "real", "real", "real");
+      const result = reporter["anonymizeFilePaths"]();
+      expect(result).equals("");
+    });
+
+    it("abcdefg", () => {
+      const reporter = new Reporter("real", "real", "real", "real");
+      const result = reporter["anonymizeFilePaths"]("abcdefg");
+      expect(result).equals("abcdefg");
+    });
+
+    it("abcrealdefg", () => {
+      const reporter = new Reporter("real", "real", "real", "real");
+      const result = reporter["anonymizeFilePaths"]("abcrealdefg");
+      expect(result).equals("abcdefg");
+    });
+
+    it("file://abc/real./defg", () => {
+      const reporter = new Reporter("real", "real", "real", "real");
+      const result = reporter["anonymizeFilePaths"]("file://abc/real./defg");
+      expect(result).equals("<REDACTED: user-file-path>");
+    });
+  });
+
+  it("sendTelemetryEvent", () => {
+    sandbox.stub(UserSettings, "getTelemetrySetting").returns(ok(false));
+    sandbox.stub(TelemetryClient.prototype, "trackEvent");
+    sandbox.stub(Logger, "debug");
+    const reporter = new Reporter("real", "real", "real", "real");
+    reporter["appInsightsClient"] = new TelemetryClient("123");
+    reporter["userOptIn"] = true;
+    reporter.sendTelemetryEvent("eventName", { a: "real" });
+  });
+
+  it("sendTelemetryErrorEvent", () => {
+    sandbox.stub(UserSettings, "getTelemetrySetting").returns(ok(false));
+    sandbox.stub(TelemetryClient.prototype, "trackEvent");
+    sandbox.stub(Logger, "debug");
+    const reporter = new Reporter("real", "real", "real", "real");
+    reporter["appInsightsClient"] = new TelemetryClient("123");
+    reporter["userOptIn"] = true;
+    reporter.sendTelemetryErrorEvent("eventName", { a: "real" });
+  });
+
+  it("sendTelemetryException", () => {
+    sandbox.stub(UserSettings, "getTelemetrySetting").returns(ok(false));
+    sandbox.stub(TelemetryClient.prototype, "trackEvent");
+    sandbox.stub(Logger, "debug");
+    const reporter = new Reporter("real", "real", "real", "real");
+    reporter["appInsightsClient"] = new TelemetryClient("123");
+    reporter["userOptIn"] = true;
+    reporter.sendTelemetryException(new Error("test error"), { a: "real" });
+  });
+
+  it("flush", async () => {
+    sandbox.stub(TelemetryClient.prototype, "flush").callsFake((op) => {
+      op?.callback?.("");
+    });
+    sandbox.stub(Logger, "debug");
+    const reporter = new Reporter("real", "real", "real", "real");
+    reporter["appInsightsClient"] = new TelemetryClient("123");
+    await reporter.flush();
+  });
+});


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/10374056

Except for the `commonlib` and `preview` part, the coverage has gone to 90%:
![image](https://user-images.githubusercontent.com/15262146/126595172-45fa460c-173b-4c48-a378-939b353b4226.png)
