### PR TITLE
refactor(local-debug): update aad plugin to use localSettings for local debug

### DIFF
--- a/packages/fx-core/src/common/localSettingsConstants.ts
+++ b/packages/fx-core/src/common/localSettingsConstants.ts
@@ -8,11 +8,11 @@ export const LocalSettingsTeamsAppKeys = Object.freeze({
 });
 
 export const LocalSettingsAuthKeys = Object.freeze({
-  AadClientId: "aadClientId",
-  AadClientSecret: "aadClientSecret",
-  AadObjectId: "aadObjectId",
-  AadOauth2PermissionScopeId: "aadOauth2PermissionScopeId",
-  AadApplicationIdUris: "aadApplicationIdUris",
+  AadClientId: "clientId",
+  AadClientSecret: "clientSecret",
+  AadObjectId: "objectId",
+  AadOauth2PermissionScopeId: "oauth2PermissionScopeId",
+  AadApplicationIdUris: "applicationIdUris",
   SimpleAuthFilePath: "simpleAuthFilePath",
   SimpleAuthEnvironmentVariableParams: "SimpleAuthEnvironmentVariableParams",
   SimpleAuthServiceEndpoint: "AuthServiceEndpoint",

--- a/packages/fx-core/src/common/localSettingsConstants.ts
+++ b/packages/fx-core/src/common/localSettingsConstants.ts
@@ -8,11 +8,11 @@ export const LocalSettingsTeamsAppKeys = Object.freeze({
 });
 
 export const LocalSettingsAuthKeys = Object.freeze({
-  AadClientId: "clientId",
-  AadClientSecret: "clientSecret",
-  AadObjectId: "objectId",
-  AadOauth2PermissionScopeId: "oauth2PermissionScopeId",
-  AadApplicationIdUris: "applicationIdUris",
+  ClientId: "clientId",
+  ClientSecret: "clientSecret",
+  ObjectId: "objectId",
+  Oauth2PermissionScopeId: "oauth2PermissionScopeId",
+  ApplicationIdUris: "applicationIdUris",
   SimpleAuthFilePath: "simpleAuthFilePath",
   SimpleAuthEnvironmentVariableParams: "SimpleAuthEnvironmentVariableParams",
   SimpleAuthServiceEndpoint: "AuthServiceEndpoint",

--- a/packages/fx-core/src/plugins/resource/aad/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/aad/plugin.ts
@@ -4,6 +4,7 @@
 import { AzureSolutionSettings, LogProvider, PluginContext } from "@microsoft/teamsfx-api";
 import { AadResult, ResultFactory } from "./results";
 import {
+  ConfigUtils,
   PostProvisionConfig,
   ProvisionConfig,
   SetApplicationInContextConfig,
@@ -62,15 +63,18 @@ export class AadAppForTeamsImpl {
     const skip: boolean = ctx.config.get(ConfigKeys.skip) as boolean;
     if (skip) {
       ctx.logProvider?.info(Messages.getLog(Messages.SkipProvision));
+
       if (
-        ctx.config.get(Utils.addLocalDebugPrefix(isLocalDebug, ConfigKeys.objectId)) &&
-        ctx.config.get(Utils.addLocalDebugPrefix(isLocalDebug, ConfigKeys.clientId)) &&
-        ctx.config.get(Utils.addLocalDebugPrefix(isLocalDebug, ConfigKeys.clientSecret)) &&
-        ctx.config.get(Utils.addLocalDebugPrefix(isLocalDebug, ConfigKeys.oauth2PermissionScopeId))
+        ConfigUtils.getAadConfig(ctx, ConfigKeys.objectId, isLocalDebug) &&
+        ConfigUtils.getAadConfig(ctx, ConfigKeys.clientId, isLocalDebug) &&
+        ConfigUtils.getAadConfig(ctx, ConfigKeys.clientSecret, isLocalDebug) &&
+        ConfigUtils.getAadConfig(ctx, ConfigKeys.oauth2PermissionScopeId, isLocalDebug)
       ) {
         const config: ProvisionConfig = new ProvisionConfig(isLocalDebug);
-        config.oauth2PermissionScopeId = ctx.config.get(
-          Utils.addLocalDebugPrefix(isLocalDebug, ConfigKeys.oauth2PermissionScopeId)
+        config.oauth2PermissionScopeId = ConfigUtils.getAadConfig(
+          ctx,
+          ConfigKeys.oauth2PermissionScopeId,
+          isLocalDebug
         ) as string;
         config.saveConfigIntoContext(ctx, TokenProvider.tenantId as string);
         Utils.addLogAndTelemetryWithLocalDebug(

--- a/packages/fx-core/src/plugins/resource/aad/utils/common.ts
+++ b/packages/fx-core/src/plugins/resource/aad/utils/common.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { LogProvider } from "@microsoft/teamsfx-api";
+import { LogProvider, PluginContext } from "@microsoft/teamsfx-api";
 import { Constants, Messages } from "../constants";
 import { TelemetryUtils } from "./telemetry";
 

--- a/packages/fx-core/src/plugins/resource/aad/utils/configs.ts
+++ b/packages/fx-core/src/plugins/resource/aad/utils/configs.ts
@@ -14,14 +14,6 @@ import {
   LocalSettingsFrontendKeys,
 } from "../../../../common/localSettingsConstants";
 
-// function checkAndSaveConfig(context: PluginContext, key: string, value: ConfigValue) {
-//   if (!value) {
-//     return;
-//   }
-
-//   context.config.set(key, value);
-// }
-
 export class ConfigUtils {
   public static getAadConfig(
     ctx: PluginContext,

--- a/packages/fx-core/src/plugins/resource/aad/utils/configs.ts
+++ b/packages/fx-core/src/plugins/resource/aad/utils/configs.ts
@@ -8,14 +8,84 @@ import { format, Formats } from "./format";
 import { Utils } from "./common";
 import { ResultFactory } from "../results";
 import { v4 as uuidv4 } from "uuid";
-import { getArmOutput, isArmSupportEnabled } from "../../../../common";
+import { getArmOutput, isArmSupportEnabled, isMultiEnvEnabled } from "../../../../common";
+import {
+  LocalSettingsBotKeys,
+  LocalSettingsFrontendKeys,
+} from "../../../../common/localSettingsConstants";
 
-function checkAndSaveConfig(context: PluginContext, key: string, value: ConfigValue) {
-  if (!value) {
-    return;
+// function checkAndSaveConfig(context: PluginContext, key: string, value: ConfigValue) {
+//   if (!value) {
+//     return;
+//   }
+
+//   context.config.set(key, value);
+// }
+
+export class ConfigUtils {
+  public static getAadConfig(
+    ctx: PluginContext,
+    key: string,
+    isLocalDebug = false
+  ): string | undefined {
+    if (isLocalDebug) {
+      if (isMultiEnvEnabled()) {
+        return ctx.localSettings?.auth?.get(key) as string;
+      } else {
+        return ctx.config?.get(Utils.addLocalDebugPrefix(true, key)) as string;
+      }
+    } else {
+      return ctx.config?.get(key) as string;
+    }
   }
 
-  context.config.set(key, value);
+  public static getLocalDebugConfigOfOtherPlugins(
+    ctx: PluginContext,
+    key: string
+  ): string | undefined {
+    const isMultiEnvEnable: boolean = isMultiEnvEnabled();
+    switch (key) {
+      case ConfigKeysOfOtherPlugin.localDebugTabDomain:
+        return isMultiEnvEnable
+          ? ctx.localSettings?.frontend?.get(LocalSettingsFrontendKeys.TabDomain)
+          : ctx.configOfOtherPlugins.get(Plugins.localDebug)?.get(key);
+      case ConfigKeysOfOtherPlugin.localDebugTabEndpoint:
+        return isMultiEnvEnable
+          ? ctx.localSettings?.frontend?.get(LocalSettingsFrontendKeys.TabEndpoint)
+          : ctx.configOfOtherPlugins.get(Plugins.localDebug)?.get(key);
+      case ConfigKeysOfOtherPlugin.localDebugBotEndpoint:
+        return isMultiEnvEnable
+          ? ctx.localSettings?.bot?.get(LocalSettingsBotKeys.BotEndpoint)
+          : ctx.configOfOtherPlugins.get(Plugins.localDebug)?.get(key);
+      case ConfigKeysOfOtherPlugin.teamsBotIdLocal:
+        return isMultiEnvEnable
+          ? ctx.localSettings?.bot?.get(LocalSettingsBotKeys.BotId)
+          : ctx.configOfOtherPlugins.get(Plugins.teamsBot)?.get(key);
+      default:
+        return undefined;
+    }
+  }
+
+  public static checkAndSaveConfig(
+    ctx: PluginContext,
+    key: string,
+    value: ConfigValue,
+    isLocalDebug = false
+  ) {
+    if (!value) {
+      return;
+    }
+
+    if (isLocalDebug) {
+      if (isMultiEnvEnabled()) {
+        ctx.localSettings?.auth?.set(key, value);
+      } else {
+        ctx.config.set(Utils.addLocalDebugPrefix(true, key), value);
+      }
+    } else {
+      ctx.config.set(key, value);
+    }
+  }
 }
 
 export class ProvisionConfig {
@@ -57,15 +127,19 @@ export class ProvisionConfig {
       );
     }
 
-    const objectId: ConfigValue = ctx.config.get(
-      Utils.addLocalDebugPrefix(this.isLocalDebug, ConfigKeys.objectId)
+    const objectId: ConfigValue = ConfigUtils.getAadConfig(
+      ctx,
+      ConfigKeys.objectId,
+      this.isLocalDebug
     );
     if (objectId) {
       this.objectId = objectId as string;
     }
 
-    const clientSecret: ConfigValue = ctx.config.get(
-      Utils.addLocalDebugPrefix(this.isLocalDebug, ConfigKeys.clientSecret)
+    const clientSecret: ConfigValue = ConfigUtils.getAadConfig(
+      ctx,
+      ConfigKeys.clientSecret,
+      this.isLocalDebug
     );
     if (clientSecret) {
       this.password = clientSecret as string;
@@ -75,35 +149,26 @@ export class ProvisionConfig {
   public saveConfigIntoContext(ctx: PluginContext, tenantId: string): void {
     const oauthAuthority = ProvisionConfig.getOauthAuthority(tenantId);
 
-    checkAndSaveConfig(
+    ConfigUtils.checkAndSaveConfig(ctx, ConfigKeys.clientId, this.clientId, this.isLocalDebug);
+    ConfigUtils.checkAndSaveConfig(ctx, ConfigKeys.clientSecret, this.password, this.isLocalDebug);
+    ConfigUtils.checkAndSaveConfig(ctx, ConfigKeys.objectId, this.objectId, this.isLocalDebug);
+    ConfigUtils.checkAndSaveConfig(
       ctx,
-      Utils.addLocalDebugPrefix(this.isLocalDebug, ConfigKeys.clientId),
-      this.clientId
+      ConfigKeys.oauth2PermissionScopeId,
+      this.oauth2PermissionScopeId,
+      this.isLocalDebug
     );
-    checkAndSaveConfig(
+    ConfigUtils.checkAndSaveConfig(ctx, ConfigKeys.tenantId, tenantId, this.isLocalDebug);
+
+    ConfigUtils.checkAndSaveConfig(
       ctx,
-      Utils.addLocalDebugPrefix(this.isLocalDebug, ConfigKeys.clientSecret),
-      this.password
+      ConfigKeys.teamsMobileDesktopAppId,
+      Constants.teamsMobileDesktopAppId
     );
-    checkAndSaveConfig(
-      ctx,
-      Utils.addLocalDebugPrefix(this.isLocalDebug, ConfigKeys.objectId),
-      this.objectId
-    );
-    checkAndSaveConfig(
-      ctx,
-      Utils.addLocalDebugPrefix(this.isLocalDebug, ConfigKeys.oauth2PermissionScopeId),
-      this.oauth2PermissionScopeId
-    );
-    checkAndSaveConfig(ctx, ConfigKeys.teamsMobileDesktopAppId, Constants.teamsMobileDesktopAppId);
-    checkAndSaveConfig(
-      ctx,
-      Utils.addLocalDebugPrefix(this.isLocalDebug, ConfigKeys.tenantId),
-      tenantId
-    );
-    checkAndSaveConfig(ctx, ConfigKeys.oauthHost, Constants.oauthAuthorityPrefix);
-    checkAndSaveConfig(ctx, ConfigKeys.teamsWebAppId, Constants.teamsWebAppId);
-    checkAndSaveConfig(ctx, ConfigKeys.oauthAuthority, oauthAuthority);
+
+    ConfigUtils.checkAndSaveConfig(ctx, ConfigKeys.oauthHost, Constants.oauthAuthorityPrefix);
+    ConfigUtils.checkAndSaveConfig(ctx, ConfigKeys.teamsWebAppId, Constants.teamsWebAppId);
+    ConfigUtils.checkAndSaveConfig(ctx, ConfigKeys.oauthAuthority, oauthAuthority);
   }
 
   private static getOauthAuthority(tenantId: string): string {
@@ -131,9 +196,10 @@ export class SetApplicationInContextConfig {
         frontendDomain = getArmOutput(ctx, ConfigKeysOfOtherPlugin.frontendHostingDomainArm);
       } else {
         frontendDomain = this.isLocalDebug
-          ? ctx.configOfOtherPlugins
-              .get(Plugins.localDebug)
-              ?.get(ConfigKeysOfOtherPlugin.localDebugTabDomain)
+          ? ConfigUtils.getLocalDebugConfigOfOtherPlugins(
+              ctx,
+              ConfigKeysOfOtherPlugin.localDebugTabDomain
+            )
           : ctx.configOfOtherPlugins
               .get(Plugins.frontendHosting)
               ?.get(ConfigKeysOfOtherPlugin.frontendHostingDomain);
@@ -144,14 +210,16 @@ export class SetApplicationInContextConfig {
     }
 
     const botId: ConfigValue = this.isLocalDebug
-      ? ctx.configOfOtherPlugins.get(Plugins.teamsBot)?.get(ConfigKeysOfOtherPlugin.teamsBotIdLocal)
+      ? ConfigUtils.getLocalDebugConfigOfOtherPlugins(ctx, ConfigKeysOfOtherPlugin.teamsBotIdLocal)
       : ctx.configOfOtherPlugins.get(Plugins.teamsBot)?.get(ConfigKeysOfOtherPlugin.teamsBotId);
     if (botId) {
       this.botId = format(botId as string, Formats.UUID);
     }
 
-    const clientId: ConfigValue = ctx.config.get(
-      Utils.addLocalDebugPrefix(this.isLocalDebug, ConfigKeys.clientId)
+    const clientId: ConfigValue = ConfigUtils.getAadConfig(
+      ctx,
+      ConfigKeys.clientId,
+      this.isLocalDebug
     );
     if (clientId) {
       this.clientId = clientId as string;
@@ -164,10 +232,11 @@ export class SetApplicationInContextConfig {
   }
 
   public saveConfigIntoContext(ctx: PluginContext): void {
-    checkAndSaveConfig(
+    ConfigUtils.checkAndSaveConfig(
       ctx,
-      Utils.addLocalDebugPrefix(this.isLocalDebug, ConfigKeys.applicationIdUri),
-      this.applicationIdUri
+      ConfigKeys.applicationIdUri,
+      this.applicationIdUri,
+      this.isLocalDebug
     );
   }
 }
@@ -192,9 +261,10 @@ export class PostProvisionConfig {
         frontendEndpoint = getArmOutput(ctx, ConfigKeysOfOtherPlugin.frontendHostingEndpointArm);
       } else {
         frontendEndpoint = this.isLocalDebug
-          ? ctx.configOfOtherPlugins
-              .get(Plugins.localDebug)
-              ?.get(ConfigKeysOfOtherPlugin.localDebugTabEndpoint)
+          ? ConfigUtils.getLocalDebugConfigOfOtherPlugins(
+              ctx,
+              ConfigKeysOfOtherPlugin.localDebugTabEndpoint
+            )
           : ctx.configOfOtherPlugins
               .get(Plugins.frontendHosting)
               ?.get(ConfigKeysOfOtherPlugin.frontendHostingEndpoint);
@@ -205,9 +275,10 @@ export class PostProvisionConfig {
     }
 
     const botEndpoint: ConfigValue = this.isLocalDebug
-      ? ctx.configOfOtherPlugins
-          .get(Plugins.localDebug)
-          ?.get(ConfigKeysOfOtherPlugin.localDebugBotEndpoint)
+      ? ConfigUtils.getLocalDebugConfigOfOtherPlugins(
+          ctx,
+          ConfigKeysOfOtherPlugin.localDebugBotEndpoint
+        )
       : ctx.configOfOtherPlugins
           .get(Plugins.teamsBot)
           ?.get(ConfigKeysOfOtherPlugin.teamsBotEndpoint);
@@ -215,8 +286,10 @@ export class PostProvisionConfig {
       this.botEndpoint = format(botEndpoint as string, Formats.Endpoint);
     }
 
-    const objectId: ConfigValue = ctx.config.get(
-      Utils.addLocalDebugPrefix(this.isLocalDebug, ConfigKeys.objectId)
+    const objectId: ConfigValue = ConfigUtils.getAadConfig(
+      ctx,
+      ConfigKeys.objectId,
+      this.isLocalDebug
     );
     if (objectId) {
       this.objectId = objectId as string;
@@ -227,8 +300,10 @@ export class PostProvisionConfig {
       );
     }
 
-    const applicationIdUri: ConfigValue = ctx.config.get(
-      Utils.addLocalDebugPrefix(this.isLocalDebug, ConfigKeys.applicationIdUri)
+    const applicationIdUri: ConfigValue = ConfigUtils.getAadConfig(
+      ctx,
+      ConfigKeys.applicationIdUri,
+      this.isLocalDebug
     );
     if (applicationIdUri) {
       this.applicationIdUri = applicationIdUri as string;
@@ -253,8 +328,10 @@ export class UpdatePermissionConfig {
   }
 
   public async restoreConfigFromContext(ctx: PluginContext): Promise<void> {
-    const objectId: ConfigValue = ctx.config.get(
-      Utils.addLocalDebugPrefix(this.isLocalDebug, ConfigKeys.objectId)
+    const objectId: ConfigValue = ConfigUtils.getAadConfig(
+      ctx,
+      ConfigKeys.objectId,
+      this.isLocalDebug
     );
     if (objectId) {
       this.objectId = objectId as string;


### PR DESCRIPTION
If multi-env feature flag is enabled, AAD plugin will use `localSettings.json` to read/write local debug related configuration. Otherwise, the local debug config logic remains the same as original.
