### PR TITLE
fix(multi-env): fix multi-env for local debug

### DIFF
--- a/packages/fx-core/src/core/middleware/projectUpgrader.ts
+++ b/packages/fx-core/src/core/middleware/projectUpgrader.ts
@@ -109,6 +109,14 @@ export async function upgradeContext(ctx: CoreHookContext): Promise<Result<undef
     : path.resolve(confFolderPath, `env.${defaultEnvName}.json`);
   const userDataPath = path.resolve(confFolderPath, `${defaultEnvName}.userdata`);
 
+  // For the multi env scenario, profile.{envName}.json and {envName}.userdata are not created when scaffolding
+  // These projects must be the new projects, so skip upgrading.
+  try {
+    await Promise.all([fs.stat(contextPath), fs.stat(userDataPath)]);
+  } catch (error) {
+    return ok(undefined);
+  }
+
   let context: Json = {};
   let userData: Record<string, string> = {};
 

--- a/packages/fx-core/src/core/middleware/projectUpgrader.ts
+++ b/packages/fx-core/src/core/middleware/projectUpgrader.ts
@@ -111,10 +111,12 @@ export async function upgradeContext(ctx: CoreHookContext): Promise<Result<undef
 
   // For the multi env scenario, profile.{envName}.json and {envName}.userdata are not created when scaffolding
   // These projects must be the new projects, so skip upgrading.
-  try {
-    await Promise.all([fs.stat(contextPath), fs.stat(userDataPath)]);
-  } catch (error) {
-    return ok(undefined);
+  if (isMultiEnvEnabled()) {
+    try {
+      await Promise.all([fs.stat(contextPath), fs.stat(userDataPath)]);
+    } catch (error) {
+      return ok(undefined);
+    }
   }
 
   let context: Json = {};

--- a/packages/fx-core/src/core/tools.ts
+++ b/packages/fx-core/src/core/tools.ts
@@ -5,6 +5,7 @@ import {
   AzureSolutionSettings,
   EnvInfo,
   ConfigMap,
+  ProjectSettingsFileName,
 } from "@microsoft/teamsfx-api";
 import * as path from "path";
 import * as fs from "fs-extra";
@@ -100,7 +101,7 @@ export function isValidProject(workspacePath?: string): boolean {
       : path.resolve(workspacePath, `.${ConfigFolderName}`);
     const settingsFile = path.resolve(
       confFolderPath,
-      isMultiEnvEnabled() ? "localSettings.json" : "settings.json"
+      isMultiEnvEnabled() ? ProjectSettingsFileName : "settings.json"
     );
     const projectSettings: ProjectSettings = fs.readJsonSync(settingsFile);
     if (validateSettings(projectSettings)) return false;

--- a/packages/fx-core/src/core/tools.ts
+++ b/packages/fx-core/src/core/tools.ts
@@ -19,6 +19,7 @@ import {
   TabOptionItem,
 } from "../plugins/solution/fx-solution/question";
 import { environmentManager } from "./environment";
+import { isMultiEnvEnabled } from "../common";
 export function validateProject(solutionContext: SolutionContext): string | undefined {
   const res = validateSettings(solutionContext.projectSettings);
   return res;
@@ -94,8 +95,13 @@ export function validateSettings(projectSettings?: ProjectSettings): string | un
 export function isValidProject(workspacePath?: string): boolean {
   if (!workspacePath) return false;
   try {
-    const confFolderPath = path.resolve(workspacePath, `.${ConfigFolderName}`);
-    const settingsFile = path.resolve(confFolderPath, "settings.json");
+    const confFolderPath = isMultiEnvEnabled()
+      ? path.resolve(workspacePath, `.${ConfigFolderName}`, "configs")
+      : path.resolve(workspacePath, `.${ConfigFolderName}`);
+    const settingsFile = path.resolve(
+      confFolderPath,
+      isMultiEnvEnabled() ? "localSettings.json" : "settings.json"
+    );
     const projectSettings: ProjectSettings = fs.readJsonSync(settingsFile);
     if (validateSettings(projectSettings)) return false;
     return true;

--- a/packages/vscode-extension/src/debug/commonUtils.ts
+++ b/packages/vscode-extension/src/debug/commonUtils.ts
@@ -282,9 +282,31 @@ function getSettingWithUserData(jsonSelector: (jsonObject: any) => any): string 
   return undefined;
 }
 
+// This is for the new folder structure for multi-env
+function getLocalSetting(jsonSelector: (jsonObject: any) => any): string | undefined {
+  if (ext.workspaceUri) {
+    const ws = ext.workspaceUri.fsPath;
+    if (isValidProject(ws)) {
+      const localSettingsPath = path.join(
+        ws,
+        `.${ConfigFolderName}/${InputConfigsFolderName}/${constants.localSettingsJsonName}`
+      );
+      const envJson = JSON.parse(fs.readFileSync(localSettingsPath, "utf8"));
+      const settingValue = jsonSelector(envJson) as string;
+      return settingValue;
+    }
+  }
+
+  return undefined;
+}
+
 export function getTeamsAppTenantId(): string | undefined {
   try {
-    return getSettingWithUserData((envJson) => envJson.solution.teamsAppTenantId);
+    if (isMultiEnvEnabled()) {
+      return getLocalSetting((localSettingsJson) => localSettingsJson.teamsApp.tenantId);
+    } else {
+      return getSettingWithUserData((envJson) => envJson.solution.teamsAppTenantId);
+    }
   } catch {
     // in case structure changes
     return undefined;
@@ -293,7 +315,11 @@ export function getTeamsAppTenantId(): string | undefined {
 
 export function getLocalTeamsAppId(): string | undefined {
   try {
-    return getSettingWithUserData((envJson) => envJson.solution.localDebugTeamsAppId);
+    if (isMultiEnvEnabled()) {
+      return getLocalSetting((localSettingsJson) => localSettingsJson.teamsApp.teamsAppId);
+    } else {
+      return getSettingWithUserData((envJson) => envJson.solution.localDebugTeamsAppId);
+    }
   } catch {
     // in case structure changes
     return undefined;

--- a/packages/vscode-extension/src/debug/constants.ts
+++ b/packages/vscode-extension/src/debug/constants.ts
@@ -24,6 +24,7 @@ export const localEnvFileName = "local.env";
 export const manifestFileName = "manifest.source.json";
 export const userDataFileName = "default.userdata"; // TODO: different file name for different environment
 export const userDataFileNameNew = "dev.userdata"; // TODO: different file name for different environment
+export const localSettingsJsonName = "localSettings.json";
 
 export const frontendLocalEnvPrefix = "FRONTEND_";
 export const backendLocalEnvPrefix = "BACKEND_";


### PR DESCRIPTION
- Fix projectUpgrader. If `profile.${envName}.json` or `{envName}.userdata` do not exist, it must be a new project. It does not need to be upgraded
- Fix the valid project checking for new folder structure
- Fix local debug teamsAppId and tenantId in the new folder structure

Tested local debug.
![Screenshot from 2021-08-30 15-26-08](https://user-images.githubusercontent.com/9698542/131301862-85500269-8c98-44b5-80ca-cd7f9242683f.png)

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/10728294