### PR TITLE
fix: start to count down (show survey) when sending the first telemetry event

### DIFF
--- a/packages/vscode-extension/src/telemetry/extTelemetry.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetry.ts
@@ -17,6 +17,12 @@ import { getTeamsAppId } from "../utils/commonUtils";
 
 export namespace ExtTelemetry {
   export let reporter: VSCodeTelemetryReporter;
+  export let hasSentTelemetry = false;
+
+  export function setHasSentTelemetry(eventName: string) {
+    if (eventName === "query-expfeature") return;
+    hasSentTelemetry = true;
+  }
 
   export function addSharedProperty(name: string, value: string): void {
     reporter.addSharedProperty(name, value);
@@ -56,6 +62,7 @@ export namespace ExtTelemetry {
     properties?: { [p: string]: string },
     measurements?: { [p: string]: number }
   ): void {
+    setHasSentTelemetry(eventName);
     if (!properties) {
       properties = {};
     }

--- a/packages/vscode-extension/src/utils/survey.ts
+++ b/packages/vscode-extension/src/utils/survey.ts
@@ -19,10 +19,10 @@ const SAMPLE_PERCENTAGE = 25; // 25 percent for public preview
 export class ExtensionSurvey {
   private context: vscode.ExtensionContext;
   private timeToShowSurvey: number;
-  private samplePercentage: number;
   private timeToDisableSurvey: number;
   private checkSurveyInterval?: NodeJS.Timeout;
   private showSurveyTimeout?: NodeJS.Timeout;
+  private needToShow = false;
 
   constructor(
     context: vscode.ExtensionContext,
@@ -32,12 +32,16 @@ export class ExtensionSurvey {
   ) {
     this.context = context;
     this.timeToShowSurvey = timeToShowSurvey ? timeToShowSurvey : TIME_TO_SHOW_SURVEY;
-    this.samplePercentage = samplePercentage ? samplePercentage : SAMPLE_PERCENTAGE;
+
+    const randomSample: number = Math.floor(Math.random() * 100) + 1;
+    if (randomSample <= (samplePercentage ? samplePercentage : SAMPLE_PERCENTAGE)) {
+      this.needToShow = true;
+    }
     this.timeToDisableSurvey = timeToDisableSurvey ? timeToDisableSurvey : TIME_TO_DISABLE_SURVEY;
   }
 
   public async activate(): Promise<void> {
-    if (!this.checkSurveyInterval) {
+    if (this.needToShow && !this.checkSurveyInterval) {
       this.checkSurveyInterval = setInterval(() => {
         if (!this.shouldShowBanner()) {
           return;
@@ -64,11 +68,6 @@ export class ExtensionSurvey {
 
     const disableSurveyForTime = globalStateGet(ExtensionSurveyStateKeys.DisableSurveyForTime, 0);
     if (disableSurveyForTime > currentTime) {
-      return false;
-    }
-
-    const randomSample: number = Math.floor(Math.random() * 100) + 1;
-    if (randomSample > this.samplePercentage) {
       return false;
     }
 
@@ -110,8 +109,6 @@ export class ExtensionSurvey {
         ExtTelemetry.sendTelemetryEvent(TelemetryEvent.Survey, {
           message: StringResources.vsc.survey.remindMeLater.message,
         });
-        const remindMeLaterTime = Date.now() + this.timeToShowSurvey;
-        await globalStateUpdate(ExtensionSurveyStateKeys.RemindMeLater, remindMeLaterTime);
       },
     };
 


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/10397347
1. set interval to check if it should start to count down (for fixing the reminding button cannot work when users don't reopen vscode extension.
2. add a flag in `ExtTelemetry` to identify the user's first activity which move the `exp` telemetry event -- query-expfeature.
3. fixed: show survey 7min later when triggering the `reminder` button.
4. fixed: the 25% flag is applied to the whole session.