### PR TITLE
fix(local-debug): add timeout to launch browser configuration

### DIFF
--- a/packages/fx-core/src/plugins/resource/localdebug/launch.ts
+++ b/packages/fx-core/src/plugins/resource/localdebug/launch.ts
@@ -27,6 +27,7 @@ export function generateConfigurations(
         group: "remote",
         order: edgeOrder,
       },
+      timeout: 20000,
     },
     {
       name: "Launch Remote (Chrome)",
@@ -37,6 +38,7 @@ export function generateConfigurations(
         group: "remote",
         order: chromeOrder,
       },
+      timeout: 20000,
     },
   ];
 
@@ -56,6 +58,7 @@ export function generateConfigurations(
             group: "all",
             hidden: true,
           },
+          timeout: 20000,
         },
         {
           name: "Start and Attach to Frontend (Chrome)",
@@ -68,6 +71,7 @@ export function generateConfigurations(
             group: "all",
             hidden: true,
           },
+          timeout: 20000,
         },
         {
           name: "Start and Attach to Backend",
@@ -95,6 +99,7 @@ export function generateConfigurations(
             group: "all",
             hidden: true,
           },
+          timeout: 20000,
         },
         {
           name: "Start and Attach to Frontend (Chrome)",
@@ -106,6 +111,7 @@ export function generateConfigurations(
             group: "all",
             hidden: true,
           },
+          timeout: 20000,
         }
       );
     }
@@ -124,6 +130,7 @@ export function generateConfigurations(
           group: "all",
           hidden: true,
         },
+        timeout: 20000,
       },
       {
         name: "Launch Bot (Chrome)",
@@ -135,6 +142,7 @@ export function generateConfigurations(
           group: "all",
           hidden: true,
         },
+        timeout: 20000,
       },
       {
         name: "Start and Attach to Bot",
@@ -167,6 +175,7 @@ export function generateConfigurations(
           group: "all",
           hidden: true,
         },
+        timeout: 20000,
       },
       {
         name: "Start and Attach to Frontend (Chrome)",
@@ -181,6 +190,7 @@ export function generateConfigurations(
           group: "all",
           hidden: true,
         },
+        timeout: 20000,
       },
       {
         name: "Start and Attach to Bot",

--- a/packages/fx-core/src/plugins/resource/localdebug/launch.ts
+++ b/packages/fx-core/src/plugins/resource/localdebug/launch.ts
@@ -27,7 +27,6 @@ export function generateConfigurations(
         group: "remote",
         order: edgeOrder,
       },
-      timeout: 20000,
     },
     {
       name: "Launch Remote (Chrome)",
@@ -38,7 +37,6 @@ export function generateConfigurations(
         group: "remote",
         order: chromeOrder,
       },
-      timeout: 20000,
     },
   ];
 
@@ -58,7 +56,6 @@ export function generateConfigurations(
             group: "all",
             hidden: true,
           },
-          timeout: 20000,
         },
         {
           name: "Start and Attach to Frontend (Chrome)",
@@ -71,7 +68,6 @@ export function generateConfigurations(
             group: "all",
             hidden: true,
           },
-          timeout: 20000,
         },
         {
           name: "Start and Attach to Backend",
@@ -99,7 +95,6 @@ export function generateConfigurations(
             group: "all",
             hidden: true,
           },
-          timeout: 20000,
         },
         {
           name: "Start and Attach to Frontend (Chrome)",
@@ -111,7 +106,6 @@ export function generateConfigurations(
             group: "all",
             hidden: true,
           },
-          timeout: 20000,
         }
       );
     }
@@ -130,7 +124,6 @@ export function generateConfigurations(
           group: "all",
           hidden: true,
         },
-        timeout: 20000,
       },
       {
         name: "Launch Bot (Chrome)",
@@ -142,7 +135,6 @@ export function generateConfigurations(
           group: "all",
           hidden: true,
         },
-        timeout: 20000,
       },
       {
         name: "Start and Attach to Bot",
@@ -175,7 +167,6 @@ export function generateConfigurations(
           group: "all",
           hidden: true,
         },
-        timeout: 20000,
       },
       {
         name: "Start and Attach to Frontend (Chrome)",
@@ -190,7 +181,6 @@ export function generateConfigurations(
           group: "all",
           hidden: true,
         },
-        timeout: 20000,
       },
       {
         name: "Start and Attach to Bot",

--- a/packages/vscode-extension/src/debug/teamsfxDebugProvider.ts
+++ b/packages/vscode-extension/src/debug/teamsfxDebugProvider.ts
@@ -5,8 +5,6 @@ import * as vscode from "vscode";
 
 import AppStudioTokenInstance from "../commonlib/appStudioLogin";
 import * as commonUtils from "./commonUtils";
-import { core, showError } from "../handlers";
-import { Func } from "@microsoft/teamsfx-api";
 
 export class TeamsfxDebugProvider implements vscode.DebugConfigurationProvider {
   public async resolveDebugConfiguration?(
@@ -35,6 +33,10 @@ export class TeamsfxDebugProvider implements vscode.DebugConfigurationProvider {
 
         if (!isLocalSideloadingConfiguration && !isSideloadingConfiguration) {
           return debugConfiguration;
+        }
+
+        if (debugConfiguration.timeout === undefined) {
+          debugConfiguration.timeout = 20000;
         }
 
         const teamsAppId = await commonUtils.getLocalDebugTeamsAppId(


### PR DESCRIPTION
- add timeout to launch browser configuration and set it to 20 seconds (default is 10 seconds) to mitigate "could not attach to main target" error

To fix: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/10576081 or #1882 