### PR TITLE
refactor(core): extract the logic to write env profiles

### DIFF
--- a/packages/fx-core/src/core/environment.ts
+++ b/packages/fx-core/src/core/environment.ts
@@ -6,17 +6,27 @@ import {
   CryptoProvider,
   err,
   FxError,
-  Json,
   ok,
   Result,
+  Void,
 } from "@microsoft/teamsfx-api";
 import path from "path";
 import fs from "fs-extra";
-import { deserializeDict, dataNeedEncryption, mergeSerectData, PathNotExistError } from "..";
+import {
+  deserializeDict,
+  dataNeedEncryption,
+  mergeSerectData,
+  PathNotExistError,
+  serializeDict,
+  sperateSecretData,
+  WriteFileError,
+  mapToJson,
+  objectToMap,
+} from "..";
 
 export interface EnvInfo {
   envName: string;
-  data: Json;
+  data: Map<string, any>;
 }
 
 export interface EnvFiles {
@@ -48,18 +58,58 @@ class EnvironmentManager {
       // TODO: handle the case that env file profile doesn't exist.
       return err(PathNotExistError(envFiles.envProfile));
     }
-    const data = await fs.readJson(envFiles.envProfile);
+    const envData = await fs.readJson(envFiles.envProfile);
 
-    mergeSerectData(userData, data);
+    mergeSerectData(userData, envData);
+    const data = objectToMap(envData);
+
     return ok({ envName, data });
   }
 
+  public async writeEnvProfile(
+    envData: Map<string, any>,
+    projectPath: string,
+    envName?: string,
+    cryptoProvider?: CryptoProvider
+  ): Promise<Result<Void, FxError>> {
+    if (!(await fs.pathExists(projectPath))) {
+      return err(PathNotExistError(projectPath));
+    }
+
+    const configFolder = this.getConfigFolder(projectPath);
+    if (!(await fs.pathExists(configFolder))) {
+      await fs.ensureDir(configFolder);
+    }
+
+    envName = envName ?? this.defaultEnvName;
+    const envFiles = this.getEnvFilesPath(envName, projectPath);
+
+    const data = mapToJson(envData);
+    const secrets = sperateSecretData(data);
+    if (cryptoProvider) {
+      this.encrypt(secrets, cryptoProvider);
+    }
+
+    try {
+      await fs.writeFile(envFiles.envProfile, JSON.stringify(data, null, 4));
+      await fs.writeFile(envFiles.userDataFile, serializeDict(secrets));
+    } catch (error) {
+      return err(WriteFileError(error));
+    }
+
+    return ok(Void);
+  }
+
   public getEnvFilesPath(envName: string, projectPath: string): EnvFiles {
-    const basePath = path.resolve(projectPath, `.${ConfigFolderName}`);
+    const basePath = this.getConfigFolder(projectPath);
     const envProfile = path.resolve(basePath, `env.${envName}.json`);
     const userDataFile = path.resolve(basePath, `${envName}.userdata`);
 
     return { envProfile, userDataFile };
+  }
+
+  private getConfigFolder(projectPath: string): string {
+    return path.resolve(projectPath, `.${ConfigFolderName}`);
   }
 
   private async loadUserData(
@@ -71,26 +121,51 @@ class EnvironmentManager {
     }
 
     const content = await fs.readFile(userDataPath, "UTF-8");
-    const data = deserializeDict(content);
+    const secrets = deserializeDict(content);
     if (!cryptoProvider) {
-      return ok(data);
+      return ok(secrets);
     }
 
-    for (const secretKey of Object.keys(data)) {
+    return this.decrypt(secrets, cryptoProvider);
+  }
+
+  private encrypt(
+    secrets: Record<string, string>,
+    cryptoProvider: CryptoProvider
+  ): Result<Record<string, string>, FxError> {
+    for (const secretKey of Object.keys(secrets)) {
+      if (!dataNeedEncryption(secretKey)) {
+        continue;
+      }
+      const encryptedSecret = cryptoProvider.encrypt(secrets[secretKey]);
+      // always success
+      if (encryptedSecret.isOk()) {
+        secrets[secretKey] = encryptedSecret.value;
+      }
+    }
+
+    return ok(secrets);
+  }
+
+  private decrypt(
+    secrets: Record<string, string>,
+    cryptoProvider: CryptoProvider
+  ): Result<Record<string, string>, FxError> {
+    for (const secretKey of Object.keys(secrets)) {
       if (!dataNeedEncryption(secretKey)) {
         continue;
       }
 
-      const secretValue = data[secretKey];
+      const secretValue = secrets[secretKey];
       const plaintext = cryptoProvider.decrypt(secretValue);
       if (plaintext.isErr()) {
         return err(plaintext.error);
       }
 
-      data[secretKey] = plaintext.value;
+      secrets[secretKey] = plaintext.value;
     }
 
-    return ok(data);
+    return ok(secrets);
   }
 }
 

--- a/packages/fx-core/src/core/middleware/contextLoader.ts
+++ b/packages/fx-core/src/core/middleware/contextLoader.ts
@@ -107,11 +107,10 @@ export async function loadSolutionContext(
     }
     const envInfo = envDataResult.value;
 
-    const solutionConfig: SolutionConfig = objectToMap(envInfo.data);
     const solutionContext: SolutionContext = {
       projectSettings: projectSettings,
       targetEnvName: envInfo.envName,
-      config: solutionConfig,
+      config: envInfo.data,
       root: inputs.projectPath || "",
       ...tools,
       ...tools.tokenProvider,

--- a/packages/fx-core/tests/core/hooks.test.ts
+++ b/packages/fx-core/tests/core/hooks.test.ts
@@ -499,9 +499,11 @@ describe("Middleware", () => {
       solutionContext.config.set("solution", new ConfigMap());
       solutionContext.projectSettings = MockProjectSettings(appName);
       const fileMap = new Map<string, any>();
+
       sandbox.stub<any, any>(fs, "writeFile").callsFake(async (file: string, data: any) => {
         fileMap.set(file, data);
       });
+      sandbox.stub(fs, "pathExists").resolves(true);
 
       const envName = solutionContext.projectSettings.currentEnv;
       const confFolderPath = path.resolve(inputs.projectPath, `.${ConfigFolderName}`);
@@ -557,6 +559,7 @@ describe("Middleware", () => {
       sandbox.stub<any, any>(fs, "writeFile").callsFake(async (file: string, data: any) => {
         fileMap.set(file, data);
       });
+      sandbox.stub(fs, "pathExists").resolves(true);
 
       const envName = solutionContext.projectSettings.currentEnv;
       const confFolderPath = path.resolve(inputs.projectPath, `.${ConfigFolderName}`);
@@ -608,9 +611,6 @@ describe("Middleware", () => {
       sandbox.stub<any, any>(fs, "readFile").callsFake(async (file: string) => {
         if (userdataFile === file) return content;
         return {};
-      });
-      sandbox.stub<any, any>(fs, "pathExists").callsFake(async (file: string) => {
-        return true;
       });
       await my.ReadConfigTrigger(inputs);
     });


### PR DESCRIPTION
This is the following PR after https://github.com/OfficeDev/TeamsFx/pull/1752: Extract the logic to persist the env profile from `configWriter.ts` to `environment.ts`, and add a few test cases for the new added API.