### PR TITLE
chore(multi-env): refine the environment view

### DIFF
--- a/packages/fx-core/src/index.ts
+++ b/packages/fx-core/src/index.ts
@@ -9,4 +9,5 @@ export * from "./plugins";
 export * from "./core";
 export * from "./folder";
 export * from "./core/environment";
+export * from "./common/localSettingsProvider";
 export { setActiveEnv } from "./core/middleware/envInfoLoader";

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -185,8 +185,17 @@
           "when": "view == teamsfx-environment && viewItem =~ /environment/"
         },
         {
+          "command": "fx-extension.viewEnvironment",
+          "when": "view == teamsfx-environment && viewItem == local"
+        },
+        {
           "command": "fx-extension.viewEnvironmentWithIcon",
           "when": "view == teamsfx-environment && viewItem =~ /environment/",
+          "group": "inline@3"
+        },
+        {
+          "command": "fx-extension.viewEnvironmentWithIcon",
+          "when": "view == teamsfx-environment && viewItem == local",
           "group": "inline@3"
         },
         {

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -182,20 +182,11 @@
         },
         {
           "command": "fx-extension.viewEnvironment",
-          "when": "view == teamsfx-environment && viewItem =~ /environment/"
-        },
-        {
-          "command": "fx-extension.viewEnvironment",
-          "when": "view == teamsfx-environment && viewItem == local"
+          "when": "view == teamsfx-environment && viewItem =~ /^environment|^local$/"
         },
         {
           "command": "fx-extension.viewEnvironmentWithIcon",
-          "when": "view == teamsfx-environment && viewItem =~ /environment/",
-          "group": "inline@3"
-        },
-        {
-          "command": "fx-extension.viewEnvironmentWithIcon",
-          "when": "view == teamsfx-environment && viewItem == local",
+          "when": "view == teamsfx-environment && viewItem =~ /^environment|^local$/",
           "group": "inline@3"
         },
         {

--- a/packages/vscode-extension/src/constants.ts
+++ b/packages/vscode-extension/src/constants.ts
@@ -9,3 +9,5 @@ export const migrateV1DocUrl = "https://aka.ms/teamsfx-migrate-v1";
 export enum SyncedState {
   Version = "teamsToolkit:synced:version",
 }
+
+export const LocalEnvironment = "local";

--- a/packages/vscode-extension/src/envTree.ts
+++ b/packages/vscode-extension/src/envTree.ts
@@ -10,6 +10,7 @@ import {
 } from "@microsoft/teamsfx-core";
 import * as vscode from "vscode";
 import TreeViewManagerInstance, { CommandsTreeViewProvider } from "./commandsTreeViewProvider";
+import { LocalEnvironment } from "./constants";
 import * as StringResources from "./resources/Strings.json";
 import { checkPermission, listCollaborator } from "./handlers";
 import { signedIn } from "./commonlib/common/constant";
@@ -40,18 +41,20 @@ export async function registerEnvTreeHandler(): Promise<Result<Void, FxError>> {
       });
     }
     showEnvList.splice(0);
-    for (const item of envNamesResult.value) {
+
+    const envNames = [LocalEnvironment].concat(envNamesResult.value);
+    for (const item of envNames) {
       showEnvList.push(item);
       environmentTreeProvider.add([
         {
           commandId: "fx-extension.environment." + item,
           label: item,
           parent: TreeCategory.Environment,
-          contextValue: "environment",
-          icon: item === activeEnv ? "folder-active" : "symbol-folder",
+          contextValue: item === LocalEnvironment ? "local" : "environment",
+          icon: getTreeViewItemIcon(item, activeEnv),
           isCustom: false,
           description:
-            item === activeEnv ? StringResources.vsc.commandsTreeViewProvider.acitve : "",
+            item === activeEnv ? StringResources.vsc.commandsTreeViewProvider.active : "",
           expanded: activeEnv === item,
         },
       ]);
@@ -92,5 +95,16 @@ export async function updateCollaboratorList(env: string): Promise<void> {
       }
       await environmentTreeProvider.add(userList);
     }
+  }
+}
+
+function getTreeViewItemIcon(envName: string, activeEnv: string | undefined) {
+  switch (envName) {
+    case activeEnv:
+      return "folder-active";
+    case LocalEnvironment:
+    // return "lock";
+    default:
+      return "symbol-folder";
   }
 }

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -46,6 +46,7 @@ import {
   environmentManager,
   isMigrateFromV1Project,
   isMultiEnvEnabled,
+  LocalSettingsProvider,
 } from "@microsoft/teamsfx-core";
 import GraphManagerInstance from "./commonlib/graphLogin";
 import AzureAccountManager from "./commonlib/azureLogin";
@@ -92,6 +93,9 @@ import * as path from "path";
 import { exp } from "./exp/index";
 import { TreatmentVariables } from "./exp/treatmentVariables";
 import { StringContext } from "./utils/stringContext";
+import { ext } from "./extensionVariables";
+import { InputConfigsFolderName } from "@microsoft/teamsfx-api";
+import { LocalEnvironment } from "./constants";
 
 export let core: FxCore;
 export let tools: Tools;
@@ -728,10 +732,14 @@ export async function createNewEnvironment(args?: any[]): Promise<Result<Void, F
 
 export async function viewEnvironment(env: string): Promise<Result<Void, FxError>> {
   if (workspace.workspaceFolders && workspace.workspaceFolders.length > 0) {
-    const envFilePath = environmentManager.getEnvConfigPath(
-      env,
-      workspace.workspaceFolders![0].uri.fsPath
-    );
+    const projectRoot = workspace.workspaceFolders![0].uri.fsPath;
+    const localSettingsProvider = new LocalSettingsProvider(projectRoot);
+
+    const envFilePath =
+      env === LocalEnvironment
+        ? localSettingsProvider.localSettingsFilePath
+        : environmentManager.getEnvConfigPath(env, projectRoot);
+
     const envPath: vscode.Uri = vscode.Uri.file(envFilePath);
     if (await fs.pathExists(envFilePath)) {
       vscode.workspace.openTextDocument(envPath).then(

--- a/packages/vscode-extension/src/resources/Strings.json
+++ b/packages/vscode-extension/src/resources/Strings.json
@@ -64,7 +64,7 @@
       "teamsDevPortalTitle": "Go To Developer Portal",
       "teamsDevPortalTitleNew": "Developer Portal for Teams",
       "teamsDevPortalDescription": "Manage your Teams app registration and access more tools",
-      "acitve": "(Active)",
+      "active": "(Active)",
       "loginM365AccountToViewCollaborators": "Login M365 account to view all collaborators",
       "noPermissionToListCollaborators": "No permission to list collaborators",
       "unableToFindTeamsAppRegistration": "Unable to find Teams app registration"


### PR DESCRIPTION
Add `local` to the environment tree view. It supports to 
* view the localSettings.json
* It can't be activated.

![local2](https://user-images.githubusercontent.com/15644078/133229676-e5a44d02-ccd0-40d7-abc0-d62c5cc4aa24.gif)
