### PR TITLE
fix: fix apim e2e test AddResource failure with null sub id

### DIFF
--- a/packages/fx-core/src/plugins/resource/apim/factory.ts
+++ b/packages/fx-core/src/plugins/resource/apim/factory.ts
@@ -163,8 +163,16 @@ export class Factory {
       "credential",
       await azureAccountProvider?.getAccountCredentialAsync()
     );
-    const maybeSubscriptionId = solutionConfig.subscriptionId;
-    const subscriptionId = AssertNotEmpty("subscriptionId", maybeSubscriptionId);
+    let subscriptionId;
+    if (solutionConfig.subscriptionId) {
+      subscriptionId = solutionConfig.subscriptionId;
+    } else {
+      // fall back to asking user subscription info because some operations like "AddResource" can be before provision
+      let subscriptionInfo = await azureAccountProvider?.getSelectedSubscription();
+      subscriptionInfo = AssertNotEmpty("subscriptionInfo", subscriptionInfo);
+      subscriptionId = subscriptionInfo.subscriptionId;
+    }
+
     const apiManagementClient = new ApiManagementClient(credential, subscriptionId);
     const resourceProviderClient = new Providers(
       new ResourceManagementClientContext(credential, subscriptionId)


### PR DESCRIPTION
AddResource can happen before provision, and it requires subscription ID to list the existing APIM instances. In that case, subscriptionId from solutionConfig does not exist yet, so it will not work. Fix this bug by falling back to the previous behavior to read subs from `azureAccountProvider` when `solutionConfig.subscriptionId` is a falsy value.

I've also checked that other plugins does not have this issue.

E2E test result: https://github.com/OfficeDev/TeamsFx/actions/runs/1204566179

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/10790598/