### PR TITLE
refactor(multi-env): rename default env to 'dev'

### DIFF
--- a/packages/fx-core/src/core/environment.ts
+++ b/packages/fx-core/src/core/environment.ts
@@ -43,6 +43,7 @@ export interface EnvFiles {
 
 class EnvironmentManager {
   public readonly defaultEnvName = "default";
+  public readonly defaultEnvNameNew = "dev";
   public readonly envNameRegex = /^[\w\d-_]+$/;
   public readonly envProfileNameRegex = /profile\.(?<envName>[\w\d-_]+)\.json/i;
 
@@ -55,7 +56,7 @@ class EnvironmentManager {
       return err(PathNotExistError(projectPath));
     }
 
-    envName = envName ?? this.defaultEnvName;
+    envName = envName ?? this.getDefaultEnvName();
     const envFiles = this.getEnvFilesPath(envName, projectPath);
     const userDataResult = await this.loadUserData(envFiles.userDataFile, cryptoProvider);
     if (userDataResult.isErr()) {
@@ -92,7 +93,7 @@ class EnvironmentManager {
       await fs.ensureDir(envProfilesFolder);
     }
 
-    envName = envName ?? this.defaultEnvName;
+    envName = envName ?? this.getDefaultEnvName();
     const envFiles = this.getEnvFilesPath(envName, projectPath);
 
     const data = mapToJson(envData);
@@ -239,6 +240,14 @@ class EnvironmentManager {
     }
 
     return ok(secrets);
+  }
+
+  public getDefaultEnvName() {
+    if (isMultiEnvEnabled()) {
+      return this.defaultEnvNameNew;
+    } else {
+      return this.defaultEnvName;
+    }
   }
 }
 

--- a/packages/fx-core/src/core/middleware/envInfoLoader.ts
+++ b/packages/fx-core/src/core/middleware/envInfoLoader.ts
@@ -68,7 +68,7 @@ export function EnvInfoLoaderMW(
       }
       lastUsedEnvName = targetEnvName ?? lastUsedEnvName;
     } else {
-      targetEnvName = environmentManager.defaultEnvName;
+      targetEnvName = environmentManager.getDefaultEnvName();
     }
 
     if (targetEnvName) {

--- a/packages/fx-core/src/core/middleware/projectUpgrader.ts
+++ b/packages/fx-core/src/core/middleware/projectUpgrader.ts
@@ -99,7 +99,7 @@ export async function upgradeContext(ctx: CoreHookContext): Promise<Result<undef
     ? path.resolve(confFolderPath, ProjectSettingsFileName)
     : path.resolve(confFolderPath, "settings.json");
   const projectSettings: ProjectSettings = await readJson(settingsFile);
-  const defaultEnvName = environmentManager.defaultEnvName;
+  const defaultEnvName = environmentManager.getDefaultEnvName();
 
   const contextPath = isMultiEnvEnabled()
     ? path.resolve(

--- a/packages/vscode-extension/src/commonlib/common/constant.ts
+++ b/packages/vscode-extension/src/commonlib/common/constant.ts
@@ -12,4 +12,4 @@ export const loggingIn = "LoggingIn";
 
 export const subscriptionInfoFile = "subscriptionInfo.json";
 export const envDefaultJsonFile = "env.default.json";
-export const profileDefaultJsonFile = "profile.default.json";
+export const profileDefaultJsonFile = "profile.dev.json";

--- a/packages/vscode-extension/src/debug/commonUtils.ts
+++ b/packages/vscode-extension/src/debug/commonUtils.ts
@@ -6,7 +6,12 @@ import * as path from "path";
 import * as dotenv from "dotenv";
 import * as vscode from "vscode";
 import * as constants from "./constants";
-import { ConfigFolderName, Func, PublishProfilesFolderName } from "@microsoft/teamsfx-api";
+import {
+  ConfigFolderName,
+  Func,
+  InputConfigsFolderName,
+  PublishProfilesFolderName,
+} from "@microsoft/teamsfx-api";
 import { core, getSystemInputs, showError } from "../handlers";
 import * as net from "net";
 import { ext } from "../extensionVariables";
@@ -147,7 +152,9 @@ async function getLocalDebugConfig(key: string): Promise<string | undefined> {
   const userDataFilePath: string = path.join(
     workspacePath,
     `.${ConfigFolderName}`,
-    constants.userDataFileName
+    isMultiEnvEnabled()
+      ? path.join(InputConfigsFolderName, constants.userDataFileNameNew)
+      : constants.userDataFileName
   );
   if (!(await fs.pathExists(userDataFilePath))) {
     return undefined;

--- a/packages/vscode-extension/src/debug/constants.ts
+++ b/packages/vscode-extension/src/debug/constants.ts
@@ -23,6 +23,7 @@ export const botFolderName = "bot";
 export const localEnvFileName = "local.env";
 export const manifestFileName = "manifest.source.json";
 export const userDataFileName = "default.userdata"; // TODO: different file name for different environment
+export const userDataFileNameNew = "dev.userdata"; // TODO: different file name for different environment
 
 export const frontendLocalEnvPrefix = "FRONTEND_";
 export const backendLocalEnvPrefix = "BACKEND_";


### PR DESCRIPTION
[design](https://microsoftapc.sharepoint.com/teams/DevDivTeamsDevXProductTeam/_layouts/OneNote.aspx?id=%2Fteams%2FDevDivTeamsDevXProductTeam%2FShared%20Documents%2FService%20infrastructure%20Team%2FInfra%20team&wd=target%28Infra.one%7C54126BB5-B660-493E-ABC2-5CDF1390B13A%2FFolder%20structure%20and%20file%20naming%7C137CF56A-5AD2-4117-9AB0-E2C7609DA551%2F%29)

- rename default env name from "default" to "dev"

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/10667418
