### PR TITLE
chore(sql): fix sql exist check

### DIFF
--- a/packages/fx-core/src/plugins/resource/sql/constants.ts
+++ b/packages/fx-core/src/plugins/resource/sql/constants.ts
@@ -31,8 +31,7 @@ export class Constants {
   public static readonly skipAddingUser: string = "skipAddingUser";
   public static readonly admin: string = "admin";
   public static readonly adminPassword: string = "adminPassword";
-  public static readonly aadAdmin: string = "aadAdmin";
-  public static readonly aadAdminObjectId: string = "aadAdminObjectId";
+  public static readonly existSql: string = "existSql";
 
   public static readonly solution: string = "solution";
   public static readonly solutionPluginFullName = "fx-solution-azure";

--- a/packages/fx-core/src/plugins/resource/sql/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/sql/plugin.ts
@@ -105,6 +105,8 @@ export class SqlPluginImpl {
         this.config.existSql = await managementClient.existAzureSQL();
       }
 
+      ctx.config.set(Constants.existSql, this.config.existSql);
+
       if (!this.config.existSql) {
         this.buildQuestionNode(sqlNode);
       }
@@ -141,6 +143,7 @@ export class SqlPluginImpl {
       this.config.skipAddingUser = skipAddingUser as boolean;
     }
 
+    this.config.existSql = ctx.config.get(Constants.existSql);
     if (!this.config.existSql) {
       this.config.admin = ctx.answers![Constants.questionKey.adminName] as string;
       this.config.adminPassword = ctx.answers![Constants.questionKey.adminPassword] as string;

--- a/packages/fx-core/tests/plugins/resource/sql/unit/index.test.ts
+++ b/packages/fx-core/tests/plugins/resource/sql/unit/index.test.ts
@@ -66,7 +66,8 @@ describe("sqlPlugin", () => {
   it("getQuestions in cli help", async function () {
     // Arrange
     sinon.stub(Servers.prototype, "checkNameAvailability").resolves({ available: false });
-    pluginContext.answers.platform === Platform.CLI_HELP;
+    pluginContext.answers === { platform: Platform.CLI_HELP };
+    // pluginContext.answers.platform === Platform.CLI_HELP;
     // Act
     const getQuestionResult = await sqlPlugin.getQuestions(Stage.provision, pluginContext);
 

--- a/packages/fx-core/tests/plugins/resource/sql/unit/index.test.ts
+++ b/packages/fx-core/tests/plugins/resource/sql/unit/index.test.ts
@@ -43,9 +43,30 @@ describe("sqlPlugin", () => {
     sinon.restore();
   });
 
-  it("getQuestions", async function () {
+  it("getQuestions without sql", async function () {
     // Arrange
     sinon.stub(Servers.prototype, "checkNameAvailability").resolves({ available: true });
+    // Act
+    const getQuestionResult = await sqlPlugin.getQuestions(Stage.provision, pluginContext);
+
+    // Assert
+    chai.assert.isTrue(getQuestionResult.isOk());
+  });
+
+  it("getQuestions with sql", async function () {
+    // Arrange
+    sinon.stub(Servers.prototype, "checkNameAvailability").resolves({ available: false });
+    // Act
+    const getQuestionResult = await sqlPlugin.getQuestions(Stage.provision, pluginContext);
+
+    // Assert
+    chai.assert.isTrue(getQuestionResult.isOk());
+  });
+
+  it("getQuestions in cli help", async function () {
+    // Arrange
+    sinon.stub(Servers.prototype, "checkNameAvailability").resolves({ available: false });
+    pluginContext.answers.platform === Platform.CLI_HELP;
     // Act
     const getQuestionResult = await sqlPlugin.getQuestions(Stage.provision, pluginContext);
 


### PR DESCRIPTION
when the provisionSucceeded flag is true, the get question step in provision will skip.
Fix it by adding the config into ctx and loading it at the pre provision step.