### PR TITLE
chore: fix env checker can't use global dotnet when user have install dotnet6

### DIFF
--- a/packages/cli/src/cmds/preview/depsChecker/dotnetChecker.ts
+++ b/packages/cli/src/cmds/preview/depsChecker/dotnetChecker.ts
@@ -456,8 +456,6 @@ export class DotnetChecker implements IDepsChecker {
     }
 
     const samplePath = path.join(os.homedir(), `.${ConfigFolderName}`, "dotnetSample");
-    const expected = "Hello World";
-    let actual = "";
     try {
       await fs.remove(samplePath);
 
@@ -472,7 +470,7 @@ export class DotnetChecker implements IDepsChecker {
         `${samplePath}`,
         "--force"
       );
-      actual = await cpUtils.executeCommand(
+      await cpUtils.executeCommand(
         undefined,
         this._logger,
         { shell: false },
@@ -482,7 +480,7 @@ export class DotnetChecker implements IDepsChecker {
         `${samplePath}`,
         "--force"
       );
-      return actual.includes(expected);
+      return true;
     } catch (error) {
       this._telemetry.sendSystemErrorEvent(
         DepsCheckerEvent.dotnetValidationError,

--- a/packages/fx-core/src/plugins/resource/function/utils/depsChecker/dotnetChecker.ts
+++ b/packages/fx-core/src/plugins/resource/function/utils/depsChecker/dotnetChecker.ts
@@ -456,8 +456,6 @@ export class DotnetChecker implements IDepsChecker {
     }
 
     const samplePath = path.join(os.homedir(), `.${ConfigFolderName}`, "dotnetSample");
-    const expected = "Hello World";
-    let actual = "";
     try {
       await fs.remove(samplePath);
 
@@ -472,7 +470,7 @@ export class DotnetChecker implements IDepsChecker {
         `${samplePath}`,
         "--force"
       );
-      actual = await cpUtils.executeCommand(
+      await cpUtils.executeCommand(
         undefined,
         this._logger,
         { shell: false },
@@ -482,7 +480,7 @@ export class DotnetChecker implements IDepsChecker {
         `${samplePath}`,
         "--force"
       );
-      return actual.includes(expected);
+      return true;
     } catch (error) {
       this._telemetry.sendSystemErrorEvent(
         DepsCheckerEvent.dotnetValidationError,

--- a/packages/vscode-extension/src/debug/depsChecker/dotnetChecker.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/dotnetChecker.ts
@@ -456,8 +456,6 @@ export class DotnetChecker implements IDepsChecker {
     }
 
     const samplePath = path.join(os.homedir(), `.${ConfigFolderName}`, "dotnetSample");
-    const expected = "Hello World";
-    let actual = "";
     try {
       await fs.remove(samplePath);
 
@@ -472,7 +470,7 @@ export class DotnetChecker implements IDepsChecker {
         `${samplePath}`,
         "--force"
       );
-      actual = await cpUtils.executeCommand(
+      await cpUtils.executeCommand(
         undefined,
         this._logger,
         { shell: false },
@@ -482,7 +480,7 @@ export class DotnetChecker implements IDepsChecker {
         `${samplePath}`,
         "--force"
       );
-      return actual.includes(expected);
+      return true;
     } catch (error) {
       this._telemetry.sendSystemErrorEvent(
         DepsCheckerEvent.dotnetValidationError,


### PR DESCRIPTION
Cause [dotnet6 template changes](https://docs.microsoft.com/en-us/dotnet/core/tutorials/top-level-templates), we need to change  the key of validating hello world app. 