### PR TITLE
fix(cli): fix rootFolder undefined when publishing

### DIFF
--- a/packages/cli/src/cmds/publish.ts
+++ b/packages/cli/src/cmds/publish.ts
@@ -41,8 +41,7 @@ export default class Publish extends YargsCommand {
       CliTelemetry.sendTelemetryEvent(TelemetryEvent.PublishStart);
       result = await activate();
     } else {
-      const rootFolder = answers["folder"] as string;
-      delete answers.folder;
+      const rootFolder = answers.projectPath || ".";
       CliTelemetry.withRootFolder(rootFolder).sendTelemetryEvent(TelemetryEvent.PublishStart);
       result = await activate(rootFolder);
     }

--- a/packages/cli/src/cmds/publish.ts
+++ b/packages/cli/src/cmds/publish.ts
@@ -41,7 +41,7 @@ export default class Publish extends YargsCommand {
       CliTelemetry.sendTelemetryEvent(TelemetryEvent.PublishStart);
       result = await activate();
     } else {
-      const rootFolder = answers.projectPath || ".";
+      const rootFolder = answers.projectPath!;
       CliTelemetry.withRootFolder(rootFolder).sendTelemetryEvent(TelemetryEvent.PublishStart);
       result = await activate(rootFolder);
     }


### PR DESCRIPTION
we should use `inputs.projectRoot` rather than `inputs.folder` because `argsToInputs` has already converted inputs.folder to inputs.projectPath.

This bug should also exist in old versions, but will only cause `AzureAccountManager.setSubscription()`. not called before calling core's `publishApplication`.
But in multienv case, it will cause active environment not set.

![Screenshot from 2021-09-17 17-59-32](https://user-images.githubusercontent.com/9698542/133764915-4d827cff-c758-47b4-93d9-4407f068a76d.png)


https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/10950624/
