### PR TITLE
fix: check lifecycle results for deploy/scaffold

### DIFF
--- a/packages/fx-core/src/plugins/solution/fx-solution/executor.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/executor.ts
@@ -151,6 +151,12 @@ export async function executeLifecycles(
     if (onLifecycleFinishedResult.isErr()) {
       return onLifecycleFinishedResult;
     }
+  } else {
+    for (const result of results) {
+      if (result.isErr()) {
+        return result;
+      }
+    }
   }
 
   const postResults = await executeConcurrently("post", postLifecycles);


### PR DESCRIPTION
For provision, will save app id and then check the results.
![image](https://user-images.githubusercontent.com/71362691/131614999-6fae28e1-a10e-4a03-8148-9e17df19ab71.png)
