### PR TITLE
fix(multi-env): local debug does not depend on default env

### DIFF
--- a/packages/fx-core/src/core/middleware/envInfoLoader.ts
+++ b/packages/fx-core/src/core/middleware/envInfoLoader.ts
@@ -64,20 +64,6 @@ export function EnvInfoLoaderMW(
 
     const core = ctx.self as FxCore;
 
-    if (inputs.ignoreEnvInfo === true) {
-      // load default env
-      const result = await loadSolutionContext(core.tools, inputs, ctx.projectSettings);
-      if (result.isErr()) {
-        ctx.result = err(result.error);
-        return;
-      }
-
-      ctx.solutionContext = result.value;
-
-      await next();
-      return;
-    }
-
     let targetEnvName: string | undefined;
     if (isMultiEnvEnabled) {
       if (inputs.env) {
@@ -96,7 +82,8 @@ export function EnvInfoLoaderMW(
         inputs,
         ctx.projectSettings,
         ctx.projectIdMissing,
-        targetEnvName
+        targetEnvName,
+        inputs.ignoreEnvInfo
       );
       if (result.isErr()) {
         ctx.result = err(result.error);
@@ -104,7 +91,6 @@ export function EnvInfoLoaderMW(
       }
 
       ctx.solutionContext = result.value;
-
       await next();
     }
   };
@@ -115,7 +101,8 @@ export async function loadSolutionContext(
   inputs: Inputs,
   projectSettings: ProjectSettings,
   projectIdMissing?: boolean,
-  targetEnvName?: string
+  targetEnvName?: string,
+  ignoreEnvInfo = false
 ): Promise<Result<SolutionContext, FxError>> {
   if (!inputs.projectPath) {
     return err(NoProjectOpenedError());
@@ -130,10 +117,20 @@ export async function loadSolutionContext(
     projectIdMissing ? undefined : cryptoProvider
   );
 
+  let envInfo: EnvInfo;
   if (envDataResult.isErr()) {
-    return err(envDataResult.error);
+    if (ignoreEnvInfo) {
+      // ignore env loading error
+      tools.logProvider.info(
+        `[core:env] failed to load '${targetEnvName}' environment, skipping because ignoreEnvInfo is set to true, error: ${envDataResult.error.message}`
+      );
+      envInfo = newEnvInfo();
+    } else {
+      return err(envDataResult.error);
+    }
+  } else {
+    envInfo = envDataResult.value;
   }
-  const envInfo = envDataResult.value;
 
   // migrate programmingLanguage and defaultFunctionName to project settings if exists in previous env config
   const solutionConfig = envInfo.profile as SolutionConfig;

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -329,8 +329,10 @@ export async function runCommand(stage: Stage): Promise<Result<any, FxError>> {
       }
     } else if (stage === Stage.provision) result = await core.provisionResources(inputs);
     else if (stage === Stage.deploy) result = await core.deployArtifacts(inputs);
-    else if (stage === Stage.debug) result = await core.localDebug(inputs);
-    else if (stage === Stage.publish) result = await core.publishApplication(inputs);
+    else if (stage === Stage.debug) {
+      inputs.ignoreEnvInfo = true;
+      result = await core.localDebug(inputs);
+    } else if (stage === Stage.publish) result = await core.publishApplication(inputs);
     else if (stage === Stage.createEnv) {
       result = await core.createEnv(inputs);
     } else {

--- a/packages/vscode-extension/test/unit/extension/handlers.test.ts
+++ b/packages/vscode-extension/test/unit/extension/handlers.test.ts
@@ -11,6 +11,8 @@ import {
   err,
   UserError,
   Void,
+  Result,
+  FxError,
 } from "@microsoft/teamsfx-api";
 import AppStudioTokenInstance from "../../../src/commonlib/appStudioLogin";
 import { ExtTelemetry } from "../../../src/telemetry/extTelemetry";
@@ -21,6 +23,7 @@ import { MockCore } from "./mocks/mockCore";
 import * as extension from "../../../src/extension";
 import * as accountTree from "../../../src/accountTree";
 import TreeViewManagerInstance from "../../../src/commandsTreeViewProvider";
+import { CoreHookContext } from "../../../../fx-core/build";
 
 suite("handlers", () => {
   test("getWorkspacePath()", () => {
@@ -144,12 +147,27 @@ suite("handlers", () => {
     test("localDebug", async () => {
       sinon.stub(handlers, "core").value(new MockCore());
       sinon.stub(ExtTelemetry, "sendTelemetryEvent");
-      const localDebug = sinon.spy(handlers.core, "localDebug");
+
+      let ignoreEnvInfo: boolean | undefined = undefined;
+      let localDebugCalled = 0;
+      sinon
+        .stub(handlers.core, "localDebug")
+        .callsFake(
+          async (
+            inputs: Inputs,
+            ctx?: CoreHookContext | undefined
+          ): Promise<Result<Void, FxError>> => {
+            ignoreEnvInfo = inputs.ignoreEnvInfo;
+            localDebugCalled += 1;
+            return ok({});
+          }
+        );
 
       await handlers.runCommand(Stage.debug);
 
       sinon.restore();
-      sinon.assert.calledOnce(localDebug);
+      chai.expect(ignoreEnvInfo).equals(true);
+      chai.expect(localDebugCalled).equals(1);
     });
 
     test("publishApplication", async () => {


### PR DESCRIPTION
This PR removes the dependency on default env for local debug.

The implementation is:
- extension will set `ignoreEnvInfo` to `true` for local debug
- when `ignoreEnvInfo` is set to `true`, 
    - Core will try to load default env for upgrading project.
    - On failure to load default env, core will ignore the error and continue to load other configs to solutionContext (e.g. project settings). This works because local debug does not use env info

Tested local debug without default env (no config.dev.json)

CLI will be changed later