### PR TITLE
fix(appstudio): add v1 project sso telemetry during migration

### DIFF
--- a/packages/fx-core/src/plugins/resource/appstudio/constants.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/constants.ts
@@ -37,7 +37,6 @@ export const FRONTEND_ENDPOINT_ARM = "frontendHosting_endpoint";
 export const FRONTEND_DOMAIN_ARM = "frontendHosting_domain";
 export const BOT_ID = "botId";
 export const LOCAL_BOT_ID = "localBotId";
-export const V1_MANIFEST = "manifest.json";
 
 /**
  * Config Keys that are useful for remote collaboration

--- a/packages/fx-core/src/plugins/resource/appstudio/index.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/index.ts
@@ -212,8 +212,10 @@ export class AppStudioPlugin implements Plugin {
     TelemetryUtils.sendStartEvent(TelemetryEventName.migrateV1Project);
 
     try {
-      await this.appStudioPluginImpl.migrateV1Project(ctx);
-      TelemetryUtils.sendSuccessEvent(TelemetryEventName.migrateV1Project);
+      const v1ProjectProperties = await this.appStudioPluginImpl.migrateV1Project(ctx);
+      TelemetryUtils.sendSuccessEvent(TelemetryEventName.migrateV1Project, {
+        enableAuth: v1ProjectProperties.enableAuth ? "true" : "false",
+      });
       return ok(Void);
     } catch (error) {
       TelemetryUtils.sendErrorEvent(TelemetryEventName.migrateV1Project, error);

--- a/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
@@ -385,7 +385,7 @@ export class AppStudioPluginImpl {
       if (await this.checkFileExist(archiveOutlineFile)) {
         await fs.copyFile(archiveOutlineFile, newOutlineFile);
       }
-      return { enableAuth: !!manifest.webApplicationInfo };
+      return { enableAuth: !!manifest?.webApplicationInfo?.id };
     } else {
       await this.scaffold(ctx);
       return { enableAuth: false };

--- a/packages/fx-core/tests/plugins/resource/appstudio/unit/migrate.test.ts
+++ b/packages/fx-core/tests/plugins/resource/appstudio/unit/migrate.test.ts
@@ -11,6 +11,7 @@ import {
   Platform,
   AppPackageFolderName,
   V1ManifestFileName,
+  ArchiveFolderName,
 } from "@microsoft/teamsfx-api";
 import * as uuid from "uuid";
 import fs, { PathLike } from "fs-extra";
@@ -22,7 +23,6 @@ import {
   STATIC_TABS_TPL,
 } from "../../../../../src/plugins/resource/appstudio/constants";
 import path from "path";
-import { ArchiveFolderName } from "@microsoft/teamsfx-api";
 
 describe("Migrate", () => {
   let plugin: AppStudioPlugin;
@@ -106,7 +106,7 @@ describe("Migrate", () => {
   it("should generate manifest from an existing manifest.json file", async () => {
     fileContent.clear();
     sandbox.stub<any, any>(fs, "readdir").callsFake(async (filePath: fs.PathLike) => {
-      return [V1_MANIFEST, "color.png"];
+      return [V1ManifestFileName, "color.png"];
     });
 
     fileContent.set(

--- a/packages/fx-core/tests/plugins/resource/appstudio/unit/migrate.test.ts
+++ b/packages/fx-core/tests/plugins/resource/appstudio/unit/migrate.test.ts
@@ -10,6 +10,7 @@ import {
   TeamsAppManifest,
   Platform,
   AppPackageFolderName,
+  V1ManifestFileName,
 } from "@microsoft/teamsfx-api";
 import * as uuid from "uuid";
 import fs, { PathLike } from "fs-extra";
@@ -19,7 +20,6 @@ import {
   CONFIGURABLE_TABS_TPL,
   REMOTE_MANIFEST,
   STATIC_TABS_TPL,
-  V1_MANIFEST,
 } from "../../../../../src/plugins/resource/appstudio/constants";
 import path from "path";
 import { ArchiveFolderName } from "@microsoft/teamsfx-api";
@@ -110,7 +110,9 @@ describe("Migrate", () => {
     });
 
     fileContent.set(
-      path.normalize(`${ctx.root}/${ArchiveFolderName}/${AppPackageFolderName}/${V1_MANIFEST}`),
+      path.normalize(
+        `${ctx.root}/${ArchiveFolderName}/${AppPackageFolderName}/${V1ManifestFileName}`
+      ),
       manifestStr
     );
     fileContent.set(


### PR DESCRIPTION
1. Replace `V1_MANIFEST` to `V1ManifestFileName`
2. Add a telemetry property to track whether a v1 tab app includes SSO.