### PR TITLE
fix: always deploy when ARM or multi-env enabled

### DIFF
--- a/packages/fx-core/src/plugins/resource/bot/deployMgr.ts
+++ b/packages/fx-core/src/plugins/resource/bot/deployMgr.ts
@@ -8,6 +8,7 @@ import { PreconditionError, SomethingMissingError } from "./errors";
 import { Logger } from "./logger";
 import { forEachFileAndDir } from "./utils/dir-walk";
 import { Messages } from "./resources/messages";
+import { isArmSupportEnabled, isMultiEnvEnabled } from "../../..";
 
 export class DeployMgr {
   private workingDir: string;
@@ -39,6 +40,11 @@ export class DeployMgr {
   }
 
   public async needsToRedeploy(): Promise<boolean> {
+    // TODO: always do deployment until we integrate with these preview feature
+    if (isArmSupportEnabled() || isMultiEnvEnabled()) {
+      return true;
+    }
+
     // Iterate all source files and config files to determine if anything changed.
     if (!this.workingDir) {
       throw new PreconditionError(Messages.WorkingDirIsMissing, []);

--- a/packages/fx-core/src/plugins/resource/frontend/ops/deploy.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/ops/deploy.ts
@@ -19,6 +19,7 @@ import { Utils } from "../utils";
 import fs from "fs-extra";
 import path from "path";
 import { TelemetryHelper } from "../utils/telemetry-helper";
+import { isArmSupportEnabled, isMultiEnvEnabled } from "../../../..";
 
 interface DeploymentInfo {
   lastBuildTime?: string;
@@ -35,6 +36,11 @@ export class FrontendDeployment {
   }
 
   public static async needDeploy(componentPath: string): Promise<boolean> {
+    // TODO: always do deployment until we integrate with these preview feature
+    if (isArmSupportEnabled() || isMultiEnvEnabled()) {
+      return true;
+    }
+
     const lastBuildTime = await FrontendDeployment.getLastBuildTime(componentPath);
     const lastDeployTime = await FrontendDeployment.getLastDeploymentTime(componentPath);
     if (!lastBuildTime || !lastDeployTime) {

--- a/packages/fx-core/src/plugins/resource/function/ops/deploy.ts
+++ b/packages/fx-core/src/plugins/resource/function/ops/deploy.ts
@@ -33,6 +33,7 @@ import { funcPluginLogger } from "../utils/depsChecker/funcPluginLogger";
 import { FuncPluginTelemetry } from "../utils/depsChecker/funcPluginTelemetry";
 import { TelemetryHelper } from "../utils/telemetry-helper";
 import { sendRequestWithRetry } from "../../../../common/templatesUtils";
+import { isArmSupportEnabled, isMultiEnvEnabled } from "../../../..";
 
 export class FunctionDeploy {
   public static async getLastDeploymentTime(componentPath: string): Promise<Date> {
@@ -57,6 +58,11 @@ export class FunctionDeploy {
     componentPath: string,
     language: FunctionLanguage
   ): Promise<boolean> {
+    // TODO: always do deployment until we integrate with these preview feature
+    if (isArmSupportEnabled() || isMultiEnvEnabled()) {
+      return true;
+    }
+
     const folderFilter = LanguageStrategyFactory.getStrategy(language).hasUpdatedContentFilter;
 
     try {


### PR DESCRIPTION
Plugin skips deployment if no code change detected. When ARM support or multiple environment enabled, plugin might wrongly skip necessary deployment. This PR is to workaround these cases and next step we will figure out an ultimate solution.