### PR TITLE
chore: prepare resolveTask for custom local debug

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -451,11 +451,26 @@
       {
         "type": "teamsfx",
         "required": [
-          "command"
+          "command",
+          "component"
         ],
         "properties": {
           "command": {
-            "type": "string"
+            "type": "string",
+            "description": "The command to be executed on a teamsfx component.",
+            "enum": [
+              "npm run dev",
+              "npm run watch"
+            ]
+          },
+          "component": {
+            "type": "string",
+            "description": "The teamsfx component.",
+            "enum": [
+              "frontend",
+              "backend",
+              "bot"
+            ]
           }
         }
       }
@@ -463,7 +478,7 @@
     "problemMatchers": [
       {
         "name": "teamsfx-frontend-watch",
-        "label": "%teamsfx.problemMatchers.teamsfxFrontendWatch%",
+        "label": "TeamsFx Frontend Problems",
         "owner": "Teams Toolkit",
         "source": "teamsfx",
         "applyTo": "allDocuments",
@@ -492,7 +507,7 @@
       },
       {
         "name": "teamsfx-backend-watch",
-        "label": "%teamsfx.problemMatchers.teamsfxbackendWatch%",
+        "label": "TeamsFx Backend Problems",
         "owner": "Teams Toolkit",
         "source": "teamsfx",
         "applyTo": "allDocuments",
@@ -516,7 +531,7 @@
       },
       {
         "name": "teamsfx-auth-watch",
-        "label": "%teamsfx.problemMatchers.teamsfxAuthWatch%",
+        "label": "TeamsFx SimpleAuth Problems",
         "owner": "Teams Toolkit",
         "source": "teamsfx",
         "applyTo": "allDocuments",
@@ -540,7 +555,7 @@
       },
       {
         "name": "teamsfx-ngrok-watch",
-        "label": "%teamsfx.problemMatchers.teamsfxNgrokWatch%",
+        "label": "TeamsFx Ngrok Problems",
         "owner": "Teams Toolkit",
         "source": "teamsfx",
         "applyTo": "allDocuments",
@@ -564,7 +579,7 @@
       },
       {
         "name": "teamsfx-bot-watch",
-        "label": "%teamsfx.problemMatchers.teamsfxBotWatch%",
+        "label": "TeamsFx Bot Problems",
         "owner": "Teams Toolkit",
         "source": "teamsfx",
         "applyTo": "allDocuments",

--- a/packages/vscode-extension/src/debug/teamsfxTaskProvider.ts
+++ b/packages/vscode-extension/src/debug/teamsfxTaskProvider.ts
@@ -100,7 +100,7 @@ export class TeamsfxTaskProvider implements vscode.TaskProvider {
         let env: { [key: string]: string } | undefined;
         let cwd: string | undefined;
         let problemMatcher: string;
-        const isWatchTask = /^npm run watch/i.test(component + "");
+        const isWatchTask = /^npm run watch/i.test(command + "");
         if (component?.toLowerCase() === "frontend") {
           env = isWatchTask ? undefined : await commonUtils.getFrontendLocalEnv();
           cwd = await commonUtils.getProjectRoot(workspacePath, constants.frontendFolderName);

--- a/packages/vscode-extension/test/unit/localdebug/teamsfxTaskProvider.test.ts
+++ b/packages/vscode-extension/test/unit/localdebug/teamsfxTaskProvider.test.ts
@@ -1,0 +1,160 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as chai from "chai";
+import * as sinon from "sinon";
+import * as path from "path";
+import * as vscode from "vscode";
+
+import * as commonUtils from "../../../src/debug/commonUtils";
+import { TeamsfxTaskProvider } from "../../../src/debug/teamsfxTaskProvider";
+
+suite("[debug > teamsfxTaskProvider]", () => {
+  const taskProvider = new TeamsfxTaskProvider();
+  const testWorkspaceFolder = {} as vscode.WorkspaceFolder;
+  suite("resolveTask", () => {
+    test("frontend npm run dev", async () => {
+      sinon.stub(vscode.workspace, "workspaceFolders").value([
+        {
+          uri: vscode.Uri.file("test"),
+          name: "test",
+          index: 0,
+        } as vscode.WorkspaceFolder,
+      ]);
+      sinon.stub(commonUtils, "isFxProject").callsFake(async (folderPath: string) => {
+        return true;
+      });
+      sinon
+        .stub(commonUtils, "getProjectRoot")
+        .callsFake(async (folderPath: string, folderName: string) => {
+          return path.join(folderPath, folderName);
+        });
+
+      const inputTask = new vscode.Task(
+        {
+          type: "teamsfx",
+          command: "npm run dev",
+          component: "frontend",
+        },
+        testWorkspaceFolder,
+        "frontend npm run dev",
+        "teamsfx"
+      );
+      const resolvedTask = await taskProvider.resolveTask(inputTask);
+      chai.expect(resolvedTask).not.to.be.undefined;
+      chai.expect(resolvedTask!.name).equals("npm run dev");
+      chai.expect(resolvedTask!.problemMatchers).eql(["$teamsfx-frontend-watch"]);
+      chai.expect(resolvedTask!.isBackground).true;
+
+      sinon.restore();
+    });
+
+    test("backend npm run dev", async () => {
+      sinon.stub(vscode.workspace, "workspaceFolders").value([
+        {
+          uri: vscode.Uri.file("test"),
+          name: "test",
+          index: 0,
+        } as vscode.WorkspaceFolder,
+      ]);
+      sinon.stub(commonUtils, "isFxProject").callsFake(async (folderPath: string) => {
+        return true;
+      });
+      sinon
+        .stub(commonUtils, "getProjectRoot")
+        .callsFake(async (folderPath: string, folderName: string) => {
+          return path.join(folderPath, folderName);
+        });
+
+      const inputTask = new vscode.Task(
+        {
+          type: "teamsfx",
+          command: "npm run dev",
+          component: "backend",
+        },
+        testWorkspaceFolder,
+        "backend npm run dev",
+        "teamsfx"
+      );
+      const resolvedTask = await taskProvider.resolveTask(inputTask);
+      chai.expect(resolvedTask).not.to.be.undefined;
+      chai.expect(resolvedTask!.name).equals("npm run dev");
+      chai.expect(resolvedTask!.problemMatchers).eql(["$teamsfx-backend-watch"]);
+      chai.expect(resolvedTask!.isBackground).true;
+
+      sinon.restore();
+    });
+
+    test("bot npm run dev", async () => {
+      sinon.stub(vscode.workspace, "workspaceFolders").value([
+        {
+          uri: vscode.Uri.file("test"),
+          name: "test",
+          index: 0,
+        } as vscode.WorkspaceFolder,
+      ]);
+      sinon.stub(commonUtils, "isFxProject").callsFake(async (folderPath: string) => {
+        return true;
+      });
+      sinon
+        .stub(commonUtils, "getProjectRoot")
+        .callsFake(async (folderPath: string, folderName: string) => {
+          return path.join(folderPath, folderName);
+        });
+
+      const inputTask = new vscode.Task(
+        {
+          type: "teamsfx",
+          command: "npm run dev",
+          component: "bot",
+        },
+        testWorkspaceFolder,
+        "bot npm run dev",
+        "teamsfx"
+      );
+      const resolvedTask = await taskProvider.resolveTask(inputTask);
+      chai.expect(resolvedTask).not.to.be.undefined;
+      chai.expect(resolvedTask!.name).equals("npm run dev");
+      chai.expect(resolvedTask!.problemMatchers).eql(["$teamsfx-bot-watch"]);
+      chai.expect(resolvedTask!.isBackground).true;
+
+      sinon.restore();
+    });
+
+    test("bot npm run watch", async () => {
+      sinon.stub(vscode.workspace, "workspaceFolders").value([
+        {
+          uri: vscode.Uri.file("test"),
+          name: "test",
+          index: 0,
+        } as vscode.WorkspaceFolder,
+      ]);
+      sinon.stub(commonUtils, "isFxProject").callsFake(async (folderPath: string) => {
+        return true;
+      });
+      sinon
+        .stub(commonUtils, "getProjectRoot")
+        .callsFake(async (folderPath: string, folderName: string) => {
+          return path.join(folderPath, folderName);
+        });
+
+      const inputTask = new vscode.Task(
+        {
+          type: "teamsfx",
+          command: "npm run watch",
+          component: "bot",
+        },
+        testWorkspaceFolder,
+        "bot npm run watch",
+        "teamsfx"
+      );
+      const resolvedTask = await taskProvider.resolveTask(inputTask);
+      chai.expect(resolvedTask).not.to.be.undefined;
+      chai.expect(resolvedTask!.name).equals("npm run watch");
+      chai.expect(resolvedTask!.problemMatchers).eql(["$tsc-watch"]);
+      chai.expect(resolvedTask!.isBackground).true;
+
+      sinon.restore();
+    });
+  });
+});


### PR DESCRIPTION
Resolve `npm run dev` and `npm run watch` tasks to support custom local debug.
UT added.

Workitem: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/10878741