### PR TITLE
refactor: remove teamsMobileDesktopAppId and teamsWebAppId from env config

### DIFF
--- a/packages/fx-core/src/common/constants.ts
+++ b/packages/fx-core/src/common/constants.ts
@@ -2,6 +2,11 @@ export class ConstantString {
   static readonly UTF8Encoding = "utf-8";
 }
 
+export class TeamsClientId {
+  static readonly MobileDesktop = "1fec8e78-bce4-4aaf-ab1b-5451cc387264";
+  static readonly Web = "5e3ce6c0-2b1f-4285-8d4b-75ee78787346";
+}
+
 export class ResourcePlugins {
   static readonly Aad = "fx-resource-aad-app-for-teams";
   static readonly FrontendHosting = "fx-resource-frontend-hosting";
@@ -12,7 +17,6 @@ export class ResourcePlugins {
   static readonly Function = "fx-resource-function";
   static readonly Identity = "fx-resource-identity";
 }
-
 export class PluginDisplayName {
   static readonly Solution = "Teams Toolkit";
 }

--- a/packages/fx-core/src/common/localSettingsConstants.ts
+++ b/packages/fx-core/src/common/localSettingsConstants.ts
@@ -12,6 +12,8 @@ export const LocalSettingsAuthKeys = Object.freeze({
   ClientSecret: "clientSecret",
   ObjectId: "objectId",
   Oauth2PermissionScopeId: "oauth2PermissionScopeId",
+  OauthAuthority: "oauthAuthority",
+  OauthHost: "oauthHost",
   ApplicationIdUris: "applicationIdUris",
   SimpleAuthFilePath: "simpleAuthFilePath",
   SimpleAuthEnvironmentVariableParams: "SimpleAuthEnvironmentVariableParams",

--- a/packages/fx-core/src/plugins/resource/aad/utils/configs.ts
+++ b/packages/fx-core/src/plugins/resource/aad/utils/configs.ts
@@ -154,13 +154,16 @@ export class ProvisionConfig {
 
     ConfigUtils.checkAndSaveConfig(
       ctx,
-      ConfigKeys.teamsMobileDesktopAppId,
-      Constants.teamsMobileDesktopAppId
+      ConfigKeys.oauthHost,
+      Constants.oauthAuthorityPrefix,
+      this.isLocalDebug
     );
-
-    ConfigUtils.checkAndSaveConfig(ctx, ConfigKeys.oauthHost, Constants.oauthAuthorityPrefix);
-    ConfigUtils.checkAndSaveConfig(ctx, ConfigKeys.teamsWebAppId, Constants.teamsWebAppId);
-    ConfigUtils.checkAndSaveConfig(ctx, ConfigKeys.oauthAuthority, oauthAuthority);
+    ConfigUtils.checkAndSaveConfig(
+      ctx,
+      ConfigKeys.oauthAuthority,
+      oauthAuthority,
+      this.isLocalDebug
+    );
   }
 
   private static getOauthAuthority(tenantId: string): string {

--- a/packages/fx-core/src/plugins/resource/function/constants.ts
+++ b/packages/fx-core/src/plugins/resource/function/constants.ts
@@ -2,13 +2,12 @@
 // Licensed under the MIT license.
 
 import { Kind, SkuName, SkuTier } from "@azure/arm-storage/esm/models";
+import { TeamsClientId } from "../../../common/constants";
 
 import { FunctionConfigKey, FunctionLanguage, NodeVersion } from "./enums";
 
 export class CommonConstants {
   public static readonly emptyString: string = "";
-  public static readonly teamsClientAppId: string = "1fec8e78-bce4-4aaf-ab1b-5451cc387264";
-  public static readonly teamsWebAppId: string = "5e3ce6c0-2b1f-4285-8d4b-75ee78787346";
   public static readonly versionSep: string = ".";
   public static readonly msInOneSecond: number = 1000;
   public static readonly zipTimeMSGranularity: number = 2 * CommonConstants.msInOneSecond;
@@ -141,7 +140,7 @@ export class DefaultProvisionConfigs {
   });
 
   public static readonly functionAppStaticSettings: { [key: string]: string } = {
-    ALLOWED_APP_IDS: [CommonConstants.teamsClientAppId, CommonConstants.teamsWebAppId].join(";"),
+    ALLOWED_APP_IDS: [TeamsClientId.MobileDesktop, TeamsClientId.Web].join(";"),
     FUNCTIONS_EXTENSION_VERSION: "~3",
     WEBSITE_RUN_FROM_PACKAGE: "1",
   };

--- a/packages/fx-core/src/plugins/resource/function/ops/provision.ts
+++ b/packages/fx-core/src/plugins/resource/function/ops/provision.ts
@@ -13,6 +13,7 @@ import {
 import { AzureLib } from "../utils/azure-client";
 import { FunctionLanguage } from "../enums";
 import { LanguageStrategyFactory } from "../language-strategy";
+import { TeamsClientId } from "../../../../common/constants";
 
 type Site = WebSiteManagementModels.Site;
 type NameValuePair = WebSiteManagementModels.NameValuePair;
@@ -217,8 +218,8 @@ export class FunctionProvision {
     }
 
     const clientIds: string[] = extClientIds.concat([
-      CommonConstants.teamsClientAppId,
-      CommonConstants.teamsWebAppId,
+      TeamsClientId.MobileDesktop,
+      TeamsClientId.Web,
     ]);
     const rawOldClientIds: string | undefined = site.siteConfig.appSettings?.find(
       (kv: NameValuePair) => kv.name === FunctionAppSettingKeys.allowedAppIds

--- a/packages/fx-core/src/plugins/resource/localdebug/index.ts
+++ b/packages/fx-core/src/plugins/resource/localdebug/index.ts
@@ -59,6 +59,7 @@ import {
   LocalSettingsFrontendKeys,
   LocalSettingsTeamsAppKeys,
 } from "../../../common/localSettingsConstants";
+import { TeamsClientId } from "../../../common/constants";
 
 @Service(ResourcePlugins.LocalDebugPlugin)
 export class LocalDebugPlugin implements Plugin {
@@ -356,7 +357,6 @@ export class LocalDebugPlugin implements Plugin {
     const includeBot = selectedPlugins?.some((pluginName) => pluginName === BotPlugin.Name);
 
     // get config for local debug
-    const aadConfigs = ctx.configOfOtherPlugins.get(AadPlugin.Name);
     const clientId = ctx.localSettings?.auth?.get(LocalSettingsAuthKeys.ClientId) as string;
     const clientSecret = ctx.localSettings?.auth?.get(LocalSettingsAuthKeys.ClientSecret) as string;
     const applicationIdUri = ctx.localSettings?.auth?.get(
@@ -366,10 +366,8 @@ export class LocalDebugPlugin implements Plugin {
       LocalSettingsTeamsAppKeys.TenantId
     ) as string;
 
-    // TODO: since this app ids of the Teams client app (mobile/desktop/web) are fixed
-    // We can read it from constants intead of the env config file.
-    const teamsMobileDesktopAppId = aadConfigs?.get(AadPlugin.TeamsMobileDesktopAppId) as string;
-    const teamsWebAppId = aadConfigs?.get(AadPlugin.TeamsWebAppId) as string;
+    const teamsMobileDesktopAppId = TeamsClientId.MobileDesktop;
+    const teamsWebAppId = TeamsClientId.Web;
 
     const localAuthPackagePath = ctx.localSettings?.auth?.get(
       LocalSettingsAuthKeys.SimpleAuthFilePath
@@ -395,9 +393,7 @@ export class LocalDebugPlugin implements Plugin {
       localEnvs[LocalEnvAuthKeys.Urls] = localAuthEndpoint;
       localEnvs[LocalEnvAuthKeys.ClientId] = clientId;
       localEnvs[LocalEnvAuthKeys.ClientSecret] = clientSecret;
-      localEnvs[LocalEnvAuthKeys.IdentifierUri] = aadConfigs?.get(
-        AadPlugin.LocalAppIdUri
-      ) as string;
+      localEnvs[LocalEnvAuthKeys.IdentifierUri] = applicationIdUri;
       localEnvs[
         LocalEnvAuthKeys.AadMetadataAddress
       ] = `https://login.microsoftonline.com/${teamsAppTenantId}/v2.0/.well-known/openid-configuration`;

--- a/packages/fx-core/src/plugins/resource/localdebug/legacyPlugin.ts
+++ b/packages/fx-core/src/plugins/resource/localdebug/legacyPlugin.ts
@@ -12,6 +12,7 @@ import {
   Result,
   VsCodeEnv,
 } from "@microsoft/teamsfx-api";
+import { TeamsClientId } from "../../../common/constants";
 import { LocalCertificateManager } from "./certificate";
 import {
   AadPlugin,
@@ -172,8 +173,8 @@ export class legacyLocalDebugPlugin {
       const clientId = aadConfigs?.get(AadPlugin.LocalClientId) as string;
       const clientSecret = aadConfigs?.get(AadPlugin.LocalClientSecret) as string;
       const teamsAppTenantId = solutionConfigs?.get(SolutionPlugin.TeamsAppTenantId) as string;
-      const teamsMobileDesktopAppId = aadConfigs?.get(AadPlugin.TeamsMobileDesktopAppId) as string;
-      const teamsWebAppId = aadConfigs?.get(AadPlugin.TeamsWebAppId) as string;
+      const teamsMobileDesktopAppId = TeamsClientId.MobileDesktop;
+      const teamsWebAppId = TeamsClientId.Web;
       const localAuthPackagePath = runtimeConnectorConfigs?.get(
         RuntimeConnectorPlugin.FilePath
       ) as string;

--- a/packages/fx-core/src/plugins/resource/simpleauth/constants.ts
+++ b/packages/fx-core/src/plugins/resource/simpleauth/constants.ts
@@ -19,8 +19,6 @@ export class Constants {
       clientSecret: "clientSecret",
       applicationIdUris: "applicationIdUris",
       oauthAuthority: "oauthAuthority",
-      teamsMobileDesktopAppId: "teamsMobileDesktopAppId",
-      teamsWebAppId: "teamsWebAppId",
     },
   };
 

--- a/packages/fx-core/src/plugins/resource/simpleauth/utils/common.ts
+++ b/packages/fx-core/src/plugins/resource/simpleauth/utils/common.ts
@@ -23,6 +23,7 @@ import {
   LocalSettingsAuthKeys,
   LocalSettingsFrontendKeys,
 } from "../../../../common/localSettingsConstants";
+import { TeamsClientId } from "../../../../common/constants";
 export class Utils {
   public static generateResourceName(appName: string, resourceNameSuffix: string): string {
     const paddingLength =
@@ -85,22 +86,10 @@ export class Utils {
   ): { [propertyName: string]: string } {
     const clientId = this.getClientId(ctx, isLocalDebug);
     const clientSecret = this.getClientSecret(ctx, isLocalDebug);
-    const oauthAuthority = Utils.getConfigValueWithValidation(
-      ctx,
-      Constants.AadAppPlugin.id,
-      Constants.AadAppPlugin.configKeys.oauthAuthority
-    ) as string;
+    const oauthAuthority = this.getOauthAuthority(ctx, isLocalDebug);
     const applicationIdUris = this.getApplicationIdUris(ctx, isLocalDebug);
-    const teamsMobileDesktopAppId = Utils.getConfigValueWithValidation(
-      ctx,
-      Constants.AadAppPlugin.id,
-      Constants.AadAppPlugin.configKeys.teamsMobileDesktopAppId
-    ) as string;
-    const teamsWebAppId = Utils.getConfigValueWithValidation(
-      ctx,
-      Constants.AadAppPlugin.id,
-      Constants.AadAppPlugin.configKeys.teamsWebAppId
-    ) as string;
+    const teamsMobileDesktopAppId = TeamsClientId.MobileDesktop;
+    const teamsWebAppId = TeamsClientId.Web;
 
     let endpoint: string;
     if (!isArmSupportEnabled() || isLocalDebug) {
@@ -227,6 +216,27 @@ export class Utils {
     }
 
     return tabEndpoint;
+  }
+
+  private static getOauthAuthority(ctx: PluginContext, isLocalDebug: boolean): string {
+    let oauthAuthority: string;
+    if (isMultiEnvEnabled()) {
+      oauthAuthority = isLocalDebug
+        ? (ctx.localSettings?.auth?.get(LocalSettingsAuthKeys.OauthAuthority) as string)
+        : (Utils.getConfigValueWithValidation(
+            ctx,
+            Constants.AadAppPlugin.id,
+            Constants.AadAppPlugin.configKeys.oauthAuthority
+          ) as string);
+    } else {
+      oauthAuthority = Utils.getConfigValueWithValidation(
+        ctx,
+        Constants.AadAppPlugin.id,
+        Constants.AadAppPlugin.configKeys.oauthAuthority
+      ) as string;
+    }
+
+    return oauthAuthority;
   }
 
   private static getApplicationIdUris(ctx: PluginContext, isLocalDebug: boolean): string {

--- a/packages/fx-core/tests/plugins/resource/simpleauth/helper.ts
+++ b/packages/fx-core/tests/plugins/resource/simpleauth/helper.ts
@@ -94,11 +94,6 @@ export class TestHelper {
               "https://login.microsoftonline.com/mock-teamsAppTenantId",
             ],
             [
-              Constants.AadAppPlugin.configKeys.teamsMobileDesktopAppId,
-              "mock-teamsMobileDesktopAppId",
-            ],
-            [Constants.AadAppPlugin.configKeys.teamsWebAppId, "mock-teamsWebAppId"],
-            [
               Constants.LocalPrefix + Constants.AadAppPlugin.configKeys.clientId,
               "mock-local-clientId",
             ],

--- a/packages/fx-core/tests/plugins/resource/simpleauth/unit/index.test.ts
+++ b/packages/fx-core/tests/plugins/resource/simpleauth/unit/index.test.ts
@@ -19,6 +19,7 @@ import { Utils } from "../../../../../src/plugins/resource/simpleauth/utils/comm
 import { PluginContext } from "@microsoft/teamsfx-api";
 import * as uuid from "uuid";
 import { ConstantString, mockSolutionUpdateArmTemplates } from "../../util";
+import { TeamsClientId } from "../../../../../src/common/constants";
 
 chai.use(chaiAsPromised);
 
@@ -62,8 +63,7 @@ describe("simpleAuthPlugin", () => {
     ) as string;
     chai.assert.isOk(filePath);
     chai.assert.isTrue(await fs.pathExists(filePath));
-    const expectedEnvironmentVariableParams =
-      'CLIENT_ID="mock-local-clientId" CLIENT_SECRET="mock-local-clientSecret" OAUTH_AUTHORITY="https://login.microsoftonline.com/mock-teamsAppTenantId" IDENTIFIER_URI="mock-local-applicationIdUris" ALLOWED_APP_IDS="mock-teamsMobileDesktopAppId;mock-teamsWebAppId" TAB_APP_ENDPOINT="https://endpoint.mock" AAD_METADATA_ADDRESS="https://login.microsoftonline.com/mock-teamsAppTenantId/v2.0/.well-known/openid-configuration"';
+    const expectedEnvironmentVariableParams = `CLIENT_ID="mock-local-clientId" CLIENT_SECRET="mock-local-clientSecret" OAUTH_AUTHORITY="https://login.microsoftonline.com/mock-teamsAppTenantId" IDENTIFIER_URI="mock-local-applicationIdUris" ALLOWED_APP_IDS="${TeamsClientId.MobileDesktop};${TeamsClientId.Web}" TAB_APP_ENDPOINT="https://endpoint.mock" AAD_METADATA_ADDRESS="https://login.microsoftonline.com/mock-teamsAppTenantId/v2.0/.well-known/openid-configuration"`;
     chai.assert.strictEqual(
       pluginContext.config.get(Constants.SimpleAuthPlugin.configKeys.environmentVariableParams),
       expectedEnvironmentVariableParams


### PR DESCRIPTION
Current Teams toolkit persists the `teamsMobileDesktopAppId` and `teamsWebAppId` in the AAD plugin config, and other resource plugins (e.g. simpleAuth, localdebug) will read these value from the config.

```json
    "fx-resource-aad-app-for-teams": {
        "teamsMobileDesktopAppId": "1fec8e78-bce4-4aaf-ab1b-5451cc387264",
        "teamsWebAppId": "5e3ce6c0-2b1f-4285-8d4b-75ee78787346",
    },
```

As these are known constant values, we can remove them from the config and use global constants to read the values.