### PR TITLE
fix(multi-env): no need to load env info for getAzureSolutionSettings

### DIFF
--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -455,6 +455,8 @@ export interface Inputs extends Json {
     // (undocumented)
     ignoreConfigPersist?: boolean;
     // (undocumented)
+    ignoreEnvInfo?: boolean;
+    // (undocumented)
     ignoreLock?: boolean;
     // (undocumented)
     ignoreTypeCheck?: boolean;

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -169,6 +169,7 @@ export interface Inputs extends Json {
   ignoreLock?: boolean;
   ignoreTypeCheck?: boolean;
   ignoreConfigPersist?: boolean;
+  ignoreEnvInfo?: boolean;
 }
 
 export interface ProjectConfig {

--- a/packages/fx-core/src/core/middleware/envInfoLoader.ts
+++ b/packages/fx-core/src/core/middleware/envInfoLoader.ts
@@ -44,7 +44,7 @@ export function EnvInfoLoaderMW(
 ): Middleware {
   return async (ctx: CoreHookContext, next: NextFunction) => {
     const inputs = ctx.arguments[ctx.arguments.length - 1] as Inputs;
-    if (shouldIgnored(ctx)) {
+    if (shouldIgnored(ctx) || inputs.ignoreEnvInfo === true) {
       await next();
       return;
     }

--- a/packages/fx-core/src/core/middleware/envInfoWriter.ts
+++ b/packages/fx-core/src/core/middleware/envInfoWriter.ts
@@ -20,6 +20,7 @@ export const EnvInfoWriterMW: Middleware = async (ctx: CoreHookContext, next: Ne
     if (
       !inputs.projectPath ||
       inputs.ignoreConfigPersist === true ||
+      inputs.ignoreEnvInfo === true ||
       StaticPlatforms.includes(inputs.platform)
     )
       return;

--- a/packages/vscode-extension/src/accountTree.ts
+++ b/packages/vscode-extension/src/accountTree.ts
@@ -39,7 +39,10 @@ export async function getSubscriptionId(): Promise<string | undefined> {
 }
 
 export async function getAzureSolutionSettings(): Promise<AzureSolutionSettings | undefined> {
-  const projectConfigRes = await core.getProjectConfig(getSystemInputs());
+  const input = getSystemInputs();
+  input.ignoreEnvInfo = true;
+  const projectConfigRes = await core.getProjectConfig(input);
+
   if (projectConfigRes.isOk()) {
     if (projectConfigRes.value) {
       return projectConfigRes.value.settings?.solutionSettings as AzureSolutionSettings;
@@ -52,7 +55,10 @@ export async function getAzureSolutionSettings(): Promise<AzureSolutionSettings 
 }
 
 export async function isValid(): Promise<boolean> {
-  const projectConfigRes = await core.getProjectConfig(getSystemInputs());
+  const input = getSystemInputs();
+  input.ignoreEnvInfo = true;
+  const projectConfigRes = await core.getProjectConfig(input);
+
   let supported = false;
   if (projectConfigRes.isOk()) {
     if (projectConfigRes.value) {


### PR DESCRIPTION
solutionSettings is from project settings `settings.json`, so there's no need to load env profile such like `env.<env_name>.json`.