### PR TITLE
fix(multi-env): fix the issue that toolkit asking env when localdebug

### DIFF
--- a/packages/fx-core/src/core/middleware/envInfoLoader.ts
+++ b/packages/fx-core/src/core/middleware/envInfoLoader.ts
@@ -65,7 +65,8 @@ export function EnvInfoLoaderMW(
     const core = ctx.self as FxCore;
 
     if (inputs.ignoreEnvInfo === true) {
-      const result = await loadSolutionContextWithoutEnv(core.tools, inputs, ctx.projectSettings);
+      // load default env
+      const result = await loadSolutionContext(core.tools, inputs, ctx.projectSettings);
       if (result.isErr()) {
         ctx.result = err(result.error);
         return;
@@ -142,30 +143,6 @@ export async function loadSolutionContext(
   const solutionContext: SolutionContext = {
     projectSettings: projectSettings,
     envInfo,
-    root: inputs.projectPath || "",
-    ...tools,
-    ...tools.tokenProvider,
-    answers: inputs,
-    cryptoProvider: cryptoProvider,
-    permissionRequestProvider: new PermissionRequestFileProvider(inputs.projectPath),
-  };
-
-  return ok(solutionContext);
-}
-
-export async function loadSolutionContextWithoutEnv(
-  tools: Tools,
-  inputs: Inputs,
-  projectSettings: ProjectSettings
-): Promise<Result<SolutionContext, FxError>> {
-  if (!inputs.projectPath) {
-    return err(NoProjectOpenedError());
-  }
-
-  const cryptoProvider = new LocalCrypto(projectSettings.projectId);
-  const solutionContext: SolutionContext = {
-    projectSettings: projectSettings,
-    envInfo: newEnvInfo(),
     root: inputs.projectPath || "",
     ...tools,
     ...tools.tokenProvider,

--- a/packages/vscode-extension/src/debug/commonUtils.ts
+++ b/packages/vscode-extension/src/debug/commonUtils.ts
@@ -133,6 +133,7 @@ async function executeLocalDebugUserTask(funcName: string, params?: unknown): Pr
     const inputs = getSystemInputs();
     inputs.ignoreLock = true;
     inputs.ignoreConfigPersist = true;
+    inputs.ignoreEnvInfo = true;
     const result = await core.executeUserTask(func, inputs);
     if (result.isErr()) {
       throw result.error;


### PR DESCRIPTION
- set `ignoreEnvInfo` to true to prevent asking for env when local debug 
- for local debug, it also needs the default env's solution context

Tested local debug with multi env feature flags on