### PR TITLE
fix: auth failed in local debug and skip local debug config persistent

### DIFF
--- a/packages/fx-core/src/core/middleware/envInfoWriter.ts
+++ b/packages/fx-core/src/core/middleware/envInfoWriter.ts
@@ -5,6 +5,7 @@
 import { NextFunction, Middleware } from "@feathersjs/hooks";
 import { Inputs, StaticPlatforms } from "@microsoft/teamsfx-api";
 import { CoreHookContext, FxCore } from "..";
+import { PluginNames } from "../../plugins/solution/fx-solution/constants";
 import { environmentManager } from "../environment";
 
 /**
@@ -25,6 +26,12 @@ export const EnvInfoWriterMW: Middleware = async (ctx: CoreHookContext, next: Ne
 
     const solutionContext = ctx.solutionContext;
     if (solutionContext === undefined) return;
+
+    // DO NOT persist local debug plugin config.
+    if (solutionContext.config.has(PluginNames.LDEBUG)) {
+      solutionContext.config.delete(PluginNames.LDEBUG);
+    }
+
     const envProfilePath = await environmentManager.writeEnvProfile(
       solutionContext.config,
       inputs.projectPath,

--- a/packages/fx-core/src/plugins/resource/aad/utils/configs.ts
+++ b/packages/fx-core/src/plugins/resource/aad/utils/configs.ts
@@ -198,12 +198,15 @@ export class SetApplicationInContextConfig {
         ConfigKeysOfOtherPlugin.localDebugTabDomain
       );
     } else {
-      if (isArmSupportEnabled()) {
-        frontendDomain = getArmOutput(ctx, ConfigKeysOfOtherPlugin.frontendHostingDomainArm);
-      } else {
-        frontendDomain = ctx.configOfOtherPlugins
-          .get(Plugins.frontendHosting)
-          ?.get(ConfigKeysOfOtherPlugin.frontendHostingDomain);
+      frontendDomain = ctx.config.get(ConfigKeys.domain);
+      if (!frontendDomain) {
+        if (isArmSupportEnabled()) {
+          frontendDomain = getArmOutput(ctx, ConfigKeysOfOtherPlugin.frontendHostingDomainArm);
+        } else {
+          frontendDomain = ctx.configOfOtherPlugins
+            .get(Plugins.frontendHosting)
+            ?.get(ConfigKeysOfOtherPlugin.frontendHostingDomain);
+        }
       }
     }
 
@@ -262,12 +265,15 @@ export class PostProvisionConfig {
         ConfigKeysOfOtherPlugin.localDebugTabEndpoint
       );
     } else {
-      if (isArmSupportEnabled()) {
-        frontendEndpoint = getArmOutput(ctx, ConfigKeysOfOtherPlugin.frontendHostingEndpointArm);
-      } else {
-        frontendEndpoint = ctx.configOfOtherPlugins
-          .get(Plugins.frontendHosting)
-          ?.get(ConfigKeysOfOtherPlugin.frontendHostingEndpoint);
+      frontendEndpoint = ctx.config.get(ConfigKeys.endpoint);
+      if (!frontendEndpoint) {
+        if (isArmSupportEnabled()) {
+          frontendEndpoint = getArmOutput(ctx, ConfigKeysOfOtherPlugin.frontendHostingEndpointArm);
+        } else {
+          frontendEndpoint = ctx.configOfOtherPlugins
+            .get(Plugins.frontendHosting)
+            ?.get(ConfigKeysOfOtherPlugin.frontendHostingEndpoint);
+        }
       }
     }
 

--- a/packages/fx-core/src/plugins/resource/aad/utils/configs.ts
+++ b/packages/fx-core/src/plugins/resource/aad/utils/configs.ts
@@ -191,25 +191,24 @@ export class SetApplicationInContextConfig {
   }
 
   public restoreConfigFromContext(ctx: PluginContext): void {
-    let frontendDomain: ConfigValue = ctx.config.get(ConfigKeys.domain);
-    if (frontendDomain) {
-      this.frontendDomain = format(frontendDomain as string, Formats.Domain);
+    let frontendDomain: ConfigValue;
+    if (this.isLocalDebug) {
+      frontendDomain = ConfigUtils.getLocalDebugConfigOfOtherPlugins(
+        ctx,
+        ConfigKeysOfOtherPlugin.localDebugTabDomain
+      );
     } else {
       if (isArmSupportEnabled()) {
         frontendDomain = getArmOutput(ctx, ConfigKeysOfOtherPlugin.frontendHostingDomainArm);
       } else {
-        frontendDomain = this.isLocalDebug
-          ? ConfigUtils.getLocalDebugConfigOfOtherPlugins(
-              ctx,
-              ConfigKeysOfOtherPlugin.localDebugTabDomain
-            )
-          : ctx.configOfOtherPlugins
-              .get(Plugins.frontendHosting)
-              ?.get(ConfigKeysOfOtherPlugin.frontendHostingDomain);
+        frontendDomain = ctx.configOfOtherPlugins
+          .get(Plugins.frontendHosting)
+          ?.get(ConfigKeysOfOtherPlugin.frontendHostingDomain);
       }
-      if (frontendDomain) {
-        this.frontendDomain = format(frontendDomain as string, Formats.Domain);
-      }
+    }
+
+    if (frontendDomain) {
+      this.frontendDomain = format(frontendDomain as string, Formats.Domain);
     }
 
     const botId: ConfigValue = this.isLocalDebug
@@ -256,25 +255,24 @@ export class PostProvisionConfig {
   }
 
   public async restoreConfigFromContext(ctx: PluginContext): Promise<void> {
-    let frontendEndpoint: ConfigValue = ctx.config.get(ConfigKeys.endpoint);
-    if (frontendEndpoint) {
-      this.frontendEndpoint = format(frontendEndpoint as string, Formats.Endpoint);
+    let frontendEndpoint: ConfigValue;
+    if (this.isLocalDebug) {
+      frontendEndpoint = ConfigUtils.getLocalDebugConfigOfOtherPlugins(
+        ctx,
+        ConfigKeysOfOtherPlugin.localDebugTabEndpoint
+      );
     } else {
       if (isArmSupportEnabled()) {
         frontendEndpoint = getArmOutput(ctx, ConfigKeysOfOtherPlugin.frontendHostingEndpointArm);
       } else {
-        frontendEndpoint = this.isLocalDebug
-          ? ConfigUtils.getLocalDebugConfigOfOtherPlugins(
-              ctx,
-              ConfigKeysOfOtherPlugin.localDebugTabEndpoint
-            )
-          : ctx.configOfOtherPlugins
-              .get(Plugins.frontendHosting)
-              ?.get(ConfigKeysOfOtherPlugin.frontendHostingEndpoint);
+        frontendEndpoint = ctx.configOfOtherPlugins
+          .get(Plugins.frontendHosting)
+          ?.get(ConfigKeysOfOtherPlugin.frontendHostingEndpoint);
       }
-      if (frontendEndpoint) {
-        this.frontendEndpoint = format(frontendEndpoint as string, Formats.Endpoint);
-      }
+    }
+
+    if (frontendEndpoint) {
+      this.frontendEndpoint = format(frontendEndpoint as string, Formats.Endpoint);
     }
 
     const botEndpoint: ConfigValue = this.isLocalDebug

--- a/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
@@ -394,9 +394,6 @@ export class TeamsAppSolution implements Solution {
           // Initialize a local settings on scaffolding
           await localSettingsProvider.save(localSettingsProvider.init(hasTab, hasBackend, hasBot));
         }
-
-        // remove local debug config from env info
-        ctx.config.delete(PluginNames.LDEBUG);
       }
     }
 


### PR DESCRIPTION
Fix in this PR:
- When local debug, retrieve the `tabDomain` and `tabEndpoint` from `localSettings` if `TEAMSFX_ARM_SUPPORT` is enabled.
- Do not persist the local debug plugin config in `env.default.json`,
