### PR TITLE
feat: migrate icons and manifest in old project when building teams package

### DIFF
--- a/packages/fx-core/src/core/index.ts
+++ b/packages/fx-core/src/core/index.ts
@@ -145,7 +145,7 @@ export class FxCore implements Core {
 
       await fs.ensureDir(projectPath);
       await fs.ensureDir(path.join(projectPath, `.${ConfigFolderName}`));
-      await fs.ensureDir(path.join(projectPath, `.${AppPackageFolderName}`));
+      await fs.ensureDir(path.join(projectPath, `${AppPackageFolderName}`));
 
       const createResult = await this.createBasicFolderStructure(inputs);
       if (createResult.isErr()) {

--- a/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
@@ -458,7 +458,7 @@ export class AppStudioPluginImpl {
       }
     }
     const status = await fs.lstat(appDirectory);
-    await fs.ensureDir(path.join(ctx.root, `.${AppPackageFolderName}`));
+    await fs.ensureDir(path.join(ctx.root, `${AppPackageFolderName}`));
 
     if (!status.isDirectory()) {
       throw AppStudioResultFactory.UserError(
@@ -496,7 +496,10 @@ export class AppStudioPluginImpl {
       await fs.copyFile(zipFileName, `${ctx.root}/SPFx/teams/TeamsSPFxApp.zip`);
     }
 
-    if (appDirectory.includes(`${ConfigFolderName}`) && ctx.answers?.platform !== Platform.VS) {
+    if (
+      appDirectory === `${ctx.root}/.${ConfigFolderName}` &&
+      ctx.answers?.platform !== Platform.VS
+    ) {
       await fs.move(
         `${appDirectory}/${manifest.icons.color}`,
         `${ctx.root}/${AppPackageFolderName}/${manifest.icons.color}`

--- a/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
@@ -458,6 +458,8 @@ export class AppStudioPluginImpl {
       }
     }
     const status = await fs.lstat(appDirectory);
+    await fs.ensureDir(path.join(ctx.root, `.${AppPackageFolderName}`));
+
     if (!status.isDirectory()) {
       throw AppStudioResultFactory.UserError(
         AppStudioError.NotADirectoryError.name,
@@ -492,6 +494,21 @@ export class AppStudioPluginImpl {
 
     if (this.isSPFxProject(ctx)) {
       await fs.copyFile(zipFileName, `${ctx.root}/SPFx/teams/TeamsSPFxApp.zip`);
+    }
+
+    if (appDirectory.includes(`${ConfigFolderName}`) && ctx.answers?.platform !== Platform.VS) {
+      await fs.move(
+        `${appDirectory}/${manifest.icons.color}`,
+        `${ctx.root}/${AppPackageFolderName}/${manifest.icons.color}`
+      );
+      await fs.move(
+        `${appDirectory}/${manifest.icons.outline}`,
+        `${ctx.root}/${AppPackageFolderName}/${manifest.icons.outline}`
+      );
+      await fs.move(
+        `${appDirectory}/${REMOTE_MANIFEST}`,
+        `${ctx.root}/${AppPackageFolderName}/${REMOTE_MANIFEST}`
+      );
     }
 
     return zipFileName;

--- a/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
@@ -486,6 +486,11 @@ export class AppStudioPluginImpl {
       );
     }
 
+    const formerZipFileName = `${ctx.root}/.${ConfigFolderName}/appPackage.zip`;
+    if ((await this.checkFileExist(formerZipFileName)) && ctx.answers?.platform !== Platform.VS) {
+      await fs.remove(formerZipFileName);
+    }
+
     const zip = new AdmZip();
     zip.addFile(Constants.MANIFEST_FILE, Buffer.from(manifestString));
     zip.addLocalFile(colorFile);

--- a/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
@@ -458,7 +458,6 @@ export class AppStudioPluginImpl {
       }
     }
     const status = await fs.lstat(appDirectory);
-    await fs.ensureDir(path.join(ctx.root, `${AppPackageFolderName}`));
 
     if (!status.isDirectory()) {
       throw AppStudioResultFactory.UserError(
@@ -486,11 +485,6 @@ export class AppStudioPluginImpl {
       );
     }
 
-    const formerZipFileName = `${ctx.root}/.${ConfigFolderName}/appPackage.zip`;
-    if ((await this.checkFileExist(formerZipFileName)) && ctx.answers?.platform !== Platform.VS) {
-      await fs.remove(formerZipFileName);
-    }
-
     const zip = new AdmZip();
     zip.addFile(Constants.MANIFEST_FILE, Buffer.from(manifestString));
     zip.addLocalFile(colorFile);
@@ -505,6 +499,13 @@ export class AppStudioPluginImpl {
       appDirectory === `${ctx.root}/.${ConfigFolderName}` &&
       ctx.answers?.platform !== Platform.VS
     ) {
+      await fs.ensureDir(path.join(ctx.root, `${AppPackageFolderName}`));
+
+      const formerZipFileName = `${appDirectory}/appPackage.zip`;
+      if (await this.checkFileExist(formerZipFileName)) {
+        await fs.remove(formerZipFileName);
+      }
+
       await fs.move(
         `${appDirectory}/${manifest.icons.color}`,
         `${ctx.root}/${AppPackageFolderName}/${manifest.icons.color}`

--- a/packages/fx-core/tests/plugins/resource/appstudio/unit/build.test.ts
+++ b/packages/fx-core/tests/plugins/resource/appstudio/unit/build.test.ts
@@ -66,6 +66,7 @@ describe("Build Teams Package", () => {
         webApplicationInfoResource: "webApplicationInfoResource",
       })
     );
+    sandbox.stub(fs, "move").resolves();
 
     const builtPackage = await plugin.buildTeamsPackage(ctx);
     chai.assert.isTrue(builtPackage.isOk());

--- a/packages/fx-core/tests/plugins/resource/appstudio/unit/publish.test.ts
+++ b/packages/fx-core/tests/plugins/resource/appstudio/unit/publish.test.ts
@@ -62,6 +62,7 @@ describe("Publish Teams app", () => {
     sandbox.stub(AppStudioClient, "publishTeamsApp").resolves(uuid());
     sandbox.stub(AppStudioClient, "publishTeamsAppUpdate").resolves(uuid());
     sandbox.stub(AppStudioClient, "updateApp").resolves();
+    sandbox.stub(fs, "move").resolves();
   });
 
   afterEach(async () => {


### PR DESCRIPTION
1. When building teamsAppPackage, if the icons are found in .fx directory, it will be moved to appPackage directory
2. Fix the wrong directory ensure 
`await fs.ensureDir(path.join(projectPath, ${AppPackageFolderName}));`