### PR TITLE
fix(local-debug): missing bot config in localSetings when add bot capability

### DIFF
--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -740,7 +740,7 @@ export interface LocalSettings {
     // (undocumented)
     frontend?: ConfigMap;
     // (undocumented)
-    teamsApp: ConfigMap;
+    teamsApp?: ConfigMap;
 }
 
 // @public (undocumented)

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -165,7 +165,7 @@ export interface AzureSolutionSettings extends SolutionSettings {
  * local debug settings
  */
 export interface LocalSettings {
-  teamsApp: ConfigMap;
+  teamsApp?: ConfigMap;
   auth?: ConfigMap;
   frontend?: ConfigMap;
   backend?: ConfigMap;

--- a/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
@@ -748,7 +748,7 @@ export class AppStudioPluginImpl {
       return teamsAppId;
     }
     if (isMultiEnvEnabled()) {
-      ctx.localSettings?.teamsApp.set(Constants.TEAMS_APP_ID, teamsAppId.value);
+      ctx.localSettings?.teamsApp?.set(Constants.TEAMS_APP_ID, teamsAppId.value);
     } else {
       (ctx.envInfo?.profile.get("solution") as ConfigMap)?.set(
         LOCAL_DEBUG_TEAMS_APP_ID,
@@ -1350,7 +1350,7 @@ export class AppStudioPluginImpl {
     let teamsAppId: string;
     if (isLocalDebug) {
       teamsAppId = isMultiEnvEnabled()
-        ? ctx.localSettings?.teamsApp.get(LocalSettingsTeamsAppKeys.TeamsAppId)
+        ? ctx.localSettings?.teamsApp?.get(LocalSettingsTeamsAppKeys.TeamsAppId)
         : (ctx.envInfo.profile.get("solution")?.get(LOCAL_DEBUG_TEAMS_APP_ID) as string);
     } else {
       teamsAppId = isMultiEnvEnabled()

--- a/packages/fx-core/src/plugins/resource/localdebug/index.ts
+++ b/packages/fx-core/src/plugins/resource/localdebug/index.ts
@@ -361,7 +361,7 @@ export class LocalDebugPlugin implements Plugin {
     const applicationIdUri = ctx.localSettings?.auth?.get(
       LocalSettingsAuthKeys.ApplicationIdUris
     ) as string;
-    const teamsAppTenantId = ctx.localSettings?.teamsApp.get(
+    const teamsAppTenantId = ctx.localSettings?.teamsApp?.get(
       LocalSettingsTeamsAppKeys.TenantId
     ) as string;
 
@@ -492,7 +492,7 @@ export class LocalDebugPlugin implements Plugin {
       } else {
         // return local teams app id
         const localTeamsAppId = isMultiEnvEnabled()
-          ? (ctx.localSettings?.teamsApp.get(LocalSettingsTeamsAppKeys.TeamsAppId) as string)
+          ? (ctx.localSettings?.teamsApp?.get(LocalSettingsTeamsAppKeys.TeamsAppId) as string)
           : (solutionConfigs?.get(SolutionPlugin.LocalTeamsAppId) as string);
         return ok(localTeamsAppId);
       }

--- a/packages/fx-core/src/plugins/resource/utils4v2.ts
+++ b/packages/fx-core/src/plugins/resource/utils4v2.ts
@@ -9,7 +9,7 @@ import {
   FxError,
   Inputs,
   Json,
-  mergeConfigMap,
+  LocalSettings,
   ok,
   Plugin,
   PluginContext,
@@ -31,7 +31,6 @@ import {
   ResourceTemplate,
   SolutionInputs,
 } from "@microsoft/teamsfx-api/build/v2";
-import { S_IFBLK } from "constants";
 import { CryptoDataMatchers, mapToJson } from "../../common";
 import { ArmResourcePlugin, ScaffoldArmTemplateResult } from "../../common/armInterface";
 import {
@@ -283,7 +282,7 @@ export async function provisionLocalResourceAdapter(
   if (res.isErr()) {
     return err(res.error);
   }
-  setLocalSettingsV2(localSettings, pluginContext);
+  setLocalSettingsV2(localSettings, pluginContext.localSettings);
   return ok(Void);
 }
 
@@ -305,7 +304,7 @@ export async function configureLocalResourceAdapter(
   if (res.isErr()) {
     return err(res.error);
   }
-  setLocalSettingsV2(localSettings, pluginContext);
+  setLocalSettingsV2(localSettings, pluginContext.localSettings);
   return ok(Void);
 }
 
@@ -337,7 +336,7 @@ export async function executeUserTaskAdapter(
   const res = await plugin.executeUserTask(func, pluginContext);
   if (res.isErr()) return err(res.error);
   envInfo.profile[plugin.name] = legacyConfig2EnvProfile(pluginContext.config, plugin.name);
-  setLocalSettingsV2(localSettings, pluginContext);
+  setLocalSettingsV2(localSettings, pluginContext.localSettings);
   return ok(res.value);
 }
 
@@ -416,25 +415,23 @@ export function setProvisionOutputs(provisionOutputs: Json, pluginContext: Plugi
   }
 }
 
-export function setLocalSettingsV2(localSettings: Json, pluginContext: PluginContext): void {
-  localSettings.teamsApp = assignJsonInc(
-    localSettings.teamsApp,
-    mapToJson(pluginContext.localSettings?.teamsApp)
+export function setLocalSettingsV2(localSettingsJson: Json, localSettings?: LocalSettings): void {
+  localSettingsJson.teamsApp = assignJsonInc(
+    localSettingsJson.teamsApp,
+    mapToJson(localSettings?.teamsApp)
   );
-  localSettings.auth = assignJsonInc(
-    localSettings.auth,
-    mapToJson(pluginContext.localSettings?.auth)
+  localSettingsJson.auth = assignJsonInc(localSettingsJson.auth, mapToJson(localSettings?.auth));
+  localSettingsJson.backend = assignJsonInc(
+    localSettingsJson.backend,
+    mapToJson(localSettings?.backend)
   );
-  localSettings.backend = assignJsonInc(
-    localSettings.backend,
-    mapToJson(pluginContext.localSettings?.backend)
+  localSettingsJson.frontend = assignJsonInc(
+    localSettingsJson.frontend,
+    mapToJson(localSettings?.frontend)
   );
-  localSettings.frontend = assignJsonInc(
-    localSettings.frontend,
-    mapToJson(pluginContext.localSettings?.frontend)
-  );
-  localSettings.bot = assignJsonInc(localSettings.bot, mapToJson(pluginContext.localSettings?.bot));
+  localSettingsJson.bot = assignJsonInc(localSettingsJson.bot, mapToJson(localSettings?.bot));
 }
+
 export function assignJsonInc(target?: Json, source?: Json): Json | undefined {
   if (!target) return source;
   if (!source) return target;

--- a/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
@@ -146,7 +146,8 @@ import {
 import { askForProvisionConsent } from "./v2/provision";
 import { scaffoldReadmeAndLocalSettings } from "./v2/scaffolding";
 import { environmentManager } from "../../..";
-import { LocalSettingsProvider } from "../../../common/localSettingsProvider";
+import { Json } from "@microsoft/teamsfx-api";
+import { setLocalSettingsV2 } from "../../resource/utils4v2";
 
 export type LoadedPlugin = Plugin;
 export type PluginsWithContext = [LoadedPlugin, PluginContext];
@@ -363,7 +364,13 @@ export class TeamsAppSolution implements Solution {
       .capabilities;
     const azureResources = (ctx.projectSettings?.solutionSettings as AzureSolutionSettings)
       .azureResources;
-    await scaffoldReadmeAndLocalSettings(capabilities, azureResources, ctx.root, true);
+    await scaffoldReadmeAndLocalSettings(
+      capabilities,
+      azureResources,
+      ctx.root,
+      ctx.localSettings,
+      true
+    );
 
     ctx.telemetryReporter?.sendTelemetryEvent(SolutionTelemetryEvent.Migrate, {
       [SolutionTelemetryProperty.Component]: SolutionTelemetryComponentName,
@@ -452,7 +459,13 @@ export class TeamsAppSolution implements Solution {
         .capabilities;
       const azureResources = (ctx.projectSettings?.solutionSettings as AzureSolutionSettings)
         .azureResources;
-      await scaffoldReadmeAndLocalSettings(capabilities, azureResources, ctx.root);
+
+      await scaffoldReadmeAndLocalSettings(
+        capabilities,
+        azureResources,
+        ctx.root,
+        ctx.localSettings
+      );
     }
 
     if (isArmSupportEnabled() && generateResourceTemplate && this.isAzureProject(ctx)) {
@@ -1186,7 +1199,7 @@ export class TeamsAppSolution implements Solution {
       await ctx.appStudioToken?.getAccessToken();
 
       // Pop-up window to confirm if local debug in another tenant
-      const localDebugTenantId = ctx.localSettings?.teamsApp.get(
+      const localDebugTenantId = ctx.localSettings?.teamsApp?.get(
         LocalSettingsTeamsAppKeys.TenantId
       );
       if (isMultiEnvEnabled() && localDebugTenantId) {
@@ -1287,7 +1300,7 @@ export class TeamsAppSolution implements Solution {
         postLocalDebugWithCtx.map(function (plugin, index) {
           if (plugin[2] === PluginNames.APPST) {
             if (isMultiEnvEnabled()) {
-              ctx.localSettings?.teamsApp.set(
+              ctx.localSettings?.teamsApp?.set(
                 LocalSettingsTeamsAppKeys.TeamsAppId,
                 combinedPostLocalDebugResults.value[index]
               );
@@ -2084,7 +2097,7 @@ export class TeamsAppSolution implements Solution {
     return parseTeamsAppTenantId(appStudioToken as Record<string, unknown> | undefined).andThen(
       (teamsAppTenantId) => {
         if (isLocalDebug && isMultiEnvEnabled()) {
-          ctx.localSettings?.teamsApp.set(LocalSettingsTeamsAppKeys.TenantId, teamsAppTenantId);
+          ctx.localSettings?.teamsApp?.set(LocalSettingsTeamsAppKeys.TenantId, teamsAppTenantId);
         } else {
           ctx.envInfo.profile.get(GLOBAL_CONFIG)?.set("teamsAppTenantId", teamsAppTenantId);
         }

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/scaffolding.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/scaffolding.ts
@@ -38,6 +38,7 @@ import {
   SolutionTelemetrySuccess,
 } from "../../../..";
 import { LocalSettingsProvider } from "../../../../common/localSettingsProvider";
+import { Json } from "@microsoft/teamsfx-api";
 
 export async function scaffoldSourceCode(
   ctx: v2.Context,
@@ -112,6 +113,7 @@ export async function scaffoldSourceCode(
 export async function scaffoldByPlugins(
   ctx: v2.Context,
   inputs: Inputs,
+  localSettings: Json,
   plugins: v2.ResourcePlugin[]
 ): Promise<Result<Void, FxError>> {
   const blockResult = blockV1Project(ctx.projectSetting.solutionSettings);
@@ -136,7 +138,12 @@ export async function scaffoldByPlugins(
     const azureResources = solutionSettings.azureResources;
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    await scaffoldReadmeAndLocalSettings(capabilities, azureResources, inputs.projectPath!);
+    await scaffoldReadmeAndLocalSettings(
+      capabilities,
+      azureResources,
+      inputs.projectPath!,
+      localSettings
+    );
 
     ctx.userInteraction.showMessage(
       "info",
@@ -153,6 +160,7 @@ export async function scaffoldReadmeAndLocalSettings(
   capabilities: string[],
   azureResources: string[],
   projectPath: string,
+  localSettings?: Json,
   migrateFromV1?: boolean
 ): Promise<void> {
   const hasBot = capabilities.includes(BotOptionItem.id);
@@ -176,17 +184,18 @@ export async function scaffoldReadmeAndLocalSettings(
 
   if (isMultiEnvEnabled()) {
     const localSettingsProvider = new LocalSettingsProvider(projectPath);
-    const localSettings = await localSettingsProvider.load();
 
     if (localSettings !== undefined) {
       // Add local settings for the new added capability/resource
+      localSettings = localSettingsProvider.incrementalInit(localSettings!, hasBackend, hasBot);
       await localSettingsProvider.save(
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        localSettingsProvider.incrementalInit(localSettings!, hasBackend, hasBot)
+        localSettings
       );
     } else {
       // Initialize a local settings on scaffolding
-      await localSettingsProvider.save(localSettingsProvider.init(hasTab, hasBackend, hasBot));
+      localSettings = localSettingsProvider.init(hasTab, hasBackend, hasBot);
+      await localSettingsProvider.save(localSettings);
     }
   }
 }

--- a/packages/fx-core/tests/plugins/resource/apiv2/utils4v2.test.ts
+++ b/packages/fx-core/tests/plugins/resource/apiv2/utils4v2.test.ts
@@ -87,7 +87,7 @@ describe("API V2 adapter", () => {
       },
     };
     const localSettings: Json = {};
-    setLocalSettingsV2(localSettings, pluginContext);
+    setLocalSettingsV2(localSettings, pluginContext.localSettings);
     const expected: Json = {
       teamsApp: { k1: "v1" },
       auth: { k2: "v2" },
@@ -96,7 +96,7 @@ describe("API V2 adapter", () => {
       frontend: undefined,
     };
     setLocalSettingsV1(pluginContext, expected);
-    assert.equal(pluginContext.localSettings?.teamsApp.get("k1"), "v1");
+    assert.equal(pluginContext.localSettings?.teamsApp?.get("k1"), "v1");
     assert.equal(pluginContext.localSettings?.auth?.get("k2"), "v2");
   });
 

--- a/packages/vscode-extension/src/debug/commonUtils.ts
+++ b/packages/vscode-extension/src/debug/commonUtils.ts
@@ -303,7 +303,7 @@ function getLocalSetting(jsonSelector: (jsonObject: any) => any): string | undef
 export function getTeamsAppTenantId(): string | undefined {
   try {
     if (isMultiEnvEnabled()) {
-      return getLocalSetting((localSettingsJson) => localSettingsJson.teamsApp.tenantId);
+      return getLocalSetting((localSettingsJson) => localSettingsJson.teamsApp?.tenantId);
     } else {
       return getSettingWithUserData((envJson) => envJson.solution.teamsAppTenantId);
     }
@@ -316,7 +316,7 @@ export function getTeamsAppTenantId(): string | undefined {
 export function getLocalTeamsAppId(): string | undefined {
   try {
     if (isMultiEnvEnabled()) {
-      return getLocalSetting((localSettingsJson) => localSettingsJson.teamsApp.teamsAppId);
+      return getLocalSetting((localSettingsJson) => localSettingsJson.teamsApp?.teamsAppId);
     } else {
       return getSettingWithUserData((envJson) => envJson.solution.localDebugTeamsAppId);
     }


### PR DESCRIPTION
### Bug description: 
`localSettings.json` didn't get updated when add bot capability.

### Root Cuase:
The updated `localSettings` wasn't synced back to context when we update the `localSettings.json` for adding capability, and finaly the `localSettingsWriterMW` will overwrite the file with an old `localSettings` object.