### PR TITLE
fix: change node version error in cli

### DIFF
--- a/packages/cli/.nycrc
+++ b/packages/cli/.nycrc
@@ -8,7 +8,8 @@
   "exclude": [
     "src/cmds/preview/depsChecker/**/*",
     "src/cmds/preview/preview.ts",
-    "src/index.ts"
+    "src/index.ts",
+    "cli.js"
   ],
   "reporter": [
     "html",

--- a/packages/cli/cli.js
+++ b/packages/cli/cli.js
@@ -3,5 +3,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+const chalk = require("chalk");
+
+process.on("uncaughtException", (err) => {
+  if (err.message.includes("async_hooks")) {
+    console.error(
+      chalk.redBright(
+        "TeamsFx CLI requires to use node version higher than 12.x, please update your node version."
+      )
+    );
+  } else {
+    console.error(err);
+  }
+  process.exit(1);
+});
+
 const cli = require("./lib");
 cli.start();

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,7 +5,7 @@
   "description": "",
   "license": "MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/10654915

When running `teamsfx -h` with node 10, it will look as below: 
![image](https://user-images.githubusercontent.com/15262146/131601242-94a5949f-78e6-4f4c-8985-455c4116aa7f.png)
