### PR TITLE
chore(multi-env): remove active env from CLI

### DIFF
--- a/packages/cli/src/activate.ts
+++ b/packages/cli/src/activate.ts
@@ -27,14 +27,6 @@ export default async function activate(rootPath?: string): Promise<Result<FxCore
       await AzureAccountManager.setSubscription(subscriptionInfo.subscriptionId);
     }
     CliTelemetry.setReporter(CliTelemetry.getReporter().withRootFolder(rootPath));
-
-    if (isMultiEnvEnabled()) {
-      const activeEnvResult = environmentManager.getActiveEnv(rootPath);
-      if (activeEnvResult.isErr()) {
-        return err(activeEnvResult.error);
-      }
-      setActiveEnv(activeEnvResult.value);
-    }
   }
 
   const tools: Tools = {

--- a/packages/cli/src/cmds/env.ts
+++ b/packages/cli/src/cmds/env.ts
@@ -12,8 +12,6 @@ import {
   environmentManager,
   InvalidEnvNameError,
   ProjectEnvAlreadyExistError,
-  ProjectFolderExistError,
-  setActiveEnv,
 } from "@microsoft/teamsfx-core";
 import * as process from "process";
 import * as os from "os";
@@ -21,19 +19,14 @@ import CLILogProvider from "../commonlib/log";
 import { WorkspaceNotSupported } from "./preview/errors";
 import HelpParamGenerator from "../helpParamGenerator";
 import activate from "../activate";
-import CliTelemetry from "../telemetry/cliTelemetry";
-import { TelemetryEvent } from "../telemetry/cliTelemetryEvents";
-import { getChoicesFromQTNodeQuestion, getSystemInputs, isWorkspaceSupported } from "../utils";
-import { EnvNodeNoCreate } from "../constants";
-
-const ActiveMark = " (active)";
+import { getSystemInputs, isWorkspaceSupported } from "../utils";
 
 export default class Env extends YargsCommand {
   public readonly commandHead = `env`;
   public readonly command = `${this.commandHead} [action]`;
   public readonly description = "Manage environments.";
 
-  public readonly subCommands: YargsCommand[] = [new EnvAdd(), new EnvList(), new EnvActivate()];
+  public readonly subCommands: YargsCommand[] = [new EnvAdd(), new EnvList()];
 
   public builder(yargs: Argv): Argv<any> {
     yargs.options("action", {
@@ -48,20 +41,7 @@ export default class Env extends YargsCommand {
     });
     return yargs.version(false);
   }
-
   public async runCommand(args: { [argName: string]: string }): Promise<Result<null, FxError>> {
-    const projectDir = args.folder || process.cwd();
-
-    if (!isWorkspaceSupported(projectDir)) {
-      return err(WorkspaceNotSupported(projectDir));
-    }
-
-    const activeEnvResult = environmentManager.getActiveEnv(projectDir);
-    if (activeEnvResult.isErr()) {
-      return err(activeEnvResult.error);
-    }
-
-    CLILogProvider.necessaryLog(LogLevel.Info, activeEnvResult.value, true);
     return ok(null);
   }
 }
@@ -171,62 +151,9 @@ class EnvList extends YargsCommand {
       return err(envResult.error);
     }
 
-    const activeEnvResult = await environmentManager.getActiveEnv(projectDir);
-    let activeEnv: string | undefined;
-    if (activeEnvResult.isOk()) {
-      activeEnv = activeEnvResult.value;
-    } else {
-      // Do not block user to list envs on failure to retrieve activeEnv
-      CLILogProvider.warning("Failed to get active env, error: " + activeEnvResult.error);
-    }
-
     // TODO: support --details
-    const envList = envResult.value
-      .map((env) => (env === activeEnv ? env + ActiveMark : env))
-      .join(os.EOL);
+    const envList = envResult.value.join(os.EOL);
     CLILogProvider.necessaryLog(LogLevel.Info, envList, true);
-    return ok(null);
-  }
-}
-
-class EnvActivate extends YargsCommand {
-  public readonly commandHead = `activate`;
-  public readonly command = `${this.commandHead} <env>`;
-  public readonly description = "Activate an environment.";
-  public params: { [_: string]: Options } = {};
-
-  public builder(yargs: Argv): Argv<any> {
-    this.params = HelpParamGenerator.getYargsParamForHelp(Stage.activateEnv);
-    yargs.positional("env", {
-      type: "string",
-      description: "Select an environment to activate",
-      demandOption: true,
-    });
-    return yargs.version(false).options(this.params);
-  }
-
-  public async runCommand(args: { [argName: string]: string }): Promise<Result<null, FxError>> {
-    const projectDir = args.folder || process.cwd();
-    // env always exists because we have `demandOption` in builder.
-    const env = args.env as string;
-
-    if (!isWorkspaceSupported(projectDir)) {
-      return err(WorkspaceNotSupported(projectDir));
-    }
-
-    const coreResult = await activate(projectDir);
-    if (coreResult.isErr()) {
-      return err(coreResult.error);
-    }
-
-    const fxCore = coreResult.value;
-    const inputs = getSystemInputs(projectDir);
-    inputs.env = env;
-    const result = await fxCore.activateEnv(inputs);
-    if (result.isErr()) {
-      return err(result.error);
-    }
-
     return ok(null);
   }
 }

