### PR TITLE
fix(multi-env): fix remote debug for multi env

### DIFF
--- a/packages/vscode-extension/src/debug/commonUtils.ts
+++ b/packages/vscode-extension/src/debug/commonUtils.ts
@@ -133,7 +133,7 @@ async function executeLocalDebugUserTask(funcName: string, params?: unknown): Pr
     const inputs = getSystemInputs();
     inputs.ignoreLock = true;
     inputs.ignoreConfigPersist = true;
-    const isRemote = typeof params === "string" && params === "remote";
+    const isRemote = params === "remote";
     inputs.ignoreEnvInfo = !isRemote;
     const result = await core.executeUserTask(func, inputs);
     if (result.isErr()) {

--- a/packages/vscode-extension/src/debug/commonUtils.ts
+++ b/packages/vscode-extension/src/debug/commonUtils.ts
@@ -133,7 +133,8 @@ async function executeLocalDebugUserTask(funcName: string, params?: unknown): Pr
     const inputs = getSystemInputs();
     inputs.ignoreLock = true;
     inputs.ignoreConfigPersist = true;
-    inputs.ignoreEnvInfo = true;
+    const isRemote = typeof params === "string" && params === "remote";
+    inputs.ignoreEnvInfo = !isRemote;
     const result = await core.executeUserTask(func, inputs);
     if (result.isErr()) {
       throw result.error;


### PR DESCRIPTION
- should not ignore env info for remote debug

Tested that local debug and remote debug works.