### PR TITLE
chore(multi-env): mark active env on env selection for creating env copy

### DIFF
--- a/packages/fx-core/src/core/middleware/envInfoLoader.ts
+++ b/packages/fx-core/src/core/middleware/envInfoLoader.ts
@@ -43,7 +43,7 @@ import { newEnvInfo } from "../tools";
 import { CoreHookContextV2 } from "../v2";
 
 const newTargetEnvNameOption = "+ new environment";
-const lastUsedMark = " (active)";
+const activeMark = " (active)";
 let activeEnv: string | undefined;
 
 export type CreateEnvCopyInput = {
@@ -227,8 +227,8 @@ export async function askTargetEnvironment(
 
   const targetEnvName = inputs.targetEnvName;
 
-  if (targetEnvName?.endsWith(lastUsedMark)) {
-    activeEnv = targetEnvName.slice(0, targetEnvName.indexOf(lastUsedMark));
+  if (targetEnvName?.endsWith(activeMark)) {
+    activeEnv = targetEnvName.slice(0, targetEnvName.indexOf(activeMark));
   } else {
     activeEnv = targetEnvName;
   }
@@ -272,8 +272,8 @@ export async function askNewEnvironment(
 
   const sourceEnvName = inputs.sourceEnvName;
   let selectedEnvName: string;
-  if (sourceEnvName?.endsWith(lastUsedMark)) {
-    selectedEnvName = sourceEnvName.slice(0, sourceEnvName.indexOf(lastUsedMark));
+  if (sourceEnvName?.endsWith(activeMark)) {
+    selectedEnvName = sourceEnvName.slice(0, sourceEnvName.indexOf(activeMark));
   } else {
     selectedEnvName = sourceEnvName;
   }
@@ -342,7 +342,7 @@ async function getQuestionsForNewEnv(
   const envList = reOrderEnvironments(envProfilesResult.value, activeEnv);
   const selectSourceEnv = QuestionSelectSourceEnvironment;
   selectSourceEnv.staticOptions = envList;
-  selectSourceEnv.default = activeEnv + lastUsedMark;
+  selectSourceEnv.default = activeEnv + activeMark;
 
   const selectSourceEnvNode = new QTreeNode(selectSourceEnv);
   node.addChild(selectSourceEnvNode);
@@ -360,7 +360,7 @@ function reOrderEnvironments(environments: Array<string>, lastUsed?: string): Ar
     return environments;
   }
 
-  return [lastUsed + lastUsedMark]
+  return [lastUsed + activeMark]
     .concat(environments.slice(0, index))
     .concat(environments.slice(index + 1));
 }

--- a/packages/fx-core/src/core/middleware/envInfoLoader.ts
+++ b/packages/fx-core/src/core/middleware/envInfoLoader.ts
@@ -43,7 +43,7 @@ import { newEnvInfo } from "../tools";
 import { CoreHookContextV2 } from "../v2";
 
 const newTargetEnvNameOption = "+ new environment";
-const lastUsedMark = " (activate)";
+const lastUsedMark = " (active)";
 let activeEnv: string | undefined;
 
 export type CreateEnvCopyInput = {
@@ -270,9 +270,17 @@ export async function askNewEnvironment(
     );
   }
 
+  const sourceEnvName = inputs.sourceEnvName;
+  let selectedEnvName: string;
+  if (sourceEnvName?.endsWith(lastUsedMark)) {
+    selectedEnvName = sourceEnvName.slice(0, sourceEnvName.indexOf(lastUsedMark));
+  } else {
+    selectedEnvName = sourceEnvName;
+  }
+
   return {
     targetEnvName: inputs.newTargetEnvName,
-    sourceEnvName: inputs.sourceEnvName,
+    sourceEnvName: selectedEnvName,
   };
 }
 
@@ -331,10 +339,10 @@ async function getQuestionsForNewEnv(
     return err(envProfilesResult.error);
   }
 
-  const envList = reOrderEnvironments(envProfilesResult.value);
+  const envList = reOrderEnvironments(envProfilesResult.value, activeEnv);
   const selectSourceEnv = QuestionSelectSourceEnvironment;
   selectSourceEnv.staticOptions = envList;
-  selectSourceEnv.default = activeEnv;
+  selectSourceEnv.default = activeEnv + lastUsedMark;
 
   const selectSourceEnvNode = new QTreeNode(selectSourceEnv);
   node.addChild(selectSourceEnvNode);


### PR DESCRIPTION
Append `(active)` on the active env when doing env selection for create env copy:
![image](https://user-images.githubusercontent.com/10163840/132640662-aa361e54-6781-4902-87f9-e276f6f65d0b.png)
