### PR TITLE
fix(multi-env): no need refresh env tree when user cancelled create env copy

### DIFF
--- a/packages/fx-core/src/core/index.ts
+++ b/packages/fx-core/src/core/index.ts
@@ -38,6 +38,7 @@ import {
   SystemError,
   TelemetryReporter,
   Tools,
+  UserCancelError,
   v2,
   Void,
 } from "@microsoft/teamsfx-api";
@@ -1022,7 +1023,7 @@ export class FxCore implements Core {
       !createEnvCopyInput.targetEnvName ||
       !createEnvCopyInput.sourceEnvName
     ) {
-      return ok(Void);
+      return err(UserCancelError);
     }
 
     const createEnvResult = await this.createEnvCopy(


### PR DESCRIPTION
Bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/11643349