### PR TITLE
feat(multi-env): support to read subs from input config

### DIFF
--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -57,6 +57,12 @@ export interface AzureSolutionSettings extends SolutionSettings {
     migrateFromV1?: boolean;
 }
 
+// @public (undocumented)
+export enum AzureTokenJSONKeys {
+    // (undocumented)
+    TenantId = "tid"
+}
+
 // @public
 export interface BaseQuestion {
     default?: unknown;

--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -57,12 +57,6 @@ export interface AzureSolutionSettings extends SolutionSettings {
     migrateFromV1?: boolean;
 }
 
-// @public (undocumented)
-export enum AzureTokenJSONKeys {
-    // (undocumented)
-    TenantId = "tid"
-}
-
 // @public
 export interface BaseQuestion {
     default?: unknown;

--- a/packages/api/src/utils/login.ts
+++ b/packages/api/src/utils/login.ts
@@ -57,6 +57,7 @@ export interface AzureAccountProvider {
    * - tid : tenantId
    * - unique_name : user name
    * - ...
+   * The keys are defined in the AzureTokenJSONKeys enum.
    * @param showDialog Control whether the UI layer displays pop-up windows
    */
   getJsonObject(showDialog?: boolean): Promise<Record<string, unknown> | undefined>;
@@ -190,3 +191,8 @@ export type TokenProvider = {
   graphTokenProvider: GraphTokenProvider;
   appStudioToken: AppStudioTokenProvider;
 };
+
+// The raw token keys returned by AzureAccountProvider.getJsonObject()
+export enum AzureTokenJSONKeys {
+  TenantId = "tid",
+}

--- a/packages/api/src/utils/login.ts
+++ b/packages/api/src/utils/login.ts
@@ -57,7 +57,6 @@ export interface AzureAccountProvider {
    * - tid : tenantId
    * - unique_name : user name
    * - ...
-   * The keys are defined in the AzureTokenJSONKeys enum.
    * @param showDialog Control whether the UI layer displays pop-up windows
    */
   getJsonObject(showDialog?: boolean): Promise<Record<string, unknown> | undefined>;
@@ -191,8 +190,3 @@ export type TokenProvider = {
   graphTokenProvider: GraphTokenProvider;
   appStudioToken: AppStudioTokenProvider;
 };
-
-// The raw token keys returned by AzureAccountProvider.getJsonObject()
-export enum AzureTokenJSONKeys {
-  TenantId = "tid",
-}

--- a/packages/api/src/utils/login.ts
+++ b/packages/api/src/utils/login.ts
@@ -12,6 +12,7 @@ import { TokenCredentialsBase } from "@azure/ms-rest-nodeauth";
 export interface AzureAccountProvider {
   /**
    * Async get ms-rest-* [credential](https://github.com/Azure/ms-rest-nodeauth/blob/master/lib/credentials/tokenCredentialsBase.ts)
+   * On login failure or user cancellation, it will throw an exception instead of returning undefined. This method never returns undefined.
    * @param showDialog Control whether the UI layer displays pop-up windows.
    * @param tenantId Tenant or directory id
    */

--- a/packages/fx-core/src/plugins/solution/fx-solution/commonQuestions.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/commonQuestions.ts
@@ -27,7 +27,7 @@ import { GLOBAL_CONFIG, LOCATION, RESOURCE_GROUP_NAME, SolutionError } from "./c
 import { v4 as uuidv4 } from "uuid";
 import { ResourceManagementClient } from "@azure/arm-resources";
 import { PluginDisplayName } from "../../../common/constants";
-import { askSubscription, isMultiEnvEnabled } from "../../../common";
+import { isMultiEnvEnabled } from "../../../common";
 import {
   CoreQuestionNames,
   QuestionNewResourceGroupLocation,

--- a/packages/fx-core/src/plugins/solution/fx-solution/commonQuestions.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/commonQuestions.ts
@@ -20,8 +20,6 @@ import {
   LogProvider,
   EnvConfigFileNameTemplate,
   EnvNamePlaceholder,
-  AzureTokenJSONKeys,
-  InputConfigsFolderName,
 } from "@microsoft/teamsfx-api";
 import { GLOBAL_CONFIG, LOCATION, RESOURCE_GROUP_NAME, SolutionError } from "./constants";
 import { v4 as uuidv4 } from "uuid";
@@ -88,21 +86,6 @@ export async function checkSubscription(
 
   // make sure the user is logged in
   await ctx.azureAccountProvider.getAccountCredentialAsync(true);
-  const tokenObject = await ctx.azureAccountProvider.getJsonObject(false);
-  if (!tokenObject) {
-    return err(
-      returnSystemError(
-        new Error("azure token JSON object is undefined"),
-        "Solution",
-        SolutionError.InternelError
-      )
-    );
-  }
-  const tenantId = tokenObject[AzureTokenJSONKeys.TenantId];
-  if (!tenantId) {
-    // Tenant ID is not required, so just write a warning log and continue.
-    ctx.logProvider?.warning(`The tenant id from the azure token is empty`);
-  }
 
   // TODO: verify valid subscription (permission)
   const subscriptions = await ctx.azureAccountProvider.listSubscriptions();
@@ -111,7 +94,7 @@ export async function checkSubscription(
     return err(
       returnUserError(
         new Error(
-          `The subscription '${subscriptionId}' is not found in the tenant '${tenantId}', please check the '${EnvConfigFileNameTemplate.replace(
+          `The subscription '${subscriptionId}' is not found in the current account, please check the '${EnvConfigFileNameTemplate.replace(
             EnvNamePlaceholder,
             ctx.envInfo.envName
           )}' file.`

--- a/packages/fx-core/src/plugins/solution/fx-solution/commonQuestions.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/commonQuestions.ts
@@ -111,10 +111,10 @@ export async function checkSubscription(
     return err(
       returnUserError(
         new Error(
-          `The subscription '${subscriptionId}' is not found in the tenant '${tenantId}', please check the ${EnvConfigFileNameTemplate.replace(
+          `The subscription '${subscriptionId}' is not found in the tenant '${tenantId}', please check the '${EnvConfigFileNameTemplate.replace(
             EnvNamePlaceholder,
             ctx.envInfo.envName
-          )}`
+          )}' file.`
         ),
         "Solution",
         SolutionError.SubscriptionNotFound

--- a/packages/fx-core/src/plugins/solution/fx-solution/commonQuestions.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/commonQuestions.ts
@@ -117,7 +117,7 @@ export async function checkSubscription(
           )}`
         ),
         "Solution",
-        SolutionError.InternelError
+        SolutionError.SubscriptionNotFound
       )
     );
   }

--- a/packages/fx-core/src/plugins/solution/fx-solution/constants.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/constants.ts
@@ -101,6 +101,7 @@ export enum SolutionError {
   FailedToListResourceGroup = "FailedToListResourceGrouop",
   FailedToGetResourceGroupInfoInputs = "FailedToGetResourceGroupInfoInputs",
   ResourceGroupNotFound = "ResourceGroupNotFound",
+  SubscriptionNotFound = "SubscriptionNotFound",
   NotLoginToAzure = "NotLoginToAzure",
   AzureAccountExtensionNotInitialized = "AzureAccountExtensionNotInitialized",
   LocalTabEndpointMissing = "LocalTabEndpointMissing",


### PR DESCRIPTION
- when multi-env is enabled, it will first read subs from input config (config.dev.json). If not found, it will pop up and ask user, same as the previous behavior)
- confirmed with @xiaolang124 that `getAccountCredentialAsync` will never return undefined

Tested remote happy path with and without feature flag


https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/10736857