### PR TITLE
fix(multi-env): missing auth section when scaffold bot only project

### DIFF
--- a/packages/fx-core/src/common/localSettingsProvider.ts
+++ b/packages/fx-core/src/common/localSettingsProvider.ts
@@ -43,10 +43,11 @@ export class LocalSettingsProvider {
       teamsApp: teamsAppLocalConfig,
     };
 
+    localSettings.auth = this.initSimpleAuth();
+
     // initialize frontend and simple auth local settings.
     if (includeFrontend) {
       localSettings.frontend = this.initFrontend();
-      localSettings.auth = this.initSimpleAuth();
     }
 
     // initialize backend local settings.


### PR DESCRIPTION
When scaffold a bot only project, toolkit should also scaffold `auth` related config in local debug config file (`localSettings.json`).