### PR TITLE
chore(multi-env): add feature flag for multiple environment support

### DIFF
--- a/packages/fx-core/src/common/constants.ts
+++ b/packages/fx-core/src/common/constants.ts
@@ -16,3 +16,7 @@ export class ResourcePlugins {
 export class PluginDisplayName {
   static readonly Solution = "Teams Toolkit";
 }
+
+export class FeatureFlagName {
+  static readonly MultiEnv = "TEAMSFX_MULTI_ENV";
+}

--- a/packages/fx-core/src/common/tools.ts
+++ b/packages/fx-core/src/common/tools.ts
@@ -40,7 +40,7 @@ import {
   TabOptionItem,
 } from "../plugins/solution/fx-solution/question";
 import * as Handlebars from "handlebars";
-import { ConstantString } from "./constants";
+import { ConstantString, FeatureFlagName } from "./constants";
 
 Handlebars.registerHelper("contains", (value, array, options) => {
   array = array instanceof Array ? array : [array];
@@ -500,6 +500,10 @@ export function isFeatureFlagEnabled(featureFlagName: string, defaultValue = fal
   } else {
     return flag === "1" || flag.toLowerCase() === "true"; // can enable feature flag by set environment variable value to "1" or "true"
   }
+}
+
+export function isMultiEnvEnabled(): boolean {
+  return isFeatureFlagEnabled(FeatureFlagName.MultiEnv, false);
 }
 
 export function isArmSupportEnabled(): boolean {

--- a/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
@@ -87,6 +87,7 @@ import {
   deepCopy,
   getStrings,
   isArmSupportEnabled,
+  isMultiEnvEnabled,
   isUserCancelError,
 } from "../../../common/tools";
 import { getTemplatesFolder } from "../../..";
@@ -381,16 +382,19 @@ export class TeamsAppSolution implements Solution {
         ?.azureResources;
       const hasBackend = azureResources?.includes(AzureResourceFunction.id);
 
-      const localSettingsProvider = new LocalSettingsProvider(ctx.root);
-      const localSettings = await localSettingsProvider.load();
-      if (localSettings !== undefined) {
-        // Add local settings for the new added capability/resource
-        await localSettingsProvider.save(
-          localSettingsProvider.incrementalInit(localSettings!, hasBackend, hasBot)
-        );
-      } else {
-        // Initialize a local settings on scaffolding
-        await localSettingsProvider.save(localSettingsProvider.init(hasTab, hasBackend, hasBot));
+      if (isMultiEnvEnabled()) {
+        const localSettingsProvider = new LocalSettingsProvider(ctx.root);
+        const localSettings = await localSettingsProvider.load();
+
+        if (localSettings !== undefined) {
+          // Add local settings for the new added capability/resource
+          await localSettingsProvider.save(
+            localSettingsProvider.incrementalInit(localSettings!, hasBackend, hasBot)
+          );
+        } else {
+          // Initialize a local settings on scaffolding
+          await localSettingsProvider.save(localSettingsProvider.init(hasTab, hasBackend, hasBot));
+        }
       }
     }
 
@@ -1105,8 +1109,10 @@ export class TeamsAppSolution implements Solution {
     } finally {
       ctx.config.get(GLOBAL_CONFIG)?.delete(PERMISSION_REQUEST);
 
-      // persistent localSettings.json.
-      localSettingsProvider.save(ctx.localSettings!);
+      if (isMultiEnvEnabled()) {
+        // persistent localSettings.json.
+        localSettingsProvider.save(ctx.localSettings!);
+      }
     }
   }
 

--- a/packages/fx-core/tests/core/other.test.ts
+++ b/packages/fx-core/tests/core/other.test.ts
@@ -20,7 +20,12 @@ import {
   WriteFileError,
 } from "../../src/core/error";
 import mockedEnv from "mocked-env";
-import { isArmSupportEnabled, isFeatureFlagEnabled } from "../../src/common/tools";
+import {
+  isArmSupportEnabled,
+  isFeatureFlagEnabled,
+  isMultiEnvEnabled,
+} from "../../src/common/tools";
+import { FeatureFlagName } from "../../src/common/constants";
 
 describe("Other test case", () => {
   const sandbox = sinon.createSandbox();
@@ -185,6 +190,26 @@ describe("Other test case", () => {
       [armSupportFeatureFlagName]: "true",
     });
     assert.isTrue(isArmSupportEnabled());
+    restore();
+  });
+
+  it("isMultiEnvEnabled: return correct result based on environment variable value", () => {
+    let restore = mockedEnv({
+      [FeatureFlagName.MultiEnv]: undefined,
+    });
+    assert.isFalse(isMultiEnvEnabled());
+    restore();
+
+    restore = mockedEnv({
+      [FeatureFlagName.MultiEnv]: "",
+    });
+    assert.isFalse(isMultiEnvEnabled());
+    restore();
+
+    restore = mockedEnv({
+      [FeatureFlagName.MultiEnv]: "true",
+    });
+    assert.isTrue(isMultiEnvEnabled());
     restore();
   });
 });

--- a/packages/fx-core/tests/plugins/solution/solution.scaffold.test.ts
+++ b/packages/fx-core/tests/plugins/solution/solution.scaffold.test.ts
@@ -195,7 +195,7 @@ describe("Solution scaffold() reading valid manifest file", () => {
     const result = await solution.scaffold(mockedCtx);
     expect(result.isOk()).to.be.true;
     // only need to check whether related files exist, tests to the content is covered by other test cases
-    expect(fileContent.size).equals(6); // there's a readme file
+    expect(fileContent.size).equals(5); // there's a readme file
     expect(fileContent.has(path.join("./infra/azure/templates", "main.bicep"))).to.be.true;
     expect(fileContent.has(path.join("./infra/azure/templates", "frontendHostingProvision.bicep")))
       .to.be.true;
@@ -233,7 +233,7 @@ describe("Solution scaffold() reading valid manifest file", () => {
     const result = await solution.scaffold(mockedCtx);
     expect(result.isOk()).to.be.true;
     // only need to check whether related files exist, tests to the content is covered by other test cases
-    expect(fileContent.size).equals(2); // only a readme file is generated
+    expect(fileContent.size).equals(1); // only a readme file is generated
 
     restore();
   });


### PR DESCRIPTION
Added environment variable `TEAMSFX_MULTI_ENV` as feature flag to control multi-env related features. 
In this PR, the toolkit will not persistent the localSettings to file system if the multi-env feature flag is not enabled.