### PR TITLE
chore: send telemetry when fail to read deployment info

### DIFF
--- a/packages/fx-core/src/plugins/resource/frontend/constants.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/constants.ts
@@ -124,6 +124,7 @@ export class TelemetryEvent {
   static readonly PreDeploy = "pre-deploy";
   static readonly Deploy = "deploy";
   static readonly SkipDeploy = "skip-deploy";
+  static readonly DeploymentInfoNotFound = "deployment-info-not-found";
 
   static readonly GenerateArmTemplates = "generate-arm-templates";
   static readonly ExecuteUserTask = "execute-user-task";

--- a/packages/fx-core/src/plugins/resource/frontend/ops/deploy.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/ops/deploy.ts
@@ -155,6 +155,7 @@ export class FrontendDeployment {
     try {
       return await fs.readJSON(deploymentInfoPath);
     } catch {
+      TelemetryHelper.sendGeneralEvent(TelemetryEvent.DeploymentInfoNotFound);
       return undefined;
     }
   }

--- a/packages/fx-core/src/plugins/resource/function/enums.ts
+++ b/packages/fx-core/src/plugins/resource/function/enums.ts
@@ -80,6 +80,7 @@ export enum FunctionEvent {
   callFunc = "call-func",
   scaffoldFallback = "scaffold-fallback",
   skipDeploy = "skip-deploy",
+  DeploymentInfoNotFound = "deployment-info-not-found",
   generateArmTemplates = "generate-arm-templates",
   addResource = "add-resource",
 }


### PR DESCRIPTION
By comparing `count EventName=deployment-info-not-found` and `distinct count MachineId+ProjectId`, we can find out how many users remove the .deployment folder and decide whether to remove the skip deployment feature.