### PR TITLE
fix: message extension local debug missing bot config

### DIFF
--- a/packages/fx-core/src/common/localSettingsProvider.ts
+++ b/packages/fx-core/src/common/localSettingsProvider.ts
@@ -32,7 +32,7 @@ export class LocalSettingsProvider {
   public init(
     includeFrontend: boolean,
     includeBackend: boolean,
-    includeBot: boolean
+    includeBotOrMessageExtension: boolean
   ): LocalSettings {
     // initialize Teams app related config for local debug.
     const teamsAppLocalConfig = new ConfigMap();
@@ -56,7 +56,7 @@ export class LocalSettingsProvider {
     }
 
     // initialize bot local settings.
-    if (includeBot) {
+    if (includeBotOrMessageExtension) {
       localSettings.bot = this.initBot();
     }
 

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/scaffolding.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/scaffolding.ts
@@ -194,7 +194,7 @@ export async function scaffoldReadmeAndLocalSettings(
       );
     } else {
       // Initialize a local settings on scaffolding
-      localSettings = localSettingsProvider.init(hasTab, hasBackend, hasBot);
+      localSettings = localSettingsProvider.init(hasTab, hasBackend, hasBot || hasMsgExt);
       await localSettingsProvider.save(localSettings);
     }
   }


### PR DESCRIPTION
Fix bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/11784397?src=WorkItemMention&src-action=artifact_link