### PR TITLE
fix(frontend): ut should not be affected by environment

### DIFF
--- a/packages/fx-core/tests/plugins/resource/frontend/unit/index.test.ts
+++ b/packages/fx-core/tests/plugins/resource/frontend/unit/index.test.ts
@@ -33,6 +33,7 @@ import { TestHelper } from "../helper";
 import { Utils } from "../../../../../src/plugins/resource/frontend/utils";
 import { StorageAccounts } from "@azure/arm-storage";
 import { AzureLib } from "../../../../../src/plugins/resource/frontend/utils/azure-client";
+import * as core from "../../../../../src";
 
 chai.use(chaiAsPromised);
 
@@ -111,6 +112,7 @@ describe("FrontendPlugin", () => {
       pluginContext = TestHelper.getFakePluginContext();
       frontendPlugin = new FrontendPlugin();
 
+      sinon.stub(core, "isArmSupportEnabled").returns(false);
       createStorageAccountStub = sinon
         .stub(StorageAccounts.prototype, "create")
         .resolves(TestHelper.storageAccount);


### PR DESCRIPTION
With ARM provision feature enabled, the ut fails for original provision method is not called.