### PR TITLE
fix: add back fx-resource-local-debug config in env.default.json

### DIFF
--- a/packages/fx-core/src/core/middleware/envInfoWriter.ts
+++ b/packages/fx-core/src/core/middleware/envInfoWriter.ts
@@ -5,6 +5,7 @@
 import { NextFunction, Middleware } from "@feathersjs/hooks";
 import { Inputs, StaticPlatforms } from "@microsoft/teamsfx-api";
 import { CoreHookContext, FxCore } from "..";
+import { isMultiEnvEnabled } from "../../common";
 import { PluginNames } from "../../plugins/solution/fx-solution/constants";
 import { environmentManager } from "../environment";
 
@@ -34,7 +35,7 @@ export function EnvInfoWriterMW(skip = false): Middleware {
       if (solutionContext === undefined) return;
 
       // DO NOT persist local debug plugin config.
-      if (solutionContext.envInfo.profile.has(PluginNames.LDEBUG)) {
+      if (isMultiEnvEnabled() && solutionContext.envInfo.profile.has(PluginNames.LDEBUG)) {
         solutionContext.envInfo.profile.delete(PluginNames.LDEBUG);
       }
 


### PR DESCRIPTION
If multi-env feature flag is not enabled, the local-debug experience keeps the same as the official release now.