### PR TITLE
fix(multi-env): refresh env tree when new env created

### DIFF
--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -784,6 +784,9 @@ export async function createNewEnvironment(args?: any[]): Promise<Result<Void, F
     getTriggerFromProperty(args)
   );
   const result = await runCommand(Stage.createEnv);
+  if (!result.isErr()) {
+    await registerEnvTreeHandler();
+  }
   return result;
 }
 


### PR DESCRIPTION
This bug is introduced by my last PR: https://github.com/OfficeDev/TeamsFx/pull/2367, and add back the logic `registerEnvTreeHandler` when new environment is created.