### PR TITLE
chore(schema): add existing AAD config to env config schema

### DIFF
--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -225,6 +225,12 @@ export const DynamicPlatforms: Platform[];
 export interface EnvConfig {
     // (undocumented)
     $schema?: string;
+    auth?: {
+        clientId?: string;
+        clientSecret?: string;
+        objectId?: string;
+        oauth2PermissionScopeId?: string;
+    };
     azure?: {
         subscriptionId?: string;
         resourceGroupName?: string;

--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -229,7 +229,7 @@ export interface EnvConfig {
         clientId?: string;
         clientSecret?: string;
         objectId?: string;
-        oauth2PermissionScopeId?: string;
+        accessAsUserScopeId?: string;
     };
     azure?: {
         subscriptionId?: string;

--- a/packages/api/src/schemas/envConfig.json
+++ b/packages/api/src/schemas/envConfig.json
@@ -6,6 +6,39 @@
     "$schema": {
       "type": "string"
     },
+    "auth": {
+      "type": "object",
+      "description": "Existing tab AAD app configuration.",
+      "properties": {
+        "clientId": {
+          "type": "string",
+          "description": "The client id of existing AAD app for tab.",
+          "minLength": 1
+        },
+        "clientSecret": {
+          "type": "string",
+          "description": "The secret of existing AAD app for tab.",
+          "minLength": 1
+        },
+        "objectId": {
+          "type": "string",
+          "description": "The object id of existing AAD app for tab.",
+          "minLength": 1
+        },
+        "oauth2PermissionScopeId": {
+          "type": "string",
+          "description": "The oauth2 permission scope id of existing AAD app for tab.",
+          "minLength": 1
+        }
+      },
+      "dependencies": {
+        "clientId": ["clientSecret", "objectId", "oauth2PermissionScopeId"],
+        "clientSecret": ["clientId", "objectId", "oauth2PermissionScopeId"],
+        "objectId": ["clientId", "clientSecret", "oauth2PermissionScopeId"],
+        "oauth2PermissionScopeId": ["clientId", "clientSecret", "objectId"]
+      },
+      "additionalProperties": false
+    },
     "azure": {
       "type": "object",
       "description": "The Azure resource related configuration.",

--- a/packages/api/src/schemas/envConfig.json
+++ b/packages/api/src/schemas/envConfig.json
@@ -17,7 +17,7 @@
         },
         "clientSecret": {
           "type": "string",
-          "description": "The secret of existing AAD app for tab.",
+          "description": "The client secret of existing AAD app for tab.",
           "minLength": 1
         },
         "objectId": {

--- a/packages/api/src/schemas/envConfig.json
+++ b/packages/api/src/schemas/envConfig.json
@@ -8,26 +8,26 @@
     },
     "auth": {
       "type": "object",
-      "description": "Existing tab AAD app configuration.",
+      "description": "Existing AAD app configuration.",
       "properties": {
         "clientId": {
           "type": "string",
-          "description": "The client id of existing AAD app for tab.",
+          "description": "The client id of existing AAD app for Teams app.",
           "minLength": 1
         },
         "clientSecret": {
           "type": "string",
-          "description": "The client secret of existing AAD app for tab.",
+          "description": "The client secret of existing AAD app for Teams app.",
           "minLength": 1
         },
         "objectId": {
           "type": "string",
-          "description": "The object id of existing AAD app for tab.",
+          "description": "The object id of existing AAD app for Teams app.",
           "minLength": 1
         },
-        "oauth2PermissionScopeId": {
+        "accessAsUserScopeId": {
           "type": "string",
-          "description": "The oauth2 permission scope id of existing AAD app for tab.",
+          "description": "The access_as_user scope id of existing AAD app for Teams app.",
           "minLength": 1
         }
       },

--- a/packages/api/src/schemas/envConfig.json
+++ b/packages/api/src/schemas/envConfig.json
@@ -32,10 +32,10 @@
         }
       },
       "dependencies": {
-        "clientId": ["clientSecret", "objectId", "oauth2PermissionScopeId"],
-        "clientSecret": ["clientId", "objectId", "oauth2PermissionScopeId"],
-        "objectId": ["clientId", "clientSecret", "oauth2PermissionScopeId"],
-        "oauth2PermissionScopeId": ["clientId", "clientSecret", "objectId"]
+        "clientId": ["clientSecret", "objectId", "accessAsUserScopeId"],
+        "clientSecret": ["clientId", "objectId", "accessAsUserScopeId"],
+        "objectId": ["clientId", "clientSecret", "accessAsUserScopeId"],
+        "accessAsUserScopeId": ["clientId", "clientSecret", "objectId"]
       },
       "additionalProperties": false
     },

--- a/packages/api/src/schemas/envConfig.ts
+++ b/packages/api/src/schemas/envConfig.ts
@@ -11,25 +11,25 @@
 export interface EnvConfig {
   $schema?: string;
   /**
-   * Existing tab AAD app configuration.
+   * Existing AAD app configuration.
    */
   auth?: {
     /**
-     * The client id of existing AAD app for tab.
+     * The client id of existing AAD app for Teams app.
      */
     clientId?: string;
     /**
-     * The client secret of existing AAD app for tab.
+     * The client secret of existing AAD app for Teams app.
      */
     clientSecret?: string;
     /**
-     * The object id of existing AAD app for tab.
+     * The object id of existing AAD app for Teams app.
      */
     objectId?: string;
     /**
-     * The oauth2 permission scope id of existing AAD app for tab.
+     * The access_as_user scope id of existing AAD app for Teams app.
      */
-    oauth2PermissionScopeId?: string;
+    accessAsUserScopeId?: string;
   };
   /**
    * The Azure resource related configuration.

--- a/packages/api/src/schemas/envConfig.ts
+++ b/packages/api/src/schemas/envConfig.ts
@@ -19,7 +19,7 @@ export interface EnvConfig {
      */
     clientId?: string;
     /**
-     * The secret of existing AAD app for tab.
+     * The client secret of existing AAD app for tab.
      */
     clientSecret?: string;
     /**

--- a/packages/api/src/schemas/envConfig.ts
+++ b/packages/api/src/schemas/envConfig.ts
@@ -11,6 +11,27 @@
 export interface EnvConfig {
   $schema?: string;
   /**
+   * Existing tab AAD app configuration.
+   */
+  auth?: {
+    /**
+     * The client id of existing AAD app for tab.
+     */
+    clientId?: string;
+    /**
+     * The secret of existing AAD app for tab.
+     */
+    clientSecret?: string;
+    /**
+     * The object id of existing AAD app for tab.
+     */
+    objectId?: string;
+    /**
+     * The oauth2 permission scope id of existing AAD app for tab.
+     */
+    oauth2PermissionScopeId?: string;
+  };
+  /**
    * The Azure resource related configuration.
    */
   azure?: {


### PR DESCRIPTION
Add config section for existing AAD app to the schema of env config, so that user can customize it and resource plugin can consume the value.