### PR TITLE
chore(multi-env): also check resource group from profile

### DIFF
--- a/packages/fx-core/src/plugins/solution/fx-solution/commonQuestions.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/commonQuestions.ts
@@ -30,7 +30,6 @@ import {
   QuestionSelectResourceGroup,
 } from "../../../core/question";
 import { desensitize } from "../../../core/middleware/questionModel";
-import { SOLUTION } from "../../resource/appstudio/constants";
 
 export type AzureSubscription = {
   displayName: string;
@@ -262,8 +261,10 @@ async function askCommonQuestions(
   //   2. publish profile (profile.{envName}.json), for reprovision
   //   3. asking user with a popup
   const resourceGroupNameFromEnvConfig = ctx.envInfo.config.azure.resourceGroupName;
-  const resourceGroupNameFromProfile = ctx.envInfo.profile.get(SOLUTION).get(RESOURCE_GROUP_NAME);
-  const resourceGroupLocationFromProfile = ctx.envInfo.profile.get(SOLUTION).get(LOCATION);
+  const resourceGroupNameFromProfile = ctx.envInfo.profile
+    .get(GLOBAL_CONFIG)
+    ?.get(RESOURCE_GROUP_NAME);
+  const resourceGroupLocationFromProfile = ctx.envInfo.profile.get(GLOBAL_CONFIG)?.get(LOCATION);
   let resourceGroupInfo: ResourceGroupInfo;
   if (resourceGroupNameFromEnvConfig) {
     const checkRes = await rmClient.resourceGroups.checkExistence(resourceGroupNameFromEnvConfig);

--- a/packages/fx-core/src/plugins/solution/fx-solution/constants.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/constants.ts
@@ -45,6 +45,11 @@ export const ARM_TEMPLATE_OUTPUT = "armTemplateOutput";
 export const RESOURCE_GROUP_NAME = "resourceGroupName";
 
 /**
+ * Config key whose value is the resource group location of project.
+ */
+export const LOCATION = "location";
+
+/**
  * Config key whose value is the user info of collaborator
  */
 export const USER_INFO = "userInfo";


### PR DESCRIPTION
Check resource group info in the following order:
- config.{envName}.json, use can only use existing resource group
- profile.{envName}.json, for reprovision
- asking user