### PR TITLE
chore: decouple CD pipeline with template-tags.txt

### DIFF
--- a/packages/fx-core/package.json
+++ b/packages/fx-core/package.json
@@ -26,7 +26,7 @@
     "clean": "rm -rf build",
     "build": "rimraf build && npx tsc -p ./",
     "lint:fix": "eslint --fix \"src/**/*.ts\" \"tests/**/*.ts\"",
-    "prepare": "npm run build && git tag --list | node ./scripts/download-templates-zip.js",
+    "prepare": "npm run build && node ./scripts/download-templates-zip.js $(git tag --list)",
     "prepublishOnly": "npm run test:unit && npm run build",
     "package": "rimraf build && webpack --mode production --config ./webpack.config.js",
     "precommit": "lint-staged"

--- a/packages/fx-core/package.json
+++ b/packages/fx-core/package.json
@@ -26,7 +26,7 @@
     "clean": "rm -rf build",
     "build": "rimraf build && npx tsc -p ./",
     "lint:fix": "eslint --fix \"src/**/*.ts\" \"tests/**/*.ts\"",
-    "prepare": "npm run build && node ./scripts/download-templates-zip.js",
+    "prepare": "npm run build && git tag --list | node.exe ./scripts/download-templates-zip.js",
     "prepublishOnly": "npm run test:unit && npm run build",
     "package": "rimraf build && webpack --mode production --config ./webpack.config.js",
     "precommit": "lint-staged"

--- a/packages/fx-core/package.json
+++ b/packages/fx-core/package.json
@@ -26,7 +26,7 @@
     "clean": "rm -rf build",
     "build": "rimraf build && npx tsc -p ./",
     "lint:fix": "eslint --fix \"src/**/*.ts\" \"tests/**/*.ts\"",
-    "prepare": "npm run build && git tag --list | node.exe ./scripts/download-templates-zip.js",
+    "prepare": "npm run build && git tag --list | node ./scripts/download-templates-zip.js",
     "prepublishOnly": "npm run test:unit && npm run build",
     "package": "rimraf build && webpack --mode production --config ./webpack.config.js",
     "precommit": "lint-staged"

--- a/packages/fx-core/scripts/download-templates-zip.js
+++ b/packages/fx-core/scripts/download-templates-zip.js
@@ -61,7 +61,7 @@ async function downloadLatestTemplates(rawTagList) {
   }
 }
 
-async function main() {
+function main() {
   tags = "";
   stdin.on("readable", () => {
     let data = stdin.read();
@@ -69,8 +69,8 @@ async function main() {
       tags += data;
     }
   });
-  stdin.on("end", async () => {
-    await downloadLatestTemplates(tags);
+  stdin.on("end", () => {
+    downloadLatestTemplates(tags);
   });
 }
 

--- a/packages/fx-core/scripts/download-templates-zip.js
+++ b/packages/fx-core/scripts/download-templates-zip.js
@@ -42,7 +42,7 @@ async function downloadLatestTemplates(rawTagList) {
   const selectedVersion = semver.maxSatisfying(versionList, config.version);
   if (!selectedVersion) {
     console.error(`Failed to find a tag for the version, ${config.version}`);
-    process.exit(-1);
+    return;
   }
 
   const tag = config.tagPrefix + selectedVersion;

--- a/packages/fx-core/scripts/download-templates-zip.js
+++ b/packages/fx-core/scripts/download-templates-zip.js
@@ -34,6 +34,8 @@ async function step(desc, fn) {
 
 async function downloadTemplates(version) {
   const tag = config.tagPrefix + version;
+  console.log(`Start to download templates with tag: ${tag}`);
+
   for (let lang of languages) {
     for (let template of templates) {
       const fileName = `${template[0]}.${lang}.${template[1]}.zip`;

--- a/packages/fx-core/scripts/download-templates-zip.js
+++ b/packages/fx-core/scripts/download-templates-zip.js
@@ -42,7 +42,7 @@ async function downloadLatestTemplates(rawTagList) {
   const selectedVersion = semver.maxSatisfying(versionList, config.version);
   if (!selectedVersion) {
     console.error(`Failed to find a tag for the version, ${config.version}`);
-    exit(-1);
+    process.exit(-1);
   }
 
   const tag = config.tagPrefix + selectedVersion;


### PR DESCRIPTION
In current CD pipeline, template-tags.txt is updated with latest template version. When packaging extension, template-tags.txt is downloaded and parsed so that fx-core gets the latest template version. 
The CD pipeline both updates and consumes the txt file. We might download the txt before the updated txt takes effect and we eventually get older version templates.
This PR is to get latest template version from git tag rather than the txt file. 