### PR TITLE
fix(multi-env): handle cancel error when selecting env

### DIFF
--- a/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
@@ -62,7 +62,6 @@ import {
   isUserCancelError,
 } from "../../../common/tools";
 import { CopyFileError } from "../../../core";
-import { askTargetEnvironment } from "../../../core/middleware/envInfoLoader";
 import { ErrorHandlerMW } from "../../../core/middleware/errorHandler";
 import { PermissionRequestFileProvider } from "../../../core/permissionRequest";
 import { SolutionPlugins } from "../../../core/SolutionPluginContainer";

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/provision.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/provision.ts
@@ -41,7 +41,6 @@ import { isUndefined } from "lodash";
 import { PluginDisplayName } from "../../../../common/constants";
 import { ProvisionContextAdapter } from "./adaptor";
 import { fillInCommonQuestions } from "../commonQuestions";
-import { askTargetEnvironment } from "../../../../core/middleware/envInfoLoader";
 import { deployArmTemplates } from "../arm";
 import Container from "typedi";
 import { ResourcePluginsV2 } from "../ResourcePluginContainer";


### PR DESCRIPTION
- If the user presses ESC to cancel the select-env dialog, it will not throw system errors.

![pr](https://user-images.githubusercontent.com/9698542/134291740-f41258d0-82a8-44ec-95ed-c38a2c8dbfa6.gif)
