### PR TITLE
feat(cli-preview): add browser argument option to preview command

### DIFF
--- a/packages/cli/src/cmds/preview/commonUtils.ts
+++ b/packages/cli/src/cmds/preview/commonUtils.ts
@@ -32,12 +32,17 @@ import open from "open";
 import { FxCore, isMultiEnvEnabled } from "@microsoft/teamsfx-core";
 import { getSystemInputs, getColorizedString } from "../../utils";
 
-export async function openBrowser(browser: constants.Browser, url: string): Promise<void> {
+export async function openBrowser(
+  browser: constants.Browser,
+  url: string,
+  browserArguments: string[] = []
+): Promise<void> {
   switch (browser) {
     case constants.Browser.chrome:
       await open(url, {
         app: {
           name: open.apps.chrome,
+          arguments: browserArguments,
         },
         wait: true,
         allowNonzeroExitCode: true,
@@ -47,6 +52,7 @@ export async function openBrowser(browser: constants.Browser, url: string): Prom
       await open(url, {
         app: {
           name: open.apps.edge,
+          arguments: browserArguments,
         },
         wait: true,
         allowNonzeroExitCode: true,


### PR DESCRIPTION
Adds a new `--browser-arg` option for the `preview` command to pass a user-supplied argument to the selected browser.

* Private session:
    * `teamsfx preview --local --browser edge --browser-arg="--inprivate"`
    * `teamsfx preview --local --browser chrome --browser-arg="--incognito"`
* Guest session:
    * `teamsfx preview --local --browser edge --browser-arg="--guest"`
    * `teamsfx preview --local --browser chrome --browser-arg="--guest"`
* Select a named profile:
    * `teamsfx preview --local --browser edge --browser-arg="--profile-directory=Profile 2"`
    * `teamsfx preview --local --browser chrome --browser-arg="--profile-directory=Profile 1"`
* Pass multiple arguments:
    * `teamsfx preview --local --browser "chrome" --browser-arg="--incognito" --browser-arg="--start-fullscreen"`

 Fixes issue #1772.

(A previous iteration had dedicated flags, keeping here for history.)

<strike>
Adds three new options for the `preview` command:
* `--browser-private` launches Chrome in InPrivate and Edge in Incognito.
* `--browser-guest` launches Chrome or Edge in a guest session.
* `--browser-profile="<profile name>"` launches Chrome or Edge with a named profile.

All three options are mutually exclusive, and require the browser to be explicitly
selected with `--browser chrome` or `--browser edge`.

Examples:
* `teamsfx preview --local --browser chrome --browser-guest`
* `teamsfx preview --local --browser edge --browser-private`
* `teamsfx preview --local --browser edge --browser-profile "Profile 2"`

Fixes issue #1772.
</strike>