### PR TITLE
fix(multi-env): fix local debug NonActiveEnvError

### DIFF
--- a/packages/fx-core/src/core/middleware/envInfoLoader.ts
+++ b/packages/fx-core/src/core/middleware/envInfoLoader.ts
@@ -63,7 +63,7 @@ export function EnvInfoLoaderMW(skip: boolean): Middleware {
     }
 
     const inputs = ctx.arguments[ctx.arguments.length - 1] as Inputs;
-    if (inputs.previewType && inputs.previewType === "local") {
+    if ((inputs.previewType && inputs.previewType === "local") || inputs.ignoreEnvInfo) {
       skip = true;
     }
 


### PR DESCRIPTION
- env loader should test `inputs.ignoreEnvInfo` to determine whether to skip loading env


tested local debug