### PR TITLE
feat(multi-env): add "teamsfx env" command

### DIFF
--- a/packages/cli/src/cmds/env.ts
+++ b/packages/cli/src/cmds/env.ts
@@ -44,7 +44,18 @@ export default class Env extends YargsCommand {
   }
 
   public async runCommand(args: { [argName: string]: string }): Promise<Result<null, FxError>> {
-    // TODO: display current active env info.
+    const projectDir = args.folder || process.cwd();
+
+    if (!isWorkspaceSupported(projectDir)) {
+      return err(WorkspaceNotSupported(projectDir));
+    }
+
+    const activeEnvResult = environmentManager.getActiveEnv(projectDir);
+    if (activeEnvResult.isErr()) {
+      return err(activeEnvResult.error);
+    }
+
+    CLILogProvider.necessaryLog(LogLevel.Info, activeEnvResult.value, true);
     return ok(null);
   }
 }


### PR DESCRIPTION
- add `teamsfx env` command to show current active env name.
- add test cases

`teamsfx env` will show active env and the `--help` parameter also works.
![Screenshot from 2021-09-14 14-04-47](https://user-images.githubusercontent.com/9698542/133205703-69dd2614-2715-47af-b738-ea0c14752da7.png)

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/10920600
