### PR TITLE
chore(sql): fix empty input bug for reprovision

### DIFF
--- a/packages/fx-core/src/core/index.ts
+++ b/packages/fx-core/src/core/index.ts
@@ -177,6 +177,10 @@ export class FxCore implements Core {
         },
       };
 
+      if (isMultiEnvEnabled()) {
+        projectSettings.activeEnvironment = environmentManager.getDefaultEnvName();
+      }
+
       const solutionContext: SolutionContext = {
         projectSettings: projectSettings,
         envInfo: newEnvInfo(),
@@ -785,7 +789,7 @@ export class FxCore implements Core {
             description: "",
             author: "",
             scripts: {
-              test: "echo \"Error: no test specified\" && exit 1",
+              test: 'echo "Error: no test specified" && exit 1',
             },
             devDependencies: {
               "@microsoft/teamsfx-cli": "0.*",

--- a/packages/fx-core/src/plugins/resource/sql/config.ts
+++ b/packages/fx-core/src/plugins/resource/sql/config.ts
@@ -19,4 +19,5 @@ export class SqlConfig {
   identity = "";
   existSql = false;
   skipAddingUser = false;
+  prepareQuestion = false;
 }

--- a/packages/fx-core/src/plugins/resource/sql/config.ts
+++ b/packages/fx-core/src/plugins/resource/sql/config.ts
@@ -19,5 +19,5 @@ export class SqlConfig {
   identity = "";
   existSql = false;
   skipAddingUser = false;
-  prepareQuestion = false;
+  prepareQuestions = false;
 }

--- a/packages/fx-core/src/plugins/resource/sql/constants.ts
+++ b/packages/fx-core/src/plugins/resource/sql/constants.ts
@@ -31,7 +31,6 @@ export class Constants {
   public static readonly skipAddingUser: string = "skipAddingUser";
   public static readonly admin: string = "admin";
   public static readonly adminPassword: string = "adminPassword";
-  public static readonly existSql: string = "existSql";
 
   public static readonly solution: string = "solution";
   public static readonly solutionPluginFullName = "fx-solution-azure";

--- a/packages/fx-core/src/plugins/resource/sql/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/sql/plugin.ts
@@ -94,7 +94,7 @@ export class SqlPluginImpl {
       }
 
       await this.init(ctx);
-      this.config.prepareQuestion = true;
+      this.config.prepareQuestions = true;
 
       if (isArmSupportEnabled()) {
         this.config.admin = ctx.config.get(Constants.admin) as string;
@@ -143,7 +143,7 @@ export class SqlPluginImpl {
       this.config.skipAddingUser = skipAddingUser as boolean;
     }
 
-    if (!this.config.prepareQuestion) {
+    if (!this.config.prepareQuestions) {
       this.config.existSql = true;
     }
 
@@ -260,7 +260,7 @@ export class SqlPluginImpl {
     ctx.config.set(Constants.sqlEndpoint, this.config.sqlEndpoint);
     ctx.config.set(Constants.databaseName, this.config.databaseName);
     ctx.config.delete(Constants.adminPassword);
-    this.config.prepareQuestion = false;
+    this.config.prepareQuestions = false;
 
     const managementClient: ManagementClient = await ManagementClient.create(ctx, this.config);
 

--- a/packages/fx-core/src/plugins/resource/sql/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/sql/plugin.ts
@@ -94,6 +94,8 @@ export class SqlPluginImpl {
       }
 
       await this.init(ctx);
+      this.config.prepareQuestion = true;
+
       if (isArmSupportEnabled()) {
         this.config.admin = ctx.config.get(Constants.admin) as string;
         this.config.adminPassword = ctx.config.get(Constants.adminPassword) as string;
@@ -104,8 +106,6 @@ export class SqlPluginImpl {
         const managementClient: ManagementClient = await ManagementClient.create(ctx, this.config);
         this.config.existSql = await managementClient.existAzureSQL();
       }
-
-      ctx.config.set(Constants.existSql, this.config.existSql);
 
       if (!this.config.existSql) {
         this.buildQuestionNode(sqlNode);
@@ -143,7 +143,10 @@ export class SqlPluginImpl {
       this.config.skipAddingUser = skipAddingUser as boolean;
     }
 
-    this.config.existSql = ctx.config.get(Constants.existSql);
+    if (!this.config.prepareQuestion) {
+      this.config.existSql = true;
+    }
+
     if (!this.config.existSql) {
       this.config.admin = ctx.answers![Constants.questionKey.adminName] as string;
       this.config.adminPassword = ctx.answers![Constants.questionKey.adminPassword] as string;
@@ -257,6 +260,7 @@ export class SqlPluginImpl {
     ctx.config.set(Constants.sqlEndpoint, this.config.sqlEndpoint);
     ctx.config.set(Constants.databaseName, this.config.databaseName);
     ctx.config.delete(Constants.adminPassword);
+    this.config.prepareQuestion = false;
 
     const managementClient: ManagementClient = await ManagementClient.create(ctx, this.config);
 

--- a/packages/vscode-extension/src/debug/commonUtils.ts
+++ b/packages/vscode-extension/src/debug/commonUtils.ts
@@ -133,7 +133,8 @@ async function executeLocalDebugUserTask(funcName: string, params?: unknown): Pr
     const inputs = getSystemInputs();
     inputs.ignoreLock = true;
     inputs.ignoreConfigPersist = true;
-    inputs.ignoreEnvInfo = true;
+    const isRemote = params === "remote";
+    inputs.ignoreEnvInfo = !isRemote;
     const result = await core.executeUserTask(func, inputs);
     if (result.isErr()) {
       throw result.error;

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -331,8 +331,10 @@ export async function runCommand(stage: Stage): Promise<Result<any, FxError>> {
       }
     } else if (stage === Stage.provision) result = await core.provisionResources(inputs);
     else if (stage === Stage.deploy) result = await core.deployArtifacts(inputs);
-    else if (stage === Stage.debug) result = await core.localDebug(inputs);
-    else if (stage === Stage.publish) result = await core.publishApplication(inputs);
+    else if (stage === Stage.debug) {
+      inputs.ignoreEnvInfo = true;
+      result = await core.localDebug(inputs);
+    } else if (stage === Stage.publish) result = await core.publishApplication(inputs);
     else if (stage === Stage.createEnv) {
       result = await core.createEnv(inputs);
     } else {

--- a/packages/vscode-extension/test/unit/extension/handlers.test.ts
+++ b/packages/vscode-extension/test/unit/extension/handlers.test.ts
@@ -11,6 +11,8 @@ import {
   err,
   UserError,
   Void,
+  Result,
+  FxError,
 } from "@microsoft/teamsfx-api";
 import AppStudioTokenInstance from "../../../src/commonlib/appStudioLogin";
 import { ExtTelemetry } from "../../../src/telemetry/extTelemetry";
@@ -21,6 +23,7 @@ import { MockCore } from "./mocks/mockCore";
 import * as extension from "../../../src/extension";
 import * as accountTree from "../../../src/accountTree";
 import TreeViewManagerInstance from "../../../src/commandsTreeViewProvider";
+import { CoreHookContext } from "../../../../fx-core/build";
 
 suite("handlers", () => {
   test("getWorkspacePath()", () => {
@@ -144,12 +147,27 @@ suite("handlers", () => {
     test("localDebug", async () => {
       sinon.stub(handlers, "core").value(new MockCore());
       sinon.stub(ExtTelemetry, "sendTelemetryEvent");
-      const localDebug = sinon.spy(handlers.core, "localDebug");
+
+      let ignoreEnvInfo: boolean | undefined = undefined;
+      let localDebugCalled = 0;
+      sinon
+        .stub(handlers.core, "localDebug")
+        .callsFake(
+          async (
+            inputs: Inputs,
+            ctx?: CoreHookContext | undefined
+          ): Promise<Result<Void, FxError>> => {
+            ignoreEnvInfo = inputs.ignoreEnvInfo;
+            localDebugCalled += 1;
+            return ok({});
+          }
+        );
 
       await handlers.runCommand(Stage.debug);
 
       sinon.restore();
-      sinon.assert.calledOnce(localDebug);
+      chai.expect(ignoreEnvInfo).equals(true);
+      chai.expect(localDebugCalled).equals(1);
     });
 
     test("publishApplication", async () => {


### PR DESCRIPTION
Since getQuestions will skip in reprovision if first provision is successful, the check status of sql existing is skipped as well.
Use the config prepareQuestions to keep the status of sql existing when the getQuestions is skipped. 