### PR TITLE
chore(multi-env): add env config telemetry

### DIFF
--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -289,6 +289,13 @@ export interface EnvConfig {
 // @public (undocumented)
 export const EnvConfigFileNameTemplate: string;
 
+declare namespace EnvConfigSchema {
+    export {
+
+    }
+}
+export { EnvConfigSchema }
+
 // @public (undocumented)
 export interface EnvInfo {
     // (undocumented)

--- a/packages/api/src/schemas/index.ts
+++ b/packages/api/src/schemas/index.ts
@@ -3,3 +3,5 @@
 "use strict";
 
 export * from "./envConfig";
+import * as EnvConfigSchema from "./envConfig.json";
+export { EnvConfigSchema };

--- a/packages/fx-core/src/common/telemetry.ts
+++ b/packages/fx-core/src/common/telemetry.ts
@@ -17,6 +17,7 @@ export enum TelemetryProperty {
   CorrelationId = "correlation-id",
   Env = "env",
   CustomizeResourceGroupType = "customize-resource-group-type",
+  EnvConfig = "env-config",
 }
 
 export enum TelemetryEvent {
@@ -28,6 +29,7 @@ export enum TelemetryEvent {
   DecryptUserdata = "decrypt-userdata",
   CheckResourceGroupStart = "check-resource-group-start",
   CheckResourceGroup = "check-resource-group",
+  EnvConfig = "env-config",
 }
 
 export enum TelemetrySuccess {

--- a/packages/fx-core/src/common/tools.ts
+++ b/packages/fx-core/src/common/tools.ts
@@ -591,7 +591,7 @@ function isBasicJsonSchema(jsonSchema: unknown): jsonSchema is BasicJsonSchema {
 //  }
 //  Output:
 //  {"name": null}
-export function redactObject(
+export function _redactObject(
   obj: unknown,
   jsonSchema: unknown,
   maxRecursionDepth = 8,
@@ -614,7 +614,7 @@ export function redactObject(
     const objAny = obj as any;
     for (const key in jsonSchema.properties) {
       if (key in objAny && objAny[key] !== undefined) {
-        const filteredObj = redactObject(
+        const filteredObj = _redactObject(
           objAny[key],
           jsonSchema.properties[key],
           maxRecursionDepth,
@@ -628,4 +628,12 @@ export function redactObject(
     // other basic type include unsupported types
     return null;
   }
+}
+
+export function redactObject(
+  obj: unknown,
+  jsonSchema: unknown,
+  maxRecursionDepth = 8,
+): unknown {
+  return _redactObject(obj, jsonSchema, maxRecursionDepth, 0);
 }

--- a/packages/fx-core/src/common/tools.ts
+++ b/packages/fx-core/src/common/tools.ts
@@ -591,7 +591,7 @@ function isBasicJsonSchema(jsonSchema: unknown): jsonSchema is BasicJsonSchema {
 //  }
 //  Output:
 //  {"name": null}
-export function _redactObject(
+function _redactObject(
   obj: unknown,
   jsonSchema: unknown,
   maxRecursionDepth = 8,

--- a/packages/fx-core/tests/core/tools.test.ts
+++ b/packages/fx-core/tests/core/tools.test.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { objectHooks } from "@feathersjs/hooks/lib";
 import { Json } from "@microsoft/teamsfx-api";
 import { assert, expect } from "chai";
 import "mocha";

--- a/packages/fx-core/tests/core/tools.test.ts
+++ b/packages/fx-core/tests/core/tools.test.ts
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+import { objectHooks } from "@feathersjs/hooks/lib";
 import { Json } from "@microsoft/teamsfx-api";
 import { assert, expect } from "chai";
 import "mocha";
+import { redactObject } from "../../src";
 import { flattenConfigJson, isValidProject, newEnvInfo } from "../../src/core/tools";
 
 describe("tools", () => {
@@ -30,5 +32,74 @@ describe("flattenConfigJson", () => {
     const expected: Json = { a: { b: 1, value: 9 }, c: 2 };
     const result = flattenConfigJson(config);
     assert.deepEqual(result, expected);
+  });
+});
+
+describe("redactObject", () => {
+  const testCases: [unknown, unknown, unknown][] = [
+    // happy path: redact unknown key and all values
+    [
+      { name: "user content 1", userContent2: "user content 3" },
+      { type: "object", properties: { name: { type: "string" } } },
+      { name: null },
+    ],
+    // no known keys
+    [
+      { userContent2: "user content 3" },
+      { type: "object", properties: { name: { type: "string" } } },
+      {},
+    ],
+    // second level
+    [
+      {
+        appName: { short: "short name", long: "long name", other: "other name" },
+        userContent2: "user content 3",
+      },
+      {
+        type: "object",
+        properties: {
+          appName: {
+            type: "object",
+            properties: { short: { type: "string" }, long: { type: "string" } },
+          },
+        },
+      },
+      { appName: { short: null, long: null } },
+    ],
+    // user specified a wrong type
+    [
+      { appName: "", userContent2: "user content 3" },
+      { type: "object", properties: { appName: { type: "object" } } },
+      { appName: null },
+    ],
+    // null input
+    [null, { type: "object", properties: { appName: { type: "object" } } }, null],
+    [{ name: "name" }, null, null],
+    // invalid JSON schema, though not likely because these are checked compile time and not changed frequently
+    [{ name: "name" }, { type: "unkown" }, null],
+    [{ name: "name" }, { type: "object", properties: "invalid" }, null],
+    [{ name: "name" }, { type: "object", properties: { name: "name" } }, { name: null }],
+    [{ name: "name" }, { type: "object", properties: { name: {} } }, { name: null }],
+  ];
+
+  it("should redact objects", () => {
+    // test that the function does not change input object
+    Object.freeze(testCases);
+    for (const [obj, schema, expectedResult] of testCases) {
+      const actualResult = redactObject(obj, schema);
+      expect(actualResult).to.deep.equal(expectedResult);
+    }
+  });
+
+  it("should prevent stackoverflow", () => {
+    const input = {};
+    (input as any).a = input;
+    const jsonSchema = {
+      type: "object",
+      properties: {},
+    };
+    (jsonSchema.properties as any).a = jsonSchema;
+    const actualResult = redactObject(input, jsonSchema, 1);
+    expect(actualResult).to.deep.equal({ a: null });
   });
 });


### PR DESCRIPTION
- send envConfig file with unknown properties and all values redacted when provisioning

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/11012613