### PR TITLE
refactor(multi-env): remove inputs.askEnvSelect

### DIFF
--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -600,8 +600,6 @@ export interface InputResult<T> {
 // @public (undocumented)
 export interface Inputs extends Json {
     // (undocumented)
-    askEnvSelect?: boolean;
-    // (undocumented)
     ignoreConfigPersist?: boolean;
     // (undocumented)
     ignoreEnvInfo?: boolean;

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -171,7 +171,6 @@ export interface Inputs extends Json {
   ignoreTypeCheck?: boolean;
   ignoreConfigPersist?: boolean;
   ignoreEnvInfo?: boolean;
-  askEnvSelect?: boolean;
 }
 
 export interface ProjectConfig {

--- a/packages/fx-core/src/core/middleware/envInfoLoader.ts
+++ b/packages/fx-core/src/core/middleware/envInfoLoader.ts
@@ -10,6 +10,7 @@ import {
   Inputs,
   Json,
   ok,
+  Platform,
   ProjectSettings,
   QTreeNode,
   Result,
@@ -76,7 +77,8 @@ export function EnvInfoLoaderMW(skip: boolean): Middleware {
 
     let targetEnvName: string;
     if (!skip && isMultiEnvEnabled()) {
-      if (inputs.askEnvSelect) {
+      // Only ask user to select an env in VS Code
+      if (inputs.platform === Platform.VSCode) {
         const result = await askTargetEnvironment(core.tools, inputs);
         if (result.isErr()) {
           ctx.result = err(result.error);

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -300,7 +300,7 @@ export async function addResourceHandler(args?: any[]): Promise<Result<null, FxE
     namespace: "fx-solution-azure",
     method: "addResource",
   };
-  return await runUserTask(func, TelemetryEvent.AddResource);
+  return await runUserTask(func, TelemetryEvent.AddResource, true);
 }
 
 export async function addCapabilityHandler(args: any[]): Promise<Result<null, FxError>> {
@@ -309,7 +309,7 @@ export async function addCapabilityHandler(args: any[]): Promise<Result<null, Fx
     namespace: "fx-solution-azure",
     method: "addCapability",
   };
-  return await runUserTask(func, TelemetryEvent.AddCap);
+  return await runUserTask(func, TelemetryEvent.AddCap, true);
 }
 
 export async function validateManifestHandler(args?: any[]): Promise<Result<null, FxError>> {
@@ -322,7 +322,7 @@ export async function validateManifestHandler(args?: any[]): Promise<Result<null
     namespace: "fx-solution-azure",
     method: "validateManifest",
   };
-  return await runUserTask(func, TelemetryEvent.ValidateManifest, true);
+  return await runUserTask(func, TelemetryEvent.ValidateManifest, false);
 }
 
 export async function buildPackageHandler(args?: any[]): Promise<Result<null, FxError>> {
@@ -332,7 +332,7 @@ export async function buildPackageHandler(args?: any[]): Promise<Result<null, Fx
     namespace: "fx-solution-azure",
     method: "buildPackage",
   };
-  return await runUserTask(func, TelemetryEvent.Build, true);
+  return await runUserTask(func, TelemetryEvent.Build, false);
 }
 
 export async function provisionHandler(args?: any[]): Promise<Result<null, FxError>> {
@@ -393,17 +393,14 @@ export async function runCommand(stage: Stage): Promise<Result<any, FxError>> {
         break;
       }
       case Stage.provision: {
-        inputs.askEnvSelect = isMultiEnvEnabled() ? true : false;
         result = await core.provisionResources(inputs);
         break;
       }
       case Stage.deploy: {
-        inputs.askEnvSelect = isMultiEnvEnabled() ? true : false;
         result = await core.deployArtifacts(inputs);
         break;
       }
       case Stage.publish: {
-        inputs.askEnvSelect = isMultiEnvEnabled() ? true : false;
         result = await core.publishApplication(inputs);
         break;
       }
@@ -460,7 +457,7 @@ export function detectVsCodeEnv(): VsCodeEnv {
 export async function runUserTask(
   func: Func,
   eventName: string,
-  needSelectEnv = false
+  ignoreEnvInfo: boolean
 ): Promise<Result<any, FxError>> {
   let result: Result<any, FxError> = ok(null);
   try {
@@ -470,7 +467,7 @@ export async function runUserTask(
     }
 
     const inputs: Inputs = getSystemInputs();
-    inputs.askEnvSelect = needSelectEnv;
+    inputs.ignoreEnvInfo = ignoreEnvInfo;
     result = await core.executeUserTask(func, inputs);
   } catch (e) {
     result = wrapError(e);


### PR DESCRIPTION
This is part of a bigger refactor, which is to unify skip logic for `EnvInfoLoaderMW`. Only `skip` argument and  `inputs.skipEnvInfo` will remain.

- remove input.askEnvSelect to prevent code like `input.askEnvSelect` scattered everywhere
- for extension, as the concept of activeEnv is removed. Every lifecycle that requires env will ask from the users. So check platform in envInfoLoader to determine whether to ask env


Tested all these button, local debug and launch remote
![Screenshot from 2021-09-23 14-19-57](https://user-images.githubusercontent.com/9698542/134462338-c0dff5bd-9301-42f9-a91f-2bb40896d9ea.png)

The operations that will ask env are:
- Provision in the cloud
- Validate manifest file
- Zip teams metadata package
- Deploy to the cloud
- Publish to Teams
- Remote launch

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/10896919