### PR TITLE
fix(function): storage account could use flat namespace to lessen cost

### DIFF
--- a/packages/fx-core/src/plugins/resource/function/constants.ts
+++ b/packages/fx-core/src/plugins/resource/function/constants.ts
@@ -154,7 +154,6 @@ export class DefaultProvisionConfigs {
     kind: "StorageV2" as Kind,
     location: location,
     enableHttpsTrafficOnly: true,
-    isHnsEnabled: true,
   });
 
   public static readonly functionAppConfig = (location: string) => ({


### PR DESCRIPTION
Also align to Azure Portal, Storage Account for Function App use flat namespace.