### PR TITLE
fix(vsc): show azure account in cpm when open empty project

### DIFF
--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -973,7 +973,8 @@ export async function cmpAccountsHandler() {
   }
 
   const solutionSettings = await getAzureSolutionSettings();
-  if (solutionSettings && "Azure" === solutionSettings.hostType) {
+  // if non-teamsfx project or Azure project then show Azure account info
+  if (!solutionSettings || (solutionSettings && "Azure" === solutionSettings.hostType)) {
     const azureAccount = await AzureAccountManager.getStatus();
     if (azureAccount.status === "SignedIn") {
       const accountInfo = azureAccount.accountInfo;


### PR DESCRIPTION
ADO: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/10793856