### PR TITLE
fix(multi-env): process env is not ready when hooks init

### DIFF
--- a/packages/fx-core/src/core/index.ts
+++ b/packages/fx-core/src/core/index.ts
@@ -179,7 +179,7 @@ export class FxCore implements Core {
     QuestionModelMW,
     ContextInjectorMW,
     ProjectSettingsWriterMW,
-    EnvInfoWriterMW(isMultiEnvEnabled()),
+    EnvInfoWriterMW(true),
   ])
   async createProject(inputs: Inputs, ctx?: CoreHookContext): Promise<Result<string, FxError>> {
     if (!ctx) {

--- a/packages/fx-core/src/core/middleware/envInfoWriter.ts
+++ b/packages/fx-core/src/core/middleware/envInfoWriter.ts
@@ -12,12 +12,12 @@ import { environmentManager } from "../environment";
 /**
  * This middleware will help to persist environment profile if necessary.
  */
-export function EnvInfoWriterMW(skip = false): Middleware {
+export function EnvInfoWriterMW(isScaffolding = false): Middleware {
   return async (ctx: CoreHookContext, next: NextFunction) => {
     try {
       await next();
     } finally {
-      if (skip) {
+      if (isScaffolding && isMultiEnvEnabled()) {
         return;
       }
 


### PR DESCRIPTION
The root cause is the hooks init step occurs before the extension activate step, so the process env is not ready if using the decorator like `EnvInfoWriterMW(isMultiEnvEnabled())`, as `isMultiEnvEnabled()` will return `false` before process env is set by extension activate.