### PR TITLE
chore(multi-env): read resource group info from input config

### DIFF
--- a/packages/fx-core/src/plugins/solution/fx-solution/constants.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/constants.ts
@@ -85,7 +85,6 @@ export enum SolutionError {
   FailedToListResourceGroup = "FailedToListResourceGrouop",
   FailedToGetResourceGroupInfoInputs = "FailedToGetResourceGroupInfoInputs",
   ResourceGroupNotFound = "ResourceGroupNotFound",
-  InvalidPublishProfileFile = "InvalidPublishProfileFile",
   NotLoginToAzure = "NotLoginToAzure",
   AzureAccountExtensionNotInitialized = "AzureAccountExtensionNotInitialized",
   LocalTabEndpointMissing = "LocalTabEndpointMissing",

--- a/packages/fx-core/src/plugins/solution/fx-solution/constants.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/constants.ts
@@ -84,6 +84,8 @@ export enum SolutionError {
   FailedToCreateResourceGroup = "FailedToCreateResourceGroup",
   FailedToListResourceGroup = "FailedToListResourceGrouop",
   FailedToGetResourceGroupInfoInputs = "FailedToGetResourceGroupInfoInputs",
+  ResourceGroupNotFound = "ResourceGroupNotFound",
+  InvalidPublishProfileFile = "InvalidPublishProfileFile",
   NotLoginToAzure = "NotLoginToAzure",
   AzureAccountExtensionNotInitialized = "AzureAccountExtensionNotInitialized",
   LocalTabEndpointMissing = "LocalTabEndpointMissing",


### PR DESCRIPTION
- read resource group from `config.{envName}.json`
- fix a typo

Tested custom input file

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/10728283