### PR TITLE
refactor(multi-env): move programming language to project settings

### DIFF
--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -682,6 +682,8 @@ export interface ProjectSettings {
     // (undocumented)
     appName: string;
     // (undocumented)
+    programmingLanguage?: string;
+    // (undocumented)
     projectId: string;
     // (undocumented)
     solutionSettings?: SolutionSettings;

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -126,6 +126,7 @@ export type EnvConfig = Dict<string>;
 export interface ProjectSettings {
   appName: string;
   projectId: string;
+  programmingLanguage?: string;
   solutionSettings?: SolutionSettings;
 }
 

--- a/packages/cli/src/cmds/preview/errors.ts
+++ b/packages/cli/src/cmds/preview/errors.ts
@@ -89,6 +89,14 @@ export function PreviewWithoutProvision(): UserError {
   );
 }
 
+export function MissingProgrammingLanguageSetting(): UserError {
+  return returnUserError(
+    new Error("The programmingLanguage config is missing in project settings."),
+    constants.cliSource,
+    "MissingProgrammingLanguage"
+  );
+}
+
 export function OpeningBrowserFailed(browser: Browser): UserError {
   return returnUserError(
     new Error(`Failed to open ${browser} browser. Check if ${browser} exists on your system.`),

--- a/packages/cli/src/cmds/preview/preview.ts
+++ b/packages/cli/src/cmds/preview/preview.ts
@@ -254,9 +254,8 @@ export default class Preview extends YargsCommand {
     }
 
     /* === start services === */
-    const programmingLanguage = config?.config
-      ?.get(constants.solutionPluginName)
-      ?.get(constants.programmingLanguageConfigKey) as string;
+    const programmingLanguage = config?.settings?.programmingLanguage;
+
     result = await this.startServices(
       workspaceFolder,
       programmingLanguage,

--- a/packages/cli/src/cmds/preview/preview.ts
+++ b/packages/cli/src/cmds/preview/preview.ts
@@ -254,7 +254,10 @@ export default class Preview extends YargsCommand {
     }
 
     /* === start services === */
-    const programmingLanguage = config?.settings?.programmingLanguage;
+    const programmingLanguage = config?.settings?.programmingLanguage as string;
+    if (programmingLanguage === undefined || programmingLanguage.length === 0) {
+      return err(errors.MissingProgrammingLanguageSetting());
+    }
 
     result = await this.startServices(
       workspaceFolder,

--- a/packages/fx-core/src/core/middleware/contextLoader.ts
+++ b/packages/fx-core/src/core/middleware/contextLoader.ts
@@ -29,7 +29,11 @@ import { Middleware, NextFunction } from "@feathersjs/hooks/lib";
 import { validateProject } from "../../common";
 import * as uuid from "uuid";
 import { LocalCrypto } from "../crypto";
-import { PluginNames } from "../../plugins/solution/fx-solution/constants";
+import {
+  GLOBAL_CONFIG,
+  PluginNames,
+  PROGRAMMING_LANGUAGE,
+} from "../../plugins/solution/fx-solution/constants";
 import { environmentManager } from "../environment";
 
 export const ContextLoaderMW: Middleware = async (ctx: CoreHookContext, next: NextFunction) => {
@@ -105,6 +109,17 @@ export async function loadSolutionContext(
       return err(envDataResult.error);
     }
     const envInfo = envDataResult.value;
+
+    // upgrade programmingLanguange if exists.
+    const solutionConfig = envInfo.data as SolutionConfig;
+    const programmingLanguage = solutionConfig.get(GLOBAL_CONFIG)?.get(PROGRAMMING_LANGUAGE);
+    if (programmingLanguage) {
+      // add programmingLanguage in project settings
+      projectSettings.programmingLanguage = programmingLanguage;
+
+      // remove programmingLanguage in solution config
+      solutionConfig.get(GLOBAL_CONFIG)?.delete(PROGRAMMING_LANGUAGE);
+    }
 
     const solutionContext: SolutionContext = {
       projectSettings: projectSettings,

--- a/packages/fx-core/src/core/middleware/contextLoader.ts
+++ b/packages/fx-core/src/core/middleware/contextLoader.ts
@@ -125,6 +125,7 @@ export async function loadSolutionContext(
 export async function newSolutionContext(tools: Tools, inputs: Inputs): Promise<SolutionContext> {
   const projectSettings: ProjectSettings = {
     appName: "",
+    programmingLanguage: "",
     projectId: uuid.v4(),
     solutionSettings: {
       name: "fx-solution-azure",

--- a/packages/fx-core/src/plugins/resource/bot/configs/scaffoldConfig.ts
+++ b/packages/fx-core/src/plugins/resource/bot/configs/scaffoldConfig.ts
@@ -32,9 +32,7 @@ export class ScaffoldConfig {
 
     this.objectId = context.config.get(PluginBot.OBJECT_ID) as string;
 
-    const rawProgrammingLanguage = context.configOfOtherPlugins
-      .get(PluginSolution.PLUGIN_NAME)
-      ?.get(PluginBot.PROGRAMMING_LANGUAGE) as string;
+    const rawProgrammingLanguage = context.projectSettings?.programmingLanguage;
 
     if (
       rawProgrammingLanguage &&

--- a/packages/fx-core/src/plugins/resource/function/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/function/plugin.ts
@@ -119,9 +119,8 @@ export class FunctionPluginImpl {
       this.config.subscriptionId = subscriptionInfo.subscriptionId;
     }
     this.config.location = solutionConfig?.get(DependentPluginInfo.location) as string;
-    this.config.functionLanguage = solutionConfig?.get(
-      DependentPluginInfo.programmingLanguage
-    ) as FunctionLanguage;
+    this.config.functionLanguage = ctx.projectSettings?.programmingLanguage as FunctionLanguage;
+
     this.config.defaultFunctionName = ctx.config.get(
       FunctionConfigKey.defaultFunctionName
     ) as string;
@@ -207,9 +206,7 @@ export class FunctionPluginImpl {
 
       const language: FunctionLanguage =
         (ctx.answers![QuestionKey.programmingLanguage] as FunctionLanguage) ??
-        (ctx.configOfOtherPlugins
-          .get(DependentPluginInfo.solutionPluginName)
-          ?.get(DependentPluginInfo.programmingLanguage) as FunctionLanguage);
+        (ctx.projectSettings?.programmingLanguage as FunctionLanguage);
 
       // If language is unknown, skip checking and let scaffold handle the error.
       if (language && (await FunctionScaffold.doesFunctionPathExist(workingPath, language, name))) {
@@ -244,9 +241,7 @@ export class FunctionPluginImpl {
 
           const language: FunctionLanguage =
             (ctx.answers![QuestionKey.programmingLanguage] as FunctionLanguage) ??
-            (ctx.configOfOtherPlugins
-              .get(DependentPluginInfo.solutionPluginName)
-              ?.get(DependentPluginInfo.programmingLanguage) as FunctionLanguage);
+            (ctx.projectSettings?.programmingLanguage as FunctionLanguage);
 
           // If language is unknown, skip checking and let scaffold handle the error.
           if (

--- a/packages/fx-core/src/plugins/resource/localdebug/index.ts
+++ b/packages/fx-core/src/plugins/resource/localdebug/index.ts
@@ -69,9 +69,7 @@ export class LocalDebugPlugin implements Plugin {
       (pluginName) => pluginName === FunctionPlugin.Name
     );
     const includeBot = selectedPlugins?.some((pluginName) => pluginName === BotPlugin.Name);
-    const programmingLanguage: string = ctx.configOfOtherPlugins
-      ?.get(SolutionPlugin.Name)
-      ?.get(SolutionPlugin.ProgrammingLanguage) as string;
+    const programmingLanguage = ctx.projectSettings?.programmingLanguage ?? "";
 
     const telemetryProperties = {
       platform: ctx.answers?.platform as string,
@@ -455,8 +453,8 @@ export class LocalDebugPlugin implements Plugin {
         return ok(solutionConfigs?.get(SolutionPlugin.LocalTeamsAppId) as string);
       }
     } else if (func.method === "getProgrammingLanguage") {
-      const solutionConfigs = ctx.configOfOtherPlugins.get(SolutionPlugin.Name);
-      return ok(solutionConfigs?.get(SolutionPlugin.ProgrammingLanguage) as string);
+      const programmingLanguage = ctx.projectSettings?.programmingLanguage;
+      return ok(programmingLanguage);
     }
 
     return ok(undefined);

--- a/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
@@ -253,7 +253,7 @@ export class TeamsAppSolution implements Solution {
     // Only non-SPFx project will ask this question.
     const lang = ctx.answers![AzureSolutionQuestionNames.ProgrammingLanguage] as string;
     if (lang) {
-      ctx.config.get(GLOBAL_CONFIG)?.set(PROGRAMMING_LANGUAGE, lang);
+      ctx.projectSettings!.programmingLanguage = lang;
     }
 
     const settingsRes = this.fillInSolutionSettings(ctx);

--- a/packages/fx-core/tests/plugins/resource/function/unit/deploy.test.ts
+++ b/packages/fx-core/tests/plugins/resource/function/unit/deploy.test.ts
@@ -29,7 +29,6 @@ const context: any = {
         [DependentPluginInfo.resourceGroupName, "ut"],
         [DependentPluginInfo.resourceNameSuffix, "ut"],
         [DependentPluginInfo.location, "ut"],
-        [DependentPluginInfo.programmingLanguage, "javascript"],
       ]),
     ],
     [
@@ -73,6 +72,10 @@ const context: any = {
     name: {
       short: "ut",
     },
+  },
+  projectSettings: {
+    appName: "ut",
+    programmingLanguage: "javascript",
   },
   config: new Map<string, string>([["functionAppName", "ut"]]),
   azureAccountProvider: {

--- a/packages/fx-core/tests/plugins/resource/function/unit/provision.test.ts
+++ b/packages/fx-core/tests/plugins/resource/function/unit/provision.test.ts
@@ -28,7 +28,6 @@ const context: any = {
         [DependentPluginInfo.subscriptionId, "ut"],
         [DependentPluginInfo.resourceNameSuffix, "ut"],
         [DependentPluginInfo.location, "ut"],
-        [DependentPluginInfo.programmingLanguage, "javascript"],
       ]),
     ],
     [
@@ -76,6 +75,7 @@ const context: any = {
   config: new Map<string, string>([["nodeVersion", NodeVersion.Version14]]),
   projectSettings: {
     appName: "ut",
+    programmingLanguage: "javascript",
     solutionSettings: {
       activeResourcePlugins: [
         DependentPluginInfo.aadPluginName,

--- a/packages/fx-core/tests/plugins/resource/function/unit/scaffold.test.ts
+++ b/packages/fx-core/tests/plugins/resource/function/unit/scaffold.test.ts
@@ -27,7 +27,6 @@ const context: any = {
         [DependentPluginInfo.resourceGroupName, "ut"],
         [DependentPluginInfo.subscriptionId, "ut"],
         [DependentPluginInfo.resourceNameSuffix, "ut"],
-        [DependentPluginInfo.programmingLanguage, "javascript"],
       ]),
     ],
   ]),
@@ -38,6 +37,7 @@ const context: any = {
   },
   projectSettings: {
     appName: "ut",
+    programmingLanguage: "javascript",
   },
   config: new Map(),
   root: path.join(__dirname, "ut"),

--- a/packages/fx-core/tests/plugins/solution/solution.create.test.ts
+++ b/packages/fx-core/tests/plugins/solution/solution.create.test.ts
@@ -124,6 +124,7 @@ describe("Solution create()", async () => {
     const mockedSolutionCtx = mockSolutionContext();
     mockedSolutionCtx.projectSettings = {
       appName: "my app",
+      programmingLanguage: "",
       projectId: uuid.v4(),
       solutionSettings: {
         name: "azure",
@@ -136,7 +137,8 @@ describe("Solution create()", async () => {
     answers[AzureSolutionQuestionNames.ProgrammingLanguage as string] = programmingLanguage;
     const result = await solution.create(mockedSolutionCtx);
     expect(result.isOk()).equals(true);
-    const lang = mockedSolutionCtx.config.get(GLOBAL_CONFIG)?.getString(PROGRAMMING_LANGUAGE);
+
+    const lang = mockedSolutionCtx.projectSettings.programmingLanguage;
     expect(lang).equals(programmingLanguage);
   });
 


### PR DESCRIPTION
Previously the `programmingLanguage` settings is saved in `env.default.json` file. As this is a project-level config, we'll move it to `settings.json` file to better support multi-env.

@YitongFeng-git As we modified bot & function plugin to read `programmingLanguage` from project settings instead of solution plugin config, please also help to review this PR. Thanks in advance.
