### PR TITLE
fix(cli-preview): do not terminate the preview if opening browser fails

### DIFF
--- a/packages/cli/src/cmds/preview/constants.ts
+++ b/packages/cli/src/cmds/preview/constants.ts
@@ -15,6 +15,8 @@ export const teamsAppIdPlaceholder = "${teamsAppId}";
 export const accountHintPlaceholder = "${account-hint}";
 
 export const serviceLogHintMessage = "A complete log of this task can be found in:";
+export const openBrowserHintMessage =
+  "WARN: Failed to open the browser, please copy the preview url and paste it into your browser.";
 export const waitCtrlPlusC =
   "WARN: Closing browser will not terminate the preview process, please press Ctrl+C to terminate.";
 

--- a/packages/cli/src/cmds/preview/preview.ts
+++ b/packages/cli/src/cmds/preview/preview.ts
@@ -441,7 +441,9 @@ export default class Preview extends YargsCommand {
         error,
         this.telemetryProperties
       );
-      return err(error);
+      cliLogger.necessaryLog(LogLevel.Warning, constants.openBrowserHintMessage);
+      cliLogger.necessaryLog(LogLevel.Warning, constants.waitCtrlPlusC);
+      return ok(null);
     }
     await previewBar.next(constants.previewSPFxSuccessMessage);
     await previewBar.end();
@@ -997,7 +999,8 @@ export default class Preview extends YargsCommand {
         error,
         this.telemetryProperties
       );
-      return err(error);
+      cliLogger.necessaryLog(LogLevel.Warning, constants.openBrowserHintMessage);
+      return ok(null);
     }
     await previewBar.next(constants.previewSuccessMessage);
     await previewBar.end();


### PR DESCRIPTION
To fix: #1773 or https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/10512957.

![image](https://user-images.githubusercontent.com/37978464/128128472-ce7c7d1e-4164-4b4b-b555-9e63ec8e43b5.png)
