### PR TITLE
fix: hide scratch and samples in CLI new parameters

### DIFF
--- a/packages/cli/src/helpParamGenerator.ts
+++ b/packages/cli/src/helpParamGenerator.ts
@@ -186,6 +186,9 @@ export class HelpParamGenerator {
         if (node.data.name === "folder") {
           (node.data as any).default = "./";
         }
+        if (node.data.name === "scratch" || node.data.name === "samples") {
+          (node.data as any).hide = true;
+        }
       }
     }
 

--- a/packages/cli/tests/unit/help.tests.ts
+++ b/packages/cli/tests/unit/help.tests.ts
@@ -27,6 +27,8 @@ describe("Help Parameter Tests", function () {
   it("Create Parameter Hardcode Check", async () => {
     const result = HelpParamGenerator.getYargsParamForHelp(Stage.create);
     expect(result.folder.default).equals("./");
+    expect(result.scratch.hidden).equals(true);
+    expect(result.samples.hidden).equals(true);
   });
 
   it("Resource Add Parameter Hardcode Check", async () => {


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/9880763

![image](https://user-images.githubusercontent.com/15262146/127085297-30f9e9fa-82d8-409a-8a1a-a12bd0dd97d1.png)
