### PR TITLE
chore(multi-env): refine the schema of env config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,6 +35,7 @@
 
 /packages/api @jayzhang @1yefuwang1 @LongOddCode
 /packages/api/src/qm @jayzhang @1yefuwang1 @LongOddCode @jiayi-ruan
+/packages/api/src/schemas @dooriya @qinezh @kimizhu
 
 /packages/sdk @tecton @blackchoey @SLdragon @dilin-MS @wenytang-ms @jiayi-ruan
 

--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -224,8 +224,6 @@ export interface EnvConfig {
     azure: {
         subscriptionId?: string;
         resourceGroupName?: string;
-        location?: string;
-        tenantId?: string;
     };
     manifest: {
         description?: string;

--- a/packages/api/src/schemas/envConfig.json
+++ b/packages/api/src/schemas/envConfig.json
@@ -12,19 +12,14 @@
       "properties": {
         "subscriptionId": {
           "type": "string",
-          "description": "The default subscription to provision Azure resources."
+          "description": "The default subscription to provision Azure resources.",
+          "minLength": 1
         },
         "resourceGroupName": {
           "type": "string",
-          "description": "The default resource group of Azure resources."
-        },
-        "location": {
-          "type": "string",
-          "description": "The location of created resource group if needed."
-        },
-        "tenantId": {
-          "type": "string",
-          "description": "The tenant to create AAD app."
+          "description": "The default resource group of Azure resources.",
+          "minLength": 1,
+          "pattern": "^[-\\w\\._\\(\\)]+$"
         }
       },
       "additionalProperties": false

--- a/packages/api/src/schemas/envConfig.ts
+++ b/packages/api/src/schemas/envConfig.ts
@@ -22,14 +22,6 @@ export interface EnvConfig {
      * The default resource group of Azure resources.
      */
     resourceGroupName?: string;
-    /**
-     * The location of created resource group if needed.
-     */
-    location?: string;
-    /**
-     * The tenant to create AAD app.
-     */
-    tenantId?: string;
   };
   /**
    * The Teams App mainfest related configuration.


### PR DESCRIPTION
1. add code owner for the schema of env config.
2. remove the location of resource group from schema, as it's only allowed to specify an existing resource group.
3. remove the tenant id from schema, as there's no P0 scenario to support to customize tenant in env config.
3. add restriction to avoid empty string.
4. add pattern to validate the resource group name.