--- a/packages/cli/tests/e2e/multienv/TestRemoteHappyPath.tests.ts
+++ b/packages/cli/tests/e2e/multienv/TestRemoteHappyPath.tests.ts
@@ -84,16 +84,6 @@ describe("Create single tab/bot/function", function () {
       await setSimpleAuthSkuNameToB1Bicep(projectPath, env);
       console.log(`[Successfully] update simple auth sku to B1`);
 
-      // set active env
-      result = await execAsync(`teamsfx env activate ${env}`, {
-        cwd: projectPath,
-        env: processEnv,
-        timeout: 0,
-      });
-      console.log(
-        `[Successfully] env activate, stdout: '${result.stdout}', stderr: '${result.stderr}'`
-      );
-
       // list env
       result = await execAsync(`teamsfx env list`, {
         cwd: projectPath,
@@ -101,27 +91,15 @@ describe("Create single tab/bot/function", function () {
         timeout: 0,
       });
       const envs = result.stdout.trim().split(/\r?\n/).sort();
-      expect(envs).to.deep.equal(["dev", "e2e (active)"]);
+      expect(envs).to.deep.equal(["dev", "e2e"]);
       expect(result.stderr).to.be.empty;
       console.log(
         `[Successfully] env list, stdout: '${result.stdout}', stderr: '${result.stderr}'`
       );
 
-      // show env
-      result = await execAsync(`teamsfx env`, {
-        cwd: projectPath,
-        env: processEnv,
-        timeout: 0,
-      });
-      expect(result.stdout).to.equal("e2e\n");
-      expect(result.stderr).to.be.empty;
-      console.log(
-        `[Successfully] env show, stdout: '${result.stdout}', stderr: '${result.stderr}'`
-      );
-
       // provision
       result = await execAsyncWithRetry(
-        `teamsfx provision --sql-admin-name e2e --sql-password 'Abc123456%'`,
+        `teamsfx provision --sql-admin-name e2e --sql-password 'Abc123456%' --env ${env}`,
         {
           cwd: projectPath,
           env: processEnv,
@@ -167,7 +145,7 @@ describe("Create single tab/bot/function", function () {
       }
 
       // deploy
-      await execAsyncWithRetry(`teamsfx deploy`, {
+      await execAsyncWithRetry(`teamsfx deploy --env ${env}`, {
         cwd: projectPath,
         env: processEnv,
         timeout: 0,
@@ -196,7 +174,7 @@ describe("Create single tab/bot/function", function () {
       }
 
       // validate manifest
-      result = await execAsyncWithRetry(`teamsfx validate`, {
+      result = await execAsyncWithRetry(`teamsfx validate --env ${env}`, {
         cwd: projectPath,
         env: processEnv,
         timeout: 0,
@@ -208,7 +186,7 @@ describe("Create single tab/bot/function", function () {
       }
 
       // package
-      await execAsyncWithRetry(`teamsfx package`, {
+      await execAsyncWithRetry(`teamsfx package --env ${env}`, {
         cwd: projectPath,
         env: processEnv,
         timeout: 0,
@@ -221,7 +199,7 @@ describe("Create single tab/bot/function", function () {
       }
 
       // publish
-      await execAsyncWithRetry(`teamsfx publish`, {
+      await execAsyncWithRetry(`teamsfx publish --env ${env}`, {
         cwd: projectPath,
         env: processEnv,
         timeout: 0,

--- a/packages/cli/tests/e2e/multienv/TestRemoteHappyPathSPFx.tests.ts
+++ b/packages/cli/tests/e2e/multienv/TestRemoteHappyPathSPFx.tests.ts
@@ -68,16 +68,6 @@ describe("Start a new project", function () {
     });
     console.log(`[Successfully] env add, stdout: '${result.stdout}', stderr: '${result.stderr}'`);
 
-    // set active env
-    result = await execAsync(`teamsfx env activate ${env}`, {
-      cwd: projectPath,
-      env: processEnv,
-      timeout: 0,
-    });
-    console.log(
-      `[Successfully] env activate, stdout: '${result.stdout}', stderr: '${result.stderr}'`
-    );
-
     // list env
     result = await execAsync(`teamsfx env list`, {
       cwd: projectPath,
@@ -85,22 +75,12 @@ describe("Start a new project", function () {
       timeout: 0,
     });
     const envs = result.stdout.trim().split(/\r?\n/).sort();
-    expect(envs).to.deep.equal(["dev", "e2e (active)"]);
+    expect(envs).to.deep.equal(["dev", "e2e"]);
     expect(result.stderr).to.be.empty;
     console.log(`[Successfully] env list, stdout: '${result.stdout}', stderr: '${result.stderr}'`);
 
-    // show env
-    result = await execAsync(`teamsfx env`, {
-      cwd: projectPath,
-      env: processEnv,
-      timeout: 0,
-    });
-    expect(result.stdout).to.equal("e2e\n");
-    expect(result.stderr).to.be.empty;
-    console.log(`[Successfully] env show, stdout: '${result.stdout}', stderr: '${result.stderr}'`);
-
     // provision
-    result = await execAsyncWithRetry(`teamsfx provision`, {
+    result = await execAsyncWithRetry(`teamsfx provision --env ${env}`, {
       cwd: projectPath,
       env: processEnv,
       timeout: 0,
@@ -121,7 +101,7 @@ describe("Start a new project", function () {
     }
 
     // deploy
-    await execAsyncWithRetry(`teamsfx deploy`, {
+    await execAsyncWithRetry(`teamsfx deploy --env ${env}`, {
       cwd: projectPath,
       env: processEnv,
       timeout: 0,
@@ -135,7 +115,7 @@ describe("Start a new project", function () {
     }
 
     // validate manifest
-    result = await execAsyncWithRetry(`teamsfx validate`, {
+    result = await execAsyncWithRetry(`teamsfx validate --env ${env}`, {
       cwd: projectPath,
       env: processEnv,
       timeout: 0,
@@ -147,7 +127,7 @@ describe("Start a new project", function () {
     }
 
     // package
-    await execAsyncWithRetry(`teamsfx package`, {
+    await execAsyncWithRetry(`teamsfx package --env ${env}`, {
       cwd: projectPath,
       env: processEnv,
       timeout: 0,
@@ -160,7 +140,7 @@ describe("Start a new project", function () {
     }
 
     // publish
-    result = await execAsyncWithRetry(`teamsfx publish`, {
+    result = await execAsyncWithRetry(`teamsfx publish --env ${env}`, {
       cwd: projectPath,
       env: processEnv,
       timeout: 0,

--- a/packages/cli/tests/unit/cmds/env.tests.ts
+++ b/packages/cli/tests/unit/cmds/env.tests.ts
@@ -94,101 +94,6 @@ function mockCommonUtils(sandbox: SinonSandbox, vars: Reference<MockVars>) {
   });
 }
 
-describe("Env Show Command Tests", function () {
-  const sandbox = sinon.createSandbox();
-  const vars = { value: new MockVars() };
-
-  let validProject = true;
-  let checkedRootDir = "";
-  let getActiveEnvError: FxError | undefined = undefined;
-  const activeEnv = "testing";
-
-  before(() => {
-    mockYargs(sandbox, vars);
-    mockCommonUtils(sandbox, vars);
-    sandbox.stub(Utils, "isWorkspaceSupported").callsFake((rootDir: string): boolean => {
-      checkedRootDir = rootDir;
-      return validProject;
-    });
-    sandbox
-      .stub(core.environmentManager, "getActiveEnv")
-      .callsFake((projectPath: string): Result<string, FxError> => {
-        if (getActiveEnvError) {
-          return err(getActiveEnvError);
-        } else {
-          return ok(activeEnv);
-        }
-      });
-  });
-
-  after(() => {
-    sandbox.restore();
-  });
-
-  beforeEach(() => {
-    vars.value = new MockVars();
-    validProject = true;
-    getActiveEnvError = undefined;
-  });
-
-  it("prints active env", async () => {
-    // Arrange
-    validProject = true;
-    const cmd = new Env();
-    const args = {};
-
-    // Act
-    await cmd.handler(args);
-
-    // Assert
-    expect(vars.value.logs).to.equal(activeEnv + "\n");
-  });
-
-  it("returns error on getActiveEnv errors.", async () => {
-    // Arrange
-    validProject = true;
-    getActiveEnvError = returnUserError(
-      new Error("fake user error message"),
-      "CLI",
-      "FakeUserError"
-    );
-    const cmd = new Env();
-    const args = {};
-
-    // Act
-    try {
-      await cmd.handler(args);
-    } catch (error) {
-      expect(error).instanceOf(UserError);
-      expect(error.name === "FakeUserError");
-    }
-
-    // Assert
-    expect(vars.value.logs).to.equal("[CLI.FakeUserError]: fake user error message\n");
-  });
-
-  it("throws on non-Teamsfx project", async () => {
-    // Arrange
-    validProject = false;
-    const cmd = new Env();
-    const args = {};
-    let exceptionThrown = false;
-
-    // Act
-    try {
-      await cmd.handler(args);
-    } catch (error) {
-      exceptionThrown = true;
-
-      // Assert
-      expect(error).instanceOf(UserError);
-      expect(error.name).equals("WorkspaceNotSupported");
-    }
-
-    expect(exceptionThrown);
-  });
-});
-
 describe("Env Add Command Tests", function () {
   const sandbox = sinon.createSandbox();
   const vars = { value: new MockVars() };
@@ -429,7 +334,7 @@ describe("Env List Command Tests", function () {
     await listCmd.handler(args);
 
     // Assert
-    expect(vars.value.logs).to.equal(`dev (active)${os.EOL}test${os.EOL}staging\n`);
+    expect(vars.value.logs).to.equal(`dev${os.EOL}test${os.EOL}staging\n`);
   });
 
   it("accepts --folder parameter", async () => {
@@ -462,87 +367,6 @@ describe("Env List Command Tests", function () {
 
     // Assert
     expect(vars.value.logs).to.equal("\n");
-  });
-
-  it("throws on non-Teamsfx project", async () => {
-    // Arrange
-    validProject = false;
-    const cmd = new Env();
-    const listCmd = getCommand(cmd, CommandName.List);
-    const args = {};
-    let exceptionThrown = false;
-
-    // Act
-    try {
-      await listCmd.handler(args);
-    } catch (error) {
-      exceptionThrown = true;
-
-      // Assert
-      expect(error).instanceOf(UserError);
-      expect(error.name).equals("WorkspaceNotSupported");
-    }
-
-    expect(exceptionThrown);
-  });
-});
-
-describe("Env Activate Command Tests", function () {
-  const sandbox = sinon.createSandbox();
-  const vars = { value: new MockVars() };
-  let validProject = true;
-  let checkedRootDir = "";
-  const envList = ["dev", "test", "staging"];
-  let activatedEnv: string | undefined = undefined;
-
-  before(() => {
-    mockYargs(sandbox, vars);
-    mockCommonUtils(sandbox, vars);
-    sandbox.stub(Utils, "isWorkspaceSupported").callsFake((rootDir: string): boolean => {
-      checkedRootDir = rootDir;
-      return validProject;
-    });
-    sandbox
-      .stub(FxCore.prototype, "activateEnv")
-      .callsFake(
-        async (inputs: Inputs, ctx?: core.CoreHookContext): Promise<Result<Void, FxError>> => {
-          activatedEnv = inputs.env;
-          return ok(Void);
-        }
-      );
-    sandbox.stub(core.environmentManager, "listEnvConfigs").callsFake(async (projectPath) => {
-      return ok(envList);
-    });
-    sandbox
-      .stub(core.environmentManager, "getActiveEnv")
-      .callsFake((projectPath: string): Result<string, FxError> => {
-        return ok(envList[0]);
-      });
-  });
-
-  after(() => {
-    sandbox.restore();
-  });
-
-  beforeEach(() => {
-    vars.value = new MockVars();
-    validProject = true;
-  });
-
-  it("passes env to core", async () => {
-    // Arrange
-    validProject = true;
-    const cmd = new Env();
-    const listCmd = getCommand(cmd, CommandName.Activate);
-    const args = {
-      [constants.EnvNodeNoCreate.data.name!]: envList[0],
-    };
-
-    // Act
-    await listCmd.handler(args);
-
-    // Assert
-    expect(activatedEnv).to.equal(envList[0]);
   });
 
   it("throws on non-Teamsfx project", async () => {


### PR DESCRIPTION
- remove CLI commands: `teamsfx env`, `teamsfx env activate`
- remove active env mark from `teamsfx env list`
- fix unit test and e2e test

e2e test result: https://github.com/OfficeDev/TeamsFx/runs/3717614569?check_suite_focus=true

interactive mode will be in the next pr

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/11012678