### PR TITLE
feat(multi-env): add --resource-group argument for provision command in CLI

### DIFF
--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -613,6 +613,8 @@ export interface Inputs extends Json {
     // (undocumented)
     targetEnvName?: string;
     // (undocumented)
+    targetResourceGroupName?: string;
+    // (undocumented)
     vscodeEnv?: VsCodeEnv;
 }
 

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -163,6 +163,7 @@ export interface Inputs extends Json {
   projectPath?: string;
   targetEnvName?: string;
   sourceEnvName?: string;
+  targetResourceGroupName?: string;
   platform: Platform;
   stage?: Stage;
   vscodeEnv?: VsCodeEnv;

--- a/packages/cli/src/cmds/provision.ts
+++ b/packages/cli/src/cmds/provision.ts
@@ -20,16 +20,25 @@ import {
 import CLIUIInstance from "../userInteraction";
 import HelpParamGenerator from "../helpParamGenerator";
 import { sqlPasswordConfirmQuestionName, sqlPasswordQustionName } from "../constants";
+import { isMultiEnvEnabled } from "@microsoft/teamsfx-core";
 
 export default class Provision extends YargsCommand {
   public readonly commandHead = `provision`;
   public readonly command = `${this.commandHead}`;
   public readonly description = "Provision the cloud resources in the current application.";
+  public readonly resourceGroupParam = "resource-group";
 
   public params: { [_: string]: Options } = {};
 
   public builder(yargs: Argv): Argv<any> {
     this.params = HelpParamGenerator.getYargsParamForHelp(Stage.provision);
+    if (isMultiEnvEnabled()) {
+      yargs.option(this.resourceGroupParam, {
+        require: false,
+        description: "The name of an existing resource group",
+        type: "string",
+      });
+    }
     return yargs.version(false).options(this.params);
   }
 
@@ -48,6 +57,13 @@ export default class Provision extends YargsCommand {
         return result;
       }
     }
+    const inputs = getSystemInputs(rootFolder, args.env);
+
+    if (isMultiEnvEnabled()) {
+      if (this.resourceGroupParam in args) {
+        inputs.targetResourceGroupName = args[this.resourceGroupParam];
+      }
+    }
 
     const result = await activate(rootFolder);
     if (result.isErr()) {
@@ -57,7 +73,7 @@ export default class Provision extends YargsCommand {
 
     const core = result.value;
     {
-      const result = await core.provisionResources(getSystemInputs(rootFolder, args.env));
+      const result = await core.provisionResources(inputs);
       if (result.isErr()) {
         CliTelemetry.sendTelemetryErrorEvent(TelemetryEvent.Provision, result.error);
         return err(result.error);


### PR DESCRIPTION
- add resource group argument for provision command
- change get resource group logic in core


It will use the specified rg without asking user
![Screenshot from 2021-09-15 14-33-47](https://user-images.githubusercontent.com/9698542/133382613-77156b8d-6608-4900-a4c1-4cd7f2425aa9.png)

It will ask user if rg is not specified
![Screenshot from 2021-09-15 14-02-53](https://user-images.githubusercontent.com/9698542/133382442-db7a3193-1f2e-4e4c-96d9-6bb0ddfa1166.png)
