### PR TITLE
chore: store secrets in azure key vault for e2e test, simpleauth, function-extension

### DIFF
--- a/.github/scripts/setup-testing-env.sh
+++ b/.github/scripts/setup-testing-env.sh
@@ -26,6 +26,6 @@ declare -A FuncExtMap=(["FUNCTION-EXTENSION-CLIENTID"]="TeamsFx_BINDING_Integrat
  ["FUNCTION-EXTENSION-ALLOWED-APP-CLIENT-SECRET"]="TeamsFx_BINDING_IntegrationTestSettings__AllowedAppClientSecret" ["FUNCTION-EXTENSION-AUTHORITY-HOST"]="TeamsFx_BINDING_IntegrationTestSettings__AuthorityHost" [""]="TeamsFx_BINDING_IntegrationTestSettings__TenantId") 
 for key in ${!FuncExtMap[*]}; do
     value=$(curl -H 'Accept: application/json' -H "Authorization: Bearer $token" "https://e2etestenv.vault.azure.net/secrets/$key?api-version=7.0" |jq -r '.value')
-    echo "${SimpleAuthMap[$key]}=$value" >> $2
+    echo "${FuncExtMap[$key]}=$value" >> $2
 done
 fi

--- a/.github/scripts/setup-testing-env.sh
+++ b/.github/scripts/setup-testing-env.sh
@@ -1,20 +1,25 @@
 #!/bin/bash
-# clientId=$(echo $creds | jq -r '.clientId')
-# clientSecret=$(echo $creds | jq -r '.clientSecret')
-# subscriptionId=$(echo $creds | jq -r '.subscriptionId')
-# tenantId=$(echo $creds | jq -r '.tenantId')
-# tokencc=$(curl -X POST -F "grant_type=client_credentials" -F "client_id=$clientId" -F "client_secret=$clientSecret" -F "scope=https://vault.azure.net/.default" "https://login.microsoftonline.com/$tenantId/oauth2/v2.0/token" | jq -r '.access_token') 
+clientId=$(echo $creds | jq -r '.clientId')
+clientSecret=$(echo $creds | jq -r '.clientSecret')
+subscriptionId=$(echo $creds | jq -r '.subscriptionId')
+tenantId=$(echo $creds | jq -r '.tenantId')
+token=$(curl -X POST -F "grant_type=client_credentials" -F "client_id=$clientId" -F "client_secret=$clientSecret" -F "scope=https://vault.azure.net/.default" "https://login.microsoftonline.com/$tenantId/oauth2/v2.0/token" | jq -r '.access_token') 
 if [ $1 == 'e2e' ]; then
 declare -A E2EMap=(["E2E-AZURE-ACCOUNT-NAME"]="AZURE_ACCOUNT_NAME" ["E2E-AZURE-ACCOUNT-PASSWORD"]="AZURE_ACCOUNT_PASSWORD"\
- ["E2E-AZURE-SUBSCRIPTION-ID"]="AZURE_SUBSCRIPTION_ID" ["E2E-AZURE-TENANT-ID"]="AZURE_TENANT_ID" ["M365_ACCOUNT_NAME"]="E2E-M365-ACCOUNT-NAME" \
+ ["E2E-AZURE-SUBSCRIPTION-ID"]="AZURE_SUBSCRIPTION_ID" ["E2E-AZURE-TENANT-ID"]="AZURE_TENANT_ID" ["E2E-M365-ACCOUNT-NAME"]="M365_ACCOUNT_NAME" \
  ["E2E-M365-ACCOUNT-PASSWORD"]="M365_ACCOUNT_PASSWORD" ["E2E-M365-TENANT-ID"]="M365_TENANT_ID" ["E2E-TEST-COLLABORATOR-USER-NAME"]="M365_ACCOUNT_COLLABORATOR")
-# value=$(curl -H 'Accept: application/json' -H "Authorization: Bearer $tokencc" https://e2etestenv.vault.azure.net/secrets/$1?api-version=2016-10-01 |jq -r '.value')
-# echo value
 for key in ${!E2EMap[*]}; do
