### PR TITLE
feat: support run-from config

### DIFF
--- a/packages/cli/src/cmds/config.ts
+++ b/packages/cli/src/cmds/config.ts
@@ -32,6 +32,7 @@ const GlobalOptions = new Set([
   CliConfigOptions.EnvCheckerValidateDotnetSdk as string,
   CliConfigOptions.EnvCheckerValidateFuncCoreTools as string,
   CliConfigOptions.EnvCheckerValidateNode as string,
+  CliConfigOptions.RunFrom as string,
 ]);
 
 export class ConfigGet extends YargsCommand {
@@ -251,6 +252,7 @@ export class ConfigSet extends YargsCommand {
       case CliConfigOptions.EnvCheckerValidateDotnetSdk:
       case CliConfigOptions.EnvCheckerValidateFuncCoreTools:
       case CliConfigOptions.EnvCheckerValidateNode:
+      case CliConfigOptions.RunFrom:
         const opt = { [option]: value };
         const result = UserSettings.setConfigSync(opt);
         if (result.isErr()) {

--- a/packages/cli/src/commonlib/telemetry.ts
+++ b/packages/cli/src/commonlib/telemetry.ts
@@ -7,6 +7,7 @@ import { TelemetryReporter } from "@microsoft/teamsfx-api";
 import { Correlator } from "@microsoft/teamsfx-core";
 import { TelemetryProperty } from "../telemetry/cliTelemetryEvents";
 import { getProjectId } from "../utils";
+import { CliConfigOptions, CliConfigRunFrom, UserSettings } from "../userSetttings";
 
 /**
  *  CLI telemetry reporter used by fx-core.
@@ -46,6 +47,11 @@ export class CliTelemetryReporter implements TelemetryReporter {
     const projectId = getProjectId(this.rootFolder);
     properties[TelemetryProperty.ProjectId] = projectId ? projectId : "";
     properties[TelemetryProperty.CorrelationId] = Correlator.getId();
+
+    const result = UserSettings.getRunFromSetting();
+    const runFrom = result.isOk() ? result.value : CliConfigRunFrom.Other;
+    properties[CliConfigOptions.RunFrom] = runFrom;
+
     this.reporter.sendTelemetryErrorEvent(eventName, properties, measurements, errorProps);
   }
 
@@ -61,6 +67,11 @@ export class CliTelemetryReporter implements TelemetryReporter {
     const projectId = getProjectId(this.rootFolder);
     properties[TelemetryProperty.ProjectId] = projectId ? projectId : "";
     properties[TelemetryProperty.CorrelationId] = Correlator.getId();
+
+    const result = UserSettings.getRunFromSetting();
+    const runFrom = result.isOk() ? result.value : CliConfigRunFrom.Other;
+    properties[CliConfigOptions.RunFrom] = runFrom;
+
     this.reporter.sendTelemetryEvent(eventName, properties, measurements);
   }
 
@@ -76,6 +87,11 @@ export class CliTelemetryReporter implements TelemetryReporter {
     const projectId = getProjectId(this.rootFolder);
     properties[TelemetryProperty.ProjectId] = projectId ? projectId : "";
     properties[TelemetryProperty.CorrelationId] = Correlator.getId();
+
+    const result = UserSettings.getRunFromSetting();
+    const runFrom = result.isOk() ? result.value : CliConfigRunFrom.Other;
+    properties[CliConfigOptions.RunFrom] = runFrom;
+
     this.reporter.sendTelemetryException(error, properties, measurements);
   }
 

--- a/packages/cli/src/userSetttings.ts
+++ b/packages/cli/src/userSetttings.ts
@@ -16,6 +16,7 @@ export enum CliConfigOptions {
   EnvCheckerValidateDotnetSdk = "validate-dotnet-sdk",
   EnvCheckerValidateFuncCoreTools = "validate-func-core-tools",
   EnvCheckerValidateNode = "validate-node",
+  RunFrom = "run-from",
 }
 
 export enum CliConfigTelemetry {
@@ -26,6 +27,12 @@ export enum CliConfigTelemetry {
 export enum CliConfigEnvChecker {
   On = "on",
   Off = "off",
+}
+
+export enum CliConfigRunFrom {
+  GitHubAction = "GitHubAction",
+  AzDoTask = "AzDoTask",
+  Other = "Other",
 }
 
 export class UserSettings {
@@ -89,5 +96,19 @@ export class UserSettings {
     }
 
     return ok(true);
+  }
+
+  public static getRunFromSetting(): Result<CliConfigRunFrom, FxError> {
+    const result = this.getConfigSync();
+    if (result.isErr()) {
+      return err(result.error);
+    }
+
+    const config = result.value[CliConfigOptions.RunFrom];
+    if (!config || !Object.values(CliConfigRunFrom).includes(config)) {
+      return ok(CliConfigRunFrom.Other);
+    }
+
+    return ok(config);
   }
 }


### PR DESCRIPTION
Add new config to support `run-from`.

`teamsfx config set run-from GitHubAction`

then, the telemetry will contains extra property p['run-from'] = 'GitHubAction'


set config by `teamsfx config set run-from GitHubAction`
receive telemetry with property:
![image](https://user-images.githubusercontent.com/1803943/129845466-a24afbc2-6d1e-42c8-85a7-13b26ce30786.png)



to support https://dev.azure.com/msazure/Microsoft%20Teams%20Extensibility/_workitems/edit/10366285

