### PR TITLE
refactor(localdebug): use localSettings in AppStudio plugin for local debug

### DIFF
--- a/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
@@ -72,7 +72,8 @@ import AdmZip from "adm-zip";
 import * as fs from "fs-extra";
 import { getTemplatesFolder } from "../../..";
 import path from "path";
-import { getArmOutput, isArmSupportEnabled } from "../../../common";
+import { getArmOutput, isArmSupportEnabled, isMultiEnvEnabled } from "../../../common";
+import { LocalSettingsTeamsAppKeys } from "../../../common/localSettingsConstants";
 
 export class AppStudioPluginImpl {
   public async getAppDefinitionAndUpdate(
@@ -99,9 +100,9 @@ export class AppStudioPluginImpl {
 
       appDefinition = maybeAppDefinition.value[0];
 
-      const localTeamsAppID = ctx.configOfOtherPlugins
-        .get("solution")
-        ?.get(LOCAL_DEBUG_TEAMS_APP_ID) as string;
+      const localTeamsAppID = isMultiEnvEnabled()
+        ? ctx.localSettings?.teamsApp.get(LocalSettingsTeamsAppKeys.TeamsAppId)
+        : (ctx.configOfOtherPlugins.get("solution")?.get(LOCAL_DEBUG_TEAMS_APP_ID) as string);
 
       let createIfNotExist = false;
       if (!localTeamsAppID) {


### PR DESCRIPTION
If multi-env feature flag is enabled, AppStudio plugin will use `localSettings.json` to read/write local debug related configuration. Otherwise, the local debug config logic remains the same as original.