### PR TITLE
refactor(multi-env): move getActiveEnv to environmentManager so we can mock in UT

### DIFF
--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -34,12 +34,7 @@ import {
 import { ConfigNotFoundError, InvalidEnvFile, ReadFileError } from "./error";
 import AzureAccountManager from "./commonlib/azureLogin";
 import { FeatureFlags } from "./constants";
-import {
-  isMultiEnvEnabled,
-  getActiveEnv,
-  environmentManager,
-  WriteFileError,
-} from "@microsoft/teamsfx-core";
+import { isMultiEnvEnabled, environmentManager, WriteFileError } from "@microsoft/teamsfx-core";
 
 type Json = { [_: string]: any };
 
@@ -134,7 +129,7 @@ export function getEnvFilePath(projectFolder: string): Result<string, FxError> {
   if (!isMultiEnvEnabled()) {
     return ok(getConfigPath(projectFolder, `env.default.json`));
   }
-  const envResult = getActiveEnv(projectFolder);
+  const envResult = environmentManager.getActiveEnv(projectFolder);
   if (envResult.isErr()) {
     return err(envResult.error);
   }
@@ -165,7 +160,7 @@ export function getSecretFilePath(projectRoot: string): Result<string, FxError> 
   if (!isMultiEnvEnabled()) {
     return ok(path.join(projectRoot, `.${ConfigFolderName}`, `default.userdata`));
   }
-  const envResult = getActiveEnv(projectRoot);
+  const envResult = environmentManager.getActiveEnv(projectRoot);
   if (envResult.isErr()) {
     return err(envResult.error);
   }
@@ -251,7 +246,7 @@ export function writeSecretToFile(
   secrets: dotenv.DotenvParseOutput,
   rootFolder: string
 ): Result<null, FxError> {
-  const envResult = getActiveEnv(rootFolder);
+  const envResult = environmentManager.getActiveEnv(rootFolder);
   if (envResult.isErr()) {
     return err(envResult.error);
   }

--- a/packages/fx-core/src/core/environment.ts
+++ b/packages/fx-core/src/core/environment.ts
@@ -397,23 +397,18 @@ class EnvironmentManager {
     if (!isMultiEnvEnabled()) {
       return ok("default");
     }
-    if (!isValidProject(projectRoot)) {
-      return err(InvalidProjectError());
-    }
+
     const settingsJsonPath = path.join(
       projectRoot,
       `.${ConfigFolderName}/${InputConfigsFolderName}/${ProjectSettingsFileName}`
     );
-    let settingsContent;
-    try {
-      settingsContent = fs.readFileSync(settingsJsonPath, "utf8");
-    } catch (error) {
-      return err(ReadFileError(error));
+    if (!fs.existsSync(settingsJsonPath)) {
+      return err(PathNotExistError(settingsJsonPath));
     }
 
     let settingsJson;
     try {
-      settingsJson = JSON.parse(settingsContent);
+      settingsJson = fs.readJSONSync(settingsJsonPath, { encoding: "utf8" });
     } catch (error) {
       return err(
         InvalidProjectSettingsFileError(

--- a/packages/fx-core/src/core/environment.ts
+++ b/packages/fx-core/src/core/environment.ts
@@ -18,6 +18,7 @@ import {
   EnvNamePlaceholder,
   EnvInfo,
   Json,
+  ProjectSettingsFileName,
 } from "@microsoft/teamsfx-api";
 import path, { basename } from "path";
 import fs from "fs-extra";
@@ -43,6 +44,12 @@ import { isMultiEnvEnabled } from "../common";
 import Ajv from "ajv";
 import * as draft6MetaSchema from "ajv/dist/refs/json-schema-draft-06.json";
 import * as envConfigSchema from "@microsoft/teamsfx-api/build/schemas/envConfig.json";
+import {
+  InvalidProjectError,
+  InvalidProjectSettingsFileError,
+  isValidProject,
+  ReadFileError,
+} from ".";
 
 export interface EnvProfileFiles {
   envProfile: string;
@@ -153,7 +160,7 @@ class EnvironmentManager {
     envName = envName ?? this.getDefaultEnvName();
     const envFiles = this.getEnvProfileFilesPath(envName, projectPath);
 
-    const data = (envData instanceof Map) ? mapToJson(envData) : envData;
+    const data = envData instanceof Map ? mapToJson(envData) : envData;
     const secrets = sperateSecretData(data);
     if (cryptoProvider) {
       this.encrypt(secrets, cryptoProvider);
@@ -171,7 +178,7 @@ class EnvironmentManager {
 
     return ok(envFiles.envProfile);
   }
-  
+
   public async listEnvConfigs(projectPath: string): Promise<Result<Array<string>, FxError>> {
     if (!(await fs.pathExists(projectPath))) {
       return err(PathNotExistError(projectPath));
@@ -384,6 +391,50 @@ class EnvironmentManager {
     } else {
       return this.defaultEnvName;
     }
+  }
+
+  public getActiveEnv(projectRoot: string): Result<string, FxError> {
+    if (!isMultiEnvEnabled()) {
+      return ok("default");
+    }
+    if (!isValidProject(projectRoot)) {
+      return err(InvalidProjectError());
+    }
+    const settingsJsonPath = path.join(
+      projectRoot,
+      `.${ConfigFolderName}/${InputConfigsFolderName}/${ProjectSettingsFileName}`
+    );
+    let settingsContent;
+    try {
+      settingsContent = fs.readFileSync(settingsJsonPath, "utf8");
+    } catch (error) {
+      return err(ReadFileError(error));
+    }
+
+    let settingsJson;
+    try {
+      settingsJson = JSON.parse(settingsContent);
+    } catch (error) {
+      return err(
+        InvalidProjectSettingsFileError(
+          `Project settings file is not a valid JSON, error: '${error}'`
+        )
+      );
+    }
+
+    if (
+      !settingsJson ||
+      !settingsJson.activeEnvironment ||
+      typeof settingsJson.activeEnvironment !== "string"
+    ) {
+      return err(
+        InvalidProjectSettingsFileError(
+          "The property 'activeEnvironment' does not exist in project settings file."
+        )
+      );
+    }
+
+    return ok(settingsJson.activeEnvironment as string);
   }
 }
 

--- a/packages/fx-core/src/core/tools.ts
+++ b/packages/fx-core/src/core/tools.ts
@@ -133,50 +133,6 @@ export function isValidProject(workspacePath?: string): boolean {
 }
 
 // TODO: add an async version
-export function getActiveEnv(projectRoot: string): Result<string, FxError> {
-  if (!isMultiEnvEnabled()) {
-    return ok("default");
-  }
-  if (!isValidProject(projectRoot)) {
-    return err(InvalidProjectError());
-  }
-  const settingsJsonPath = path.join(
-    projectRoot,
-    `.${ConfigFolderName}/${InputConfigsFolderName}/${ProjectSettingsFileName}`
-  );
-  let settingsContent;
-  try {
-    settingsContent = fs.readFileSync(settingsJsonPath, "utf8");
-  } catch (error) {
-    return err(ReadFileError(error));
-  }
-
-  let settingsJson;
-  try {
-    settingsJson = JSON.parse(settingsContent);
-  } catch (error) {
-    return err(
-      InvalidProjectSettingsFileError(
-        `Project settings file is not a valid JSON, error: '${error}'`
-      )
-    );
-  }
-
-  if (
-    !settingsJson ||
-    !settingsJson.activeEnvironment ||
-    typeof settingsJson.activeEnvironment !== "string"
-  ) {
-    return err(
-      InvalidProjectSettingsFileError(
-        "The property 'activeEnvironment' does not exist in project settings file."
-      )
-    );
-  }
-
-  return ok(settingsJson.activeEnvironment as string);
-}
-
 export async function validateV1Project(
   workspacePath: string | undefined
 ): Promise<string | undefined> {

--- a/packages/vscode-extension/src/envTree.ts
+++ b/packages/vscode-extension/src/envTree.ts
@@ -2,12 +2,7 @@
 // Licensed under the MIT license.
 
 import { FxError, Result, err, ok, Void, TreeCategory } from "@microsoft/teamsfx-api";
-import {
-  isMultiEnvEnabled,
-  environmentManager,
-  setActiveEnv,
-  getActiveEnv,
-} from "@microsoft/teamsfx-core";
+import { isMultiEnvEnabled, environmentManager, setActiveEnv } from "@microsoft/teamsfx-core";
 import * as vscode from "vscode";
 import TreeViewManagerInstance, { CommandsTreeViewProvider } from "./commandsTreeViewProvider";
 import * as StringResources from "./resources/Strings.json";
@@ -23,7 +18,7 @@ export async function registerEnvTreeHandler(): Promise<Result<Void, FxError>> {
       return err(envNamesResult.error);
     }
     let activeEnv: string | undefined = undefined;
-    const envResult = getActiveEnv(workspacePath);
+    const envResult = environmentManager.getActiveEnv(workspacePath);
     // do not block user to manage env if active env cannot be retrieved
     if (envResult.isOk()) {
       activeEnv = envResult.value;

--- a/packages/vscode-extension/src/utils/commonUtils.ts
+++ b/packages/vscode-extension/src/utils/commonUtils.ts
@@ -11,7 +11,7 @@ import {
   ProjectSettingsFileName,
   EnvProfileFileNameTemplate,
 } from "@microsoft/teamsfx-api";
-import { isMultiEnvEnabled, isValidProject, getActiveEnv } from "@microsoft/teamsfx-core";
+import { environmentManager, isMultiEnvEnabled, isValidProject } from "@microsoft/teamsfx-core";
 import { workspace, WorkspaceConfiguration } from "vscode";
 import * as commonUtils from "../debug/commonUtils";
 import { ConfigurationKey, CONFIGURATION_PREFIX } from "../constants";
@@ -57,7 +57,7 @@ export function getTeamsAppId() {
   try {
     const ws = ext.workspaceUri.fsPath;
     if (isValidProject(ws)) {
-      const envResult = getActiveEnv(ws);
+      const envResult = environmentManager.getActiveEnv(ws);
       // ignore env error for telemetry
       if (envResult.isErr()) {
         return undefined;


### PR DESCRIPTION
Global functions in ESM exported by reimporting from another file cannot be mocked by sinon. Take `setActiveEnv` as an example, in core's index.ts, there are code like this:
  
```
export { setActiveEnv } from "./core/middleware/envInfoLoader";
```

This will be compiled to 
```
Object.defineProperty(exports, "setActiveEnv", { enumerable: true, get: function () { return envInfoLoader_1.setActiveEnv; } });
```

From [mozzila docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty#description), we can know that this is wrapped as an readonly function (`defineProperty` without `writable: true`). This will cause sinon to fail to mock it.

This is a known issue of sinon and they said these types of issues related to module system is [out of scope](https://github.com/sinonjs/sinon/issues/1711).

One possible solution is to convert the whole core to a common js module which is too much efforts and may affect too many things.

Another solution I have tried is to manually write dependency injection code which will also affect too much because these are util functions used everywhere. And it is not consistent with other parts of CLI.

So I take the third solution to move the function to a modifiable object
- To make is possible to mock with sinon 
- and it also makes sense to make `getActiveEnv` belong to `environmentManager`.

Thanks @tecton to help me debug.