### PR TITLE
refactor(multi-env): update the contract of SolutionContext

### DIFF
--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -1023,7 +1023,7 @@ export type SolutionConfig = Map<PluginIdentity, PluginConfig>;
 // @public (undocumented)
 export interface SolutionContext extends Context {
     // (undocumented)
-    config: SolutionConfig;
+    envInfo: EnvInfo;
 }
 
 // @public (undocumented)

--- a/packages/api/src/context.ts
+++ b/packages/api/src/context.ts
@@ -71,7 +71,7 @@ export interface SolutionContext extends Context {
 
   // app: TeamsAppManifest;
 
-  config: SolutionConfig;
+  envInfo: EnvInfo;
 }
 
 export interface PluginContext extends Context {

--- a/packages/fx-core/src/core/index.ts
+++ b/packages/fx-core/src/core/index.ts
@@ -96,6 +96,7 @@ import { EnvInfoWriterMW } from "./middleware/envInfoWriter";
 import { LocalSettingsLoaderMW } from "./middleware/localSettingsLoader";
 import { LocalSettingsWriterMW } from "./middleware/localSettingsWriter";
 import { MigrateConditionHandlerMW } from "./middleware/migrateConditionHandler";
+import { newEnvInfo } from "./tools";
 
 export interface CoreHookContext extends HookContext {
   projectSettings?: ProjectSettings;
@@ -169,7 +170,7 @@ export class FxCore implements Core {
 
       const solutionContext: SolutionContext = {
         projectSettings: projectSettings,
-        config: new Map<string, PluginConfig>(),
+        envInfo: newEnvInfo(),
         root: projectPath,
         ...this.tools,
         ...this.tools.tokenProvider,
@@ -254,7 +255,7 @@ export class FxCore implements Core {
 
     const solutionContext: SolutionContext = {
       projectSettings: projectSettings,
-      config: new Map<string, PluginConfig>(),
+      envInfo: newEnvInfo(),
       root: projectPath,
       ...this.tools,
       ...this.tools.tokenProvider,
@@ -448,11 +449,11 @@ export class FxCore implements Core {
   async localDebug(inputs: Inputs, ctx?: CoreHookContext): Promise<Result<Void, FxError>> {
     currentStage = Stage.debug;
     upgradeProgrammingLanguage(
-      ctx!.solutionContext!.config as SolutionConfig,
+      ctx!.solutionContext!.envInfo.profile as SolutionConfig,
       ctx!.projectSettings!
     );
     upgradeDefaultFunctionName(
-      ctx!.solutionContext!.config as SolutionConfig,
+      ctx!.solutionContext!.envInfo.profile as SolutionConfig,
       ctx!.projectSettings!
     );
 
@@ -571,7 +572,7 @@ export class FxCore implements Core {
   ): Promise<Result<ProjectConfig | undefined, FxError>> {
     return ok({
       settings: ctx!.projectSettings,
-      config: ctx!.solutionContext?.config,
+      config: ctx!.solutionContext?.envInfo.profile,
       localSettings: ctx!.solutionContext?.localSettings,
     });
   }
@@ -586,11 +587,12 @@ export class FxCore implements Core {
   ])
   async setSubscriptionInfo(inputs: Inputs, ctx?: CoreHookContext): Promise<Result<Void, FxError>> {
     const solutionContext = ctx!.solutionContext! as SolutionContext;
-    if (inputs.tenantId) solutionContext.config.get("solution")?.set("tenantId", inputs.tenantId);
-    else solutionContext.config.get("solution")?.delete("tenantId");
+    if (inputs.tenantId)
+      solutionContext.envInfo.profile.get("solution")?.set("tenantId", inputs.tenantId);
+    else solutionContext.envInfo.profile.get("solution")?.delete("tenantId");
     if (inputs.subscriptionId)
-      solutionContext.config.get("solution")?.set("subscriptionId", inputs.subscriptionId);
-    else solutionContext.config.get("solution")?.delete("subscriptionId");
+      solutionContext.envInfo.profile.get("solution")?.set("subscriptionId", inputs.subscriptionId);
+    else solutionContext.envInfo.profile.get("solution")?.delete("subscriptionId");
     return ok(Void);
   }
 

--- a/packages/fx-core/src/core/middleware/envInfoLoader.ts
+++ b/packages/fx-core/src/core/middleware/envInfoLoader.ts
@@ -124,7 +124,6 @@ export async function loadSolutionContext(
   const solutionContext: SolutionContext = {
     projectSettings: projectSettings,
     envInfo,
-    config: envInfo.profile,
     root: inputs.projectPath || "",
     ...tools,
     ...tools.tokenProvider,

--- a/packages/fx-core/src/core/middleware/envInfoWriter.ts
+++ b/packages/fx-core/src/core/middleware/envInfoWriter.ts
@@ -29,12 +29,12 @@ export const EnvInfoWriterMW: Middleware = async (ctx: CoreHookContext, next: Ne
     if (solutionContext === undefined) return;
 
     // DO NOT persist local debug plugin config.
-    if (solutionContext.config.has(PluginNames.LDEBUG)) {
-      solutionContext.config.delete(PluginNames.LDEBUG);
+    if (solutionContext.envInfo.profile.has(PluginNames.LDEBUG)) {
+      solutionContext.envInfo.profile.delete(PluginNames.LDEBUG);
     }
 
     const envProfilePath = await environmentManager.writeEnvProfile(
-      solutionContext.config,
+      solutionContext.envInfo.profile,
       inputs.projectPath,
       solutionContext.envInfo?.envName,
       solutionContext.cryptoProvider

--- a/packages/fx-core/src/core/middleware/projectSettingsLoader.ts
+++ b/packages/fx-core/src/core/middleware/projectSettingsLoader.ts
@@ -8,7 +8,6 @@ import {
   InputConfigsFolderName,
   Inputs,
   ok,
-  PluginConfig,
   ProjectSettings,
   ProjectSettingsFileName,
   Result,
@@ -27,7 +26,7 @@ import {
 import * as path from "path";
 import * as fs from "fs-extra";
 import { Middleware, NextFunction } from "@feathersjs/hooks/lib";
-import { validateSettings } from "../tools";
+import { newEnvInfo, validateSettings } from "../tools";
 import * as uuid from "uuid";
 import { LocalCrypto } from "../crypto";
 import { PluginNames } from "../../plugins/solution/fx-solution/constants";
@@ -115,7 +114,7 @@ export async function newSolutionContext(tools: Tools, inputs: Inputs): Promise<
   };
   const solutionContext: SolutionContext = {
     projectSettings: projectSettings,
-    config: new Map<string, PluginConfig>(),
+    envInfo: newEnvInfo(),
     root: inputs.projectPath || "",
     ...tools,
     ...tools.tokenProvider,

--- a/packages/fx-core/src/core/middleware/telemetrySender.ts
+++ b/packages/fx-core/src/core/middleware/telemetrySender.ts
@@ -21,7 +21,7 @@ export const TelemetrySenderMW: Middleware = async (ctx: CoreHookContext, next: 
   const core = ctx.self as FxCore;
   const inputs = ctx.arguments[ctx.arguments.length - 1] as Inputs;
   const solutionContext = ctx.solutionContext;
-  const appId = solutionContext?.config?.get("solution")?.get("remoteTeamsAppId") as string;
+  const appId = solutionContext?.envInfo.profile.get("solution")?.get("remoteTeamsAppId") as string;
   const properties: any = { module: "fx-core" };
   if (appId) properties[TelemetryProperty.AppId] = appId;
   const correlationId = inputs.correlationId === undefined ? "" : inputs.correlationId;

--- a/packages/fx-core/src/core/tools.ts
+++ b/packages/fx-core/src/core/tools.ts
@@ -3,10 +3,12 @@ import {
   SolutionContext,
   ProjectSettings,
   AzureSolutionSettings,
+  EnvInfo,
+  ConfigMap,
 } from "@microsoft/teamsfx-api";
 import * as path from "path";
 import * as fs from "fs-extra";
-import { PluginNames } from "../plugins/solution/fx-solution/constants";
+import { GLOBAL_CONFIG, PluginNames } from "../plugins/solution/fx-solution/constants";
 import {
   AzureResourceApim,
   AzureResourceFunction,
@@ -16,6 +18,7 @@ import {
   MessageExtensionItem,
   TabOptionItem,
 } from "../plugins/solution/fx-solution/question";
+import { environmentManager } from "./environment";
 export function validateProject(solutionContext: SolutionContext): string | undefined {
   const res = validateSettings(solutionContext.projectSettings);
   return res;
@@ -134,4 +137,17 @@ export function isMigrateFromV1Project(workspacePath?: string): boolean {
   } catch (e) {
     return false;
   }
+}
+
+export function newEnvInfo(): EnvInfo {
+  return {
+    envName: environmentManager.getDefaultEnvName(),
+    config: {
+      azure: {},
+      manifest: {
+        values: {},
+      },
+    },
+    profile: new Map<string, any>([[GLOBAL_CONFIG, new ConfigMap()]]),
+  };
 }

--- a/packages/fx-core/src/plugins/solution/fx-solution/arm.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/arm.ts
@@ -142,7 +142,7 @@ export async function doDeployArmTemplates(ctx: SolutionContext): Promise<Result
   // update parameters
   const parameterJson = await getParameterJson(ctx);
 
-  const resourceGroupName = ctx.config.get(GLOBAL_CONFIG)?.getString(RESOURCE_GROUP_NAME);
+  const resourceGroupName = ctx.envInfo.profile.get(GLOBAL_CONFIG)?.getString(RESOURCE_GROUP_NAME);
   if (!resourceGroupName) {
     throw new Error("Failed to get resource group from project solution settings.");
   }
@@ -184,7 +184,9 @@ export async function doDeployArmTemplates(ctx: SolutionContext): Promise<Result
             deploymentName
           )
         );
-        ctx.config.get(GLOBAL_CONFIG)?.set(ARM_TEMPLATE_OUTPUT, result.properties?.outputs);
+        ctx.envInfo.profile
+          .get(GLOBAL_CONFIG)
+          ?.set(ARM_TEMPLATE_OUTPUT, result.properties?.outputs);
         return result;
       })
       .finally(() => {
@@ -524,7 +526,7 @@ function expandParameterPlaceholders(
     }
   }
   // Add solution config to available variables
-  const solutionConfig = ctx.config.get(GLOBAL_CONFIG);
+  const solutionConfig = ctx.envInfo.profile.get(GLOBAL_CONFIG);
   if (solutionConfig) {
     for (const configItem of solutionConfig) {
       if (typeof configItem[1] === "string") {
@@ -551,9 +553,9 @@ function normalizeToEnvName(input: string): string {
 function generateResourceName(ctx: SolutionContext): void {
   const maxAppNameLength = 10;
   const appName = ctx.projectSettings!.appName;
-  const suffix = ctx.config.get(GLOBAL_CONFIG)?.getString("resourceNameSuffix");
+  const suffix = ctx.envInfo.profile.get(GLOBAL_CONFIG)?.getString("resourceNameSuffix");
   const normalizedAppName = appName.replace(/[^a-zA-Z0-9]/g, "").toLowerCase();
-  ctx.config
+  ctx.envInfo.profile
     .get(GLOBAL_CONFIG)
     ?.set("resource_base_name", normalizedAppName.substr(0, maxAppNameLength) + suffix);
 }

--- a/packages/fx-core/src/plugins/solution/fx-solution/commonQuestions.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/commonQuestions.ts
@@ -55,7 +55,6 @@ export async function checkSubscription(
       )
     );
   }
-  const activeSubscriptionId = ctx.config.get(GLOBAL_CONFIG)?.get("subscriptionId");
   const askSubRes = await ctx.azureAccountProvider!.getSelectedSubscription(true);
   return ok(askSubRes!);
 }

--- a/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
@@ -309,8 +309,8 @@ export class TeamsAppSolution implements Solution {
     });
 
     // ensure that global namespace is present
-    if (!ctx.config.has(GLOBAL_CONFIG)) {
-      ctx.config.set(GLOBAL_CONFIG, new ConfigMap());
+    if (!ctx.envInfo.profile.has(GLOBAL_CONFIG)) {
+      ctx.envInfo.profile.set(GLOBAL_CONFIG, new ConfigMap());
     }
 
     // Only non-SPFx project will ask this question.
@@ -354,8 +354,8 @@ export class TeamsAppSolution implements Solution {
     });
 
     // ensure that global namespace is present
-    if (!ctx.config.has(GLOBAL_CONFIG)) {
-      ctx.config.set(GLOBAL_CONFIG, new ConfigMap());
+    if (!ctx.envInfo.profile.has(GLOBAL_CONFIG)) {
+      ctx.envInfo.profile.set(GLOBAL_CONFIG, new ConfigMap());
     }
 
     const settingsRes = await this.fillInV1SolutionSettings(ctx);
@@ -611,7 +611,7 @@ export class TeamsAppSolution implements Solution {
         );
         ctx.logProvider?.info(msg);
         ctx.ui?.showMessage("info", msg, false);
-        ctx.config.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
+        ctx.envInfo.profile.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
       } else {
         if (!isUserCancelError(provisionResult.error)) {
           const msg = util.format(
@@ -619,7 +619,7 @@ export class TeamsAppSolution implements Solution {
             ctx.projectSettings?.appName
           );
           ctx.logProvider?.error(msg);
-          ctx.config.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, false);
+          ctx.envInfo.profile.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, false);
         }
       }
       return provisionResult;
@@ -644,7 +644,7 @@ export class TeamsAppSolution implements Solution {
       const res = await fillInCommonQuestions(
         ctx,
         appName,
-        ctx.config,
+        ctx.envInfo.profile,
         ctx.azureAccountProvider,
         await ctx.appStudioToken?.getJsonObject()
       );
@@ -719,7 +719,9 @@ export class TeamsAppSolution implements Solution {
             if (plugin[2] === PluginNames.APPST) {
               const teamsAppResult = provisionResults[index];
               if (teamsAppResult.isOk()) {
-                ctx.config.get(GLOBAL_CONFIG)?.set(REMOTE_TEAMS_APP_ID, teamsAppResult.value);
+                ctx.envInfo.profile
+                  .get(GLOBAL_CONFIG)
+                  ?.set(REMOTE_TEAMS_APP_ID, teamsAppResult.value);
               }
             }
           });
@@ -758,7 +760,7 @@ export class TeamsAppSolution implements Solution {
         return ok(undefined);
       },
       async () => {
-        ctx.config.get(GLOBAL_CONFIG)?.delete(ARM_TEMPLATE_OUTPUT);
+        ctx.envInfo.profile.get(GLOBAL_CONFIG)?.delete(ARM_TEMPLATE_OUTPUT);
         ctx.logProvider?.info(
           util.format(getStrings().solution.ConfigurationFinishNotice, PluginDisplayName.Solution)
         );
@@ -775,7 +777,7 @@ export class TeamsAppSolution implements Solution {
     }
 
     const isAzureProject = this.isAzureProject(ctx);
-    const provisioned = this.checkWetherProvisionSucceeded(ctx.config);
+    const provisioned = this.checkWetherProvisionSucceeded(ctx.envInfo.profile);
     if (isAzureProject && !provisioned) {
       return err(
         returnUserError(
@@ -890,7 +892,7 @@ export class TeamsAppSolution implements Solution {
     const checkRes = this.checkWhetherSolutionIsIdle();
     if (checkRes.isErr()) return err(checkRes.error);
     const isAzureProject = this.isAzureProject(ctx);
-    const provisioned = this.checkWetherProvisionSucceeded(ctx.config);
+    const provisioned = this.checkWetherProvisionSucceeded(ctx.envInfo.profile);
     if (!provisioned) {
       return err(
         returnUserError(
@@ -1059,7 +1061,7 @@ export class TeamsAppSolution implements Solution {
         if (v1Blocked.isErr()) {
           return v1Blocked;
         }
-        const provisioned = this.checkWetherProvisionSucceeded(ctx.config);
+        const provisioned = this.checkWetherProvisionSucceeded(ctx.envInfo.profile);
         if (provisioned) return ok(undefined);
       }
       let pluginsToProvision: LoadedPlugin[];
@@ -1094,7 +1096,7 @@ export class TeamsAppSolution implements Solution {
         }
 
         const isAzureProject = this.isAzureProject(ctx);
-        const provisioned = this.checkWetherProvisionSucceeded(ctx.config);
+        const provisioned = this.checkWetherProvisionSucceeded(ctx.envInfo.profile);
         if (isAzureProject && !provisioned) {
           return err(
             returnUserError(
@@ -1167,7 +1169,7 @@ export class TeamsAppSolution implements Solution {
           return v1Blocked;
         }
         const isAzureProject = this.isAzureProject(ctx);
-        const provisioned = this.checkWetherProvisionSucceeded(ctx.config);
+        const provisioned = this.checkWetherProvisionSucceeded(ctx.envInfo.profile);
         if (isAzureProject && !provisioned) {
           return err(
             returnUserError(
@@ -1293,7 +1295,7 @@ export class TeamsAppSolution implements Solution {
               combinedPostLocalDebugResults.value[index]
             );
           } else {
-            ctx.config
+            ctx.envInfo.profile
               .get(GLOBAL_CONFIG)
               ?.set(LOCAL_DEBUG_TEAMS_APP_ID, combinedPostLocalDebugResults.value[index]);
           }
@@ -1327,7 +1329,7 @@ export class TeamsAppSolution implements Solution {
         );
       }
 
-      ctx.config.get(GLOBAL_CONFIG)?.set(USER_INFO, JSON.stringify(userInfo));
+      ctx.envInfo.profile.get(GLOBAL_CONFIG)?.set(USER_INFO, JSON.stringify(userInfo));
 
       const pluginsWithCtx: PluginsWithContext[] = this.getPluginAndContextArray(ctx, [
         this.AadPlugin,
@@ -1341,7 +1343,7 @@ export class TeamsAppSolution implements Solution {
       );
 
       if (ctx.answers?.platform === Platform.CLI) {
-        const aadAppTenantId = ctx.config?.get(PluginNames.AAD)?.get(REMOTE_TENANT_ID);
+        const aadAppTenantId = ctx.envInfo.profile?.get(PluginNames.AAD)?.get(REMOTE_TENANT_ID);
 
         // Todo, when multi-environment is ready, we will update to current environment
         ctx.ui?.showMessage("info", `Starting permission grant for environment: default`, false);
@@ -1404,7 +1406,7 @@ export class TeamsAppSolution implements Solution {
 
       return ok(permissions);
     } finally {
-      ctx.config.get(GLOBAL_CONFIG)?.delete(USER_INFO);
+      ctx.envInfo.profile.get(GLOBAL_CONFIG)?.delete(USER_INFO);
       this.runningState = SolutionRunningState.Idle;
     }
   }
@@ -1419,7 +1421,7 @@ export class TeamsAppSolution implements Solution {
 
       const userInfo = result.value as IUserList;
 
-      ctx.config.get(GLOBAL_CONFIG)?.set(USER_INFO, JSON.stringify(userInfo));
+      ctx.envInfo.profile.get(GLOBAL_CONFIG)?.set(USER_INFO, JSON.stringify(userInfo));
 
       const pluginsWithCtx: PluginsWithContext[] = this.getPluginAndContextArray(ctx, [
         this.AadPlugin,
@@ -1433,7 +1435,7 @@ export class TeamsAppSolution implements Solution {
       );
 
       if (ctx.answers?.platform === Platform.CLI) {
-        const aadAppTenantId = ctx.config?.get(PluginNames.AAD)?.get(REMOTE_TENANT_ID);
+        const aadAppTenantId = ctx.envInfo.profile?.get(PluginNames.AAD)?.get(REMOTE_TENANT_ID);
 
         ctx.ui?.showMessage("info", `Account used to check: ${userInfo.userPrincipalName}`, false);
         // Todo, when multi-environment is ready, we will update to current environment
@@ -1484,7 +1486,7 @@ export class TeamsAppSolution implements Solution {
 
       return ok(permissions);
     } finally {
-      ctx.config.get(GLOBAL_CONFIG)?.delete(USER_INFO);
+      ctx.envInfo.profile.get(GLOBAL_CONFIG)?.delete(USER_INFO);
       this.runningState = SolutionRunningState.Idle;
     }
   }
@@ -1510,7 +1512,7 @@ export class TeamsAppSolution implements Solution {
       );
 
       if (ctx.answers?.platform === Platform.CLI) {
-        const aadAppTenantId = ctx.config?.get(PluginNames.AAD)?.get(REMOTE_TENANT_ID);
+        const aadAppTenantId = ctx.envInfo.profile?.get(PluginNames.AAD)?.get(REMOTE_TENANT_ID);
         ctx.ui?.showMessage("info", `Account used to check: ${userInfo.userPrincipalName}`, false);
 
         // Todo, when multi-environment is ready, we will update to current environment
@@ -1596,7 +1598,7 @@ export class TeamsAppSolution implements Solution {
       return canProcess;
     }
 
-    const provisioned = this.checkWetherProvisionSucceeded(ctx.config);
+    const provisioned = this.checkWetherProvisionSucceeded(ctx.envInfo.profile);
     if (!provisioned) {
       return err(
         returnUserError(
@@ -1621,7 +1623,7 @@ export class TeamsAppSolution implements Solution {
       );
     }
 
-    const aadAppTenantId = ctx.config?.get(PluginNames.AAD)?.get(REMOTE_TENANT_ID);
+    const aadAppTenantId = ctx.envInfo.profile?.get(PluginNames.AAD)?.get(REMOTE_TENANT_ID);
     if (!aadAppTenantId || user.tenantId != (aadAppTenantId as string)) {
       return err(
         returnUserError(
@@ -1674,7 +1676,7 @@ export class TeamsAppSolution implements Solution {
       if (isLocalDebug && isMultiEnvEnabled()) {
         ctx.localSettings?.teamsApp.set(LocalSettingsTeamsAppKeys.TenantId, teamsAppTenantId);
       } else {
-        ctx.config.get(GLOBAL_CONFIG)?.set("teamsAppTenantId", teamsAppTenantId);
+        ctx.envInfo.profile.get(GLOBAL_CONFIG)?.set("teamsAppTenantId", teamsAppTenantId);
       }
 
       return ok(ctx);
@@ -2020,7 +2022,7 @@ export class TeamsAppSolution implements Solution {
       }
       ctx.logProvider?.info(`finish scaffolding ${notifications.join(",")}!`);
       if (addNewResoruceToProvision)
-        ctx.config.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, false); //if selected plugin changed, we need to re-do provision
+        ctx.envInfo.profile.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, false); //if selected plugin changed, we need to re-do provision
       ctx.ui?.showMessage(
         "info",
         util.format(
@@ -2140,7 +2142,7 @@ export class TeamsAppSolution implements Solution {
         );
       }
       ctx.logProvider?.info(`finish scaffolding ${notifications.join(",")}!`);
-      ctx.config.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, false);
+      ctx.envInfo.profile.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, false);
       const msg = util.format(
         ctx.answers.platform === Platform.CLI
           ? getStrings().solution.AddCapabilityNoticeForCli
@@ -2360,7 +2362,7 @@ export class TeamsAppSolution implements Solution {
     const isLocal: boolean = params.environment === "local";
     const mockedManifest = new TeamsAppManifest();
     mockedManifest.name.short = params["app-name"];
-    const domain = this.prepareConfigForRegisterTeamsAppAndAad(ctx.config, params);
+    const domain = this.prepareConfigForRegisterTeamsAppAndAad(ctx.envInfo.profile, params);
     const aadPlugin = this.AadPlugin as AadAppForTeamsPlugin;
     const aadPluginCtx = getPluginContext(ctx, aadPlugin.name);
 
@@ -2396,7 +2398,7 @@ export class TeamsAppSolution implements Solution {
       return postProvisionResult;
     }
 
-    const configResult = this.extractConfigForRegisterTeamsAppAndAad(ctx.config, isLocal);
+    const configResult = this.extractConfigForRegisterTeamsAppAndAad(ctx.envInfo.profile, isLocal);
     if (configResult.isErr()) {
       return err(configResult.error);
     }

--- a/packages/fx-core/src/plugins/solution/fx-solution/utils/util.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/utils/util.ts
@@ -26,14 +26,14 @@ export function getPluginContext(
   pluginIdentifier: string
 ): PluginContext {
   const baseCtx: Context = solutionCtx;
-  if (!solutionCtx.config.has(pluginIdentifier)) {
-    solutionCtx.config.set(pluginIdentifier, new ConfigMap());
+  if (!solutionCtx.envInfo.profile.has(pluginIdentifier)) {
+    solutionCtx.envInfo.profile.set(pluginIdentifier, new ConfigMap());
   }
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const pluginConfig: PluginConfig = solutionCtx.config.get(pluginIdentifier)!;
+  const pluginConfig: PluginConfig = solutionCtx.envInfo.profile.get(pluginIdentifier)!;
   const pluginCtx: PluginContext = {
     ...baseCtx,
-    configOfOtherPlugins: solutionCtx.config,
+    configOfOtherPlugins: solutionCtx.envInfo.profile,
     config: pluginConfig,
   };
   return pluginCtx;

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/adaptor.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/adaptor.ts
@@ -15,9 +15,10 @@ import {
   UserInteraction,
   ConfigMap,
 } from "@microsoft/teamsfx-api";
+import { newEnvInfo } from "../../../../core/tools";
 
 class BaseSolutionContextAdaptor implements SolutionContext {
-  config: SolutionConfig = new Map();
+  envInfo = newEnvInfo();
   root = "";
   targetEnvName?: string | undefined;
   logProvider?: LogProvider | undefined;
@@ -54,6 +55,6 @@ export class ScaffoldingContextAdapter extends BaseSolutionContextAdaptor {
     this.localSettings = undefined;
     this.ui = v2context.userInteraction;
     this.cryptoProvider = undefined;
-    this.config = new Map(); // tbd
+    this.envInfo = newEnvInfo(); // tbd
   }
 }

--- a/packages/fx-core/tests/core/core.test.ts
+++ b/packages/fx-core/tests/core/core.test.ts
@@ -139,7 +139,7 @@ describe("Core basic APIs", () => {
       const validRes = validateProject(solutionContext);
       assert.isTrue(validRes === undefined);
 
-      const solutioConfig = solutionContext.config.get("solution");
+      const solutioConfig = solutionContext.envInfo.profile.get("solution");
       assert.isTrue(solutioConfig !== undefined);
       assert.isTrue(solutioConfig!.get("create") === true);
       assert.isTrue(solutioConfig!.get("scaffold") === true);
@@ -185,7 +185,7 @@ describe("Core basic APIs", () => {
       const validRes = validateProject(solutionContext);
       assert.isTrue(validRes === undefined);
 
-      const solutioConfig = solutionContext.config.get("solution");
+      const solutioConfig = solutionContext.envInfo.profile.get("solution");
       assert.isTrue(solutioConfig !== undefined);
       assert.isTrue(solutioConfig!.get("provision") === true);
       assert.isTrue(solutioConfig!.get("deploy") === true);
@@ -343,7 +343,7 @@ describe("Core basic APIs", () => {
       const validRes = validateProject(solutionContext);
       assert.isTrue(validRes === undefined);
 
-      const solutioConfig = solutionContext.config.get("solution");
+      const solutioConfig = solutionContext.envInfo.profile.get("solution");
       assert.isTrue(solutioConfig !== undefined);
     }
     {
@@ -387,7 +387,7 @@ describe("Core basic APIs", () => {
       const validRes = validateProject(solutionContext);
       assert.isTrue(validRes === undefined);
 
-      const solutioConfig = solutionContext.config.get("solution");
+      const solutioConfig = solutionContext.envInfo.profile.get("solution");
       assert.isTrue(solutioConfig !== undefined);
       assert.isTrue(solutioConfig!.get("provision") === true);
       assert.isTrue(solutioConfig!.get("deploy") === true);
@@ -688,7 +688,7 @@ describe("Core basic APIs", () => {
         const validRes = validateProject(solutionContext);
         assert.isTrue(validRes === undefined);
 
-        const solutioConfig = solutionContext.config.get("solution");
+        const solutioConfig = solutionContext.envInfo.profile.get("solution");
         assert.isTrue(solutioConfig !== undefined);
       }
     });

--- a/packages/fx-core/tests/core/hooks.test.ts
+++ b/packages/fx-core/tests/core/hooks.test.ts
@@ -416,7 +416,7 @@ describe("Middleware", () => {
           assert.isTrue(ctx !== undefined);
           assert.isTrue(ctx!.solutionContext !== undefined);
           const solutionContext = ctx!.solutionContext!;
-          assert.isTrue(solutionContext.config.get("solution") !== undefined);
+          assert.isTrue(solutionContext.envInfo.profile.get("solution") !== undefined);
           assert.deepEqual(projectSettings, solutionContext.projectSettings);
           return ok("");
         }
@@ -439,7 +439,7 @@ describe("Middleware", () => {
           const solutionContext = ctx!.solutionContext!;
           assert.isTrue(solutionContext.projectSettings !== undefined);
           assert.isTrue(solutionContext.projectSettings!.appName === appName);
-          assert.isTrue(solutionContext.config.get("solution") !== undefined);
+          assert.isTrue(solutionContext.envInfo.profile.get("solution") !== undefined);
           return ok("");
         }
       }
@@ -502,7 +502,7 @@ describe("Middleware", () => {
       inputs.projectPath = path.join(os.tmpdir(), appName);
       const tools = new MockTools();
       const solutionContext = await newSolutionContext(tools, inputs);
-      solutionContext.config.set("solution", new ConfigMap());
+      solutionContext.envInfo.profile.set("solution", new ConfigMap());
       solutionContext.projectSettings = MockProjectSettings(appName);
       const fileMap = new Map<string, any>();
 
@@ -532,7 +532,7 @@ describe("Middleware", () => {
       const settingsInFile = JSON.parse(content);
       content = fileMap.get(envJsonFile);
       const configInFile = JSON.parse(content);
-      const configExpected = mapToJson(solutionContext.config);
+      const configExpected = mapToJson(solutionContext.envInfo.profile);
       assert.deepEqual(solutionContext.projectSettings, settingsInFile);
       assert.deepEqual(configExpected, configInFile);
     });
@@ -556,8 +556,8 @@ describe("Middleware", () => {
       const secretName = "clientSecret";
       const secretText = "test";
       configMap.set(secretName, secretText);
-      solutionContext.config.set("solution", new ConfigMap());
-      solutionContext.config.set(pluginName, configMap);
+      solutionContext.envInfo.profile.set("solution", new ConfigMap());
+      solutionContext.envInfo.profile.set(pluginName, configMap);
       const oldProjectId = solutionContext.projectSettings!.projectId;
       solutionContext.projectSettings = MockProjectSettings(appName);
       solutionContext.projectSettings!.projectId = oldProjectId;
@@ -591,8 +591,8 @@ describe("Middleware", () => {
           const solutionContext = ctx!.solutionContext!;
           assert.isTrue(solutionContext.projectSettings !== undefined);
           assert.isTrue(solutionContext.projectSettings!.appName === appName);
-          assert.isTrue(solutionContext.config.get(pluginName) !== undefined);
-          const value = solutionContext.config.get(pluginName)!.get(secretName);
+          assert.isTrue(solutionContext.envInfo.profile.get(pluginName) !== undefined);
+          const value = solutionContext.envInfo.profile.get(pluginName)!.get(secretName);
           assert.isTrue(value === secretText);
           return ok("");
         }

--- a/packages/fx-core/tests/core/utils.ts
+++ b/packages/fx-core/tests/core/utils.ts
@@ -60,7 +60,7 @@ export class MockSolution implements Solution {
     ctx.projectSettings!.solutionSettings = this.solutionSettings();
     const config = new ConfigMap();
     config.set("create", true);
-    ctx.config.set("solution", config);
+    ctx.envInfo.profile.set("solution", config);
     return ok(Void);
   }
   solutionSettings(): AzureSolutionSettings {
@@ -74,23 +74,23 @@ export class MockSolution implements Solution {
     } as AzureSolutionSettings;
   }
   async scaffold(ctx: SolutionContext): Promise<Result<any, FxError>> {
-    ctx.config.get("solution")!.set("scaffold", true);
+    ctx.envInfo.profile.get("solution")!.set("scaffold", true);
     return ok(Void);
   }
   async provision(ctx: SolutionContext): Promise<Result<any, FxError>> {
-    ctx.config.get("solution")!.set("provision", true);
+    ctx.envInfo.profile.get("solution")!.set("provision", true);
     return ok(Void);
   }
   async deploy(ctx: SolutionContext): Promise<Result<any, FxError>> {
-    ctx.config.get("solution")!.set("deploy", true);
+    ctx.envInfo.profile.get("solution")!.set("deploy", true);
     return ok(Void);
   }
   async publish(ctx: SolutionContext): Promise<Result<any, FxError>> {
-    ctx.config.get("solution")!.set("publish", true);
+    ctx.envInfo.profile.get("solution")!.set("publish", true);
     return ok(Void);
   }
   async localDebug(ctx: SolutionContext): Promise<Result<any, FxError>> {
-    ctx.config.get("solution")!.set("localDebug", true);
+    ctx.envInfo.profile.get("solution")!.set("localDebug", true);
     return ok(Void);
   }
   async getQuestions(
@@ -106,13 +106,13 @@ export class MockSolution implements Solution {
     return ok(undefined);
   }
   async executeUserTask(func: Func, ctx: SolutionContext): Promise<Result<any, FxError>> {
-    ctx.config.get("solution")!.set("executeUserTask", true);
+    ctx.envInfo.profile.get("solution")!.set("executeUserTask", true);
     return ok(Void);
   }
   async migrate(ctx: SolutionContext): Promise<Result<any, FxError>> {
     ctx.projectSettings!.solutionSettings = this.solutionSettings();
     const config = new ConfigMap();
-    ctx.config.set("solution", config);
+    ctx.envInfo.profile.set("solution", config);
     return ok(Void);
   }
 }

--- a/packages/fx-core/tests/plugins/solution/solution.arm.test.ts
+++ b/packages/fx-core/tests/plugins/solution/solution.arm.test.ts
@@ -75,7 +75,6 @@ function mockSolutionContext(): SolutionContext {
       profile: new Map<string, any>(),
       config: environmentManager.newEnvConfigData(),
     },
-    config,
     answers: { platform: Platform.VSCode },
     projectSettings: undefined,
     azureAccountProvider: Object as any & AzureAccountProvider,
@@ -355,11 +354,11 @@ describe("Deploy ARM Template to Azure", () => {
         capabilities: [TabOptionItem.id],
       },
     };
-    mockedCtx.config.set(
+    mockedCtx.envInfo.profile.set(
       "fx-resource-aad-app-for-teams",
       new ConfigMap([["clientId", testClientId]])
     );
-    mockedCtx.config.set(
+    mockedCtx.envInfo.profile.set(
       SOLUTION_CONFIG,
       new ConfigMap([
         ["resource-base-name", "mocked resource base name"],
@@ -413,14 +412,14 @@ describe("Deploy ARM Template to Azure", () => {
       } as SubscriptionInfo;
       return subscriptionInfo;
     };
-    mockedCtx.config.set(
+    mockedCtx.envInfo.profile.set(
       "fx-resource-aad-app-for-teams",
       new ConfigMap([
         ["clientId", testClientId],
         ["clientSecret", testClientSecret],
       ])
     );
-    mockedCtx.config.set(
+    mockedCtx.envInfo.profile.set(
       SOLUTION_CONFIG,
       new ConfigMap([
         ["resourceGroupName", "mocked resource group name"],
@@ -497,7 +496,7 @@ describe("Deploy ARM Template to Azure", () => {
       }`)
     );
     chai.assert.strictEqual(
-      mockedCtx.config.get(SOLUTION_CONFIG)?.get("armTemplateOutput"),
+      mockedCtx.envInfo.profile.get(SOLUTION_CONFIG)?.get("armTemplateOutput"),
       testArmTemplateOutput
     );
   });

--- a/packages/fx-core/tests/plugins/solution/solution.checkPermission.test.ts
+++ b/packages/fx-core/tests/plugins/solution/solution.checkPermission.test.ts
@@ -32,6 +32,7 @@ import sinon from "sinon";
 import { EnvConfig, MockGraphTokenProvider } from "../resource/apim/testUtil";
 import Container from "typedi";
 import { ResourcePlugins } from "../../../src/plugins/solution/fx-solution/ResourcePluginContainer";
+import { newEnvInfo } from "../../../src";
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;
@@ -43,8 +44,6 @@ describe("checkPermission() for Teamsfx projects", () => {
   const mockProjectTenantId = "mock_project_tenant_id";
 
   function mockSolutionContext(): SolutionContext {
-    const config: SolutionConfig = new Map();
-    config.set(GLOBAL_CONFIG, new ConfigMap());
     const mockGraphTokenProvider = new MockGraphTokenProvider(
       mockProjectTenantId,
       EnvConfig.servicePrincipalClientId,
@@ -52,7 +51,7 @@ describe("checkPermission() for Teamsfx projects", () => {
     );
     return {
       root: ".",
-      config,
+      envInfo: newEnvInfo(),
       answers: { platform: Platform.VSCode },
       projectSettings: undefined,
       graphTokenProvider: mockGraphTokenProvider,
@@ -111,7 +110,7 @@ describe("checkPermission() for Teamsfx projects", () => {
         version: "1.0",
       },
     };
-    mockedCtx.config.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
+    mockedCtx.envInfo.profile.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
 
     sandbox
       .stub(mockedCtx.graphTokenProvider as GraphTokenProvider, "getJsonObject")
@@ -136,7 +135,7 @@ describe("checkPermission() for Teamsfx projects", () => {
         version: "1.0",
       },
     };
-    mockedCtx.config.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
+    mockedCtx.envInfo.profile.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
 
     sandbox.stub(mockedCtx.graphTokenProvider as GraphTokenProvider, "getJsonObject").resolves({
       tid: "fake_tid",
@@ -145,8 +144,8 @@ describe("checkPermission() for Teamsfx projects", () => {
       name: "fake_name",
     });
 
-    mockedCtx.config.set(PluginNames.AAD, new ConfigMap());
-    mockedCtx.config.get(PluginNames.AAD)?.set(REMOTE_TENANT_ID, mockProjectTenantId);
+    mockedCtx.envInfo.profile.set(PluginNames.AAD, new ConfigMap());
+    mockedCtx.envInfo.profile.get(PluginNames.AAD)?.set(REMOTE_TENANT_ID, mockProjectTenantId);
 
     const result = await solution.checkPermission(mockedCtx);
     expect(result.isErr()).to.be.true;
@@ -167,7 +166,7 @@ describe("checkPermission() for Teamsfx projects", () => {
         version: "1.0",
       },
     };
-    mockedCtx.config.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
+    mockedCtx.envInfo.profile.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
 
     sandbox.stub(mockedCtx.graphTokenProvider as GraphTokenProvider, "getJsonObject").resolves({
       tid: mockProjectTenantId,
@@ -201,8 +200,8 @@ describe("checkPermission() for Teamsfx projects", () => {
       ]);
     };
 
-    mockedCtx.config.set(PluginNames.AAD, new ConfigMap());
-    mockedCtx.config.get(PluginNames.AAD)?.set(REMOTE_TENANT_ID, mockProjectTenantId);
+    mockedCtx.envInfo.profile.set(PluginNames.AAD, new ConfigMap());
+    mockedCtx.envInfo.profile.get(PluginNames.AAD)?.set(REMOTE_TENANT_ID, mockProjectTenantId);
 
     const result = await solution.checkPermission(mockedCtx);
     expect(result.isErr()).to.be.true;
@@ -223,7 +222,7 @@ describe("checkPermission() for Teamsfx projects", () => {
         version: "1.0",
       },
     };
-    mockedCtx.config.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
+    mockedCtx.envInfo.profile.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
 
     sandbox.stub(mockedCtx.graphTokenProvider as GraphTokenProvider, "getJsonObject").resolves({
       tid: mockProjectTenantId,
@@ -257,8 +256,8 @@ describe("checkPermission() for Teamsfx projects", () => {
         },
       ]);
     };
-    mockedCtx.config.set(PluginNames.AAD, new ConfigMap());
-    mockedCtx.config.get(PluginNames.AAD)?.set(REMOTE_TENANT_ID, mockProjectTenantId);
+    mockedCtx.envInfo.profile.set(PluginNames.AAD, new ConfigMap());
+    mockedCtx.envInfo.profile.get(PluginNames.AAD)?.set(REMOTE_TENANT_ID, mockProjectTenantId);
 
     const result = await solution.checkPermission(mockedCtx);
     if (result.isErr()) {

--- a/packages/fx-core/tests/plugins/solution/solution.create.test.ts
+++ b/packages/fx-core/tests/plugins/solution/solution.create.test.ts
@@ -19,6 +19,7 @@ import {
   TabOptionItem,
 } from "../../../src/plugins/solution/fx-solution/question";
 import * as uuid from "uuid";
+import { newEnvInfo } from "../../../src";
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;
@@ -32,10 +33,9 @@ describe("Solution running state on creation", () => {
 
 describe("Solution create()", async () => {
   function mockSolutionContext(): SolutionContext {
-    const config: SolutionConfig = new Map();
     return {
       root: ".",
-      config,
+      envInfo: newEnvInfo(),
       answers: { platform: Platform.VSCode },
       projectSettings: undefined,
     };
@@ -65,7 +65,7 @@ describe("Solution create()", async () => {
     const result = await solution.create(mockedSolutionCtx);
     expect(result.isErr()).equals(true);
     expect(result._unsafeUnwrapErr().name).equals(SolutionError.InternelError);
-    expect(mockedSolutionCtx.config.get(GLOBAL_CONFIG)).to.be.not.undefined;
+    expect(mockedSolutionCtx.envInfo.profile.get(GLOBAL_CONFIG)).to.be.not.undefined;
   });
 
   it("should fail if projectSettings.solutionSettings is undefined", async () => {
@@ -115,7 +115,7 @@ describe("Solution create()", async () => {
     answers[AzureSolutionQuestionNames.Capabilities] = [BotOptionItem.id];
     const result = await solution.create(mockedSolutionCtx);
     expect(result.isOk()).equals(true);
-    expect(mockedSolutionCtx.config.get(GLOBAL_CONFIG)).is.not.undefined;
+    expect(mockedSolutionCtx.envInfo.profile.get(GLOBAL_CONFIG)).is.not.undefined;
   });
 
   it("should set programmingLanguage in config if programmingLanguage is in answers", async () => {
@@ -158,7 +158,9 @@ describe("Solution create()", async () => {
     answers[AzureSolutionQuestionNames.Capabilities as string] = [BotOptionItem.id];
     const result = await solution.create(mockedSolutionCtx);
     expect(result.isOk()).equals(true);
-    const lang = mockedSolutionCtx.config.get(GLOBAL_CONFIG)?.getString(PROGRAMMING_LANGUAGE);
+    const lang = mockedSolutionCtx.envInfo.profile
+      .get(GLOBAL_CONFIG)
+      ?.getString(PROGRAMMING_LANGUAGE);
     expect(lang).to.be.undefined;
   });
 

--- a/packages/fx-core/tests/plugins/solution/solution.deploy.test.ts
+++ b/packages/fx-core/tests/plugins/solution/solution.deploy.test.ts
@@ -35,7 +35,7 @@ import {
 import { MockedAzureAccountProvider, MockedV2Context, validManifest } from "./util";
 import _ from "lodash";
 import * as uuid from "uuid";
-import { AadAppForTeamsPlugin } from "../../../src";
+import { AadAppForTeamsPlugin, newEnvInfo } from "../../../src";
 import { ResourcePlugins } from "../../../src/plugins/solution/fx-solution/ResourcePluginContainer";
 import Container from "typedi";
 import { deploy } from "../../../src/plugins/solution/fx-solution/v2/deploy";
@@ -47,11 +47,9 @@ const aadPlugin = Container.get<Plugin>(ResourcePlugins.AadPlugin);
 const spfxPlugin = Container.get<Plugin>(ResourcePlugins.SpfxPlugin);
 const fehostPlugin = Container.get<Plugin>(ResourcePlugins.FrontendPlugin);
 function mockSolutionContext(): SolutionContext {
-  const config: SolutionConfig = new Map();
-  config.set(GLOBAL_CONFIG, new ConfigMap());
   return {
     root: ".",
-    config,
+    envInfo: newEnvInfo(),
     answers: { platform: Platform.VSCode },
     projectSettings: undefined,
   };
@@ -101,7 +99,7 @@ describe("deploy() for Azure projects", () => {
         activeResourcePlugins: [aadPlugin.name],
       },
     };
-    mockedCtx.config.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
+    mockedCtx.envInfo.profile.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
     const result = await solution.deploy(mockedCtx);
     expect(result.isErr()).to.be.true;
     expect(result._unsafeUnwrapErr().name).equals("NoResourcePluginSelected");
@@ -137,7 +135,7 @@ describe("deploy() for Azure projects", () => {
           activeResourcePlugins: [aadPlugin.name],
         },
       };
-      mockedCtx.config.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
+      mockedCtx.envInfo.profile.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
       const result = await solution.deploy(mockedCtx);
       expect(result.isErr()).to.be.true;
       expect(result._unsafeUnwrapErr().name).equals(SolutionError.NoResourcePluginSelected);
@@ -156,7 +154,7 @@ describe("deploy() for Azure projects", () => {
           activeResourcePlugins: [aadPlugin.name],
         },
       };
-      mockedCtx.config.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
+      mockedCtx.envInfo.profile.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
       mockedCtx.answers![AzureSolutionQuestionNames.PluginSelectionDeploy] = [fehostPlugin.name];
       mockDeployThatAlwaysSucceed(fehostPlugin);
 

--- a/packages/fx-core/tests/plugins/solution/solution.grantPermission.test.ts
+++ b/packages/fx-core/tests/plugins/solution/solution.grantPermission.test.ts
@@ -32,6 +32,7 @@ import sinon from "sinon";
 import { EnvConfig, MockGraphTokenProvider } from "../resource/apim/testUtil";
 import Container from "typedi";
 import { ResourcePlugins } from "../../../src/plugins/solution/fx-solution/ResourcePluginContainer";
+import { newEnvInfo } from "../../../src";
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;
@@ -43,8 +44,6 @@ describe("grantPermission() for Teamsfx projects", () => {
   const mockProjectTenantId = "mock_project_tenant_id";
 
   function mockSolutionContext(): SolutionContext {
-    const config: SolutionConfig = new Map();
-    config.set(GLOBAL_CONFIG, new ConfigMap());
     const mockGraphTokenProvider = new MockGraphTokenProvider(
       mockProjectTenantId,
       EnvConfig.servicePrincipalClientId,
@@ -52,7 +51,7 @@ describe("grantPermission() for Teamsfx projects", () => {
     );
     return {
       root: ".",
-      config,
+      envInfo: newEnvInfo(),
       answers: { platform: Platform.VSCode },
       projectSettings: undefined,
       graphTokenProvider: mockGraphTokenProvider,
@@ -111,7 +110,7 @@ describe("grantPermission() for Teamsfx projects", () => {
         version: "1.0",
       },
     };
-    mockedCtx.config.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
+    mockedCtx.envInfo.profile.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
 
     sandbox
       .stub(mockedCtx.graphTokenProvider as GraphTokenProvider, "getJsonObject")
@@ -136,7 +135,7 @@ describe("grantPermission() for Teamsfx projects", () => {
         version: "1.0",
       },
     };
-    mockedCtx.config.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
+    mockedCtx.envInfo.profile.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
 
     sandbox.stub(mockedCtx.graphTokenProvider as GraphTokenProvider, "getJsonObject").resolves({
       tid: "fake_tid",
@@ -145,8 +144,8 @@ describe("grantPermission() for Teamsfx projects", () => {
       name: "fake_name",
     });
 
-    mockedCtx.config.set(PluginNames.AAD, new ConfigMap());
-    mockedCtx.config.get(PluginNames.AAD)?.set(REMOTE_TENANT_ID, mockProjectTenantId);
+    mockedCtx.envInfo.profile.set(PluginNames.AAD, new ConfigMap());
+    mockedCtx.envInfo.profile.get(PluginNames.AAD)?.set(REMOTE_TENANT_ID, mockProjectTenantId);
 
     const result = await solution.grantPermission(mockedCtx);
     expect(result.isErr()).to.be.true;
@@ -167,7 +166,7 @@ describe("grantPermission() for Teamsfx projects", () => {
         version: "1.0",
       },
     };
-    mockedCtx.config.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
+    mockedCtx.envInfo.profile.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
 
     sandbox
       .stub(mockedCtx.graphTokenProvider as GraphTokenProvider, "getJsonObject")
@@ -181,8 +180,8 @@ describe("grantPermission() for Teamsfx projects", () => {
       .onCall(1)
       .resolves(undefined);
 
-    mockedCtx.config.set(PluginNames.AAD, new ConfigMap());
-    mockedCtx.config.get(PluginNames.AAD)?.set(REMOTE_TENANT_ID, mockProjectTenantId);
+    mockedCtx.envInfo.profile.set(PluginNames.AAD, new ConfigMap());
+    mockedCtx.envInfo.profile.get(PluginNames.AAD)?.set(REMOTE_TENANT_ID, mockProjectTenantId);
 
     const result = await solution.grantPermission(mockedCtx);
     expect(result.isErr()).to.be.true;
@@ -203,7 +202,7 @@ describe("grantPermission() for Teamsfx projects", () => {
         version: "1.0",
       },
     };
-    mockedCtx.config.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
+    mockedCtx.envInfo.profile.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
 
     sandbox
       .stub(mockedCtx.graphTokenProvider as GraphTokenProvider, "getJsonObject")
@@ -247,8 +246,8 @@ describe("grantPermission() for Teamsfx projects", () => {
       ]);
     };
 
-    mockedCtx.config.set(PluginNames.AAD, new ConfigMap());
-    mockedCtx.config.get(PluginNames.AAD)?.set(REMOTE_TENANT_ID, mockProjectTenantId);
+    mockedCtx.envInfo.profile.set(PluginNames.AAD, new ConfigMap());
+    mockedCtx.envInfo.profile.get(PluginNames.AAD)?.set(REMOTE_TENANT_ID, mockProjectTenantId);
 
     const result = await solution.grantPermission(mockedCtx);
     expect(result.isErr()).to.be.true;
@@ -270,7 +269,7 @@ describe("grantPermission() for Teamsfx projects", () => {
         version: "1.0",
       },
     };
-    mockedCtx.config.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
+    mockedCtx.envInfo.profile.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
 
     sandbox
       .stub(mockedCtx.graphTokenProvider as GraphTokenProvider, "getJsonObject")
@@ -314,8 +313,8 @@ describe("grantPermission() for Teamsfx projects", () => {
         },
       ]);
     };
-    mockedCtx.config.set(PluginNames.AAD, new ConfigMap());
-    mockedCtx.config.get(PluginNames.AAD)?.set(REMOTE_TENANT_ID, mockProjectTenantId);
+    mockedCtx.envInfo.profile.set(PluginNames.AAD, new ConfigMap());
+    mockedCtx.envInfo.profile.get(PluginNames.AAD)?.set(REMOTE_TENANT_ID, mockProjectTenantId);
 
     const result = await solution.grantPermission(mockedCtx);
     if (result.isErr()) {

--- a/packages/fx-core/tests/plugins/solution/solution.listCollaborator.test.ts
+++ b/packages/fx-core/tests/plugins/solution/solution.listCollaborator.test.ts
@@ -31,6 +31,7 @@ import sinon from "sinon";
 import { EnvConfig, MockGraphTokenProvider } from "../resource/apim/testUtil";
 import Container from "typedi";
 import { ResourcePlugins } from "../../../src/plugins/solution/fx-solution/ResourcePluginContainer";
+import { newEnvInfo } from "../../../src";
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;
@@ -51,7 +52,7 @@ describe("listCollaborator() for Teamsfx projects", () => {
     );
     return {
       root: ".",
-      config,
+      envInfo: newEnvInfo(),
       answers: { platform: Platform.VSCode },
       projectSettings: undefined,
       graphTokenProvider: mockGraphTokenProvider,
@@ -110,7 +111,7 @@ describe("listCollaborator() for Teamsfx projects", () => {
         version: "1.0",
       },
     };
-    mockedCtx.config.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
+    mockedCtx.envInfo.profile.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
 
     sandbox
       .stub(mockedCtx.graphTokenProvider as GraphTokenProvider, "getJsonObject")
@@ -135,7 +136,7 @@ describe("listCollaborator() for Teamsfx projects", () => {
         version: "1.0",
       },
     };
-    mockedCtx.config.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
+    mockedCtx.envInfo.profile.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
 
     sandbox.stub(mockedCtx.graphTokenProvider as GraphTokenProvider, "getJsonObject").resolves({
       tid: "fake_tid",
@@ -144,8 +145,8 @@ describe("listCollaborator() for Teamsfx projects", () => {
       name: "fake_name",
     });
 
-    mockedCtx.config.set(PluginNames.AAD, new ConfigMap());
-    mockedCtx.config.get(PluginNames.AAD)?.set(REMOTE_TENANT_ID, mockProjectTenantId);
+    mockedCtx.envInfo.profile.set(PluginNames.AAD, new ConfigMap());
+    mockedCtx.envInfo.profile.get(PluginNames.AAD)?.set(REMOTE_TENANT_ID, mockProjectTenantId);
 
     const result = await solution.listCollaborator(mockedCtx);
     expect(result.isErr()).to.be.true;
@@ -166,7 +167,7 @@ describe("listCollaborator() for Teamsfx projects", () => {
         version: "1.0",
       },
     };
-    mockedCtx.config.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
+    mockedCtx.envInfo.profile.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
 
     sandbox.stub(mockedCtx.graphTokenProvider as GraphTokenProvider, "getJsonObject").resolves({
       tid: mockProjectTenantId,
@@ -199,8 +200,8 @@ describe("listCollaborator() for Teamsfx projects", () => {
       ]);
     };
 
-    mockedCtx.config.set(PluginNames.AAD, new ConfigMap());
-    mockedCtx.config.get(PluginNames.AAD)?.set(REMOTE_TENANT_ID, mockProjectTenantId);
+    mockedCtx.envInfo.profile.set(PluginNames.AAD, new ConfigMap());
+    mockedCtx.envInfo.profile.get(PluginNames.AAD)?.set(REMOTE_TENANT_ID, mockProjectTenantId);
 
     const result = await solution.listCollaborator(mockedCtx);
     expect(result.isErr()).to.be.true;
@@ -221,7 +222,7 @@ describe("listCollaborator() for Teamsfx projects", () => {
         version: "1.0",
       },
     };
-    mockedCtx.config.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
+    mockedCtx.envInfo.profile.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
 
     sandbox.stub(mockedCtx.graphTokenProvider as GraphTokenProvider, "getJsonObject").resolves({
       tid: mockProjectTenantId,
@@ -255,8 +256,8 @@ describe("listCollaborator() for Teamsfx projects", () => {
         },
       ]);
     };
-    mockedCtx.config.set(PluginNames.AAD, new ConfigMap());
-    mockedCtx.config.get(PluginNames.AAD)?.set(REMOTE_TENANT_ID, mockProjectTenantId);
+    mockedCtx.envInfo.profile.set(PluginNames.AAD, new ConfigMap());
+    mockedCtx.envInfo.profile.get(PluginNames.AAD)?.set(REMOTE_TENANT_ID, mockProjectTenantId);
 
     const result = await solution.listCollaborator(mockedCtx);
     if (result.isErr()) {

--- a/packages/fx-core/tests/plugins/solution/solution.migrate.test.ts
+++ b/packages/fx-core/tests/plugins/solution/solution.migrate.test.ts
@@ -25,16 +25,16 @@ import {
   TabOptionItem,
 } from "../../../src/plugins/solution/fx-solution/question";
 import * as uuid from "uuid";
+import { newEnvInfo } from "../../../src";
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;
 
 describe("Solution migrate()", async () => {
   function mockSolutionContext(): SolutionContext {
-    const config: SolutionConfig = new Map();
     return {
       root: ".",
-      config,
+      envInfo: newEnvInfo(),
       answers: { platform: Platform.VSCode },
       projectSettings: undefined,
     };
@@ -56,7 +56,7 @@ describe("Solution migrate()", async () => {
     expect(result.isErr()).equals(true);
     expect(result._unsafeUnwrapErr().name).equals(SolutionError.InternelError);
     expect(result._unsafeUnwrapErr().message).equals("projectSettings is undefined");
-    expect(mockedSolutionCtx.config.get(GLOBAL_CONFIG)).to.be.not.undefined;
+    expect(mockedSolutionCtx.envInfo.profile.get(GLOBAL_CONFIG)).to.be.not.undefined;
   });
 
   it("should fail if projectSettings.solutionSettings is undefined", async () => {
@@ -73,7 +73,7 @@ describe("Solution migrate()", async () => {
     expect(result.isErr()).equals(true);
     expect(result._unsafeUnwrapErr().name).equals(SolutionError.InternelError);
     expect(result._unsafeUnwrapErr().message).equals("solutionSettings is undefined");
-    expect(mockedSolutionCtx.config.get(GLOBAL_CONFIG)).to.be.not.undefined;
+    expect(mockedSolutionCtx.envInfo.profile.get(GLOBAL_CONFIG)).to.be.not.undefined;
   });
 
   it("should fail if capability is undefined", async () => {
@@ -95,7 +95,7 @@ describe("Solution migrate()", async () => {
     expect(result.isErr()).equals(true);
     expect(result._unsafeUnwrapErr().name).equals(SolutionError.InternelError);
     expect(result._unsafeUnwrapErr().message).equals("capabilities is empty");
-    expect(mockedSolutionCtx.config.get(GLOBAL_CONFIG)).to.be.not.undefined;
+    expect(mockedSolutionCtx.envInfo.profile.get(GLOBAL_CONFIG)).to.be.not.undefined;
   });
 
   it("should succeed if projectSettings, solution settings and v1 capability are provided, language is javascript", async () => {
@@ -121,7 +121,7 @@ describe("Solution migrate()", async () => {
 
     const result = await solution.migrate(mockedSolutionCtx);
     expect(result.isOk()).equals(true);
-    expect(mockedSolutionCtx.config.get(GLOBAL_CONFIG)).is.not.undefined;
+    expect(mockedSolutionCtx.envInfo.profile.get(GLOBAL_CONFIG)).is.not.undefined;
     const lang = mockedSolutionCtx.projectSettings.programmingLanguage;
     expect(lang).equals("javascript");
   });
@@ -149,7 +149,7 @@ describe("Solution migrate()", async () => {
 
     const result = await solution.migrate(mockedSolutionCtx);
     expect(result.isOk()).equals(true);
-    expect(mockedSolutionCtx.config.get(GLOBAL_CONFIG)).is.not.undefined;
+    expect(mockedSolutionCtx.envInfo.profile.get(GLOBAL_CONFIG)).is.not.undefined;
     const lang = mockedSolutionCtx.projectSettings.programmingLanguage;
     expect(lang).equals("typescript");
   });

--- a/packages/fx-core/tests/plugins/solution/solution.publish.test.ts
+++ b/packages/fx-core/tests/plugins/solution/solution.publish.test.ts
@@ -39,6 +39,7 @@ import _ from "lodash";
 import * as uuid from "uuid";
 import { ResourcePlugins } from "../../../src/plugins/solution/fx-solution/ResourcePluginContainer";
 import Container from "typedi";
+import { newEnvInfo } from "../../../src";
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;
@@ -48,11 +49,9 @@ const fehostPlugin = Container.get<Plugin>(ResourcePlugins.FrontendPlugin);
 const appStudioPlugin = Container.get<Plugin>(ResourcePlugins.AppStudioPlugin);
 const botPlugin = Container.get<Plugin>(ResourcePlugins.BotPlugin);
 function mockSolutionContext(): SolutionContext {
-  const config: SolutionConfig = new Map();
-  config.set(GLOBAL_CONFIG, new ConfigMap());
   return {
     root: ".",
-    config,
+    envInfo: newEnvInfo(),
     answers: { platform: Platform.VSCode },
     projectSettings: undefined,
   };
@@ -108,7 +107,7 @@ describe("publish()", () => {
         activeResourcePlugins: [aadPlugin.name],
       },
     };
-    mockedCtx.config.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
+    mockedCtx.envInfo.profile.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
     const result = await solution.publish(mockedCtx);
     expect(result.isErr()).to.be.true;
     // expect(result._unsafeUnwrapErr().name).equals("ManifestLoadFailed");
@@ -149,7 +148,7 @@ describe("publish()", () => {
         },
       };
       solution.runningState = SolutionRunningState.ProvisionInProgress;
-      mockedCtx.config.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
+      mockedCtx.envInfo.profile.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
       let result = await solution.publish(mockedCtx);
       expect(result.isErr()).to.be.true;
       expect(result._unsafeUnwrapErr().name).equals(SolutionError.ProvisionInProgress);
@@ -178,7 +177,7 @@ describe("publish()", () => {
           activeResourcePlugins: [appStudioPlugin.name, spfxPlugin.name],
         },
       };
-      mockedCtx.config.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
+      mockedCtx.envInfo.profile.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
       mockPublishThatAlwaysSucceed(appStudioPlugin);
       mockPublishThatAlwaysSucceed(spfxPlugin);
       const result = await solution.publish(mockedCtx);
@@ -188,9 +187,9 @@ describe("publish()", () => {
     it("should return ok for Azure Tab projects on happy path", async () => {
       const solution = new TeamsAppSolution();
       const mockedCtx = mockSolutionContext();
-      mockedCtx.config.set(aadPlugin.name, new ConfigMap());
-      mockedCtx.config.set(fehostPlugin.name, new ConfigMap());
-      mockedCtx.config.set(appStudioPlugin.name, new ConfigMap());
+      mockedCtx.envInfo.profile.set(aadPlugin.name, new ConfigMap());
+      mockedCtx.envInfo.profile.set(fehostPlugin.name, new ConfigMap());
+      mockedCtx.envInfo.profile.set(appStudioPlugin.name, new ConfigMap());
       mockedCtx.projectSettings = {
         appName: "my app",
         projectId: uuid.v4(),
@@ -202,13 +201,15 @@ describe("publish()", () => {
           capabilities: [TabOptionItem.id],
         },
       };
-      mockedCtx.config.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
-      mockedCtx.config.get(fehostPlugin.name)?.set(FRONTEND_ENDPOINT, "http://example.com");
-      mockedCtx.config.get(fehostPlugin.name)?.set(FRONTEND_DOMAIN, "http://example.com");
-      mockedCtx.config
+      mockedCtx.envInfo.profile.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
+      mockedCtx.envInfo.profile
+        .get(fehostPlugin.name)
+        ?.set(FRONTEND_ENDPOINT, "http://example.com");
+      mockedCtx.envInfo.profile.get(fehostPlugin.name)?.set(FRONTEND_DOMAIN, "http://example.com");
+      mockedCtx.envInfo.profile
         .get(aadPlugin.name)
         ?.set(WEB_APPLICATION_INFO_SOURCE, "mockedWebApplicationInfoResouce");
-      mockedCtx.config.get(aadPlugin.name)?.set(REMOTE_AAD_ID, "mockedRemoteAadId");
+      mockedCtx.envInfo.profile.get(aadPlugin.name)?.set(REMOTE_AAD_ID, "mockedRemoteAadId");
       mockPublishThatAlwaysSucceed(appStudioPlugin);
       const result = await solution.publish(mockedCtx);
       expect(result.isOk()).to.be.true;
@@ -217,9 +218,9 @@ describe("publish()", () => {
     it("should return ok for Azure Bot projects on happy path", async () => {
       const solution = new TeamsAppSolution();
       const mockedCtx = mockSolutionContext();
-      mockedCtx.config.set(aadPlugin.name, new ConfigMap());
-      mockedCtx.config.set(botPlugin.name, new ConfigMap());
-      mockedCtx.config.set(appStudioPlugin.name, new ConfigMap());
+      mockedCtx.envInfo.profile.set(aadPlugin.name, new ConfigMap());
+      mockedCtx.envInfo.profile.set(botPlugin.name, new ConfigMap());
+      mockedCtx.envInfo.profile.set(appStudioPlugin.name, new ConfigMap());
       mockedCtx.projectSettings = {
         appName: "my app",
         projectId: uuid.v4(),
@@ -231,13 +232,13 @@ describe("publish()", () => {
           capabilities: [BotOptionItem.id],
         },
       };
-      mockedCtx.config.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
-      mockedCtx.config.get(botPlugin.name)?.set(BOT_ID, "someFakeId");
-      mockedCtx.config.get(botPlugin.name)?.set(BOT_DOMAIN, "http://example.com");
-      mockedCtx.config
+      mockedCtx.envInfo.profile.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
+      mockedCtx.envInfo.profile.get(botPlugin.name)?.set(BOT_ID, "someFakeId");
+      mockedCtx.envInfo.profile.get(botPlugin.name)?.set(BOT_DOMAIN, "http://example.com");
+      mockedCtx.envInfo.profile
         .get(aadPlugin.name)
         ?.set(WEB_APPLICATION_INFO_SOURCE, "mockedWebApplicationInfoResouce");
-      mockedCtx.config.get(aadPlugin.name)?.set(REMOTE_AAD_ID, "mockedRemoteAadId");
+      mockedCtx.envInfo.profile.get(aadPlugin.name)?.set(REMOTE_AAD_ID, "mockedRemoteAadId");
       mockPublishThatAlwaysSucceed(appStudioPlugin);
       const result = await solution.publish(mockedCtx);
       expect(result.isOk()).to.be.true;

--- a/packages/fx-core/tests/plugins/solution/solution.scaffold.test.ts
+++ b/packages/fx-core/tests/plugins/solution/solution.scaffold.test.ts
@@ -27,7 +27,7 @@ import {
 } from "../../../src/plugins/solution/fx-solution/question";
 import _ from "lodash";
 import path from "path";
-import { getTemplatesFolder } from "../../../src";
+import { getTemplatesFolder, newEnvInfo } from "../../../src";
 import { validManifest } from "./util";
 import * as uuid from "uuid";
 import { ResourcePlugins } from "../../../src/plugins/solution/fx-solution/ResourcePluginContainer";
@@ -50,7 +50,7 @@ function mockSolutionContext(): SolutionContext {
   const config: SolutionConfig = new Map();
   return {
     root: ".",
-    config,
+    envInfo: newEnvInfo(),
     answers: { platform: Platform.VSCode },
     projectSettings: undefined,
   };

--- a/packages/fx-core/tests/plugins/solution/solution.update.test.ts
+++ b/packages/fx-core/tests/plugins/solution/solution.update.test.ts
@@ -41,6 +41,7 @@ import { ResourcePlugins } from "../../../src/plugins/solution/fx-solution/Resou
 import Container from "typedi";
 import { MockUserInteraction } from "../../core/utils";
 import mockedEnv from "mocked-env";
+import { newEnvInfo } from "../../../src";
 
 const fehostPlugin = Container.get<Plugin>(ResourcePlugins.FrontendPlugin);
 const localDebug = Container.get<Plugin>(ResourcePlugins.LocalDebugPlugin);
@@ -51,7 +52,7 @@ function mockSolutionContext(): SolutionContext {
   const config: SolutionConfig = new Map();
   return {
     root: ".",
-    config,
+    envInfo: newEnvInfo(),
     answers: { platform: Platform.VSCode },
     projectSettings: undefined,
   };
@@ -258,8 +259,8 @@ describe("update()", () => {
       return ok(Void);
     };
     // mock that provision already succeeded
-    mockedCtx.config.set(GLOBAL_CONFIG, new ConfigMap());
-    mockedCtx.config.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
+    mockedCtx.envInfo.profile.set(GLOBAL_CONFIG, new ConfigMap());
+    mockedCtx.envInfo.profile.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
     const result = await solution.update(mockedCtx);
     expect(result.isOk()).equals(true);
     expect(mockedCtx.projectSettings?.solutionSettings?.azureResources as string[]).contains(
@@ -268,7 +269,8 @@ describe("update()", () => {
     expect(mockedCtx.projectSettings?.solutionSettings?.azureResources as string[]).contains(
       AzureResourceFunction.id
     );
-    expect(mockedCtx.config.get(GLOBAL_CONFIG)?.get(SOLUTION_PROVISION_SUCCEEDED)).is.false;
+    expect(mockedCtx.envInfo.profile.get(GLOBAL_CONFIG)?.get(SOLUTION_PROVISION_SUCCEEDED)).is
+      .false;
   });
 
   it("should leave projectSettings unchanged if scaffold fails", async () => {
@@ -296,13 +298,14 @@ describe("update()", () => {
       return err(returnSystemError(new Error("Some fake error"), "SolutionTest", "FakeError"));
     };
     // mock that provision already succeeded
-    mockedCtx.config.set(GLOBAL_CONFIG, new ConfigMap());
-    mockedCtx.config.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
+    mockedCtx.envInfo.profile.set(GLOBAL_CONFIG, new ConfigMap());
+    mockedCtx.envInfo.profile.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
     const result = await solution.update(mockedCtx);
     expect(result.isOk()).equals(false);
     expect(mockedCtx.projectSettings).to.be.deep.equal(originalProjectSettings);
     // provisionSucceeded is not changed due to the failure of solution.update()
-    expect(mockedCtx.config.get(GLOBAL_CONFIG)?.get(SOLUTION_PROVISION_SUCCEEDED)).to.be.true;
+    expect(mockedCtx.envInfo.profile.get(GLOBAL_CONFIG)?.get(SOLUTION_PROVISION_SUCCEEDED)).to.be
+      .true;
   });
 
   it("shouldn't set provisionSucceeded to false when adding a new Function endpoint", async () => {
@@ -329,12 +332,13 @@ describe("update()", () => {
       return ok(Void);
     };
     // mock that provision already succeeded
-    mockedCtx.config.set(GLOBAL_CONFIG, new ConfigMap());
-    mockedCtx.config.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
+    mockedCtx.envInfo.profile.set(GLOBAL_CONFIG, new ConfigMap());
+    mockedCtx.envInfo.profile.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
     const result = await solution.update(mockedCtx);
     expect(result.isOk()).equals(true);
     // provisionSucceeded is not changed because function is already added.
-    expect(mockedCtx.config.get(GLOBAL_CONFIG)?.get(SOLUTION_PROVISION_SUCCEEDED)).to.be.true;
+    expect(mockedCtx.envInfo.profile.get(GLOBAL_CONFIG)?.get(SOLUTION_PROVISION_SUCCEEDED)).to.be
+      .true;
   });
 
   it("should set provisionSucceeded to false when adding SQL to a project with Function", async () => {
@@ -364,12 +368,13 @@ describe("update()", () => {
       return ok(Void);
     };
     // mock that provision already succeeded
-    mockedCtx.config.set(GLOBAL_CONFIG, new ConfigMap());
-    mockedCtx.config.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
+    mockedCtx.envInfo.profile.set(GLOBAL_CONFIG, new ConfigMap());
+    mockedCtx.envInfo.profile.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
     const result = await solution.update(mockedCtx);
     expect(result.isOk()).equals(true);
     // provisionSucceeded is not changed because function is already added.
-    expect(mockedCtx.config.get(GLOBAL_CONFIG)?.get(SOLUTION_PROVISION_SUCCEEDED)).to.be.false;
+    expect(mockedCtx.envInfo.profile.get(GLOBAL_CONFIG)?.get(SOLUTION_PROVISION_SUCCEEDED)).to.be
+      .false;
   });
 
   it("should ask for confirm regenerate ARM template when adding resources", async () => {

--- a/packages/fx-core/tests/plugins/solution/solution.usertask.test.ts
+++ b/packages/fx-core/tests/plugins/solution/solution.usertask.test.ts
@@ -11,7 +11,7 @@ import { mockPublishThatAlwaysSucceed } from "./util";
 import _ from "lodash";
 import { ResourcePlugins } from "../../../src/plugins/solution/fx-solution/ResourcePluginContainer";
 import Container from "typedi";
-import { AppStudioPlugin } from "../../../src";
+import { AppStudioPlugin, newEnvInfo } from "../../../src";
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;
@@ -21,7 +21,7 @@ function mockSolutionContextWithPlatform(platform?: Platform): SolutionContext {
   config.set(GLOBAL_CONFIG, new ConfigMap());
   return {
     root: ".",
-    config,
+    envInfo: newEnvInfo(),
     answers: { platform: platform ? platform : Platform.VSCode },
     projectSettings: undefined,
   };


### PR DESCRIPTION
In `SolutionContext`, the `config: SolutionConfig` is replaced with `envInfo: EnvInfo`. Since the data of `config` is equal to `envInfo.profile`, the code snippet of `solutionContext.config` is replaced with `solutionContext.envInfo.profile` in this PR.

After this update, Solution is able to get the data of `profile.<env>.json` or `env.<env>.json` (**output**) as well as the `config.<env>.json` (**input**) from `SolutionContext`.