### PR TITLE
fix(multi-env): fix activate command argument format

### DIFF
--- a/packages/cli/src/cmds/env.ts
+++ b/packages/cli/src/cmds/env.ts
@@ -199,7 +199,7 @@ class EnvActivate extends YargsCommand {
     this.params = HelpParamGenerator.getYargsParamForHelp(Stage.activateEnv);
     yargs.positional("env", {
       type: "string",
-      description: "Select a environment to activate",
+      description: "Select an environment to activate",
       demandOption: true,
     });
     return yargs.version(false).options(this.params);

--- a/packages/cli/src/cmds/env.ts
+++ b/packages/cli/src/cmds/env.ts
@@ -191,13 +191,18 @@ class EnvList extends YargsCommand {
 
 class EnvActivate extends YargsCommand {
   public readonly commandHead = `activate`;
-  public readonly command = `${this.commandHead}`;
+  public readonly command = `${this.commandHead} <env>`;
   public readonly description = "Activate an environment.";
   public params: { [_: string]: Options } = {};
 
   public builder(yargs: Argv): Argv<any> {
     this.params = HelpParamGenerator.getYargsParamForHelp(Stage.activateEnv);
-    return yargs.version(false).options(this.params).demandOption(EnvNodeNoCreate.data.name!);
+    yargs.positional("env", {
+      type: "string",
+      description: "Select a environment to activate",
+      demandOption: true,
+    });
+    return yargs.version(false).options(this.params);
   }
 
   public async runCommand(args: { [argName: string]: string }): Promise<Result<null, FxError>> {

--- a/packages/cli/src/helpParamGenerator.ts
+++ b/packages/cli/src/helpParamGenerator.ts
@@ -49,7 +49,6 @@ export class HelpParamGenerator {
     Stage.grantPermission,
     Stage.checkPermission,
     "validate",
-    Stage.activateEnv,
     Stage.createEnv,
   ];
 


### PR DESCRIPTION
The design is `teamsfx env activate <name>`.

![Screenshot from 2021-09-16 13-30-58](https://user-images.githubusercontent.com/9698542/133555189-f9312a9d-c108-449b-8017-820baaca85c4.png)
