### PR TITLE
feat(multi-env): add "teamsfx env list" command

### DIFF
--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -1085,6 +1085,8 @@ export enum Stage {
     // (undocumented)
     listCollaborator = "listCollaborator",
     // (undocumented)
+    listEnv = "listEnv",
+    // (undocumented)
     migrateV1 = "migrateV1",
     // (undocumented)
     package = "package",

--- a/packages/api/src/constants.ts
+++ b/packages/api/src/constants.ts
@@ -47,6 +47,7 @@ export enum Stage {
   package = "package",
   publish = "publish",
   createEnv = "createEnv",
+  listEnv = "listEnv",
   removeEnv = "removeEnv",
   switchEnv = "switchEnv",
   userTask = "userTask",

--- a/packages/cli/src/cmds/env.ts
+++ b/packages/cli/src/cmds/env.ts
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+"use strict";
+
+import { Argv, Options } from "yargs";
+
+import { FxError, err, ok, Result, Stage, LogLevel } from "@microsoft/teamsfx-api";
+
+import { YargsCommand } from "../yargsCommand";
+import { environmentManager, isValidProject } from "@microsoft/teamsfx-core";
+import * as process from "process";
+import * as os from "os";
+import CLILogProvider from "../commonlib/log";
+import { WorkspaceNotSupported } from "./preview/errors";
+import HelpParamGenerator from "../helpParamGenerator";
+import activate from "../activate";
+import CliTelemetry from "../telemetry/cliTelemetry";
+import { TelemetryEvent } from "../telemetry/cliTelemetryEvents";
+import { getSystemInputs } from "../utils";
+
+export default class Env extends YargsCommand {
+  public readonly commandHead = `env`;
+  public readonly command = `${this.commandHead} [action]`;
+  public readonly description = "Manage environments.";
+
+  public readonly subCommands: YargsCommand[] = [new EnvList()];
+
+  public builder(yargs: Argv): Argv<any> {
+    yargs.options("action", {
+      description: `${this.subCommands.map((cmd) => cmd.commandHead).join("|")}`,
+      type: "string",
+      choices: this.subCommands.map((cmd) => cmd.commandHead),
+      // Action is not required because we support "teamsfx env" to show current active env.
+      require: false,
+    });
+    this.subCommands.forEach((cmd) => {
+      yargs.command(cmd.command, cmd.description, cmd.builder.bind(cmd), cmd.handler.bind(cmd));
+    });
+    return yargs.version(false);
+  }
+
+  public async runCommand(args: { [argName: string]: string }): Promise<Result<null, FxError>> {
+    // TODO: display current active env info.
+    return ok(null);
+  }
+}
+
+class EnvList extends YargsCommand {
+  public readonly commandHead = `list`;
+  public readonly command = `${this.commandHead}`;
+  public readonly description = "List all environments.";
+  public params: { [_: string]: Options } = {};
+
+  public builder(yargs: Argv): Argv<any> {
+    // TODO: support --details
+    this.params = HelpParamGenerator.getYargsParamForHelp(Stage.listEnv);
+    return yargs.version(false).options(this.params);
+  }
+
+  public async runCommand(args: { [argName: string]: string }): Promise<Result<null, FxError>> {
+    const projectDir = args.folder || process.cwd();
+
+    if (!isValidProject(projectDir)) {
+      return err(WorkspaceNotSupported(projectDir));
+    }
+
+    const envResult = await environmentManager.listEnvConfigs(projectDir);
+    if (envResult.isErr()) {
+      return err(envResult.error);
+    }
+
+    // TODO: support --details
+    const envList = envResult.value.join(os.EOL);
+    CLILogProvider.necessaryLog(LogLevel.Info, envList, true);
+    return ok(null);
+  }
+}

--- a/packages/cli/src/cmds/env.ts
+++ b/packages/cli/src/cmds/env.ts
@@ -8,7 +8,7 @@ import { Argv, Options } from "yargs";
 import { FxError, err, ok, Result, Stage, LogLevel } from "@microsoft/teamsfx-api";
 
 import { YargsCommand } from "../yargsCommand";
-import { environmentManager, isValidProject } from "@microsoft/teamsfx-core";
+import { environmentManager } from "@microsoft/teamsfx-core";
 import * as process from "process";
 import * as os from "os";
 import CLILogProvider from "../commonlib/log";
@@ -17,7 +17,7 @@ import HelpParamGenerator from "../helpParamGenerator";
 import activate from "../activate";
 import CliTelemetry from "../telemetry/cliTelemetry";
 import { TelemetryEvent } from "../telemetry/cliTelemetryEvents";
-import { getSystemInputs } from "../utils";
+import { getSystemInputs, isWorkspaceSupported } from "../utils";
 
 export default class Env extends YargsCommand {
   public readonly commandHead = `env`;
@@ -61,7 +61,7 @@ class EnvList extends YargsCommand {
   public async runCommand(args: { [argName: string]: string }): Promise<Result<null, FxError>> {
     const projectDir = args.folder || process.cwd();
 
-    if (!isValidProject(projectDir)) {
+    if (!isWorkspaceSupported(projectDir)) {
       return err(WorkspaceNotSupported(projectDir));
     }
 

--- a/packages/cli/src/cmds/index.ts
+++ b/packages/cli/src/cmds/index.ts
@@ -20,6 +20,8 @@ import Config from "./config";
 import Preview from "./preview/preview";
 import { isRemoteCollaborationEnabled } from "../utils";
 import Permission from "./permission";
+import { isMultiEnvEnabled } from "@microsoft/teamsfx-core";
+import Env from "./env";
 
 export const commands: YargsCommand[] = [
   new Account(),
@@ -35,6 +37,10 @@ export const commands: YargsCommand[] = [
   new Config(),
   new Preview(),
 ];
+
+if (isMultiEnvEnabled()) {
+  commands.push(new Env());
+}
 
 /**
  * Registers cli and partner commands with yargs.

--- a/packages/cli/tests/unit/cmds/env.tests.ts
+++ b/packages/cli/tests/unit/cmds/env.tests.ts
@@ -1,0 +1,160 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import sinon from "sinon";
+import yargs, { Options } from "yargs";
+import * as dotenv from "dotenv";
+
+import { FxError, Inputs, LogLevel, Result, ok, err, UserError } from "@microsoft/teamsfx-api";
+import * as core from "@microsoft/teamsfx-core";
+
+import Env from "../../../src/cmds/env";
+import CliTelemetry from "../../../src/telemetry/cliTelemetry";
+import { RootFolderNode } from "../../../src/constants";
+import { TelemetryEvent } from "../../../src/telemetry/cliTelemetryEvents";
+import * as constants from "../../../src/constants";
+import LogProvider from "../../../src/commonlib/log";
+import { expect } from "../utils";
+import * as Utils from "../../../src/utils";
+import { UserSettings } from "../../../src/userSetttings";
+import { NonTeamsFxProjectFolder } from "../../../src/error";
+import HelpParamGenerator from "../../../src/helpParamGenerator";
+import { iteratee } from "underscore";
+import { WorkspaceNotSupported } from "../../../src/cmds/preview/errors";
+
+describe("Env List Command Tests", function () {
+  const sandbox = sinon.createSandbox();
+  let registeredCommands: string[] = [];
+  let options: string[] = [];
+  let positionals: string[] = [];
+  let telemetryEvents: string[] = [];
+  let logs = "";
+  let decrypted: string[] = [];
+  let validProject = true;
+  let checkedRootDir = "";
+  let envList = ["dev", "test", "staging"];
+
+  before(() => {
+    sandbox.stub(HelpParamGenerator, "getYargsParamForHelp").callsFake(() => {
+      return {};
+    });
+    sandbox.stub(Utils, "isWorkspaceSupported").callsFake((rootDir: string): boolean => {
+      checkedRootDir = rootDir;
+      return validProject;
+    });
+    sandbox
+      .stub<any, any>(yargs, "command")
+      .callsFake((command: string, description: string, builder: any, handler: any) => {
+        console.log("builder");
+        registeredCommands.push(command);
+        builder(yargs);
+      });
+    sandbox.stub(yargs, "options").callsFake((ops: { [key: string]: Options }) => {
+      if (typeof ops === "string") {
+        options.push(ops);
+      } else {
+        options = options.concat(...Object.keys(ops));
+      }
+      return yargs;
+    });
+    sandbox.stub(yargs, "positional").callsFake((name: string) => {
+      positionals.push(name);
+      return yargs;
+    });
+    sandbox.stub(yargs, "exit").callsFake((code: number, err: Error) => {
+      throw err;
+    });
+    sandbox.stub(CliTelemetry, "sendTelemetryEvent").callsFake((eventName: string) => {
+      telemetryEvents.push(eventName);
+    });
+    sandbox
+      .stub(CliTelemetry, "sendTelemetryErrorEvent")
+      .callsFake((eventName: string, error: FxError) => {
+        telemetryEvents.push(eventName);
+      });
+    sandbox.stub(core.environmentManager, "listEnvConfigs").callsFake(async (projectPath) => {
+      return ok(envList);
+    });
+    sandbox.stub(LogProvider, "necessaryLog").callsFake((level: LogLevel, message: string) => {
+      logs += message + "\n";
+    });
+  });
+
+  after(() => {
+    sandbox.restore();
+  });
+
+  beforeEach(() => {
+    registeredCommands = [];
+    options = [];
+    positionals = [];
+    telemetryEvents = [];
+    logs = "";
+    decrypted = [];
+    validProject = true;
+  });
+
+  it("prints all env names", async () => {
+    // Arrange
+    validProject = true;
+    const cmd = new Env();
+    const args = {};
+
+    // Act
+    await cmd.subCommands[0].handler(args);
+
+    // Assert
+    expect(logs).to.equal("dev\ntest\nstaging\n");
+  });
+
+  it("accepts --folder parameter", async () => {
+    // Arrange
+    validProject = true;
+    const testRootFolder = "test/root/folder";
+    const cmd = new Env();
+    const args = {
+      [constants.RootFolderNode.data.name as string]: testRootFolder,
+    };
+
+    // Act
+    await cmd.subCommands[0].handler(args);
+
+    // Assert
+    expect(checkedRootDir).to.equal(testRootFolder);
+  });
+
+  it("prints nothing without an env", async () => {
+    // Arrange
+    validProject = true;
+    envList = [];
+    const cmd = new Env();
+    const args = {};
+
+    // Act
+    await cmd.subCommands[0].handler(args);
+
+    // Assert
+    expect(logs).to.equal("\n");
+  });
+
+  it("throws on non-Teamsfx project", async () => {
+    // Arrange
+    validProject = false;
+    const cmd = new Env();
+    const args = {};
+    let exceptionThrown = false;
+
+    // Act
+    try {
+      await cmd.subCommands[0].handler(args);
+    } catch (error) {
+      exceptionThrown = true;
+
+      // Assert
+      expect(error).instanceOf(UserError);
+      expect(error.name).equals("WorkspaceNotSupported");
+    }
+
+    expect(exceptionThrown);
+  });
+});

--- a/packages/cli/tests/unit/cmds/env.tests.ts
+++ b/packages/cli/tests/unit/cmds/env.tests.ts
@@ -45,7 +45,6 @@ describe("Env List Command Tests", function () {
     sandbox
       .stub<any, any>(yargs, "command")
       .callsFake((command: string, description: string, builder: any, handler: any) => {
-        console.log("builder");
         registeredCommands.push(command);
         builder(yargs);
       });


### PR DESCRIPTION
- add "teamsfx env list" command. Highlighting current env will be added with activate command in another pr
- add unit test cases for env list
- teamsfx env xxx will only be available with TEAMSFX_MULTI_ENV feature flag

![Screenshot from 2021-09-08 15-49-10](https://user-images.githubusercontent.com/9698542/132468585-03775df5-1f4c-4576-a526-0c3df93eba8b.png)

![Screenshot from 2021-09-08 15-47-22](https://user-images.githubusercontent.com/9698542/132468462-014d7662-1765-43ed-9b37-258e868614d9.png)

