### PR TITLE
perf(collaboration): remove unnecessary concurrent locker

### DIFF
--- a/packages/fx-core/src/core/index.ts
+++ b/packages/fx-core/src/core/index.ts
@@ -737,7 +737,6 @@ export class FxCore implements Core {
 
   @hooks([
     ErrorHandlerMW,
-    ConcurrentLockerMW,
     ProjectSettingsLoaderMW,
     EnvInfoLoaderMW(isMultiEnvEnabled()),
     SolutionLoaderMW(),
@@ -753,7 +752,6 @@ export class FxCore implements Core {
 
   @hooks([
     ErrorHandlerMW,
-    ConcurrentLockerMW,
     ProjectSettingsLoaderMW,
     EnvInfoLoaderMW(isMultiEnvEnabled()),
     SolutionLoaderMW(),
@@ -769,7 +767,6 @@ export class FxCore implements Core {
 
   @hooks([
     ErrorHandlerMW,
-    ConcurrentLockerMW,
     ProjectSettingsLoaderMW,
     EnvInfoLoaderMW(isMultiEnvEnabled()),
     SolutionLoaderMW(),

--- a/packages/fx-core/src/core/index.ts
+++ b/packages/fx-core/src/core/index.ts
@@ -742,8 +742,6 @@ export class FxCore implements Core {
     SolutionLoaderMW(),
     QuestionModelMW,
     ContextInjectorMW,
-    ProjectSettingsWriterMW,
-    EnvInfoWriterMW(),
   ])
   async grantPermission(inputs: Inputs, ctx?: CoreHookContext): Promise<Result<any, FxError>> {
     currentStage = Stage.grantPermission;
@@ -757,8 +755,6 @@ export class FxCore implements Core {
     SolutionLoaderMW(),
     QuestionModelMW,
     ContextInjectorMW,
-    ProjectSettingsWriterMW,
-    EnvInfoWriterMW(),
   ])
   async checkPermission(inputs: Inputs, ctx?: CoreHookContext): Promise<Result<any, FxError>> {
     currentStage = Stage.checkPermission;
@@ -772,8 +768,6 @@ export class FxCore implements Core {
     SolutionLoaderMW(),
     QuestionModelMW,
     ContextInjectorMW,
-    ProjectSettingsWriterMW,
-    EnvInfoWriterMW(),
   ])
   async listCollaborator(inputs: Inputs, ctx?: CoreHookContext): Promise<Result<any, FxError>> {
     currentStage = Stage.listCollaborator;


### PR DESCRIPTION
These functions do not read or write configuration files, so remove concurrent locker to avoid errors when used on tree view