### PR TITLE
refactor(multi-env): change foler structure for cli

### DIFF
--- a/packages/cli/src/commonlib/azureLogin.ts
+++ b/packages/cli/src/commonlib/azureLogin.ts
@@ -23,7 +23,7 @@ import { NotFoundSubscriptionId, NotSupportedProjectType } from "../error";
 import {
   changeLoginTenantMessage,
   env,
-  envDefaultJsonFile,
+  profileDefaultJsonFile,
   failToFindSubscription,
   loginComponent,
   MFACode,
@@ -33,6 +33,7 @@ import {
   signedOut,
   subscription,
   subscriptionInfoFile,
+  envDefaultJsonFile,
 } from "./common/constant";
 import { login, LoginStatus } from "./common/login";
 import { LogLevel as LLevel } from "@microsoft/teamsfx-api";
@@ -40,7 +41,8 @@ import { CodeFlowTenantLogin } from "./codeFlowTenantLogin";
 import CLIUIInstance from "../userInteraction";
 import * as path from "path";
 import * as fs from "fs-extra";
-import { isWorkspaceSupported } from "../utils";
+import { getEnvProfilePath, isWorkspaceSupported } from "../utils";
+import { isMultiEnvEnabled } from "@microsoft/teamsfx-core";
 
 const accountName = "azure";
 const scopes = ["https://management.core.windows.net/user_impersonation"];
@@ -585,15 +587,14 @@ export class AzureAccountManager extends login implements AzureAccountProvider {
       if (!isWorkspaceSupported(AzureAccountManager.rootPath)) {
         return undefined;
       }
-      const envDefalultFile = path.join(
+      const envDefaultFile = getEnvProfilePath(
         AzureAccountManager.rootPath,
-        `.${ConfigFolderName}`,
-        envDefaultJsonFile
+        isMultiEnvEnabled() ? envDefaultJsonFile : profileDefaultJsonFile
       );
-      if (!fs.existsSync(envDefalultFile)) {
+      if (!fs.existsSync(envDefaultFile)) {
         return undefined;
       }
-      const envDefaultJson = (await fs.readFile(envDefalultFile)).toString();
+      const envDefaultJson = (await fs.readFile(envDefaultFile)).toString();
       const envDefault = JSON.parse(envDefaultJson);
       if (envDefault.solution && envDefault.solution.subscriptionId) {
         return {

--- a/packages/cli/src/commonlib/common/constant.ts
+++ b/packages/cli/src/commonlib/common/constant.ts
@@ -45,5 +45,6 @@ export const loginComponent = "login";
 
 export const subscriptionInfoFile = "subscriptionInfo.json";
 export const envDefaultJsonFile = "env.default.json";
+export const profileDefaultJsonFile = "profile.dev.json";
 
 export const sendFileTimeout = "Send success page timeout.";


### PR DESCRIPTION
[design](https://microsoftapc.sharepoint.com/teams/DevDivTeamsDevXProductTeam/_layouts/OneNote.aspx?id=%2Fteams%2FDevDivTeamsDevXProductTeam%2FShared%20Documents%2FService%20infrastructure%20Team%2FInfra%20team&wd=target%28Infra.one%7C54126BB5-B660-493E-ABC2-5CDF1390B13A%2FFolder%20structure%20and%20file%20naming%7C137CF56A-5AD2-4117-9AB0-E2C7609DA551%2F%29)


- move `.fx/env.{envName}.json` to `.fx/publishProfiles/profile.{envName}.json`
- move `.fx/{envName}.userdata` to `.fx/publishProfiles/{envName}.userdata`

### Test
- Tested local preview and remote preview
- Folder structure:
![image](https://user-images.githubusercontent.com/9698542/130910314-8c527d73-5cef-41b4-9019-4cc9dcfe3e6e.png)
