### PR TITLE
refactor(multi-env): plugin retrieves subscription from ctx instead of accountProvider

### DIFF
--- a/packages/fx-core/src/plugins/resource/apim/config.ts
+++ b/packages/fx-core/src/plugins/resource/apim/config.ts
@@ -49,6 +49,7 @@ export interface ISolutionConfig {
   resourceGroupName: string;
   location: string;
   remoteTeamsAppId?: string | undefined;
+  subscriptionId?: string | undefined;
 }
 
 export class ApimPluginConfig implements IApimPluginConfig {

--- a/packages/fx-core/src/plugins/resource/bot/configs/provisionConfig.ts
+++ b/packages/fx-core/src/plugins/resource/bot/configs/provisionConfig.ts
@@ -38,9 +38,9 @@ export class ProvisionConfig {
   public functionEndpoint?: string;
 
   public async restoreConfigFromContext(context: PluginContext): Promise<void> {
-    this.subscriptionId = (
-      await context.azureAccountProvider?.getSelectedSubscription()
-    )?.subscriptionId;
+    this.subscriptionId = context.envInfo.profile
+      .get(PluginSolution.PLUGIN_NAME)
+      ?.get(PluginSolution.SUBSCRIPTION_ID) as string;
 
     this.resourceGroup = context.envInfo.profile
       .get(PluginSolution.PLUGIN_NAME)

--- a/packages/fx-core/src/plugins/resource/bot/resources/strings.ts
+++ b/packages/fx-core/src/plugins/resource/bot/resources/strings.ts
@@ -38,6 +38,7 @@ export class PluginLocalDebug {
 
 export class PluginSolution {
   public static readonly PLUGIN_NAME = "solution";
+  public static readonly SUBSCRIPTION_ID = "subscriptionId";
   public static readonly RESOURCE_GROUP_NAME = "resourceGroupName";
   public static readonly LOCATION = "location";
   public static readonly M365_TENANT_ID = "teamsAppTenantId";

--- a/packages/fx-core/src/plugins/resource/frontend/configs.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/configs.ts
@@ -52,11 +52,10 @@ export class FrontendConfig {
     const appName = ctx.projectSettings!.appName;
     const solutionConfigs = ctx.envInfo.profile.get(DependentPluginInfo.SolutionPluginName);
 
-    const subscriptionInfo = await ctx.azureAccountProvider?.getSelectedSubscription();
-    if (!subscriptionInfo) {
-      throw new InvalidConfigError(DependentPluginInfo.SubscriptionId);
-    }
-    const subscriptionId = subscriptionInfo.subscriptionId;
+    const subscriptionId = FrontendConfig.getConfig<string>(
+      DependentPluginInfo.SubscriptionId,
+      solutionConfigs
+    );
     const resourceNameSuffix = FrontendConfig.getConfig<string>(
       DependentPluginInfo.ResourceNameSuffix,
       solutionConfigs

--- a/packages/fx-core/src/plugins/resource/function/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/function/plugin.ts
@@ -126,10 +126,7 @@ export class FunctionPluginImpl {
     this.config.resourceGroupName = solutionConfig?.get(
       DependentPluginInfo.resourceGroupName
     ) as string;
-    const subscriptionInfo = await ctx.azureAccountProvider?.getSelectedSubscription();
-    if (subscriptionInfo) {
-      this.config.subscriptionId = subscriptionInfo.subscriptionId;
-    }
+    this.config.subscriptionId = solutionConfig?.get(DependentPluginInfo.subscriptionId) as string;
 
     this.config.location = solutionConfig?.get(DependentPluginInfo.location) as string;
     this.config.functionLanguage = ctx.projectSettings?.programmingLanguage as FunctionLanguage;

--- a/packages/fx-core/src/plugins/resource/identity/index.ts
+++ b/packages/fx-core/src/plugins/resource/identity/index.ts
@@ -78,10 +78,10 @@ export class IdentityPlugin implements Plugin {
     TelemetryUtils.sendEvent(Telemetry.stage.provision + Telemetry.startSuffix);
 
     ContextUtils.init(ctx);
-    const subscriptionInfo = await ctx.azureAccountProvider?.getSelectedSubscription();
-    if (subscriptionInfo) {
-      this.config.azureSubscriptionId = subscriptionInfo.subscriptionId;
-    }
+    this.config.azureSubscriptionId = ContextUtils.getConfigString(
+      Constants.solution,
+      Constants.subscriptionId
+    );
     this.config.resourceGroup = ContextUtils.getConfigString(
       Constants.solution,
       Constants.resourceGroupName

--- a/packages/fx-core/src/plugins/resource/simpleauth/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/simpleauth/plugin.ts
@@ -223,17 +223,11 @@ export class SimpleAuthPluginImpl {
       Constants.SolutionPlugin.id,
       Constants.SolutionPlugin.configKeys.resourceNameSuffix
     ) as string;
-    const subscriptionInfo = await ctx.azureAccountProvider?.getSelectedSubscription();
-    if (!subscriptionInfo) {
-      throw ResultFactory.SystemError(
-        NoConfigError.name,
-        NoConfigError.message(
-          Constants.SolutionPlugin.id,
-          Constants.SolutionPlugin.configKeys.subscriptionId
-        )
-      );
-    }
-    const subscriptionId = subscriptionInfo!.subscriptionId;
+    const subscriptionId = Utils.getConfigValueWithValidation(
+      ctx,
+      Constants.SolutionPlugin.id,
+      Constants.SolutionPlugin.configKeys.subscriptionId
+    ) as string;
     const resourceGroupName = Utils.getConfigValueWithValidation(
       ctx,
       Constants.SolutionPlugin.id,

--- a/packages/fx-core/src/plugins/resource/sql/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/sql/plugin.ts
@@ -49,10 +49,10 @@ export class SqlPluginImpl {
 
   async init(ctx: PluginContext) {
     ContextUtils.init(ctx);
-    const subscriptionInfo = await ctx.azureAccountProvider?.getSelectedSubscription();
-    if (subscriptionInfo) {
-      this.config.azureSubscriptionId = subscriptionInfo.subscriptionId;
-    }
+    this.config.azureSubscriptionId = ContextUtils.getConfigString(
+      Constants.solution,
+      Constants.solutionConfigKey.subscriptionId
+    );
     this.config.resourceGroup = ContextUtils.getConfigString(
       Constants.solution,
       Constants.solutionConfigKey.resourceGroupName

--- a/packages/fx-core/src/plugins/solution/fx-solution/arm.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/arm.ts
@@ -32,6 +32,7 @@ import {
   SolutionTelemetryEvent,
   SolutionTelemetryProperty,
   SolutionTelemetrySuccess,
+  SUBSCRIPTION_ID,
 } from "./constants";
 import { ResourceManagementClient, ResourceManagementModels } from "@azure/arm-resources";
 import { DeployArmTemplatesSteps, ProgressHelper } from "./utils/progressHelper";
@@ -463,8 +464,9 @@ async function getResourceManagementClientForArmDeployment(
     );
   }
 
-  const subscriptionId = (await ctx.azureAccountProvider?.getSelectedSubscription())
-    ?.subscriptionId;
+  const subscriptionId = ctx.envInfo.profile.get(GLOBAL_CONFIG)?.get(SUBSCRIPTION_ID) as
+    | string
+    | undefined;
   if (!subscriptionId) {
     throw returnSystemError(
       new Error(`Failed to get subscription id.`),

--- a/packages/fx-core/src/plugins/solution/fx-solution/commonQuestions.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/commonQuestions.ts
@@ -55,6 +55,7 @@ class CommonQuestions {
   resourceGroupName = "";
   tenantId = "";
   subscriptionId = "";
+  subscriptionName = "";
   // default to East US for now
   location = "East US";
   teamsAppTenantId = "";
@@ -274,6 +275,7 @@ async function askCommonQuestions(
   }
   const subscriptionId = subscriptionResult.value.subscriptionId;
   commonQuestions.subscriptionId = subscriptionId;
+  commonQuestions.subscriptionName = subscriptionResult.value.subscriptionName;
   commonQuestions.tenantId = subscriptionResult.value.tenantId;
   ctx.logProvider?.info(
     `[${PluginDisplayName.Solution}] askCommonQuestions, step 1 - check subscriptionId pass!`

--- a/packages/fx-core/src/plugins/solution/fx-solution/constants.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/constants.ts
@@ -50,6 +50,16 @@ export const RESOURCE_GROUP_NAME = "resourceGroupName";
 export const LOCATION = "location";
 
 /**
+ * Config key whose value is the subscription ID of project.
+ */
+export const SUBSCRIPTION_ID = "subscriptionId";
+
+/**
+ * Config key whose value is the subscription ID of project.
+ */
+export const SUBSCRIPTION_NAME = "subscriptionName";
+
+/**
  * Config key whose value is the user info of collaborator
  */
 export const USER_INFO = "userInfo";

--- a/packages/fx-core/src/plugins/solution/fx-solution/constants.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/constants.ts
@@ -55,7 +55,7 @@ export const LOCATION = "location";
 export const SUBSCRIPTION_ID = "subscriptionId";
 
 /**
- * Config key whose value is the subscription ID of project.
+ * Config key whose value is the subscription name of project.
  */
 export const SUBSCRIPTION_NAME = "subscriptionName";
 

--- a/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
@@ -1864,7 +1864,6 @@ export class TeamsAppSolution implements Solution {
           AskSubscriptionQuestion.func = async (
             inputs: Inputs
           ): Promise<Result<SubscriptionInfo, FxError>> => {
-            ctx.envInfo.profile.get(GLOBAL_CONFIG)?.get(SUBSCRIPTION_ID);
             const res = await checkSubscription(ctx);
             if (res.isOk()) {
               const sub = res.value;

--- a/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
@@ -61,6 +61,8 @@ import {
   ARM_TEMPLATE_OUTPUT,
   USER_INFO,
   REMOTE_TENANT_ID,
+  SUBSCRIPTION_ID,
+  SUBSCRIPTION_NAME,
 } from "./constants";
 
 import {
@@ -641,10 +643,11 @@ export class TeamsAppSolution implements Solution {
 
       // Only Azure project requires this confirm dialog
       const username = (azureToken as any).username ? (azureToken as any).username : "";
-      const subscriptionInfo = await ctx.azureAccountProvider?.getSelectedSubscription();
+      const subscriptionId = ctx.envInfo.profile.get(GLOBAL_CONFIG)?.get(SUBSCRIPTION_ID) as string;
+      const subscriptionName = ctx.envInfo.profile
+        .get(GLOBAL_CONFIG)
+        ?.get(SUBSCRIPTION_NAME) as string;
 
-      const subscriptionId = subscriptionInfo?.subscriptionId;
-      const subscriptionName = subscriptionInfo?.subscriptionName;
       const msg = util.format(
         getStrings().solution.ProvisionConfirmNotice,
         username,
@@ -1861,6 +1864,7 @@ export class TeamsAppSolution implements Solution {
           AskSubscriptionQuestion.func = async (
             inputs: Inputs
           ): Promise<Result<SubscriptionInfo, FxError>> => {
+            ctx.envInfo.profile.get(GLOBAL_CONFIG)?.get(SUBSCRIPTION_ID);
             const res = await checkSubscription(ctx);
             if (res.isOk()) {
               const sub = res.value;

--- a/packages/fx-core/tests/plugins/resource/bot/unit/utils.ts
+++ b/packages/fx-core/tests/plugins/resource/bot/unit/utils.ts
@@ -187,6 +187,7 @@ export function newPluginContext(): PluginContext {
             [PluginSolution.LOCATION, "Central US"],
             [PluginSolution.RESOURCE_GROUP_NAME, "anything"],
             [PluginSolution.M365_TENANT_ID, "anything"],
+            [PluginSolution.SUBSCRIPTION_ID, "subscriptionId"],
           ]),
         ],
         [

--- a/packages/fx-core/tests/plugins/resource/frontend/helper.ts
+++ b/packages/fx-core/tests/plugins/resource/frontend/helper.ts
@@ -86,6 +86,7 @@ export class TestHelper {
 
   static getFakePluginContext(): PluginContext {
     const solutionConfig = new Map();
+    solutionConfig.set(DependentPluginInfo.SubscriptionId, TestHelper.fakeSubscriptionId);
     solutionConfig.set(DependentPluginInfo.ResourceNameSuffix, TestHelper.storageSuffix);
     solutionConfig.set(DependentPluginInfo.ResourceGroupName, TestHelper.rgName);
     solutionConfig.set(DependentPluginInfo.Location, TestHelper.location);

--- a/packages/fx-core/tests/plugins/resource/function/unit/deploy.test.ts
+++ b/packages/fx-core/tests/plugins/resource/function/unit/deploy.test.ts
@@ -30,6 +30,7 @@ const context: any = {
       [
         DependentPluginInfo.solutionPluginName,
         new Map<string, string>([
+          [DependentPluginInfo.subscriptionId, "ut"],
           [DependentPluginInfo.resourceGroupName, "ut"],
           [DependentPluginInfo.resourceNameSuffix, "ut"],
           [DependentPluginInfo.location, "ut"],

--- a/packages/fx-core/tests/plugins/solution/solution.arm.test.ts
+++ b/packages/fx-core/tests/plugins/solution/solution.arm.test.ts
@@ -549,6 +549,7 @@ describe("Deploy ARM Template to Azure", () => {
       new ConfigMap([
         ["resourceGroupName", "mocked resource group name"],
         ["resourceNameSuffix", testResourceSuffix],
+        ["subscriptionId", "mocked subscription id"],
       ])
     );
 


### PR DESCRIPTION
Plugins will read sub from `ctx` (just like resource group) instead of `accountProvider`. This will clear the path to change the logic of reading subs in solution.

Tested local debug and remote happy path.

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/10736857