### PR TITLE
feat(multi-env): add localSettings in context and implement provider for init/load/save

### DIFF
--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -117,6 +117,8 @@ export interface Context {
     // (undocumented)
     graphTokenProvider?: GraphTokenProvider;
     // (undocumented)
+    localSettings?: LocalSettings;
+    // (undocumented)
     logProvider?: LogProvider;
     // (undocumented)
     projectSettings?: ProjectSettings;
@@ -512,6 +514,20 @@ export function loadOptions(q: Question, inputs: Inputs): Promise<{
 
 // @public
 export type LocalFunc<T> = (inputs: Inputs) => T | Promise<T>;
+
+// @public
+export interface LocalSettings {
+    // (undocumented)
+    auth?: ConfigMap;
+    // (undocumented)
+    backend?: ConfigMap;
+    // (undocumented)
+    bot?: ConfigMap;
+    // (undocumented)
+    frontend?: ConfigMap;
+    // (undocumented)
+    teamsApp: ConfigMap;
+}
 
 // @public (undocumented)
 export enum LogLevel {

--- a/packages/api/src/context.ts
+++ b/packages/api/src/context.ts
@@ -4,6 +4,7 @@
 
 import {
   Inputs,
+  LocalSettings,
   PluginConfig,
   ProjectSettings,
   ReadonlySolutionConfig,
@@ -45,6 +46,8 @@ export interface Context {
   answers?: Inputs;
 
   projectSettings?: ProjectSettings;
+
+  localSettings?: LocalSettings;
 
   ui?: UserInteraction;
 

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -145,6 +145,17 @@ export interface AzureSolutionSettings extends SolutionSettings {
 }
 
 /**
+ * local debug settings
+ */
+export interface LocalSettings {
+  teamsApp: ConfigMap;
+  auth?: ConfigMap;
+  frontend?: ConfigMap;
+  backend?: ConfigMap;
+  bot?: ConfigMap;
+}
+
+/**
  * project dynamic states
  */
 export interface ProjectStates {

--- a/packages/fx-core/src/common/localSettingsConstants.ts
+++ b/packages/fx-core/src/common/localSettingsConstants.ts
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+"use strict";
+
+export const LocalSettingsTeamsAppKeys = Object.freeze({
+  TenantId: "tenantId",
+  TeamsAppId: "teamsAppId",
+});
+
+export const LocalSettingsAuthKeys = Object.freeze({
+  AadClientId: "aadClientId",
+  AadClientSecret: "aadClientSecret",
+  AadObjectId: "aadObjectId",
+  AadOauth2PermissionScopeId: "aadOauth2PermissionScopeId",
+  AadApplicationIdUris: "aadApplicationIdUris",
+  SimpleAuthFilePath: "simpleAuthFilePath",
+  SimpleAuthEnvironmentVariableParams: "SimpleAuthEnvironmentVariableParams",
+  SimpleAuthServiceEndpoint: "AuthServiceEndpoint",
+});
+
+export const LocalSettingsFrontendKeys = Object.freeze({
+  TabDomain: "tabDomain",
+  TabEndpoint: "tabEndpoint",
+  Browser: "browser",
+  Https: "https",
+  TrustDevCert: "trustDevCert",
+  SslCertFile: "sslCertFile",
+  SslKeyFile: "sslKeyFile",
+});
+
+export const LocalSettingsBackendKeys = Object.freeze({
+  FunctionEndpoint: "functionEndpoint",
+  FunctionName: "functionName",
+  SqlEndpoint: "sqlEndpoint",
+  SqlDatabaseName: "sqlDatabaseName",
+  SqlUserName: "sqlUserName",
+  SqlPassword: "sqlPassword",
+});
+
+export const LocalSettingsBotKeys = Object.freeze({
+  SkipNgrok: "skipNgrok",
+  BotId: "botId",
+  BotPassword: "botPassword",
+  BotAadObject: "botAadObject",
+  BotRedirectUri: "botRedirectUri",
+  BotDomain: "botDomain",
+  BotEndpoint: "botEndpoint",
+});

--- a/packages/fx-core/src/common/localSettingsProvider.ts
+++ b/packages/fx-core/src/common/localSettingsProvider.ts
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+"use strict";
+
+import * as fs from "fs-extra";
+import * as os from "os";
+import { ConfigFolderName, ConfigMap, LocalSettings } from "@microsoft/teamsfx-api";
+import {
+  LocalSettingsAuthKeys,
+  LocalSettingsBackendKeys,
+  LocalSettingsBotKeys,
+  LocalSettingsFrontendKeys,
+  LocalSettingsTeamsAppKeys,
+} from "./localSettingsConstants";
+
+export const localSettingsFileName = "localSettings.json";
+
+export class LocalSettingsProvider {
+  public readonly localSettingsFilePath: string;
+  constructor(workspaceFolder: string) {
+    this.localSettingsFilePath = `${workspaceFolder}/.${ConfigFolderName}/${localSettingsFileName}`;
+  }
+
+  public init(
+    includeFrontend: boolean,
+    includeBackend: boolean,
+    includeBot: boolean
+  ): LocalSettings {
+    // initialize Teams app related config for local debug.
+    const teamsAppLocalConfig = new ConfigMap();
+    teamsAppLocalConfig.set(LocalSettingsTeamsAppKeys.TenantId, "");
+    teamsAppLocalConfig.set(LocalSettingsTeamsAppKeys.TeamsAppId, "");
+
+    const localSettings: LocalSettings = {
+      teamsApp: teamsAppLocalConfig,
+    };
+
+    let keys: string[];
+
+    // initialize frontend and simplee auth local settings.
+    if (includeFrontend) {
+      const frontendLocalConfig = new ConfigMap();
+      frontendLocalConfig.set(LocalSettingsFrontendKeys.Browser, "none");
+      frontendLocalConfig.set(LocalSettingsFrontendKeys.Https, true);
+      frontendLocalConfig.set(LocalSettingsFrontendKeys.TrustDevCert, true);
+      frontendLocalConfig.set(LocalSettingsFrontendKeys.SslCertFile, "");
+      frontendLocalConfig.set(LocalSettingsFrontendKeys.SslKeyFile, "");
+      frontendLocalConfig.set(LocalSettingsFrontendKeys.TabDomain, "");
+      frontendLocalConfig.set(LocalSettingsFrontendKeys.TabEndpoint, "");
+
+      // simple auth is only required by frontend
+      const authLocalConfig = new ConfigMap();
+      keys = Object.values(LocalSettingsAuthKeys);
+      for (const key of keys) {
+        authLocalConfig.set(key, "");
+      }
+
+      localSettings.frontend = frontendLocalConfig;
+      localSettings.auth = authLocalConfig;
+    }
+
+    // initialize simple auth local settings.
+    if (includeBackend) {
+      const backendLocalConfig = new ConfigMap();
+      keys = Object.values(LocalSettingsBackendKeys);
+      for (const key of keys) {
+        backendLocalConfig.set(key, "");
+      }
+
+      localSettings.backend = backendLocalConfig;
+    }
+
+    if (includeBot) {
+      const botLocalConfig = new ConfigMap();
+      keys = Object.values(LocalSettingsBotKeys);
+      for (const key of keys) {
+        if (key === LocalSettingsBotKeys.SkipNgrok) {
+          botLocalConfig.set(key, false);
+        } else {
+          botLocalConfig.set(key, "");
+        }
+      }
+
+      localSettings.bot = botLocalConfig;
+    }
+
+    return localSettings;
+  }
+
+  public async load(): Promise<LocalSettings | undefined> {
+    if (await fs.pathExists(this.localSettingsFilePath)) {
+      const localSettingsJson = await fs.readJSON(this.localSettingsFilePath);
+      const localSettings: LocalSettings = {
+        teamsApp: ConfigMap.fromJSON(localSettingsJson.teamsApp)!,
+        auth: ConfigMap.fromJSON(localSettingsJson.auth),
+        frontend: ConfigMap.fromJSON(localSettingsJson.frontend),
+        backend: ConfigMap.fromJSON(localSettingsJson.backend),
+        bot: ConfigMap.fromJSON(localSettingsJson.bot),
+      };
+
+      return localSettings;
+    } else {
+      return undefined;
+    }
+  }
+
+  public async save(localSettings: LocalSettings): Promise<void> {
+    await fs.createFile(this.localSettingsFilePath);
+    await fs.writeFile(this.localSettingsFilePath, JSON.stringify(localSettings, null, 4));
+  }
+}

--- a/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
@@ -1095,7 +1095,7 @@ export class TeamsAppSolution implements Solution {
     if (await fs.pathExists(localSettingsProvider.localSettingsFilePath)) {
       ctx.localSettings = await localSettingsProvider.load();
     } else {
-      ctx.localSettings = await localSettingsProvider.init(hasFrontend, hasBackend, hasBot);
+      ctx.localSettings = localSettingsProvider.init(hasFrontend, hasBackend, hasBot);
     }
 
     try {

--- a/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
@@ -379,10 +379,10 @@ export class TeamsAppSolution implements Solution {
 
       const azureResources = (ctx.projectSettings?.solutionSettings as AzureSolutionSettings)
         ?.azureResources;
-      const hasBackend = azureResources.includes(AzureResourceFunction.id);
+      const hasBackend = azureResources?.includes(AzureResourceFunction.id);
 
       const localSettingsProvider = new LocalSettingsProvider(ctx.root);
-      let localSettings = await localSettingsProvider.load();
+      const localSettings = await localSettingsProvider.load();
       if (localSettings !== undefined) {
         // Add local settings for the new added capability/resource
         await localSettingsProvider.save(

--- a/packages/fx-core/tests/core/localSettings.test.ts
+++ b/packages/fx-core/tests/core/localSettings.test.ts
@@ -53,6 +53,30 @@ describe("LocalSettings provider APIs", () => {
       const localSettings = localSettingsProvider.init(hasFrontend, hasBackend, hasBot);
       assertLocalSettings(localSettings, hasFrontend, hasBackend, hasBot);
     });
+
+    it("should incremental init if localSettings exists", async () => {
+      let localSettings: LocalSettings | undefined;
+      localSettings = localSettingsProvider.init(true, false, false);
+      const updateValue = "http://localhost:5000";
+      localSettings.auth?.set(LocalSettingsAuthKeys.SimpleAuthServiceEndpoint, updateValue);
+
+      await localSettingsProvider.save(localSettings);
+      localSettings = await localSettingsProvider.load();
+
+      const addBackaned = true;
+      const addBot = true;
+      const updatedLocalSettings = localSettingsProvider.incrementalInit(
+        localSettings!,
+        addBackaned,
+        addBot
+      );
+
+      assertLocalSettings(updatedLocalSettings, true, true, true);
+      chai.assert.equal(
+        updatedLocalSettings!.auth?.get(LocalSettingsAuthKeys.SimpleAuthServiceEndpoint),
+        updateValue
+      );
+    });
   });
 
   describe("save localSettings", () => {

--- a/packages/fx-core/tests/core/localSettings.test.ts
+++ b/packages/fx-core/tests/core/localSettings.test.ts
@@ -1,0 +1,162 @@
+import "mocha";
+import * as chai from "chai";
+import * as fs from "fs-extra";
+import * as os from "os";
+import * as path from "path";
+import { ConfigFolderName, LocalSettings, LocalSettingsProvider } from "@microsoft/teamsfx-api";
+import {
+  LocalSettingsAuthKeys,
+  LocalSettingsBackendKeys,
+  LocalSettingsBotKeys,
+  LocalSettingsFrontendKeys,
+  LocalSettingsTeamsAppKeys,
+} from "../../src/common/localSettingsConstants";
+import {
+  LocalEnvBackendKeys,
+  LocalEnvFrontendKeys,
+} from "../../src/plugins/resource/localdebug/constants";
+
+describe("LocalSettings provider APIs", () => {
+  const workspaceFolder = path.resolve(__dirname, "./data/");
+  const testFilePath = path.resolve(__dirname, `./data/.${ConfigFolderName}/localSettings.json`);
+
+  let hasFrontend: boolean;
+  let hasBackend: boolean;
+  let hasBot: boolean;
+  let localSettingsProvider: LocalSettingsProvider;
+
+  beforeEach(() => {
+    localSettingsProvider = new LocalSettingsProvider(workspaceFolder);
+    fs.emptyDirSync(workspaceFolder);
+  });
+
+  describe("init localSettings", () => {
+    it("should init with tab and backaned", () => {
+      hasFrontend = true;
+      hasBackend = true;
+      hasBot = false;
+
+      const localSettings = localSettingsProvider.init(hasFrontend, hasBackend, hasBot);
+      assertLocalSettings(localSettings, hasFrontend, hasBackend, hasBot);
+    });
+
+    it("should init with tab and without backaned", () => {
+      hasFrontend = true;
+      hasBackend = false;
+      hasBot = false;
+
+      const localSettings = localSettingsProvider.init(hasFrontend, hasBackend, hasBot);
+      assertLocalSettings(localSettings, hasFrontend, hasBackend, hasBot);
+    });
+
+    it("should init with bot", () => {
+      hasFrontend = false;
+      hasBackend = false;
+      hasBot = true;
+
+      const localSettings = localSettingsProvider.init(hasFrontend, hasBackend, hasBot);
+      assertLocalSettings(localSettings, hasFrontend, hasBackend, hasBot);
+    });
+  });
+
+  describe("save localSettings", () => {
+    it("should create with default settings", async () => {
+      hasFrontend = true;
+      hasBackend = true;
+      hasBot = true;
+
+      const localSettings: LocalSettings = localSettingsProvider.init(
+        hasFrontend,
+        hasBackend,
+        hasBot
+      );
+      await localSettingsProvider.save(localSettings);
+
+      chai.assert.isTrue(await fs.pathExists(testFilePath));
+      const expectedContent = JSON.stringify(localSettings, null, 4);
+      const actualContent = await fs.readFile(testFilePath, "utf8");
+      chai.assert.equal(actualContent, expectedContent);
+    });
+  });
+
+  describe("load localSettings", () => {
+    it("should load after save", async () => {
+      const localSettings = localSettingsProvider.init(true, true, true);
+      const updateValue = "http://localhost:5000";
+      localSettings.auth?.set(LocalSettingsAuthKeys.SimpleAuthServiceEndpoint, updateValue);
+
+      await localSettingsProvider.save(localSettings);
+      const updatedLocalSettings = await localSettingsProvider.load();
+
+      assertLocalSettings(updatedLocalSettings, true, true, true);
+      chai.assert.equal(
+        updatedLocalSettings!.auth?.get(LocalSettingsAuthKeys.SimpleAuthServiceEndpoint),
+        updateValue
+      );
+    });
+
+    it("should return undefined if file doesn't exist", async () => {
+      const localSettings = await localSettingsProvider.load();
+      chai.assert.isUndefined(localSettings);
+    });
+  });
+
+  function assertLocalSettings(
+    localSettings: LocalSettings | undefined,
+    hasFrontend: boolean,
+    hasBackend: boolean,
+    hasBot: boolean
+  ) {
+    chai.assert.isDefined(localSettings);
+
+    // Teams app settings is always required.
+    chai.assert.isDefined(localSettings!.teamsApp);
+
+    const expectedTeamsAppKeys = Object.values(LocalSettingsTeamsAppKeys);
+    for (const key of expectedTeamsAppKeys) {
+      chai.assert.isTrue(localSettings!.teamsApp?.has(key));
+    }
+
+    // Verify frontend related settings.
+    if (hasFrontend) {
+      chai.assert.isDefined(localSettings!.frontend);
+      chai.assert.isDefined(localSettings!.auth);
+
+      const expectedTeamsAppKeys = Object.values(LocalSettingsTeamsAppKeys);
+      const expectedFrontendKeys = Object.values(LocalSettingsFrontendKeys);
+      const expectedAuthKeys = Object.values(LocalSettingsAuthKeys);
+
+      for (const key of expectedTeamsAppKeys) {
+        chai.assert.isTrue(localSettings!.teamsApp?.has(key));
+      }
+
+      for (const key of expectedAuthKeys) {
+        chai.assert.isTrue(localSettings!.auth?.has(key));
+      }
+
+      for (const key of expectedFrontendKeys) {
+        chai.assert.isTrue(localSettings?.frontend?.has(key));
+      }
+    }
+
+    // Verify backend related settings.
+    if (hasBackend) {
+      chai.assert.isDefined(localSettings!.backend);
+
+      const expectedBackendKeys = Object.values(LocalSettingsBackendKeys);
+      for (const key of expectedBackendKeys) {
+        chai.assert.isTrue(localSettings!.backend?.has(key));
+      }
+    }
+
+    // Verify bot related settings.
+    if (hasBot) {
+      chai.assert.isDefined(localSettings!.bot);
+
+      const expectedBotKeys = Object.values(LocalSettingsBotKeys);
+      for (const key of expectedBotKeys) {
+        chai.assert.isTrue(localSettings!.bot?.has(key));
+      }
+    }
+  }
+});

--- a/packages/fx-core/tests/core/localSettings.test.ts
+++ b/packages/fx-core/tests/core/localSettings.test.ts
@@ -1,9 +1,9 @@
 import "mocha";
 import * as chai from "chai";
 import * as fs from "fs-extra";
-import * as os from "os";
 import * as path from "path";
-import { ConfigFolderName, LocalSettings, LocalSettingsProvider } from "@microsoft/teamsfx-api";
+import { ConfigFolderName, LocalSettings } from "@microsoft/teamsfx-api";
+import { LocalSettingsProvider } from "../../src/common/localSettingsProvider";
 import {
   LocalSettingsAuthKeys,
   LocalSettingsBackendKeys,
@@ -11,10 +11,6 @@ import {
   LocalSettingsFrontendKeys,
   LocalSettingsTeamsAppKeys,
 } from "../../src/common/localSettingsConstants";
-import {
-  LocalEnvBackendKeys,
-  LocalEnvFrontendKeys,
-} from "../../src/plugins/resource/localdebug/constants";
 
 describe("LocalSettings provider APIs", () => {
   const workspaceFolder = path.resolve(__dirname, "./data/");

--- a/packages/fx-core/tests/plugins/solution/solution.scaffold.test.ts
+++ b/packages/fx-core/tests/plugins/solution/solution.scaffold.test.ts
@@ -195,7 +195,7 @@ describe("Solution scaffold() reading valid manifest file", () => {
     const result = await solution.scaffold(mockedCtx);
     expect(result.isOk()).to.be.true;
     // only need to check whether related files exist, tests to the content is covered by other test cases
-    expect(fileContent.size).equals(5); // there's a readme file
+    expect(fileContent.size).equals(6); // there's a readme file
     expect(fileContent.has(path.join("./infra/azure/templates", "main.bicep"))).to.be.true;
     expect(fileContent.has(path.join("./infra/azure/templates", "frontendHostingProvision.bicep")))
       .to.be.true;
@@ -233,7 +233,7 @@ describe("Solution scaffold() reading valid manifest file", () => {
     const result = await solution.scaffold(mockedCtx);
     expect(result.isOk()).to.be.true;
     // only need to check whether related files exist, tests to the content is covered by other test cases
-    expect(fileContent.size).equals(1); // only a readme file is generated
+    expect(fileContent.size).equals(2); // only a readme file is generated
 
     restore();
   });


### PR DESCRIPTION
**Changes in this PR**:
1. Add `localSettings` API contract in solution & plugin context.
2. Define interface `LocalSettings` for the schema of `localSettings.json` file.
3. Provide a `LocalSetingsProvider` to init/local/save `localSettings.json` file.

**Changes in upcoming PRs**:
1. Update resource plugins to read/write local debug related configs from `localSettings.json` file.
2. Update local debug component to generated env variables from `localSettings.json` file.
3. Update VS Code extension & CLI to integrate with the new `localSettings.json` file. 
4. Add feature flag to enable/disable using the new local debug settings.
5. Clean up legacy code for `local.env`.
6. ...