### PR TITLE
refactor(multi-env): rename project/local settings file and fix local debug

### DIFF
--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -231,6 +231,9 @@ export interface EnvMeta {
 }
 
 // @public (undocumented)
+export const EnvProfileFileNameTemplate = "profile.@envName.json";
+
+// @public (undocumented)
 export interface FolderQuestion extends UserInputQuestion {
     default?: string | LocalFunc<string | undefined>;
     // (undocumented)
@@ -449,6 +452,9 @@ export interface IName {
     // (undocumented)
     short: string;
 }
+
+// @public (undocumented)
+export const InputConfigsFolderName = "configs";
 
 // @public
 export interface InputResult<T> {
@@ -774,6 +780,9 @@ export interface ProjectSettings {
     // (undocumented)
     version?: string;
 }
+
+// @public (undocumented)
+export const ProjectSettingsFileName = "projectSettings.json";
 
 // @public
 export interface ProjectStates {

--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -795,6 +795,9 @@ type ProvisionOutput = {
     secrets: Json;
 };
 
+// @public (undocumented)
+export const PublishProfilesFolderName = "publishProfiles";
+
 // @public
 export class QTreeNode {
     constructor(data: Question | Group);

--- a/packages/api/src/constants.ts
+++ b/packages/api/src/constants.ts
@@ -4,7 +4,10 @@
 
 export const ConfigFolderName = "fx";
 export const AppPackageFolderName = "appPackage";
+export const InputConfigsFolderName = "configs";
 export const PublishProfilesFolderName = "publishProfiles";
+export const ProjectSettingsFileName = "projectSettings.json";
+export const EnvProfileFileNameTemplate = "profile.@envName.json";
 export const ProductName = "teamsfx";
 export const ArchiveFolderName = ".archive";
 export const ArchiveLogFileName = ".archive.log";

--- a/packages/api/src/constants.ts
+++ b/packages/api/src/constants.ts
@@ -4,6 +4,7 @@
 
 export const ConfigFolderName = "fx";
 export const AppPackageFolderName = "appPackage";
+export const PublishProfilesFolderName = "publishProfiles";
 export const ProductName = "teamsfx";
 export const ArchiveFolderName = ".archive";
 export const ArchiveLogFileName = ".archive.log";

--- a/packages/fx-core/src/common/localSettingsProvider.ts
+++ b/packages/fx-core/src/common/localSettingsProvider.ts
@@ -3,7 +3,12 @@
 "use strict";
 
 import * as fs from "fs-extra";
-import { ConfigFolderName, ConfigMap, LocalSettings } from "@microsoft/teamsfx-api";
+import {
+  ConfigFolderName,
+  ConfigMap,
+  InputConfigsFolderName,
+  LocalSettings,
+} from "@microsoft/teamsfx-api";
 import {
   LocalSettingsAuthKeys,
   LocalSettingsBackendKeys,
@@ -19,7 +24,7 @@ export class LocalSettingsProvider {
   public readonly localSettingsFilePath: string;
   constructor(workspaceFolder: string) {
     this.localSettingsFilePath = isMultiEnvEnabled()
-      ? `${workspaceFolder}/.${ConfigFolderName}/configs/${localSettingsFileName}`
+      ? `${workspaceFolder}/.${ConfigFolderName}/${InputConfigsFolderName}/${localSettingsFileName}`
       : `${workspaceFolder}/.${ConfigFolderName}/${localSettingsFileName}`;
   }
 

--- a/packages/fx-core/src/common/localSettingsProvider.ts
+++ b/packages/fx-core/src/common/localSettingsProvider.ts
@@ -11,13 +11,16 @@ import {
   LocalSettingsFrontendKeys,
   LocalSettingsTeamsAppKeys,
 } from "./localSettingsConstants";
+import { isMultiEnvEnabled } from "./tools";
 
 export const localSettingsFileName = "localSettings.json";
 
 export class LocalSettingsProvider {
   public readonly localSettingsFilePath: string;
   constructor(workspaceFolder: string) {
-    this.localSettingsFilePath = `${workspaceFolder}/.${ConfigFolderName}/${localSettingsFileName}`;
+    this.localSettingsFilePath = isMultiEnvEnabled()
+      ? `${workspaceFolder}/.${ConfigFolderName}/configs/${localSettingsFileName}`
+      : `${workspaceFolder}/.${ConfigFolderName}/${localSettingsFileName}`;
   }
 
   public init(

--- a/packages/fx-core/src/core/environment.ts
+++ b/packages/fx-core/src/core/environment.ts
@@ -5,6 +5,7 @@ import {
   ConfigFolderName,
   ConfigMap,
   CryptoProvider,
+  EnvProfileFileNameTemplate,
   err,
   FxError,
   ok,
@@ -144,7 +145,9 @@ class EnvironmentManager {
     const basePath = this.getEnvProfilesFolder(projectPath);
     const envProfile = path.resolve(
       basePath,
-      isMultiEnvEnabled() ? `profile.${envName}.json` : `env.${envName}.json`
+      isMultiEnvEnabled()
+        ? EnvProfileFileNameTemplate.replace("@envName", envName)
+        : `env.${envName}.json`
     );
     const userDataFile = path.resolve(basePath, `${envName}.userdata`);
 

--- a/packages/fx-core/src/core/environment.ts
+++ b/packages/fx-core/src/core/environment.ts
@@ -8,6 +8,7 @@ import {
   err,
   FxError,
   ok,
+  PublishProfilesFolderName,
   Result,
   SystemError,
 } from "@microsoft/teamsfx-api";
@@ -164,7 +165,7 @@ class EnvironmentManager {
   }
 
   private getPublishProfilesFolder(projectPath: string): string {
-    return path.resolve(this.getConfigFolder(projectPath), "publishProfiles");
+    return path.resolve(this.getConfigFolder(projectPath), PublishProfilesFolderName);
   }
 
   private getEnvProfilesFolder(projectPath: string): string {

--- a/packages/fx-core/src/core/middleware/projectSettingsLoader.ts
+++ b/packages/fx-core/src/core/middleware/projectSettingsLoader.ts
@@ -5,10 +5,12 @@ import {
   ConfigFolderName,
   err,
   FxError,
+  InputConfigsFolderName,
   Inputs,
   ok,
   PluginConfig,
   ProjectSettings,
+  ProjectSettingsFileName,
   Result,
   SolutionContext,
   Stage,
@@ -79,7 +81,7 @@ export async function loadProjectSettings(
 
     const confFolderPath = path.resolve(inputs.projectPath, `.${ConfigFolderName}`);
     const settingsFile = isMultiEnvEnabled()
-      ? path.resolve(confFolderPath, "configs", "projectSettings.json")
+      ? path.resolve(confFolderPath, InputConfigsFolderName, ProjectSettingsFileName)
       : path.resolve(confFolderPath, "settings.json");
     const projectSettings: ProjectSettings = await readJson(settingsFile);
     let projectIdMissing = false;

--- a/packages/fx-core/src/core/middleware/projectSettingsLoader.ts
+++ b/packages/fx-core/src/core/middleware/projectSettingsLoader.ts
@@ -31,6 +31,7 @@ import { LocalCrypto } from "../crypto";
 import { PluginNames } from "../../plugins/solution/fx-solution/constants";
 import { PermissionRequestFileProvider } from "../permissionRequest";
 import { readJson } from "../../common/fileUtils";
+import { isMultiEnvEnabled } from "../../common";
 
 export const ProjectSettingsLoaderMW: Middleware = async (
   ctx: CoreHookContext,
@@ -77,7 +78,9 @@ export async function loadProjectSettings(
     }
 
     const confFolderPath = path.resolve(inputs.projectPath, `.${ConfigFolderName}`);
-    const settingsFile = path.resolve(confFolderPath, "settings.json");
+    const settingsFile = isMultiEnvEnabled()
+      ? path.resolve(confFolderPath, "configs", "projectSettings.json")
+      : path.resolve(confFolderPath, "settings.json");
     const projectSettings: ProjectSettings = await readJson(settingsFile);
     let projectIdMissing = false;
     if (!projectSettings.projectId) {

--- a/packages/fx-core/src/core/middleware/projectSettingsWriter.ts
+++ b/packages/fx-core/src/core/middleware/projectSettingsWriter.ts
@@ -9,7 +9,9 @@ import {
   AzureSolutionSettings,
   ConfigFolderName,
   err,
+  InputConfigsFolderName,
   Inputs,
+  ProjectSettingsFileName,
   StaticPlatforms,
 } from "@microsoft/teamsfx-api";
 import { WriteFileError } from "../error";
@@ -44,9 +46,9 @@ export const ProjectSettingsWriterMW: Middleware = async (
       if (!solutionSettings.azureResources) solutionSettings.azureResources = [];
       let settingFile;
       if (isMultiEnvEnabled()) {
-        const confFolderPathNew = path.resolve(confFolderPath, "configs");
+        const confFolderPathNew = path.resolve(confFolderPath, InputConfigsFolderName);
         await fs.ensureDir(confFolderPathNew);
-        settingFile = path.resolve(confFolderPathNew, "projectSettings.json");
+        settingFile = path.resolve(confFolderPathNew, ProjectSettingsFileName);
       } else {
         settingFile = path.resolve(confFolderPath, "settings.json");
       }

--- a/packages/fx-core/src/core/middleware/projectUpgrader.ts
+++ b/packages/fx-core/src/core/middleware/projectUpgrader.ts
@@ -1,6 +1,7 @@
 import { Middleware, NextFunction } from "@feathersjs/hooks";
 import {
   ConfigFolderName,
+  PublishProfilesFolderName,
   err,
   FxError,
   Inputs,
@@ -89,7 +90,7 @@ export async function upgradeContext(ctx: CoreHookContext): Promise<Result<undef
   const publishProfilesFolderPath = path.resolve(
     inputs.projectPath,
     `.${ConfigFolderName}`,
-    "publishProfiles"
+    PublishProfilesFolderName
   );
   const settingsFile = isMultiEnvEnabled()
     ? path.resolve(confFolderPath, "projectSettings.json")

--- a/packages/fx-core/src/core/middleware/projectUpgrader.ts
+++ b/packages/fx-core/src/core/middleware/projectUpgrader.ts
@@ -23,6 +23,7 @@ import {
   WriteFileError,
 } from "..";
 import { dataNeedEncryption, deserializeDict, serializeDict } from "../..";
+import { isMultiEnvEnabled } from "../../common";
 import { readJson } from "../../common/fileUtils";
 import {
   Component,
@@ -82,12 +83,23 @@ export async function upgradeContext(ctx: CoreHookContext): Promise<Result<undef
   if (!projectPathExist) {
     return err(PathNotExistError(inputs.projectPath));
   }
-  const confFolderPath = path.resolve(inputs.projectPath!, `.${ConfigFolderName}`);
-  const settingsFile = path.resolve(confFolderPath, "settings.json");
+  const confFolderPath = isMultiEnvEnabled()
+    ? path.resolve(inputs.projectPath, `.${ConfigFolderName}`, "configs")
+    : path.resolve(inputs.projectPath, `.${ConfigFolderName}`);
+  const publishProfilesFolderPath = path.resolve(
+    inputs.projectPath,
+    `.${ConfigFolderName}`,
+    "publishProfiles"
+  );
+  const settingsFile = isMultiEnvEnabled()
+    ? path.resolve(confFolderPath, "projectSettings.json")
+    : path.resolve(confFolderPath, "settings.json");
   const projectSettings: ProjectSettings = await readJson(settingsFile);
   const defaultEnvName = environmentManager.defaultEnvName;
 
-  const contextPath = path.resolve(confFolderPath, `env.${defaultEnvName}.json`);
+  const contextPath = isMultiEnvEnabled()
+    ? path.resolve(publishProfilesFolderPath, `profile.${defaultEnvName}.json`)
+    : path.resolve(confFolderPath, `env.${defaultEnvName}.json`);
   const userDataPath = path.resolve(confFolderPath, `${defaultEnvName}.userdata`);
 
   let context: Json = {};

--- a/packages/fx-core/src/core/middleware/projectUpgrader.ts
+++ b/packages/fx-core/src/core/middleware/projectUpgrader.ts
@@ -10,6 +10,9 @@ import {
   ProjectSettings,
   Result,
   SystemError,
+  ProjectSettingsFileName,
+  InputConfigsFolderName,
+  EnvProfileFileNameTemplate,
 } from "@microsoft/teamsfx-api";
 import * as fs from "fs-extra";
 import * as path from "path";
@@ -85,7 +88,7 @@ export async function upgradeContext(ctx: CoreHookContext): Promise<Result<undef
     return err(PathNotExistError(inputs.projectPath));
   }
   const confFolderPath = isMultiEnvEnabled()
-    ? path.resolve(inputs.projectPath, `.${ConfigFolderName}`, "configs")
+    ? path.resolve(inputs.projectPath, `.${ConfigFolderName}`, InputConfigsFolderName)
     : path.resolve(inputs.projectPath, `.${ConfigFolderName}`);
   const publishProfilesFolderPath = path.resolve(
     inputs.projectPath,
@@ -93,13 +96,16 @@ export async function upgradeContext(ctx: CoreHookContext): Promise<Result<undef
     PublishProfilesFolderName
   );
   const settingsFile = isMultiEnvEnabled()
-    ? path.resolve(confFolderPath, "projectSettings.json")
+    ? path.resolve(confFolderPath, ProjectSettingsFileName)
     : path.resolve(confFolderPath, "settings.json");
   const projectSettings: ProjectSettings = await readJson(settingsFile);
   const defaultEnvName = environmentManager.defaultEnvName;
 
   const contextPath = isMultiEnvEnabled()
-    ? path.resolve(publishProfilesFolderPath, `profile.${defaultEnvName}.json`)
+    ? path.resolve(
+        publishProfilesFolderPath,
+        EnvProfileFileNameTemplate.replace("@envName", defaultEnvName)
+      )
     : path.resolve(confFolderPath, `env.${defaultEnvName}.json`);
   const userDataPath = path.resolve(confFolderPath, `${defaultEnvName}.userdata`);
 

--- a/packages/vscode-extension/src/commonlib/azureLogin.ts
+++ b/packages/vscode-extension/src/commonlib/azureLogin.ts
@@ -25,6 +25,7 @@ import {
   loggedIn,
   loggedOut,
   loggingIn,
+  profileDefaultJsonFile,
   signedIn,
   signedOut,
   signingIn,
@@ -47,6 +48,7 @@ import TreeViewManagerInstance from "../commandsTreeViewProvider";
 import * as path from "path";
 import * as fs from "fs-extra";
 import * as commonUtils from "../debug/commonUtils";
+import { isMultiEnvEnabled } from "@microsoft/teamsfx-core";
 
 export class AzureAccountManager extends login implements AzureAccountProvider {
   private static instance: AzureAccountManager;
@@ -564,7 +566,13 @@ export class AzureAccountManager extends login implements AzureAccountProvider {
         workspaceFolder.uri.fsPath,
         `.${ConfigFolderName}`
       );
-      const envDefalultFile = path.join(configRoot!, envDefaultJsonFile);
+
+      const envDefalultFile = path.join(
+        configRoot!,
+        isMultiEnvEnabled()
+          ? path.join("publishProfiles", profileDefaultJsonFile)
+          : envDefaultJsonFile
+      );
       if (!fs.existsSync(envDefalultFile)) {
         return undefined;
       }

--- a/packages/vscode-extension/src/commonlib/azureLogin.ts
+++ b/packages/vscode-extension/src/commonlib/azureLogin.ts
@@ -14,6 +14,7 @@ import {
   OptionItem,
   ok,
   ConfigFolderName,
+  PublishProfilesFolderName,
 } from "@microsoft/teamsfx-api";
 import { ExtensionErrors } from "../error";
 import { AzureAccount } from "./azure-account.api";
@@ -570,7 +571,7 @@ export class AzureAccountManager extends login implements AzureAccountProvider {
       const envDefalultFile = path.join(
         configRoot!,
         isMultiEnvEnabled()
-          ? path.join("publishProfiles", profileDefaultJsonFile)
+          ? path.join(PublishProfilesFolderName, profileDefaultJsonFile)
           : envDefaultJsonFile
       );
       if (!fs.existsSync(envDefalultFile)) {

--- a/packages/vscode-extension/src/commonlib/common/constant.ts
+++ b/packages/vscode-extension/src/commonlib/common/constant.ts
@@ -12,3 +12,4 @@ export const loggingIn = "LoggingIn";
 
 export const subscriptionInfoFile = "subscriptionInfo.json";
 export const envDefaultJsonFile = "env.default.json";
+export const profileDefaultJsonFile = "profile.default.json";

--- a/packages/vscode-extension/src/debug/commonUtils.ts
+++ b/packages/vscode-extension/src/debug/commonUtils.ts
@@ -6,7 +6,7 @@ import * as path from "path";
 import * as dotenv from "dotenv";
 import * as vscode from "vscode";
 import * as constants from "./constants";
-import { ConfigFolderName, Func } from "@microsoft/teamsfx-api";
+import { ConfigFolderName, Func, PublishProfilesFolderName } from "@microsoft/teamsfx-api";
 import { core, getSystemInputs, showError } from "../handlers";
 import * as net from "net";
 import { ext } from "../extensionVariables";
@@ -244,8 +244,8 @@ function getSettingWithUserData(jsonSelector: (jsonObject: any) => any): string 
     if (isValidProject(ws)) {
       const env = getActiveEnv();
       const envJsonPath = isMultiEnvEnabled()
-        ? path.join(ws, `.${ConfigFolderName}/publishProfiles/profile.${env}.json`)
-        : path.join(ws, `.${ConfigFolderName}/env.${env}.json`);
+        ? path.join(ws, `.${ConfigFolderName}/${PublishProfilesFolderName}/profile.${env}.json`)
+        : path.join(ws, `.${ConfigFolderName}/${PublishProfilesFolderName}/env.${env}.json`);
       const envJson = JSON.parse(fs.readFileSync(envJsonPath, "utf8"));
       const settingValue = jsonSelector(envJson) as string;
       if (settingValue && settingValue.startsWith("{{") && settingValue.endsWith("}}")) {

--- a/packages/vscode-extension/src/debug/commonUtils.ts
+++ b/packages/vscode-extension/src/debug/commonUtils.ts
@@ -245,7 +245,7 @@ function getSettingWithUserData(jsonSelector: (jsonObject: any) => any): string 
       const env = getActiveEnv();
       const envJsonPath = isMultiEnvEnabled()
         ? path.join(ws, `.${ConfigFolderName}/${PublishProfilesFolderName}/profile.${env}.json`)
-        : path.join(ws, `.${ConfigFolderName}/${PublishProfilesFolderName}/env.${env}.json`);
+        : path.join(ws, `.${ConfigFolderName}/env.${env}.json`);
       const envJson = JSON.parse(fs.readFileSync(envJsonPath, "utf8"));
       const settingValue = jsonSelector(envJson) as string;
       if (settingValue && settingValue.startsWith("{{") && settingValue.endsWith("}}")) {

--- a/packages/vscode-extension/src/utils/commonUtils.ts
+++ b/packages/vscode-extension/src/utils/commonUtils.ts
@@ -5,7 +5,12 @@ import * as extensionPackage from "./../../package.json";
 import * as fs from "fs-extra";
 import { ext } from "../extensionVariables";
 import * as path from "path";
-import { ConfigFolderName } from "@microsoft/teamsfx-api";
+import {
+  ConfigFolderName,
+  InputConfigsFolderName,
+  ProjectSettingsFileName,
+  EnvProfileFileNameTemplate,
+} from "@microsoft/teamsfx-api";
 import { isMultiEnvEnabled, isValidProject } from "@microsoft/teamsfx-core";
 import { workspace } from "vscode";
 import * as commonUtils from "../debug/commonUtils";
@@ -57,7 +62,12 @@ export function getTeamsAppId() {
     const ws = ext.workspaceUri.fsPath;
     if (isValidProject(ws)) {
       const env = getActiveEnv();
-      const envJsonPath = path.join(ws, `.${ConfigFolderName}/env.${env}.json`);
+      const envJsonPath = isMultiEnvEnabled()
+        ? `.${ConfigFolderName}/${InputConfigsFolderName}/${EnvProfileFileNameTemplate.replace(
+            "@envName",
+            env
+          )}`
+        : `.${ConfigFolderName}/env.${env}.json`;
       const envJson = JSON.parse(fs.readFileSync(envJsonPath, "utf8"));
       return envJson.solution.remoteTeamsAppId;
     }
@@ -73,7 +83,7 @@ export function getProjectId(): string | undefined {
       const settingsJsonPath = path.join(
         ws,
         isMultiEnvEnabled()
-          ? `.${ConfigFolderName}/configs/projectSettings.json`
+          ? `.${ConfigFolderName}/${InputConfigsFolderName}/${ProjectSettingsFileName}`
           : `.${ConfigFolderName}/settings.json`
       );
       const settingsJson = JSON.parse(fs.readFileSync(settingsJsonPath, "utf8"));

--- a/packages/vscode-extension/src/utils/commonUtils.ts
+++ b/packages/vscode-extension/src/utils/commonUtils.ts
@@ -62,12 +62,15 @@ export function getTeamsAppId() {
     const ws = ext.workspaceUri.fsPath;
     if (isValidProject(ws)) {
       const env = getActiveEnv();
-      const envJsonPath = isMultiEnvEnabled()
-        ? `.${ConfigFolderName}/${InputConfigsFolderName}/${EnvProfileFileNameTemplate.replace(
-            "@envName",
-            env
-          )}`
-        : `.${ConfigFolderName}/env.${env}.json`;
+      const envJsonPath = path.join(
+        ws,
+        isMultiEnvEnabled()
+          ? `.${ConfigFolderName}/${InputConfigsFolderName}/${EnvProfileFileNameTemplate.replace(
+              "@envName",
+              env
+            )}`
+          : `.${ConfigFolderName}/env.${env}.json`
+      );
       const envJson = JSON.parse(fs.readFileSync(envJsonPath, "utf8"));
       return envJson.solution.remoteTeamsAppId;
     }

--- a/packages/vscode-extension/src/utils/commonUtils.ts
+++ b/packages/vscode-extension/src/utils/commonUtils.ts
@@ -6,7 +6,7 @@ import * as fs from "fs-extra";
 import { ext } from "../extensionVariables";
 import * as path from "path";
 import { ConfigFolderName } from "@microsoft/teamsfx-api";
-import { isValidProject } from "@microsoft/teamsfx-core";
+import { isMultiEnvEnabled, isValidProject } from "@microsoft/teamsfx-core";
 import { workspace } from "vscode";
 import * as commonUtils from "../debug/commonUtils";
 
@@ -70,7 +70,12 @@ export function getProjectId(): string | undefined {
   try {
     const ws = ext.workspaceUri.fsPath;
     if (isValidProject(ws)) {
-      const settingsJsonPath = path.join(ws, `.${ConfigFolderName}/settings.json`);
+      const settingsJsonPath = path.join(
+        ws,
+        isMultiEnvEnabled()
+          ? `.${ConfigFolderName}/configs/projectSettings.json`
+          : `.${ConfigFolderName}/settings.json`
+      );
       const settingsJson = JSON.parse(fs.readFileSync(settingsJsonPath, "utf8"));
       return settingsJson.projectId;
     }


### PR DESCRIPTION
[design](https://microsoftapc.sharepoint.com/teams/DevDivTeamsDevXProductTeam/_layouts/OneNote.aspx?id=%2Fteams%2FDevDivTeamsDevXProductTeam%2FShared%20Documents%2FService%20infrastructure%20Team%2FInfra%20team&wd=target%28Infra.one%7C54126BB5-B660-493E-ABC2-5CDF1390B13A%2FFolder%20structure%20and%20file%20naming%7C137CF56A-5AD2-4117-9AB0-E2C7609DA551%2F%29)

- move `.fx/localSettings.json` to `.fx/configs/localSettings.json`
- move `.fx/settings.json` to `.fx/projectSettings.json`
- fix default profile file name for local debug
- for CLI part, I will change in another PR

Test result:
![image](https://user-images.githubusercontent.com/9698542/130721620-440a66fb-82de-4e9b-87bb-dceb2013abe5.png)



https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/10667418/