### PR TITLE
fix(multi-env): env tree didn't refresh automatically when env config is renamed

### DIFF
--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -233,6 +233,16 @@ export async function activate(): Promise<Result<Void, FxError>> {
       workspace.onDidDeleteFiles(async (event) => {
         await refreshEnvTreeOnFileChanged(workspacePath, event.files);
       });
+
+      workspace.onDidRenameFiles(async (event) => {
+        const files = [];
+        for (const f of event.files) {
+          files.push(f.newUri);
+          files.push(f.oldUri);
+        }
+
+        await refreshEnvTreeOnFileChanged(workspacePath, files);
+      });
     }
   } catch (e) {
     const FxError: FxError = {


### PR DESCRIPTION
bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/11643501/