### PR TITLE
feat(multi-env): read active env for all cmds

### DIFF
--- a/packages/cli/src/activate.ts
+++ b/packages/cli/src/activate.ts
@@ -3,9 +3,14 @@
 
 "use strict";
 
-import { Result, FxError, ok, Tools } from "@microsoft/teamsfx-api";
+import { Result, FxError, ok, Tools, err } from "@microsoft/teamsfx-api";
 
-import { FxCore } from "@microsoft/teamsfx-core";
+import {
+  environmentManager,
+  FxCore,
+  isMultiEnvEnabled,
+  setActiveEnv,
+} from "@microsoft/teamsfx-core";
 
 import AzureAccountManager from "./commonlib/azureLogin";
 import AppStudioTokenProvider from "./commonlib/appStudioLogin";
@@ -22,6 +27,14 @@ export default async function activate(rootPath?: string): Promise<Result<FxCore
       await AzureAccountManager.setSubscription(subscriptionInfo.subscriptionId);
     }
     CliTelemetry.setReporter(CliTelemetry.getReporter().withRootFolder(rootPath));
+
+    if (isMultiEnvEnabled()) {
+      const activeEnvResult = environmentManager.getActiveEnv(rootPath);
+      if (activeEnvResult.isErr()) {
+        return err(activeEnvResult.error);
+      }
+      setActiveEnv(activeEnvResult.value);
+    }
   }
 
   const tools: Tools = {


### PR DESCRIPTION
- Set the active env when activating, similar to the vscode extension, so that core can fallback to using currrent active env when not specified

For example, the provision command will use the current active env
![Screenshot from 2021-09-15 10-47-11](https://user-images.githubusercontent.com/9698542/133362255-22c600c4-b6a6-4e44-bc5b-27fc4119de12.png)
