### PR TITLE
fix(tab): refine type annotation in ts error handling

### DIFF
--- a/templates/tab/ts/default/src/components/sample/AzureFunctions.tsx
+++ b/templates/tab/ts/default/src/components/sample/AzureFunctions.tsx
@@ -17,25 +17,30 @@ async function callFunction() {
       },
     });
     return response.data;
-  } catch (err) {
-    let funcErrorMsg = "";
-    if (err?.response?.status === 404) {
-      funcErrorMsg = `There may be a problem with the deployment of Azure Function App, please deploy Azure Function (Run command palette "TeamsFx - Deploy Package") first before running this App`;
-    } else if (err.message === "Network Error") {
-      funcErrorMsg =
-        "Cannot call Azure Function due to network error, please check your network connection status and ";
-      if (err.config.url.indexOf("localhost") >= 0) {
-        funcErrorMsg += `make sure to start Azure Function locally (Run "npm run start" command inside api folder from terminal) first before running this App`;
+  } catch (err: unknown) {
+    if (axios.default.isAxiosError(err)) {
+      let funcErrorMsg = "";
+
+      if (err?.response?.status === 404) {
+        funcErrorMsg = `There may be a problem with the deployment of Azure Function App, please deploy Azure Function (Run command palette "TeamsFx - Deploy Package") first before running this App`;
+      } else if (err.message === "Network Error") {
+        funcErrorMsg =
+          "Cannot call Azure Function due to network error, please check your network connection status and ";
+        if (err.config?.url && err.config.url.indexOf("localhost") >= 0) {
+          funcErrorMsg += `make sure to start Azure Function locally (Run "npm run start" command inside api folder from terminal) first before running this App`;
+        } else {
+          funcErrorMsg += `make sure to provision and deploy Azure Function (Run command palette "TeamsFx - Provision Resource" and "TeamsFx - Deploy Package") first before running this App`;
+        }
       } else {
-        funcErrorMsg += `make sure to provision and deploy Azure Function (Run command palette "TeamsFx - Provision Resource" and "TeamsFx - Deploy Package") first before running this App`;
+        funcErrorMsg = err.message;
+        if (err.response?.data?.error) {
+          funcErrorMsg += ": " + err.response.data.error;
+        }
       }
-    } else {
-      funcErrorMsg = err.message;
-      if (err.response?.data?.error) {
-        funcErrorMsg += ": " + err.response.data.error;
-      }
+
+      throw new Error(funcErrorMsg);
     }
-    throw new Error(funcErrorMsg);
+    throw err;
   }
 }
 

--- a/templates/tab/ts/default/src/components/sample/lib/useGraph.ts
+++ b/templates/tab/ts/default/src/components/sample/lib/useGraph.ts
@@ -1,5 +1,5 @@
 import { useData } from "./useData";
-import { TeamsUserCredential, createMicrosoftGraphClient } from "@microsoft/teamsfx";
+import { TeamsUserCredential, createMicrosoftGraphClient, ErrorWithCode } from "@microsoft/teamsfx";
 import { Client } from "@microsoft/microsoft-graph-client";
 
 export function useGraph<T>(
@@ -12,8 +12,8 @@ export function useGraph<T>(
       const credential = new TeamsUserCredential();
       const graph = createMicrosoftGraphClient(credential, scope);
       return await asyncFunc(graph);
-    } catch (err) {
-      if (err.code.includes("UiRequiredError")) {
+    } catch (err: unknown) {
+      if (err instanceof ErrorWithCode && err.code?.includes("UiRequiredError")) {
         // Silently fail for user didn't login error
       } else {
         throw err;


### PR DESCRIPTION
This PR is going to fix the compiler error:
```
Object is of type 'unknown'.  TS2571

    27 |   } catch (err) {
    28 |     let funcErrorMsg = "";
  > 29 |     if (err.response?.status === 404) {
       |         ^
    30 |       funcErrorMsg = `There may be a problem with the deployment of Azure Function App, please deploy Azure Function (Run command palette "TeamsFx - Deploy Package") first before running this App`;
    31 |     } else if (err.message === "Network Error") {
    32 |       funcErrorMsg =
```

Before TypeScript 4.4, the `catch` clause bindings were set to `any`. TypeScript 4.4 introduced a new compiler option [`useUnknownInCatchVariables`](https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables) which is `true` by default if you have `strict` option turned on (as we have done).
By turning on `useUnknownInCatchVariables` option, the `catch` clause bindings are set to 'unknown'.
