### PR TITLE
fix: make sure SystemError and UserError has stack

### DIFF
--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -631,6 +631,12 @@ export interface MultiSelectQuestion extends UserInputQuestion {
 // @public (undocumented)
 export type MultiSelectResult = InputResult<StaticOptions>;
 
+// @public (undocumented)
+export function newSystemError(source: string, name: string, message: string, issueLink?: string): SystemError;
+
+// @public (undocumented)
+export function newUserError(source: string, name: string, message: string, helpLink?: string): UserError;
+
 // @public
 export interface OptionItem {
     cliName?: string;
@@ -1045,14 +1051,11 @@ export type SubscriptionInfo = {
 };
 
 // @public
-export class SystemError implements FxError {
+export class SystemError extends Error implements FxError {
     constructor(name: string, message: string, source: string, stack?: string, issueLink?: string, innerError?: any);
     innerError?: any;
     issueLink?: string;
-    message: string;
-    name: string;
     source: string;
-    stack?: string;
     timestamp: Date;
 }
 
@@ -1222,14 +1225,11 @@ export interface UIConfig<T> {
 export const UserCancelError: UserError;
 
 // @public
-export class UserError implements FxError {
+export class UserError extends Error implements FxError {
     constructor(name: string, message: string, source: string, stack?: string, helpLink?: string, innerError?: any);
     helpLink?: string;
     innerError?: any;
-    message: string;
-    name: string;
     source: string;
-    stack?: string;
     timestamp: Date;
 }
 

--- a/packages/api/src/error.ts
+++ b/packages/api/src/error.ts
@@ -179,6 +179,9 @@ export function assembleError(e: any, source?: string): FxError {
         e
       );
       Object.assign(fxError, e);
+      if (e.stack) {
+        fxError.stack = e.stack;
+      }
       return fxError;
     }
   }

--- a/packages/api/src/error.ts
+++ b/packages/api/src/error.ts
@@ -47,7 +47,6 @@ export class UserError extends Error implements FxError {
   ) {
     super(message);
     this.name = name;
-    if (stack) this.stack = stack;
     this.source = source;
     this.timestamp = new Date();
     this.helpLink = helpLink;
@@ -87,7 +86,6 @@ export class SystemError extends Error implements FxError {
   ) {
     super(message);
     this.name = name;
-    if (stack) this.stack = stack;
     this.source = source;
     this.timestamp = new Date();
     this.issueLink = issueLink;

--- a/packages/api/src/error.ts
+++ b/packages/api/src/error.ts
@@ -46,7 +46,8 @@ export class UserError extends Error implements FxError {
     innerError?: any
   ) {
     super(message);
-    super.name = name;
+    this.name = name;
+    if (stack) this.stack = stack;
     this.source = source;
     this.timestamp = new Date();
     this.helpLink = helpLink;
@@ -85,7 +86,8 @@ export class SystemError extends Error implements FxError {
     innerError?: any
   ) {
     super(message);
-    super.name = name;
+    this.name = name;
+    if (stack) this.stack = stack;
     this.source = source;
     this.timestamp = new Date();
     this.issueLink = issueLink;

--- a/packages/api/tests/error.test.ts
+++ b/packages/api/tests/error.test.ts
@@ -39,7 +39,7 @@ describe("error", function () {
         chai.assert.equal(temp.name, myName);
         chai.assert.equal(temp.message, myMessage);
         chai.assert.equal(temp.source, mySource);
-        chai.assert.equal(temp.stack, myStack);
+        chai.assert.isTrue(temp.stack !== undefined && temp.stack.includes("error.test.ts"));
         chai.assert.equal(temp.helpLink, myHelpLink);
         chai.assert.equal(temp.innerError, myInnerError);
       });
@@ -89,7 +89,7 @@ describe("error", function () {
         chai.assert.equal(temp.name, myName);
         chai.assert.equal(temp.message, myMessage);
         chai.assert.equal(temp.source, mySource);
-        chai.assert.equal(temp.stack, myStack);
+        chai.assert.isTrue(temp.stack !== undefined && temp.stack.includes("error.test.ts"));
         chai.assert.equal(temp.issueLink, myIssueLink);
         chai.assert.equal(temp.innerError, myInnerError);
       });

--- a/packages/api/tests/error.test.ts
+++ b/packages/api/tests/error.test.ts
@@ -6,6 +6,8 @@ import "mocha";
 import {
   assembleError,
   FxError,
+  newSystemError,
+  newUserError,
   returnSystemError,
   returnUserError,
   SystemError,
@@ -29,6 +31,8 @@ describe("error", function () {
       chai.assert.equal(temp.name, myName);
       chai.assert.equal(temp.message, myMessage);
       chai.assert.equal(temp.source, mySource);
+      chai.assert.isTrue(temp.stack !== undefined && temp.stack.includes("error.test.ts"));
+      chai.assert.isDefined(temp.timestamp);
     }),
       it("happy path with more info", () => {
         const temp = new UserError(myName, myMessage, mySource, myStack, myHelpLink, myInnerError);
@@ -70,6 +74,8 @@ describe("error", function () {
       chai.assert.equal(temp.name, myName);
       chai.assert.equal(temp.message, myMessage);
       chai.assert.equal(temp.source, mySource);
+      chai.assert.isTrue(temp.stack !== undefined && temp.stack.includes("error.test.ts"));
+      chai.assert.isDefined(temp.timestamp);
     }),
       it("happy path with more info", () => {
         const temp = new SystemError(
@@ -132,27 +138,34 @@ describe("error", function () {
 
   describe("assembleError", function () {
     it("error is string", () => {
-      const fxError = assembleError("error string");
+      const fxError = assembleError(myMessage);
       chai.assert.isTrue(fxError instanceof SystemError);
-      chai.assert.isTrue(fxError.message === "error string");
+      chai.assert.isTrue(fxError.message === myMessage);
       chai.assert.isTrue(fxError.name === "Error");
       chai.assert.isTrue(fxError.source === "unknown");
+      chai.assert.isTrue(fxError.stack !== undefined && fxError.stack.includes("error.test.ts"));
     });
 
     it("error is Error", () => {
-      const fxError = assembleError(new Error("hello error"));
+      const raw = new Error(myMessage);
+      const fxError = assembleError(raw);
       chai.assert.isTrue(fxError instanceof SystemError);
-      chai.assert.isTrue(fxError.message === "hello error");
+      chai.assert.isTrue(fxError.message === myMessage);
       chai.assert.isTrue(fxError.name === "Error");
       chai.assert.isTrue(fxError.source === "unknown");
+      chai.assert.isTrue(fxError.stack !== undefined && fxError.stack.includes("error.test.ts"));
+      chai.assert.isTrue(raw === fxError.innerError);
     });
 
     it("error has source", () => {
-      const fxError = assembleError(new Error("hello error"), "API");
+      const raw = new Error(myMessage);
+      const fxError = assembleError(raw, mySource);
       chai.assert.isTrue(fxError instanceof SystemError);
-      chai.assert.isTrue(fxError.message === "hello error");
+      chai.assert.isTrue(fxError.message === myMessage);
       chai.assert.isTrue(fxError.name === "Error");
-      chai.assert.isTrue(fxError.source === "API");
+      chai.assert.isTrue(fxError.source === mySource);
+      chai.assert.isTrue(fxError.stack !== undefined && fxError.stack.includes("error.test.ts"));
+      chai.assert.isTrue(raw === fxError.innerError);
     });
 
     it("error has source", () => {
@@ -160,16 +173,49 @@ describe("error", function () {
         fs.readFileSync("12345" + new Date().getTime());
         chai.assert.fail("Should not reach here");
       } catch (e) {
-        const fxError = assembleError(e, "API");
+        const fxError = assembleError(e, mySource);
+        chai.assert.isTrue(e === fxError.innerError);
         chai.assert.isTrue(fxError instanceof SystemError);
         chai.assert.isTrue(
           fxError.message !== undefined &&
             fxError.message.includes("ENOENT: no such file or directory")
         );
         chai.assert.isTrue(fxError.name === "ENOENT");
-        chai.assert.isTrue(fxError.stack !== undefined);
-        chai.assert.isTrue(fxError.source === "API");
+        chai.assert.isTrue(fxError.source === mySource);
+        chai.assert.isTrue(fxError.stack !== undefined && fxError.stack.includes("error.test.ts"));
       }
+    });
+
+    it("error has other type", () => {
+      const raw = [1, 2, 3];
+      const fxError = assembleError(raw);
+      chai.assert.isTrue(raw === fxError.innerError);
+      chai.assert.isTrue(fxError instanceof SystemError);
+      chai.assert.isTrue(fxError.message === JSON.stringify(raw));
+      chai.assert.isTrue(fxError.stack !== undefined && fxError.stack.includes("error.test.ts"));
+    });
+  });
+  describe("newUserError", function () {
+    it("happy path", () => {
+      const error = newUserError(mySource, myName, myMessage, myHelpLink);
+      chai.assert.isTrue(error instanceof UserError);
+      chai.assert.isFalse(error instanceof SystemError);
+      chai.assert.equal(error.message, myMessage);
+      chai.assert.equal(error.name, myName);
+      chai.assert.equal(error.source, mySource);
+      chai.assert.equal(error.helpLink, myHelpLink);
+    });
+  });
+
+  describe("newSystemError", function () {
+    it("happy path", () => {
+      const error = newSystemError(mySource, myName, myMessage, myIssueLink);
+      chai.assert.isTrue(error instanceof SystemError);
+      chai.assert.isFalse(error instanceof UserError);
+      chai.assert.equal(error.message, myMessage);
+      chai.assert.equal(error.name, myName);
+      chai.assert.equal(error.source, mySource);
+      chai.assert.equal(error.issueLink, myIssueLink);
     });
   });
 });

--- a/packages/api/tests/error.test.ts
+++ b/packages/api/tests/error.test.ts
@@ -182,7 +182,7 @@ describe("error", function () {
         );
         chai.assert.isTrue(fxError.name === "ENOENT");
         chai.assert.isTrue(fxError.source === mySource);
-        chai.assert.isTrue(fxError.stack !== undefined && fxError.stack.includes("error.test.ts"));
+        chai.assert.isTrue(fxError.stack === e.stack);
       }
     });
 


### PR DESCRIPTION
When creating UserError or SystemError, the stack fields will be created automatically, user don't need to input.
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/10577820