### PR TITLE
refactor(core): clean up currentEnv from project settings

### DIFF
--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -663,8 +663,6 @@ export interface ProjectSettings {
     // (undocumented)
     appName: string;
     // (undocumented)
-    currentEnv?: string;
-    // (undocumented)
     projectId: string;
     // (undocumented)
     solutionSettings?: SolutionSettings;

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -126,7 +126,6 @@ export type EnvConfig = Dict<string>;
 export interface ProjectSettings {
   appName: string;
   projectId: string;
-  currentEnv?: string;
   solutionSettings?: SolutionSettings;
 }
 

--- a/packages/fx-core/src/common/tools.ts
+++ b/packages/fx-core/src/common/tools.ts
@@ -356,7 +356,6 @@ export function isValidProject(workspacePath?: string): boolean {
     const projectSettings: ProjectSettings = fs.readJsonSync(settingsFile);
     const manifest = fs.readJSONSync(manifestFile);
     if (!manifest) return false;
-    if (!projectSettings.currentEnv) projectSettings.currentEnv = "default";
     if (validateSettings(projectSettings)) return false;
     // const envName = projectSettings.currentEnv;
     // const jsonFilePath = path.resolve(confFolderPath, `env.${envName}.json`);

--- a/packages/fx-core/src/core/environment.ts
+++ b/packages/fx-core/src/core/environment.ts
@@ -35,7 +35,7 @@ export interface EnvFiles {
 }
 
 class EnvironmentManager {
-  private readonly defaultEnvName = "default";
+  public readonly defaultEnvName = "default";
 
   public async loadEnvProfile(
     projectPath: string,

--- a/packages/fx-core/src/core/index.ts
+++ b/packages/fx-core/src/core/index.ts
@@ -127,7 +127,6 @@ export class FxCore implements Core {
       const projectSettings: ProjectSettings = {
         appName: appName,
         projectId: uuid.v4(),
-        currentEnv: "default",
         solutionSettings: {
           name: solution.name,
           version: "1.0.0",

--- a/packages/fx-core/src/core/middleware/contextLoader.ts
+++ b/packages/fx-core/src/core/middleware/contextLoader.ts
@@ -81,7 +81,6 @@ export async function loadSolutionContext(
     const settingsFile = path.resolve(confFolderPath, "settings.json");
     const projectSettings: ProjectSettings = await fs.readJson(settingsFile);
     let projectIdMissing = false;
-    if (!projectSettings.currentEnv) projectSettings.currentEnv = "default";
     if (!projectSettings.projectId) {
       projectSettings.projectId = uuid.v4();
       projectIdMissing = true;
@@ -127,7 +126,6 @@ export async function newSolutionContext(tools: Tools, inputs: Inputs): Promise<
   const projectSettings: ProjectSettings = {
     appName: "",
     projectId: uuid.v4(),
-    currentEnv: "default",
     solutionSettings: {
       name: "fx-solution-azure",
       version: "1.0.0",

--- a/packages/fx-core/src/core/middleware/projectUpgrader.ts
+++ b/packages/fx-core/src/core/middleware/projectUpgrader.ts
@@ -27,6 +27,7 @@ import {
   TelemetryProperty,
   TelemetrySuccess,
 } from "../../common/telemetry";
+import { environmentManager } from "../environment";
 
 const resourceContext = [
   {
@@ -75,12 +76,10 @@ export async function upgradeContext(ctx: CoreHookContext): Promise<void> {
     const confFolderPath = path.resolve(inputs.projectPath!, `.${ConfigFolderName}`);
     const settingsFile = path.resolve(confFolderPath, "settings.json");
     const projectSettings: ProjectSettings = await fs.readJson(settingsFile);
-    if (!projectSettings.currentEnv) {
-      projectSettings.currentEnv = "default";
-    }
 
+    const defaultEnvName = environmentManager.defaultEnvName;
     // Read context file.
-    const contextPath = path.resolve(confFolderPath, `env.${projectSettings.currentEnv}.json`);
+    const contextPath = path.resolve(confFolderPath, `env.${defaultEnvName}.json`);
     const context = await readContext(contextPath);
 
     // Update value of specific key in context file to secret pattern.
@@ -96,7 +95,7 @@ export async function upgradeContext(ctx: CoreHookContext): Promise<void> {
     sendTelemetryEvent(core?.tools?.telemetryReporter, inputs, TelemetryEvent.ProjectUpgradeStart);
 
     // Read UserData file.
-    const userDataPath = path.resolve(confFolderPath, `${projectSettings.currentEnv}.userdata`);
+    const userDataPath = path.resolve(confFolderPath, `${defaultEnvName}.userdata`);
     const userData = await readUserData(userDataPath, projectSettings.projectId);
 
     // Merge updatedKeys into UserData.

--- a/packages/fx-core/tests/core/environment.test.ts
+++ b/packages/fx-core/tests/core/environment.test.ts
@@ -165,6 +165,15 @@ describe("APIs of Environment Manager", () => {
       assert.equal(envInfo.data.get("solution").get("teamsAppTenantId"), encreptedSecret);
       assert.equal(envInfo.data.get("solution").get("key"), expectedSolutionConfig.key);
     });
+
+    it("expected error: environment profile doesn't exist", async () => {
+      const actualEnvDataResult = await environmentManager.loadEnvProfile(projectPath);
+      assert.isTrue(actualEnvDataResult.isErr());
+      actualEnvDataResult.mapErr((error) => {
+        assert.instanceOf(error, UserError);
+        assert.isTrue(error.name === "PathNotExist");
+      });
+    });
   });
 
   describe("Write Environment Profile", () => {
@@ -253,15 +262,6 @@ describe("APIs of Environment Manager", () => {
       );
     });
   });
-
-  it("expected error: environment profile doesn't exist", async () => {
-    const actualEnvDataResult = await environmentManager.loadEnvProfile(projectPath);
-    assert.isTrue(actualEnvDataResult.isErr());
-    actualEnvDataResult.mapErr((error) => {
-      assert.instanceOf(error, UserError);
-      assert.isTrue(error.name === "PathNotExist");
-    });
-  });
 });
 
 async function mockEnvProfiles(
@@ -270,7 +270,7 @@ async function mockEnvProfiles(
   envName?: string,
   userData?: Record<string, string>
 ) {
-  envName = envName ?? "default";
+  envName = envName ?? environmentManager.defaultEnvName;
   const envFiles = environmentManager.getEnvFilesPath(envName, projectPath);
 
   await fs.ensureFile(envFiles.envProfile);

--- a/packages/fx-core/tests/core/hooks.test.ts
+++ b/packages/fx-core/tests/core/hooks.test.ts
@@ -62,6 +62,7 @@ import { AzureResourceSQL } from "../../src/plugins/solution/fx-solution/questio
 import { PluginNames } from "../../src/plugins/solution/fx-solution/constants";
 import { QuestionModelMW } from "../../src/core/middleware/questionModel";
 import { ProjectUpgraderMW } from "../../src/core/middleware/projectUpgrader";
+import { environmentManager } from "../../src/core/environment";
 
 describe("Middleware", () => {
   describe("ErrorHandlerMW", () => {
@@ -379,7 +380,7 @@ describe("Middleware", () => {
 
     const inputs: Inputs = { platform: Platform.VSCode };
     inputs.projectPath = path.join(os.tmpdir(), appName);
-    const envName = projectSettings.currentEnv;
+    const envName = environmentManager.defaultEnvName;
     const confFolderPath = path.resolve(inputs.projectPath, `.${ConfigFolderName}`);
     const settingsFile = path.resolve(confFolderPath, "settings.json");
     const envJsonFile = path.resolve(confFolderPath, `env.${envName}.json`);
@@ -505,7 +506,7 @@ describe("Middleware", () => {
       });
       sandbox.stub(fs, "pathExists").resolves(true);
 
-      const envName = solutionContext.projectSettings.currentEnv;
+      const envName = environmentManager.defaultEnvName;
       const confFolderPath = path.resolve(inputs.projectPath, `.${ConfigFolderName}`);
       const settingsFile = path.resolve(confFolderPath, "settings.json");
       const envJsonFile = path.resolve(confFolderPath, `env.${envName}.json`);
@@ -561,7 +562,7 @@ describe("Middleware", () => {
       });
       sandbox.stub(fs, "pathExists").resolves(true);
 
-      const envName = solutionContext.projectSettings.currentEnv;
+      const envName = environmentManager.defaultEnvName;
       const confFolderPath = path.resolve(inputs.projectPath, `.${ConfigFolderName}`);
       const userdataFile = path.resolve(confFolderPath, `${envName}.userdata`);
       const settingsFile = path.resolve(confFolderPath, "settings.json");
@@ -901,7 +902,7 @@ describe("Middleware", () => {
 
     const inputs: Inputs = { platform: Platform.VSCode };
     inputs.projectPath = path.join(os.tmpdir(), appName);
-    const envName = projectSettings.currentEnv;
+    const envName = environmentManager.defaultEnvName;
     const confFolderPath = path.resolve(inputs.projectPath, `.${ConfigFolderName}`);
     const settingsFile = path.resolve(confFolderPath, "settings.json");
     const envJsonFile = path.resolve(confFolderPath, `env.${envName}.json`);

--- a/packages/fx-core/tests/core/utils.ts
+++ b/packages/fx-core/tests/core/utils.ts
@@ -374,7 +374,6 @@ export class MockLogProvider implements LogProvider {
 export function MockProjectSettings(appName: string): ProjectSettings {
   return {
     appName: appName,
-    currentEnv: "default",
     projectId: uuid.v4(),
     solutionSettings: {
       name: PluginNames.SOLUTION,

--- a/packages/fx-core/tests/plugins/resource/appstudio/unit/build.test.ts
+++ b/packages/fx-core/tests/plugins/resource/appstudio/unit/build.test.ts
@@ -28,7 +28,6 @@ describe("Build Teams Package", () => {
     };
     ctx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: "project id",
       solutionSettings: {
         name: "azure",

--- a/packages/fx-core/tests/plugins/resource/appstudio/unit/getAppDefinitionAndUpdate.test.ts
+++ b/packages/fx-core/tests/plugins/resource/appstudio/unit/getAppDefinitionAndUpdate.test.ts
@@ -125,7 +125,6 @@ describe("Get AppDefinition and Update", () => {
     };
     ctx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         name: "azure",
@@ -166,7 +165,6 @@ describe("Get AppDefinition and Update", () => {
     };
     ctx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         name: "azure",
@@ -200,7 +198,6 @@ describe("Get AppDefinition and Update", () => {
     };
     ctx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         name: "azure",
@@ -237,7 +234,6 @@ describe("Get AppDefinition and Update", () => {
     };
     ctx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         name: "azure",
@@ -274,7 +270,6 @@ describe("Get AppDefinition and Update", () => {
     };
     ctx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         name: "azure",
@@ -313,7 +308,6 @@ describe("Get AppDefinition and Update", () => {
     };
     ctx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         name: "azure",
@@ -348,7 +342,6 @@ describe("Get AppDefinition and Update", () => {
     };
     ctx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         name: "azure",
@@ -391,7 +384,6 @@ describe("Get AppDefinition and Update", () => {
     };
     ctx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         name: "azure",
@@ -426,7 +418,6 @@ describe("Get AppDefinition and Update", () => {
     };
     ctx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         name: "azure",
@@ -472,7 +463,6 @@ describe("Get AppDefinition and Update", () => {
     };
     ctx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         name: "azure",
@@ -536,7 +526,6 @@ describe("Get AppDefinition and Update", () => {
     };
     ctx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         name: "azure",
@@ -597,7 +586,6 @@ describe("Get AppDefinition and Update", () => {
     };
     ctx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         name: "azure",
@@ -632,7 +620,6 @@ describe("Get AppDefinition and Update", () => {
     };
     ctx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         name: "azure",
@@ -696,7 +683,6 @@ describe("Get AppDefinition and Update", () => {
     };
     ctx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         name: "azure",

--- a/packages/fx-core/tests/plugins/resource/appstudio/unit/localDebug.test.ts
+++ b/packages/fx-core/tests/plugins/resource/appstudio/unit/localDebug.test.ts
@@ -129,7 +129,6 @@ describe("Post Local Debug", () => {
     };
     ctx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         name: "azure",
@@ -160,7 +159,6 @@ describe("Post Local Debug", () => {
     };
     ctx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         name: "azure",
@@ -200,7 +198,6 @@ describe("Post Local Debug", () => {
     };
     ctx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         name: "azure",

--- a/packages/fx-core/tests/plugins/resource/appstudio/unit/publish.test.ts
+++ b/packages/fx-core/tests/plugins/resource/appstudio/unit/publish.test.ts
@@ -45,7 +45,6 @@ describe("Publish Teams app", () => {
     };
     ctx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: "project id",
       solutionSettings: {
         name: "azure",

--- a/packages/fx-core/tests/plugins/resource/appstudio/unit/scaffold.test.ts
+++ b/packages/fx-core/tests/plugins/resource/appstudio/unit/scaffold.test.ts
@@ -62,7 +62,6 @@ describe("Scaffold", () => {
     fileContent.clear();
     ctx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         hostType: HostTypeOptionAzure.id,
@@ -94,7 +93,6 @@ describe("Scaffold", () => {
     fileContent.clear();
     ctx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         name: "azure",
@@ -130,7 +128,6 @@ describe("Scaffold", () => {
     fileContent.clear();
     ctx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         name: "azure",
@@ -163,7 +160,6 @@ describe("Scaffold", () => {
     fileContent.clear();
     ctx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         hostType: HostTypeOptionAzure.id,
@@ -188,7 +184,6 @@ describe("Scaffold", () => {
     fileContent.clear();
     ctx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         hostType: HostTypeOptionSPFx.id,

--- a/packages/fx-core/tests/plugins/resource/bot/unit/utils.ts
+++ b/packages/fx-core/tests/plugins/resource/bot/unit/utils.ts
@@ -194,7 +194,6 @@ export function newPluginContext(): PluginContext {
     answers: { platform: Platform.VSCode },
     projectSettings: {
       appName: "My App",
-      currentEnv: "default",
       projectId: utils.genUUID(),
       solutionSettings: {
         name: "AnyName",

--- a/packages/fx-core/tests/plugins/resource/frontend/helper.ts
+++ b/packages/fx-core/tests/plugins/resource/frontend/helper.ts
@@ -116,7 +116,6 @@ export class TestHelper {
       ]),
       projectSettings: {
         appName: TestHelper.appName,
-        currentEnv: "default",
         projectId: uuid(),
         solutionSettings: {
           name: "",

--- a/packages/fx-core/tests/plugins/resource/localdebug/unit/index.test.ts
+++ b/packages/fx-core/tests/plugins/resource/localdebug/unit/index.test.ts
@@ -8,7 +8,7 @@ import * as path from "path";
 
 import { LocalDebugPluginInfo } from "../../../../../src/plugins/resource/localdebug/constants";
 import { LocalDebugPlugin } from "../../../../../src/plugins/resource/localdebug";
-import * as uuid  from "uuid";
+import * as uuid from "uuid";
 chai.use(chaiAsPromised);
 
 interface TestParameter {
@@ -33,10 +33,10 @@ describe(LocalDebugPluginInfo.pluginName, () => {
       pluginContext = {
         root: path.resolve(__dirname, "../data/"),
         config: new Map(),
-        answers: {platform:Platform.VSCode}
+        answers: { platform: Platform.VSCode },
       } as PluginContext;
       plugin = new LocalDebugPlugin();
-      fs.emptyDirSync(pluginContext.root); 
+      fs.emptyDirSync(pluginContext.root);
     });
 
     const parameters1: TestParameter[] = [
@@ -62,7 +62,6 @@ describe(LocalDebugPluginInfo.pluginName, () => {
         ]);
         pluginContext.projectSettings = {
           appName: "",
-          currentEnv: "default",
           projectId: uuid.v4(),
           solutionSettings: {
             name: "",
@@ -126,7 +125,6 @@ describe(LocalDebugPluginInfo.pluginName, () => {
         pluginContext.projectSettings = {
           appName: "",
           projectId: uuid.v4(),
-          currentEnv: "default",
           solutionSettings: {
             name: "",
             version: "",
@@ -183,7 +181,6 @@ describe(LocalDebugPluginInfo.pluginName, () => {
         ]);
         pluginContext.projectSettings = {
           appName: "",
-          currentEnv: "default",
           projectId: uuid.v4(),
           solutionSettings: {
             name: "",
@@ -239,7 +236,6 @@ describe(LocalDebugPluginInfo.pluginName, () => {
         pluginContext.projectSettings = {
           appName: "",
           projectId: uuid.v4(),
-          currentEnv: "default",
           solutionSettings: {
             name: "",
             version: "",
@@ -302,7 +298,6 @@ describe(LocalDebugPluginInfo.pluginName, () => {
         ]);
         pluginContext.projectSettings = {
           appName: "",
-          currentEnv: "default",
           projectId: uuid.v4(),
           solutionSettings: {
             name: "",
@@ -342,7 +337,6 @@ describe(LocalDebugPluginInfo.pluginName, () => {
       pluginContext.configOfOtherPlugins = new Map();
       pluginContext.projectSettings = {
         appName: "",
-        currentEnv: "default",
         projectId: uuid.v4(),
         solutionSettings: {
           name: "",
@@ -377,7 +371,6 @@ describe(LocalDebugPluginInfo.pluginName, () => {
       pluginContext.configOfOtherPlugins = new Map([["fx-resource-function", new Map()]]);
       pluginContext.projectSettings = {
         appName: "",
-        currentEnv: "default",
         projectId: uuid.v4(),
         solutionSettings: {
           name: "",

--- a/packages/fx-core/tests/plugins/solution/solution.arm.test.ts
+++ b/packages/fx-core/tests/plugins/solution/solution.arm.test.ts
@@ -81,7 +81,6 @@ describe("Generate ARM Template for project", () => {
     const mockedCtx = mockSolutionContext(testProjectDir);
     mockedCtx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         hostType: HostTypeOptionSPFx.id,
@@ -102,7 +101,6 @@ describe("Generate ARM Template for project", () => {
     const mockedCtx = mockSolutionContext(testProjectDir);
     mockedCtx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         hostType: HostTypeOptionAzure.id,
@@ -235,7 +233,6 @@ describe("Deploy ARM Template to Azure", () => {
     const mockedCtx = mockSolutionContext(testProjectDir);
     mockedCtx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         hostType: HostTypeOptionAzure.id,

--- a/packages/fx-core/tests/plugins/solution/solution.create.test.ts
+++ b/packages/fx-core/tests/plugins/solution/solution.create.test.ts
@@ -74,7 +74,6 @@ describe("Solution create()", async () => {
     const mockedSolutionCtx = mockSolutionContext();
     mockedSolutionCtx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: undefined,
     };
@@ -89,7 +88,6 @@ describe("Solution create()", async () => {
     const mockedSolutionCtx = mockSolutionContext();
     mockedSolutionCtx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         name: "azure",
@@ -107,7 +105,6 @@ describe("Solution create()", async () => {
     const mockedSolutionCtx = mockSolutionContext();
     mockedSolutionCtx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         name: "azure",
@@ -127,7 +124,6 @@ describe("Solution create()", async () => {
     const mockedSolutionCtx = mockSolutionContext();
     mockedSolutionCtx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         name: "azure",
@@ -150,7 +146,6 @@ describe("Solution create()", async () => {
     const mockedSolutionCtx = mockSolutionContext();
     mockedSolutionCtx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         name: "azure",
@@ -171,7 +166,6 @@ describe("Solution create()", async () => {
     const mockedSolutionCtx = mockSolutionContext();
     mockedSolutionCtx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         hostType: HostTypeOptionAzure.id,

--- a/packages/fx-core/tests/plugins/solution/solution.provision.test.ts
+++ b/packages/fx-core/tests/plugins/solution/solution.provision.test.ts
@@ -318,7 +318,6 @@ describe("provision() simple cases", () => {
     const mockedCtx = mockSolutionContext();
     mockedCtx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         hostType: HostTypeOptionSPFx.id,
@@ -366,7 +365,6 @@ describe("provision() with permission.json file missing", () => {
     const mockedCtx = mockSolutionContext();
     mockedCtx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         hostType: HostTypeOptionAzure.id,
@@ -385,7 +383,6 @@ describe("provision() with permission.json file missing", () => {
     const mockedCtx = mockSolutionContext();
     mockedCtx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         hostType: HostTypeOptionSPFx.id,
@@ -441,7 +438,6 @@ describe("provision() happy path for SPFx projects", () => {
     const mockedCtx = mockSolutionContext();
     mockedCtx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         hostType: HostTypeOptionSPFx.id,
@@ -502,7 +498,6 @@ describe("provision() happy path for Azure projects", () => {
     const mockedCtx = mockSolutionContext();
     mockedCtx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         hostType: HostTypeOptionAzure.id,

--- a/packages/fx-core/tests/plugins/solution/solution.scaffold.test.ts
+++ b/packages/fx-core/tests/plugins/solution/solution.scaffold.test.ts
@@ -98,7 +98,6 @@ describe("Solution scaffold() reading valid manifest file", () => {
     const mockedCtx = mockSolutionContext();
     mockedCtx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         hostType: HostTypeOptionAzure.id,
@@ -120,7 +119,6 @@ describe("Solution scaffold() reading valid manifest file", () => {
     const mockedCtx = mockSolutionContext();
     mockedCtx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         hostType: HostTypeOptionAzure.id,
@@ -144,7 +142,6 @@ describe("Solution scaffold() reading valid manifest file", () => {
     const mockedCtx = mockSolutionContext();
     mockedCtx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         hostType: HostTypeOptionAzure.id,
@@ -173,7 +170,6 @@ describe("Solution scaffold() reading valid manifest file", () => {
     const mockedCtx = mockSolutionContext();
     mockedCtx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         hostType: HostTypeOptionAzure.id,
@@ -222,7 +218,6 @@ describe("Solution scaffold() reading valid manifest file", () => {
     const mockedCtx = mockSolutionContext();
     mockedCtx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         hostType: HostTypeOptionSPFx.id,

--- a/packages/fx-core/tests/plugins/solution/solution.update.test.ts
+++ b/packages/fx-core/tests/plugins/solution/solution.update.test.ts
@@ -74,7 +74,6 @@ describe("update()", () => {
     mockedCtx.answers = { platform: Platform.VSCode };
     mockedCtx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         hostType: HostTypeOptionSPFx.id,
@@ -93,7 +92,6 @@ describe("update()", () => {
     mockedCtx.answers = { platform: Platform.VSCode };
     mockedCtx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         hostType: HostTypeOptionAzure.id,
@@ -112,7 +110,6 @@ describe("update()", () => {
     mockedCtx.answers = { platform: Platform.VSCode };
     mockedCtx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         hostType: HostTypeOptionAzure.id,
@@ -132,7 +129,6 @@ describe("update()", () => {
     mockedCtx.answers = { platform: Platform.VSCode };
     mockedCtx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         hostType: HostTypeOptionAzure.id,
@@ -154,7 +150,6 @@ describe("update()", () => {
     mockedCtx.answers = { platform: Platform.VSCode };
     mockedCtx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         hostType: HostTypeOptionAzure.id,
@@ -176,7 +171,6 @@ describe("update()", () => {
     mockedCtx.answers = { platform: Platform.VSCode };
     mockedCtx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         hostType: HostTypeOptionAzure.id,
@@ -210,7 +204,6 @@ describe("update()", () => {
     mockedCtx.answers = { platform: Platform.VSCode };
     mockedCtx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         hostType: HostTypeOptionAzure.id,
@@ -244,7 +237,6 @@ describe("update()", () => {
     mockedCtx.answers = { platform: Platform.VSCode };
     mockedCtx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         hostType: HostTypeOptionAzure.id,
@@ -282,7 +274,6 @@ describe("update()", () => {
     mockedCtx.answers = { platform: Platform.VSCode };
     mockedCtx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         hostType: HostTypeOptionAzure.id,
@@ -317,7 +308,6 @@ describe("update()", () => {
     mockedCtx.answers = { platform: Platform.VSCode };
     mockedCtx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         hostType: HostTypeOptionAzure.id,
@@ -350,7 +340,6 @@ describe("update()", () => {
     mockedCtx.answers = { platform: Platform.VSCode };
     mockedCtx.projectSettings = {
       appName: "my app",
-      currentEnv: "default",
       projectId: uuid.v4(),
       solutionSettings: {
         hostType: HostTypeOptionAzure.id,


### PR DESCRIPTION
This is the following PR after https://github.com/OfficeDev/TeamsFx/pull/1752 and https://github.com/OfficeDev/TeamsFx/pull/1798 : clean up the usage of `currentEnv` from project settings because the target env name from user input will be respected.

For current usage of `currentEnv`, the default value of target env name (`default`) will be used, because only single default environment is supported until the user input of env is enabled.