### PR TITLE
fix(solution): pass the right plugin v2 name

### DIFF
--- a/packages/fx-core/src/plugins/solution/fx-solution/ResourcePluginContainer.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/ResourcePluginContainer.ts
@@ -52,8 +52,10 @@ export function getAllResourcePlugins(): Plugin[] {
  */
 export function getAllV2ResourcePlugins(): v2.ResourcePlugin[] {
   const plugins: v2.ResourcePlugin[] = [];
-  for (const k in ResourcePluginsV2) {
-    const plugin = Container.get<v2.ResourcePlugin>(k);
+  let k: keyof typeof ResourcePluginsV2;
+  for (k in ResourcePluginsV2) {
+    const pluginName = ResourcePluginsV2[k];
+    const plugin = Container.get<v2.ResourcePlugin>(pluginName);
     if (plugin) {
       plugins.push(plugin);
     }

--- a/packages/fx-core/tests/plugins/solution/solution.provision.test.ts
+++ b/packages/fx-core/tests/plugins/solution/solution.provision.test.ts
@@ -941,6 +941,7 @@ describe("API v2 implementation", () => {
         profile: {},
       };
       mockProvisionV2ThatAlwaysSucceed(spfxPluginV2);
+      mockProvisionV2ThatAlwaysSucceed(appStudioPluginV2);
 
       const solution = new TeamsAppSolutionV2();
       const result = await solution.provisionResources(


### PR DESCRIPTION
closes https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_sprints/taskboard/Teams%20Extensibility%20E2E%20Team/Microsoft%20Teams%20Extensibility/CY21-9.1?workitem=10942102