### PR TITLE
chore(sql): fix reprovision bug

### DIFF
--- a/packages/fx-core/src/plugins/resource/sql/config.ts
+++ b/packages/fx-core/src/plugins/resource/sql/config.ts
@@ -19,4 +19,5 @@ export class SqlConfig {
   identity = "";
   existSql = false;
   skipAddingUser = false;
+  prepareQuestions = false;
 }

--- a/packages/fx-core/src/plugins/resource/sql/constants.ts
+++ b/packages/fx-core/src/plugins/resource/sql/constants.ts
@@ -31,7 +31,6 @@ export class Constants {
   public static readonly skipAddingUser: string = "skipAddingUser";
   public static readonly admin: string = "admin";
   public static readonly adminPassword: string = "adminPassword";
-  public static readonly existSql: string = "existSql";
 
   public static readonly solution: string = "solution";
   public static readonly solutionPluginFullName = "fx-solution-azure";

--- a/packages/fx-core/src/plugins/resource/sql/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/sql/plugin.ts
@@ -94,6 +94,7 @@ export class SqlPluginImpl {
       }
 
       await this.init(ctx);
+      this.config.prepareQuestions = true;
       if (isArmSupportEnabled()) {
         this.config.admin = ctx.config.get(Constants.admin) as string;
         this.config.adminPassword = ctx.config.get(Constants.adminPassword) as string;
@@ -104,8 +105,6 @@ export class SqlPluginImpl {
         const managementClient: ManagementClient = await ManagementClient.create(ctx, this.config);
         this.config.existSql = await managementClient.existAzureSQL();
       }
-
-      ctx.config.set(Constants.existSql, this.config.existSql);
 
       if (!this.config.existSql) {
         this.buildQuestionNode(sqlNode);
@@ -143,7 +142,10 @@ export class SqlPluginImpl {
       this.config.skipAddingUser = skipAddingUser as boolean;
     }
 
-    this.config.existSql = ctx.config.get(Constants.existSql);
+    if (!this.config.prepareQuestions) {
+      this.config.existSql = true;
+    }
+
     if (!this.config.existSql) {
       this.config.admin = ctx.answers![Constants.questionKey.adminName] as string;
       this.config.adminPassword = ctx.answers![Constants.questionKey.adminPassword] as string;
@@ -257,6 +259,7 @@ export class SqlPluginImpl {
     ctx.config.set(Constants.sqlEndpoint, this.config.sqlEndpoint);
     ctx.config.set(Constants.databaseName, this.config.databaseName);
     ctx.config.delete(Constants.adminPassword);
+    this.config.prepareQuestions = false;
 
     const managementClient: ManagementClient = await ManagementClient.create(ctx, this.config);
 


### PR DESCRIPTION
Since getQuestions will skip in reprovision if first provision is successful, the check status of sql existing is skipped as well.
Use the config prepareQuestions to keep the status of sql existing when the getQuestions is skipped.