### PR TITLE
chore(multi-env): update env config schema with root level description

### DIFF
--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -273,14 +273,12 @@ export interface EnvConfig {
         appPassword?: string;
         [k: string]: unknown;
     };
+    // (undocumented)
+    description?: string;
     manifest: {
-        description?: string;
-        values: {
-            appName: {
-                short: string;
-                full?: string;
-                [k: string]: unknown;
-            };
+        appName: {
+            short: string;
+            full?: string;
             [k: string]: unknown;
         };
         [k: string]: unknown;

--- a/packages/api/src/schemas/envConfig.json
+++ b/packages/api/src/schemas/envConfig.json
@@ -6,6 +6,9 @@
     "$schema": {
       "type": "string"
     },
+    "description": {
+      "type": "string"
+    },
     "auth": {
       "type": "object",
       "description": "Existing AAD app configuration.",
@@ -79,36 +82,26 @@
       "type": "object",
       "description": "The Teams App manifest related configuration.",
       "properties": {
-        "description": {
-          "type": "string"
-        },
-        "values": {
+        "appName": {
           "type": "object",
-          "description": "Configs to customize the Teams app manifest.",
+          "description": "Teams app name.",
           "properties": {
-            "appName": {
-              "type": "object",
-              "description": "Teams app name.",
-              "properties": {
-                "short": {
-                  "type": "string",
-                  "description": "A short display name for teams app.",
-                  "maxLength": 30,
-                  "minLength": 1
-                },
-                "full": {
-                  "type": "string",
-                  "description": "The full name for teams app.",
-                  "maxLength": 100
-                }
-              },
-              "required": ["short"]
+            "short": {
+              "type": "string",
+              "description": "A short display name for teams app.",
+              "maxLength": 30,
+              "minLength": 1
+            },
+            "full": {
+              "type": "string",
+              "description": "The full name for teams app.",
+              "maxLength": 100
             }
           },
-          "required": ["appName"]
+          "required": ["short"]
         }
       },
-      "required": ["values"]
+      "required": ["appName"]
     },
     "skipAddingSqlUser": {
       "type": "boolean",

--- a/packages/api/src/schemas/envConfig.ts
+++ b/packages/api/src/schemas/envConfig.ts
@@ -10,6 +10,7 @@
  */
 export interface EnvConfig {
   $schema?: string;
+  description?: string;
   /**
    * Existing AAD app configuration.
    */
@@ -64,25 +65,18 @@ export interface EnvConfig {
    * The Teams App manifest related configuration.
    */
   manifest: {
-    description?: string;
     /**
-     * Configs to customize the Teams app manifest.
+     * Teams app name.
      */
-    values: {
+    appName: {
       /**
-       * Teams app name.
+       * A short display name for teams app.
        */
-      appName: {
-        /**
-         * A short display name for teams app.
-         */
-        short: string;
-        /**
-         * The full name for teams app.
-         */
-        full?: string;
-        [k: string]: unknown;
-      };
+      short: string;
+      /**
+       * The full name for teams app.
+       */
+      full?: string;
       [k: string]: unknown;
     };
     [k: string]: unknown;

--- a/packages/fx-core/src/core/environment.ts
+++ b/packages/fx-core/src/core/environment.ts
@@ -63,8 +63,8 @@ class EnvironmentManager {
   private readonly checksumKey = "_checksum";
   private readonly schema =
     "https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/packages/api/src/schemas/envConfig.json";
-  private readonly manifestConfigDescription =
-    `You can customize the 'values' object to customize Teams app manifest for different environments.` +
+  private readonly envConfigDescription =
+    `You can customize the TeamsFx config for different environments.` +
     ` Visit https://aka.ms/teamsfx-config to learn more about this.`;
 
   constructor() {
@@ -98,13 +98,11 @@ class EnvironmentManager {
   public newEnvConfigData(appName: string): EnvConfig {
     const envConfig: EnvConfig = {
       $schema: this.schema,
+      description: this.envConfigDescription,
       manifest: {
-        description: this.manifestConfigDescription,
-        values: {
-          appName: {
-            short: appName,
-            full: `Full name for ${appName}`,
-          },
+        appName: {
+          short: appName,
+          full: `Full name for ${appName}`,
         },
       },
     };
@@ -243,7 +241,7 @@ class EnvironmentManager {
   ): Promise<Result<EnvConfig, FxError>> {
     if (!isMultiEnvEnabled()) {
       return ok({
-        manifest: { values: { appName: { short: "" } } },
+        manifest: { appName: { short: "" } },
       });
     }
 

--- a/packages/fx-core/src/core/middleware/projectMigrator.ts
+++ b/packages/fx-core/src/core/middleware/projectMigrator.ts
@@ -192,8 +192,8 @@ async function migrateMultiEnv(projectPath: string): Promise<void> {
     "{{profile.fx-resource-bot.botId}}"
   );
   const manifest: TeamsAppManifest = JSON.parse(manifestString);
-  manifest.name.short = "{{config.manifest.values.appName.short}}";
-  manifest.name.full = "{{config.manifest.values.appName.full}}";
+  manifest.name.short = "{{config.manifest.appName.short}}";
+  manifest.name.full = "{{config.manifest.appName.full}}";
   manifest.id = "{{profile.fx-resource-appstudio.teamsAppId}}";
   await fs.writeFile(targetManifestFile, JSON.stringify(manifest, null, 4));
   await moveIconsToResourceFolder(templateAppPackage);

--- a/packages/fx-core/src/core/tools.ts
+++ b/packages/fx-core/src/core/tools.ts
@@ -133,10 +133,8 @@ export function newEnvInfo(
     envName: envName ?? environmentManager.getDefaultEnvName(),
     config: config ?? {
       manifest: {
-        values: {
-          appName: {
-            short: "teamsfx_app",
-          },
+        appName: {
+          short: "teamsfx_app",
         },
       },
     },

--- a/packages/fx-core/src/plugins/resource/appstudio/constants.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/constants.ts
@@ -102,12 +102,12 @@ export const TEAMS_APP_MANIFEST_TEMPLATE_FOR_MULTI_ENV = `{
       "outline": "resources/outline.png"
   },
   "name": {
-      "short": "{{config.manifest.values.appName.short}}",
-      "full": "{{config.manifest.values.appName.full}}"
+      "short": "{{config.manifest.appName.short}}",
+      "full": "{{config.manifest.appName.full}}"
   },
   "description": {
-      "short": "Short description of {{config.manifest.values.appName.short}}",
-      "full": "Full description of {{config.manifest.values.appName.short}}"
+      "short": "Short description of {{config.manifest.appName.short}}",
+      "full": "Full description of {{config.manifest.appName.short}}"
   },
   "accentColor": "#FFFFFF",
   "bots": [],

--- a/packages/fx-core/templates/plugins/resource/spfx/solution/manifest_multi_env.json
+++ b/packages/fx-core/templates/plugins/resource/spfx/solution/manifest_multi_env.json
@@ -11,8 +11,8 @@
         "termsOfUseUrl": "https://www.microsoft.com/en-us/servicesagreement"
     },
     "name": {
-        "short": "{{config.manifest.values.appName.short}}",
-        "full": "{{config.manifest.values.appName.full}}"
+        "short": "{{config.manifest.appName.short}}",
+        "full": "{{config.manifest.appName.full}}"
 },
     "description": {
         "short": "<%= componentNameUnescaped %>",

--- a/packages/fx-core/tests/core/environment.test.ts
+++ b/packages/fx-core/tests/core/environment.test.ts
@@ -51,11 +51,8 @@ describe("APIs of Environment Manager", () => {
   const targetEnvName = "dev";
   const validEnvConfigData = {
     manifest: {
-      description: "",
-      values: {
-        appName: {
-          short: appName,
-        },
+      appName: {
+        short: appName,
       },
     },
   };
@@ -109,8 +106,7 @@ describe("APIs of Environment Manager", () => {
       const envConfigInfo = actualEnvDataResult.value;
       assert.equal(envConfigInfo.envName, environmentManager.getDefaultEnvName());
       assert.isUndefined(envConfigInfo.config.azure);
-      assert.equal(envConfigInfo.config.manifest.description, "");
-      assert.equal(envConfigInfo.config.manifest.values.appName.short, appName);
+      assert.equal(envConfigInfo.config.manifest.appName.short, appName);
     });
 
     it("load valid environment config file with target env", async () => {
@@ -125,8 +121,7 @@ describe("APIs of Environment Manager", () => {
       const envConfigInfo = actualEnvDataResult.value;
       assert.equal(envConfigInfo.envName, envName);
       assert.isUndefined(envConfigInfo.config.azure);
-      assert.equal(envConfigInfo.config.manifest.description, "");
-      assert.equal(envConfigInfo.config.manifest.values.appName.short, appName);
+      assert.equal(envConfigInfo.config.manifest.appName.short, appName);
     });
 
     it("load invalid environment config file", async () => {

--- a/packages/fx-core/tests/core/hooks.test.ts
+++ b/packages/fx-core/tests/core/hooks.test.ts
@@ -675,10 +675,8 @@ describe("Middleware - others", () => {
 
             const envConfig: EnvConfig = {
               manifest: {
-                values: {
-                  appName: {
-                    short: "testApp",
-                  },
+                appName: {
+                  short: "testApp",
                 },
               },
             };

--- a/packages/fx-core/tests/plugins/resource/apiv2/utils4v2.test.ts
+++ b/packages/fx-core/tests/plugins/resource/apiv2/utils4v2.test.ts
@@ -166,7 +166,7 @@ describe("API V2 adapter", () => {
     };
     const provisionInputConfig: EnvConfig = {
       azure: { subscriptionId: "123455", resourceGroupName: "rg" },
-      manifest: { values: { appName: { short: appName } } },
+      manifest: { appName: { short: appName } },
     };
     const envInfo: EnvInfoV2 = {
       envName: "default",

--- a/packages/fx-core/tests/plugins/resource/appstudio/spfx-resources/appPackage/manifest.template.json
+++ b/packages/fx-core/tests/plugins/resource/appstudio/spfx-resources/appPackage/manifest.template.json
@@ -11,8 +11,8 @@
     "termsOfUseUrl": "https://www.microsoft.com/en-us/servicesagreement"
   },
   "name": {
-    "short": "{{config.manifest.values.appName.short}}",
-    "full": "{{config.manifest.values.appName.full}}"
+    "short": "{{config.manifest.appName.short}}",
+    "full": "{{config.manifest.appName.full}}"
   },
   "description": {
     "short": "<%= componentNameUnescaped %>",

--- a/packages/fx-core/tests/plugins/solution/solution.provision.test.ts
+++ b/packages/fx-core/tests/plugins/solution/solution.provision.test.ts
@@ -953,7 +953,7 @@ describe("API v2 implementation", () => {
       };
       const mockedEnvInfo: EnvInfoV2 = {
         envName: "default",
-        config: { manifest: { values: { appName: { short: "test-app" } } } },
+        config: { manifest: { appName: { short: "test-app" } } },
         profile: {},
       };
       mockProvisionV2ThatAlwaysSucceed(spfxPluginV2);
@@ -1005,7 +1005,7 @@ describe("API v2 implementation", () => {
       };
       const mockedEnvInfo: EnvInfoV2 = {
         envName: "default",
-        config: { manifest: { values: { appName: { short: "test-app" } } } },
+        config: { manifest: { appName: { short: "test-app" } } },
         profile: {},
       };
       mockProvisionV2ThatAlwaysSucceed(fehostPluginV2);

--- a/packages/fx-core/tests/plugins/solution/solution.publish.test.ts
+++ b/packages/fx-core/tests/plugins/solution/solution.publish.test.ts
@@ -287,7 +287,7 @@ describe("v2 implementation for publish()", () => {
     const mockedTokenProvider: AppStudioTokenProvider = new MockedAppStudioProvider();
     const mockedEnvInfo: v2.EnvInfoV2 = {
       envName: "default",
-      config: { manifest: { values: { appName: { short: "test-app" } } } },
+      config: { manifest: { appName: { short: "test-app" } } },
       profile: { solution: {} },
     };
 


### PR DESCRIPTION
Bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/11033171

Update env config schema with root level description and remove the original `description` and `values` for manifest section.

sample env config:
```json
{
    "$schema": "https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/packages/api/src/schemas/envConfig.json",
    "description": "You can customize the TeamsFx config for different environments. Visit https://aka.ms/teamsfx-config to learn more about this.",
    "manifest": {
        "appName": {
            "short": "qinezh1011",
            "full": "Full name for qinezh1011"
        }
    }
}
```