### PR TITLE
chore(multi-env): telemetry for resource group when provision

### DIFF
--- a/packages/fx-core/src/common/telemetry.ts
+++ b/packages/fx-core/src/common/telemetry.ts
@@ -15,6 +15,8 @@ export enum TelemetryProperty {
   SampleAppName = "sample-app-name",
   ProjectId = "project-id",
   CorrelationId = "correlation-id",
+  Env = "env",
+  CustomizeResourceGroupType = "customize-resource-group-type",
 }
 
 export enum TelemetryEvent {
@@ -24,6 +26,8 @@ export enum TelemetryEvent {
   ProjectUpgradeStart = "project-upgrade-start",
   ReadJson = "read-json",
   DecryptUserdata = "decrypt-userdata",
+  CheckResourceGroupStart = "check-resource-group-start",
+  CheckResourceGroup = "check-resource-group",
 }
 
 export enum TelemetrySuccess {
@@ -42,6 +46,16 @@ export enum Component {
   vs = "vs",
   core = "core",
   solution = "solution",
+}
+
+export enum CustomizeResourceGroupType {
+  CommandLine = "command-line",
+  EnvConfig = "env-config",
+  EnvProfile = "env-profile",
+  InteractiveCreateDefault = "interactive-create-default",
+  InteractiveCreateCustomized = "interactive-create-customized",
+  InteractiveUseExisting = "interactive-use-existing",
+  FallbackDefault = "fallback-default",
 }
 
 export function sendTelemetryEvent(

--- a/packages/fx-core/src/plugins/solution/fx-solution/commonQuestions.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/commonQuestions.ts
@@ -42,8 +42,14 @@ import {
   QuestionNewResourceGroupName,
   QuestionSelectResourceGroup,
 } from "../../../core/question";
+import { getHashedEnv } from "../../../common/tools";
 import { desensitize } from "../../../core/middleware/questionModel";
 import { ResourceGroupsCreateOrUpdateResponse } from "@azure/arm-resources/esm/models";
+import {
+  CustomizeResourceGroupType,
+  TelemetryEvent,
+  TelemetryProperty,
+} from "../../../common/telemetry";
 
 const MsResources = "Microsoft.Resources";
 const ResourceGroups = "resourceGroups";
@@ -359,11 +365,16 @@ async function askCommonQuestions(
   }
 
   //2. check resource group
+  ctx.telemetryReporter?.sendTelemetryEvent(
+    TelemetryEvent.CheckResourceGroupStart,
+    ctx.answers?.env ? { [TelemetryProperty.Env]: getHashedEnv(ctx.answers.env) } : {}
+  );
+
   const rmClient = new ResourceManagementClient(azureToken, subscriptionId);
 
   // Resource group info precedence are:
-  //   1. ctx.answers, for CLI --resource-group argument, only support exsting resource group
-  //   2. env config (config.{envName}.json), for user customization, only support exsting resource group
+  //   1. ctx.answers, for CLI --resource-group argument, only support existing resource group
+  //   2. env config (config.{envName}.json), for user customization, only support existing resource group
   //   3. publish profile (profile.{envName}.json), for reprovision
   //   4. asking user with a popup
   const resourceGroupNameFromEnvConfig = ctx.envInfo.config.azure?.resourceGroupName;
@@ -375,6 +386,10 @@ async function askCommonQuestions(
     isMultiEnvEnabled() ? "-" + ctx.envInfo.envName : ""
   }-rg`;
   let resourceGroupInfo: ResourceGroupInfo;
+  const telemetryProperties: { [key: string]: string } = {};
+  if (ctx.answers?.env) {
+    telemetryProperties[TelemetryProperty.Env] = getHashedEnv(ctx.answers.env);
+  }
 
   if (ctx.answers?.targetResourceGroupName) {
     const maybeResourceGroupInfo = await getResourceGroupInfo(
@@ -394,6 +409,8 @@ async function askCommonQuestions(
         )
       );
     }
+    telemetryProperties[TelemetryProperty.CustomizeResourceGroupType] =
+      CustomizeResourceGroupType.CommandLine;
     resourceGroupInfo = maybeResourceGroupInfo;
   } else if (resourceGroupNameFromEnvConfig) {
     const resourceGroupName = resourceGroupNameFromEnvConfig;
@@ -411,6 +428,8 @@ async function askCommonQuestions(
         )
       );
     }
+    telemetryProperties[TelemetryProperty.CustomizeResourceGroupType] =
+      CustomizeResourceGroupType.EnvConfig;
     resourceGroupInfo = maybeResourceGroupInfo;
   } else if (resourceGroupNameFromProfile && resourceGroupLocationFromProfile) {
     try {
@@ -428,6 +447,9 @@ async function askCommonQuestions(
           location: resourceGroupLocationFromProfile,
         };
       }
+
+      telemetryProperties[TelemetryProperty.CustomizeResourceGroupType] =
+        CustomizeResourceGroupType.EnvProfile;
     } catch (e) {
       return err(
         returnUserError(e, SolutionSource, SolutionError.FailedToCheckResourceGroupExistence)
@@ -444,7 +466,20 @@ async function askCommonQuestions(
     if (resourceGroupInfoResult.isErr()) {
       return err(resourceGroupInfoResult.error);
     }
+
     resourceGroupInfo = resourceGroupInfoResult.value;
+    if (resourceGroupInfo.createNewResourceGroup) {
+      if (resourceGroupInfo.name === defaultResourceGroupName) {
+        telemetryProperties[TelemetryProperty.CustomizeResourceGroupType] =
+          CustomizeResourceGroupType.InteractiveCreateDefault;
+      } else {
+        telemetryProperties[TelemetryProperty.CustomizeResourceGroupType] =
+          CustomizeResourceGroupType.InteractiveCreateCustomized;
+      }
+    } else {
+      telemetryProperties[TelemetryProperty.CustomizeResourceGroupType] =
+        CustomizeResourceGroupType.InteractiveUseExisting;
+    }
   } else {
     // fall back to default values when user interaction is not available
     resourceGroupInfo = {
@@ -452,7 +487,12 @@ async function askCommonQuestions(
       name: defaultResourceGroupName,
       location: DefaultResourceGroupLocation,
     };
+    telemetryProperties[TelemetryProperty.CustomizeResourceGroupType] =
+      CustomizeResourceGroupType.FallbackDefault;
   }
+
+  ctx.telemetryReporter?.sendTelemetryEvent(TelemetryEvent.CheckResourceGroup, telemetryProperties);
+
   if (resourceGroupInfo.createNewResourceGroup) {
     const maybeRgName = await createNewResourceGroup(rmClient, resourceGroupInfo, ctx.logProvider);
     if (maybeRgName.isErr()) {


### PR DESCRIPTION
- add telemetry events `check-resource-group-start` and `check-resource-group` to track how the user customizes the resource group when provision

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/11012613