### PR TITLE
fix(core): projectSettingsWriter should read from ctx

### DIFF
--- a/packages/fx-core/src/core/index.ts
+++ b/packages/fx-core/src/core/index.ts
@@ -143,9 +143,9 @@ export interface CoreHookContext extends HookContext {
 export function isV2() {
   const flag = process.env[FeatureFlagName.APIV2];
   if (flag === undefined) {
-    return false; 
+    return false;
   } else {
-    return flag === "1" || flag.toLowerCase() === "true"; 
+    return flag === "1" || flag.toLowerCase() === "true";
   }
 }
 
@@ -266,6 +266,7 @@ export class FxCore implements Core {
           ...this.tools.tokenProvider,
           answers: inputs,
         };
+        ctx.projectSettings = projectSettings;
         ctx.solutionContext = solutionContext;
         const createRes = await solution.create(solutionContext);
         if (createRes.isErr()) {
@@ -367,6 +368,7 @@ export class FxCore implements Core {
 
     ctx!.solution = solution;
     ctx!.solutionContext = solutionContext;
+    ctx!.projectSettings = projectSettings;
 
     if (inputs.platform === Platform.VSCode) {
       await globalStateUpdate(globalStateDescription, true);
@@ -1093,7 +1095,7 @@ export async function createBasicFolderStructure(inputs: Inputs): Promise<Result
           description: "",
           author: "",
           scripts: {
-            test: "echo \"Error: no test specified\" && exit 1",
+            test: 'echo "Error: no test specified" && exit 1',
           },
           devDependencies: {
             "@microsoft/teamsfx-cli": "0.*",

--- a/packages/fx-core/src/core/middleware/projectSettingsWriter.ts
+++ b/packages/fx-core/src/core/middleware/projectSettingsWriter.ts
@@ -36,9 +36,7 @@ export const ProjectSettingsWriterMW: Middleware = async (
       StaticPlatforms.includes(inputs.platform)
     )
       return;
-    const projectSettings = isV2()
-      ? ctx.contextV2?.projectSetting
-      : ctx.solutionContext?.projectSettings;
+    const projectSettings = ctx.projectSettings;
     if (projectSettings === undefined) return;
     try {
       const confFolderPath = path.resolve(inputs.projectPath, `.${ConfigFolderName}`);

--- a/packages/fx-core/tests/core/hooks.test.ts
+++ b/packages/fx-core/tests/core/hooks.test.ts
@@ -602,7 +602,7 @@ describe("Middleware", () => {
       const tools = new MockTools();
       const solutionContext = await newSolutionContext(tools, inputs);
       solutionContext.envInfo.profile.set("solution", new ConfigMap());
-      solutionContext.projectSettings = MockProjectSettings(appName);
+      const mockProjectSettings = MockProjectSettings(appName);
       const fileMap = new Map<string, any>();
 
       sandbox.stub<any, any>(fs, "writeFile").callsFake(async (file: string, data: any) => {
@@ -620,6 +620,7 @@ describe("Middleware", () => {
         tools = tools;
         async myMethod(inputs: Inputs, ctx?: CoreHookContext): Promise<Result<any, FxError>> {
           ctx!.solutionContext = solutionContext;
+          ctx!.projectSettings = mockProjectSettings;
           return ok("");
         }
       }
@@ -633,7 +634,7 @@ describe("Middleware", () => {
       content = fileMap.get(envJsonFile);
       const configInFile = JSON.parse(content);
       const configExpected = mapToJson(solutionContext.envInfo.profile);
-      assert.deepEqual(solutionContext.projectSettings, settingsInFile);
+      assert.deepEqual(mockProjectSettings, settingsInFile);
       assert.deepEqual(configExpected, configInFile);
     });
   });
@@ -1386,7 +1387,6 @@ describe("Middleware", () => {
   });
 
   describe("LocalSettingsLoaderMW, ContextInjectorMW", () => {
-    
     it("NoProjectOpenedError", async () => {
       const original = process.env[FeatureFlagName.MultiEnv];
       process.env[FeatureFlagName.MultiEnv] = "true";
@@ -1404,6 +1404,6 @@ describe("Middleware", () => {
       const res = await my.other(inputs);
       assert.isTrue(res.isErr() && res.error.name === NoProjectOpenedError().name);
       process.env[FeatureFlagName.MultiEnv] = original;
-    }); 
+    });
   });
 });


### PR DESCRIPTION
Offline discuss with @jayzhang, this is a bug of ProjectSettingsWriter.  ProjectSettingsReader/ProjectSettingsWriter should be consistent to read/write from `ctx` instead of `solutionContext`