### PR TITLE
chore(multi-env): show sub and resource group in env tree

### DIFF
--- a/packages/vscode-extension/src/commonlib/azureLogin.ts
+++ b/packages/vscode-extension/src/commonlib/azureLogin.ts
@@ -50,6 +50,7 @@ import * as path from "path";
 import * as fs from "fs-extra";
 import * as commonUtils from "../debug/commonUtils";
 import { isMultiEnvEnabled } from "@microsoft/teamsfx-core";
+import { getDefaultEnv, getSubscriptionInfoFromEnv } from "../utils/commonUtils";
 
 export class AzureAccountManager extends login implements AzureAccountProvider {
   private static instance: AzureAccountManager;
@@ -518,7 +519,7 @@ export class AzureAccountManager extends login implements AzureAccountProvider {
   async readSubscription(): Promise<SubscriptionInfo | undefined> {
     const subscriptionFilePath = await this.getSubscriptionInfoPath();
     if (!subscriptionFilePath || !fs.existsSync(subscriptionFilePath)) {
-      const solutionSubscriptionInfo = await this.getSubscriptionInfoFromEnv();
+      const solutionSubscriptionInfo = await getSubscriptionInfoFromEnv(getDefaultEnv());
       if (solutionSubscriptionInfo) {
         await this.saveSubscription(solutionSubscriptionInfo);
         return solutionSubscriptionInfo;
@@ -551,43 +552,6 @@ export class AzureAccountManager extends login implements AzureAccountProvider {
       );
       const subscriptionFile = path.join(configRoot!, subscriptionInfoFile);
       return subscriptionFile;
-    } else {
-      return undefined;
-    }
-  }
-
-  async getSubscriptionInfoFromEnv(): Promise<SubscriptionInfo | undefined> {
-    if (vscode.workspace.workspaceFolders) {
-      const workspaceFolder: vscode.WorkspaceFolder = vscode.workspace.workspaceFolders[0];
-      const workspacePath: string = workspaceFolder.uri.fsPath;
-      if (!(await commonUtils.isFxProject(workspacePath))) {
-        return undefined;
-      }
-      const configRoot = await commonUtils.getProjectRoot(
-        workspaceFolder.uri.fsPath,
-        `.${ConfigFolderName}`
-      );
-
-      const envDefalultFile = path.join(
-        configRoot!,
-        isMultiEnvEnabled()
-          ? path.join(PublishProfilesFolderName, profileDefaultJsonFile)
-          : envDefaultJsonFile
-      );
-      if (!fs.existsSync(envDefalultFile)) {
-        return undefined;
-      }
-      const envDefaultJson = (await fs.readFile(envDefalultFile)).toString();
-      const envDefault = JSON.parse(envDefaultJson);
-      if (envDefault.solution && envDefault.solution.subscriptionId) {
-        return {
-          subscriptionId: envDefault.solution.subscriptionId,
-          tenantId: envDefault.solution.tenantId,
-          subscriptionName: "",
-        };
-      } else {
-        return undefined;
-      }
     } else {
       return undefined;
     }

--- a/packages/vscode-extension/src/commonlib/azureLogin.ts
+++ b/packages/vscode-extension/src/commonlib/azureLogin.ts
@@ -14,7 +14,6 @@ import {
   OptionItem,
   ok,
   ConfigFolderName,
-  PublishProfilesFolderName,
 } from "@microsoft/teamsfx-api";
 import { ExtensionErrors } from "../error";
 import { AzureAccount } from "./azure-account.api";
@@ -22,11 +21,9 @@ import { LoginFailureError } from "./codeFlowLogin";
 import * as vscode from "vscode";
 import * as identity from "@azure/identity";
 import {
-  envDefaultJsonFile,
   loggedIn,
   loggedOut,
   loggingIn,
-  profileDefaultJsonFile,
   signedIn,
   signedOut,
   signingIn,
@@ -49,8 +46,8 @@ import TreeViewManagerInstance from "../commandsTreeViewProvider";
 import * as path from "path";
 import * as fs from "fs-extra";
 import * as commonUtils from "../debug/commonUtils";
-import { isMultiEnvEnabled } from "@microsoft/teamsfx-core";
-import { getDefaultEnv, getSubscriptionInfoFromEnv } from "../utils/commonUtils";
+import { environmentManager } from "@microsoft/teamsfx-core";
+import { getSubscriptionInfoFromEnv } from "../utils/commonUtils";
 
 export class AzureAccountManager extends login implements AzureAccountProvider {
   private static instance: AzureAccountManager;
@@ -519,7 +516,9 @@ export class AzureAccountManager extends login implements AzureAccountProvider {
   async readSubscription(): Promise<SubscriptionInfo | undefined> {
     const subscriptionFilePath = await this.getSubscriptionInfoPath();
     if (!subscriptionFilePath || !fs.existsSync(subscriptionFilePath)) {
-      const solutionSubscriptionInfo = await getSubscriptionInfoFromEnv(getDefaultEnv());
+      const solutionSubscriptionInfo = await getSubscriptionInfoFromEnv(
+        environmentManager.getDefaultEnvName()
+      );
       if (solutionSubscriptionInfo) {
         await this.saveSubscription(solutionSubscriptionInfo);
         return solutionSubscriptionInfo;

--- a/packages/vscode-extension/src/envTree.ts
+++ b/packages/vscode-extension/src/envTree.ts
@@ -121,7 +121,7 @@ async function localSettingsExists(projectRoot: string): Promise<boolean> {
 }
 
 export async function addSubscriptionAndResourceGroupNode(env: string) {
-  if (!environmentTreeProvider) {
+  if (!environmentTreeProvider || env === LocalEnvironment) {
     return;
   }
 

--- a/packages/vscode-extension/src/utils/commonUtils.ts
+++ b/packages/vscode-extension/src/utils/commonUtils.ts
@@ -218,10 +218,6 @@ export function getIsExistingUser(): string | undefined {
   return ext.context.globalState.get<string>(UserState.IsExisting);
 }
 
-export function getDefaultEnv(): string {
-  return isMultiEnvEnabled() ? "dev" : "default";
-}
-
 export async function getSubscriptionInfoFromEnv(
   env: string
 ): Promise<SubscriptionInfo | undefined> {


### PR DESCRIPTION
If the env has already been provisioned, then the resource group and sub info will be showed in the tree view:
![image](https://user-images.githubusercontent.com/10163840/133379058-ca3af692-21d7-45d5-be53-c5f0f1d3a581.png)

