### PR TITLE
refactor(multi-env): unify skip flags for EnvInfoLoaderMW

### DIFF
--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -606,8 +606,6 @@ export interface Inputs extends Json {
     // (undocumented)
     ignoreLock?: boolean;
     // (undocumented)
-    ignoreTypeCheck?: boolean;
-    // (undocumented)
     platform: Platform;
     // (undocumented)
     projectPath?: string;

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -168,7 +168,6 @@ export interface Inputs extends Json {
   stage?: Stage;
   vscodeEnv?: VsCodeEnv;
   ignoreLock?: boolean;
-  ignoreTypeCheck?: boolean;
   ignoreConfigPersist?: boolean;
   ignoreEnvInfo?: boolean;
 }

--- a/packages/cli/src/cmds/preview/commonUtils.ts
+++ b/packages/cli/src/cmds/preview/commonUtils.ts
@@ -199,9 +199,10 @@ async function getLocalEnv(
       namespace: "fx-solution-azure/fx-resource-local-debug",
       method: "getLocalDebugEnvs",
     };
-    const inputs = getSystemInputs(workspaceFolder, undefined, "local");
+    const inputs = getSystemInputs(workspaceFolder, undefined);
     inputs.ignoreLock = true;
     inputs.ignoreConfigPersist = true;
+    inputs.ignoreEnvInfo = true;
     const result = await core.executeUserTask(func, inputs);
     if (result.isErr()) {
       throw result.error;

--- a/packages/cli/src/cmds/preview/constants.ts
+++ b/packages/cli/src/cmds/preview/constants.ts
@@ -27,6 +27,7 @@ export const functionPluginName = "fx-resource-function";
 export const botPluginName = "fx-resource-bot";
 export const localDebugPluginName = "fx-resource-local-debug";
 export const solutionPluginName = "solution";
+export const appstudioPluginName = "fx-resource-appstudio";
 export const spfxPluginName = "fx-resource-spfx";
 
 export enum ProgrammingLanguage {
@@ -38,6 +39,7 @@ export const programmingLanguageConfigKey = "programmingLanguage";
 export const skipNgrokConfigKey = "skipNgrok";
 export const teamsAppTenantIdConfigKey = "teamsAppTenantId";
 export const remoteTeamsAppIdConfigKey = "remoteTeamsAppId";
+export const remoteTeamsAppIdConfigKeyNew = "teamsAppId";
 export const localTeamsAppIdConfigKey = "localDebugTeamsAppId";
 
 export const localSettingsTenantIdConfigKey = "tenantId";

--- a/packages/cli/src/cmds/preview/preview.ts
+++ b/packages/cli/src/cmds/preview/preview.ts
@@ -169,7 +169,7 @@ export default class Preview extends YargsCommand {
     const inputs: Inputs = {
       projectPath: workspaceFolder,
       platform: Platform.CLI,
-      previewType: "local",
+      ignoreEnvInfo: true, // local debug does not require environments
     };
 
     let configResult = await core.getProjectConfig(inputs);
@@ -491,7 +491,7 @@ export default class Preview extends YargsCommand {
     env: string | undefined
   ): Promise<Result<null, FxError>> {
     /* === get remote teams app id === */
-    const coreResult = await activate();
+    const coreResult = await activate(workspaceFolder);
     if (coreResult.isErr()) {
       return err(coreResult.error);
     }
@@ -525,9 +525,12 @@ export default class Preview extends YargsCommand {
     const tenantId = config?.config
       ?.get(constants.solutionPluginName)
       ?.get(constants.teamsAppTenantIdConfigKey) as string;
-    const remoteTeamsAppId = config?.config
-      ?.get(constants.solutionPluginName)
-      ?.get(constants.remoteTeamsAppIdConfigKey) as string;
+
+    const remoteTeamsAppId: string = isMultiEnvEnabled()
+      ? config?.config
+          ?.get(constants.appstudioPluginName)
+          ?.get(constants.remoteTeamsAppIdConfigKeyNew)
+      : config?.config?.get(constants.solutionPluginName)?.get(constants.remoteTeamsAppIdConfigKey);
     if (remoteTeamsAppId === undefined || remoteTeamsAppId.length === 0) {
       return err(errors.PreviewWithoutProvision());
     }

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -414,13 +414,12 @@ export function getProjectId(rootfolder: string | undefined): any {
   return undefined;
 }
 
-export function getSystemInputs(projectPath?: string, env?: string, previewType?: string): Inputs {
+export function getSystemInputs(projectPath?: string, env?: string): Inputs {
   const systemInputs: Inputs = {
     platform: Platform.CLI,
     projectPath: projectPath,
     correlationId: uuid.v4(),
     env: env,
-    previewType: previewType,
   };
   return systemInputs;
 }

--- a/packages/fx-core/src/core/middleware/envInfoLoader.ts
+++ b/packages/fx-core/src/core/middleware/envInfoLoader.ts
@@ -64,7 +64,7 @@ export function EnvInfoLoaderMW(skip: boolean): Middleware {
     }
 
     const inputs = ctx.arguments[ctx.arguments.length - 1] as Inputs;
-    if ((inputs.previewType && inputs.previewType === "local") || inputs.ignoreEnvInfo) {
+    if (inputs.ignoreEnvInfo) {
       skip = true;
     }
 

--- a/packages/fx-core/src/core/middleware/projectSettingsLoader.ts
+++ b/packages/fx-core/src/core/middleware/projectSettingsLoader.ts
@@ -142,5 +142,5 @@ export function shouldIgnored(ctx: CoreHookContext): boolean {
     isCreate = task === Stage.create;
   }
 
-  return inputs.ignoreTypeCheck === true || StaticPlatforms.includes(inputs.platform) || isCreate;
+  return StaticPlatforms.includes(inputs.platform) || isCreate;
 }

--- a/packages/fx-core/tests/core/hooks.test.ts
+++ b/packages/fx-core/tests/core/hooks.test.ts
@@ -530,8 +530,6 @@ describe("Middleware", () => {
       await my.other(inputs);
       inputs.platform = Platform.VS;
       await my.other(inputs);
-      inputs.ignoreTypeCheck = true;
-      await my.other(inputs);
     });
 
     it("failed to load: NoProjectOpenedError, PathNotExistError", async () => {


### PR DESCRIPTION
- remove `ignoreTypeCheck`. Discussed with @jayzhang that this is not used anymore.
- remove `previewType` because it is only used by CLI preview to determine whether to skip loading env. This functionality is the same as `ignoreEnvInfo`, so just reuse it.
- fix bugs in remote preview

tested CLI local/remote preview 