### PR TITLE
fix: fix appstudio localDebug cornercase

### DIFF
--- a/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
@@ -93,9 +93,17 @@ export class AppStudioPluginImpl {
         .get("solution")
         ?.get(LOCAL_DEBUG_TEAMS_APP_ID) as string;
 
-      let createIfNotExist = true;
-      if (localTeamsAppID) {
-        createIfNotExist = false;
+      let createIfNotExist = false;
+      if (!localTeamsAppID) {
+        createIfNotExist = true;
+      } else {
+        const appStudioToken = await ctx?.appStudioToken?.getAccessToken();
+        try {
+          await AppStudioClient.getApp(localTeamsAppID, appStudioToken!, ctx.logProvider);
+        } catch (error) {
+          //ctx.logProvider?.error(error);
+          createIfNotExist = true;
+        }
       }
 
       maybeTeamsAppId = await this.updateApp(
@@ -103,11 +111,12 @@ export class AppStudioPluginImpl {
         appStudioToken!,
         type,
         createIfNotExist,
-        localTeamsAppID ? localTeamsAppID : undefined,
+        createIfNotExist ? undefined : localTeamsAppID,
         ctx.logProvider,
         ctx.root
       );
 
+      console.log(maybeTeamsAppId);
       return maybeTeamsAppId;
     } else {
       appDefinition = this.convertToAppDefinition(manifest, true);

--- a/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
@@ -101,7 +101,6 @@ export class AppStudioPluginImpl {
         try {
           await AppStudioClient.getApp(localTeamsAppID, appStudioToken!, ctx.logProvider);
         } catch (error) {
-          //ctx.logProvider?.error(error);
           createIfNotExist = true;
         }
       }

--- a/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
@@ -1090,7 +1090,7 @@ export class TeamsAppSolution implements Solution {
 
     if (postLocalDebugWithCtx.length === combinedPostLocalDebugResults.value.length) {
       postLocalDebugWithCtx.map(function (plugin, index) {
-        if (plugin[2] === PluginNames.APPST && !localTeamsAppID) {
+        if (plugin[2] === PluginNames.APPST) {
           ctx.config
             .get(GLOBAL_CONFIG)
             ?.set(LOCAL_DEBUG_TEAMS_APP_ID, combinedPostLocalDebugResults.value[index]);


### PR DESCRIPTION
Create an app again if the user manually deletes the app from dev portal and run localDebug.