### PR TITLE
feat: add support for insider features in cicd

### DIFF
--- a/docs/cicd/README.md
+++ b/docs/cicd/README.md
@@ -26,6 +26,7 @@ You may want to change:
 1. Create GitHub [repository secrets](https://docs.github.com/en/actions/reference/encrypted-secrets) by environment to hold Azure/M365 login credentials. The table below lists all the secrets you need to create on GitHub, and for detailed usage, please refer to the GitHub Actions [README.md](https://github.com/OfficeDev/teamsfx-cli-action/blob/main/README.md).
 1. Change the build scripts if necessary.
 1. Remove the test scripts if you don't have tests.
+1. Enable insider preview features if necessary.
 
 > Note: The provision step is expected to run separately by hand or by workflow. Please remember to commit after provisioning (results of provisioning will be deposited inside the `.fx` folder) and save the file content of `default.userdata` into Jenkins credentials to generate file `default.userdata`.
 
@@ -73,6 +74,7 @@ You may want to change:
 1. Create Jenkins [pipeline credentials](https://www.jenkins.io/doc/book/using/using-credentials/) to hold Azure/M365 login credentials. The table below lists all the credentials you need to create on Jenkins.
 1. Change the build scripts if necessary.
 1. Remove the test scripts if you don't have tests.
+1. Enable insider preview features if necessary.
 
 > Note: The provision step is expected to run separately by hand or by pipeline. Please remember to commit after provisioning (results of provisioning will be deposited inside the `.fx` folder) and save the file content of `default.userdata` into Jenkins credentials to generate file `default.userdata`.
 

--- a/docs/cicd/github-cd-template.yml
+++ b/docs/cicd/github-cd-template.yml
@@ -19,6 +19,11 @@ jobs:
       M365_ACCOUNT_NAME: ${{secrets.M365_ACCOUNT_NAME}}
       M365_ACCOUNT_PASSWORD: ${{secrets.M365_ACCOUNT_PASSWORD}}
 
+      # Please uncomment the next line to enable insider preview features (multi-env, arm support and collaboration). 
+      #TEAMSFX_INSIDER_PREVIEW: true
+      # Please uncomment the next line to specify the env name for multi-env feature.
+      #TEAMSFX_ENV_NAME: test
+
     steps:
       # Setup environment.
       - uses: actions/setup-node@v2
@@ -50,6 +55,8 @@ jobs:
       #  with:
       #    commands: provision
       #    subscription: ${{env.AZURE_SUBSCRIPTION_ID}}
+      # Uncomment the next line to use the insider feature of multi-env.
+      #    env: ${{env.TEAMSFX_ENV_NAME}}
 
       #- name: Commit provision configs if necessary
       #  uses: stefanzweifel/git-auto-commit-action@v4
@@ -73,6 +80,8 @@ jobs:
         uses: OfficeDev/teamsfx-cli-action@v1
         with:
           commands: deploy
+          # Uncomment the next line to use the insider feature of multi-env.
+          #env: ${{env.TEAMSFX_ENV_NAME}}
 
       # This step is to pack the Teams App as zip file,
       # which can be used to be uploaded onto Teams Client for installation.
@@ -80,6 +89,8 @@ jobs:
         uses: OfficeDev/teamsfx-cli-action@v1
         with:
           commands: package
+          # Uncomment the next line to use the insider feature of multi-env.
+          #env: ${{env.TEAMSFX_ENV_NAME}}
 
       - name: Upload Teams App's package as artifact
         uses: actions/upload-artifact@v2
@@ -91,3 +102,5 @@ jobs:
         uses: OfficeDev/teamsfx-cli-action@v1
         with:
           commands: publish
+          # Uncomment the next line to use the insider feature of multi-env.
+          #env: ${{env.TEAMSFX_ENV_NAME}}

--- a/docs/cicd/jenkins-cd-template.Jenkinsfile
+++ b/docs/cicd/jenkins-cd-template.Jenkinsfile
@@ -19,6 +19,10 @@ pipeline {
         # To enable @microsoft/teamsfx-cli running in CI mode, turn on CI_ENABLED like below.
         # In CI mode, @microsoft/teamsfx-cli is friendly for CI/CD. 
         CI_ENABLED = 'true'
+        # Please uncomment the next line to enable insider preview features (multi-env, arm support and collaboration). 
+        #TEAMSFX_INSIDER_PREVIEW = 'true'
+        # Please uncomment the next line to specify the env name for multi-env feature.
+        #TEAMSFX_ENV_NAME = 'test'
     }
 
     stages {
@@ -56,6 +60,7 @@ pipeline {
         # You should save the content of .fx/default.userdata into credentials (https://www.jenkins.io/doc/book/using/using-credentials/) which can be refered by the stage with name 'Generate default.userdata'. 
         # stage('Provision hosting environment') {
         #     steps {
+        # To use the insider feature of multi-env, add option --env ${TEAMS_ENV_NAME} to the following command.
         #         sh 'npx teamsfx provision --subscription ${AZURE_SUBSCRIPTION_ID}'
         #     }
         # }
@@ -85,6 +90,7 @@ pipeline {
 
         stage('Deploy to hosting environment') {
             steps {
+                # To use the insider feature of multi-env, add option --env ${TEAMS_ENV_NAME} to the following command.
                 sh 'npx teamsfx deploy'
             }
         }
@@ -93,6 +99,7 @@ pipeline {
         # which can be used to be uploaded onto Teams Client for installation.
         stage('Package Teams App for publishing') {
             steps {
+                # To use the insider feature of multi-env, add option --env ${TEAMS_ENV_NAME} to the following command.
                 sh 'npx teamsfx package'
             }
         }
@@ -105,6 +112,7 @@ pipeline {
 
         stage('Publish Teams App') {
             steps {
+                # To use the insider feature of multi-env, add option --env ${TEAMS_ENV_NAME} to the following command.
                 sh 'npx teamsfx publish'
             }
         }

--- a/docs/cicd/others-script-cd-template.sh
+++ b/docs/cicd/others-script-cd-template.sh
@@ -11,6 +11,11 @@ set -euxo pipefail
 # export M365_ACCOUNT_NAME={M365_ACCOUNT_NAME}
 # export M365_ACCOUNT_PASSWORD={M365_ACCOUNT_PASSWORD}
 
+# Please uncomment the next line to enable insider preview features (multi-env, arm support and collaboration). 
+# export TEAMSFX_INSIDER_PREVIEW=true
+# Please uncomment the next line to specify the env name for multi-env feature.
+# export TEAMSFX_ENV_NAME=test
+
 # To enable @microsoft/teamsfx-cli running in CI mode, turn on CI_ENABLED like below.
 # In CI mode, @microsoft/teamsfx-cli is friendly for CI/CD. 
 export CI_ENABLED=true
@@ -45,7 +50,8 @@ npm run test
 # You should pick required secrets from .fx/default.userdata, and export them in your environment which can be refered by the step with name 'Generate default.userdata'. 
 
 # Provision hosting environment.
-# npx teamsfx provision --subscription ${AZURE_SUBSCRIPTION_ID}
+# To use the insider feature of multi-env, add option --env ${TEAMS_ENV_NAME} to the following command.
+# npx teamsfx provision --subscription ${AZURE_SUBSCRIPTION_ID} 
 
 # Commit provision configs if necessary.
 # git add .fx/env.default.json
@@ -56,11 +62,13 @@ npm run test
 [ ! -z "${USERDATA_CONTENT}" ] && echo "${USERDATA_CONTENT}" > .fx/default.userdata
 
 # Deploy to hosting environment.
+# To use the insider feature of multi-env, add option --env ${TEAMS_ENV_NAME} to the following command.
 cd .. && npx teamsfx deploy
 
 # This step is to pack the Teams App as zip file,
 # which can be used to be uploaded onto Teams Client for installation.
 # Build Teams App's Package.
+# To use the insider feature of multi-env, add option --env ${TEAMS_ENV_NAME} to the following command.
 npx teamsfx package
 
 # Upload Teams App's Package as artifacts.
@@ -68,4 +76,5 @@ npx teamsfx package
 # upload appPackage/appPackage.zip as artifacts.
 
 # Publish Teams App.
+# To use the insider feature of multi-env, add option --env ${TEAMS_ENV_NAME} to the following command.
 npx teamsfx publish


### PR DESCRIPTION
Under testing, not ready for review, but it's okay if you want to look ahead.

To support insider preview features(multi-env) inside cicd scenario.
>Note: teamsfx-cli-action needs to be updated too, and will update it soon.

to finish: https://dev.azure.com/msazure/Microsoft%20Teams%20Extensibility/_workitems/edit/11808585