### PR TITLE
chore: add feature flag function for arm

### DIFF
--- a/packages/fx-core/src/common/tools.ts
+++ b/packages/fx-core/src/common/tools.ts
@@ -492,11 +492,7 @@ export function isFeatureFlagEnabled(featureFlagName: string, defaultValue = fal
   if (flag === undefined) {
     return defaultValue; // allows consumer to set a default value when environment variable not set
   } else {
-    if (flag === "1" || flag.toLowerCase() === "true") {
-      return true; // can enable feature flag by set environment variable value to "1" or "true"
-    } else {
-      return false;
-    }
+    return flag === "1" || flag.toLowerCase() === "true"; // can enable feature flag by set environment variable value to "1" or "true"
   }
 }
 

--- a/packages/fx-core/src/common/tools.ts
+++ b/packages/fx-core/src/common/tools.ts
@@ -487,13 +487,21 @@ export async function askSubscription(
 }
 
 // Determine whether feature flag is enabled based on environment variable setting
-export function isFeatureFlagEnabled(featureFlagName: string): boolean {
+export function isFeatureFlagEnabled(featureFlagName: string, defaultValue = false): boolean {
   const flag = process.env[featureFlagName];
-  // can enable feature flag by set environment variable value to "1" or "true"
-  if (flag && (flag === "1" || flag.toLowerCase() === "true")) {
-    return true;
+  if (flag === undefined) {
+    return defaultValue; // allows consumer to set a default value when environment variable not set
+  } else {
+    if (flag === "1" || flag.toLowerCase() === "true") {
+      return true; // can enable feature flag by set environment variable value to "1" or "true"
+    } else {
+      return false;
+    }
   }
-  return false;
+}
+
+export function isArmSupportEnabled(): boolean {
+  return isFeatureFlagEnabled("TEAMSFX_ARM_SUPPORT", false);
 }
 
 export async function generateBicepFiles(

--- a/packages/fx-core/tests/core/other.test.ts
+++ b/packages/fx-core/tests/core/other.test.ts
@@ -20,7 +20,7 @@ import {
   WriteFileError,
 } from "../../src/core/error";
 import mockedEnv from "mocked-env";
-import { isFeatureFlagEnabled } from "../../src/common/tools";
+import { isArmSupportEnabled, isFeatureFlagEnabled } from "../../src/common/tools";
 
 describe("Other test case", () => {
   const sandbox = sinon.createSandbox();
@@ -114,13 +114,14 @@ describe("Other test case", () => {
     assert.isTrue(error.message === "Failed to download sample app");
   });
 
-  it("tools: isFeatureFlagEnabled should return true when related environment variable is set to 1 or true", () => {
+  it("isFeatureFlagEnabled: return true when related environment variable is set to 1 or true", () => {
     const featureFlagName = "FEATURE_FLAG_UNIT_TEST";
 
     let restore = mockedEnv({
       [featureFlagName]: "1",
     });
     assert.isTrue(isFeatureFlagEnabled(featureFlagName));
+    assert.isTrue(isFeatureFlagEnabled(featureFlagName, false)); // default value should be override
     restore();
 
     restore = mockedEnv({
@@ -136,13 +137,26 @@ describe("Other test case", () => {
     restore();
   });
 
-  it("tools: isFeatureFlagEnabled should return false when related environment variable is not set", () => {
+  it("isFeatureFlagEnabled: return default value when related environment variable is not set", () => {
     const featureFlagName = "FEATURE_FLAG_UNIT_TEST";
 
-    let restore = mockedEnv({
+    const restore = mockedEnv({
       [featureFlagName]: undefined, // delete it from process.env
     });
     assert.isFalse(isFeatureFlagEnabled(featureFlagName));
+    assert.isFalse(isFeatureFlagEnabled(featureFlagName, false));
+    assert.isTrue(isFeatureFlagEnabled(featureFlagName, true));
+    restore();
+  });
+
+  it("isFeatureFlagEnabled: return false when related environment variable is set to non 1 or true value", () => {
+    const featureFlagName = "FEATURE_FLAG_UNIT_TEST";
+
+    let restore = mockedEnv({
+      [featureFlagName]: "one",
+    });
+    assert.isFalse(isFeatureFlagEnabled(featureFlagName));
+    assert.isFalse(isFeatureFlagEnabled(featureFlagName, true)); // default value should be override
     restore();
 
     restore = mockedEnv({
@@ -152,13 +166,25 @@ describe("Other test case", () => {
     restore();
   });
 
-  it("tools: isFeatureFlagEnabled should return false when related environment variable is set to non 1 or true value", () => {
-    const featureFlagName = "FEATURE_FLAG_UNIT_TEST";
+  it("isArmSupportEnabled: return correct result based on environment variable value", () => {
+    const armSupportFeatureFlagName = "TEAMSFX_ARM_SUPPORT";
 
-    const restore = mockedEnv({
-      [featureFlagName]: "one",
+    let restore = mockedEnv({
+      [armSupportFeatureFlagName]: undefined,
     });
-    assert.isFalse(isFeatureFlagEnabled(featureFlagName));
+    assert.isFalse(isArmSupportEnabled());
+    restore();
+
+    restore = mockedEnv({
+      [armSupportFeatureFlagName]: "",
+    });
+    assert.isFalse(isArmSupportEnabled());
+    restore();
+
+    restore = mockedEnv({
+      [armSupportFeatureFlagName]: "true",
+    });
+    assert.isTrue(isArmSupportEnabled());
     restore();
   });
 });


### PR DESCRIPTION
Add an extra `isArmSupportEnabled` function for ARM, so we can turn on/off ARM support by default in code easily.