### PR TITLE
chore: update script to fix webview debug issue temporarily

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -643,7 +643,7 @@
     "copy-test-files": "copyfiles -u 1 test/**/*.ps1 test/**/*.sh out/test/",
     "compile": "tsc -p ./ && npm run copy-files && npm run copy-changelog-files",
     "build": "rimraf out && npm run compile",
-    "build-webpack": "rimraf out && webpack --mode development --config ./webpack.config.js",
+    "build-webpack": "rimraf out && webpack --mode development --config ./webpack.config.js && npm run compile",
     "build-failpoint": "rimraf out && npx ttsc -p ./",
     "watch": "webpack --watch --devtool nosources-source-map --info-verbosity verbose --config ./webpack.config.js",
     "package": "rimraf out && webpack --mode production --config ./webpack.config.js",


### PR DESCRIPTION
For webpacked code, there's generated soucemap. In theory, that's enough for debug locally. 
I compared our soucemaps with other project and didn't find any difference.
So use this way as a workaround for now.