### PR TITLE
chore(multi-env): support to display the last used env with new order

### DIFF
--- a/packages/fx-core/src/core/middleware/envInfoLoader.ts
+++ b/packages/fx-core/src/core/middleware/envInfoLoader.ts
@@ -25,6 +25,8 @@ import { desensitize } from "./questionModel";
 import { shouldIgnored } from "./projectSettingsLoader";
 
 const newTargetEnvNameOption = "+ new environment";
+const lastUsedMark = " (current)";
+let lastUsedEnvName: string | undefined;
 
 export function EnvInfoLoaderMW(
   isMultiEnvEnabled: boolean,
@@ -43,9 +45,14 @@ export function EnvInfoLoaderMW(
     }
 
     const core = ctx.self as FxCore;
-    const targetEnvName = isMultiEnvEnabled
-      ? await askTargetEnvironment(ctx, inputs, allowCreateNewEnv)
-      : environmentManager.defaultEnvName;
+    let targetEnvName: string | undefined;
+    if (isMultiEnvEnabled) {
+      targetEnvName = await askTargetEnvironment(ctx, inputs, allowCreateNewEnv, lastUsedEnvName);
+      lastUsedEnvName = targetEnvName ?? lastUsedEnvName;
+    } else {
+      targetEnvName = environmentManager.defaultEnvName;
+    }
+
     if (targetEnvName) {
       const result = await loadSolutionContext(
         core.tools,
@@ -119,9 +126,10 @@ export async function loadSolutionContext(
 async function askTargetEnvironment(
   ctx: CoreHookContext,
   inputs: Inputs,
-  allowCreateNewEnv: boolean
+  allowCreateNewEnv: boolean,
+  lastUsed?: string
 ): Promise<string | undefined> {
-  const getQuestionRes = await getQuestionsForTargetEnv(inputs, allowCreateNewEnv);
+  const getQuestionRes = await getQuestionsForTargetEnv(inputs, allowCreateNewEnv, lastUsed);
   const core = ctx.self as FxCore;
   if (getQuestionRes.isErr()) {
     core.tools.logProvider.error(
@@ -152,16 +160,20 @@ async function askTargetEnvironment(
     );
   }
 
-  if (inputs.targetEnvName === newTargetEnvNameOption) {
+  const targetEnvName = inputs.targetEnvName;
+  if (targetEnvName === newTargetEnvNameOption) {
     return inputs.newTargetEnvName;
+  } else if (targetEnvName?.endsWith(lastUsedMark)) {
+    return targetEnvName.slice(0, targetEnvName.indexOf(lastUsedMark));
   } else {
-    return inputs.targetEnvName;
+    return targetEnvName;
   }
 }
 
 async function getQuestionsForTargetEnv(
   inputs: Inputs,
-  allowCreateNewEnv: boolean
+  allowCreateNewEnv: boolean,
+  lastUsed?: string
 ): Promise<Result<QTreeNode | undefined, FxError>> {
   if (!inputs.projectPath) {
     return err(NoProjectOpenedError());
@@ -172,11 +184,12 @@ async function getQuestionsForTargetEnv(
     return err(envProfilesResult.error);
   }
 
+  const envList = reOrderEnvironments(envProfilesResult.value, lastUsed);
   const selectEnv = QuestionSelectTargetEnvironment;
   if (allowCreateNewEnv) {
-    selectEnv.staticOptions = [newTargetEnvNameOption].concat(envProfilesResult.value);
+    selectEnv.staticOptions = [newTargetEnvNameOption].concat(envList);
   } else {
-    selectEnv.staticOptions = envProfilesResult.value;
+    selectEnv.staticOptions = envList;
   }
 
   const node = new QTreeNode(selectEnv);
@@ -187,4 +200,19 @@ async function getQuestionsForTargetEnv(
   node.addChild(childNode);
 
   return ok(node.trim());
+}
+
+function reOrderEnvironments(environments: Array<string>, lastUsed?: string): Array<string> {
+  if (!lastUsed) {
+    return environments;
+  }
+
+  const index = environments.indexOf(lastUsed);
+  if (index === -1) {
+    return environments;
+  }
+
+  return [lastUsed + lastUsedMark]
+    .concat(environments.slice(0, index))
+    .concat(environments.slice(index + 1));
 }


### PR DESCRIPTION
* append `(current)` if user has choose the target env before.
* the last used env will be in the first place of all environments except for the new environment.

Please note, since the last used info won't be persisted in project, it will reset to undefined if the vscode is reopened.

**Provision**:
![image](https://user-images.githubusercontent.com/15644078/129298958-f18cbb80-bbe3-43f6-907f-185373d1a427.png)

**Deploy/Publish**:
![image](https://user-images.githubusercontent.com/15644078/129298774-95eb239d-0bd8-4f3d-9732-b2f6550a108d.png)
