### PR TITLE
chore(arm): use target env name from context

### DIFF
--- a/packages/fx-core/src/plugins/solution/fx-solution/arm.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/arm.ts
@@ -36,7 +36,7 @@ const parameterFolder = "parameters";
 const bicepOrchestrationFileName = "main.bicep";
 const armTemplateJsonFileName = "main.json";
 const parameterTemplateFileName = "parameters.template.json";
-const parameterDefaultFileName = "parameters.default.json";
+const parameterFileNameTemplate = "parameters.@envName.json";
 const solutionLevelParameters = `param resourceBaseName string\n`;
 const solutionLevelParameterObject = {
   resourceBaseName: {
@@ -260,8 +260,13 @@ export async function deployArmTemplates(ctx: SolutionContext): Promise<Result<v
 }
 
 async function getParameterJson(ctx: SolutionContext) {
+  if (!ctx.targetEnvName) {
+    throw new Error("Failed to get target environment name from solution context.");
+  }
+
+  const parameterFileName = parameterFileNameTemplate.replace("@envName", ctx.targetEnvName);
   const parameterDir = path.join(ctx.root, baseFolder, parameterFolder);
-  const parameterDefaultFilePath = path.join(parameterDir, parameterDefaultFileName);
+  const parameterDefaultFilePath = path.join(parameterDir, parameterFileName);
   const parameterTemplateFilePath = path.join(parameterDir, parameterTemplateFileName);
   let parameterFilePath = parameterDefaultFilePath;
   try {

--- a/packages/fx-core/tests/plugins/solution/solution.arm.test.ts
+++ b/packages/fx-core/tests/plugins/solution/solution.arm.test.ts
@@ -60,6 +60,7 @@ function mockSolutionContext(): SolutionContext {
   const config: SolutionConfig = new Map();
   return {
     root: "./",
+    targetEnvName: "default",
     config,
     answers: { platform: Platform.VSCode },
     projectSettings: undefined,


### PR DESCRIPTION
Replace the hardcoded `default` env name with the target env name from context. 

- When the feature flag `TEAMSFX_MULTI_ENV` is not enabled, the target env equals to `default`.
- When the feature flag `TEAMSFX_MULTI_ENV` enabled, the target env is specified by user and would be accessed from context.