### PR TITLE
refactor(localdebug): update localdebug plugin and UX(ext&cli) to use localSettings

### DIFF
--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -722,6 +722,8 @@ export interface ProjectConfig {
     // (undocumented)
     config?: SolutionConfig;
     // (undocumented)
+    localSettings?: LocalSettings;
+    // (undocumented)
     settings?: ProjectSettings;
 }
 

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -172,4 +172,5 @@ export interface Inputs extends Json {
 export interface ProjectConfig {
   settings?: ProjectSettings;
   config?: SolutionConfig;
+  localSettings?: LocalSettings;
 }

--- a/packages/cli/src/cmds/preview/commonUtils.ts
+++ b/packages/cli/src/cmds/preview/commonUtils.ts
@@ -5,7 +5,13 @@
 
 import * as path from "path";
 import * as fs from "fs-extra";
-import { ConfigFolderName, FxError, IProgressHandler, LogLevel } from "@microsoft/teamsfx-api";
+import {
+  ConfigFolderName,
+  Func,
+  FxError,
+  IProgressHandler,
+  LogLevel,
+} from "@microsoft/teamsfx-api";
 import * as dotenv from "dotenv";
 import * as net from "net";
 
@@ -22,6 +28,8 @@ import {
 import { getNpmInstallLogInfo } from "./npmLogHandler";
 import { ServiceLogWriter } from "./serviceLogWriter";
 import open from "open";
+import { FxCore, isMultiEnvEnabled } from "@microsoft/teamsfx-core";
+import { getSystemInputs } from "../../utils";
 
 export async function openBrowser(browser: constants.Browser, url: string): Promise<void> {
   switch (browser) {
@@ -177,6 +185,7 @@ export function createTaskStopCb(
 }
 
 async function getLocalEnv(
+  core: FxCore,
   workspaceFolder: string,
   prefix = ""
 ): Promise<{ [key: string]: string } | undefined> {
@@ -185,12 +194,32 @@ async function getLocalEnv(
     `.${ConfigFolderName}`,
     constants.localEnvFileName
   );
-  if (!(await fs.pathExists(localEnvFilePath))) {
-    return undefined;
-  }
+  let env: { [name: string]: string };
 
-  const contents = await fs.readFile(localEnvFilePath);
-  const env: dotenv.DotenvParseOutput = dotenv.parse(contents);
+  if (isMultiEnvEnabled()) {
+    // use localSettings.json as input to generate the local debug envs
+    const func: Func = {
+      namespace: "fx-solution-azure/fx-resource-local-debug",
+      method: "getLocalDebugEnvs",
+    };
+    const inputs = getSystemInputs();
+    inputs.ignoreLock = true;
+    inputs.ignoreConfigPersist = true;
+    const result = await core.executeUserTask(func, inputs);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    env = result.value as Record<string, string>;
+  } else {
+    // use local.env file as input to generate the local debug envs
+    if (!(await fs.pathExists(localEnvFilePath))) {
+      return undefined;
+    }
+
+    const contents = await fs.readFile(localEnvFilePath);
+    env = dotenv.parse(contents);
+  }
 
   const result: { [key: string]: string } = {};
   for (const key of Object.keys(env)) {
@@ -202,33 +231,40 @@ async function getLocalEnv(
 }
 
 export async function getFrontendLocalEnv(
+  core: FxCore,
   workspaceFolder: string
 ): Promise<{ [key: string]: string } | undefined> {
-  return getLocalEnv(workspaceFolder, constants.frontendLocalEnvPrefix);
+  return getLocalEnv(core, workspaceFolder, constants.frontendLocalEnvPrefix);
 }
 
 export async function getBackendLocalEnv(
+  core: FxCore,
   workspaceFolder: string
 ): Promise<{ [key: string]: string } | undefined> {
-  return getLocalEnv(workspaceFolder, constants.backendLocalEnvPrefix);
+  return getLocalEnv(core, workspaceFolder, constants.backendLocalEnvPrefix);
 }
 
 export async function getAuthLocalEnv(
+  core: FxCore,
   workspaceFolder: string
 ): Promise<{ [key: string]: string } | undefined> {
   // SERVICE_PATH will also be included, but it has no side effect
-  return getLocalEnv(workspaceFolder, constants.authLocalEnvPrefix);
+  return getLocalEnv(core, workspaceFolder, constants.authLocalEnvPrefix);
 }
 
-export async function getAuthServicePath(workspaceFolder: string): Promise<string | undefined> {
-  const result = await getLocalEnv(workspaceFolder);
+export async function getAuthServicePath(
+  core: FxCore,
+  workspaceFolder: string
+): Promise<string | undefined> {
+  const result = await getLocalEnv(core, workspaceFolder);
   return result ? result[constants.authServicePathEnvKey] : undefined;
 }
 
 export async function getBotLocalEnv(
+  core: FxCore,
   workspaceFolder: string
 ): Promise<{ [key: string]: string } | undefined> {
-  return getLocalEnv(workspaceFolder, constants.botLocalEnvPrefix);
+  return getLocalEnv(core, workspaceFolder, constants.botLocalEnvPrefix);
 }
 
 async function detectPortListeningImpl(port: number, host: string): Promise<boolean> {

--- a/packages/cli/src/cmds/preview/constants.ts
+++ b/packages/cli/src/cmds/preview/constants.ts
@@ -40,6 +40,9 @@ export const teamsAppTenantIdConfigKey = "teamsAppTenantId";
 export const remoteTeamsAppIdConfigKey = "remoteTeamsAppId";
 export const localTeamsAppIdConfigKey = "localDebugTeamsAppId";
 
+export const localSettingsTenantIdConfigKey = "tenantId";
+export const localSettingsTeamsAppIdConfigKey = "teamsAppId";
+
 export const spfxFolderName = "SPFx";
 export const frontendFolderName = "tabs";
 export const backendFolderName = "api";

--- a/packages/fx-core/.nycrc
+++ b/packages/fx-core/.nycrc
@@ -7,6 +7,7 @@
   ],
   "exclude": [
       "src/plugins/resource/function/utils/depsChecker/**/*"
+      "src/plugins/resourcelocaldebug/legacyPlugin.ts"
   ],
   "reporter": [
     "text",

--- a/packages/fx-core/.nycrc
+++ b/packages/fx-core/.nycrc
@@ -6,7 +6,7 @@
     "src/**/*.js"
   ],
   "exclude": [
-      "src/plugins/resource/function/utils/depsChecker/**/*"
+      "src/plugins/resource/function/utils/depsChecker/**/*",
       "src/plugins/resource/localdebug/legacyPlugin.ts"
   ],
   "reporter": [

--- a/packages/fx-core/.nycrc
+++ b/packages/fx-core/.nycrc
@@ -7,7 +7,7 @@
   ],
   "exclude": [
       "src/plugins/resource/function/utils/depsChecker/**/*"
-      "src/plugins/resourcelocaldebug/legacyPlugin.ts"
+      "src/plugins/resource/localdebug/legacyPlugin.ts"
   ],
   "reporter": [
     "text",

--- a/packages/fx-core/src/plugins/resource/localdebug/legacyPlugin.ts
+++ b/packages/fx-core/src/plugins/resource/localdebug/legacyPlugin.ts
@@ -1,0 +1,287 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+"use strict";
+
+import {
+  AzureSolutionSettings,
+  err,
+  FxError,
+  ok,
+  Platform,
+  PluginContext,
+  Result,
+  VsCodeEnv,
+} from "@microsoft/teamsfx-api";
+import { LocalCertificateManager } from "./certificate";
+import {
+  AadPlugin,
+  BotPlugin,
+  FrontendHostingPlugin,
+  FunctionPlugin,
+  LocalDebugConfigKeys,
+  LocalEnvAuthKeys,
+  LocalEnvBackendKeys,
+  LocalEnvBotKeys,
+  LocalEnvCertKeys,
+  LocalEnvFrontendKeys,
+  RuntimeConnectorPlugin,
+  SolutionPlugin,
+} from "./constants";
+import { LocalEnvProvider } from "./localEnv";
+import { getCodespaceName, getCodespaceUrl } from "./util/codespace";
+import {
+  InvalidLocalBotEndpointFormat,
+  LocalBotEndpointNotConfigured,
+  NgrokTunnelNotConnected,
+} from "./util/error";
+import { prepareLocalAuthService } from "./util/localService";
+import { getNgrokHttpUrl } from "./util/ngrok";
+import { TelemetryEventName, TelemetryUtils } from "./util/telemetry";
+
+export class legacyLocalDebugPlugin {
+  public static async localDebug(ctx: PluginContext): Promise<Result<any, FxError>> {
+    const vscEnv = ctx.answers?.vscodeEnv;
+    const selectedPlugins = (ctx.projectSettings?.solutionSettings as AzureSolutionSettings)
+      ?.activeResourcePlugins;
+    const includeFrontend = selectedPlugins?.some(
+      (pluginName) => pluginName === FrontendHostingPlugin.Name
+    );
+    const includeBackend = selectedPlugins?.some(
+      (pluginName) => pluginName === FunctionPlugin.Name
+    );
+    const includeBot = selectedPlugins?.some((pluginName) => pluginName === BotPlugin.Name);
+    let skipNgrok = ctx.config?.get(LocalDebugConfigKeys.SkipNgrok) as string;
+
+    const telemetryProperties = {
+      platform: ctx.answers?.platform as string,
+      vscenv: vscEnv as string,
+      frontend: includeFrontend ? "true" : "false",
+      function: includeBackend ? "true" : "false",
+      bot: includeBot ? "true" : "false",
+      "skip-ngrok": skipNgrok,
+    };
+    TelemetryUtils.init(ctx);
+    TelemetryUtils.sendStartEvent(TelemetryEventName.localDebug, telemetryProperties);
+
+    // setup configs used by other plugins
+    // TODO: dynamicly determine local ports
+    if (ctx.answers?.platform === Platform.VSCode || ctx.answers?.platform === Platform.CLI) {
+      let localTabEndpoint: string;
+      let localTabDomain: string;
+      let localAuthEndpoint: string;
+      let localFuncEndpoint: string;
+
+      if (vscEnv === VsCodeEnv.codespaceBrowser || vscEnv === VsCodeEnv.codespaceVsCode) {
+        const codespaceName = await getCodespaceName();
+
+        localTabEndpoint = getCodespaceUrl(codespaceName, 3000);
+        localTabDomain = new URL(localTabEndpoint).host;
+        localAuthEndpoint = getCodespaceUrl(codespaceName, 5000);
+        localFuncEndpoint = getCodespaceUrl(codespaceName, 7071);
+      } else {
+        localTabDomain = "localhost";
+        localTabEndpoint = "https://localhost:3000";
+        localAuthEndpoint = "http://localhost:5000";
+        localFuncEndpoint = "http://localhost:7071";
+      }
+
+      ctx.config.set(LocalDebugConfigKeys.LocalAuthEndpoint, localAuthEndpoint);
+
+      if (includeFrontend) {
+        ctx.config.set(LocalDebugConfigKeys.LocalTabEndpoint, localTabEndpoint);
+        ctx.config.set(LocalDebugConfigKeys.LocalTabDomain, localTabDomain);
+      }
+
+      if (includeBackend) {
+        ctx.config.set(LocalDebugConfigKeys.LocalFunctionEndpoint, localFuncEndpoint);
+      }
+
+      if (includeBot) {
+        if (skipNgrok === undefined) {
+          skipNgrok = "false";
+          ctx.config.set(LocalDebugConfigKeys.SkipNgrok, skipNgrok);
+        }
+        if (skipNgrok?.trim().toLowerCase() === "true") {
+          const localBotEndpoint = ctx.config.get(LocalDebugConfigKeys.LocalBotEndpoint) as string;
+          if (localBotEndpoint === undefined) {
+            const error = LocalBotEndpointNotConfigured();
+            TelemetryUtils.sendErrorEvent(TelemetryEventName.localDebug, error);
+            return err(error);
+          }
+          const botEndpointRegex = /https:\/\/.*(:\d+)?/g;
+          if (!botEndpointRegex.test(localBotEndpoint)) {
+            const error = InvalidLocalBotEndpointFormat(localBotEndpoint);
+            TelemetryUtils.sendErrorEvent(TelemetryEventName.localDebug, error);
+            return err(error);
+          }
+          ctx.config.set(LocalDebugConfigKeys.LocalBotEndpoint, localBotEndpoint);
+          ctx.config.set(LocalDebugConfigKeys.LocalBotDomain, localBotEndpoint.slice(8));
+        } else {
+          const ngrokHttpUrl = await getNgrokHttpUrl(3978);
+          if (!ngrokHttpUrl) {
+            const error = NgrokTunnelNotConnected();
+            TelemetryUtils.sendErrorEvent(TelemetryEventName.localDebug, error);
+            return err(error);
+          } else {
+            ctx.config.set(LocalDebugConfigKeys.LocalBotEndpoint, ngrokHttpUrl);
+            ctx.config.set(LocalDebugConfigKeys.LocalBotDomain, ngrokHttpUrl.slice(8));
+          }
+        }
+      }
+    }
+
+    TelemetryUtils.sendSuccessEvent(TelemetryEventName.localDebug, telemetryProperties);
+    return ok(undefined);
+  }
+
+  public static async postLocalDebug(ctx: PluginContext): Promise<Result<any, FxError>> {
+    const selectedPlugins = (ctx.projectSettings?.solutionSettings as AzureSolutionSettings)
+      ?.activeResourcePlugins;
+    const includeFrontend = selectedPlugins?.some(
+      (pluginName) => pluginName === FrontendHostingPlugin.Name
+    );
+    const includeBackend = selectedPlugins?.some(
+      (pluginName) => pluginName === FunctionPlugin.Name
+    );
+    const includeBot = selectedPlugins?.some((pluginName) => pluginName === BotPlugin.Name);
+    let trustDevCert = ctx.config?.get(LocalDebugConfigKeys.TrustDevelopmentCertificate) as string;
+
+    const telemetryProperties = {
+      platform: ctx.answers?.platform as string,
+      frontend: includeFrontend ? "true" : "false",
+      function: includeBackend ? "true" : "false",
+      bot: includeBot ? "true" : "false",
+      "trust-development-certificate": trustDevCert,
+    };
+    TelemetryUtils.init(ctx);
+    TelemetryUtils.sendStartEvent(TelemetryEventName.postLocalDebug, telemetryProperties);
+
+    if (ctx.answers?.platform === Platform.VSCode || ctx.answers?.platform === Platform.CLI) {
+      const localEnvProvider = new LocalEnvProvider(ctx.root);
+      const localEnvs = await localEnvProvider.loadLocalEnv(
+        includeFrontend,
+        includeBackend,
+        includeBot
+      );
+
+      // configs
+      const localDebugConfigs = ctx.config;
+      const aadConfigs = ctx.configOfOtherPlugins.get(AadPlugin.Name);
+      const runtimeConnectorConfigs = ctx.configOfOtherPlugins.get(RuntimeConnectorPlugin.Name);
+      const solutionConfigs = ctx.configOfOtherPlugins.get(SolutionPlugin.Name);
+      const clientId = aadConfigs?.get(AadPlugin.LocalClientId) as string;
+      const clientSecret = aadConfigs?.get(AadPlugin.LocalClientSecret) as string;
+      const teamsAppTenantId = solutionConfigs?.get(SolutionPlugin.TeamsAppTenantId) as string;
+      const teamsMobileDesktopAppId = aadConfigs?.get(AadPlugin.TeamsMobileDesktopAppId) as string;
+      const teamsWebAppId = aadConfigs?.get(AadPlugin.TeamsWebAppId) as string;
+      const localAuthPackagePath = runtimeConnectorConfigs?.get(
+        RuntimeConnectorPlugin.FilePath
+      ) as string;
+
+      if (includeFrontend) {
+        // frontend local envs
+        localEnvs[LocalEnvFrontendKeys.TeamsFxEndpoint] = localDebugConfigs.get(
+          LocalDebugConfigKeys.LocalAuthEndpoint
+        ) as string;
+        localEnvs[LocalEnvFrontendKeys.LoginUrl] = `${
+          localDebugConfigs.get(LocalDebugConfigKeys.LocalTabEndpoint) as string
+        }/auth-start.html`;
+        localEnvs[LocalEnvFrontendKeys.ClientId] = clientId;
+
+        // auth local envs (auth is only required by frontend)
+        localEnvs[LocalEnvAuthKeys.ClientId] = clientId;
+        localEnvs[LocalEnvAuthKeys.ClientSecret] = clientSecret;
+        localEnvs[LocalEnvAuthKeys.IdentifierUri] = aadConfigs?.get(
+          AadPlugin.LocalAppIdUri
+        ) as string;
+        localEnvs[
+          LocalEnvAuthKeys.AadMetadataAddress
+        ] = `https://login.microsoftonline.com/${teamsAppTenantId}/v2.0/.well-known/openid-configuration`;
+        localEnvs[
+          LocalEnvAuthKeys.OauthAuthority
+        ] = `https://login.microsoftonline.com/${teamsAppTenantId}`;
+        localEnvs[LocalEnvAuthKeys.TabEndpoint] = localDebugConfigs.get(
+          LocalDebugConfigKeys.LocalTabEndpoint
+        ) as string;
+        localEnvs[LocalEnvAuthKeys.AllowedAppIds] = [teamsMobileDesktopAppId, teamsWebAppId].join(
+          ";"
+        );
+        localEnvs[LocalEnvAuthKeys.ServicePath] = await prepareLocalAuthService(
+          localAuthPackagePath
+        );
+
+        if (includeBackend) {
+          localEnvs[LocalEnvFrontendKeys.FuncEndpoint] = localDebugConfigs.get(
+            LocalDebugConfigKeys.LocalFunctionEndpoint
+          ) as string;
+          localEnvs[LocalEnvFrontendKeys.FuncName] = ctx.configOfOtherPlugins
+            .get(FunctionPlugin.Name)
+            ?.get(FunctionPlugin.DefaultFunctionName) as string;
+
+          // function local envs
+          localEnvs[LocalEnvBackendKeys.ClientId] = clientId;
+          localEnvs[LocalEnvBackendKeys.ClientSecret] = clientSecret;
+          localEnvs[LocalEnvBackendKeys.AuthorityHost] = "https://login.microsoftonline.com";
+          localEnvs[LocalEnvBackendKeys.TenantId] = teamsAppTenantId;
+          localEnvs[LocalEnvBackendKeys.ApiEndpoint] = localDebugConfigs.get(
+            LocalDebugConfigKeys.LocalFunctionEndpoint
+          ) as string;
+          localEnvs[LocalEnvBackendKeys.ApplicationIdUri] = aadConfigs?.get(
+            AadPlugin.LocalAppIdUri
+          ) as string;
+          localEnvs[LocalEnvBackendKeys.AllowedAppIds] = [
+            teamsMobileDesktopAppId,
+            teamsWebAppId,
+          ].join(";");
+        }
+
+        // local certificate
+        try {
+          if (trustDevCert === undefined) {
+            trustDevCert = "true";
+            ctx.config.set(LocalDebugConfigKeys.TrustDevelopmentCertificate, trustDevCert);
+          }
+          const needTrust = trustDevCert.trim().toLowerCase() === "true";
+          const certManager = new LocalCertificateManager(ctx);
+          const localCert = await certManager.setupCertificate(needTrust);
+          if (localCert) {
+            localEnvs[LocalEnvCertKeys.SslCrtFile] = localCert.certPath;
+            localEnvs[LocalEnvCertKeys.SslKeyFile] = localCert.keyPath;
+          }
+        } catch (error) {
+          // do not break if cert error
+        }
+      }
+
+      if (includeBot) {
+        // bot local env
+        const botConfigs = ctx.configOfOtherPlugins.get(BotPlugin.Name);
+        localEnvs[LocalEnvBotKeys.BotId] = botConfigs?.get(BotPlugin.LocalBotId) as string;
+        localEnvs[LocalEnvBotKeys.BotPassword] = botConfigs?.get(
+          BotPlugin.LocalBotPassword
+        ) as string;
+        localEnvs[LocalEnvBotKeys.ClientId] = clientId;
+        localEnvs[LocalEnvBotKeys.ClientSecret] = clientSecret;
+        localEnvs[LocalEnvBotKeys.TenantID] = teamsAppTenantId;
+        localEnvs[LocalEnvBotKeys.OauthAuthority] = "https://login.microsoftonline.com";
+        localEnvs[LocalEnvBotKeys.LoginEndpoint] = `${
+          localDebugConfigs.get(LocalDebugConfigKeys.LocalBotEndpoint) as string
+        }/auth-start.html`;
+        localEnvs[LocalEnvBotKeys.ApplicationIdUri] = aadConfigs?.get(
+          AadPlugin.LocalAppIdUri
+        ) as string;
+
+        if (includeBackend) {
+          localEnvs[LocalEnvBackendKeys.ApiEndpoint] = localDebugConfigs.get(
+            LocalDebugConfigKeys.LocalFunctionEndpoint
+          ) as string;
+        }
+      }
+
+      await localEnvProvider.saveLocalEnv(localEnvs);
+    }
+
+    TelemetryUtils.sendSuccessEvent(TelemetryEventName.postLocalDebug, telemetryProperties);
+    return ok(undefined);
+  }
+}

--- a/packages/vscode-extension/src/debug/commonUtils.ts
+++ b/packages/vscode-extension/src/debug/commonUtils.ts
@@ -12,7 +12,7 @@ import * as net from "net";
 import { ext } from "../extensionVariables";
 import { getActiveEnv } from "../utils/commonUtils";
 import { initializeFocusRects } from "@fluentui/utilities";
-import { isValidProject } from "@microsoft/teamsfx-core";
+import { isMultiEnvEnabled, isValidProject } from "@microsoft/teamsfx-core";
 
 export async function getProjectRoot(
   folderPath: string,
@@ -34,12 +34,20 @@ async function getLocalEnv(prefix = ""): Promise<{ [key: string]: string } | und
     `.${ConfigFolderName}`,
     constants.localEnvFileName
   );
-  if (!(await fs.pathExists(localEnvFilePath))) {
-    return undefined;
-  }
 
-  const contents = await fs.readFile(localEnvFilePath);
-  const env: dotenv.DotenvParseOutput = dotenv.parse(contents);
+  let env: { [name: string]: string };
+  if (isMultiEnvEnabled()) {
+    // use localSettings.json as input to generate the local debug envs
+    env = await getLocalDebugEnvs();
+  } else {
+    // use local.env file as input to generate the local debug envs
+    if (!(await fs.pathExists(localEnvFilePath))) {
+      return undefined;
+    }
+
+    const contents = await fs.readFile(localEnvFilePath);
+    env = dotenv.parse(contents);
+  }
 
   const result: { [key: string]: string } = {};
   for (const key of Object.keys(env)) {
@@ -92,32 +100,29 @@ export async function hasTeamsfxBackend(): Promise<boolean> {
   return backendRoot !== undefined;
 }
 
+export async function getLocalDebugEnvs(): Promise<Record<string, string>> {
+  const localDebugEnvs = await executeLocalDebugUserTask("getLocalDebugEnvs");
+  return localDebugEnvs as Record<string, string>;
+}
+
 export async function getLocalDebugTeamsAppId(
   isLocalSideloadingConfiguration: boolean
 ): Promise<string | undefined> {
-  const func: Func = {
-    namespace: "fx-solution-azure/fx-resource-local-debug",
-    method: "getLaunchInput",
-    params: isLocalSideloadingConfiguration ? "local" : "remote"
-  };
-  try {
-    const inputs = getSystemInputs();
-    inputs.ignoreLock = true;
-    inputs.ignoreConfigPersist = true;
-    const result = await core.executeUserTask(func, inputs);
-    if (result.isErr()) {
-      throw result.error;
-    }
-    return result.value as string;
-  } catch (err) {
-    await showError(err);
-  }
+  const params = isLocalSideloadingConfiguration ? "local" : "remote";
+  const localDebugTeamsAppId = await executeLocalDebugUserTask("getLaunchInput", params);
+  return localDebugTeamsAppId as string;
 }
 
 export async function getProgrammingLanguage(): Promise<string | undefined> {
+  const programmingLanguage = await executeLocalDebugUserTask("getProgrammingLanguage");
+  return programmingLanguage as string;
+}
+
+async function executeLocalDebugUserTask(funcName: string, params?: unknown): Promise<any> {
   const func: Func = {
     namespace: "fx-solution-azure/fx-resource-local-debug",
-    method: "getProgrammingLanguage",
+    method: funcName,
+    params,
   };
   try {
     const inputs = getSystemInputs();
@@ -127,7 +132,7 @@ export async function getProgrammingLanguage(): Promise<string | undefined> {
     if (result.isErr()) {
       throw result.error;
     }
-    return result.value as string;
+    return result.value;
   } catch (err) {
     await showError(err);
   }
@@ -154,8 +159,18 @@ async function getLocalDebugConfig(key: string): Promise<string | undefined> {
   return configs[key];
 }
 
-export async function getSkipNgrokConfig(): Promise<string | undefined> {
-  return getLocalDebugConfig(constants.skipNgrokConfigKey);
+export async function getSkipNgrokConfig(): Promise<boolean> {
+  if (isMultiEnvEnabled()) {
+    const skipNgrok = (await executeLocalDebugUserTask("getSkipNgrokConfig")) as boolean;
+    return skipNgrok;
+  } else {
+    const skipNgrokConfig = await getLocalDebugConfig(constants.skipNgrokConfigKey);
+    if (skipNgrokConfig === undefined || skipNgrokConfig.length === 0) {
+      return false;
+    } else {
+      return skipNgrokConfig.trim().toLocaleLowerCase() === "true";
+    }
+  }
 }
 
 async function detectPortListeningImpl(port: number, host: string): Promise<boolean> {

--- a/packages/vscode-extension/src/debug/teamsfxTaskProvider.ts
+++ b/packages/vscode-extension/src/debug/teamsfxTaskProvider.ts
@@ -186,8 +186,7 @@ export class TeamsfxTaskProvider implements vscode.TaskProvider {
     const command: string = constants.ngrokStartCommand;
     definition = definition || { type: TeamsfxTaskProvider.type, command };
     let commandLine = "npx ngrok http 3978 --log=stdout";
-    const skipNgrokConfig = await commonUtils.getSkipNgrokConfig();
-    const skipNgrok = skipNgrokConfig && skipNgrokConfig.trim().toLocaleLowerCase() === "true";
+    const skipNgrok = await commonUtils.getSkipNgrokConfig();
     if (skipNgrok) {
       commandLine = "echo 'Do not start ngrok, but use predefined bot endpoint.'";
     }


### PR DESCRIPTION
## Changes:
If `TEAMSFX_MULTI_ENV` feature flag is enabled:
- LocalDebug plugin will use `localSettings` to read/write configurations for local debug.
- The `local.env` file will not be used in `post-localdebug` to persist the environment variables passed to UX layer. Instead, we maintain these local envs in-memory, and expose an user task to invoke by the toolkit extension.
- Extension and CLI will use the `localSetings.json` file  as the source-of-truth to read configuration for local debug.

Otherwise:
- The local debug behavior keeps the same as original, which still uses `env.default.json`, `local.env`, `default.userdata` to run local debug.

**NOTE**: To make this PR more friendly to be reviewed, I copy the [original `localDebug` & `postLocalDebug`](https://github.com/OfficeDev/TeamsFx/blob/dev/packages/fx-core/src/plugins/resource/localdebug/index.ts#L193) lifecycle API implementation to `legacyPlugin.ts`, so you can skip reviewing this file @kuojianlu @swatDong. 