### PR TITLE
chore(sdk): add a new bundle output for Blazor interop

### DIFF
--- a/packages/sdk/rollup.base.config.js
+++ b/packages/sdk/rollup.base.config.js
@@ -125,3 +125,36 @@ export function browserConfig(testType) {
 
   return baseConfig;
 }
+
+export function blazorConfig() {
+  let baseConfig = {
+    input: input,
+    output: {
+      file: "dist/teamsfx.js",
+      format: "es",
+      sourcemap: true,
+      name: "TeamsFx",
+    },
+    preserveSymlinks: false,
+    plugins: [
+      sourcemaps(),
+      replace({
+        delimiters: ["", ""],
+        // replace dynamic checks with if (false) since this is for
+        // browser only. Rollup's dead code elimination will remove
+        // any code guarded by if (isNode) { ... }
+        "if (isNode)": "if (false)",
+        preventAssignment: true,
+      }),
+      nodeResolve({
+        mainFields: ["module", "browser"],
+        preferBuiltins: false,
+        browser: true,
+      }),
+      cjs(),
+      terser(),
+    ],
+  };
+
+  return baseConfig;
+}

--- a/packages/sdk/rollup.config.js
+++ b/packages/sdk/rollup.config.js
@@ -10,4 +10,6 @@ if (!process.env.ONLY_NODE) {
   inputs.push(base.browserConfig());
 }
 
+inputs.push(base.blazorConfig());
+
 export default inputs;


### PR DESCRIPTION
The ES format output could be used in .NET SDK.