### PR TITLE
fix(local-debug): improve local debug experience

### DIFF
--- a/packages/cli/src/cmds/preview/npmLogHandler.ts
+++ b/packages/cli/src/cmds/preview/npmLogHandler.ts
@@ -7,6 +7,8 @@ import * as path from "path";
 import { cpUtils } from "./depsChecker/cpUtils";
 
 export interface NpmInstallLogInfo {
+  logFile: string;
+  timestamp: Date;
   nodeVersion: string | undefined;
   npmVersion: string | undefined;
   cwd: string | undefined;
@@ -53,6 +55,9 @@ export async function getNpmInstallLogInfo(): Promise<NpmInstallLogInfo | undefi
     if (latestNpmLogFile === undefined) {
       return undefined;
     }
+    const latestNpmLogFileName = path.basename(latestNpmLogFile);
+    const str = latestNpmLogFileName.replace(/_/g, ":");
+    const timestamp = new Date(`${str.slice(0, 19)}.${str.slice(20, 24)}`);
     const log = (await fs.readFile(latestNpmLogFile)).toString();
 
     const nodePattern = /\d+\s+verbose\s+node\s+(v.*)/;
@@ -80,6 +85,8 @@ export async function getNpmInstallLogInfo(): Promise<NpmInstallLogInfo | undefi
       : undefined;
 
     const npmInstallLogInfo: NpmInstallLogInfo = {
+      logFile: latestNpmLogFile,
+      timestamp,
       nodeVersion,
       npmVersion,
       cwd,

--- a/packages/fx-core/src/plugins/resource/localdebug/tasks.ts
+++ b/packages/fx-core/src/plugins/resource/localdebug/tasks.ts
@@ -90,9 +90,6 @@ export function generateTasks(
           options: {
             cwd: "${workspaceFolder}/api",
           },
-          presentation: {
-            reveal: "silent",
-          },
           dependsOn: "backend extensions install",
         },
         {
@@ -228,9 +225,6 @@ export function generateTasks(
           command: "npm install",
           options: {
             cwd: "${workspaceFolder}/api",
-          },
-          presentation: {
-            reveal: "silent",
           },
           dependsOn: "backend extensions install",
         },

--- a/packages/vscode-extension/src/debug/constants.ts
+++ b/packages/vscode-extension/src/debug/constants.ts
@@ -56,8 +56,8 @@ export const botPorts: [number, string[]][] = [
   [9239, hosts],
 ];
 
-export const npmInstall = "npmInstall";
-export const npmInstallErrorMessage= "NPM install encountered an error. Please refer to the output window for detailed error information or click 'Report Issue' button to report the issue.";
+export const npmInstallFailedHintMessage =
+  "Task '%s' failed. Please refer to the '%s' terminal window for detailed error information or click 'Report Issue' button to report the issue.";
 export const issueLink = "https://github.com/OfficeDev/TeamsFx/issues/new?";
 export const issueTemplate = `
 **Describe the bug**

--- a/packages/vscode-extension/src/debug/npmLogHandler.ts
+++ b/packages/vscode-extension/src/debug/npmLogHandler.ts
@@ -7,6 +7,8 @@ import * as path from "path";
 import { cpUtils } from "./depsChecker/cpUtils";
 
 export interface NpmInstallLogInfo {
+  logFile: string;
+  timestamp: Date;
   nodeVersion: string | undefined;
   npmVersion: string | undefined;
   cwd: string | undefined;
@@ -53,6 +55,9 @@ export async function getNpmInstallLogInfo(): Promise<NpmInstallLogInfo | undefi
     if (latestNpmLogFile === undefined) {
       return undefined;
     }
+    const latestNpmLogFileName = path.basename(latestNpmLogFile);
+    const str = latestNpmLogFileName.replace(/_/g, ":");
+    const timestamp = new Date(`${str.slice(0, 19)}.${str.slice(20, 24)}`);
     const log = (await fs.readFile(latestNpmLogFile)).toString();
 
     const nodePattern = /\d+\s+verbose\s+node\s+(v.*)/;
@@ -80,6 +85,8 @@ export async function getNpmInstallLogInfo(): Promise<NpmInstallLogInfo | undefi
       : undefined;
 
     const npmInstallLogInfo: NpmInstallLogInfo = {
+      logFile: latestNpmLogFile,
+      timestamp,
       nodeVersion,
       npmVersion,
       cwd,

--- a/packages/vscode-extension/src/debug/teamsfxTaskHandler.ts
+++ b/packages/vscode-extension/src/debug/teamsfxTaskHandler.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { ProductName, SystemError } from "@microsoft/teamsfx-api";
+import { ProductName } from "@microsoft/teamsfx-api";
 import * as vscode from "vscode";
 
 import { getLocalTeamsAppId } from "./commonUtils";
@@ -10,16 +10,12 @@ import { ExtTelemetry } from "../telemetry/extTelemetry";
 import { TelemetryEvent, TelemetryProperty } from "../telemetry/extTelemetryEvents";
 import { getTeamsAppId } from "../utils/commonUtils";
 import { isValidProject } from "@microsoft/teamsfx-core";
-import { getNpmInstallLogInfo, NpmInstallLogInfo } from "./npmLogHandler";
+import { getNpmInstallLogInfo } from "./npmLogHandler";
 import * as path from "path";
-import { showError } from "../handlers";
-import {
-  errorDetail,
-  issueLink,
-  issueTemplate,
-  npmInstall,
-  npmInstallErrorMessage,
-} from "./constants";
+import { errorDetail, issueLink, issueTemplate, npmInstallFailedHintMessage } from "./constants";
+import * as StringResources from "../resources/Strings.json";
+import * as util from "util";
+import VsCodeLogInstance from "../commonlib/log";
 
 interface IRunningTeamsfxTask {
   source: string;
@@ -101,6 +97,7 @@ function onDidStartTaskProcessHandler(event: vscode.TaskProcessStartEvent): void
 }
 
 async function onDidEndTaskProcessHandler(event: vscode.TaskProcessEndEvent): Promise<void> {
+  const timestamp = new Date();
   const task = event.execution.task;
   const activeTerminal = vscode.window.activeTerminal;
 
@@ -128,10 +125,7 @@ async function onDidEndTaskProcessHandler(event: vscode.TaskProcessEndEvent): Pr
         cwd = path.join(ext.workspaceUri.fsPath, cwdOption?.replace("${workspaceFolder}/", ""));
       }
       const npmInstallLogInfo = await getNpmInstallLogInfo();
-      const properties: { [key: string]: string } = {
-        [TelemetryProperty.DebugNpmInstallName]: task.name,
-        [TelemetryProperty.DebugNpmInstallExitCode]: event.exitCode + "", // "undefined" or number value
-      };
+      let validNpmInstallLogInfo = false;
       if (
         cwd !== undefined &&
         npmInstallLogInfo?.cwd !== undefined &&
@@ -139,33 +133,45 @@ async function onDidEndTaskProcessHandler(event: vscode.TaskProcessEndEvent): Pr
         event.exitCode !== undefined &&
         npmInstallLogInfo.exitCode === event.exitCode
       ) {
+        const timeDiff = timestamp.getTime() - npmInstallLogInfo.timestamp.getTime();
+        if (timeDiff >= 0 && timeDiff <= 20000) {
+          validNpmInstallLogInfo = true;
+        }
+      }
+      const properties: { [key: string]: string } = {
+        [TelemetryProperty.DebugNpmInstallName]: task.name,
+        [TelemetryProperty.DebugNpmInstallExitCode]: event.exitCode + "", // "undefined" or number value
+      };
+      if (validNpmInstallLogInfo) {
         properties[TelemetryProperty.DebugNpmInstallNodeVersion] =
           npmInstallLogInfo?.nodeVersion + ""; // "undefined" or string value
         properties[TelemetryProperty.DebugNpmInstallNpmVersion] =
           npmInstallLogInfo?.npmVersion + ""; // "undefined" or string value
         properties[TelemetryProperty.DebugNpmInstallErrorMessage] =
-          npmInstallLogInfo.errorMessage?.join("\n") + ""; // "undefined" or string value
+          npmInstallLogInfo?.errorMessage?.join("\n") + ""; // "undefined" or string value
       }
       ExtTelemetry.sendTelemetryEvent(TelemetryEvent.DebugNpmInstall, properties);
 
       if (cwd !== undefined && event.exitCode !== undefined && event.exitCode !== 0) {
-        terminateAllRunningTeamsfxTasks();
-        if (npmInstallLogInfo !== undefined) {
-          await showError(
-            new SystemError(
-              npmInstall,
-              npmInstallErrorMessage,
-              task.name,
-              issueTemplate + errorDetail + JSON.stringify(npmInstallLogInfo),
-              issueLink,
-              npmInstallLogInfo
-            )
-          );
-        } else {
-          await showError(
-            new SystemError(npmInstall, npmInstallErrorMessage, task.name, issueTemplate, issueLink)
-          );
+        let url = `${issueLink}title=new+bug+report: Task '${task.name}' failed&body=${issueTemplate}`;
+        if (validNpmInstallLogInfo) {
+          url = `${url}${errorDetail}${JSON.stringify(npmInstallLogInfo, undefined, 4)}`;
         }
+        const issue = {
+          title: StringResources.vsc.handlers.reportIssue,
+          run: async (): Promise<void> => {
+            vscode.commands.executeCommand("vscode.open", vscode.Uri.parse(url));
+          },
+        };
+        vscode.window
+          .showErrorMessage(util.format(npmInstallFailedHintMessage, task.name, task.name), issue)
+          .then(async (button) => {
+            await button?.run();
+          });
+        await VsCodeLogInstance.error(
+          util.format(npmInstallFailedHintMessage, task.name, task.name)
+        );
+        terminateAllRunningTeamsfxTasks();
       }
     } catch {
       // ignore any error


### PR DESCRIPTION
- remove silent config for backend install task since we already have switching running terminal function
- make npm install failed hint message clearer
- check the time difference between the timestamp of npm install log and when the task stops

Fix https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/10523883

![image](https://user-images.githubusercontent.com/37978464/128460039-d2bc3231-154b-45c1-ba21-d1b17d8dc75d.png)

![image](https://user-images.githubusercontent.com/37978464/128459756-9320048d-2c2c-4c29-8f01-1c7bb0149ce2.png)
