### PR TITLE
chore: support telemetry test

### DIFF
--- a/packages/vscode-extension/package-lock.json
+++ b/packages/vscode-extension/package-lock.json
@@ -3875,6 +3875,11 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "date-format": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/date-format/-/date-format-3.0.0.tgz",
+      "integrity": "sha512-eyTcpKOcamdhWJXj56DpQMo1ylSQpcGtGKXcU0Tb97+K56/CF5amAqqqNj0+KvA0iw2ynxtHWFsPDSClCxe48w=="
+    },
     "date-utils": {
       "version": "1.2.21",
       "resolved": "https://registry.npmjs.org/date-utils/-/date-utils-1.2.21.tgz",
@@ -6306,6 +6311,25 @@
         }
       }
     },
+    "log4js": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.3.0.tgz",
+      "integrity": "sha512-Mc8jNuSFImQUIateBFwdOQcmC6Q5maU0VVvdC2R6XMb66/VnT+7WS4D/0EeNMZu1YODmJe5NIn2XftCzEocUgw==",
+      "requires": {
+        "date-format": "^3.0.0",
+        "debug": "^4.1.1",
+        "flatted": "^2.0.1",
+        "rfdc": "^1.1.4",
+        "streamroller": "^2.2.4"
+      },
+      "dependencies": {
+        "flatted": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+          "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA=="
+        }
+      }
+    },
     "logform": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/logform/-/logform-2.2.0.tgz",
@@ -8347,6 +8371,11 @@
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true
     },
+    "rfdc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA=="
+    },
     "rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -8995,6 +9024,46 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
       "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw=="
+    },
+    "streamroller": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-2.2.4.tgz",
+      "integrity": "sha512-OG79qm3AujAM9ImoqgWEY1xG4HX+Lw+yY6qZj9R1K2mhF5bEmQ849wvrb+4vt4jLMLzwXttJlQbOdPOQVRv7DQ==",
+      "requires": {
+        "date-format": "^2.1.0",
+        "debug": "^4.1.1",
+        "fs-extra": "^8.1.0"
+      },
+      "dependencies": {
+        "date-format": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/date-format/-/date-format-2.1.0.tgz",
+          "integrity": "sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA=="
+        },
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+        }
+      }
     },
     "string-argv": {
       "version": "0.3.1",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -739,6 +739,7 @@
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "jsonschema": "^1.4.0",
+    "log4js": "^6.3.0",
     "sudo-prompt": "^9.2.1",
     "underscore": "^1.12.1",
     "vscode-extension-telemetry": "^0.2.9",

--- a/packages/vscode-extension/src/commonlib/telemetry.ts
+++ b/packages/vscode-extension/src/commonlib/telemetry.ts
@@ -31,7 +31,7 @@ const TelemetryTestLoggerFile = "telemetryTest.log";
 export class VSCodeTelemetryReporter extends vscode.Disposable implements TelemetryReporter {
   private readonly reporter: Reporter;
   private readonly extVersion: string;
-  private readonly logger: Logger;
+  private readonly logger: Logger | undefined;
   private readonly testFeatureFlag: boolean;
 
   private sharedProperties: { [key: string]: string } = {};
@@ -40,13 +40,15 @@ export class VSCodeTelemetryReporter extends vscode.Disposable implements Teleme
     super(async () => await this.reporter.dispose());
     this.reporter = new Reporter(extensionId, extensionVersion, key, true);
     this.extVersion = getPackageVersion(extensionVersion);
-    const logFile = path.join(os.homedir(), `.${ConfigFolderName}`, TelemetryTestLoggerFile);
-    configure({
-      appenders: { everything: { type: "file", filename: logFile } },
-      categories: { default: { appenders: ["everything"], level: "debug" } },
-    });
-    this.logger = getLogger("TelemTest");
     this.testFeatureFlag = isFeatureFlagEnabled(FeatureFlags.TelemetryTest);
+    if (this.testFeatureFlag) {
+      const logFile = path.join(os.homedir(), `.${ConfigFolderName}`, TelemetryTestLoggerFile);
+      configure({
+        appenders: { everything: { type: "file", filename: logFile } },
+        categories: { default: { appenders: ["everything"], level: "debug" } },
+      });
+      this.logger = getLogger("TelemTest");
+    }
   }
 
   addSharedProperty(name: string, value: string): void {

--- a/packages/vscode-extension/src/commonlib/telemetry.ts
+++ b/packages/vscode-extension/src/commonlib/telemetry.ts
@@ -60,7 +60,7 @@ export class VSCodeTelemetryReporter extends vscode.Disposable implements Teleme
     properties?: { [p: string]: string },
     measurements?: { [p: string]: number }
   ): void {
-    this.logger.debug(eventName, properties, measurements);
+    this.logger?.debug(eventName, properties, measurements);
   }
 
   logTelemetryErrorEvent(
@@ -69,7 +69,7 @@ export class VSCodeTelemetryReporter extends vscode.Disposable implements Teleme
     measurements?: { [p: string]: number },
     errorProps?: string[]
   ): void {
-    this.logger.debug(eventName, properties, measurements, errorProps);
+    this.logger?.debug(eventName, properties, measurements, errorProps);
   }
 
   logTelemetryException(
@@ -77,7 +77,7 @@ export class VSCodeTelemetryReporter extends vscode.Disposable implements Teleme
     properties?: { [p: string]: string },
     measurements?: { [p: string]: number }
   ): void {
-    this.logger.debug(error, properties, measurements);
+    this.logger?.debug(error, properties, measurements);
   }
 
   sendTelemetryErrorEvent(

--- a/packages/vscode-extension/src/utils/commonUtils.ts
+++ b/packages/vscode-extension/src/utils/commonUtils.ts
@@ -247,6 +247,8 @@ export class FeatureFlags {
   static readonly MultiEnv = "TEAMSFX_MULTI_ENV";
 
   static readonly ArmSupport = "TEAMSFX_ARM_SUPPORT";
+
+  static readonly TelemetryTest = "TEAMSFX_TELEMETRY_TEST";
 }
 
 // Determine whether feature flag is enabled based on environment variable setting


### PR DESCRIPTION
chore: support telemetry test

To support telemetry UITEST we need to send telemetry into a log file instead of sending to AI. The test need to set a env variable  (TEAMSFX_TELEMETRY_TEST) to enable it.

![image](https://user-images.githubusercontent.com/831821/135203082-1a898365-fa6d-4f67-805c-3607dc3d0f8e.png)


https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/10676875