### PR TITLE
refactor(multi-env): skip to create env profile during scaffolding

### DIFF
--- a/packages/fx-core/src/core/index.ts
+++ b/packages/fx-core/src/core/index.ts
@@ -122,7 +122,7 @@ export class FxCore implements Core {
     QuestionModelMW,
     ContextInjecterMW,
     ProjectSettingsWriterMW,
-    EnvInfoWriterMW,
+    EnvInfoWriterMW(isMultiEnvEnabled()),
   ])
   async createProject(inputs: Inputs, ctx?: CoreHookContext): Promise<Result<string, FxError>> {
     currentStage = Stage.create;
@@ -220,7 +220,7 @@ export class FxCore implements Core {
     QuestionModelMW,
     ContextInjecterMW,
     ProjectSettingsWriterMW,
-    EnvInfoWriterMW,
+    EnvInfoWriterMW(),
   ])
   async migrateV1Project(inputs: Inputs, ctx?: CoreHookContext): Promise<Result<string, FxError>> {
     currentStage = Stage.migrateV1;
@@ -409,7 +409,7 @@ export class FxCore implements Core {
     QuestionModelMW,
     ContextInjecterMW,
     ProjectSettingsWriterMW,
-    EnvInfoWriterMW,
+    EnvInfoWriterMW(),
   ])
   async provisionResources(inputs: Inputs, ctx?: CoreHookContext): Promise<Result<Void, FxError>> {
     currentStage = Stage.provision;
@@ -425,7 +425,7 @@ export class FxCore implements Core {
     QuestionModelMW,
     ContextInjecterMW,
     ProjectSettingsWriterMW,
-    EnvInfoWriterMW,
+    EnvInfoWriterMW(),
   ])
   async deployArtifacts(inputs: Inputs, ctx?: CoreHookContext): Promise<Result<Void, FxError>> {
     currentStage = Stage.deploy;
@@ -443,7 +443,7 @@ export class FxCore implements Core {
     QuestionModelMW,
     ContextInjecterMW,
     ProjectSettingsWriterMW,
-    EnvInfoWriterMW,
+    EnvInfoWriterMW(),
     LocalSettingsWriterMW,
   ])
   async localDebug(inputs: Inputs, ctx?: CoreHookContext): Promise<Result<Void, FxError>> {
@@ -469,7 +469,7 @@ export class FxCore implements Core {
     QuestionModelMW,
     ContextInjecterMW,
     ProjectSettingsWriterMW,
-    EnvInfoWriterMW,
+    EnvInfoWriterMW(),
   ])
   async publishApplication(inputs: Inputs, ctx?: CoreHookContext): Promise<Result<Void, FxError>> {
     currentStage = Stage.publish;
@@ -486,7 +486,7 @@ export class FxCore implements Core {
     QuestionModelMW,
     ContextInjecterMW,
     ProjectSettingsWriterMW,
-    EnvInfoWriterMW,
+    EnvInfoWriterMW(),
     LocalSettingsWriterMW,
   ])
   async executeUserTask(
@@ -512,7 +512,7 @@ export class FxCore implements Core {
     EnvInfoLoaderMW(false, false),
     SolutionLoaderMW(defaultSolutionLoader),
     ContextInjecterMW,
-    EnvInfoWriterMW,
+    EnvInfoWriterMW(),
   ])
   async getQuestions(
     task: Stage,
@@ -541,7 +541,7 @@ export class FxCore implements Core {
     EnvInfoLoaderMW(false, false),
     SolutionLoaderMW(defaultSolutionLoader),
     ContextInjecterMW,
-    EnvInfoWriterMW,
+    EnvInfoWriterMW(),
   ])
   async getQuestionsForUserTask(
     func: FunctionRouter,
@@ -583,7 +583,7 @@ export class FxCore implements Core {
     EnvInfoLoaderMW(false, false),
     ContextInjecterMW,
     ProjectSettingsWriterMW,
-    EnvInfoWriterMW,
+    EnvInfoWriterMW(),
   ])
   async setSubscriptionInfo(inputs: Inputs, ctx?: CoreHookContext): Promise<Result<Void, FxError>> {
     const solutionContext = ctx!.solutionContext! as SolutionContext;
@@ -605,7 +605,7 @@ export class FxCore implements Core {
     QuestionModelMW,
     ContextInjecterMW,
     ProjectSettingsWriterMW,
-    EnvInfoWriterMW,
+    EnvInfoWriterMW(),
   ])
   async grantPermission(inputs: Inputs, ctx?: CoreHookContext): Promise<Result<any, FxError>> {
     currentStage = Stage.grantPermission;
@@ -621,7 +621,7 @@ export class FxCore implements Core {
     QuestionModelMW,
     ContextInjecterMW,
     ProjectSettingsWriterMW,
-    EnvInfoWriterMW,
+    EnvInfoWriterMW(),
   ])
   async checkPermission(inputs: Inputs, ctx?: CoreHookContext): Promise<Result<any, FxError>> {
     currentStage = Stage.checkPermission;
@@ -637,7 +637,7 @@ export class FxCore implements Core {
     QuestionModelMW,
     ContextInjecterMW,
     ProjectSettingsWriterMW,
-    EnvInfoWriterMW,
+    EnvInfoWriterMW(),
   ])
   async listCollaborator(inputs: Inputs, ctx?: CoreHookContext): Promise<Result<any, FxError>> {
     currentStage = Stage.listCollaborator;
@@ -790,7 +790,7 @@ export class FxCore implements Core {
     ProjectSettingsLoaderMW,
     EnvInfoLoaderMW(false, false),
     ContextInjecterMW,
-    EnvInfoWriterMW,
+    EnvInfoWriterMW(),
   ])
   async encrypt(
     plaintext: string,
@@ -805,7 +805,7 @@ export class FxCore implements Core {
     ProjectSettingsLoaderMW,
     EnvInfoLoaderMW(false, false),
     ContextInjecterMW,
-    EnvInfoWriterMW,
+    EnvInfoWriterMW(),
   ])
   async decrypt(
     ciphertext: string,

--- a/packages/fx-core/src/core/middleware/envInfoWriter.ts
+++ b/packages/fx-core/src/core/middleware/envInfoWriter.ts
@@ -11,38 +11,44 @@ import { environmentManager } from "../environment";
 /**
  * This middleware will help to persist environment profile if necessary.
  */
-export const EnvInfoWriterMW: Middleware = async (ctx: CoreHookContext, next: NextFunction) => {
-  try {
-    await next();
-  } finally {
-    const lastArg = ctx.arguments[ctx.arguments.length - 1];
-    const inputs: Inputs = lastArg === ctx ? ctx.arguments[ctx.arguments.length - 2] : lastArg;
-    if (
-      !inputs.projectPath ||
-      inputs.ignoreConfigPersist === true ||
-      inputs.ignoreEnvInfo === true ||
-      StaticPlatforms.includes(inputs.platform)
-    )
-      return;
+export function EnvInfoWriterMW(skip = false): Middleware {
+  return async (ctx: CoreHookContext, next: NextFunction) => {
+    try {
+      await next();
+    } finally {
+      if (skip) {
+        return;
+      }
 
-    const solutionContext = ctx.solutionContext;
-    if (solutionContext === undefined) return;
+      const lastArg = ctx.arguments[ctx.arguments.length - 1];
+      const inputs: Inputs = lastArg === ctx ? ctx.arguments[ctx.arguments.length - 2] : lastArg;
+      if (
+        !inputs.projectPath ||
+        inputs.ignoreConfigPersist === true ||
+        inputs.ignoreEnvInfo === true ||
+        StaticPlatforms.includes(inputs.platform)
+      )
+        return;
 
-    // DO NOT persist local debug plugin config.
-    if (solutionContext.envInfo.profile.has(PluginNames.LDEBUG)) {
-      solutionContext.envInfo.profile.delete(PluginNames.LDEBUG);
+      const solutionContext = ctx.solutionContext;
+      if (solutionContext === undefined) return;
+
+      // DO NOT persist local debug plugin config.
+      if (solutionContext.envInfo.profile.has(PluginNames.LDEBUG)) {
+        solutionContext.envInfo.profile.delete(PluginNames.LDEBUG);
+      }
+
+      const envProfilePath = await environmentManager.writeEnvProfile(
+        solutionContext.envInfo.profile,
+        inputs.projectPath,
+        solutionContext.envInfo?.envName,
+        solutionContext.cryptoProvider
+      );
+
+      if (envProfilePath.isOk()) {
+        const core = ctx.self as FxCore;
+        core.tools.logProvider.debug(`[core] persist env profile: ${envProfilePath.value}`);
+      }
     }
-
-    const envProfilePath = await environmentManager.writeEnvProfile(
-      solutionContext.envInfo.profile,
-      inputs.projectPath,
-      solutionContext.envInfo?.envName,
-      solutionContext.cryptoProvider
-    );
-
-    if (envProfilePath.isOk()) {
-      const core = ctx.self as FxCore;
-      core.tools.logProvider.debug(`[core] persist env profile: ${envProfilePath.value}`);
-    }
-  }
-};
+  };
+}

--- a/packages/fx-core/tests/core/hooks.test.ts
+++ b/packages/fx-core/tests/core/hooks.test.ts
@@ -524,7 +524,7 @@ describe("Middleware", () => {
         }
       }
       hooks(MyClass, {
-        myMethod: [ContextInjecterMW, ProjectSettingsWriterMW, EnvInfoWriterMW],
+        myMethod: [ContextInjecterMW, ProjectSettingsWriterMW, EnvInfoWriterMW()],
       });
       const my = new MyClass();
       await my.myMethod(inputs);
@@ -598,7 +598,7 @@ describe("Middleware", () => {
         }
       }
       hooks(MyClass, {
-        WriteConfigTrigger: [ContextInjecterMW, ProjectSettingsWriterMW, EnvInfoWriterMW],
+        WriteConfigTrigger: [ContextInjecterMW, ProjectSettingsWriterMW, EnvInfoWriterMW()],
         ReadConfigTrigger: [
           ProjectSettingsLoaderMW,
           EnvInfoLoaderMW(false, false),


### PR DESCRIPTION
When multi-env is enabled, no need to scaffold `profile.<env>.json` any more.