### PR TITLE
fix(migrate-v1): remove open v1 project telemetry

### DIFF
--- a/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
@@ -98,7 +98,6 @@ export enum TelemetryEvent {
   MigrateV1Project = "migrate-v1-project",
   MigrateV1ProjectNotificationStart = "migrate-v1-project-notification-start",
   MigrateV1ProjectNotification = "migrate-v1-project-notification",
-  OpenV1Project = "open-v1-project",
 
   ViewEnvironment = "view-environment",
 

--- a/packages/vscode-extension/src/utils/migrateV1.ts
+++ b/packages/vscode-extension/src/utils/migrateV1.ts
@@ -10,10 +10,6 @@ import * as constants from "../constants";
 export async function enableMigrateV1(): Promise<void> {
   const v1ProjectErrorMessage = await validateV1Project(ext.workspaceUri?.fsPath);
   const validV1Project = !v1ProjectErrorMessage;
-  ExtTelemetry.sendTelemetryEvent(TelemetryEvent.OpenV1Project, {
-    v1: validV1Project ? "true" : "false",
-    reason: v1ProjectErrorMessage ?? "",
-  });
   vscode.commands.executeCommand("setContext", "fx-extension.v1Project", validV1Project);
   if (validV1Project) {
     showNotification();


### PR DESCRIPTION
Remove open-v1-project telemetry to avoid send telemetry when open vscode