### PR TITLE
refactor: don't use solution config for AAD permission request

### DIFF
--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -128,6 +128,8 @@ export interface Context {
     // (undocumented)
     logProvider?: LogProvider;
     // (undocumented)
+    permissionRequestProvider?: PermissionRequestProvider;
+    // (undocumented)
     projectSettings?: ProjectSettings;
     // (undocumented)
     root: string;
@@ -648,6 +650,11 @@ export interface OptionItem {
 }
 
 // @public
+export interface PermissionRequestProvider {
+    getPermissionRequest(): Promise<Result<string, FxError>>;
+}
+
+// @public
 export enum Platform {
     // (undocumented)
     CLI = "cli",
@@ -1151,6 +1158,8 @@ export interface Tools {
     cryptoProvider?: CryptoProvider;
     // (undocumented)
     logProvider: LogProvider;
+    // (undocumented)
+    permissionRequest?: PermissionRequestProvider;
     // (undocumented)
     telemetryReporter?: TelemetryReporter;
     // (undocumented)

--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -651,6 +651,7 @@ export interface OptionItem {
 
 // @public
 export interface PermissionRequestProvider {
+    checkPermissionRequest(): Promise<Result<undefined, FxError>>;
     getPermissionRequest(): Promise<Result<string, FxError>>;
 }
 

--- a/packages/api/src/context.ts
+++ b/packages/api/src/context.ts
@@ -18,6 +18,7 @@ import {
   AzureAccountProvider,
   AppStudioTokenProvider,
   TreeProvider,
+  PermissionRequestProvider,
 } from "./utils";
 import { UserInteraction } from "./qm";
 import { CryptoProvider } from "./utils";
@@ -52,6 +53,8 @@ export interface Context {
   ui?: UserInteraction;
 
   cryptoProvider?: CryptoProvider;
+
+  permissionRequestProvider?: PermissionRequestProvider;
 }
 
 export interface SolutionContext extends Context {

--- a/packages/api/src/utils/index.ts
+++ b/packages/api/src/utils/index.ts
@@ -6,6 +6,7 @@ import { UserInteraction } from "../qm/ui";
 import { CryptoProvider } from "./crypto";
 import { LogProvider } from "./log";
 import { TokenProvider } from "./login";
+import { PermissionRequestProvider } from "./permissionRequest";
 import { TelemetryReporter } from "./telemetry";
 import { TreeProvider } from "./tree";
 
@@ -14,6 +15,7 @@ export * from "./log";
 export * from "./telemetry";
 export * from "./tree";
 export * from "./crypto";
+export * from "./permissionRequest";
 
 export interface Tools {
   logProvider: LogProvider;
@@ -22,4 +24,5 @@ export interface Tools {
   treeProvider?: TreeProvider;
   ui: UserInteraction;
   cryptoProvider?: CryptoProvider;
+  permissionRequest?: PermissionRequestProvider;
 }

--- a/packages/api/src/utils/permissionRequest.ts
+++ b/packages/api/src/utils/permissionRequest.ts
@@ -9,6 +9,11 @@ import { FxError } from "../error";
  */
 export interface PermissionRequestProvider {
   /**
+   * check if perrmission request source content exists
+   */
+  checkPermissionRequest(): Promise<Result<undefined, FxError>>;
+
+  /**
    * Load the content of the latest permission request
    */
   getPermissionRequest(): Promise<Result<string, FxError>>;

--- a/packages/api/src/utils/permissionRequest.ts
+++ b/packages/api/src/utils/permissionRequest.ts
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { Result } from "neverthrow";
+import { FxError } from "../error";
+
+/**
+ * AAD permission request provider
+ */
+export interface PermissionRequestProvider {
+  /**
+   * Load the content of the latest permission request
+   */
+  getPermissionRequest(): Promise<Result<string, FxError>>;
+}

--- a/packages/fx-core/src/core/middleware/envInfoLoader.ts
+++ b/packages/fx-core/src/core/middleware/envInfoLoader.ts
@@ -23,6 +23,7 @@ import { GLOBAL_CONFIG, PROGRAMMING_LANGUAGE } from "../../plugins/solution/fx-s
 import { QuestionSelectTargetEnvironment, QuestionNewTargetEnvironmentName } from "../question";
 import { desensitize } from "./questionModel";
 import { shouldIgnored } from "./projectSettingsLoader";
+import { PermissionRequestFileProvider } from "../permissionRequest";
 
 const newTargetEnvNameOption = "+ new environment";
 const lastUsedMark = " (current)";
@@ -118,6 +119,7 @@ export async function loadSolutionContext(
     ...tools.tokenProvider,
     answers: inputs,
     cryptoProvider: cryptoProvider,
+    permissionRequestProvider: new PermissionRequestFileProvider(inputs.projectPath),
   };
 
   return ok(solutionContext);

--- a/packages/fx-core/src/core/middleware/projectSettingsLoader.ts
+++ b/packages/fx-core/src/core/middleware/projectSettingsLoader.ts
@@ -29,6 +29,7 @@ import { validateSettings } from "../../common";
 import * as uuid from "uuid";
 import { LocalCrypto } from "../crypto";
 import { PluginNames } from "../../plugins/solution/fx-solution/constants";
+import { PermissionRequestFileProvider } from "../permissionRequest";
 
 export const ProjectSettingsLoaderMW: Middleware = async (
   ctx: CoreHookContext,
@@ -114,6 +115,9 @@ export async function newSolutionContext(tools: Tools, inputs: Inputs): Promise<
     ...tools.tokenProvider,
     answers: inputs,
     cryptoProvider: new LocalCrypto(projectSettings.projectId),
+    permissionRequestProvider: inputs.projectPath
+      ? new PermissionRequestFileProvider(inputs.projectPath)
+      : undefined,
   };
   return solutionContext;
 }

--- a/packages/fx-core/src/core/permissionRequest.ts
+++ b/packages/fx-core/src/core/permissionRequest.ts
@@ -7,29 +7,38 @@ import {
   Result,
   FxError,
   ok,
-  err,
   returnSystemError,
+  err,
 } from "@microsoft/teamsfx-api";
 import { SolutionError } from "../plugins/solution/fx-solution/constants";
 
 export class PermissionRequestFileProvider implements PermissionRequestProvider {
   private rootPath: string;
+  public readonly permissionFileName = "permissions.json";
 
   constructor(rootPath: string) {
     this.rootPath = rootPath;
   }
 
-  public async getPermissionRequest(): Promise<Result<string, FxError>> {
-    const path = `${this.rootPath}/permissions.json`;
+  public async checkPermissionRequest(): Promise<Result<undefined, FxError>> {
+    const path = `${this.rootPath}/${this.permissionFileName}`;
     if (!(await fs.pathExists(path))) {
-      returnSystemError(
-        new Error("permissions.json is missing"),
-        "Solution",
-        SolutionError.MissingPermissionsJson
+      return err(
+        returnSystemError(
+          new Error(`${this.permissionFileName} is missing`),
+          "Solution",
+          SolutionError.MissingPermissionsJson
+        )
       );
     }
 
-    const permissionRequest = await fs.readJSON(path);
+    return ok(undefined);
+  }
+
+  public async getPermissionRequest(): Promise<Result<string, FxError>> {
+    this.checkPermissionRequest();
+
+    const permissionRequest = await fs.readJSON(`${this.rootPath}/${this.permissionFileName}`);
     return ok(JSON.stringify(permissionRequest));
   }
 }

--- a/packages/fx-core/src/core/permissionRequest.ts
+++ b/packages/fx-core/src/core/permissionRequest.ts
@@ -7,8 +7,8 @@ import {
   Result,
   FxError,
   ok,
-  returnSystemError,
   err,
+  returnUserError,
 } from "@microsoft/teamsfx-api";
 import { SolutionError } from "../plugins/solution/fx-solution/constants";
 
@@ -24,7 +24,7 @@ export class PermissionRequestFileProvider implements PermissionRequestProvider 
     const path = `${this.rootPath}/${this.permissionFileName}`;
     if (!(await fs.pathExists(path))) {
       return err(
-        returnSystemError(
+        returnUserError(
           new Error(`${this.permissionFileName} is missing`),
           "Solution",
           SolutionError.MissingPermissionsJson

--- a/packages/fx-core/src/core/permissionRequest.ts
+++ b/packages/fx-core/src/core/permissionRequest.ts
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as fs from "fs-extra";
+import {
+  PermissionRequestProvider,
+  Result,
+  FxError,
+  ok,
+  err,
+  returnSystemError,
+} from "@microsoft/teamsfx-api";
+import { SolutionError } from "../plugins/solution/fx-solution/constants";
+
+export class PermissionRequestFileProvider implements PermissionRequestProvider {
+  private rootPath: string;
+
+  constructor(rootPath: string) {
+    this.rootPath = rootPath;
+  }
+
+  public async getPermissionRequest(): Promise<Result<string, FxError>> {
+    const path = `${this.rootPath}/permissions.json`;
+    if (!(await fs.pathExists(path))) {
+      returnSystemError(
+        new Error("permissions.json is missing"),
+        "Solution",
+        SolutionError.MissingPermissionsJson
+      );
+    }
+
+    const permissionRequest = await fs.readJSON(path);
+    return ok(JSON.stringify(permissionRequest));
+  }
+}

--- a/packages/fx-core/src/plugins/resource/aad/errors.ts
+++ b/packages/fx-core/src/plugins/resource/aad/errors.ts
@@ -118,6 +118,11 @@ export const GetConfigError: AadError = {
   message: (message: string) => message,
 };
 
+export const MissingPermissionsRequestProvider: AadError = {
+  name: "MissingPermissionsRequestProvider",
+  message: () => "permissionRequestProvider is missing in plugin context",
+};
+
 export class ConfigErrorMessages {
   static readonly GetDisplayNameError = "Failed to get display name.";
   static readonly GetConfigError = (configName: string, plugin: string) =>

--- a/packages/fx-core/src/plugins/resource/aad/utils/configs.ts
+++ b/packages/fx-core/src/plugins/resource/aad/utils/configs.ts
@@ -91,7 +91,7 @@ export class ConfigUtils {
       );
     }
 
-    const permissionRequestResult = await ctx.permissionRequestProvider?.getPermissionRequest();
+    const permissionRequestResult = await ctx.permissionRequestProvider.getPermissionRequest();
     if (permissionRequestResult.isOk()) {
       return permissionRequestResult.value;
     } else {

--- a/packages/fx-core/src/plugins/solution/fx-solution/constants.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/constants.ts
@@ -25,11 +25,6 @@ export const GLOBAL_CONFIG = "solution";
 export const SOLUTION_PROVISION_SUCCEEDED = "provisionSucceeded";
 
 /**
- * Config key whose value is the content of permissions.json file
- */
-export const PERMISSION_REQUEST = "permissionRequest";
-
-/**
  * Config key whose value is either javascript, typescript or csharp.
  */
 export const PROGRAMMING_LANGUAGE = "programmingLanguage";

--- a/packages/fx-core/tests/core/utils.ts
+++ b/packages/fx-core/tests/core/utils.ts
@@ -364,6 +364,10 @@ export class MockCryptoProvider implements CryptoProvider {
 }
 
 export class MockPermissionRequestProvider implements PermissionRequestProvider {
+  async checkPermissionRequest(): Promise<Result<undefined, FxError>> {
+    return ok(undefined);
+  }
+
   async getPermissionRequest(): Promise<Result<string, FxError>> {
     return ok(JSON.stringify(DEFAULT_PERMISSION_REQUEST));
   }

--- a/packages/fx-core/tests/core/utils.ts
+++ b/packages/fx-core/tests/core/utils.ts
@@ -43,11 +43,15 @@ import {
   Colors,
   Json,
   CryptoProvider,
+  PermissionRequestProvider,
 } from "@microsoft/teamsfx-api";
 import { TokenCredential } from "@azure/core-auth";
 import { TokenCredentialsBase } from "@azure/ms-rest-nodeauth";
 import { SolutionLoader } from "../../src/core/loader";
-import { PluginNames } from "../../src/plugins/solution/fx-solution/constants";
+import {
+  DEFAULT_PERMISSION_REQUEST,
+  PluginNames,
+} from "../../src/plugins/solution/fx-solution/constants";
 import * as uuid from "uuid";
 
 export class MockSolution implements Solution {
@@ -347,6 +351,7 @@ export class MockTools implements Tools {
   telemetryReporter = new MockTelemetryReporter();
   ui = new MockUserInteraction();
   cryptoProvider = new MockCryptoProvider();
+  permissionRequestProvider = new MockPermissionRequestProvider();
 }
 
 export class MockCryptoProvider implements CryptoProvider {
@@ -355,6 +360,12 @@ export class MockCryptoProvider implements CryptoProvider {
   }
   decrypt(ciphertext: string): Result<string, FxError> {
     return ok(ciphertext);
+  }
+}
+
+export class MockPermissionRequestProvider implements PermissionRequestProvider {
+  async getPermissionRequest(): Promise<Result<string, FxError>> {
+    return ok(JSON.stringify(DEFAULT_PERMISSION_REQUEST));
   }
 }
 

--- a/packages/fx-core/tests/plugins/resource/aad/helper.ts
+++ b/packages/fx-core/tests/plugins/resource/aad/helper.ts
@@ -31,6 +31,9 @@ const permissionsWrong =
   '[{"resource": "Microsoft Graph","delegated": ["User.ReadData"],"application":[]}]';
 
 const mockPermissionRequestProvider: PermissionRequestProvider = {
+  async checkPermissionRequest(): Promise<Result<undefined, FxError>> {
+    return ok(undefined);
+  },
   async getPermissionRequest(): Promise<Result<string, FxError>> {
     return ok(JSON.stringify(DEFAULT_PERMISSION_REQUEST));
   },


### PR DESCRIPTION
**Changes:**
Add `permissionRequestProvider` in the context interface so that AAD plugin can get permissionRequest content to set/update the AAD permissions. 

**Reasons to do so:**
- Remove the dependency of using solution config to set the permission request content and pass to the resource plugins.
- Separate the provider implementation out of AAD plugin, e.g. for VSC it is a file provider, which read content from `permissions.json`, while for "teamsfx init" for Blazor app it should be an constant default value since there is no `permissions.json` in the project.
- For better testability.
