### PR TITLE
chore(multi-env): add telemetry for remote debug

### DIFF
--- a/packages/fx-core/src/plugins/resource/localdebug/index.ts
+++ b/packages/fx-core/src/plugins/resource/localdebug/index.ts
@@ -485,16 +485,20 @@ export class LocalDebugPlugin implements Plugin {
               ?.get(AppStudioPlugin.TeamsAppId) as string)
           : (solutionConfigs?.get(SolutionPlugin.RemoteTeamsAppId) as string);
         if (/^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$/.test(remoteId)) {
-          return ok(remoteId);
+          return ok({
+            appId: remoteId,
+            env: ctx.envInfo.envName
+          });
         } else {
           return err(MissingStep("launching remote", "Teams: Provision and Teams: Deploy"));
         }
+
       } else {
         // return local teams app id
         const localTeamsAppId = isMultiEnvEnabled()
           ? (ctx.localSettings?.teamsApp?.get(LocalSettingsTeamsAppKeys.TeamsAppId) as string)
           : (solutionConfigs?.get(SolutionPlugin.LocalTeamsAppId) as string);
-        return ok(localTeamsAppId);
+        return ok({ appId: localTeamsAppId });
       }
     } else if (func.method === "getProgrammingLanguage") {
       const programmingLanguage = ctx.projectSettings?.programmingLanguage;

--- a/packages/vscode-extension/src/debug/commonUtils.ts
+++ b/packages/vscode-extension/src/debug/commonUtils.ts
@@ -109,12 +109,11 @@ export async function getLocalDebugEnvs(): Promise<Record<string, string>> {
   return localDebugEnvs as Record<string, string>;
 }
 
-export async function getLocalDebugTeamsAppId(
+export async function getDebugConfig(
   isLocalSideloadingConfiguration: boolean
-): Promise<string | undefined> {
+): Promise<{appId: string, env?: string} | undefined> {
   const params = isLocalSideloadingConfiguration ? "local" : "remote";
-  const localDebugTeamsAppId = await executeLocalDebugUserTask("getLaunchInput", params);
-  return localDebugTeamsAppId as string;
+  return await executeLocalDebugUserTask("getLaunchInput", params);
 }
 
 export async function getProgrammingLanguage(): Promise<string | undefined> {

--- a/packages/vscode-extension/src/debug/teamsfxDebugProvider.ts
+++ b/packages/vscode-extension/src/debug/teamsfxDebugProvider.ts
@@ -6,10 +6,15 @@ import * as vscode from "vscode";
 import AppStudioTokenInstance from "../commonlib/appStudioLogin";
 import * as commonUtils from "./commonUtils";
 
+export interface TeamsfxDebugConfiguration extends vscode.DebugConfiguration {
+  teamsfxEnv?: string;
+  teamsfxAppId?: string;
+}
+
 export class TeamsfxDebugProvider implements vscode.DebugConfigurationProvider {
   public async resolveDebugConfiguration?(
     folder: vscode.WorkspaceFolder | undefined,
-    debugConfiguration: vscode.DebugConfiguration,
+    debugConfiguration: TeamsfxDebugConfiguration,
     token?: vscode.CancellationToken
   ): Promise<vscode.DebugConfiguration | undefined> {
     try {
@@ -39,12 +44,16 @@ export class TeamsfxDebugProvider implements vscode.DebugConfigurationProvider {
           debugConfiguration.timeout = 20000;
         }
 
-        const teamsAppId = await commonUtils.getLocalDebugTeamsAppId(
+        const debugConfig = await commonUtils.getDebugConfig(
           isLocalSideloadingConfiguration
         );
+
+        // Put env and appId in `debugConfiguration` so debug handlers can retrieve it and send telemetry
+        debugConfiguration.teamsfxEnv = debugConfig?.env;
+        debugConfiguration.teamsfxAppId = debugConfig?.appId;
         debugConfiguration.url = (debugConfiguration.url as string).replace(
           isLocalSideloadingConfiguration ? localTeamsAppIdPlaceholder : teamsAppIdPlaceholder,
-          teamsAppId as string
+          debugConfig?.appId!
         );
 
         const accountHintPlaceholder = "${account-hint}";

--- a/packages/vscode-extension/src/debug/teamsfxTaskHandler.ts
+++ b/packages/vscode-extension/src/debug/teamsfxTaskHandler.ts
@@ -9,7 +9,7 @@ import { ext } from "../extensionVariables";
 import { ExtTelemetry } from "../telemetry/extTelemetry";
 import { TelemetryEvent, TelemetryProperty } from "../telemetry/extTelemetryEvents";
 import { getTeamsAppId } from "../utils/commonUtils";
-import { isValidProject } from "@microsoft/teamsfx-core";
+import { getHashedEnv, isValidProject } from "@microsoft/teamsfx-core";
 import { getNpmInstallLogInfo } from "./npmLogHandler";
 import * as path from "path";
 import { errorDetail, issueLink, issueTemplate } from "./constants";
@@ -20,6 +20,7 @@ import { globalStateGet, globalStateUpdate } from "@microsoft/teamsfx-core";
 import * as constants from "../debug/constants";
 import { ExtensionSurvey } from "../utils/survey";
 import { TreatmentVariableValue } from "../exp/treatmentVariables";
+import { TeamsfxDebugConfiguration } from "./teamsfxDebugProvider";
 
 interface IRunningTeamsfxTask {
   source: string;
@@ -202,7 +203,7 @@ async function onDidEndTaskProcessHandler(event: vscode.TaskProcessEndEvent): Pr
 
 function onDidStartDebugSessionHandler(event: vscode.DebugSession): void {
   if (ext.workspaceUri && isValidProject(ext.workspaceUri.fsPath)) {
-    const debugConfig = event.configuration;
+    const debugConfig = event.configuration as TeamsfxDebugConfiguration;
     if (
       debugConfig &&
       debugConfig.name &&
@@ -212,24 +213,37 @@ function onDidStartDebugSessionHandler(event: vscode.DebugSession): void {
       // and not a restart one
       // send f5 event telemetry
       try {
-        const remoteAppId = getTeamsAppId() as string;
         const localAppId = getLocalTeamsAppId() as string;
-        const isRemote =
+        const isLocal =
           (debugConfig.url as string) &&
-          remoteAppId &&
-          (debugConfig.url as string).includes(remoteAppId);
+          localAppId &&
+          (debugConfig.url as string).includes(localAppId);
+        let appId: string = "";
+        let env: string = "";
+        if (isLocal) {
+          appId = localAppId;
+        } else {
+          if (debugConfig.teamsfxAppId) {
+            appId = debugConfig.teamsfxAppId;
+          }
+          if (debugConfig.teamsfxEnv) {
+            env = getHashedEnv(event.configuration.env);
+          }
+        }
+
         ExtTelemetry.sendTelemetryEvent(TelemetryEvent.DebugStart, {
           [TelemetryProperty.DebugSessionId]: event.id,
           [TelemetryProperty.DebugType]: debugConfig.type,
           [TelemetryProperty.DebugRequest]: debugConfig.request,
           [TelemetryProperty.DebugPort]: debugConfig.port + "",
-          [TelemetryProperty.DebugRemote]: isRemote ? "true" : "false",
-          [TelemetryProperty.DebugAppId]: isRemote ? remoteAppId : localAppId,
+          [TelemetryProperty.DebugRemote]: isLocal ? "false" : "true",
+          [TelemetryProperty.DebugAppId]: appId,
+          [TelemetryProperty.Env]: env,
         });
 
         if (
           debugConfig.request === "launch" &&
-          !isRemote &&
+          isLocal &&
           !globalStateGet(constants.SideloadingHintStateKeys.DoNotShowAgain, false)
         ) {
           vscode.window

--- a/packages/vscode-extension/src/debug/teamsfxTaskProvider.ts
+++ b/packages/vscode-extension/src/debug/teamsfxTaskProvider.ts
@@ -246,7 +246,8 @@ export class TeamsfxTaskProvider implements vscode.TaskProvider {
     const command: string = constants.openWenClientCommand;
     definition = definition || { type: TeamsfxTaskProvider.type, command };
 
-    const localTeamsAppId: string | undefined = await commonUtils.getLocalDebugTeamsAppId(true);
+    const debugConfig = await commonUtils.getDebugConfig(true);
+    const localTeamsAppId: string | undefined = debugConfig?.appId;
     const commandLine = `npx open-cli https://teams.microsoft.com/_#/l/app/${localTeamsAppId}?installAppPackage=true`;
 
     const task = new vscode.Task(


### PR DESCRIPTION
- add `env` and fix `remoteAppId` for remote debug

tested local debug and remote debug happy path