### PR TITLE
fix(vsc): multiline error not colorized

### DIFF
--- a/packages/vscode-extension/.prettierignore
+++ b/packages/vscode-extension/.prettierignore
@@ -2,3 +2,4 @@
 coverage/
 .nyc_output/
 .prettierignore
+syntaxes/*.tmLanguage

--- a/packages/vscode-extension/syntaxes/teamsfx-toolkit-output.tmLanguage
+++ b/packages/vscode-extension/syntaxes/teamsfx-toolkit-output.tmLanguage
@@ -45,10 +45,14 @@
                         <string>token.error-token</string>
                     </dict>
                 </dict>
-                <key>match</key>
-                <string>(\[Error\].*)</string>
                 <key>name</key>
                 <string>teamsfx-toolkit.errorMessage</string>
+                <key>begin</key>
+                <string>(\[Error\])</string>
+                <key>end</key>
+                <string>^\[[\d\-TZ:.]*\]</string>
+                <key>contentName</key>
+                <string>token.error-token</string>
             </dict>
         </array>
     </dict>


### PR DESCRIPTION
Update language grammar to support multi-line message matching.

![image](https://user-images.githubusercontent.com/886116/135208973-8ef2511c-2af3-4f67-a7db-50b1dd36833a.png)
