### PR TITLE
refactor(multi-env): move appPackage to templates folder

### DIFF
--- a/packages/fx-core/src/common/tools.ts
+++ b/packages/fx-core/src/common/tools.ts
@@ -441,6 +441,8 @@ export async function getAppDirectory(projectRoot: string): Promise<string> {
   if (isMultiEnvEnabled()) {
     if (await fs.pathExists(`${appDirNewLocForMultiEnv}/${MANIFEST_TEMPLATE}`)) {
       return appDirNewLocForMultiEnv;
+    } else if (await fs.pathExists(`${appDirNewLoc}/${REMOTE_MANIFEST}`)) {
+      return appDirNewLoc;
     } else {
       return appDirOldLoc;
     }

--- a/packages/fx-core/src/common/tools.ts
+++ b/packages/fx-core/src/common/tools.ts
@@ -433,13 +433,23 @@ export function compileHandlebarsTemplateString(templateString: string, context:
 
 export async function getAppDirectory(projectRoot: string): Promise<string> {
   const REMOTE_MANIFEST = "manifest.source.json";
+  const MANIFEST_TEMPLATE = "manifest.template.json";
+  const appDirNewLocForMultiEnv = `${projectRoot}/templates/${AppPackageFolderName}`;
   const appDirNewLoc = `${projectRoot}/${AppPackageFolderName}`;
   const appDirOldLoc = `${projectRoot}/.${ConfigFolderName}`;
 
-  if (await fs.pathExists(`${appDirNewLoc}/${REMOTE_MANIFEST}`)) {
-    return appDirNewLoc;
+  if (isMultiEnvEnabled()) {
+    if (await fs.pathExists(`${appDirNewLocForMultiEnv}/${MANIFEST_TEMPLATE}`)) {
+      return appDirNewLocForMultiEnv;
+    } else {
+      return appDirOldLoc;
+    }
   } else {
-    return appDirOldLoc;
+    if (await fs.pathExists(`${appDirNewLoc}/${REMOTE_MANIFEST}`)) {
+      return appDirNewLoc;
+    } else {
+      return appDirOldLoc;
+    }
   }
 }
 

--- a/packages/fx-core/src/core/index.ts
+++ b/packages/fx-core/src/core/index.ts
@@ -178,7 +178,14 @@ export class FxCore implements Core {
 
       await fs.ensureDir(projectPath);
       await fs.ensureDir(path.join(projectPath, `.${ConfigFolderName}`));
-      await fs.ensureDir(path.join(projectPath, `${AppPackageFolderName}`));
+      await fs.ensureDir(
+        path.join(
+          projectPath,
+          isMultiEnvEnabled()
+            ? path.join("templates", `${AppPackageFolderName}`)
+            : `${AppPackageFolderName}`
+        )
+      );
 
       const createResult = await this.createBasicFolderStructure(inputs);
       if (createResult.isErr()) {

--- a/packages/fx-core/src/plugins/resource/appstudio/constants.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/constants.ts
@@ -30,6 +30,7 @@ export class ErrorMessages {
  * Config keys that are useful for generating remote teams app manifest
  */
 export const REMOTE_MANIFEST = "manifest.source.json";
+export const MANIFEST_TEMPLATE = "manifest.template.json";
 export const FRONTEND_ENDPOINT = "endpoint";
 export const FRONTEND_DOMAIN = "domain";
 export const FRONTEND_ENDPOINT_ARM = "frontendHosting_endpoint";
@@ -59,6 +60,46 @@ export const TEAMS_APP_MANIFEST_TEMPLATE = `{
   "icons": {
       "color": "color.png",
       "outline": "outline.png"
+  },
+  "name": {
+      "short": "{appName}",
+      "full": "This field is not used"
+  },
+  "description": {
+      "short": "Short description of {appName}.",
+      "full": "Full description of {appName}."
+  },
+  "accentColor": "#FFFFFF",
+  "bots": [],
+  "composeExtensions": [],
+  "configurableTabs": [],
+  "staticTabs": [],
+  "permissions": [
+      "identity",
+      "messageTeamMembers"
+  ],
+  "validDomains": [],
+  "webApplicationInfo": {
+      "id": "{appClientId}",
+      "resource": "{webApplicationInfoResource}"
+  }
+}`;
+
+export const TEAMS_APP_MANIFEST_TEMPLATE_FOR_MULTI_ENV = `{
+  "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.9/MicrosoftTeams.schema.json",
+  "manifestVersion": "1.9",
+  "version": "{version}",
+  "id": "{appid}",
+  "packageName": "com.microsoft.teams.extension",
+  "developer": {
+      "name": "Teams App, Inc.",
+      "websiteUrl": "{baseUrl}",
+      "privacyUrl": "{baseUrl}/index.html#/privacy",
+      "termsOfUseUrl": "{baseUrl}/index.html#/termsofuse"
+  },
+  "icons": {
+      "color": "resources/color.png",
+      "outline": "resources/outline.png"
   },
   "name": {
       "short": "{appName}",

--- a/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
@@ -432,20 +432,15 @@ export class AppStudioPluginImpl {
     let manifestString: string | undefined = undefined;
     let appDirectory: string;
     let zipFileName: string;
-    let manifestOutputPath: string | undefined = undefined;
 
     if (ctx.answers?.platform === Platform.VS) {
       appDirectory = ctx.answers![Constants.PUBLISH_PATH_QUESTION] as string;
       zipFileName = `${appDirectory}/appPackage.zip`;
     } else {
       appDirectory = await getAppDirectory(ctx.root);
-      if (isMultiEnvEnabled()) {
-        const publishProfile = `${ctx.root}/.${ConfigFolderName}/publishProfiles/`;
-        zipFileName = `${publishProfile}/appPackage.${ctx.targetEnvName}.zip`;
-        manifestOutputPath = `${publishProfile}/manifest.${ctx.targetEnvName}.json`;
-      } else {
-        zipFileName = `${ctx.root}/${AppPackageFolderName}/appPackage.zip`;
-      }
+      zipFileName = isMultiEnvEnabled()
+        ? `${ctx.root}/${AppPackageFolderName}/appPackage.${ctx.targetEnvName}.zip`
+        : (zipFileName = `${ctx.root}/${AppPackageFolderName}/appPackage.zip`);
     }
 
     if (this.isSPFxProject(ctx)) {
@@ -500,9 +495,8 @@ export class AppStudioPluginImpl {
       );
     }
 
-    if (isMultiEnvEnabled() && manifestOutputPath) {
-      await fs.ensureDir(path.dirname(manifestOutputPath));
-      await fs.writeJSON(manifestOutputPath, manifestString, { spaces: 4 });
+    if (isMultiEnvEnabled()) {
+      await fs.ensureDir(path.dirname(zipFileName));
     }
 
     const zip = new AdmZip();

--- a/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
@@ -1522,8 +1522,6 @@ export class AppStudioPluginImpl {
 
   private async getManifestTemplatePath(projectRoot: string): Promise<string> {
     const appDir = await getAppDirectory(projectRoot);
-    return isMultiEnvEnabled()
-      ? `./${appDir}/${MANIFEST_TEMPLATE}`
-      : `./${appDir}/${REMOTE_MANIFEST}`;
+    return isMultiEnvEnabled() ? `${appDir}/${MANIFEST_TEMPLATE}` : `${appDir}/${REMOTE_MANIFEST}`;
   }
 }

--- a/packages/fx-core/src/plugins/resource/spfx/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/spfx/plugin.ts
@@ -11,9 +11,9 @@ import { Constants, PlaceHolders, PreDeployProgressMessage } from "./utils/const
 import { BuildSPPackageError, NoSPPackageError, ScaffoldError } from "./error";
 import * as util from "util";
 import { ProgressHelper } from "./utils/progress-helper";
-import { getStrings, getAppDirectory } from "../../../common/tools";
+import { getStrings, getAppDirectory, isMultiEnvEnabled } from "../../../common/tools";
 import { getTemplatesFolder } from "../../..";
-import { REMOTE_MANIFEST } from "../appstudio/constants";
+import { MANIFEST_TEMPLATE, REMOTE_MANIFEST } from "../appstudio/constants";
 
 export class SPFxPluginImpl {
   public async postScaffold(ctx: PluginContext): Promise<Result<any, FxError>> {
@@ -169,7 +169,10 @@ export class SPFxPluginImpl {
 
       const appDirectory = await getAppDirectory(ctx.root);
       await Utils.configure(outputFolderPath, replaceMap);
-      await Utils.configure(`${appDirectory}/${REMOTE_MANIFEST}`, replaceMap);
+      const manifestTemplatePath = isMultiEnvEnabled()
+        ? path.join(appDirectory, MANIFEST_TEMPLATE)
+        : path.join(appDirectory, REMOTE_MANIFEST);
+      await Utils.configure(manifestTemplatePath, replaceMap);
       return ok(undefined);
     } catch (error) {
       return err(ScaffoldError(error));


### PR DESCRIPTION
[feature design](https://microsoftapc.sharepoint.com/teams/DevDivTeamsDevXProductTeam/_layouts/OneNote.aspx?id=%2Fteams%2FDevDivTeamsDevXProductTeam%2FShared%20Documents%2FService%20infrastructure%20Team%2FInfra%20team&wd=target%28Infra.one%7C54126BB5-B660-493E-ABC2-5CDF1390B13A%2FFolder%20structure%20and%20file%20naming%7C137CF56A-5AD2-4117-9AB0-E2C7609DA551%2F%29)


- move `appPackage/appPackage.zip` to `appPackage/appPackage.{envName}.zip`
- move `appPackage/manifest.source.json` to `templates/appPackage/manifest.template.json`
- move `appPackage/*.png` to `templates/appPackage/resources/*.png`

![image](https://user-images.githubusercontent.com/9698542/130740491-31174bac-8b85-47de-bc30-73da72c47e14.png)


https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/10667418/