### PR TITLE
chore(multi-env): remove active env from CLI part 2

### DIFF
--- a/packages/cli/src/activate.ts
+++ b/packages/cli/src/activate.ts
@@ -5,12 +5,7 @@
 
 import { Result, FxError, ok, Tools, err } from "@microsoft/teamsfx-api";
 
-import {
-  environmentManager,
-  FxCore,
-  isMultiEnvEnabled,
-  setActiveEnv,
-} from "@microsoft/teamsfx-core";
+import { FxCore } from "@microsoft/teamsfx-core";
 
 import AzureAccountManager from "./commonlib/azureLogin";
 import AppStudioTokenProvider from "./commonlib/appStudioLogin";

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -16,12 +16,6 @@ export const RootFolderNode = new QTreeNode({
   default: "./",
 });
 
-export const EnvNode = new QTreeNode({
-  type: "text",
-  name: "env",
-  title: "Select or create an environment for the project",
-});
-
 export const EnvNodeNoCreate = new QTreeNode({
   type: "text",
   name: "env",

--- a/packages/cli/src/helpParamGenerator.ts
+++ b/packages/cli/src/helpParamGenerator.ts
@@ -30,7 +30,6 @@ import { flattenNodes, getSingleOptionString, toYargsOptions } from "./utils";
 import { Options } from "yargs";
 import {
   CollaboratorEmailNode,
-  EnvNode,
   EnvNodeNoCreate,
   RootFolderNode,
   sqlPasswordConfirmQuestionName,
@@ -45,6 +44,7 @@ export class HelpParamGenerator {
   private static showEnvStage: string[] = [
     Stage.build,
     Stage.publish,
+    Stage.provision,
     Stage.deploy,
     Stage.grantPermission,
     Stage.checkPermission,
@@ -217,9 +217,7 @@ export class HelpParamGenerator {
 
     // Add env node
     if (isMultiEnvEnabled()) {
-      if (stage === Stage.provision) {
-        nodes = nodes.concat([EnvNode]);
-      } else if (HelpParamGenerator.showEnvStage.indexOf(stage) >= 0) {
+      if (HelpParamGenerator.showEnvStage.indexOf(stage) >= 0) {
         nodes = nodes.concat([EnvNodeNoCreate]);
       }
     }

--- a/packages/fx-core/src/core/middleware/envInfoLoader.ts
+++ b/packages/fx-core/src/core/middleware/envInfoLoader.ts
@@ -47,7 +47,6 @@ import { PermissionRequestFileProvider } from "../permissionRequest";
 import { newEnvInfo } from "../tools";
 
 const newTargetEnvNameOption = "+ new environment";
-let activeEnv: string | undefined;
 const lastUsedMark = " (last used)";
 let lastUsedEnv: string | undefined;
 
@@ -85,8 +84,7 @@ export function EnvInfoLoaderMW(skip: boolean): Middleware {
           return;
         }
         targetEnvName = result.value;
-      } else if (inputs.platform === Platform.VSCode) {
-        // Only ask user to select an env in VS Code
+      } else {
         const result = await askTargetEnvironment(core.tools, inputs);
         if (result.isErr()) {
           ctx.result = err(result.error);
@@ -100,11 +98,6 @@ export function EnvInfoLoaderMW(skip: boolean): Middleware {
         );
 
         lastUsedEnv = targetEnvName;
-      } else if (activeEnv) {
-        targetEnvName = activeEnv;
-      } else {
-        ctx.result = err(NonActiveEnvError);
-        return;
       }
     } else {
       targetEnvName = environmentManager.getDefaultEnvName();
@@ -138,10 +131,6 @@ export function EnvInfoLoaderMW(skip: boolean): Middleware {
     }
     await next();
   };
-}
-
-export function setActiveEnv(env: string) {
-  activeEnv = env;
 }
 
 export async function loadSolutionContext(

--- a/packages/fx-core/src/index.ts
+++ b/packages/fx-core/src/index.ts
@@ -10,4 +10,3 @@ export * from "./core";
 export * from "./folder";
 export * from "./core/environment";
 export * from "./common/localSettingsProvider";
-export { setActiveEnv } from "./core/middleware/envInfoLoader";


### PR DESCRIPTION
- In CLI, if `--env` is not specified, it will ask from user. This behavior is the same as vscode extension.
- Remove related unit test code.

![image](https://user-images.githubusercontent.com/9698542/135025459-e67c6fb8-e213-4a0e-bddb-e20840195e66.png)

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/11012678