### PR TITLE
fix: identify app not found as UserError

### DIFF
--- a/packages/fx-core/src/plugins/resource/appstudio/errors.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/errors.ts
@@ -159,4 +159,9 @@ export class AppStudioError {
     name: "ListCollaboratorFailedError",
     message: (error: any) => `List collaborator failed. Reason: ${error.message}`,
   };
+
+  public static readonly TeamsAppNotFoundError = {
+    name: "TeamsAppNotFound",
+    message: (appId: string) => `Cannot found teams app with id ${appId}`,
+  };
 }

--- a/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
@@ -162,7 +162,8 @@ export class AppStudioPluginImpl {
    * @returns
    */
   public async createManifest(settings: ProjectSettings): Promise<TeamsAppManifest | undefined> {
-    const solutionSettings: AzureSolutionSettings = settings.solutionSettings as AzureSolutionSettings;
+    const solutionSettings: AzureSolutionSettings =
+      settings.solutionSettings as AzureSolutionSettings;
     if (
       !solutionSettings.capabilities ||
       (!solutionSettings.capabilities.includes(BotOptionItem.id) &&
@@ -231,8 +232,9 @@ export class AppStudioPluginImpl {
     manifest.id = "{appid}";
     manifest.validDomains = [];
 
-    const includeBot = (ctx.projectSettings
-      ?.solutionSettings as AzureSolutionSettings).activeResourcePlugins?.includes(PluginNames.BOT);
+    const includeBot = (
+      ctx.projectSettings?.solutionSettings as AzureSolutionSettings
+    ).activeResourcePlugins?.includes(PluginNames.BOT);
     if (includeBot) {
       if (manifest.bots !== undefined && manifest.bots.length > 0) {
         manifest.bots[0].botId = `{${BOT_ID}}`;
@@ -823,14 +825,23 @@ export class AppStudioPluginImpl {
         manifest.icons.outline && !manifest.icons.outline.startsWith("https://")
           ? (await fs.readFile(`${appDirectory}/${manifest.icons.outline}`)).toString("base64")
           : undefined;
-      await AppStudioClient.updateApp(
-        remoteTeamsAppId!,
-        appDefinition,
-        appStudioToken!,
-        undefined,
-        colorIconContent,
-        outlineIconContent
-      );
+      try {
+        await AppStudioClient.updateApp(
+          remoteTeamsAppId!,
+          appDefinition,
+          appStudioToken!,
+          undefined,
+          colorIconContent,
+          outlineIconContent
+        );
+      } catch (e) {
+        if (e.name === 404) {
+          throw AppStudioResultFactory.UserError(
+            AppStudioError.TeamsAppNotFoundError.name,
+            AppStudioError.TeamsAppNotFoundError.message(remoteTeamsAppId!)
+          );
+        }
+      }
 
       // Build Teams App package
       // Platforms will be checked in buildTeamsAppPackage(ctx)


### PR DESCRIPTION
Users may manually delete teams app in dev portal, treat it as user error. 

1) Before publish, we will identify this error.
2) For local debug/provision, if app not found we will automatically create one