### PR TITLE
fix(multi-env): incorrect target env name when copy bicep parameter file

### DIFF
--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -549,6 +549,8 @@ export interface Inputs extends Json {
     // (undocumented)
     projectPath?: string;
     // (undocumented)
+    sourceEnvName?: string;
+    // (undocumented)
     stage?: Stage;
     // (undocumented)
     targetEnvName?: string;

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -162,6 +162,7 @@ export interface ProjectStates {
 export interface Inputs extends Json {
   projectPath?: string;
   targetEnvName?: string;
+  sourceEnvName?: string;
   platform: Platform;
   stage?: Stage;
   vscodeEnv?: VsCodeEnv;

--- a/packages/fx-core/src/core/middleware/envInfoLoader.ts
+++ b/packages/fx-core/src/core/middleware/envInfoLoader.ts
@@ -277,7 +277,7 @@ export async function askNewEnvironment(
     );
   }
 
-  const sourceEnvName = inputs.sourceEnvName;
+  const sourceEnvName = inputs.sourceEnvName!;
   let selectedEnvName: string;
   if (sourceEnvName?.endsWith(activeMark)) {
     selectedEnvName = sourceEnvName.slice(0, sourceEnvName.indexOf(activeMark));

--- a/packages/fx-core/src/plugins/solution/fx-solution/arm.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/arm.ts
@@ -299,16 +299,17 @@ export async function deployArmTemplates(ctx: SolutionContext): Promise<Result<v
   return result;
 }
 
-export async function copyParameterJson(ctx: SolutionContext, sourceEnvName: string) {
-  if (!isMultiEnvEnabled() || !ctx.envInfo?.envName || !sourceEnvName) {
+export async function copyParameterJson(
+  ctx: SolutionContext,
+  targetEnvName: string,
+  sourceEnvName: string
+) {
+  if (!isMultiEnvEnabled() || !targetEnvName || !sourceEnvName) {
     return;
   }
 
   const parameterFolderPath = path.join(ctx.root, configsFolder);
-  const targetParameterFileName = parameterFileNameTemplateNew.replace(
-    "@envName",
-    ctx.envInfo.envName
-  );
+  const targetParameterFileName = parameterFileNameTemplateNew.replace("@envName", targetEnvName);
   const sourceParameterFileName = parameterFileNameTemplateNew.replace("@envName", sourceEnvName);
   const targetParameterFilePath = path.join(parameterFolderPath, targetParameterFileName);
   const sourceParameterFilePath = path.join(parameterFolderPath, sourceParameterFileName);

--- a/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
@@ -63,7 +63,12 @@ import { PermissionRequestFileProvider } from "../../../core/permissionRequest";
 import { SolutionPlugins } from "../../../core/SolutionPluginContainer";
 import { AadAppForTeamsPlugin, AppStudioPlugin, SpfxPlugin } from "../../resource";
 import { IUserList } from "../../resource/appstudio/interfaces/IAppDefinition";
-import { copyParameterJson, deployArmTemplates, generateArmTemplate, getParameterJson } from "./arm";
+import {
+  copyParameterJson,
+  deployArmTemplates,
+  generateArmTemplate,
+  getParameterJson,
+} from "./arm";
 import { checkSubscription, fillInCommonQuestions } from "./commonQuestions";
 import {
   ARM_TEMPLATE_OUTPUT,
@@ -127,7 +132,12 @@ import {
   ParamForRegisterTeamsAppAndAad,
 } from "./v2/executeUserTask";
 import { scaffoldReadmeAndLocalSettings } from "./v2/scaffolding";
-import { ensurePermissionRequest, fillInSolutionSettings, isAzureProject, parseTeamsAppTenantId } from "./v2/utils";
+import {
+  ensurePermissionRequest,
+  fillInSolutionSettings,
+  isAzureProject,
+  parseTeamsAppTenantId,
+} from "./v2/utils";
 
 export type LoadedPlugin = Plugin;
 export type PluginsWithContext = [LoadedPlugin, PluginContext];
@@ -247,7 +257,10 @@ export class TeamsAppSolution implements Solution {
     ctx.telemetryReporter?.sendTelemetryEvent(SolutionTelemetryEvent.CreateStart, {
       [SolutionTelemetryProperty.Component]: SolutionTelemetryComponentName,
     });
-    if(!ctx.projectSettings) return err(new SystemError(SolutionError.InternelError, "projectSettings undefined", "Solution"));
+    if (!ctx.projectSettings)
+      return err(
+        new SystemError(SolutionError.InternelError, "projectSettings undefined", "Solution")
+      );
     // ensure that global namespace is present
     if (!ctx.envInfo.profile.has(GLOBAL_CONFIG)) {
       ctx.envInfo.profile.set(GLOBAL_CONFIG, new ConfigMap());
@@ -441,10 +454,9 @@ export class TeamsAppSolution implements Solution {
       isAzureProject(ctx.projectSettings!.solutionSettings as AzureSolutionSettings)
     ) {
       try {
-        if(ctx.answers!.copy === true) {
-          await copyParameterJson(ctx, ctx.answers!.sourceEnvName);
-        }
-        else {
+        if (ctx.answers!.copy === true) {
+          await copyParameterJson(ctx, ctx.answers!.targetEnvName!, ctx.answers!.sourceEnvName!);
+        } else {
           await getParameterJson(ctx);
         }
       } catch (e) {
@@ -1194,7 +1206,7 @@ export class TeamsAppSolution implements Solution {
         ctx.projectSettings?.solutionSettings as AzureSolutionSettings,
         ctx.permissionRequestProvider
       );
-      
+
       if (result.isErr()) {
         return result;
       }

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/createEnv.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/createEnv.ts
@@ -26,10 +26,9 @@ export async function createEnv(ctx: v2.Context, inputs: Inputs): Promise<Result
       answers: inputs,
     };
     try {
-      if(inputs.copy === true) {
-        await copyParameterJson(solutionContext, inputs.sourceEnvName);
-      }
-      else {
+      if (inputs.copy === true) {
+        await copyParameterJson(solutionContext, inputs.targetEnvName!, inputs.sourceEnvName!);
+      } else {
         await getParameterJson(solutionContext);
       }
     } catch (e) {


### PR DESCRIPTION
**Bug**: use the active env name in context as the target env when copy bicep parameter JSON file.
**Expected**: should use the input new env name as the target env name when copy bicep parameter JSON file.