### PR TITLE
fix(bot): copy adaptive cards to lib

### DIFF
--- a/templates/bot/ts/default/package.json
+++ b/templates/bot/ts/default/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "main": "./lib/index.js",
   "scripts": {
-    "build": "tsc --build",
+    "build": "tsc --build && shx cp -r ./adaptiveCards ./lib/",
     "start": "node ./lib/index.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "watch": "nodemon --watch ./src -e ts --exec \"npm run start\""
@@ -28,6 +28,7 @@
     "ts-node": "~9.1.1",
     "typescript": "~3.9.2",
     "ngrok": "^3.4.0",
-    "nodemon": "^2.0.7"
+    "nodemon": "^2.0.7",
+    "shx": "^0.3.3"
   }
 }


### PR DESCRIPTION
To fix remote debug failed, for it runs index.js under lib/ when remote debug. Local debug works well.