### PR TITLE
fix: save teams app id when provisioning failed for other resources

### DIFF
--- a/packages/fx-core/src/plugins/solution/fx-solution/executor.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/executor.ts
@@ -130,7 +130,7 @@ export async function executeLifecycles(
   lifecycles: LifecyclesWithContext[],
   postLifecycles: LifecyclesWithContext[],
   onPreLifecycleFinished?: (result?: any[]) => Promise<Result<any, FxError>>,
-  onLifecycleFinished?: (result?: any[]) => Promise<Result<any, FxError>>,
+  onLifecycleFinished?: (result?: Result<any, FxError>[]) => Promise<Result<any, FxError>>,
   onPostLifecycleFinished?: (result?: any[]) => Promise<Result<any, FxError>>
 ): Promise<Result<any, FxError>> {
   // Questions are asked sequentially during preLifecycles.
@@ -146,11 +146,6 @@ export async function executeLifecycles(
   }
 
   const results = await executeConcurrently("", lifecycles);
-  for (const result of results) {
-    if (result.isErr()) {
-      return result;
-    }
-  }
   if (onLifecycleFinished) {
     const onLifecycleFinishedResult = await onLifecycleFinished(results);
     if (onLifecycleFinishedResult.isErr()) {


### PR DESCRIPTION
Save remote teams app id into config file, even if other resources provision failed. (like app service plan quota)

Otherwise, the toolkit will create multiple teams app when provision again.