-    echo $key
-    echo ${E2EMap[$key]}
+    value=$(curl -H 'Accept: application/json' -H "Authorization: Bearer $token" "https://e2etestenv.vault.azure.net/secrets/$key?api-version=2016-10-01" |jq -r '.value')
+    echo "${E2EMap[$key]}=$value" >> $2
 done
-elif [ $1 == 'simpleauth']; then
-
+elif [ $1 == 'simpleauth' ]; then
+declare -A SimpleAuthMap=(["SIMPLE-AUTH-TEST-ADMIN-CLIENT-ID"]="TEAMS_SIMPLE_AUTH_IntegrationTestSettings__AdminClientId" ["SIMPLE-AUTH-TEST-ADMIN-CLIENT-SECRET"]="TEAMS_SIMPLE_AUTH_IntegrationTestSettings__AdminClientSecret"\
+ ["SIMPLE-AUTH-TEST-TENANT-ID"]="TEAMS_SIMPLE_AUTH_IntegrationTestSettings__TenantId" ["SIMPLE-AUTH-TEST-USER-NAME"]="TEAMS_SIMPLE_AUTH_IntegrationTestSettings__TestUserName" ["SIMPLE-AUTH-TEST-PASSWORD"]="TEAMS_SIMPLE_AUTH_IntegrationTestSettings__TestPassword"\
+ ["SIMPLE-AUTH-TEST-USER-NAME-2"]="TEAMS_SIMPLE_AUTH_IntegrationTestSettings__TestUserName2" ["SIMPLE-AUTH-TEST-PASSWORD-2"]="TEAMS_SIMPLE_AUTH_IntegrationTestSettings__TestPassword2") 
+for key in ${!SimpleAuthMap[*]}; do
+    value=$(curl -H 'Accept: application/json' -H "Authorization: Bearer $token" "https://e2etestenv.vault.azure.net/secrets/$key?api-version=7.0" |jq -r '.value')
+    echo "${SimpleAuthMap[$key]}=$value" >> $2
+done
 elif [ $1 == 'function-extension' ]; then
+
 fi

--- a/.github/scripts/setup-testing-env.sh
+++ b/.github/scripts/setup-testing-env.sh
@@ -21,11 +21,12 @@ for key in ${!SimpleAuthMap[*]}; do
     echo "${SimpleAuthMap[$key]}=$value" >> $2
 done
 elif [ $1 == 'function-extension' ]; then
-declare -A FuncExtMap=(["FUNCTION-EXTENSION-CLIENTID"]="TeamsFx_BINDING_IntegrationTestSettings__ClientId" ["FUNCTION-EXTENSION-CLIENT-SECRET"]="TeamsFx_BINDING_IntegrationTestSettings__ClientSecret"\
- ["FUNCTION-EXTENSION-UNAUTHORIZED-AAD-APP-CLIENT-ID"]="TeamsFx_BINDING_IntegrationTestSettings__UnauthorizedAadAppClientId" ["FUNCTION-EXTENSION-UNAUTHORIZED-AAD-APP-CLIENT-SECRET"]="TeamsFx_BINDING_IntegrationTestSettings__UnauthorizedAadAppClientSecret" ["FUNCTION-EXTENSION-ALLOWED-APP-CLIENT-ID"]="TeamsFx_BINDING_IntegrationTestSettings__AllowedAppClientId"\
- ["FUNCTION-EXTENSION-ALLOWED-APP-CLIENT-SECRET"]="TeamsFx_BINDING_IntegrationTestSettings__AllowedAppClientSecret" ["FUNCTION-EXTENSION-AUTHORITY-HOST"]="TeamsFx_BINDING_IntegrationTestSettings__AuthorityHost" [""]="TeamsFx_BINDING_IntegrationTestSettings__TenantId") 
+declare -A FuncExtMap=(["FUNCTION-EXTENSION-CLIENTID"]="TeamsFx_BINDING_IntegrationTestSettings__ClientId" ["FUNCTION-EXTENSION-CLIENT-SECRET"]="TeamsFx_BINDING_IntegrationTestSettings__ClientSecret" ["FUNCTION-EXTENSION-UNAUTHORIZED-AAD-APP-CLIENT-ID"]="TeamsFx_BINDING_IntegrationTestSettings__UnauthorizedAadAppClientId"\
+ ["FUNCTION-EXTENSION-UNAUTHORIZED-AAD-APP-CLIENT-SECRET"]="TeamsFx_BINDING_IntegrationTestSettings__UnauthorizedAadAppClientSecret" ["FUNCTION-EXTENSION-ALLOWED-APP-CLIENT-ID"]="TeamsFx_BINDING_IntegrationTestSettings__AllowedAppClientId"\
+ ["FUNCTION-EXTENSION-ALLOWED-APP-CLIENT-SECRET"]="TeamsFx_BINDING_IntegrationTestSettings__AllowedAppClientSecret" ["FUNCTION-EXTENSION-AUTHORITY-HOST"]="TeamsFx_BINDING_IntegrationTestSettings__AuthorityHost" ["FUNCTION-EXTENSION-TENANT-ID"]="TeamsFx_BINDING_IntegrationTestSettings__TenantId") 
 for key in ${!FuncExtMap[*]}; do
     value=$(curl -H 'Accept: application/json' -H "Authorization: Bearer $token" "https://e2etestenv.vault.azure.net/secrets/$key?api-version=7.0" |jq -r '.value')
