### PR TITLE
feat(multi-env): add "teamsfx env add" command in CLI

### DIFF
--- a/packages/cli/src/cmds/env.ts
+++ b/packages/cli/src/cmds/env.ts
@@ -112,7 +112,7 @@ class EnvAdd extends YargsCommand {
       sourceEnv = activeEnvResult.value;
     }
 
-    const validNewTargetEnvResult = await this.validNewTargetEnvName(projectDir, targetEnv);
+    const validNewTargetEnvResult = await this.validateNewTargetEnvName(projectDir, targetEnv);
     if (validNewTargetEnvResult.isErr()) {
       return err(validNewTargetEnvResult.error);
     }

--- a/packages/cli/src/cmds/env.ts
+++ b/packages/cli/src/cmds/env.ts
@@ -129,7 +129,7 @@ class EnvAdd extends YargsCommand {
     return ok(null);
   }
 
-  private async validNewTargetEnvName(
+  private async validateNewTargetEnvName(
     projectDir: string,
     newTargetEnvName: string
   ): Promise<Result<null, FxError>> {

--- a/packages/cli/src/cmds/env.ts
+++ b/packages/cli/src/cmds/env.ts
@@ -8,7 +8,13 @@ import { Argv, Options } from "yargs";
 import { FxError, err, ok, Result, Stage, LogLevel } from "@microsoft/teamsfx-api";
 
 import { YargsCommand } from "../yargsCommand";
-import { environmentManager } from "@microsoft/teamsfx-core";
+import {
+  environmentManager,
+  InvalidEnvNameError,
+  ProjectEnvAlreadyExistError,
+  ProjectFolderExistError,
+  setActiveEnv,
+} from "@microsoft/teamsfx-core";
 import * as process from "process";
 import * as os from "os";
 import CLILogProvider from "../commonlib/log";
@@ -17,7 +23,7 @@ import HelpParamGenerator from "../helpParamGenerator";
 import activate from "../activate";
 import CliTelemetry from "../telemetry/cliTelemetry";
 import { TelemetryEvent } from "../telemetry/cliTelemetryEvents";
-import { getSystemInputs, isWorkspaceSupported } from "../utils";
+import { getChoicesFromQTNodeQuestion, getSystemInputs, isWorkspaceSupported } from "../utils";
 import { EnvNodeNoCreate } from "../constants";
 
 const ActiveMark = " (active)";
@@ -27,7 +33,7 @@ export default class Env extends YargsCommand {
   public readonly command = `${this.commandHead} [action]`;
   public readonly description = "Manage environments.";
 
-  public readonly subCommands: YargsCommand[] = [new EnvList(), new EnvActivate()];
+  public readonly subCommands: YargsCommand[] = [new EnvAdd(), new EnvList(), new EnvActivate()];
 
   public builder(yargs: Argv): Argv<any> {
     yargs.options("action", {
@@ -56,6 +62,87 @@ export default class Env extends YargsCommand {
     }
 
     CLILogProvider.necessaryLog(LogLevel.Info, activeEnvResult.value, true);
+    return ok(null);
+  }
+}
+
+class EnvAdd extends YargsCommand {
+  public readonly commandHead = `add`;
+  public readonly command = `${this.commandHead} <name>`;
+  public readonly description =
+    "Add a new environment by copying from current active environment or the specified environment.";
+  public params: { [_: string]: Options } = {};
+
+  public builder(yargs: Argv): Argv<any> {
+    // TODO: support --details
+    this.params = HelpParamGenerator.getYargsParamForHelp(Stage.createEnv);
+    yargs.positional("name", {
+      description: "The new environment name",
+      type: "string",
+      require: true,
+    });
+    return yargs.version(false).options(this.params);
+  }
+
+  public async runCommand(args: { [argName: string]: string }): Promise<Result<null, FxError>> {
+    const projectDir = args.folder || process.cwd();
+    // args.name always exists because or `require: true` in builder
+    const targetEnv = args.name as string;
+    const argsEnv = args.env as string | undefined;
+
+    if (!isWorkspaceSupported(projectDir)) {
+      return err(WorkspaceNotSupported(projectDir));
+    }
+
+    const coreResult = await activate(projectDir);
+    if (coreResult.isErr()) {
+      return err(coreResult.error);
+    }
+    const fxCore = coreResult.value;
+
+    let sourceEnv;
+    if (argsEnv) {
+      sourceEnv = argsEnv;
+    } else {
+      // fallback to copy from current active environment
+      const activeEnvResult = environmentManager.getActiveEnv(projectDir);
+      if (activeEnvResult.isErr()) {
+        return err(activeEnvResult.error);
+      }
+      sourceEnv = activeEnvResult.value;
+    }
+
+    const validNewTargetEnvResult = await this.validNewTargetEnvName(projectDir, targetEnv);
+    if (validNewTargetEnvResult.isErr()) {
+      return err(validNewTargetEnvResult.error);
+    }
+
+    const inputs = getSystemInputs(projectDir);
+    inputs.newTargetEnvName = targetEnv;
+    inputs.sourceEnvName = sourceEnv;
+
+    const result = await fxCore.createEnv(inputs);
+    if (result.isErr()) {
+      return err(result.error);
+    }
+
+    return ok(null);
+  }
+
+  private async validNewTargetEnvName(
+    projectDir: string,
+    newTargetEnvName: string
+  ): Promise<Result<null, FxError>> {
+    // valid target environment name
+    const match = newTargetEnvName.match(environmentManager.envNameRegex);
+    if (!match) {
+      return err(InvalidEnvNameError());
+    }
+    const envConfigs = await environmentManager.listEnvConfigs(projectDir);
+    if (!envConfigs.isErr() && envConfigs.value!.indexOf(newTargetEnvName) >= 0) {
+      return err(ProjectEnvAlreadyExistError(newTargetEnvName));
+    }
+
     return ok(null);
   }
 }

--- a/packages/cli/src/helpParamGenerator.ts
+++ b/packages/cli/src/helpParamGenerator.ts
@@ -50,6 +50,7 @@ export class HelpParamGenerator {
     Stage.checkPermission,
     "validate",
     Stage.activateEnv,
+    Stage.createEnv,
   ];
 
   private static instance: HelpParamGenerator;


### PR DESCRIPTION
- add `teamsfx env add <name> [--env sourceEnv]` command. If --env is not specified, it will use current active env.
- add test cases (the test cases might be somewhat too long, so I split them into 3 commits for easier reading)

![Screenshot from 2021-09-14 16-57-03](https://user-images.githubusercontent.com/9698542/133227939-7bb97693-d915-4af5-944b-f6d2cabcabb6.png)

The --help output
![Screenshot from 2021-09-15 11-39-53](https://user-images.githubusercontent.com/9698542/133366855-cd007183-2549-49b2-b795-fa785be3aeeb.png)


https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/10921113
