### PR TITLE
fix: logging status notify

### DIFF
--- a/packages/vscode-extension/src/commonlib/codeFlowLogin.ts
+++ b/packages/vscode-extension/src/commonlib/codeFlowLogin.ts
@@ -61,7 +61,7 @@ export class CodeFlowLogin {
         this.account = dataCache;
         this.status = loggedIn;
       }
-    } else if (this.status != loggingIn) {
+    } else if (this.status !== loggingIn) {
       this.account = undefined;
       this.status = loggedOut;
     }

--- a/packages/vscode-extension/src/commonlib/codeFlowLogin.ts
+++ b/packages/vscode-extension/src/commonlib/codeFlowLogin.ts
@@ -61,7 +61,7 @@ export class CodeFlowLogin {
         this.account = dataCache;
         this.status = loggedIn;
       }
-    } else {
+    } else if (this.status != loggingIn) {
       this.account = undefined;
       this.status = loggedOut;
     }


### PR DESCRIPTION
1. Fix logging notify logic, when signing in show singing status in tree view. (Cli does not need notify logic)

![image](https://user-images.githubusercontent.com/13211513/136642595-c72eff12-430d-4247-a5fd-faddaededec1.png)