+    echo $key $value
     echo "${FuncExtMap[$key]}=$value" >> $2
 done
 fi

--- a/.github/scripts/setup-testing-env.sh
+++ b/.github/scripts/setup-testing-env.sh
@@ -1,9 +1,20 @@
 #!/bin/bash
-clientId=$(echo $creds | jq -r '.clientId')
-clientSecret=$(echo $creds | jq -r '.clientSecret')
-subscriptionId=$(echo $creds | jq -r '.subscriptionId')
-tenantId=$(echo $creds | jq -r '.tenantId')
-tokencc=$(curl -X POST -F "grant_type=client_credentials" -F "client_id=$clientId" -F "client_secret=$clientSecret" -F "scope=https://vault.azure.net/.default" "https://login.microsoftonline.com/$tenantId/oauth2/v2.0/token" | jq -r '.access_token') 
-value=$(curl -H 'Accept: application/json' -H "Authorization: Bearer $tokencc" https://e2etestenv.vault.azure.net/secrets/$1?api-version=2016-10-01 |jq -r '.value')
-echo value
+# clientId=$(echo $creds | jq -r '.clientId')
+# clientSecret=$(echo $creds | jq -r '.clientSecret')
+# subscriptionId=$(echo $creds | jq -r '.subscriptionId')
+# tenantId=$(echo $creds | jq -r '.tenantId')
+# tokencc=$(curl -X POST -F "grant_type=client_credentials" -F "client_id=$clientId" -F "client_secret=$clientSecret" -F "scope=https://vault.azure.net/.default" "https://login.microsoftonline.com/$tenantId/oauth2/v2.0/token" | jq -r '.access_token') 
+if [ $1 == 'e2e' ]; then
+declare -A E2EMap=(["E2E-AZURE-ACCOUNT-NAME"]="AZURE_ACCOUNT_NAME" ["E2E-AZURE-ACCOUNT-PASSWORD"]="AZURE_ACCOUNT_PASSWORD"\
+ ["E2E-AZURE-SUBSCRIPTION-ID"]="AZURE_SUBSCRIPTION_ID" ["E2E-AZURE-TENANT-ID"]="AZURE_TENANT_ID" ["M365_ACCOUNT_NAME"]="E2E-M365-ACCOUNT-NAME" \
+ ["E2E-M365-ACCOUNT-PASSWORD"]="M365_ACCOUNT_PASSWORD" ["E2E-M365-TENANT-ID"]="M365_TENANT_ID" ["E2E-TEST-COLLABORATOR-USER-NAME"]="M365_ACCOUNT_COLLABORATOR")
+# value=$(curl -H 'Accept: application/json' -H "Authorization: Bearer $tokencc" https://e2etestenv.vault.azure.net/secrets/$1?api-version=2016-10-01 |jq -r '.value')
+# echo value
+for key in ${!E2EMap[*]}; do
+    echo $key
+    echo ${E2EMap[$key]}
+done
+elif [ $1 == 'simpleauth']; then
 
+elif [ $1 == 'function-extension' ]; then
+fi

--- a/.github/scripts/setup-testing-env.sh
+++ b/.github/scripts/setup-testing-env.sh
@@ -21,5 +21,11 @@ for key in ${!SimpleAuthMap[*]}; do
     echo "${SimpleAuthMap[$key]}=$value" >> $2
 done
 elif [ $1 == 'function-extension' ]; then
-
+declare -A FuncExtMap=(["FUNCTION-EXTENSION-CLIENTID"]="TeamsFx_BINDING_IntegrationTestSettings__ClientId" ["FUNCTION-EXTENSION-CLIENT-SECRET"]="TeamsFx_BINDING_IntegrationTestSettings__ClientSecret"\
+ ["FUNCTION-EXTENSION-UNAUTHORIZED-AAD-APP-CLIENT-ID"]="TeamsFx_BINDING_IntegrationTestSettings__UnauthorizedAadAppClientId" ["FUNCTION-EXTENSION-UNAUTHORIZED-AAD-APP-CLIENT-SECRET"]="TeamsFx_BINDING_IntegrationTestSettings__UnauthorizedAadAppClientSecret" ["FUNCTION-EXTENSION-ALLOWED-APP-CLIENT-ID"]="TeamsFx_BINDING_IntegrationTestSettings__AllowedAppClientId"\
+ ["FUNCTION-EXTENSION-ALLOWED-APP-CLIENT-SECRET"]="TeamsFx_BINDING_IntegrationTestSettings__AllowedAppClientSecret" ["FUNCTION-EXTENSION-AUTHORITY-HOST"]="TeamsFx_BINDING_IntegrationTestSettings__AuthorityHost" [""]="TeamsFx_BINDING_IntegrationTestSettings__TenantId") 
+for key in ${!FuncExtMap[*]}; do
+    value=$(curl -H 'Accept: application/json' -H "Authorization: Bearer $token" "https://e2etestenv.vault.azure.net/secrets/$key?api-version=7.0" |jq -r '.value')
+    echo "${SimpleAuthMap[$key]}=$value" >> $2
+done
 fi

--- a/.github/scripts/setup-testing-env.sh
+++ b/.github/scripts/setup-testing-env.sh
@@ -4,29 +4,49 @@ clientSecret=$(echo $creds | jq -r '.clientSecret')
 subscriptionId=$(echo $creds | jq -r '.subscriptionId')
 tenantId=$(echo $creds | jq -r '.tenantId')
 token=$(curl -X POST -F "grant_type=client_credentials" -F "client_id=$clientId" -F "client_secret=$clientSecret" -F "scope=https://vault.azure.net/.default" "https://login.microsoftonline.com/$tenantId/oauth2/v2.0/token" | jq -r '.access_token') 
+
+declare -A E2EMap=(\
+ ["E2E-AZURE-ACCOUNT-NAME"]="AZURE_ACCOUNT_NAME"\
+ ["E2E-AZURE-ACCOUNT-PASSWORD"]="AZURE_ACCOUNT_PASSWORD"\
+ ["E2E-AZURE-SUBSCRIPTION-ID"]="AZURE_SUBSCRIPTION_ID"\
+ ["E2E-AZURE-TENANT-ID"]="AZURE_TENANT_ID"\
+ ["E2E-M365-ACCOUNT-NAME"]="M365_ACCOUNT_NAME" \
+ ["E2E-M365-ACCOUNT-PASSWORD"]="M365_ACCOUNT_PASSWORD"\
+ ["E2E-M365-TENANT-ID"]="M365_TENANT_ID"\
+ ["E2E-TEST-COLLABORATOR-USER-NAME"]="M365_ACCOUNT_COLLABORATOR")
+
+declare -A SimpleAuthMap=(\
+ ["SIMPLE-AUTH-TEST-ADMIN-CLIENT-ID"]="TEAMS_SIMPLE_AUTH_IntegrationTestSettings__AdminClientId"\
+ ["SIMPLE-AUTH-TEST-ADMIN-CLIENT-SECRET"]="TEAMS_SIMPLE_AUTH_IntegrationTestSettings__AdminClientSecret"\
+ ["SIMPLE-AUTH-TEST-TENANT-ID"]="TEAMS_SIMPLE_AUTH_IntegrationTestSettings__TenantId"\
+ ["SIMPLE-AUTH-TEST-USER-NAME"]="TEAMS_SIMPLE_AUTH_IntegrationTestSettings__TestUserName"\
+ ["SIMPLE-AUTH-TEST-PASSWORD"]="TEAMS_SIMPLE_AUTH_IntegrationTestSettings__TestPassword"\
+ ["SIMPLE-AUTH-TEST-USER-NAME-2"]="TEAMS_SIMPLE_AUTH_IntegrationTestSettings__TestUserName2"\
+ ["SIMPLE-AUTH-TEST-PASSWORD-2"]="TEAMS_SIMPLE_AUTH_IntegrationTestSettings__TestPassword2") 
+
+declare -A FuncExtMap=(\
+ ["FUNCTION-EXTENSION-CLIENTID"]="TeamsFx_BINDING_IntegrationTestSettings__ClientId"\
+ ["FUNCTION-EXTENSION-CLIENT-SECRET"]="TeamsFx_BINDING_IntegrationTestSettings__ClientSecret"\
+ ["FUNCTION-EXTENSION-UNAUTHORIZED-AAD-APP-CLIENT-ID"]="TeamsFx_BINDING_IntegrationTestSettings__UnauthorizedAadAppClientId"\
+ ["FUNCTION-EXTENSION-UNAUTHORIZED-AAD-APP-CLIENT-SECRET"]="TeamsFx_BINDING_IntegrationTestSettings__UnauthorizedAadAppClientSecret"\
+ ["FUNCTION-EXTENSION-ALLOWED-APP-CLIENT-ID"]="TeamsFx_BINDING_IntegrationTestSettings__AllowedAppClientId"\
+ ["FUNCTION-EXTENSION-ALLOWED-APP-CLIENT-SECRET"]="TeamsFx_BINDING_IntegrationTestSettings__AllowedAppClientSecret"\
+ ["FUNCTION-EXTENSION-AUTHORITY-HOST"]="TeamsFx_BINDING_IntegrationTestSettings__AuthorityHost"\
+ ["FUNCTION-EXTENSION-TENANT-ID"]="TeamsFx_BINDING_IntegrationTestSettings__TenantId") 
+
 if [ $1 == 'e2e' ]; then
-declare -A E2EMap=(["E2E-AZURE-ACCOUNT-NAME"]="AZURE_ACCOUNT_NAME" ["E2E-AZURE-ACCOUNT-PASSWORD"]="AZURE_ACCOUNT_PASSWORD"\
- ["E2E-AZURE-SUBSCRIPTION-ID"]="AZURE_SUBSCRIPTION_ID" ["E2E-AZURE-TENANT-ID"]="AZURE_TENANT_ID" ["E2E-M365-ACCOUNT-NAME"]="M365_ACCOUNT_NAME" \
- ["E2E-M365-ACCOUNT-PASSWORD"]="M365_ACCOUNT_PASSWORD" ["E2E-M365-TENANT-ID"]="M365_TENANT_ID" ["E2E-TEST-COLLABORATOR-USER-NAME"]="M365_ACCOUNT_COLLABORATOR")
 for key in ${!E2EMap[*]}; do
-    value=$(curl -H 'Accept: application/json' -H "Authorization: Bearer $token" "https://e2etestenv.vault.azure.net/secrets/$key?api-version=2016-10-01" |jq -r '.value')
+    value=$(curl -H 'Accept: application/json' -H "Authorization: Bearer $token" "https://e2etestenv.vault.azure.net/secrets/$key?api-version=7.0" |jq -r '.value')
     echo "${E2EMap[$key]}=$value" >> $2
 done
 elif [ $1 == 'simpleauth' ]; then
-declare -A SimpleAuthMap=(["SIMPLE-AUTH-TEST-ADMIN-CLIENT-ID"]="TEAMS_SIMPLE_AUTH_IntegrationTestSettings__AdminClientId" ["SIMPLE-AUTH-TEST-ADMIN-CLIENT-SECRET"]="TEAMS_SIMPLE_AUTH_IntegrationTestSettings__AdminClientSecret"\
- ["SIMPLE-AUTH-TEST-TENANT-ID"]="TEAMS_SIMPLE_AUTH_IntegrationTestSettings__TenantId" ["SIMPLE-AUTH-TEST-USER-NAME"]="TEAMS_SIMPLE_AUTH_IntegrationTestSettings__TestUserName" ["SIMPLE-AUTH-TEST-PASSWORD"]="TEAMS_SIMPLE_AUTH_IntegrationTestSettings__TestPassword"\
- ["SIMPLE-AUTH-TEST-USER-NAME-2"]="TEAMS_SIMPLE_AUTH_IntegrationTestSettings__TestUserName2" ["SIMPLE-AUTH-TEST-PASSWORD-2"]="TEAMS_SIMPLE_AUTH_IntegrationTestSettings__TestPassword2") 
 for key in ${!SimpleAuthMap[*]}; do
     value=$(curl -H 'Accept: application/json' -H "Authorization: Bearer $token" "https://e2etestenv.vault.azure.net/secrets/$key?api-version=7.0" |jq -r '.value')
     echo "${SimpleAuthMap[$key]}=$value" >> $2
 done
 elif [ $1 == 'function-extension' ]; then
-declare -A FuncExtMap=(["FUNCTION-EXTENSION-CLIENTID"]="TeamsFx_BINDING_IntegrationTestSettings__ClientId" ["FUNCTION-EXTENSION-CLIENT-SECRET"]="TeamsFx_BINDING_IntegrationTestSettings__ClientSecret" ["FUNCTION-EXTENSION-UNAUTHORIZED-AAD-APP-CLIENT-ID"]="TeamsFx_BINDING_IntegrationTestSettings__UnauthorizedAadAppClientId"\
- ["FUNCTION-EXTENSION-UNAUTHORIZED-AAD-APP-CLIENT-SECRET"]="TeamsFx_BINDING_IntegrationTestSettings__UnauthorizedAadAppClientSecret" ["FUNCTION-EXTENSION-ALLOWED-APP-CLIENT-ID"]="TeamsFx_BINDING_IntegrationTestSettings__AllowedAppClientId"\
- ["FUNCTION-EXTENSION-ALLOWED-APP-CLIENT-SECRET"]="TeamsFx_BINDING_IntegrationTestSettings__AllowedAppClientSecret" ["FUNCTION-EXTENSION-AUTHORITY-HOST"]="TeamsFx_BINDING_IntegrationTestSettings__AuthorityHost" ["FUNCTION-EXTENSION-TENANT-ID"]="TeamsFx_BINDING_IntegrationTestSettings__TenantId") 
 for key in ${!FuncExtMap[*]}; do
     value=$(curl -H 'Accept: application/json' -H "Authorization: Bearer $token" "https://e2etestenv.vault.azure.net/secrets/$key?api-version=7.0" |jq -r '.value')
-    echo $key $value
     echo "${FuncExtMap[$key]}=$value" >> $2
 done
 fi

--- a/.github/workflows/FunctionExtensionCI.yml
+++ b/.github/workflows/FunctionExtensionCI.yml
@@ -3,45 +3,39 @@ name: FunctionExtension CI
 on:
   push:
     paths:
-    - 'packages/function-extension/**'
-    branches: [ main ]
+      - "packages/function-extension/**"
+    branches: [main]
   pull_request:
     paths:
-      - 'packages/function-extension/**'
+      - "packages/function-extension/**"
   workflow_dispatch:
 
 defaults:
   run:
     working-directory: packages/function-extension/
 
-jobs:  
+jobs:
   Function-Extension:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 3.1.x
-    - name: Install Func CLI
-      run: 
-        wget -q https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb && sudo dpkg -i packages-microsoft-prod.deb &&
-        sudo apt-get update && sudo apt-get install azure-functions-core-tools-3
-    - name: Build
-      run: 
-        dotnet build -c Release Microsoft.Azure.WebJobs.Extensions.TeamsFx.sln 
-    - name: Pack
-      run: 
-        dotnet pack -c Release ./src/Microsoft.Azure.WebJobs.Extensions.TeamsFx.csproj
-    - name: Test
-      env: 
-        TeamsFx_BINDING_IntegrationTestSettings__ClientId: 4c7c4582-ac3d-4097-97bb-f818a91b60d9
-        TeamsFx_BINDING_IntegrationTestSettings__ClientSecret: ${{secrets.FUNCTION_EXTENSION_CLIENT_SECRET}}
-        TeamsFx_BINDING_IntegrationTestSettings__UnauthorizedAadAppClientId: 079ba771-5807-4eb9-bb7a-51e6e2f088f3
-        TeamsFx_BINDING_IntegrationTestSettings__UnauthorizedAadAppClientSecret: ${{secrets.FUNCTION_EXTENSION_UNAUTHORIZED_AAD_APP_CLIENT_SECRET}}
-        TeamsFx_BINDING_IntegrationTestSettings__AllowedAppClientId: 6c7b6e6f-242a-42d0-ae07-823434beb336
-        TeamsFx_BINDING_IntegrationTestSettings__AllowedAppClientSecret: ${{secrets.FUNCTION_EXTENSION_ALLOWED_APP_SECRET}}
-        TeamsFx_BINDING_IntegrationTestSettings__AuthorityHost: https://login.microsoftonline.com
-        TeamsFx_BINDING_IntegrationTestSettings__TenantId: 546a2d59-2038-4a68-acff-f0239a409516
-      run:
-        chmod +x "scripts/test.sh" && chmod +x "scripts/start_js_function.sh" && "scripts/test.sh"
+      - uses: actions/checkout@v2
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.x
+      - name: Install Func CLI
+        run:
+          wget -q https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb && sudo dpkg -i packages-microsoft-prod.deb &&
+          sudo apt-get update && sudo apt-get install azure-functions-core-tools-3
+      - name: Build
+        run: dotnet build -c Release Microsoft.Azure.WebJobs.Extensions.TeamsFx.sln
+      - name: Pack
+        run: dotnet pack -c Release ./src/Microsoft.Azure.WebJobs.Extensions.TeamsFx.csproj
+      - name: setup env
+        env:
+          creds: ${{ secrets.AZURE_TEST_CREDENTIALS }}
+        run: |
+          bash setup-testing-env.sh function-extension $GITHUB_ENV
+        working-directory: .github/scripts
+      - name: Test
+        run: chmod +x "scripts/test.sh" && chmod +x "scripts/start_js_function.sh" && "scripts/test.sh"

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -22,7 +22,6 @@ jobs:
           clean: false
 
       - name: setup env
-        id: keyvault
         env:
           creds: ${{ secrets.AZURE_TEST_CREDENTIALS }}
         run: |

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -74,7 +74,7 @@ jobs:
           npx lerna run test:e2e:clean
 
       - name: E2E Test in Parallel
-        env: 
+        env:
           M365_ACCOUNT_COLLABORATOR: ${{ steps.version-change.outputs.M365_ACCOUNT_COLLABORATOR }}
         run: |
           npx lerna run test:e2e:parallel

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -9,13 +9,6 @@ jobs:
   e2e-tests:
     name: run e2e test on (self-hosted linux 8cpu node14)
     env:
-      AZURE_ACCOUNT_NAME: ${{ secrets.TEST_USER_NAME }}
-      AZURE_ACCOUNT_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
-      AZURE_SUBSCRIPTION_ID: ${{ secrets.TEST_SUBSCRIPTION_ID }}
-      AZURE_TENANT_ID: ${{ secrets.TEST_TENANT_ID }}
-      M365_ACCOUNT_NAME: ${{ secrets.TEST_USER_NAME }}
-      M365_ACCOUNT_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
-      M365_TENANT_ID: ${{ secrets.TEST_TENANT_ID_2 }}
       CI_ENABLED: "true"
 
     runs-on: [self-hosted, linux, 8cpu]
@@ -33,8 +26,7 @@ jobs:
         env:
           creds: ${{ secrets.AZURE_TEST_CREDENTIALS }}
         run: |
-          output=$(bash setup-testing-env.sh E2E-TEST-COLLABORATOR-USER-NAME)
-          echo "::set-output name=M365_ACCOUNT_COLLABORATOR::$output"
+          bash setup-testing-env.sh e2e $GITHUB_ENV
         working-directory: .github/scripts
 
       - name: Setup node
@@ -74,8 +66,6 @@ jobs:
           npx lerna run test:e2e:clean
 
       - name: E2E Test in Parallel
-        env:
-          M365_ACCOUNT_COLLABORATOR: ${{ steps.version-change.outputs.M365_ACCOUNT_COLLABORATOR }}
         run: |
           npx lerna run test:e2e:parallel
 

--- a/.github/workflows/simpleauthCI.yml
+++ b/.github/workflows/simpleauthCI.yml
@@ -3,11 +3,11 @@ name: SimpleAuth CI
 on:
   push:
     paths:
-    - 'packages/simpleauth/**'
-    branches: [ main ]
+      - "packages/simpleauth/**"
+    branches: [main]
   pull_request:
     paths:
-      - 'packages/simpleauth/**'
+      - "packages/simpleauth/**"
   workflow_dispatch:
 
 defaults:
@@ -16,26 +16,21 @@ defaults:
 
 jobs:
   test:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 3.1.x
-    - name: Build
-      run: 
-        dotnet build -c Release -p:WebDriverPlatform=linux64 Microsoft.TeamsFx.SimpleAuth.sln
-    - name: Test
-      env: 
-        TEAMS_SIMPLE_AUTH_IntegrationTestSettings__AdminClientId: ${{secrets.SIMPLE_AUTH_TEST_ADMIN_CLIENT_ID}}
-        TEAMS_SIMPLE_AUTH_IntegrationTestSettings__AdminClientSecret: ${{secrets.SIMPLE_AUTH_TEST_ADMIN_CLIENT_SECRET}}
-        TEAMS_SIMPLE_AUTH_IntegrationTestSettings__TenantId: ${{secrets.SIMPLE_AUTH_TEST_TENANT_ID}}
-        TEAMS_SIMPLE_AUTH_IntegrationTestSettings__TestUserName: ${{secrets.SIMPLE_AUTH_TEST_USER_NAME}}
-        TEAMS_SIMPLE_AUTH_IntegrationTestSettings__TestPassword: ${{secrets.SIMPLE_AUTH_TEST_PASSWORD}}
-        TEAMS_SIMPLE_AUTH_IntegrationTestSettings__TestUserName2: ${{secrets.SIMPLE_AUTH_TEST_USER_NAME_2}}
-        TEAMS_SIMPLE_AUTH_IntegrationTestSettings__TestPassword2: ${{secrets.SIMPLE_AUTH_TEST_PASSWORD_2}}
-      run:
-        chmod +x "scripts/test.sh" && "scripts/test.sh"
+      - uses: actions/checkout@v2
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.x
+      - name: Build
+        run: dotnet build -c Release -p:WebDriverPlatform=linux64 Microsoft.TeamsFx.SimpleAuth.sln
+      - name: setup env
+        env:
+          creds: ${{ secrets.AZURE_TEST_CREDENTIALS }}
+        run: |
+          bash setup-testing-env.sh simpleauth $GITHUB_ENV
+        working-directory: .github/scripts
+      - name: Test
+        run: chmod +x "scripts/test.sh" && "scripts/test.sh"


### PR DESCRIPTION
store these secrets in azure key vault https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/e24d88be-b95f-4815-ba25-ae48defc8da2/resourceGroups/Github-Pipelines/providers/Microsoft.KeyVault/vaults/e2etestenv/overview
TEST_USER_NAME
TEST_USER_PASSWORD
TEST_SUBSCRIPTION_ID
TEST_TENANT_ID
TEST_TENANT_ID_2
FUNCTION_EXTENSION_CLIENT_SECRET
FUNCTION_EXTENSION_UNAUTHORIZED_AAD_APP_CLIENT_SECRET
FUNCTION_EXTENSION_ALLOWED_APP_SECRET
SIMPLE_AUTH_TEST_ADMIN_CLIENT_ID
SIMPLE_AUTH_TEST_ADMIN_CLIENT_SECRET
SIMPLE_AUTH_TEST_TENANT_ID
SIMPLE_AUTH_TEST_USER_NAME
SIMPLE_AUTH_TEST_PASSWORD
SIMPLE_AUTH_TEST_USER_NAME_2
SIMPLE_AUTH_TEST_PASSWORD_2
and we could remove these secrets in GitHub Secret page