### PR TITLE
chore(multi-env): support create environment copy

### DIFF
--- a/packages/fx-core/src/core/error.ts
+++ b/packages/fx-core/src/core/error.ts
@@ -59,6 +59,13 @@ export function ReadFileError(e: Error): SystemError {
   return error;
 }
 
+export function CopyFileError(e: Error): SystemError {
+  const error = assembleError(e);
+  error.name = "CopyFileError";
+  error.source = CoreSource;
+  return error;
+}
+
 export function NoneFxError(e: any): FxError {
   const err = assembleError(e);
   err.name = "NoneFxError";

--- a/packages/fx-core/src/core/index.ts
+++ b/packages/fx-core/src/core/index.ts
@@ -41,7 +41,6 @@ import * as fs from "fs-extra";
 import * as jsonschema from "jsonschema";
 import * as path from "path";
 import * as uuid from "uuid";
-import { environmentManager } from "..";
 import { globalStateUpdate } from "../common/globalState";
 import {
   Component,
@@ -58,9 +57,8 @@ import {
   isMultiEnvEnabled,
   saveFilesRecursively,
 } from "../common/tools";
-import { getParameterJson } from "../plugins/solution/fx-solution/arm";
-import { LocalCrypto } from "./crypto";
 import {
+  CopyFileError,
   FetchSampleError,
   FunctionRouterError,
   InvalidInputError,
@@ -86,11 +84,10 @@ import { ErrorHandlerMW } from "./middleware/errorHandler";
 import { LocalSettingsLoaderMW } from "./middleware/localSettingsLoader";
 import { LocalSettingsWriterMW } from "./middleware/localSettingsWriter";
 import { MigrateConditionHandlerMW } from "./middleware/migrateConditionHandler";
-import { newSolutionContext, ProjectSettingsLoaderMW } from "./middleware/projectSettingsLoader";
-import { ProjectSettingsWriterMW } from "./middleware/projectSettingsWriter";
-import { ProjectUpgraderMW } from "./middleware/projectUpgrader";
-import { QuestionModelMW } from "./middleware/questionModel";
-import { SolutionLoaderMW } from "./middleware/solutionLoader";
+import { environmentManager } from "..";
+import { newEnvInfo } from "./tools";
+import { copyParameterJson, getParameterJson } from "../plugins/solution/fx-solution/arm";
+import { LocalCrypto } from "./crypto";
 import { PermissionRequestFileProvider } from "./permissionRequest";
 import { HostTypeOptionAzure } from "../plugins/solution/fx-solution/question";
 import {
@@ -106,8 +103,12 @@ import {
   ScratchOptionNo,
   ScratchOptionYes,
 } from "./question";
-import { newEnvInfo } from "./tools";
 import { FxCoreV2 } from "./v2";
+import { QuestionModelMW } from "./middleware/questionModel";
+import { ProjectSettingsWriterMW } from "./middleware/projectSettingsWriter";
+import { newSolutionContext, ProjectSettingsLoaderMW } from "./middleware/projectSettingsLoader";
+import { SolutionLoaderMW } from "./middleware/solutionLoader";
+import { ProjectUpgraderMW } from "./middleware/projectUpgrader";
 
 export interface CoreHookContext extends HookContext {
   projectSettings?: ProjectSettings;
@@ -717,7 +718,7 @@ export class FxCore implements Core {
             description: "",
             author: "",
             scripts: {
-              test: "echo \"Error: no test specified\" && exit 1",
+              test: 'echo "Error: no test specified" && exit 1',
             },
             devDependencies: {
               "@microsoft/teamsfx-cli": "0.*",
@@ -780,22 +781,26 @@ export class FxCore implements Core {
     }
 
     const core = ctx!.self as FxCore;
-    const targetEnvName = await askNewEnvironment(ctx!, inputs);
+    const createEnvCopyInput = await askNewEnvironment(ctx!, inputs);
 
-    if (!targetEnvName) {
+    if (
+      !createEnvCopyInput ||
+      !createEnvCopyInput.targetEnvName ||
+      !createEnvCopyInput.sourceEnvName
+    ) {
       return ok(Void);
     }
 
-    if (targetEnvName) {
-      const createEnvResult = await this.createEnvWithName(
-        targetEnvName,
-        projectSettings,
-        inputs,
-        core
-      );
-      if (createEnvResult.isErr()) {
-        return createEnvResult;
-      }
+    const createEnvResult = await this.createEnvCopy(
+      createEnvCopyInput.targetEnvName,
+      createEnvCopyInput.sourceEnvName,
+      projectSettings,
+      inputs,
+      core
+    );
+
+    if (createEnvResult.isErr()) {
+      return createEnvResult;
     }
 
     return ok(Void);
@@ -838,6 +843,58 @@ export class FxCore implements Core {
       };
 
       await getParameterJson(solutionContext);
+    }
+
+    return ok(Void);
+  }
+
+  async createEnvCopy(
+    targetEnvName: string,
+    sourceEnvName: string,
+    projectSettings: ProjectSettings,
+    inputs: Inputs,
+    core: FxCore
+  ): Promise<Result<Void, FxError>> {
+    // copy env config file
+    const targetEnvConfigFilePath = environmentManager.getEnvConfigPath(
+      targetEnvName,
+      inputs.projectPath!
+    );
+    const sourceEnvConfigFilePath = environmentManager.getEnvConfigPath(
+      sourceEnvName,
+      inputs.projectPath!
+    );
+
+    try {
+      await fs.copy(sourceEnvConfigFilePath, targetEnvConfigFilePath);
+    } catch (e) {
+      return err(CopyFileError(e));
+    }
+
+    core.tools.logProvider.debug(
+      `[core] copy env config file for ${targetEnvName} environment to path ${targetEnvConfigFilePath}`
+    );
+
+    // copy bicep parameter file
+    if (isArmSupportEnabled() && isAzureProject(projectSettings.solutionSettings)) {
+      const solutionContext: SolutionContext = {
+        projectSettings,
+        envInfo: newEnvInfo(targetEnvName),
+        root: inputs.projectPath || "",
+        ...core.tools,
+        ...core.tools.tokenProvider,
+        answers: inputs,
+        cryptoProvider: new LocalCrypto(projectSettings.projectId),
+        permissionRequestProvider: inputs.projectPath
+          ? new PermissionRequestFileProvider(inputs.projectPath)
+          : undefined,
+      };
+
+      try {
+        await copyParameterJson(solutionContext, sourceEnvName);
+      } catch (e) {
+        return err(CopyFileError(e));
+      }
     }
 
     return ok(Void);

--- a/packages/fx-core/src/core/middleware/envInfoLoader.ts
+++ b/packages/fx-core/src/core/middleware/envInfoLoader.ts
@@ -18,8 +18,6 @@ import {
 import { CoreHookContext, FxCore } from "../..";
 import {
   NoProjectOpenedError,
-  ProjectEnvAlreadyExistError,
-  InvalidEnvNameError,
   ProjectEnvNotExistError,
   ProjectSettingsUndefinedError,
   NonActiveEnvError,
@@ -33,7 +31,11 @@ import {
   PluginNames,
   PROGRAMMING_LANGUAGE,
 } from "../../plugins/solution/fx-solution/constants";
-import { getQuestionNewTargetEnvironmentName, QuestionSelectTargetEnvironment } from "../question";
+import {
+  getQuestionNewTargetEnvironmentName,
+  QuestionSelectSourceEnvironment,
+  QuestionSelectTargetEnvironment,
+} from "../question";
 import { desensitize } from "./questionModel";
 import { shouldIgnored } from "./projectSettingsLoader";
 import { PermissionRequestFileProvider } from "../permissionRequest";
@@ -43,6 +45,11 @@ import { CoreHookContextV2 } from "../v2";
 const newTargetEnvNameOption = "+ new environment";
 const lastUsedMark = " (activate)";
 let activeEnv: string | undefined;
+
+export type CreateEnvCopyInput = {
+  targetEnvName: string;
+  sourceEnvName: string;
+};
 
 export function EnvInfoLoaderMW(isMultiEnvEnabled: boolean): Middleware {
   return async (ctx: CoreHookContext, next: NextFunction) => {
@@ -231,7 +238,7 @@ export async function askTargetEnvironment(
 export async function askNewEnvironment(
   ctx: CoreHookContext | CoreHookContextV2,
   inputs: Inputs
-): Promise<string | undefined> {
+): Promise<CreateEnvCopyInput | undefined> {
   const getQuestionRes = await getQuestionsForNewEnv(inputs);
   const core = ctx.self as FxCore;
   if (getQuestionRes.isErr()) {
@@ -263,7 +270,10 @@ export async function askNewEnvironment(
     );
   }
 
-  return inputs.newTargetEnvName;
+  return {
+    targetEnvName: inputs.newTargetEnvName,
+    sourceEnvName: inputs.sourceEnvName,
+  };
 }
 
 async function useUserSetEnv(ctx: CoreHookContext, inputs: Inputs): Promise<string | undefined> {
@@ -315,6 +325,19 @@ async function getQuestionsForNewEnv(
   }
 
   const node = new QTreeNode(getQuestionNewTargetEnvironmentName(inputs.projectPath));
+
+  const envProfilesResult = await environmentManager.listEnvConfigs(inputs.projectPath);
+  if (envProfilesResult.isErr()) {
+    return err(envProfilesResult.error);
+  }
+
+  const envList = reOrderEnvironments(envProfilesResult.value);
+  const selectSourceEnv = QuestionSelectSourceEnvironment;
+  selectSourceEnv.staticOptions = envList;
+  selectSourceEnv.default = activeEnv;
+
+  const selectSourceEnvNode = new QTreeNode(selectSourceEnv);
+  node.addChild(selectSourceEnvNode);
 
   return ok(node.trim());
 }

--- a/packages/fx-core/src/core/question.ts
+++ b/packages/fx-core/src/core/question.ts
@@ -23,6 +23,7 @@ export enum CoreQuestionNames {
   Samples = "samples",
   Stage = "stage",
   SubStage = "substage",
+  SourceEnvName = "sourceEnvName",
   TargetEnvName = "targetEnvName",
   TargetResourceGroupName = "targetResourceGroupName",
   NewResourceGroupName = "newResourceGroupName",
@@ -134,6 +135,15 @@ export function getQuestionNewTargetEnvironmentName(projectPath: string): TextIn
     placeholder: "New environment name",
   };
 }
+
+export const QuestionSelectSourceEnvironment: SingleSelectQuestion = {
+  type: "singleSelect",
+  name: CoreQuestionNames.SourceEnvName,
+  title: "Select an environment to create copy",
+  staticOptions: [],
+  skipSingleOption: true,
+  forgetLastValue: true,
+};
 
 export const QuestionSelectResourceGroup: SingleSelectQuestion = {
   type: "singleSelect",

--- a/packages/fx-core/src/core/v2/index.ts
+++ b/packages/fx-core/src/core/v2/index.ts
@@ -6,6 +6,7 @@ import {
   AppPackageFolderName,
   ArchiveFolderName,
   ArchiveLogFileName,
+  AzureSolutionSettings,
   ConfigFolderName,
   Core,
   err,
@@ -25,6 +26,7 @@ import {
   Solution,
   SolutionConfig,
   SolutionContext,
+  SolutionSettings,
   Stage,
   TelemetryReporter,
   Tools,
@@ -39,9 +41,11 @@ import { downloadSample, FxCore, LoadSolutionError, NotImplementedError } from "
 import { environmentManager } from "../../";
 import { globalStateUpdate } from "../../common/globalState";
 import { isArmSupportEnabled, isMultiEnvEnabled } from "../../common/tools";
-import { getParameterJson } from "../../plugins/solution/fx-solution/arm";
+import { copyParameterJson, getParameterJson } from "../../plugins/solution/fx-solution/arm";
+import { HostTypeOptionAzure } from "../../plugins/solution/fx-solution/question";
 import { LocalCrypto } from "../crypto";
 import {
+  CopyFileError,
   InvalidInputError,
   NonExistEnvNameError,
   ProjectFolderExistError,
@@ -636,7 +640,7 @@ export class FxCoreV2 implements Core {
             description: "",
             author: "",
             scripts: {
-              test: "echo \"Error: no test specified\" && exit 1",
+              test: 'echo "Error: no test specified" && exit 1',
             },
             devDependencies: {
               "@microsoft/teamsfx-cli": "0.*",
@@ -698,22 +702,27 @@ export class FxCoreV2 implements Core {
       return ok(Void);
     }
 
-    const targetEnvName = await askNewEnvironment(ctx!, inputs);
+    const core = ctx!.self as FxCore;
+    const createEnvCopyInput = await askNewEnvironment(ctx!, inputs);
 
-    if (!targetEnvName) {
+    if (
+      !createEnvCopyInput ||
+      !createEnvCopyInput.targetEnvName ||
+      !createEnvCopyInput.sourceEnvName
+    ) {
       return ok(Void);
     }
 
-    if (targetEnvName) {
-      const createEnvResult = await this.createEnvWithName(
-        targetEnvName,
-        projectSettings,
-        inputs,
-        this
-      );
-      if (createEnvResult.isErr()) {
-        return createEnvResult;
-      }
+    const createEnvResult = await this.createEnvCopy(
+      createEnvCopyInput.targetEnvName,
+      createEnvCopyInput.sourceEnvName,
+      projectSettings,
+      inputs,
+      core
+    );
+
+    if (createEnvResult.isErr()) {
+      return createEnvResult;
     }
 
     return ok(Void);
@@ -740,7 +749,7 @@ export class FxCoreV2 implements Core {
       }: ${JSON.stringify(newEnvConfig)}`
     );
 
-    if (isArmSupportEnabled()) {
+    if (isArmSupportEnabled() && isAzureProject(projectSettings.solutionSettings)) {
       const solutionContext: SolutionContext = {
         projectSettings,
         envInfo: newEnvInfo(targetEnvName),
@@ -755,6 +764,58 @@ export class FxCoreV2 implements Core {
       };
 
       await getParameterJson(solutionContext);
+    }
+
+    return ok(Void);
+  }
+
+  async createEnvCopy(
+    targetEnvName: string,
+    sourceEnvName: string,
+    projectSettings: ProjectSettings,
+    inputs: Inputs,
+    core: FxCore
+  ): Promise<Result<Void, FxError>> {
+    // copy env config file
+    const targetEnvConfigFilePath = environmentManager.getEnvConfigPath(
+      targetEnvName,
+      inputs.projectPath!
+    );
+    const sourceEnvConfigFilePath = environmentManager.getEnvConfigPath(
+      sourceEnvName,
+      inputs.projectPath!
+    );
+
+    try {
+      await fs.copy(sourceEnvConfigFilePath, targetEnvConfigFilePath);
+    } catch (e) {
+      return err(CopyFileError(e));
+    }
+
+    core.tools.logProvider.debug(
+      `[core] copy env config file for ${targetEnvName} environment to path ${targetEnvConfigFilePath}`
+    );
+
+    // copy bicep parameter file
+    if (isArmSupportEnabled() && isAzureProject(projectSettings.solutionSettings)) {
+      const solutionContext: SolutionContext = {
+        projectSettings,
+        envInfo: newEnvInfo(targetEnvName),
+        root: inputs.projectPath || "",
+        ...core.tools,
+        ...core.tools.tokenProvider,
+        answers: inputs,
+        cryptoProvider: new LocalCrypto(projectSettings.projectId),
+        permissionRequestProvider: inputs.projectPath
+          ? new PermissionRequestFileProvider(inputs.projectPath)
+          : undefined,
+      };
+
+      try {
+        await copyParameterJson(solutionContext, sourceEnvName);
+      } catch (e) {
+        return err(CopyFileError(e));
+      }
     }
 
     return ok(Void);
@@ -822,4 +883,9 @@ export function newProjectSettings() {
     },
   };
   return projectSettings;
+}
+
+function isAzureProject(solutionSettings: SolutionSettings): boolean {
+  const settings = solutionSettings as AzureSolutionSettings;
+  return settings?.hostType === HostTypeOptionAzure.id;
 }

--- a/packages/fx-core/src/plugins/solution/fx-solution/arm.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/arm.ts
@@ -299,6 +299,24 @@ export async function deployArmTemplates(ctx: SolutionContext): Promise<Result<v
   return result;
 }
 
+export async function copyParameterJson(ctx: SolutionContext, sourceEnvName: string) {
+  if (!isMultiEnvEnabled() || !ctx.envInfo?.envName || !sourceEnvName) {
+    return;
+  }
+
+  const parameterFolderPath = path.join(ctx.root, configsFolder);
+  const targetParameterFileName = parameterFileNameTemplateNew.replace(
+    "@envName",
+    ctx.envInfo.envName
+  );
+  const sourceParameterFileName = parameterFileNameTemplateNew.replace("@envName", sourceEnvName);
+  const targetParameterFilePath = path.join(parameterFolderPath, targetParameterFileName);
+  const sourceParameterFilePath = path.join(parameterFolderPath, sourceParameterFileName);
+
+  await fs.ensureDir(parameterFolderPath);
+  await fs.copy(sourceParameterFilePath, targetParameterFilePath);
+}
+
 export async function getParameterJson(ctx: SolutionContext) {
   if (!ctx.envInfo?.envName) {
     throw new Error("Failed to get target environment name from solution context.");

--- a/packages/fx-core/tests/core/core.test.ts
+++ b/packages/fx-core/tests/core/core.test.ts
@@ -29,6 +29,7 @@ import fs from "fs-extra";
 import * as path from "path";
 import * as os from "os";
 import {
+  environmentManager,
   FunctionRouterError,
   FxCore,
   InvalidInputError,
@@ -75,8 +76,9 @@ describe("Core basic APIs", () => {
       projectPath: projectPath,
       solution: mockSolution.name,
     };
-    sandbox.stub<any, any>(ui, "inputText").callsFake(
-      async (config: InputTextConfig): Promise<Result<InputTextResult, FxError>> => {
+    sandbox
+      .stub<any, any>(ui, "inputText")
+      .callsFake(async (config: InputTextConfig): Promise<Result<InputTextResult, FxError>> => {
         if (config.name === CoreQuestionNames.AppName) {
           return ok({
             type: "success",
@@ -84,30 +86,33 @@ describe("Core basic APIs", () => {
           });
         }
         throw err(InvalidInputError("invalid question"));
-      }
-    );
-    sandbox.stub<any, any>(ui, "selectFolder").callsFake(
-      async (config: SelectFolderConfig): Promise<Result<SelectFolderResult, FxError>> => {
-        if (config.name === CoreQuestionNames.Folder) {
-          return ok({
-            type: "success",
-            result: expectedInputs[CoreQuestionNames.Folder] as string,
-          });
+      });
+    sandbox
+      .stub<any, any>(ui, "selectFolder")
+      .callsFake(
+        async (config: SelectFolderConfig): Promise<Result<SelectFolderResult, FxError>> => {
+          if (config.name === CoreQuestionNames.Folder) {
+            return ok({
+              type: "success",
+              result: expectedInputs[CoreQuestionNames.Folder] as string,
+            });
+          }
+          throw err(InvalidInputError("invalid question"));
         }
-        throw err(InvalidInputError("invalid question"));
-      }
-    );
-    sandbox.stub<any, any>(ui, "selectOption").callsFake(
-      async (config: SingleSelectConfig): Promise<Result<SingleSelectResult, FxError>> => {
-        if (config.name === CoreQuestionNames.CreateFromScratch) {
-          return ok({
-            type: "success",
-            result: expectedInputs[CoreQuestionNames.CreateFromScratch] as string,
-          });
+      );
+    sandbox
+      .stub<any, any>(ui, "selectOption")
+      .callsFake(
+        async (config: SingleSelectConfig): Promise<Result<SingleSelectResult, FxError>> => {
+          if (config.name === CoreQuestionNames.CreateFromScratch) {
+            return ok({
+              type: "success",
+              result: expectedInputs[CoreQuestionNames.CreateFromScratch] as string,
+            });
+          }
+          throw err(InvalidInputError("invalid question"));
         }
-        throw err(InvalidInputError("invalid question"));
-      }
-    );
+      );
     const core = new FxCore(tools);
     {
       const inputs: Inputs = { platform: Platform.CLI };
@@ -282,31 +287,35 @@ describe("Core basic APIs", () => {
       [CoreQuestionNames.CreateFromScratch]: ScratchOptionNoVSC.id,
       [CoreQuestionNames.Samples]: sampleOption,
     };
-    sandbox.stub<any, any>(ui, "selectFolder").callsFake(
-      async (config: SelectFolderConfig): Promise<Result<SelectFolderResult, FxError>> => {
-        if (config.name === CoreQuestionNames.Folder) {
-          return ok({
-            type: "success",
-            result: expectedInputs[CoreQuestionNames.Folder] as string,
-          });
+    sandbox
+      .stub<any, any>(ui, "selectFolder")
+      .callsFake(
+        async (config: SelectFolderConfig): Promise<Result<SelectFolderResult, FxError>> => {
+          if (config.name === CoreQuestionNames.Folder) {
+            return ok({
+              type: "success",
+              result: expectedInputs[CoreQuestionNames.Folder] as string,
+            });
+          }
+          throw err(InvalidInputError("invalid question"));
         }
-        throw err(InvalidInputError("invalid question"));
-      }
-    );
-    sandbox.stub<any, any>(ui, "selectOption").callsFake(
-      async (config: SingleSelectConfig): Promise<Result<SingleSelectResult, FxError>> => {
-        if (config.name === CoreQuestionNames.CreateFromScratch) {
-          return ok({
-            type: "success",
-            result: expectedInputs[CoreQuestionNames.CreateFromScratch] as string,
-          });
+      );
+    sandbox
+      .stub<any, any>(ui, "selectOption")
+      .callsFake(
+        async (config: SingleSelectConfig): Promise<Result<SingleSelectResult, FxError>> => {
+          if (config.name === CoreQuestionNames.CreateFromScratch) {
+            return ok({
+              type: "success",
+              result: expectedInputs[CoreQuestionNames.CreateFromScratch] as string,
+            });
+          }
+          if (config.name === CoreQuestionNames.Samples) {
+            return ok({ type: "success", result: sampleOption });
+          }
+          throw err(InvalidInputError("invalid question"));
         }
-        if (config.name === CoreQuestionNames.Samples) {
-          return ok({ type: "success", result: sampleOption });
-        }
-        throw err(InvalidInputError("invalid question"));
-      }
-    );
+      );
     const core = new FxCore(tools);
     {
       const inputs: Inputs = { platform: Platform.CLI };
@@ -400,8 +409,9 @@ describe("Core basic APIs", () => {
       [CoreQuestionNames.CreateFromScratch]: ScratchOptionYesVSC.id,
       solution: mockSolution.name,
     };
-    sandbox.stub<any, any>(ui, "inputText").callsFake(
-      async (config: InputTextConfig): Promise<Result<InputTextResult, FxError>> => {
+    sandbox
+      .stub<any, any>(ui, "inputText")
+      .callsFake(async (config: InputTextConfig): Promise<Result<InputTextResult, FxError>> => {
         if (config.name === CoreQuestionNames.AppName) {
           return ok({
             type: "success",
@@ -409,30 +419,33 @@ describe("Core basic APIs", () => {
           });
         }
         throw err(InvalidInputError("invalid question"));
-      }
-    );
-    sandbox.stub<any, any>(ui, "selectFolder").callsFake(
-      async (config: SelectFolderConfig): Promise<Result<SelectFolderResult, FxError>> => {
-        if (config.name === CoreQuestionNames.Folder) {
-          return ok({
-            type: "success",
-            result: expectedInputs[CoreQuestionNames.Folder] as string,
-          });
+      });
+    sandbox
+      .stub<any, any>(ui, "selectFolder")
+      .callsFake(
+        async (config: SelectFolderConfig): Promise<Result<SelectFolderResult, FxError>> => {
+          if (config.name === CoreQuestionNames.Folder) {
+            return ok({
+              type: "success",
+              result: expectedInputs[CoreQuestionNames.Folder] as string,
+            });
+          }
+          throw err(InvalidInputError("invalid question"));
         }
-        throw err(InvalidInputError("invalid question"));
-      }
-    );
-    sandbox.stub<any, any>(ui, "selectOption").callsFake(
-      async (config: SingleSelectConfig): Promise<Result<SingleSelectResult, FxError>> => {
-        if (config.name === CoreQuestionNames.CreateFromScratch) {
-          return ok({
-            type: "success",
-            result: expectedInputs[CoreQuestionNames.CreateFromScratch] as string,
-          });
+      );
+    sandbox
+      .stub<any, any>(ui, "selectOption")
+      .callsFake(
+        async (config: SingleSelectConfig): Promise<Result<SingleSelectResult, FxError>> => {
+          if (config.name === CoreQuestionNames.CreateFromScratch) {
+            return ok({
+              type: "success",
+              result: expectedInputs[CoreQuestionNames.CreateFromScratch] as string,
+            });
+          }
+          throw err(InvalidInputError("invalid question"));
         }
-        throw err(InvalidInputError("invalid question"));
-      }
-    );
+      );
 
     const core = new FxCore(tools);
     const inputs: Inputs = { platform: Platform.CLI };
@@ -480,31 +493,38 @@ describe("Core basic APIs", () => {
       assert.isTrue(res.isErr() && res.error.name === FunctionRouterError(func).name);
     }
 
-    sandbox.stub<any, any>(mockSolution, "getQuestions").callsFake(
-      async (
-        task: Stage,
-        ctx: SolutionContext
-      ): Promise<Result<QTreeNode | undefined, FxError>> => {
-        return ok(
-          new QTreeNode({
-            type: "text",
-            name: "mock-question",
-            title: "mock-question",
-          })
-        );
-      }
-    );
-    sandbox.stub<any, any>(mockSolution, "getQuestionsForUserTask").callsFake(
-      async (func: Func, ctx: SolutionContext): Promise<Result<QTreeNode | undefined, FxError>> => {
-        return ok(
-          new QTreeNode({
-            type: "text",
-            name: "mock-question-user-task",
-            title: "mock-question-user-task",
-          })
-        );
-      }
-    );
+    sandbox
+      .stub<any, any>(mockSolution, "getQuestions")
+      .callsFake(
+        async (
+          task: Stage,
+          ctx: SolutionContext
+        ): Promise<Result<QTreeNode | undefined, FxError>> => {
+          return ok(
+            new QTreeNode({
+              type: "text",
+              name: "mock-question",
+              title: "mock-question",
+            })
+          );
+        }
+      );
+    sandbox
+      .stub<any, any>(mockSolution, "getQuestionsForUserTask")
+      .callsFake(
+        async (
+          func: Func,
+          ctx: SolutionContext
+        ): Promise<Result<QTreeNode | undefined, FxError>> => {
+          return ok(
+            new QTreeNode({
+              type: "text",
+              name: "mock-question-user-task",
+              title: "mock-question-user-task",
+            })
+          );
+        }
+      );
 
     {
       const inputs: Inputs = { platform: Platform.VS };
@@ -541,8 +561,9 @@ describe("Core basic APIs", () => {
       projectPath: projectPath,
       solution: mockSolution.name,
     };
-    sandbox.stub<any, any>(ui, "inputText").callsFake(
-      async (config: InputTextConfig): Promise<Result<InputTextResult, FxError>> => {
+    sandbox
+      .stub<any, any>(ui, "inputText")
+      .callsFake(async (config: InputTextConfig): Promise<Result<InputTextResult, FxError>> => {
         if (config.name === CoreQuestionNames.AppName) {
           return ok({
             type: "success",
@@ -550,30 +571,33 @@ describe("Core basic APIs", () => {
           });
         }
         throw err(InvalidInputError("invalid question"));
-      }
-    );
-    sandbox.stub<any, any>(ui, "selectFolder").callsFake(
-      async (config: SelectFolderConfig): Promise<Result<SelectFolderResult, FxError>> => {
-        if (config.name === CoreQuestionNames.Folder) {
-          return ok({
-            type: "success",
-            result: expectedInputs[CoreQuestionNames.Folder] as string,
-          });
+      });
+    sandbox
+      .stub<any, any>(ui, "selectFolder")
+      .callsFake(
+        async (config: SelectFolderConfig): Promise<Result<SelectFolderResult, FxError>> => {
+          if (config.name === CoreQuestionNames.Folder) {
+            return ok({
+              type: "success",
+              result: expectedInputs[CoreQuestionNames.Folder] as string,
+            });
+          }
+          throw err(InvalidInputError("invalid question"));
         }
-        throw err(InvalidInputError("invalid question"));
-      }
-    );
-    sandbox.stub<any, any>(ui, "selectOption").callsFake(
-      async (config: SingleSelectConfig): Promise<Result<SingleSelectResult, FxError>> => {
-        if (config.name === CoreQuestionNames.CreateFromScratch) {
-          return ok({
-            type: "success",
-            result: expectedInputs[CoreQuestionNames.CreateFromScratch] as string,
-          });
+      );
+    sandbox
+      .stub<any, any>(ui, "selectOption")
+      .callsFake(
+        async (config: SingleSelectConfig): Promise<Result<SingleSelectResult, FxError>> => {
+          if (config.name === CoreQuestionNames.CreateFromScratch) {
+            return ok({
+              type: "success",
+              result: expectedInputs[CoreQuestionNames.CreateFromScratch] as string,
+            });
+          }
+          throw err(InvalidInputError("invalid question"));
         }
-        throw err(InvalidInputError("invalid question"));
-      }
-    );
+      );
     const core = new FxCore(tools);
     {
       const inputs: Inputs = { platform: Platform.CLI };
@@ -631,8 +655,9 @@ describe("Core basic APIs", () => {
         expectedInputs[CoreQuestionNames.AppName] = testParam.appName;
       }
 
-      sandbox.stub<any, any>(ui, "inputText").callsFake(
-        async (config: InputTextConfig): Promise<Result<InputTextResult, FxError>> => {
+      sandbox
+        .stub<any, any>(ui, "inputText")
+        .callsFake(async (config: InputTextConfig): Promise<Result<InputTextResult, FxError>> => {
           if (config.name === CoreQuestionNames.AppName) {
             return ok({
               type: "success",
@@ -640,8 +665,7 @@ describe("Core basic APIs", () => {
             });
           }
           throw err(InvalidInputError("invalid question"));
-        }
-      );
+        });
       const core = new FxCore(tools);
       {
         const inputs: Inputs = { platform: Platform.VSCode, projectPath: testParam.projectPath };
@@ -689,7 +713,7 @@ describe("Core basic APIs", () => {
   ];
 
   envParameters.forEach((testParam) => {
-    it(`happy path: create new env`, async () => {
+    it(`happy path: scaffold and create new env copy`, async () => {
       const expectedInputs: Inputs = {
         platform: Platform.CLI,
         [CoreQuestionNames.AppName]: appName,
@@ -698,8 +722,11 @@ describe("Core basic APIs", () => {
         projectPath: projectPath,
         solution: mockSolution.name,
       };
-      sandbox.stub<any, any>(ui, "inputText").callsFake(
-        async (config: InputTextConfig): Promise<Result<InputTextResult, FxError>> => {
+
+      const newEnvName = "newEnv";
+      sandbox
+        .stub<any, any>(ui, "inputText")
+        .callsFake(async (config: InputTextConfig): Promise<Result<InputTextResult, FxError>> => {
           if (config.name === CoreQuestionNames.AppName) {
             return ok({
               type: "success",
@@ -709,34 +736,37 @@ describe("Core basic APIs", () => {
           if (config.name === CoreQuestionNames.NewTargetEnvName) {
             return ok({
               type: "success",
-              result: "newEnv",
+              result: newEnvName,
             });
           }
           throw err(InvalidInputError("invalid question"));
-        }
-      );
-      sandbox.stub<any, any>(ui, "selectFolder").callsFake(
-        async (config: SelectFolderConfig): Promise<Result<SelectFolderResult, FxError>> => {
-          if (config.name === CoreQuestionNames.Folder) {
-            return ok({
-              type: "success",
-              result: expectedInputs[CoreQuestionNames.Folder] as string,
-            });
+        });
+      sandbox
+        .stub<any, any>(ui, "selectFolder")
+        .callsFake(
+          async (config: SelectFolderConfig): Promise<Result<SelectFolderResult, FxError>> => {
+            if (config.name === CoreQuestionNames.Folder) {
+              return ok({
+                type: "success",
+                result: expectedInputs[CoreQuestionNames.Folder] as string,
+              });
+            }
+            throw err(InvalidInputError("invalid question"));
           }
-          throw err(InvalidInputError("invalid question"));
-        }
-      );
-      sandbox.stub<any, any>(ui, "selectOption").callsFake(
-        async (config: SingleSelectConfig): Promise<Result<SingleSelectResult, FxError>> => {
-          if (config.name === CoreQuestionNames.CreateFromScratch) {
-            return ok({
-              type: "success",
-              result: expectedInputs[CoreQuestionNames.CreateFromScratch] as string,
-            });
+        );
+      sandbox
+        .stub<any, any>(ui, "selectOption")
+        .callsFake(
+          async (config: SingleSelectConfig): Promise<Result<SingleSelectResult, FxError>> => {
+            if (config.name === CoreQuestionNames.CreateFromScratch) {
+              return ok({
+                type: "success",
+                result: expectedInputs[CoreQuestionNames.CreateFromScratch] as string,
+              });
+            }
+            throw err(InvalidInputError("invalid question"));
           }
-          throw err(InvalidInputError("invalid question"));
-        }
-      );
+        );
       sandbox.stub(commonTools, "isMultiEnvEnabled").returns(true);
       const core = new FxCore(tools);
       {
@@ -750,12 +780,28 @@ describe("Core basic APIs", () => {
           assert.fail("failed to load project settings");
         }
 
+        // assert default env is created on scaffold
+        const envListResult = await environmentManager.listEnvConfigs(inputs.projectPath!);
+        if (envListResult.isErr()) {
+          assert.fail("failed to list env names");
+        }
+        assert.isTrue(envListResult.value.length === 1);
+        assert.isTrue(envListResult.value[0] === environmentManager.getDefaultEnvName());
+
         const [projectSettings, projectIdMissing] = projectSettingsResult.value;
         const validSettingsResult = validateSettings(projectSettings);
         assert.isTrue(validSettingsResult === undefined);
 
         const createEnvRes = await core.createEnv(inputs);
         assert.isTrue(createEnvRes.isOk());
+
+        const newEnvListResult = await environmentManager.listEnvConfigs(inputs.projectPath!);
+        if (newEnvListResult.isErr()) {
+          assert.fail("failed to list env names");
+        }
+        assert.isTrue(newEnvListResult.value.length === 2);
+        assert.isTrue(newEnvListResult.value[0] === environmentManager.getDefaultEnvName());
+        assert.isTrue(newEnvListResult.value[1] === newEnvName);
       }
     });
   });


### PR DESCRIPTION
## User experience for adding environment:
1. On scaffold, a default environment "dev" will be created for user;
2. When project is scaffolded, user can user "create new environment copy" command to add a new environment.
    -  User need to provide an existing environment name to copy (by default, the new env is copied from the active environment)
    - The environment input file (`config.{env}.json` and `azure.parameters.{env}.json`) are copied from the specified env.
    
## Steps to add new env copy:
Select "+" button:
![image](https://user-images.githubusercontent.com/10163840/132462690-825c52fb-2c9a-450c-a7c0-783be15c9f8a.png)

Provide new environment name:
![image](https://user-images.githubusercontent.com/10163840/132461253-b7fe7787-5891-483a-94cf-0077b3c74af5.png)

Select an existing env to create copy (default is the active env):
![image](https://user-images.githubusercontent.com/10163840/132462818-574ea261-b798-49fb-ba92-26441856d806.png)

### Follow-ups:
1. @jayzhang will help to consolidate the duplicate code and sync the behavior between v1 and v2 APIs.
2. @blackchoey will help tp modify the resource base name in bicep parameter file when copy env.
3. @blackchoey will help to remove parameter.template.json.