### PR TITLE
refactor(multi-env): move getActiveEnv to core

### DIFF
--- a/packages/cli/src/cmds/config.ts
+++ b/packages/cli/src/cmds/config.ts
@@ -302,7 +302,7 @@ export class ConfigSet extends YargsCommand {
     }
     const writeFileResult = writeSecretToFile(secretData, rootFolder);
     if (writeFileResult.isErr()) {
-      return err(writeFileResult.error);
+      return writeFileResult;
     }
     CLILogProvider.necessaryLog(
       LogLevel.Info,

--- a/packages/cli/src/cmds/config.ts
+++ b/packages/cli/src/cmds/config.ts
@@ -300,7 +300,10 @@ export class ConfigSet extends YargsCommand {
       }
       secretData[option] = encrypted.value;
     }
-    writeSecretToFile(secretData, rootFolder);
+    const writeFileResult = writeSecretToFile(secretData, rootFolder);
+    if (writeFileResult.isErr()) {
+      return err(writeFileResult.error);
+    }
     CLILogProvider.necessaryLog(
       LogLevel.Info,
       `Successfully configured project setting ${option}.`

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -250,7 +250,7 @@ export async function readProjectSecrets(
 export function writeSecretToFile(
   secrets: dotenv.DotenvParseOutput,
   rootFolder: string
-): Result<undefined, FxError> {
+): Result<null, FxError> {
   const envResult = getActiveEnv(rootFolder);
   if (envResult.isErr()) {
     return err(envResult.error);
@@ -267,7 +267,7 @@ export function writeSecretToFile(
   } catch (e) {
     return err(WriteFileError(e));
   }
-  return ok(undefined);
+  return ok(null);
 }
 
 export async function getSolutionPropertyFromEnvFile(

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -126,22 +126,21 @@ export function getConfigPath(projectFolder: string, filePath: string): string {
 
 // TODO: move config read/write utils to core
 export function getEnvFilePath(projectFolder: string): Result<string, FxError> {
-  if (isMultiEnvEnabled()) {
-    const envResult = getActiveEnv(projectFolder);
-    if (envResult.isErr()) {
-      return err(envResult.error);
-    }
-    return ok(
-      path.join(
-        projectFolder,
-        `.${ConfigFolderName}`,
-        PublishProfilesFolderName,
-        EnvProfileFileNameTemplate.replace(EnvNamePlaceholder, envResult.value)
-      )
-    );
-  } else {
+  if (!isMultiEnvEnabled()) {
     return ok(getConfigPath(projectFolder, `env.default.json`));
   }
+  const envResult = getActiveEnv(projectFolder);
+  if (envResult.isErr()) {
+    return err(envResult.error);
+  }
+  return ok(
+    path.join(
+      projectFolder,
+      `.${ConfigFolderName}`,
+      PublishProfilesFolderName,
+      EnvProfileFileNameTemplate.replace(EnvNamePlaceholder, envResult.value)
+    )
+  );
 }
 
 export function getSettingsFilePath(projectFolder: string) {
@@ -182,9 +181,7 @@ export async function readEnvJsonFile(projectFolder: string): Promise<Result<Jso
     return err(filePathResult.error);
   }
   const filePath = filePathResult.value;
-  try {
-    fs.stat(filePath);
-  } catch (error) {
+  if (!fs.existsSync(filePath)) {
     return err(ConfigNotFoundError(filePath));
   }
   try {
@@ -201,9 +198,7 @@ export function readEnvJsonFileSync(projectFolder: string): Result<Json, FxError
     return err(filePathResult.error);
   }
   const filePath = filePathResult.value;
-  try {
-    fs.stat(filePath);
-  } catch (error) {
+  if (!fs.existsSync(filePath)) {
     return err(ConfigNotFoundError(filePath));
   }
   try {

--- a/packages/cli/tests/unit/cmds/config.tests.ts
+++ b/packages/cli/tests/unit/cmds/config.tests.ts
@@ -318,9 +318,12 @@ describe("Config Set Command Check", () => {
       });
     sandbox
       .stub(Utils, "writeSecretToFile")
-      .callsFake((secrets: dotenv.DotenvParseOutput, rootFolder: string): void => {
-        secretFile = secrets;
-      });
+      .callsFake(
+        (secrets: dotenv.DotenvParseOutput, rootFolder: string): Result<undefined, FxError> => {
+          secretFile = secrets;
+          return ok(undefined);
+        }
+      );
     sandbox
       .stub(Utils, "readProjectSecrets")
       .returns(Promise.resolve(ok(dotenv.parse("fx-resource-bot.botPassword=password\ntest=abc"))));

--- a/packages/cli/tests/unit/cmds/config.tests.ts
+++ b/packages/cli/tests/unit/cmds/config.tests.ts
@@ -318,12 +318,10 @@ describe("Config Set Command Check", () => {
       });
     sandbox
       .stub(Utils, "writeSecretToFile")
-      .callsFake(
-        (secrets: dotenv.DotenvParseOutput, rootFolder: string): Result<undefined, FxError> => {
-          secretFile = secrets;
-          return ok(undefined);
-        }
-      );
+      .callsFake((secrets: dotenv.DotenvParseOutput, rootFolder: string): Result<null, FxError> => {
+        secretFile = secrets;
+        return ok(null);
+      });
     sandbox
       .stub(Utils, "readProjectSecrets")
       .returns(Promise.resolve(ok(dotenv.parse("fx-resource-bot.botPassword=password\ntest=abc"))));

--- a/packages/fx-core/src/core/error.ts
+++ b/packages/fx-core/src/core/error.ts
@@ -110,6 +110,14 @@ export class ConcurrentError extends UserError {
   }
 }
 
+export function InvalidProjectSettingsFileError(msg?: string): UserError {
+  return newUserError(
+    CoreSource,
+    "InvalidProjectSettingsFile",
+    `The projectSettings.json file is corrupted.`
+  );
+}
+
 export function TaskNotSupportError(task: Stage | string): SystemError {
   return newSystemError(CoreSource, "TaskNotSupport", `Task is not supported yet: ${task}`);
 }

--- a/packages/fx-core/src/core/tools.ts
+++ b/packages/fx-core/src/core/tools.ts
@@ -108,7 +108,7 @@ export function validateSettings(projectSettings?: ProjectSettings): string | un
       !projectSettings.activeEnvironment ||
       typeof projectSettings.activeEnvironment !== "string"
     ) {
-      return `activeEnvironment is missing or not a string in settings.json`;
+      return `activeEnvironment is missing or not a string in ${ProjectSettingsFileName}`;
     }
   }
   return undefined;

--- a/packages/fx-core/src/core/tools.ts
+++ b/packages/fx-core/src/core/tools.ts
@@ -11,6 +11,10 @@ import {
   ProjectSettingsFileName,
   EnvConfig,
   InputConfigsFolderName,
+  err,
+  FxError,
+  Result,
+  ok,
 } from "@microsoft/teamsfx-api";
 import * as path from "path";
 import * as fs from "fs-extra";
@@ -25,9 +29,9 @@ import {
   TabOptionItem,
 } from "../plugins/solution/fx-solution/question";
 import { environmentManager } from "./environment";
-import * as dotenv from "dotenv";
 import { ConstantString } from "../common/constants";
 import { isMultiEnvEnabled } from "../common";
+import { InvalidProjectError, InvalidProjectSettingsFileError, ReadFileError } from ".";
 
 export function validateProject(solutionContext: SolutionContext): string | undefined {
   const res = validateSettings(solutionContext.projectSettings);
@@ -98,6 +102,15 @@ export function validateSettings(projectSettings?: ProjectSettings): string | un
         return `${PluginNames.APIM} setting is missing in settings.json`;
     }
   }
+
+  if (isMultiEnvEnabled()) {
+    if (
+      !projectSettings.activeEnvironment ||
+      typeof projectSettings.activeEnvironment !== "string"
+    ) {
+      return `activeEnvironment is missing or not a string in settings.json`;
+    }
+  }
   return undefined;
 }
 
@@ -119,22 +132,49 @@ export function isValidProject(workspacePath?: string): boolean {
   }
 }
 
-export function getActiveEnv(projectRoot: string): string | undefined {
+// TODO: add an async version
+export function getActiveEnv(projectRoot: string): Result<string, FxError> {
   if (!isMultiEnvEnabled()) {
-    return "default";
+    return ok("default");
   }
+  if (!isValidProject(projectRoot)) {
+    return err(InvalidProjectError());
+  }
+  const settingsJsonPath = path.join(
+    projectRoot,
+    `.${ConfigFolderName}/${InputConfigsFolderName}/${ProjectSettingsFileName}`
+  );
+  let settingsContent;
   try {
-    if (isValidProject(projectRoot)) {
-      const settingsJsonPath = path.join(
-        projectRoot,
-        `.${ConfigFolderName}/${InputConfigsFolderName}/${ProjectSettingsFileName}`
-      );
-      const settingsJson = JSON.parse(fs.readFileSync(settingsJsonPath, "utf8"));
-      return settingsJson.activeEnvironment;
-    }
-  } catch (e) {
-    return undefined;
+    settingsContent = fs.readFileSync(settingsJsonPath, "utf8");
+  } catch (error) {
+    return err(ReadFileError(error));
   }
+
+  let settingsJson;
+  try {
+    settingsJson = JSON.parse(settingsContent);
+  } catch (error) {
+    return err(
+      InvalidProjectSettingsFileError(
+        `Project settings file is not a valid JSON, error: '${error}'`
+      )
+    );
+  }
+
+  if (
+    !settingsJson ||
+    !settingsJson.activeEnvironment ||
+    typeof settingsJson.activeEnvironment !== "string"
+  ) {
+    return err(
+      InvalidProjectSettingsFileError(
+        "The property 'activeEnvironment' does not exist in project settings file."
+      )
+    );
+  }
+
+  return ok(settingsJson.activeEnvironment as string);
 }
 
 export async function validateV1Project(

--- a/packages/fx-core/src/core/tools.ts
+++ b/packages/fx-core/src/core/tools.ts
@@ -10,6 +10,7 @@ import {
   V1ManifestFileName,
   ProjectSettingsFileName,
   EnvConfig,
+  InputConfigsFolderName,
 } from "@microsoft/teamsfx-api";
 import * as path from "path";
 import * as fs from "fs-extra";
@@ -115,6 +116,24 @@ export function isValidProject(workspacePath?: string): boolean {
     return true;
   } catch (e) {
     return false;
+  }
+}
+
+export function getActiveEnv(projectRoot: string): string | undefined {
+  if (!isMultiEnvEnabled()) {
+    return "default";
+  }
+  try {
+    if (isValidProject(projectRoot)) {
+      const settingsJsonPath = path.join(
+        projectRoot,
+        `.${ConfigFolderName}/${InputConfigsFolderName}/${ProjectSettingsFileName}`
+      );
+      const settingsJson = JSON.parse(fs.readFileSync(settingsJsonPath, "utf8"));
+      return settingsJson.activeEnvironment;
+    }
+  } catch (e) {
+    return undefined;
   }
 }
 

--- a/packages/vscode-extension/src/debug/commonUtils.ts
+++ b/packages/vscode-extension/src/debug/commonUtils.ts
@@ -15,9 +15,13 @@ import {
 import { core, getSystemInputs, showError } from "../handlers";
 import * as net from "net";
 import { ext } from "../extensionVariables";
-import { getActiveEnv } from "../utils/commonUtils";
 import { initializeFocusRects } from "@fluentui/utilities";
-import { isMultiEnvEnabled, isValidProject, isMigrateFromV1Project } from "@microsoft/teamsfx-core";
+import {
+  isMultiEnvEnabled,
+  isValidProject,
+  isMigrateFromV1Project,
+  getActiveEnv,
+} from "@microsoft/teamsfx-core";
 
 export async function getProjectRoot(
   folderPath: string,
@@ -257,7 +261,7 @@ function getSettingWithUserData(jsonSelector: (jsonObject: any) => any): string 
   if (ext.workspaceUri) {
     const ws = ext.workspaceUri.fsPath;
     if (isValidProject(ws)) {
-      const env = getActiveEnv();
+      const env = getActiveEnv(ws);
       const envJsonPath = isMultiEnvEnabled()
         ? path.join(ws, `.${ConfigFolderName}/${PublishProfilesFolderName}/profile.${env}.json`)
         : path.join(ws, `.${ConfigFolderName}/env.${env}.json`);

--- a/packages/vscode-extension/src/envTree.ts
+++ b/packages/vscode-extension/src/envTree.ts
@@ -2,10 +2,14 @@
 // Licensed under the MIT license.
 
 import { FxError, Result, err, ok, Void, TreeCategory } from "@microsoft/teamsfx-api";
-import { isMultiEnvEnabled, environmentManager, setActiveEnv } from "@microsoft/teamsfx-core";
+import {
+  isMultiEnvEnabled,
+  environmentManager,
+  setActiveEnv,
+  getActiveEnv,
+} from "@microsoft/teamsfx-core";
 import * as vscode from "vscode";
 import TreeViewManagerInstance, { CommandsTreeViewProvider } from "./commandsTreeViewProvider";
-import { getActiveEnv } from "./utils/commonUtils";
 import * as StringResources from "./resources/Strings.json";
 
 const showEnvList: Array<string> = [];
@@ -18,7 +22,7 @@ export async function registerEnvTreeHandler(): Promise<Result<Void, FxError>> {
     if (envNamesResult.isErr()) {
       return err(envNamesResult.error);
     }
-    const activeEnv = getActiveEnv();
+    const activeEnv = getActiveEnv(workspacePath);
     if (activeEnv) {
       setActiveEnv(activeEnv);
     }

--- a/packages/vscode-extension/src/envTree.ts
+++ b/packages/vscode-extension/src/envTree.ts
@@ -22,8 +22,11 @@ export async function registerEnvTreeHandler(): Promise<Result<Void, FxError>> {
     if (envNamesResult.isErr()) {
       return err(envNamesResult.error);
     }
-    const activeEnv = getActiveEnv(workspacePath);
-    if (activeEnv) {
+    let activeEnv: string | undefined = undefined;
+    const envResult = getActiveEnv(workspacePath);
+    // do not block user to manage env if active env cannot be retrieved
+    if (envResult.isOk()) {
+      activeEnv = envResult.value;
       setActiveEnv(activeEnv);
     }
     const environmentTreeProvider: CommandsTreeViewProvider =

--- a/packages/vscode-extension/src/utils/commonUtils.ts
+++ b/packages/vscode-extension/src/utils/commonUtils.ts
@@ -11,7 +11,7 @@ import {
   ProjectSettingsFileName,
   EnvProfileFileNameTemplate,
 } from "@microsoft/teamsfx-api";
-import { isMultiEnvEnabled, isValidProject } from "@microsoft/teamsfx-core";
+import { isMultiEnvEnabled, isValidProject, getActiveEnv } from "@microsoft/teamsfx-core";
 import { workspace, WorkspaceConfiguration } from "vscode";
 import * as commonUtils from "../debug/commonUtils";
 import { ConfigurationKey, CONFIGURATION_PREFIX } from "../constants";
@@ -53,30 +53,14 @@ export function isLinux() {
   return os.type() === "Linux";
 }
 
-export function getActiveEnv() {
-  if (!isMultiEnvEnabled()) {
-    return "default";
-  }
-  try {
-    const ws = ext.workspaceUri.fsPath;
-    if (isValidProject(ws)) {
-      const settingsJsonPath = path.join(
-        ws,
-        `.${ConfigFolderName}/${InputConfigsFolderName}/${ProjectSettingsFileName}`
-      );
-      const settingsJson = JSON.parse(fs.readFileSync(settingsJsonPath, "utf8"));
-      return settingsJson.activeEnvironment;
-    }
-  } catch (e) {
-    return undefined;
-  }
-}
-
 export function getTeamsAppId() {
   try {
     const ws = ext.workspaceUri.fsPath;
     if (isValidProject(ws)) {
-      const env = getActiveEnv();
+      const env = getActiveEnv(ws);
+      if (!env) {
+        return undefined;
+      }
       const envJsonPath = path.join(
         ws,
         isMultiEnvEnabled()

--- a/packages/vscode-extension/src/utils/commonUtils.ts
+++ b/packages/vscode-extension/src/utils/commonUtils.ts
@@ -57,8 +57,9 @@ export function getTeamsAppId() {
   try {
     const ws = ext.workspaceUri.fsPath;
     if (isValidProject(ws)) {
-      const env = getActiveEnv(ws);
-      if (!env) {
+      const envResult = getActiveEnv(ws);
+      // ignore env error for telemetry
+      if (envResult.isErr()) {
         return undefined;
       }
       const envJsonPath = path.join(
@@ -66,9 +67,9 @@ export function getTeamsAppId() {
         isMultiEnvEnabled()
           ? `.${ConfigFolderName}/${InputConfigsFolderName}/${EnvProfileFileNameTemplate.replace(
               "@envName",
-              env
+              envResult.value
             )}`
-          : `.${ConfigFolderName}/env.${env}.json`
+          : `.${ConfigFolderName}/env.${envResult.value}.json`
       );
       const envJson = JSON.parse(fs.readFileSync(envJsonPath, "utf8"));
       return envJson.solution.remoteTeamsAppId;


### PR DESCRIPTION
- move `getActiveEnv` to core so extension and CLI can share the function
- add error handling for `getActiveEnv`
- add error handling for callers of `getActiveEnv`