### PR TITLE
chore(env checker): exclude depsChecker in fx-core

### DIFF
--- a/packages/fx-core/.nycrc
+++ b/packages/fx-core/.nycrc
@@ -7,6 +7,7 @@
   ],
   "exclude": [
       "src/plugins/resource/function/utils/depsChecker/**/*",
+      "src/plugins/solution/fx-solution/utils/depsChecker/**/*",
       "src/plugins/resource/localdebug/legacyPlugin.ts"
   ],
   "reporter": [


### PR DESCRIPTION
exclude bicep env checker in fx-core, will add e2e test case to cover ut test  