### PR TITLE
test(multi-env): add EnvInfoLoader UT for skip logic and fix a bug

### DIFF
--- a/packages/fx-core/src/core/middleware/envInfoLoader.ts
+++ b/packages/fx-core/src/core/middleware/envInfoLoader.ts
@@ -159,7 +159,8 @@ export async function loadSolutionContext(
   const cryptoProvider = new LocalCrypto(projectSettings.projectId);
 
   let envInfo: EnvInfo;
-  if (ignoreEnvInfo) {
+  // in pre-multi-env case, envInfo is always loaded.
+  if (ignoreEnvInfo && isMultiEnvEnabled()) {
     envInfo = newEnvInfo();
   } else {
     // ensure backwards compatibility:

--- a/packages/fx-core/src/core/middleware/envInfoLoader.ts
+++ b/packages/fx-core/src/core/middleware/envInfoLoader.ts
@@ -116,7 +116,7 @@ export function EnvInfoLoaderMW(skip: boolean): Middleware {
       ctx.projectSettings,
       ctx.projectIdMissing,
       targetEnvName,
-      inputs.ignoreEnvInfo
+      skip
     );
     if (result.isErr()) {
       ctx.result = err(result.error);
@@ -157,26 +157,22 @@ export async function loadSolutionContext(
   }
 
   const cryptoProvider = new LocalCrypto(projectSettings.projectId);
-  // ensure backwards compatibility:
-  // no need to decrypt the secrets in *.userdata for previous TeamsFx project, which has no project id.
-  const envDataResult = await environmentManager.loadEnvInfo(
-    inputs.projectPath,
-    targetEnvName,
-    projectIdMissing ? undefined : cryptoProvider
-  );
 
   let envInfo: EnvInfo;
-  if (envDataResult.isErr()) {
-    if (ignoreEnvInfo) {
-      // ignore env loading error
-      tools.logProvider.info(
-        `[core:env] failed to load '${targetEnvName}' environment, skipping because ignoreEnvInfo is set to true, error: ${envDataResult.error.message}`
-      );
-      envInfo = newEnvInfo();
-    } else {
+  if (ignoreEnvInfo) {
+    envInfo = newEnvInfo();
+  } else {
+    // ensure backwards compatibility:
+    // no need to decrypt the secrets in *.userdata for previous TeamsFx project, which has no project id.
+    const envDataResult = await environmentManager.loadEnvInfo(
+      inputs.projectPath,
+      targetEnvName,
+      projectIdMissing ? undefined : cryptoProvider
+    );
+
+    if (envDataResult.isErr()) {
       return err(envDataResult.error);
     }
-  } else {
     envInfo = envDataResult.value;
   }
 

--- a/packages/fx-core/tests/core/environment.test.ts
+++ b/packages/fx-core/tests/core/environment.test.ts
@@ -139,6 +139,18 @@ describe("APIs of Environment Manager", () => {
         assert.fail("Failed to get expected error.");
       }
     });
+
+    it("load non existent env name", async () => {
+      const actualEnvDataResult = await environmentManager.loadEnvInfo(
+        projectPath,
+        "this does not exist"
+      );
+      if (actualEnvDataResult.isErr()) {
+        assert.equal(actualEnvDataResult.error.name, "ProjectEnvNotExistError");
+      } else {
+        assert.fail("Failed to get expected error.");
+      }
+    });
   });
 
   describe("Load Environment Profile File", () => {

--- a/packages/fx-core/tests/core/hooks.test.ts
+++ b/packages/fx-core/tests/core/hooks.test.ts
@@ -1535,7 +1535,6 @@ describe("Middleware", () => {
 
   describe("LocalSettingsLoaderMW, ContextInjectorMW", () => {
     it("NoProjectOpenedError", async () => {
-      console.log("no project opened");
       const original = process.env[FeatureFlagName.MultiEnv];
       process.env[FeatureFlagName.MultiEnv] = "true";
 

--- a/packages/fx-core/tests/core/hooks.test.ts
+++ b/packages/fx-core/tests/core/hooks.test.ts
@@ -10,6 +10,8 @@ import {
   ConfigFolderName,
   ConfigMap,
   CoreCallbackEvent,
+  EnvConfig,
+  EnvInfo,
   err,
   Func,
   FunctionRouter,
@@ -23,10 +25,12 @@ import {
   ProjectSettings,
   QTreeNode,
   Result,
+  returnSystemError,
   Solution,
   SolutionContext,
   Stage,
   SystemError,
+  Tools,
   UserCancelError,
   UserError,
   UserInteraction,
@@ -37,7 +41,7 @@ import fs from "fs-extra";
 import "mocha";
 import * as os from "os";
 import * as path from "path";
-import sinon from "sinon";
+import sinon, { stub } from "sinon";
 import { Container } from "typedi";
 import {
   base64Encode,
@@ -60,6 +64,7 @@ import {
 import { ConcurrentLockerMW } from "../../src/core/middleware/concurrentLocker";
 import { ContextInjectorMW } from "../../src/core/middleware/contextInjector";
 import { EnvInfoLoaderMW } from "../../src/core/middleware/envInfoLoader";
+import * as envInfoLoader from "../../src/core/middleware/envInfoLoader";
 import { EnvInfoWriterMW } from "../../src/core/middleware/envInfoWriter";
 import { ErrorHandlerMW } from "../../src/core/middleware/errorHandler";
 import { LocalSettingsLoaderMW } from "../../src/core/middleware/localSettingsLoader";
@@ -87,6 +92,7 @@ import {
   MockUserInteraction,
   randomAppName,
 } from "./utils";
+import * as commonTools from "../../src/common/tools";
 import { ProjectMigratorMW, migrateArm } from "../../src/core/middleware/projectMigrator";
 import exp = require("constants");
 import mockedEnv from "mocked-env";
@@ -1529,6 +1535,7 @@ describe("Middleware", () => {
 
   describe("LocalSettingsLoaderMW, ContextInjectorMW", () => {
     it("NoProjectOpenedError", async () => {
+      console.log("no project opened");
       const original = process.env[FeatureFlagName.MultiEnv];
       process.env[FeatureFlagName.MultiEnv] = "true";
 
@@ -1666,6 +1673,112 @@ describe("Middleware", () => {
       } finally {
         await fs.rmdir(inputs.projectPath!, { recursive: true });
       }
+    });
+  });
+  describe("EnvInfoLoaderMW", () => {
+    const expectedResult = "ok";
+    const projectPath = "mock/this/does/not/exists";
+
+    sandbox.stub(commonTools, "isMultiEnvEnabled").returns(true);
+
+    // stub environmentManager.loadEnvInfo()
+    const envConfig: EnvConfig = {
+      manifest: {
+        values: {
+          appName: {
+            short: "testApp",
+          },
+        },
+      },
+    };
+    const envProfile = new Map<string, any>();
+    const envInfo = {
+      envName: "test",
+      config: envConfig,
+      profile: envProfile,
+    };
+    sandbox.stub(environmentManager, "loadEnvInfo").returns(Promise.resolve(ok(envInfo)));
+
+    // mock fs.existsSync for EnvInfoLoader
+    const originalPathExists = fs.pathExists;
+    sandbox.stub(fs, "pathExists").callsFake(async (path: string) => {
+      if (path === projectPath) {
+        return true;
+      } else {
+        return originalPathExists(path);
+      }
+    });
+
+    function MockProjectSettingsLoaderMW() {
+      return async (ctx: CoreHookContext, next: NextFunction) => {
+        ctx.projectSettings = {
+          appName: "testApp",
+          version: "1.0",
+          projectId: "abcd",
+          solutionSettings: {
+            name: "fx-solution-azure",
+          },
+          activeEnvironment: "test",
+        };
+        await next();
+      };
+    }
+    async function SolutionContextSpyMW(ctx: CoreHookContext, next: NextFunction) {
+      await next();
+      solutionContext = ctx.solutionContext;
+    }
+
+    // test variables
+    let solutionContext: SolutionContext | undefined;
+    beforeEach(() => {
+      solutionContext = undefined;
+    });
+
+    it("skip statically", async () => {
+      const inputs: Inputs = {
+        platform: Platform.VSCode,
+        projectPath: projectPath,
+      };
+      class MyClass {
+        tools: Tools = new MockTools();
+        async myMethod(inputs: Inputs): Promise<Result<string, FxError>> {
+          return ok(expectedResult);
+        }
+      }
+
+      hooks(MyClass, {
+        myMethod: [MockProjectSettingsLoaderMW(), EnvInfoLoaderMW(true), SolutionContextSpyMW],
+      });
+      const my = new MyClass();
+      const res = await my.myMethod(inputs);
+      assert.isTrue(res.isOk());
+      assert(solutionContext);
+      // envInfo should be set to a default value when envInfo loading is skipped.
+      assert.isTrue(solutionContext?.envInfo.envName === environmentManager.getDefaultEnvName());
+    });
+
+    it("skip dynamically with inputs.ignoreEnvInfo", async () => {
+      const inputs: Inputs = {
+        platform: Platform.VSCode,
+        projectPath: projectPath,
+        ignoreEnvInfo: true,
+      };
+      class MyClass {
+        tools: Tools = new MockTools();
+        async myMethod(inputs: Inputs): Promise<Result<string, FxError>> {
+          return ok(expectedResult);
+        }
+      }
+
+      hooks(MyClass, {
+        myMethod: [MockProjectSettingsLoaderMW(), EnvInfoLoaderMW(false), SolutionContextSpyMW],
+      });
+      const my = new MyClass();
+      const res = await my.myMethod(inputs);
+      assert.isTrue(res.isOk());
+      assert(solutionContext);
+      // envInfo should be set to a default value when envInfo loading is skipped.
+      assert.isTrue(solutionContext?.envInfo.envName === environmentManager.getDefaultEnvName());
     });
   });
 });

--- a/packages/fx-core/tests/core/hooks.test.ts
+++ b/packages/fx-core/tests/core/hooks.test.ts
@@ -1753,7 +1753,7 @@ describe("Middleware", () => {
       assert.isTrue(res.isOk());
       assert(solutionContext);
       // envInfo should be set to a default value when envInfo loading is skipped.
-      assert.isTrue(solutionContext?.envInfo.envName === environmentManager.getDefaultEnvName());
+      assert.equal(solutionContext?.envInfo.envName, environmentManager.getDefaultEnvName());
     });
 
     it("skip dynamically with inputs.ignoreEnvInfo", async () => {
@@ -1777,7 +1777,7 @@ describe("Middleware", () => {
       assert.isTrue(res.isOk());
       assert(solutionContext);
       // envInfo should be set to a default value when envInfo loading is skipped.
-      assert.isTrue(solutionContext?.envInfo.envName === environmentManager.getDefaultEnvName());
+      assert.equal(solutionContext?.envInfo.envName, environmentManager.getDefaultEnvName());
     });
   });
 });

--- a/packages/fx-core/tests/core/hooks.test.ts
+++ b/packages/fx-core/tests/core/hooks.test.ts
@@ -1678,36 +1678,6 @@ describe("Middleware", () => {
     const expectedResult = "ok";
     const projectPath = "mock/this/does/not/exists";
 
-    sandbox.stub(commonTools, "isMultiEnvEnabled").returns(true);
-
-    // stub environmentManager.loadEnvInfo()
-    const envConfig: EnvConfig = {
-      manifest: {
-        values: {
-          appName: {
-            short: "testApp",
-          },
-        },
-      },
-    };
-    const envProfile = new Map<string, any>();
-    const envInfo = {
-      envName: "test",
-      config: envConfig,
-      profile: envProfile,
-    };
-    sandbox.stub(environmentManager, "loadEnvInfo").returns(Promise.resolve(ok(envInfo)));
-
-    // mock fs.existsSync for EnvInfoLoader
-    const originalPathExists = fs.pathExists;
-    sandbox.stub(fs, "pathExists").callsFake(async (path: string) => {
-      if (path === projectPath) {
-        return true;
-      } else {
-        return originalPathExists(path);
-      }
-    });
-
     function MockProjectSettingsLoaderMW() {
       return async (ctx: CoreHookContext, next: NextFunction) => {
         ctx.projectSettings = {
@@ -1731,6 +1701,37 @@ describe("Middleware", () => {
     let solutionContext: SolutionContext | undefined;
     beforeEach(() => {
       solutionContext = undefined;
+
+      // stub functions before
+      sandbox.stub(commonTools, "isMultiEnvEnabled").returns(true);
+
+      // stub environmentManager.loadEnvInfo()
+      const envConfig: EnvConfig = {
+        manifest: {
+          values: {
+            appName: {
+              short: "testApp",
+            },
+          },
+        },
+      };
+      const envProfile = new Map<string, any>();
+      const envInfo = {
+        envName: "test",
+        config: envConfig,
+        profile: envProfile,
+      };
+      sandbox.stub(environmentManager, "loadEnvInfo").returns(Promise.resolve(ok(envInfo)));
+
+      // mock fs.existsSync for EnvInfoLoader
+      const originalPathExists = fs.pathExists;
+      sandbox.stub(fs, "pathExists").callsFake(async (path: string) => {
+        if (path === projectPath) {
+          return true;
+        } else {
+          return originalPathExists(path);
+        }
+      });
     });
 
     it("skip statically", async () => {

--- a/packages/fx-core/tests/core/hooks.test.ts
+++ b/packages/fx-core/tests/core/hooks.test.ts
@@ -1675,7 +1675,7 @@ describe("Middleware", () => {
       }
     });
   });
-  describe("EnvInfoLoaderMW", () => {
+  describe("EnvInfoLoaderMW with MultiEnv enabled", () => {
     const expectedResult = "ok";
     const projectPath = "mock/this/does/not/exists";
 


### PR DESCRIPTION
- when skip is set, EnvInfo should not be loaded
- add UT for skip logic
- add a test case for NonExistEnvError to prevent the coverage drop because after the bugfix, this exception is not thrown in the happy path case.