### PR TITLE
fix: multi m365 login

### DIFF
--- a/packages/cli/src/commonlib/codeFlowLogin.ts
+++ b/packages/cli/src/commonlib/codeFlowLogin.ts
@@ -85,6 +85,8 @@ export class CodeFlowLogin {
       if (dataCache) {
         this.account = dataCache;
       }
+    } else {
+      this.account = undefined;
     }
   }
 

--- a/packages/vscode-extension/src/commonlib/codeFlowLogin.ts
+++ b/packages/vscode-extension/src/commonlib/codeFlowLogin.ts
@@ -61,6 +61,9 @@ export class CodeFlowLogin {
         this.account = dataCache;
         this.status = loggedIn;
       }
+    } else {
+      this.account = undefined;
+      this.status = loggedOut;
     }
   }
 


### PR DESCRIPTION
1. Fix when user already gets graph token and app studio token, and then logout app studio, user can still get graph token bug.
2. Long term: merge graph, app studio into one m365 provider.