### PR TITLE
refactor(multi-env): rename project/local settings file and fix local debug

### DIFF
--- a/packages/cli/src/commonlib/azureLogin.ts
+++ b/packages/cli/src/commonlib/azureLogin.ts
@@ -24,6 +24,7 @@ import {
   changeLoginTenantMessage,
   env,
   envDefaultJsonFile,
+  profileDefaultJsonFile,
   failToFindSubscription,
   loginComponent,
   MFACode,
@@ -41,6 +42,7 @@ import CLIUIInstance from "../userInteraction";
 import * as path from "path";
 import * as fs from "fs-extra";
 import { isWorkspaceSupported } from "../utils";
+import { isMultiEnvEnabled } from "@microsoft/teamsfx-core";
 
 const accountName = "azure";
 const scopes = ["https://management.core.windows.net/user_impersonation"];
@@ -588,7 +590,9 @@ export class AzureAccountManager extends login implements AzureAccountProvider {
       const envDefalultFile = path.join(
         AzureAccountManager.rootPath,
         `.${ConfigFolderName}`,
-        envDefaultJsonFile
+        isMultiEnvEnabled()
+          ? path.join("publishProfiles", profileDefaultJsonFile)
+          : envDefaultJsonFile
       );
       if (!fs.existsSync(envDefalultFile)) {
         return undefined;

--- a/packages/cli/src/commonlib/azureLoginCI.ts
+++ b/packages/cli/src/commonlib/azureLoginCI.ts
@@ -10,11 +10,20 @@ import { SubscriptionClient } from "@azure/arm-subscriptions";
 import * as fs from "fs-extra";
 import * as path from "path";
 
-import { AzureAccountProvider, ConfigFolderName, err, FxError, ok, Result, SubscriptionInfo } from "@microsoft/teamsfx-api";
+import {
+  AzureAccountProvider,
+  ConfigFolderName,
+  err,
+  FxError,
+  ok,
+  Result,
+  SubscriptionInfo,
+} from "@microsoft/teamsfx-api";
 
 import { NotSupportedProjectType, NotFoundSubscriptionId } from "../error";
 import { login, LoginStatus } from "./common/login";
 import { signedOut } from "./common/constant";
+import { isMultiEnvEnabled } from "@microsoft/teamsfx-core";
 
 const clientId = process.env.E2E_CLIENT_ID ?? "";
 const secret = process.env.E2E_SECRET ?? "";
@@ -111,7 +120,12 @@ export class AzureAccountManager extends login implements AzureAccountProvider {
     AzureAccountManager.subscriptionId = subscriptionId;
 
     /// TODO: use api's constant
-    const configPath = path.resolve(root_folder, `.${ConfigFolderName}/env.default.json`);
+    const configPath = path.resolve(
+      root_folder,
+      isMultiEnvEnabled()
+        ? `.${ConfigFolderName}/publishProfiles/profile.default.json`
+        : `.${ConfigFolderName}/env.default.json`
+    );
     if (!(await fs.pathExists(configPath))) {
       return err(NotSupportedProjectType());
     }

--- a/packages/cli/src/commonlib/common/constant.ts
+++ b/packages/cli/src/commonlib/common/constant.ts
@@ -45,5 +45,6 @@ export const loginComponent = "login";
 
 export const subscriptionInfoFile = "subscriptionInfo.json";
 export const envDefaultJsonFile = "env.default.json";
+export const profileDefaultJsonFile = "profile.default.json";
 
 export const sendFileTimeout = "Send success page timeout.";

--- a/packages/fx-core/src/common/localSettingsProvider.ts
+++ b/packages/fx-core/src/common/localSettingsProvider.ts
@@ -11,13 +11,16 @@ import {
   LocalSettingsFrontendKeys,
   LocalSettingsTeamsAppKeys,
 } from "./localSettingsConstants";
+import { isMultiEnvEnabled } from "./tools";
 
 export const localSettingsFileName = "localSettings.json";
 
 export class LocalSettingsProvider {
   public readonly localSettingsFilePath: string;
   constructor(workspaceFolder: string) {
-    this.localSettingsFilePath = `${workspaceFolder}/.${ConfigFolderName}/${localSettingsFileName}`;
+    this.localSettingsFilePath = isMultiEnvEnabled()
+      ? `${workspaceFolder}/.${ConfigFolderName}/configs/${localSettingsFileName}`
+      : `${workspaceFolder}/.${ConfigFolderName}/${localSettingsFileName}`;
   }
 
   public init(

--- a/packages/fx-core/src/common/tools.ts
+++ b/packages/fx-core/src/common/tools.ts
@@ -433,13 +433,23 @@ export function compileHandlebarsTemplateString(templateString: string, context:
 
 export async function getAppDirectory(projectRoot: string): Promise<string> {
   const REMOTE_MANIFEST = "manifest.source.json";
+  const MANIFEST_TEMPLATE = "manifest.template.json";
+  const appDirNewLocForMultiEnv = `${projectRoot}/templates/${AppPackageFolderName}`;
   const appDirNewLoc = `${projectRoot}/${AppPackageFolderName}`;
   const appDirOldLoc = `${projectRoot}/.${ConfigFolderName}`;
 
-  if (await fs.pathExists(`${appDirNewLoc}/${REMOTE_MANIFEST}`)) {
-    return appDirNewLoc;
+  if (isMultiEnvEnabled()) {
+    if (await fs.pathExists(`${appDirNewLocForMultiEnv}/${MANIFEST_TEMPLATE}`)) {
+      return appDirNewLocForMultiEnv;
+    } else {
+      return appDirOldLoc;
+    }
   } else {
-    return appDirOldLoc;
+    if (await fs.pathExists(`${appDirNewLoc}/${REMOTE_MANIFEST}`)) {
+      return appDirNewLoc;
+    } else {
+      return appDirOldLoc;
+    }
   }
 }
 

--- a/packages/fx-core/src/core/index.ts
+++ b/packages/fx-core/src/core/index.ts
@@ -178,7 +178,14 @@ export class FxCore implements Core {
 
       await fs.ensureDir(projectPath);
       await fs.ensureDir(path.join(projectPath, `.${ConfigFolderName}`));
-      await fs.ensureDir(path.join(projectPath, `${AppPackageFolderName}`));
+      await fs.ensureDir(
+        path.join(
+          projectPath,
+          isMultiEnvEnabled()
+            ? path.join("templates", `${AppPackageFolderName}`)
+            : `${AppPackageFolderName}`
+        )
+      );
 
       const createResult = await this.createBasicFolderStructure(inputs);
       if (createResult.isErr()) {
@@ -755,7 +762,7 @@ export class FxCore implements Core {
             description: "",
             author: "",
             scripts: {
-              test: "echo \"Error: no test specified\" && exit 1",
+              test: 'echo "Error: no test specified" && exit 1',
             },
             devDependencies: {
               "@microsoft/teamsfx-cli": "0.*",

--- a/packages/fx-core/src/core/middleware/projectSettingsLoader.ts
+++ b/packages/fx-core/src/core/middleware/projectSettingsLoader.ts
@@ -31,6 +31,7 @@ import { LocalCrypto } from "../crypto";
 import { PluginNames } from "../../plugins/solution/fx-solution/constants";
 import { PermissionRequestFileProvider } from "../permissionRequest";
 import { readJson } from "../../common/fileUtils";
+import { isMultiEnvEnabled } from "../../common";
 
 export const ProjectSettingsLoaderMW: Middleware = async (
   ctx: CoreHookContext,
@@ -77,7 +78,9 @@ export async function loadProjectSettings(
     }
 
     const confFolderPath = path.resolve(inputs.projectPath, `.${ConfigFolderName}`);
-    const settingsFile = path.resolve(confFolderPath, "settings.json");
+    const settingsFile = isMultiEnvEnabled()
+      ? path.resolve(confFolderPath, "configs", "projectSettings.json")
+      : path.resolve(confFolderPath, "settings.json");
     const projectSettings: ProjectSettings = await readJson(settingsFile);
     let projectIdMissing = false;
     if (!projectSettings.projectId) {

--- a/packages/fx-core/src/core/middleware/projectUpgrader.ts
+++ b/packages/fx-core/src/core/middleware/projectUpgrader.ts
@@ -23,6 +23,7 @@ import {
   WriteFileError,
 } from "..";
 import { dataNeedEncryption, deserializeDict, serializeDict } from "../..";
+import { isMultiEnvEnabled } from "../../common";
 import { readJson } from "../../common/fileUtils";
 import {
   Component,
@@ -82,12 +83,23 @@ export async function upgradeContext(ctx: CoreHookContext): Promise<Result<undef
   if (!projectPathExist) {
     return err(PathNotExistError(inputs.projectPath));
   }
-  const confFolderPath = path.resolve(inputs.projectPath!, `.${ConfigFolderName}`);
-  const settingsFile = path.resolve(confFolderPath, "settings.json");
+  const confFolderPath = isMultiEnvEnabled()
+    ? path.resolve(inputs.projectPath, `.${ConfigFolderName}`, "configs")
+    : path.resolve(inputs.projectPath, `.${ConfigFolderName}`);
+  const publishProfilesFolderPath = path.resolve(
+    inputs.projectPath,
+    `.${ConfigFolderName}`,
+    "publishProfiles"
+  );
+  const settingsFile = isMultiEnvEnabled()
+    ? path.resolve(confFolderPath, "projectSettings.json")
+    : path.resolve(confFolderPath, "settings.json");
   const projectSettings: ProjectSettings = await readJson(settingsFile);
   const defaultEnvName = environmentManager.defaultEnvName;
 
-  const contextPath = path.resolve(confFolderPath, `env.${defaultEnvName}.json`);
+  const contextPath = isMultiEnvEnabled()
+    ? path.resolve(publishProfilesFolderPath, `profile.${defaultEnvName}.json`)
+    : path.resolve(confFolderPath, `env.${defaultEnvName}.json`);
   const userDataPath = path.resolve(confFolderPath, `${defaultEnvName}.userdata`);
 
   let context: Json = {};

--- a/packages/fx-core/src/plugins/resource/appstudio/constants.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/constants.ts
@@ -30,6 +30,7 @@ export class ErrorMessages {
  * Config keys that are useful for generating remote teams app manifest
  */
 export const REMOTE_MANIFEST = "manifest.source.json";
+export const MANIFEST_TEMPLATE = "manifest.template.json";
 export const FRONTEND_ENDPOINT = "endpoint";
 export const FRONTEND_DOMAIN = "domain";
 export const FRONTEND_ENDPOINT_ARM = "frontendHosting_endpoint";
@@ -59,6 +60,46 @@ export const TEAMS_APP_MANIFEST_TEMPLATE = `{
   "icons": {
       "color": "color.png",
       "outline": "outline.png"
+  },
+  "name": {
+      "short": "{appName}",
+      "full": "This field is not used"
+  },
+  "description": {
+      "short": "Short description of {appName}.",
+      "full": "Full description of {appName}."
+  },
+  "accentColor": "#FFFFFF",
+  "bots": [],
+  "composeExtensions": [],
+  "configurableTabs": [],
+  "staticTabs": [],
+  "permissions": [
+      "identity",
+      "messageTeamMembers"
+  ],
+  "validDomains": [],
+  "webApplicationInfo": {
+      "id": "{appClientId}",
+      "resource": "{webApplicationInfoResource}"
+  }
+}`;
+
+export const TEAMS_APP_MANIFEST_TEMPLATE_FOR_MULTI_ENV = `{
+  "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.9/MicrosoftTeams.schema.json",
+  "manifestVersion": "1.9",
+  "version": "{version}",
+  "id": "{appid}",
+  "packageName": "com.microsoft.teams.extension",
+  "developer": {
+      "name": "Teams App, Inc.",
+      "websiteUrl": "{baseUrl}",
+      "privacyUrl": "{baseUrl}/index.html#/privacy",
+      "termsOfUseUrl": "{baseUrl}/index.html#/termsofuse"
+  },
+  "icons": {
+      "color": "resources/color.png",
+      "outline": "resources/outline.png"
   },
   "name": {
       "short": "{appName}",

--- a/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
@@ -72,6 +72,8 @@ import {
   V1_MANIFEST,
   ErrorMessages,
   SOLUTION,
+  MANIFEST_TEMPLATE,
+  TEAMS_APP_MANIFEST_TEMPLATE_FOR_MULTI_ENV,
 } from "./constants";
 import { REMOTE_TEAMS_APP_ID } from "../../solution/fx-solution/constants";
 import AdmZip from "adm-zip";
@@ -175,7 +177,9 @@ export class AppStudioPluginImpl {
       solutionSettings.capabilities.includes(BotOptionItem.id) ||
       solutionSettings.capabilities.includes(MessageExtensionItem.id)
     ) {
-      let manifestString = TEAMS_APP_MANIFEST_TEMPLATE;
+      let manifestString = isMultiEnvEnabled()
+        ? TEAMS_APP_MANIFEST_TEMPLATE_FOR_MULTI_ENV
+        : TEAMS_APP_MANIFEST_TEMPLATE;
       manifestString = this.replaceConfigValue(manifestString, "appName", settings.appName);
       manifestString = this.replaceConfigValue(manifestString, "version", "1.0.0");
       const manifest: TeamsAppManifest = JSON.parse(manifestString);
@@ -281,7 +285,7 @@ export class AppStudioPluginImpl {
     const remoteTeamsAppId = this.getTeamsAppId(ctx, false);
     let manifest: TeamsAppManifest;
     const appDirectory = await getAppDirectory(ctx.root);
-    const manifestPath = path.join(appDirectory, REMOTE_MANIFEST);
+    const manifestPath = await this.getManifestTemplatePath(ctx.root);
     const manifestResult = await this.reloadManifestAndCheckRequiredFields(manifestPath);
     if (manifestResult.isErr()) {
       throw manifestResult;
@@ -356,11 +360,11 @@ export class AppStudioPluginImpl {
     let manifest: TeamsAppManifest | undefined;
     const archiveAppPackageFolder = path.join(ctx.root, ArchiveFolderName, AppPackageFolderName);
     const archiveManifestPath = path.join(archiveAppPackageFolder, V1_MANIFEST);
-    const newAppPackageFolder = path.join(ctx.root, AppPackageFolderName);
+    const newAppPackageFolder = await getAppDirectory(ctx.root);
     await fs.ensureDir(newAppPackageFolder);
     if (await this.checkFileExist(archiveManifestPath)) {
       manifest = await this.createV1Manifest(ctx);
-      const newManifestPath = path.join(newAppPackageFolder, REMOTE_MANIFEST);
+      const newManifestPath = await this.getManifestTemplatePath(ctx.root);
       await fs.writeFile(newManifestPath, JSON.stringify(manifest, null, 4));
 
       const archiveColorFile = path.join(archiveAppPackageFolder, manifest.icons.color);
@@ -392,10 +396,16 @@ export class AppStudioPluginImpl {
       manifest = await this.createManifest(ctx.projectSettings!);
     }
 
-    await fs.writeFile(
-      `${ctx.root}/${AppPackageFolderName}/${REMOTE_MANIFEST}`,
-      JSON.stringify(manifest, null, 4)
-    );
+    // cannot use getAppDirectory before creating the manifest file
+    const appDir = isMultiEnvEnabled()
+      ? `${ctx.root}/templates/${AppPackageFolderName}`
+      : `${ctx.root}/${AppPackageFolderName}`;
+
+    await fs.ensureDir(appDir);
+    const manifestTemplatePath = isMultiEnvEnabled()
+      ? `${appDir}/${MANIFEST_TEMPLATE}`
+      : `${appDir}/${REMOTE_MANIFEST}`;
+    await fs.writeFile(manifestTemplatePath, JSON.stringify(manifest, null, 4));
 
     const defaultColorPath = path.join(
       templatesFolder,
@@ -411,8 +421,10 @@ export class AppStudioPluginImpl {
       "appstudio",
       "defaultOutline.png"
     );
-    await fs.copy(defaultColorPath, `${ctx.root}/${AppPackageFolderName}/color.png`);
-    await fs.copy(defaultOutlinePath, `${ctx.root}/${AppPackageFolderName}/outline.png`);
+    const resourcesDir = isMultiEnvEnabled() ? path.join(appDir, "resources") : appDir;
+    await fs.ensureDir(resourcesDir);
+    await fs.copy(defaultColorPath, `${resourcesDir}/color.png`);
+    await fs.copy(defaultOutlinePath, `${resourcesDir}/outline.png`);
 
     return undefined;
   }
@@ -427,11 +439,13 @@ export class AppStudioPluginImpl {
       zipFileName = `${appDirectory}/appPackage.zip`;
     } else {
       appDirectory = await getAppDirectory(ctx.root);
-      zipFileName = `${ctx.root}/${AppPackageFolderName}/appPackage.zip`;
+      zipFileName = isMultiEnvEnabled()
+        ? `${ctx.root}/templates/${AppPackageFolderName}/appPackage.zip`
+        : `${ctx.root}/${AppPackageFolderName}/appPackage.zip`;
     }
 
     if (this.isSPFxProject(ctx)) {
-      manifestString = (await fs.readFile(`${appDirectory}/${REMOTE_MANIFEST}`)).toString();
+      manifestString = (await fs.readFile(await this.getManifestTemplatePath(ctx.root))).toString();
     } else {
       const manifest = await this.getAppDefinitionAndManifest(ctx, false);
       if (manifest.isOk()) {
@@ -484,8 +498,8 @@ export class AppStudioPluginImpl {
 
     const zip = new AdmZip();
     zip.addFile(Constants.MANIFEST_FILE, Buffer.from(manifestString));
-    zip.addLocalFile(colorFile);
-    zip.addLocalFile(outlineFile);
+    zip.addLocalFile(colorFile, isMultiEnvEnabled() ? "resources" : "");
+    zip.addLocalFile(outlineFile, isMultiEnvEnabled() ? "resources" : "");
     zip.writeZip(zipFileName);
 
     if (this.isSPFxProject(ctx)) {
@@ -505,15 +519,21 @@ export class AppStudioPluginImpl {
 
       await fs.move(
         `${appDirectory}/${manifest.icons.color}`,
-        `${ctx.root}/${AppPackageFolderName}/${manifest.icons.color}`
+        isMultiEnvEnabled()
+          ? `${ctx.root}/templates/${AppPackageFolderName}/resources/${manifest.icons.color}`
+          : `${ctx.root}/${AppPackageFolderName}/${manifest.icons.color}`
       );
       await fs.move(
         `${appDirectory}/${manifest.icons.outline}`,
-        `${ctx.root}/${AppPackageFolderName}/${manifest.icons.outline}`
+        isMultiEnvEnabled()
+          ? `${ctx.root}/templates/${AppPackageFolderName}/resources/${manifest.icons.outline}`
+          : `${ctx.root}/${AppPackageFolderName}/${manifest.icons.outline}`
       );
       await fs.move(
         `${appDirectory}/${REMOTE_MANIFEST}`,
-        `${ctx.root}/${AppPackageFolderName}/${REMOTE_MANIFEST}`
+        isMultiEnvEnabled()
+          ? `${ctx.root}/templates/${AppPackageFolderName}/${MANIFEST_TEMPLATE}`
+          : `${ctx.root}/${AppPackageFolderName}/${REMOTE_MANIFEST}`
       );
     }
 
@@ -548,7 +568,9 @@ export class AppStudioPluginImpl {
       }
     } else {
       appDirectory = await getAppDirectory(ctx.root);
-      const manifestTpl: TeamsAppManifest = await fs.readJSON(`${appDirectory}/${REMOTE_MANIFEST}`);
+      const manifestTpl: TeamsAppManifest = await fs.readJSON(
+        await this.getManifestTemplatePath(ctx.root)
+      );
       if (this.isSPFxProject(ctx)) {
         manifest = manifestTpl;
       } else {
@@ -604,8 +626,7 @@ export class AppStudioPluginImpl {
   }
 
   public async postLocalDebug(ctx: PluginContext): Promise<string> {
-    const appDirectory = await getAppDirectory(ctx.root);
-    const manifestPath = path.join(appDirectory, REMOTE_MANIFEST);
+    const manifestPath = await this.getManifestTemplatePath(ctx.root);
     const manifest = await this.reloadManifestAndCheckRequiredFields(manifestPath);
     if (manifest.isErr()) {
       throw manifest;
@@ -1277,7 +1298,9 @@ export class AppStudioPluginImpl {
         AppStudioError.NotADirectoryError.message(appDirectory)
       );
     }
-    const manifest: TeamsAppManifest = await fs.readJSON(`${appDirectory}/${REMOTE_MANIFEST}`);
+    const manifest: TeamsAppManifest = await fs.readJSON(
+      await this.getManifestTemplatePath(ctx.root)
+    );
     manifest.bots = undefined;
     manifest.composeExtensions = undefined;
     // For SPFX remote teams app, manifest.id == componentId
@@ -1438,8 +1461,7 @@ export class AppStudioPluginImpl {
       validDomains.push(botDomain);
     }
 
-    const appDirectory: string = await getAppDirectory(ctx.root);
-    let manifest = (await fs.readFile(`${appDirectory}/${REMOTE_MANIFEST}`)).toString();
+    let manifest = (await fs.readFile(await this.getManifestTemplatePath(ctx.root))).toString();
 
     const appName = ctx.projectSettings?.appName;
     if (appName) {
@@ -1497,5 +1519,17 @@ export class AppStudioPluginImpl {
     }
 
     return ok([appDefinition, updatedManifest]);
+  }
+
+  private async getManifestTemplatePath(projectRoot: string): Promise<string> {
+    const appDir = await getAppDirectory(projectRoot);
+    return isMultiEnvEnabled()
+      ? path.join(appDir, MANIFEST_TEMPLATE)
+      : path.join(appDir, REMOTE_MANIFEST);
+  }
+
+  private async getAppPackageResourcesPath(projectRoot: string): Promise<string> {
+    const appDir = await getAppDirectory(projectRoot);
+    return isMultiEnvEnabled() ? path.join(appDir, "resources") : appDir;
   }
 }

--- a/packages/fx-core/src/plugins/resource/spfx/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/spfx/plugin.ts
@@ -11,9 +11,9 @@ import { Constants, PlaceHolders, PreDeployProgressMessage } from "./utils/const
 import { BuildSPPackageError, NoSPPackageError, ScaffoldError } from "./error";
 import * as util from "util";
 import { ProgressHelper } from "./utils/progress-helper";
-import { getStrings, getAppDirectory } from "../../../common/tools";
+import { getStrings, getAppDirectory, isMultiEnvEnabled } from "../../../common/tools";
 import { getTemplatesFolder } from "../../..";
-import { REMOTE_MANIFEST } from "../appstudio/constants";
+import { MANIFEST_TEMPLATE, REMOTE_MANIFEST } from "../appstudio/constants";
 
 export class SPFxPluginImpl {
   public async postScaffold(ctx: PluginContext): Promise<Result<any, FxError>> {
@@ -169,7 +169,10 @@ export class SPFxPluginImpl {
 
       const appDirectory = await getAppDirectory(ctx.root);
       await Utils.configure(outputFolderPath, replaceMap);
-      await Utils.configure(`${appDirectory}/${REMOTE_MANIFEST}`, replaceMap);
+      const manifestTemplatePath = isMultiEnvEnabled()
+        ? path.join(appDirectory, MANIFEST_TEMPLATE)
+        : path.join(appDirectory, REMOTE_MANIFEST);
+      await Utils.configure(manifestTemplatePath, replaceMap);
       return ok(undefined);
     } catch (error) {
       return err(ScaffoldError(error));

--- a/packages/vscode-extension/src/commonlib/azureLogin.ts
+++ b/packages/vscode-extension/src/commonlib/azureLogin.ts
@@ -25,6 +25,7 @@ import {
   loggedIn,
   loggedOut,
   loggingIn,
+  profileDefaultJsonFile,
   signedIn,
   signedOut,
   signingIn,
@@ -47,6 +48,7 @@ import TreeViewManagerInstance from "../commandsTreeViewProvider";
 import * as path from "path";
 import * as fs from "fs-extra";
 import * as commonUtils from "../debug/commonUtils";
+import { isMultiEnvEnabled } from "@microsoft/teamsfx-core";
 
 export class AzureAccountManager extends login implements AzureAccountProvider {
   private static instance: AzureAccountManager;
@@ -564,7 +566,13 @@ export class AzureAccountManager extends login implements AzureAccountProvider {
         workspaceFolder.uri.fsPath,
         `.${ConfigFolderName}`
       );
-      const envDefalultFile = path.join(configRoot!, envDefaultJsonFile);
+
+      const envDefalultFile = path.join(
+        configRoot!,
+        isMultiEnvEnabled()
+          ? path.join("publishProfiles", profileDefaultJsonFile)
+          : envDefaultJsonFile
+      );
       if (!fs.existsSync(envDefalultFile)) {
         return undefined;
       }

--- a/packages/vscode-extension/src/commonlib/common/constant.ts
+++ b/packages/vscode-extension/src/commonlib/common/constant.ts
@@ -12,3 +12,4 @@ export const loggingIn = "LoggingIn";
 
 export const subscriptionInfoFile = "subscriptionInfo.json";
 export const envDefaultJsonFile = "env.default.json";
+export const profileDefaultJsonFile = "profile.default.json";

--- a/packages/vscode-extension/src/utils/commonUtils.ts
+++ b/packages/vscode-extension/src/utils/commonUtils.ts
@@ -6,7 +6,7 @@ import * as fs from "fs-extra";
 import { ext } from "../extensionVariables";
 import * as path from "path";
 import { ConfigFolderName } from "@microsoft/teamsfx-api";
-import { isValidProject } from "@microsoft/teamsfx-core";
+import { isMultiEnvEnabled, isValidProject } from "@microsoft/teamsfx-core";
 
 export function getPackageVersion(versionStr: string): string {
   if (versionStr.includes("alpha")) {
@@ -68,7 +68,12 @@ export function getProjectId(): string | undefined {
   try {
     const ws = ext.workspaceUri.fsPath;
     if (isValidProject(ws)) {
-      const settingsJsonPath = path.join(ws, `.${ConfigFolderName}/settings.json`);
+      const settingsJsonPath = path.join(
+        ws,
+        isMultiEnvEnabled()
+          ? `.${ConfigFolderName}/configs/projectSettings.json`
+          : `.${ConfigFolderName}/settings.json`
+      );
       const settingsJson = JSON.parse(fs.readFileSync(settingsJsonPath, "utf8"));
       return settingsJson.projectId;
     }


### PR DESCRIPTION
- move `.fx/settings.json` to `.fx/configs/projectSettings.json`
- move `.fx/localSettings.json` to `.fx/configs/localSettings.json`
- fix default profile name for local debug in extension/cli

### Test

Tested happy path for local debug

#### MultiEnv/ARM/NewFolderStructure feature flag enabled
![image](https://user-images.githubusercontent.com/9698542/130590887-3bf65a90-af5a-4716-b3b7-caf1369611b6.png)


https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/10667418/