### PR TITLE
refactor(core): extract the env info loader/writer from context loader/writer middleware

### DIFF
--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -576,6 +576,9 @@ export function loadOptions(q: Question, inputs: Inputs): Promise<{
 // @public
 export type LocalFunc<T> = (inputs: Inputs) => T | Promise<T>;
 
+// @public (undocumented)
+type LocalProvisionOutput = ProvisionOutput;
+
 // @public
 export interface LocalSettings {
     // (undocumented)
@@ -589,9 +592,6 @@ export interface LocalSettings {
     // (undocumented)
     teamsApp: ConfigMap;
 }
-
-// @public (undocumented)
-type LocalProvisionOutput = ProvisionOutput;
 
 // @public (undocumented)
 export enum LogLevel {

--- a/packages/fx-core/src/core/environment.ts
+++ b/packages/fx-core/src/core/environment.ts
@@ -72,7 +72,7 @@ class EnvironmentManager {
     projectPath: string,
     envName?: string,
     cryptoProvider?: CryptoProvider
-  ): Promise<Result<Void, FxError>> {
+  ): Promise<Result<string, FxError>> {
     if (!(await fs.pathExists(projectPath))) {
       return err(PathNotExistError(projectPath));
     }
@@ -98,7 +98,7 @@ class EnvironmentManager {
       return err(WriteFileError(error));
     }
 
-    return ok(Void);
+    return ok(envFiles.envProfile);
   }
 
   public async listEnvProfiles(projectPath: string): Promise<Result<Array<string>, FxError>> {

--- a/packages/fx-core/src/core/middleware/configWriter.ts
+++ b/packages/fx-core/src/core/middleware/configWriter.ts
@@ -12,13 +12,11 @@ import {
   Inputs,
   StaticPlatforms,
 } from "@microsoft/teamsfx-api";
-import { mapToJson } from "../../common/tools";
 import { WriteFileError } from "../error";
 import { CoreHookContext, FxCore } from "..";
-import { environmentManager } from "../environment";
 
 /**
- * This middleware will help to persist configs if necessary.
+ * This middleware will help to persist project settings if necessary.
  */
 export const ConfigWriterMW: Middleware = async (ctx: CoreHookContext, next: NextFunction) => {
   try {
@@ -40,12 +38,6 @@ export const ConfigWriterMW: Middleware = async (ctx: CoreHookContext, next: Nex
         ?.solutionSettings as AzureSolutionSettings;
       if (!solutionSettings.activeResourcePlugins) solutionSettings.activeResourcePlugins = [];
       if (!solutionSettings.azureResources) solutionSettings.azureResources = [];
-      await environmentManager.writeEnvProfile(
-        solutionContext.config,
-        inputs.projectPath,
-        solutionContext.targetEnvName,
-        solutionContext.cryptoProvider
-      );
       const settingFile = path.resolve(confFolderPath, "settings.json");
       const core = ctx.self as FxCore;
       await fs.writeFile(settingFile, JSON.stringify(solutionContext.projectSettings, null, 4));

--- a/packages/fx-core/src/core/middleware/envInfoLoader.ts
+++ b/packages/fx-core/src/core/middleware/envInfoLoader.ts
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import {
+  err,
+  FxError,
+  Inputs,
+  ok,
+  ProjectSettings,
+  Result,
+  SolutionConfig,
+  SolutionContext,
+  Tools,
+} from "@microsoft/teamsfx-api";
+import { CoreHookContext, FxCore } from "../..";
+import { NoProjectOpenedError } from "../error";
+import { Middleware, NextFunction } from "@feathersjs/hooks/lib";
+import { LocalCrypto } from "../crypto";
+import { environmentManager } from "../environment";
+import { GLOBAL_CONFIG, PROGRAMMING_LANGUAGE } from "../../plugins/solution/fx-solution/constants";
+
+export const EnvInfoLoaderMW: Middleware = async (ctx: CoreHookContext, next: NextFunction) => {
+  if (ctx.projectSettings) {
+    const inputs = ctx.arguments[ctx.arguments.length - 1] as Inputs;
+    const core = ctx.self as FxCore;
+
+    const result = await loadSolutionContext(
+      core.tools,
+      inputs,
+      ctx.projectSettings,
+      ctx.projectIdMissing
+    );
+    if (result.isErr()) {
+      ctx.result = err(result.error);
+      return;
+    }
+
+    ctx.solutionContext = result.value;
+  }
+
+  await next();
+};
+
+export async function loadSolutionContext(
+  tools: Tools,
+  inputs: Inputs,
+  projectSettings: ProjectSettings,
+  projectIdMissing?: boolean
+): Promise<Result<SolutionContext, FxError>> {
+  if (!inputs.projectPath) {
+    return err(NoProjectOpenedError());
+  }
+
+  // TODO: ask user input for the target environment name with question model.
+  const targetEnvName = inputs.targetEnvName ?? environmentManager.defaultEnvName;
+  const cryptoProvider = new LocalCrypto(projectSettings.projectId);
+  // ensure backwards compatibility:
+  // no need to decrypt the secrets in *.userdata for previous TeamsFx project, which has no project id.
+  const envDataResult = await environmentManager.loadEnvProfile(
+    inputs.projectPath,
+    targetEnvName,
+    projectIdMissing ? undefined : cryptoProvider
+  );
+
+  if (envDataResult.isErr()) {
+    return err(envDataResult.error);
+  }
+  const envInfo = envDataResult.value;
+
+  // upgrade programmingLanguange if exists.
+  const solutionConfig = envInfo.data as SolutionConfig;
+  const programmingLanguage = solutionConfig.get(GLOBAL_CONFIG)?.get(PROGRAMMING_LANGUAGE);
+  if (programmingLanguage) {
+    // add programmingLanguage in project settings
+    projectSettings.programmingLanguage = programmingLanguage;
+
+    // remove programmingLanguage in solution config
+    solutionConfig.get(GLOBAL_CONFIG)?.delete(PROGRAMMING_LANGUAGE);
+  }
+
+  const solutionContext: SolutionContext = {
+    projectSettings: projectSettings,
+    targetEnvName: envInfo.envName,
+    config: envInfo.data,
+    root: inputs.projectPath || "",
+    ...tools,
+    ...tools.tokenProvider,
+    answers: inputs,
+    cryptoProvider: cryptoProvider,
+  };
+
+  return ok(solutionContext);
+}

--- a/packages/fx-core/src/core/middleware/envInfoWriter.ts
+++ b/packages/fx-core/src/core/middleware/envInfoWriter.ts
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+"use strict";
+
+import { NextFunction, Middleware } from "@feathersjs/hooks";
+import { Inputs, StaticPlatforms } from "@microsoft/teamsfx-api";
+import { CoreHookContext, FxCore } from "..";
+import { environmentManager } from "../environment";
+
+/**
+ * This middleware will help to persist environment profile if necessary.
+ */
+export const EnvInfoWriterMW: Middleware = async (ctx: CoreHookContext, next: NextFunction) => {
+  try {
+    await next();
+  } finally {
+    const lastArg = ctx.arguments[ctx.arguments.length - 1];
+    const inputs: Inputs = lastArg === ctx ? ctx.arguments[ctx.arguments.length - 2] : lastArg;
+    if (
+      !inputs.projectPath ||
+      inputs.ignoreConfigPersist === true ||
+      StaticPlatforms.includes(inputs.platform)
+    )
+      return;
+
+    const solutionContext = ctx.solutionContext;
+    if (solutionContext === undefined) return;
+    const envProfilePath = await environmentManager.writeEnvProfile(
+      solutionContext.config,
+      inputs.projectPath,
+      solutionContext.targetEnvName,
+      solutionContext.cryptoProvider
+    );
+
+    const core = ctx.self as FxCore;
+    core.tools.logProvider.debug(`[core] persist env profile: ${envProfilePath}`);
+  }
+};

--- a/packages/fx-core/tests/core/core.test.ts
+++ b/packages/fx-core/tests/core/core.test.ts
@@ -26,10 +26,16 @@ import {
 import fs from "fs-extra";
 import * as path from "path";
 import * as os from "os";
-import { FunctionRouterError, FxCore, InvalidInputError, validateProject } from "../../src";
+import {
+  FunctionRouterError,
+  FxCore,
+  InvalidInputError,
+  validateProject,
+  validateSettings,
+} from "../../src";
 import sinon from "sinon";
 import { MockSolution, MockTools, randomAppName } from "./utils";
-import { loadSolutionContext } from "../../src/core/middleware/contextLoader";
+import { loadProjectSettings } from "../../src/core/middleware/contextLoader";
 import { defaultSolutionLoader } from "../../src/core/loader";
 import {
   CoreQuestionNames,
@@ -37,6 +43,7 @@ import {
   ScratchOptionNoVSC,
   ScratchOptionYesVSC,
 } from "../../src/core/question";
+import { loadSolutionContext } from "../../src/core/middleware/envInfoLoader";
 
 describe("Core basic APIs", () => {
   const sandbox = sinon.createSandbox();
@@ -108,17 +115,34 @@ describe("Core basic APIs", () => {
       const res = await core.createProject(inputs);
       assert.isTrue(res.isOk() && res.value === projectPath);
       assert.deepEqual(expectedInputs, inputs);
-      const loadRes = await loadSolutionContext(tools, inputs);
-      assert.isTrue(loadRes.isOk());
-      if (loadRes.isOk()) {
-        const solutionContext = loadRes.value;
-        const validRes = validateProject(solutionContext);
-        assert.isTrue(validRes === undefined);
-        const solutioConfig = solutionContext.config.get("solution");
-        assert.isTrue(solutioConfig !== undefined);
-        assert.isTrue(solutioConfig!.get("create") === true);
-        assert.isTrue(solutioConfig!.get("scaffold") === true);
+
+      const projectSettingsResult = await loadProjectSettings(inputs);
+      if (projectSettingsResult.isErr()) {
+        assert.fail("failed to load project settings");
       }
+
+      const [projectSettings, projectIdMissing] = projectSettingsResult.value;
+      const validSettingsResult = validateSettings(projectSettings);
+      assert.isTrue(validSettingsResult === undefined);
+
+      const envInfoResult = await loadSolutionContext(
+        tools,
+        inputs,
+        projectSettings,
+        projectIdMissing
+      );
+      if (envInfoResult.isErr()) {
+        assert.fail("failed to load env info");
+      }
+
+      const solutionContext = envInfoResult.value;
+      const validRes = validateProject(solutionContext);
+      assert.isTrue(validRes === undefined);
+
+      const solutioConfig = solutionContext.config.get("solution");
+      assert.isTrue(solutioConfig !== undefined);
+      assert.isTrue(solutioConfig!.get("create") === true);
+      assert.isTrue(solutioConfig!.get("scaffold") === true);
     }
     {
       const inputs: Inputs = { platform: Platform.CLI, projectPath: projectPath };
@@ -138,20 +162,36 @@ describe("Core basic APIs", () => {
       const res2 = await core.executeUserTask(func, inputs);
       assert.isTrue(res2.isOk());
 
-      const loadRes = await loadSolutionContext(tools, inputs);
-      assert.isTrue(loadRes.isOk());
-      if (loadRes.isOk()) {
-        const solutionContext = loadRes.value;
-        const validRes = validateProject(solutionContext);
-        assert.isTrue(validRes === undefined);
-        const solutioConfig = solutionContext.config.get("solution");
-        assert.isTrue(solutioConfig !== undefined);
-        assert.isTrue(solutioConfig!.get("provision") === true);
-        assert.isTrue(solutioConfig!.get("deploy") === true);
-        assert.isTrue(solutioConfig!.get("localDebug") === true);
-        assert.isTrue(solutioConfig!.get("publish") === true);
-        assert.isTrue(solutioConfig!.get("executeUserTask") === true);
+      const projectSettingsResult = await loadProjectSettings(inputs);
+      if (projectSettingsResult.isErr()) {
+        assert.fail("failed to load project settings");
       }
+
+      const [projectSettings, projectIdMissing] = projectSettingsResult.value;
+      const validSettingsResult = validateSettings(projectSettings);
+      assert.isTrue(validSettingsResult === undefined);
+
+      const envInfoResult = await loadSolutionContext(
+        tools,
+        inputs,
+        projectSettings,
+        projectIdMissing
+      );
+      if (envInfoResult.isErr()) {
+        assert.fail("failed to load env info");
+      }
+
+      const solutionContext = envInfoResult.value;
+      const validRes = validateProject(solutionContext);
+      assert.isTrue(validRes === undefined);
+
+      const solutioConfig = solutionContext.config.get("solution");
+      assert.isTrue(solutioConfig !== undefined);
+      assert.isTrue(solutioConfig!.get("provision") === true);
+      assert.isTrue(solutioConfig!.get("deploy") === true);
+      assert.isTrue(solutioConfig!.get("localDebug") === true);
+      assert.isTrue(solutioConfig!.get("publish") === true);
+      assert.isTrue(solutioConfig!.get("executeUserTask") === true);
     }
 
     //getQuestion
@@ -279,15 +319,32 @@ describe("Core basic APIs", () => {
       assert.isTrue(res.isOk() && res.value === projectPath);
       assert.deepEqual(expectedInputs, inputs);
       inputs.projectPath = projectPath;
-      const loadRes = await loadSolutionContext(tools, inputs);
-      assert.isTrue(loadRes.isOk());
-      if (loadRes.isOk()) {
-        const solutionContext = loadRes.value;
-        const validRes = validateProject(solutionContext);
-        assert.isTrue(validRes === undefined);
-        const solutioConfig = solutionContext.config.get("solution");
-        assert.isTrue(solutioConfig !== undefined);
+
+      const projectSettingsResult = await loadProjectSettings(inputs);
+      if (projectSettingsResult.isErr()) {
+        assert.fail("failed to load project settings");
       }
+
+      const [projectSettings, projectIdMissing] = projectSettingsResult.value;
+      const validSettingsResult = validateSettings(projectSettings);
+      assert.isTrue(validSettingsResult === undefined);
+
+      const envInfoResult = await loadSolutionContext(
+        tools,
+        inputs,
+        projectSettings,
+        projectIdMissing
+      );
+      if (envInfoResult.isErr()) {
+        assert.fail("failed to load env info");
+      }
+
+      const solutionContext = envInfoResult.value;
+      const validRes = validateProject(solutionContext);
+      assert.isTrue(validRes === undefined);
+
+      const solutioConfig = solutionContext.config.get("solution");
+      assert.isTrue(solutioConfig !== undefined);
     }
     {
       const inputs: Inputs = { platform: Platform.CLI, projectPath: projectPath };
@@ -306,20 +363,37 @@ describe("Core basic APIs", () => {
       const func: Func = { method: "test", namespace: "fx-solution-mock" };
       const res2 = await core.executeUserTask(func, inputs);
       assert.isTrue(res2.isOk());
-      const loadRes = await loadSolutionContext(tools, inputs);
-      assert.isTrue(loadRes.isOk());
-      if (loadRes.isOk()) {
-        const solutionContext = loadRes.value;
-        const validRes = validateProject(solutionContext);
-        assert.isTrue(validRes === undefined);
-        const solutioConfig = solutionContext.config.get("solution");
-        assert.isTrue(solutioConfig !== undefined);
-        assert.isTrue(solutioConfig!.get("provision") === true);
-        assert.isTrue(solutioConfig!.get("deploy") === true);
-        assert.isTrue(solutioConfig!.get("localDebug") === true);
-        assert.isTrue(solutioConfig!.get("publish") === true);
-        assert.isTrue(solutioConfig!.get("executeUserTask") === true);
+
+      const projectSettingsResult = await loadProjectSettings(inputs);
+      if (projectSettingsResult.isErr()) {
+        assert.fail("failed to load project settings");
       }
+
+      const [projectSettings, projectIdMissing] = projectSettingsResult.value;
+      const validSettingsResult = validateSettings(projectSettings);
+      assert.isTrue(validSettingsResult === undefined);
+
+      const envInfoResult = await loadSolutionContext(
+        tools,
+        inputs,
+        projectSettings,
+        projectIdMissing
+      );
+      if (envInfoResult.isErr()) {
+        assert.fail("failed to load env info");
+      }
+
+      const solutionContext = envInfoResult.value;
+      const validRes = validateProject(solutionContext);
+      assert.isTrue(validRes === undefined);
+
+      const solutioConfig = solutionContext.config.get("solution");
+      assert.isTrue(solutioConfig !== undefined);
+      assert.isTrue(solutioConfig!.get("provision") === true);
+      assert.isTrue(solutioConfig!.get("deploy") === true);
+      assert.isTrue(solutioConfig!.get("localDebug") === true);
+      assert.isTrue(solutioConfig!.get("publish") === true);
+      assert.isTrue(solutioConfig!.get("executeUserTask") === true);
     }
   });
 

--- a/packages/fx-core/tests/core/hooks.test.ts
+++ b/packages/fx-core/tests/core/hooks.test.ts
@@ -63,6 +63,8 @@ import { PluginNames } from "../../src/plugins/solution/fx-solution/constants";
 import { QuestionModelMW } from "../../src/core/middleware/questionModel";
 import { ProjectUpgraderMW } from "../../src/core/middleware/projectUpgrader";
 import { environmentManager } from "../../src/core/environment";
+import { EnvInfoLoaderMW } from "../../src/core/middleware/envInfoLoader";
+import { EnvInfoWriterMW } from "../../src/core/middleware/envInfoWriter";
 
 describe("Middleware", () => {
   describe("ErrorHandlerMW", () => {
@@ -417,7 +419,7 @@ describe("Middleware", () => {
         }
       }
       hooks(MyClass, {
-        other: [ContextLoaderMW, ContextInjecterMW],
+        other: [ContextLoaderMW, EnvInfoLoaderMW, ContextInjecterMW],
       });
       const my = new MyClass();
       const res = await my.other(inputs);
@@ -519,7 +521,7 @@ describe("Middleware", () => {
         }
       }
       hooks(MyClass, {
-        myMethod: [ContextInjecterMW, ConfigWriterMW],
+        myMethod: [ContextInjecterMW, ConfigWriterMW, EnvInfoWriterMW],
       });
       const my = new MyClass();
       await my.myMethod(inputs);
@@ -593,8 +595,8 @@ describe("Middleware", () => {
         }
       }
       hooks(MyClass, {
-        WriteConfigTrigger: [ContextInjecterMW, ConfigWriterMW],
-        ReadConfigTrigger: [ContextLoaderMW, ContextInjecterMW],
+        WriteConfigTrigger: [ContextInjecterMW, ConfigWriterMW, EnvInfoWriterMW],
+        ReadConfigTrigger: [ContextLoaderMW, EnvInfoLoaderMW, ContextInjecterMW],
       });
       const my = new MyClass();
       await my.WriteConfigTrigger(inputs);


### PR DESCRIPTION
Separate the original `ContextLoad` and `ConfigWriter` middleware into two parts:
- Project settings loader/writer
- Env profile loader/writer

Reason to do it:
- Some lifecycle or operation doesn't need to load env profile, such like local debug.
- Env profile loader would require user input for the target env name if there're multiple environments, while project settings loader doesn't need.