### PR TITLE
chore(multi-env): support user input for target env

### DIFF
--- a/packages/fx-core/src/core/environment.ts
+++ b/packages/fx-core/src/core/environment.ts
@@ -1,15 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import {
-  ConfigFolderName,
-  CryptoProvider,
-  err,
-  FxError,
-  ok,
-  Result,
-  Void,
-} from "@microsoft/teamsfx-api";
+import { ConfigFolderName, CryptoProvider, err, FxError, ok, Result } from "@microsoft/teamsfx-api";
 import path from "path";
 import fs from "fs-extra";
 import {
@@ -36,7 +28,8 @@ export interface EnvFiles {
 
 class EnvironmentManager {
   public readonly defaultEnvName = "default";
-  private readonly envNameRegex = /env\.(?<envName>[\w\d-_]+)\.json/i;
+  public readonly envNameRegex = /^[\w\d-_]+$/;
+  public readonly envProfileNameRegex = /env\.(?<envName>[\w\d-_]+)\.json/i;
 
   public async loadEnvProfile(
     projectPath: string,
@@ -56,9 +49,9 @@ class EnvironmentManager {
     const userData = userDataResult.value;
 
     if (!(await fs.pathExists(envFiles.envProfile))) {
-      // TODO: handle the case that env file profile doesn't exist.
-      return err(PathNotExistError(envFiles.envProfile));
+      return ok({ envName, data: new Map<string, any>() });
     }
+
     const envData = await fs.readJson(envFiles.envProfile);
 
     mergeSerectData(userData, envData);
@@ -128,7 +121,7 @@ class EnvironmentManager {
   }
 
   private getEnvNameFromPath(filePath: string): string | null {
-    const match = this.envNameRegex.exec(filePath);
+    const match = this.envProfileNameRegex.exec(filePath);
     if (match != null && match.groups != null) {
       return match.groups.envName;
     }

--- a/packages/fx-core/src/core/environment.ts
+++ b/packages/fx-core/src/core/environment.ts
@@ -1,7 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { ConfigFolderName, CryptoProvider, err, FxError, ok, Result } from "@microsoft/teamsfx-api";
+import {
+  ConfigFolderName,
+  ConfigMap,
+  CryptoProvider,
+  err,
+  FxError,
+  ok,
+  Result,
+} from "@microsoft/teamsfx-api";
 import path from "path";
 import fs from "fs-extra";
 import {
@@ -15,6 +23,7 @@ import {
   mapToJson,
   objectToMap,
 } from "..";
+import { GLOBAL_CONFIG } from "../plugins/solution/fx-solution/constants";
 
 export interface EnvInfo {
   envName: string;
@@ -49,7 +58,9 @@ class EnvironmentManager {
     const userData = userDataResult.value;
 
     if (!(await fs.pathExists(envFiles.envProfile))) {
-      return ok({ envName, data: new Map<string, any>() });
+      const data = new Map<string, any>([[GLOBAL_CONFIG, new ConfigMap()]]);
+
+      return ok({ envName, data });
     }
 
     const envData = await fs.readJson(envFiles.envProfile);

--- a/packages/fx-core/src/core/error.ts
+++ b/packages/fx-core/src/core/error.ts
@@ -131,11 +131,19 @@ export function ContextUpgradeError(error: any): FxError {
   );
 }
 
-
 export function PluginHasNoTaskImpl(pluginName: string, task: string){
   return new SystemError(
     "PluginHasNoTaskImplError",
     `Plugin ${pluginName} has not implemented method: ${task}`,
+    CoreSource,
+    new Error().stack
+  );
+}
+
+export function ProjectSettingsUndefinedError(): FxError {
+  return new SystemError(
+    "ProjectSettingsUndefinedError",
+    "Project settings is undefined",
     CoreSource,
     new Error().stack
   );

--- a/packages/fx-core/src/core/index.ts
+++ b/packages/fx-core/src/core/index.ts
@@ -31,7 +31,12 @@ import {
   AppPackageFolderName,
 } from "@microsoft/teamsfx-api";
 import * as path from "path";
-import { downloadSampleHook, fetchCodeZip, saveFilesRecursively } from "../common/tools";
+import {
+  downloadSampleHook,
+  fetchCodeZip,
+  isMultiEnvEnabled,
+  saveFilesRecursively,
+} from "../common/tools";
 import {
   CoreQuestionNames,
   ProjectNamePattern,
@@ -296,7 +301,7 @@ export class FxCore implements Core {
     ErrorHandlerMW,
     ConcurrentLockerMW,
     ProjectSettingsLoaderMW,
-    EnvInfoLoaderMW,
+    EnvInfoLoaderMW(isMultiEnvEnabled(), true),
     SolutionLoaderMW(defaultSolutionLoader),
     QuestionModelMW,
     ContextInjecterMW,
@@ -311,7 +316,7 @@ export class FxCore implements Core {
     ErrorHandlerMW,
     ConcurrentLockerMW,
     ProjectSettingsLoaderMW,
-    EnvInfoLoaderMW,
+    EnvInfoLoaderMW(isMultiEnvEnabled(), false),
     SolutionLoaderMW(defaultSolutionLoader),
     QuestionModelMW,
     ContextInjecterMW,
@@ -327,7 +332,7 @@ export class FxCore implements Core {
     ConcurrentLockerMW,
     ProjectUpgraderMW,
     ProjectSettingsLoaderMW,
-    EnvInfoLoaderMW,
+    EnvInfoLoaderMW(false, false),
     LocalSettingsLoaderMW,
     SolutionLoaderMW(defaultSolutionLoader),
     QuestionModelMW,
@@ -344,7 +349,7 @@ export class FxCore implements Core {
     ErrorHandlerMW,
     ConcurrentLockerMW,
     ProjectSettingsLoaderMW,
-    EnvInfoLoaderMW,
+    EnvInfoLoaderMW(isMultiEnvEnabled(), false),
     SolutionLoaderMW(defaultSolutionLoader),
     QuestionModelMW,
     ContextInjecterMW,
@@ -359,7 +364,7 @@ export class FxCore implements Core {
     ErrorHandlerMW,
     ConcurrentLockerMW,
     ProjectSettingsLoaderMW,
-    EnvInfoLoaderMW,
+    EnvInfoLoaderMW(isMultiEnvEnabled(), false),
     LocalSettingsLoaderMW,
     SolutionLoaderMW(defaultSolutionLoader),
     QuestionModelMW,
@@ -387,7 +392,7 @@ export class FxCore implements Core {
   @hooks([
     ErrorHandlerMW,
     ProjectSettingsLoaderMW,
-    EnvInfoLoaderMW,
+    EnvInfoLoaderMW(false, false),
     SolutionLoaderMW(defaultSolutionLoader),
     ContextInjecterMW,
     EnvInfoWriterMW,
@@ -416,7 +421,7 @@ export class FxCore implements Core {
   @hooks([
     ErrorHandlerMW,
     ProjectSettingsLoaderMW,
-    EnvInfoLoaderMW,
+    EnvInfoLoaderMW(false, false),
     SolutionLoaderMW(defaultSolutionLoader),
     ContextInjecterMW,
     EnvInfoWriterMW,
@@ -437,7 +442,12 @@ export class FxCore implements Core {
     return await this._getQuestionsForUserTask(solutionContext, solution, func, inputs);
   }
 
-  @hooks([ErrorHandlerMW, ProjectSettingsLoaderMW, EnvInfoLoaderMW, ContextInjecterMW])
+  @hooks([
+    ErrorHandlerMW,
+    ProjectSettingsLoaderMW,
+    EnvInfoLoaderMW(false, false),
+    ContextInjecterMW,
+  ])
   async getProjectConfig(
     inputs: Inputs,
     ctx?: CoreHookContext
@@ -452,7 +462,7 @@ export class FxCore implements Core {
   @hooks([
     ErrorHandlerMW,
     ProjectSettingsLoaderMW,
-    EnvInfoLoaderMW,
+    EnvInfoLoaderMW(false, false),
     ContextInjecterMW,
     ProjectSettingsWriterMW,
     EnvInfoWriterMW,
@@ -557,7 +567,7 @@ export class FxCore implements Core {
             description: "",
             author: "",
             scripts: {
-              test: 'echo "Error: no test specified" && exit 1',
+              test: "echo \"Error: no test specified\" && exit 1",
             },
             devDependencies: {
               "@microsoft/teamsfx-cli": "0.*",
@@ -581,7 +591,7 @@ export class FxCore implements Core {
   @hooks([
     ErrorHandlerMW,
     ProjectSettingsLoaderMW,
-    EnvInfoLoaderMW,
+    EnvInfoLoaderMW(false, false),
     ContextInjecterMW,
     EnvInfoWriterMW,
   ])
@@ -596,7 +606,7 @@ export class FxCore implements Core {
   @hooks([
     ErrorHandlerMW,
     ProjectSettingsLoaderMW,
-    EnvInfoLoaderMW,
+    EnvInfoLoaderMW(false, false),
     ContextInjecterMW,
     EnvInfoWriterMW,
   ])

--- a/packages/fx-core/src/core/middleware/envInfoLoader.ts
+++ b/packages/fx-core/src/core/middleware/envInfoLoader.ts
@@ -7,52 +7,76 @@ import {
   Inputs,
   ok,
   ProjectSettings,
+  QTreeNode,
   Result,
   SolutionConfig,
   SolutionContext,
   Tools,
+  traverse,
 } from "@microsoft/teamsfx-api";
 import { CoreHookContext, FxCore } from "../..";
-import { NoProjectOpenedError } from "../error";
+import { NoProjectOpenedError, ProjectSettingsUndefinedError } from "../error";
 import { Middleware, NextFunction } from "@feathersjs/hooks/lib";
 import { LocalCrypto } from "../crypto";
 import { environmentManager } from "../environment";
 import { GLOBAL_CONFIG, PROGRAMMING_LANGUAGE } from "../../plugins/solution/fx-solution/constants";
+import { QuestionSelectTargetEnvironment, QuestionNewTargetEnvironmentName } from "../question";
+import { desensitize } from "./questionModel";
+import { shouldIgnored } from "./projectSettingsLoader";
 
-export const EnvInfoLoaderMW: Middleware = async (ctx: CoreHookContext, next: NextFunction) => {
-  if (ctx.projectSettings) {
+const newTargetEnvNameOption = "+ new environment";
+
+export function EnvInfoLoaderMW(
+  isMultiEnvEnabled: boolean,
+  allowCreateNewEnv: boolean
+): Middleware {
+  return async (ctx: CoreHookContext, next: NextFunction) => {
     const inputs = ctx.arguments[ctx.arguments.length - 1] as Inputs;
-    const core = ctx.self as FxCore;
-
-    const result = await loadSolutionContext(
-      core.tools,
-      inputs,
-      ctx.projectSettings,
-      ctx.projectIdMissing
-    );
-    if (result.isErr()) {
-      ctx.result = err(result.error);
+    if (shouldIgnored(ctx)) {
+      await next();
       return;
     }
 
-    ctx.solutionContext = result.value;
-  }
+    if (!ctx.projectSettings) {
+      ctx.result = err(ProjectSettingsUndefinedError());
+      return;
+    }
 
-  await next();
-};
+    const core = ctx.self as FxCore;
+    const targetEnvName = isMultiEnvEnabled
+      ? await askTargetEnvironment(ctx, inputs, allowCreateNewEnv)
+      : environmentManager.defaultEnvName;
+    if (targetEnvName) {
+      const result = await loadSolutionContext(
+        core.tools,
+        inputs,
+        ctx.projectSettings,
+        ctx.projectIdMissing,
+        targetEnvName
+      );
+      if (result.isErr()) {
+        ctx.result = err(result.error);
+        return;
+      }
+
+      ctx.solutionContext = result.value;
+
+      await next();
+    }
+  };
+}
 
 export async function loadSolutionContext(
   tools: Tools,
   inputs: Inputs,
   projectSettings: ProjectSettings,
-  projectIdMissing?: boolean
+  projectIdMissing?: boolean,
+  targetEnvName?: string
 ): Promise<Result<SolutionContext, FxError>> {
   if (!inputs.projectPath) {
     return err(NoProjectOpenedError());
   }
 
-  // TODO: ask user input for the target environment name with question model.
-  const targetEnvName = inputs.targetEnvName ?? environmentManager.defaultEnvName;
   const cryptoProvider = new LocalCrypto(projectSettings.projectId);
   // ensure backwards compatibility:
   // no need to decrypt the secrets in *.userdata for previous TeamsFx project, which has no project id.
@@ -90,4 +114,77 @@ export async function loadSolutionContext(
   };
 
   return ok(solutionContext);
+}
+
+async function askTargetEnvironment(
+  ctx: CoreHookContext,
+  inputs: Inputs,
+  allowCreateNewEnv: boolean
+): Promise<string | undefined> {
+  const getQuestionRes = await getQuestionsForTargetEnv(inputs, allowCreateNewEnv);
+  const core = ctx.self as FxCore;
+  if (getQuestionRes.isErr()) {
+    core.tools.logProvider.error(
+      `[core:env] failed to get questions for target environment: ${getQuestionRes.error.message}`
+    );
+    ctx.result = err(getQuestionRes.error);
+    return undefined;
+  }
+
+  core.tools.logProvider.debug(`[core:env] success to get questions for target environment.`);
+
+  const node = getQuestionRes.value;
+  if (node) {
+    const res = await traverse(node, inputs, core.tools.ui);
+    if (res.isErr()) {
+      core.tools.logProvider.debug(
+        `[core:env] failed to run question model for target environment.`
+      );
+      ctx.result = err(res.error);
+      return undefined;
+    }
+
+    const desensitized = desensitize(node, inputs);
+    core.tools.logProvider.info(
+      `[core:env] success to run question model for target environment, answers:${JSON.stringify(
+        desensitized
+      )}`
+    );
+  }
+
+  if (inputs.targetEnvName === newTargetEnvNameOption) {
+    return inputs.newTargetEnvName;
+  } else {
+    return inputs.targetEnvName;
+  }
+}
+
+async function getQuestionsForTargetEnv(
+  inputs: Inputs,
+  allowCreateNewEnv: boolean
+): Promise<Result<QTreeNode | undefined, FxError>> {
+  if (!inputs.projectPath) {
+    return err(NoProjectOpenedError());
+  }
+
+  const envProfilesResult = await environmentManager.listEnvProfiles(inputs.projectPath);
+  if (envProfilesResult.isErr()) {
+    return err(envProfilesResult.error);
+  }
+
+  const selectEnv = QuestionSelectTargetEnvironment;
+  if (allowCreateNewEnv) {
+    selectEnv.staticOptions = [newTargetEnvNameOption].concat(envProfilesResult.value);
+  } else {
+    selectEnv.staticOptions = envProfilesResult.value;
+  }
+
+  const node = new QTreeNode(selectEnv);
+
+  const childNode = new QTreeNode(QuestionNewTargetEnvironmentName);
+  childNode.condition = { equals: newTargetEnvNameOption };
+
+  node.addChild(childNode);
+
+  return ok(node.trim());
 }

--- a/packages/fx-core/src/core/middleware/envInfoWriter.ts
+++ b/packages/fx-core/src/core/middleware/envInfoWriter.ts
@@ -32,7 +32,9 @@ export const EnvInfoWriterMW: Middleware = async (ctx: CoreHookContext, next: Ne
       solutionContext.cryptoProvider
     );
 
-    const core = ctx.self as FxCore;
-    core.tools.logProvider.debug(`[core] persist env profile: ${envProfilePath}`);
+    if (envProfilePath.isOk()) {
+      const core = ctx.self as FxCore;
+      core.tools.logProvider.debug(`[core] persist env profile: ${envProfilePath.value}`);
+    }
   }
 };

--- a/packages/fx-core/src/core/question.ts
+++ b/packages/fx-core/src/core/question.ts
@@ -61,7 +61,7 @@ export const QuestionRootFolder: FolderQuestion = {
 export const QuestionSelectTargetEnvironment: SingleSelectQuestion = {
   type: "singleSelect",
   name: CoreQuestionNames.TargetEnvName,
-  title: "Select the target environment",
+  title: "Select an environment",
   staticOptions: [],
   skipSingleOption: true,
   forgetLastValue: true,
@@ -70,7 +70,7 @@ export const QuestionSelectTargetEnvironment: SingleSelectQuestion = {
 export const QuestionNewTargetEnvironmentName: TextInputQuestion = {
   type: "text",
   name: CoreQuestionNames.NewTargetEnvName,
-  title: "New target environment name",
+  title: "New environment name",
   validation: {
     validFunc: async (input: string): Promise<string | undefined> => {
       const targetEnvName = input as string;
@@ -82,7 +82,7 @@ export const QuestionNewTargetEnvironmentName: TextInputQuestion = {
       return undefined;
     },
   },
-  placeholder: "New target environment name",
+  placeholder: "New environment name",
 };
 
 export const QuestionSelectSolution: SingleSelectQuestion = {

--- a/packages/fx-core/src/core/question.ts
+++ b/packages/fx-core/src/core/question.ts
@@ -11,6 +11,7 @@ import {
 import * as jsonschema from "jsonschema";
 import * as path from "path";
 import * as fs from "fs-extra";
+import { environmentManager } from "./environment";
 
 export enum CoreQuestionNames {
   AppName = "app-name",
@@ -20,6 +21,8 @@ export enum CoreQuestionNames {
   Samples = "samples",
   Stage = "stage",
   SubStage = "substage",
+  TargetEnvName = "targetEnvName",
+  NewTargetEnvName = "newTargetEnvName",
 }
 
 export const ProjectNamePattern = "^[a-zA-Z][\\da-zA-Z]+$";
@@ -53,6 +56,33 @@ export const QuestionRootFolder: FolderQuestion = {
   type: "folder",
   name: CoreQuestionNames.Folder,
   title: "Workspace folder",
+};
+
+export const QuestionSelectTargetEnvironment: SingleSelectQuestion = {
+  type: "singleSelect",
+  name: CoreQuestionNames.TargetEnvName,
+  title: "Select the target environment",
+  staticOptions: [],
+  skipSingleOption: true,
+  forgetLastValue: true,
+};
+
+export const QuestionNewTargetEnvironmentName: TextInputQuestion = {
+  type: "text",
+  name: CoreQuestionNames.NewTargetEnvName,
+  title: "New target environment name",
+  validation: {
+    validFunc: async (input: string): Promise<string | undefined> => {
+      const targetEnvName = input as string;
+      const match = targetEnvName.match(environmentManager.envNameRegex);
+      if (!match) {
+        return "Environment name can only contain letters, digits, _ and -.";
+      }
+
+      return undefined;
+    },
+  },
+  placeholder: "New target environment name",
 };
 
 export const QuestionSelectSolution: SingleSelectQuestion = {

--- a/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
@@ -485,10 +485,6 @@ export class TeamsAppSolution implements Solution {
       return canProvision;
     }
 
-    if (!ctx.config.get(GLOBAL_CONFIG)) {
-      ctx.config.set(GLOBAL_CONFIG, new ConfigMap());
-    }
-
     const provisioned = this.checkWetherProvisionSucceeded(ctx.config);
     if (provisioned) {
       const msg = util.format(

--- a/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
@@ -484,6 +484,11 @@ export class TeamsAppSolution implements Solution {
     if (canProvision.isErr()) {
       return canProvision;
     }
+
+    if (!ctx.config.get(GLOBAL_CONFIG)) {
+      ctx.config.set(GLOBAL_CONFIG, new ConfigMap());
+    }
+
     const provisioned = this.checkWetherProvisionSucceeded(ctx.config);
     if (provisioned) {
       const msg = util.format(

--- a/packages/fx-core/tests/core/environment.test.ts
+++ b/packages/fx-core/tests/core/environment.test.ts
@@ -174,13 +174,12 @@ describe("APIs of Environment Manager", () => {
       assert.equal(envInfo.data.get("solution").get("key"), expectedSolutionConfig.key);
     });
 
-    it("expected error: environment profile doesn't exist", async () => {
+    it("environment profile doesn't exist", async () => {
       const actualEnvDataResult = await environmentManager.loadEnvProfile(projectPath);
-      assert.isTrue(actualEnvDataResult.isErr());
-      actualEnvDataResult.mapErr((error) => {
-        assert.instanceOf(error, UserError);
-        assert.isTrue(error.name === "PathNotExist");
-      });
+      if (actualEnvDataResult.isErr()) {
+        assert.fail("Error ocurrs while loading environment profile.");
+      }
+      assert.equal(actualEnvDataResult.value.envName, "default");
     });
   });
 

--- a/packages/fx-core/tests/core/hooks.test.ts
+++ b/packages/fx-core/tests/core/hooks.test.ts
@@ -422,7 +422,7 @@ describe("Middleware", () => {
         }
       }
       hooks(MyClass, {
-        other: [ProjectSettingsLoaderMW, EnvInfoLoaderMW, ContextInjecterMW],
+        other: [ProjectSettingsLoaderMW, EnvInfoLoaderMW(false, false), ContextInjecterMW],
       });
       const my = new MyClass();
       const res = await my.other(inputs);
@@ -599,7 +599,11 @@ describe("Middleware", () => {
       }
       hooks(MyClass, {
         WriteConfigTrigger: [ContextInjecterMW, ProjectSettingsWriterMW, EnvInfoWriterMW],
-        ReadConfigTrigger: [ProjectSettingsLoaderMW, EnvInfoLoaderMW, ContextInjecterMW],
+        ReadConfigTrigger: [
+          ProjectSettingsLoaderMW,
+          EnvInfoLoaderMW(false, false),
+          ContextInjecterMW,
+        ],
       });
       const my = new MyClass();
       await my.WriteConfigTrigger(inputs);


### PR DESCRIPTION
If `TEAMSFX_MULTI_ENV` feature flag is enabled, user will be asked to input the target environment when provision, deploy and publish.

Here's the gif for the new UX:
![Animation](https://user-images.githubusercontent.com/15644078/128987583-32f2dfb7-e59e-4323-befd-88e73194176f.gif)


Please note:
* the UX design is not finalized and above user behavoir might be changed in future.
* only **VS Code extension** is supported, while **CLI** is not supported at the moment.
* only projects contain **Tab** or **Function** is supported, while **Bot/SQL** is not support.