### PR TITLE
fix(multi-env): fix a bug that cause profile.dev.json to be cleared

### DIFF
--- a/packages/fx-core/src/core/index.ts
+++ b/packages/fx-core/src/core/index.ts
@@ -538,6 +538,7 @@ export class FxCore implements Core {
     QuestionModelMW,
     ContextInjectorMW,
     ProjectSettingsWriterMW,
+    EnvInfoWriterMW(true),
     LocalSettingsWriterMW,
   ])
   async localDebug(inputs: Inputs, ctx?: CoreHookContext): Promise<Result<Void, FxError>> {

--- a/packages/fx-core/src/core/index.ts
+++ b/packages/fx-core/src/core/index.ts
@@ -538,7 +538,6 @@ export class FxCore implements Core {
     QuestionModelMW,
     ContextInjectorMW,
     ProjectSettingsWriterMW,
-    EnvInfoWriterMW(),
     LocalSettingsWriterMW,
   ])
   async localDebug(inputs: Inputs, ctx?: CoreHookContext): Promise<Result<Void, FxError>> {
@@ -914,13 +913,7 @@ export class FxCore implements Core {
     return ok(undefined);
   }
 
-  @hooks([
-    ErrorHandlerMW,
-    ProjectSettingsLoaderMW,
-    EnvInfoLoaderMW(true),
-    ContextInjectorMW,
-    EnvInfoWriterMW(),
-  ])
+  @hooks([ErrorHandlerMW, ProjectSettingsLoaderMW, EnvInfoLoaderMW(true), ContextInjectorMW])
   async encrypt(
     plaintext: string,
     inputs: Inputs,
@@ -929,13 +922,7 @@ export class FxCore implements Core {
     return ctx!.solutionContext!.cryptoProvider!.encrypt(plaintext);
   }
 
-  @hooks([
-    ErrorHandlerMW,
-    ProjectSettingsLoaderMW,
-    EnvInfoLoaderMW(true),
-    ContextInjectorMW,
-    EnvInfoWriterMW(),
-  ])
+  @hooks([ErrorHandlerMW, ProjectSettingsLoaderMW, EnvInfoLoaderMW(true), ContextInjectorMW])
   async decrypt(
     ciphertext: string,
     inputs: Inputs,

--- a/packages/fx-core/src/core/middleware/envInfoWriter.ts
+++ b/packages/fx-core/src/core/middleware/envInfoWriter.ts
@@ -12,12 +12,12 @@ import { environmentManager } from "../environment";
 /**
  * This middleware will help to persist environment profile if necessary.
  */
-export function EnvInfoWriterMW(isScaffolding = false): Middleware {
+export function EnvInfoWriterMW(skip = false): Middleware {
   return async (ctx: CoreHookContext, next: NextFunction) => {
     try {
       await next();
     } finally {
-      if (isScaffolding && isMultiEnvEnabled()) {
+      if (skip && isMultiEnvEnabled()) {
         return;
       }
 


### PR DESCRIPTION
Decrypting and local debugging will cause `profile.dev.json` to be cleared. The root cause is `ctx.envInfo` is set to an empty value because `EnvInfoLoaderMW` is skipped for these stages, but `EnvInfoWriteMW` is not skipped.

Tested local debug and decrypt with and without feature flags.

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/11013525