### PR TITLE
chore: generate .env.teamsfx.local for multienv local debug

### DIFF
--- a/packages/fx-core/src/core/index.ts
+++ b/packages/fx-core/src/core/index.ts
@@ -1252,6 +1252,7 @@ export async function createBasicFolderStructure(inputs: Inputs): Promise<Result
             ".DS_Store",
             `${ArchiveFolderName}`,
             `${ArchiveLogFileName}`,
+            ".env.teamsfx.local",
           ].join("\n")
         : `node_modules\n/.${ConfigFolderName}/*.env\n/.${ConfigFolderName}/*.userdata\n.DS_Store\n${ArchiveFolderName}\n${ArchiveLogFileName}`
     );

--- a/packages/fx-core/src/plugins/resource/localdebug/constants.ts
+++ b/packages/fx-core/src/plugins/resource/localdebug/constants.ts
@@ -50,6 +50,7 @@ export class AadPlugin {
 }
 
 export class FunctionPlugin {
+  public static readonly FolderName: string = "api";
   public static readonly Name: string = "fx-resource-function";
   public static readonly DefaultFunctionName: string = "defaultFunctionName";
 }
@@ -78,10 +79,12 @@ export class AppStudioPlugin {
 }
 
 export class FrontendHostingPlugin {
+  public static readonly FolderName: string = "tabs";
   public static readonly Name: string = "fx-resource-frontend-hosting";
 }
 
 export class BotPlugin {
+  public static readonly FolderName: string = "bot";
   public static readonly Name: string = "fx-resource-bot";
   public static readonly LocalBotId: string = "localBotId";
   public static readonly LocalBotPassword: string = "localBotPassword";

--- a/packages/fx-core/src/plugins/resource/localdebug/index.ts
+++ b/packages/fx-core/src/plugins/resource/localdebug/index.ts
@@ -36,6 +36,13 @@ import * as Settings from "./settings";
 import * as Tasks from "./tasks";
 import { LocalEnvProvider } from "./localEnv";
 import {
+  EnvKeysFrontend,
+  EnvKeysBackend,
+  EnvKeysBot,
+  EnvKeysBotV1,
+  LocalEnvMultiProvider,
+} from "./localEnvMulti";
+import {
   LocalBotEndpointNotConfigured,
   MissingStep,
   NgrokTunnelNotConnected,
@@ -194,6 +201,16 @@ export class LocalDebugPlugin implements Plugin {
             ctx.config.set(LocalDebugConfigKeys.SkipNgrok, "false");
             ctx.config.set(LocalDebugConfigKeys.LocalBotEndpoint, "");
           }
+        } else {
+          // multi-env, prepare .env.teamsfx.local
+          const localEnvMultiProvider = new LocalEnvMultiProvider(ctx.root);
+          await localEnvMultiProvider.saveLocalEnvs(
+            includeFrontend
+              ? localEnvMultiProvider.initFrontendLocalEnvs(includeBackend, includeAuth)
+              : undefined,
+            includeBackend ? localEnvMultiProvider.initBackendLocalEnvs() : undefined,
+            includeBot ? localEnvMultiProvider.initBotLocalEnvs(isMigrateFromV1) : undefined
+          );
         }
 
         if (includeBackend) {
@@ -326,25 +343,144 @@ export class LocalDebugPlugin implements Plugin {
       return await legacyLocalDebugPlugin.postLocalDebug(ctx);
     }
 
-    let trustDevCert = ctx.localSettings?.frontend?.get(LocalSettingsFrontendKeys.TrustDevCert);
+    const includeFrontend = ProjectSettingLoader.includeFrontend(ctx);
+    const includeBackend = ProjectSettingLoader.includeBackend(ctx);
+    const includeBot = ProjectSettingLoader.includeBot(ctx);
+    const includeAuth = ProjectSettingLoader.includeAuth(ctx);
+    let trustDevCert = ctx.localSettings?.frontend?.get(LocalSettingsFrontendKeys.TrustDevCert) as
+      | boolean
+      | undefined;
 
-    // setup local certificate
-    try {
-      if (trustDevCert === undefined) {
-        trustDevCert = true;
-        ctx.localSettings?.frontend?.set(LocalSettingsFrontendKeys.TrustDevCert, trustDevCert);
+    const telemetryProperties = {
+      platform: ctx.answers?.platform as string,
+      frontend: includeFrontend ? "true" : "false",
+      function: includeBackend ? "true" : "false",
+      bot: includeBot ? "true" : "false",
+      auth: includeAuth ? "true" : "false",
+      "trust-development-certificate": trustDevCert + "",
+    };
+    TelemetryUtils.init(ctx);
+    TelemetryUtils.sendStartEvent(TelemetryEventName.postLocalDebug, telemetryProperties);
+
+    if (ctx.answers?.platform === Platform.VSCode || ctx.answers?.platform === Platform.CLI) {
+      const isMigrateFromV1 = ProjectSettingLoader.isMigrateFromV1(ctx);
+
+      const localEnvMultiProvider = new LocalEnvMultiProvider(ctx.root);
+      const frontendEnvs = includeFrontend
+        ? await localEnvMultiProvider.loadFrontendLocalEnvs(includeBackend, includeAuth)
+        : undefined;
+      const backendEnvs = includeBackend
+        ? await localEnvMultiProvider.loadBackendLocalEnvs()
+        : undefined;
+      const botEnvs = includeBot
+        ? await localEnvMultiProvider.loadBotLocalEnvs(isMigrateFromV1)
+        : undefined;
+
+      // get config for local debug
+      const clientId = ctx.localSettings?.auth?.get(LocalSettingsAuthKeys.ClientId) as string;
+      const clientSecret = ctx.localSettings?.auth?.get(
+        LocalSettingsAuthKeys.ClientSecret
+      ) as string;
+      const applicationIdUri = ctx.localSettings?.auth?.get(
+        LocalSettingsAuthKeys.ApplicationIdUris
+      ) as string;
+      const teamsAppTenantId = ctx.localSettings?.teamsApp?.get(
+        LocalSettingsTeamsAppKeys.TenantId
+      ) as string;
+      const teamsMobileDesktopAppId = TeamsClientId.MobileDesktop;
+      const teamsWebAppId = TeamsClientId.Web;
+      const localAuthEndpoint = ctx.localSettings?.auth?.get(
+        LocalSettingsAuthKeys.SimpleAuthServiceEndpoint
+      ) as string;
+      const localTabEndpoint = ctx.localSettings?.frontend?.get(
+        LocalSettingsFrontendKeys.TabEndpoint
+      ) as string;
+      const localFuncEndpoint = ctx.localSettings?.backend?.get(
+        LocalSettingsBackendKeys.FunctionEndpoint
+      ) as string;
+
+      if (includeFrontend) {
+        if (includeAuth) {
+          frontendEnvs!.teamsfxLocalEnvs[EnvKeysFrontend.TeamsFxEndpoint] = localAuthEndpoint;
+          frontendEnvs!.teamsfxLocalEnvs[
+            EnvKeysFrontend.LoginUrl
+          ] = `${localTabEndpoint}/auth-start.html`;
+          frontendEnvs!.teamsfxLocalEnvs[EnvKeysFrontend.ClientId] = clientId;
+        }
+
+        if (includeBackend) {
+          frontendEnvs!.teamsfxLocalEnvs[EnvKeysFrontend.FuncEndpoint] = localFuncEndpoint;
+          frontendEnvs!.teamsfxLocalEnvs[EnvKeysFrontend.FuncName] = ctx.projectSettings
+            ?.defaultFunctionName as string;
+
+          backendEnvs!.teamsfxLocalEnvs[EnvKeysBackend.FuncWorkerRuntime] = "node";
+          backendEnvs!.teamsfxLocalEnvs[EnvKeysBackend.ClientId] = clientId;
+          backendEnvs!.teamsfxLocalEnvs[EnvKeysBackend.ClientSecret] = clientSecret;
+          backendEnvs!.teamsfxLocalEnvs[EnvKeysBackend.AuthorityHost] =
+            "https://login.microsoftonline.com";
+          backendEnvs!.teamsfxLocalEnvs[EnvKeysBackend.TenantId] = teamsAppTenantId;
+          backendEnvs!.teamsfxLocalEnvs[EnvKeysBackend.ApiEndpoint] = localFuncEndpoint;
+          backendEnvs!.teamsfxLocalEnvs[EnvKeysBackend.ApplicationIdUri] = applicationIdUri;
+          backendEnvs!.teamsfxLocalEnvs[EnvKeysBackend.AllowedAppIds] = [
+            teamsMobileDesktopAppId,
+            teamsWebAppId,
+          ].join(";");
+        }
+
+        // setup local certificate
+        try {
+          if (trustDevCert === undefined) {
+            trustDevCert = true;
+            ctx.localSettings?.frontend?.set(LocalSettingsFrontendKeys.TrustDevCert, trustDevCert);
+          }
+
+          const certManager = new LocalCertificateManager(ctx);
+          const localCert = await certManager.setupCertificate(trustDevCert);
+          if (localCert) {
+            ctx.localSettings?.frontend?.set(
+              LocalSettingsFrontendKeys.SslCertFile,
+              localCert.certPath
+            );
+            ctx.localSettings?.frontend?.set(
+              LocalSettingsFrontendKeys.SslKeyFile,
+              localCert.keyPath
+            );
+            frontendEnvs!.teamsfxLocalEnvs[EnvKeysFrontend.SslCrtFile] = localCert.certPath;
+            frontendEnvs!.teamsfxLocalEnvs[EnvKeysFrontend.SslKeyFile] = localCert.keyPath;
+          }
+        } catch (error) {
+          // do not break if cert error
+        }
       }
 
-      const certManager = new LocalCertificateManager(ctx);
-      const localCert = await certManager.setupCertificate(trustDevCert);
-      if (localCert) {
-        ctx.localSettings?.frontend?.set(LocalSettingsFrontendKeys.SslCertFile, localCert.certPath);
+      if (includeBot) {
+        const botId = ctx.localSettings?.bot?.get(LocalSettingsBotKeys.BotId) as string;
+        const botPassword = ctx.localSettings?.bot?.get(LocalSettingsBotKeys.BotPassword) as string;
+        if (isMigrateFromV1) {
+          botEnvs!.teamsfxLocalEnvs[EnvKeysBotV1.BotId] = botId;
+          botEnvs!.teamsfxLocalEnvs[EnvKeysBotV1.BotPassword] = botPassword;
+        } else {
+          botEnvs!.teamsfxLocalEnvs[EnvKeysBot.BotId] = botId;
+          botEnvs!.teamsfxLocalEnvs[EnvKeysBot.BotPassword] = botPassword;
+          botEnvs!.teamsfxLocalEnvs[EnvKeysBot.ClientId] = clientId;
+          botEnvs!.teamsfxLocalEnvs[EnvKeysBot.ClientSecret] = clientSecret;
+          botEnvs!.teamsfxLocalEnvs[EnvKeysBot.TenantID] = teamsAppTenantId;
+          botEnvs!.teamsfxLocalEnvs[EnvKeysBot.OauthAuthority] =
+            "https://login.microsoftonline.com";
+          botEnvs!.teamsfxLocalEnvs[EnvKeysBot.LoginEndpoint] = `${
+            ctx.localSettings?.bot?.get(LocalSettingsBotKeys.BotEndpoint) as string
+          }/auth-start.html`;
+          botEnvs!.teamsfxLocalEnvs[EnvKeysBot.ApplicationIdUri] = applicationIdUri;
+        }
 
-        ctx.localSettings?.frontend?.set(LocalSettingsFrontendKeys.SslKeyFile, localCert.keyPath);
-        ctx.localSettings?.frontend?.set(LocalSettingsFrontendKeys.SslCertFile, localCert.certPath);
+        if (includeBackend) {
+          backendEnvs!.teamsfxLocalEnvs[EnvKeysBackend.ApiEndpoint] = localFuncEndpoint;
+          botEnvs!.teamsfxLocalEnvs[EnvKeysBot.ApiEndpoint] = localFuncEndpoint;
+        }
       }
-    } catch (error) {
-      // do not break if cert error
+
+      // save .env.teamsfx.local
+      await localEnvMultiProvider.saveLocalEnvs(frontendEnvs, backendEnvs, botEnvs);
     }
 
     return ok(undefined);

--- a/packages/fx-core/src/plugins/resource/localdebug/localEnv.ts
+++ b/packages/fx-core/src/plugins/resource/localdebug/localEnv.ts
@@ -15,6 +15,7 @@ import {
   LocalEnvBotKeysMigratedFromV1,
 } from "./constants";
 
+// Manage local envs for legacy project. For multi-env supported one, see `localEnvMulti.ts`.
 export class LocalEnvProvider {
   private readonly localEnvFilePath: string;
   constructor(workspaceFolder: string) {

--- a/packages/fx-core/src/plugins/resource/localdebug/localEnvMulti.ts
+++ b/packages/fx-core/src/plugins/resource/localdebug/localEnvMulti.ts
@@ -1,0 +1,268 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+"use strict";
+
+import * as dotenv from "dotenv";
+import * as fs from "fs-extra";
+import * as path from "path";
+import * as os from "os";
+import { FrontendHostingPlugin, FunctionPlugin, BotPlugin } from "./constants";
+
+export interface LocalEnvs {
+  teamsfxLocalEnvs: { [key: string]: string };
+  customizedLocalEnvs: { [name: string]: string };
+}
+
+export const EnvKeysFrontend = Object.freeze({
+  Browser: "BROWSER",
+  Https: "HTTPS",
+  SslCrtFile: "SSL_CRT_FILE",
+  SslKeyFile: "SSL_KEY_FILE",
+  TeamsFxEndpoint: "REACT_APP_TEAMSFX_ENDPOINT",
+  LoginUrl: "REACT_APP_START_LOGIN_PAGE_URL",
+  FuncEndpoint: "REACT_APP_FUNC_ENDPOINT",
+  FuncName: "REACT_APP_FUNC_NAME",
+  ClientId: "REACT_APP_CLIENT_ID",
+});
+
+export const EnvKeysBackend = Object.freeze({
+  WebJobsStorage: "AzureWebJobsStorage",
+  FuncWorkerRuntime: "FUNCTIONS_WORKER_RUNTIME",
+  AuthorityHost: "M365_AUTHORITY_HOST",
+  TenantId: "M365_TENANT_ID",
+  ClientId: "M365_CLIENT_ID",
+  ClientSecret: "M365_CLIENT_SECRET",
+  IdentityId: "IDENTITY_ID",
+  ApiEndpoint: "API_ENDPOINT",
+  ApplicationIdUri: "M365_APPLICATION_ID_URI",
+  AllowedAppIds: "ALLOWED_APP_IDS",
+});
+
+export const EnvKeysBackendCustom = Object.freeze({
+  SqlEndpoint: "SQL_ENDPOINT",
+  SqlDbName: "SQL_DATABASE_NAME",
+  SqlUserName: "SQL_USER_NAME",
+  SqlPassword: "SQL_PASSWORD",
+});
+
+export const EnvKeysBot = Object.freeze({
+  BotId: "BOT_ID",
+  BotPassword: "BOT_PASSWORD",
+  ClientId: "M365_CLIENT_ID",
+  ClientSecret: "M365_CLIENT_SECRET",
+  TenantID: "M365_TENANT_ID",
+  OauthAuthority: "M365_AUTHORITY_HOST",
+  LoginEndpoint: "INITIATE_LOGIN_ENDPOINT",
+  IdentityId: "IDENTITY_ID",
+  ApiEndpoint: "API_ENDPOINT",
+  ApplicationIdUri: "M365_APPLICATION_ID_URI",
+});
+
+export const EnvKeysBotV1 = Object.freeze({
+  BotId: "BotId",
+  BotPassword: "BotPassword",
+});
+
+export const EnvKeysBotCustom = Object.freeze({
+  SqlEndpoint: "SQL_ENDPOINT",
+  SqlDbName: "SQL_DATABASE_NAME",
+  SqlUserName: "SQL_USER_NAME",
+  SqlPassword: "SQL_PASSWORD",
+});
+
+// Manage local envs for multi-env project. For legacy supported one, see `localEnv.ts`.
+export class LocalEnvMultiProvider {
+  public static readonly LocalEnvFileName: string = ".env.teamsfx.local";
+
+  private readonly projectRoot: string;
+
+  constructor(workspaceFolder: string) {
+    this.projectRoot = workspaceFolder;
+  }
+
+  public async loadFrontendLocalEnvs(
+    includeBackend: boolean,
+    includeAuth: boolean
+  ): Promise<LocalEnvs> {
+    const envs = await this.loadLocalEnvFile(
+      path.join(
+        this.projectRoot,
+        FrontendHostingPlugin.FolderName,
+        LocalEnvMultiProvider.LocalEnvFileName
+      ),
+      Object.values(EnvKeysFrontend)
+    );
+
+    return envs ?? this.initFrontendLocalEnvs(includeBackend, includeAuth);
+  }
+
+  public async loadBackendLocalEnvs(): Promise<LocalEnvs> {
+    const envs = await this.loadLocalEnvFile(
+      path.join(
+        this.projectRoot,
+        FunctionPlugin.FolderName,
+        LocalEnvMultiProvider.LocalEnvFileName
+      ),
+      Object.values(EnvKeysBackend)
+    );
+
+    return envs ?? this.initBackendLocalEnvs();
+  }
+
+  public async loadBotLocalEnvs(isMigrateFromV1: boolean): Promise<LocalEnvs> {
+    const envs = await this.loadLocalEnvFile(
+      path.join(this.projectRoot, BotPlugin.FolderName, LocalEnvMultiProvider.LocalEnvFileName),
+      Object.values(EnvKeysBot)
+    );
+
+    return envs ?? this.initBotLocalEnvs(isMigrateFromV1);
+  }
+
+  public async saveLocalEnvs(
+    frontendEnvs: LocalEnvs | undefined,
+    backendEnvs: LocalEnvs | undefined,
+    botEnvs: LocalEnvs | undefined
+  ): Promise<void> {
+    if (frontendEnvs !== undefined) {
+      await this.saveLocalEnvFile(
+        path.join(this.projectRoot, FrontendHostingPlugin.FolderName),
+        frontendEnvs
+      );
+    }
+
+    if (backendEnvs !== undefined) {
+      await this.saveLocalEnvFile(
+        path.join(this.projectRoot, FunctionPlugin.FolderName),
+        backendEnvs
+      );
+    }
+
+    if (botEnvs !== undefined) {
+      await this.saveLocalEnvFile(path.join(this.projectRoot, BotPlugin.FolderName), botEnvs);
+    }
+  }
+
+  public initFrontendLocalEnvs(includeBackend: boolean, includeAuth: boolean): LocalEnvs {
+    const result: LocalEnvs = {
+      teamsfxLocalEnvs: {},
+      customizedLocalEnvs: {},
+    };
+
+    result.teamsfxLocalEnvs[EnvKeysFrontend.Browser] = "none";
+    result.teamsfxLocalEnvs[EnvKeysFrontend.Https] = "true";
+
+    if (includeAuth) {
+      result.teamsfxLocalEnvs[EnvKeysFrontend.TeamsFxEndpoint] = "";
+      result.teamsfxLocalEnvs[EnvKeysFrontend.LoginUrl] = "";
+      result.teamsfxLocalEnvs[EnvKeysFrontend.ClientId] = "";
+    }
+
+    if (includeBackend) {
+      result.teamsfxLocalEnvs[EnvKeysFrontend.FuncEndpoint] = "";
+      result.teamsfxLocalEnvs[EnvKeysFrontend.FuncName] = "";
+    }
+
+    return result;
+  }
+
+  public initBackendLocalEnvs(): LocalEnvs {
+    const result: LocalEnvs = {
+      teamsfxLocalEnvs: {},
+      customizedLocalEnvs: {},
+    };
+
+    result.teamsfxLocalEnvs[EnvKeysBackend.WebJobsStorage] = "";
+    result.teamsfxLocalEnvs[EnvKeysBackend.FuncWorkerRuntime] = "node";
+    result.teamsfxLocalEnvs[EnvKeysBackend.AuthorityHost] = "";
+    result.teamsfxLocalEnvs[EnvKeysBackend.TenantId] = "";
+    result.teamsfxLocalEnvs[EnvKeysBackend.ClientId] = "";
+    result.teamsfxLocalEnvs[EnvKeysBackend.ClientSecret] = "";
+    result.teamsfxLocalEnvs[EnvKeysBackend.IdentityId] = "";
+    result.teamsfxLocalEnvs[EnvKeysBackend.ApiEndpoint] = "";
+    result.teamsfxLocalEnvs[EnvKeysBackend.ApplicationIdUri] = "";
+    result.teamsfxLocalEnvs[EnvKeysBackend.AllowedAppIds] = "";
+
+    result.customizedLocalEnvs[EnvKeysBackendCustom.SqlEndpoint] = "";
+    result.customizedLocalEnvs[EnvKeysBackendCustom.SqlDbName] = "";
+    result.customizedLocalEnvs[EnvKeysBackendCustom.SqlUserName] = "";
+    result.customizedLocalEnvs[EnvKeysBackendCustom.SqlPassword] = "";
+
+    return result;
+  }
+
+  public initBotLocalEnvs(isMigrateFromV1: boolean): LocalEnvs {
+    const result: LocalEnvs = {
+      teamsfxLocalEnvs: {},
+      customizedLocalEnvs: {},
+    };
+
+    if (isMigrateFromV1) {
+      result.teamsfxLocalEnvs[EnvKeysBotV1.BotId] = "";
+      result.teamsfxLocalEnvs[EnvKeysBotV1.BotPassword] = "";
+    } else {
+      result.teamsfxLocalEnvs[EnvKeysBot.BotId] = "";
+      result.teamsfxLocalEnvs[EnvKeysBot.BotPassword] = "";
+      result.teamsfxLocalEnvs[EnvKeysBot.ClientId] = "";
+      result.teamsfxLocalEnvs[EnvKeysBot.ClientSecret] = "";
+      result.teamsfxLocalEnvs[EnvKeysBot.TenantID] = "";
+      result.teamsfxLocalEnvs[EnvKeysBot.OauthAuthority] = "";
+      result.teamsfxLocalEnvs[EnvKeysBot.LoginEndpoint] = "";
+      result.teamsfxLocalEnvs[EnvKeysBot.IdentityId] = "";
+      result.teamsfxLocalEnvs[EnvKeysBot.ApiEndpoint] = "";
+      result.teamsfxLocalEnvs[EnvKeysBot.ApplicationIdUri] = "";
+
+      result.customizedLocalEnvs[EnvKeysBotCustom.SqlEndpoint] = "";
+      result.customizedLocalEnvs[EnvKeysBotCustom.SqlDbName] = "";
+      result.customizedLocalEnvs[EnvKeysBotCustom.SqlUserName] = "";
+      result.customizedLocalEnvs[EnvKeysBotCustom.SqlPassword] = "";
+    }
+
+    return result;
+  }
+
+  private async loadLocalEnvFile(
+    path: string,
+    teamsfxKeys: string[]
+  ): Promise<LocalEnvs | undefined> {
+    if (await fs.pathExists(path)) {
+      const envs = dotenv.parse(await fs.readFile(path));
+      const result: LocalEnvs = {
+        teamsfxLocalEnvs: {},
+        customizedLocalEnvs: {},
+      };
+      const entries = Object.entries(envs);
+      for (const [key, value] of entries) {
+        if (teamsfxKeys.includes(key)) {
+          result.teamsfxLocalEnvs[key] = value;
+        } else {
+          result.customizedLocalEnvs[key] = value;
+        }
+      }
+
+      return result;
+    } else {
+      return undefined;
+    }
+  }
+
+  private async saveLocalEnvFile(folder: string, envs: LocalEnvs): Promise<void> {
+    await fs.ensureDir(folder);
+    const envPath = path.join(folder, LocalEnvMultiProvider.LocalEnvFileName);
+    await fs.createFile(envPath);
+
+    await fs.writeFile(envPath, `# Following variables are generated by TeamsFx${os.EOL}`);
+    const teamsfxEntries = Object.entries(envs.teamsfxLocalEnvs);
+    for (const [key, value] of teamsfxEntries) {
+      await fs.appendFile(envPath, `${key}=${value}${os.EOL}`);
+    }
+
+    await fs.appendFile(
+      envPath,
+      `${os.EOL}# Following variables can be customized or you can add your owns${os.EOL}# FOO=BAR${os.EOL}`
+    );
+    const customizedEntries = Object.entries(envs.customizedLocalEnvs);
+    for (const [key, value] of customizedEntries) {
+      await fs.appendFile(envPath, `${key}=${value}${os.EOL}`);
+    }
+  }
+}

--- a/packages/fx-core/tests/plugins/resource/localdebug/unit/index.test.ts
+++ b/packages/fx-core/tests/plugins/resource/localdebug/unit/index.test.ts
@@ -9,7 +9,7 @@ import * as path from "path";
 import { LocalDebugPluginInfo } from "../../../../../src/plugins/resource/localdebug/constants";
 import { LocalDebugPlugin } from "../../../../../src/plugins/resource/localdebug";
 import * as uuid from "uuid";
-import { newEnvInfo } from "../../../../../src";
+import { newEnvInfo } from "../../../../../src/core/tools";
 chai.use(chaiAsPromised);
 
 interface TestParameter {

--- a/packages/fx-core/tests/plugins/resource/localdebug/unit/localEnvMulti.test.ts
+++ b/packages/fx-core/tests/plugins/resource/localdebug/unit/localEnvMulti.test.ts
@@ -1,0 +1,334 @@
+import "mocha";
+import * as chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+import * as fs from "fs-extra";
+import * as path from "path";
+import * as os from "os";
+
+import {
+  LocalEnvMultiProvider,
+  LocalEnvs,
+} from "../../../../../src/plugins/resource/localdebug/localEnvMulti";
+
+chai.use(chaiAsPromised);
+
+describe("LocalEnvProvider-MultiEnv", () => {
+  const workspaceFolder = path.resolve(__dirname, "../data/.teamsfx/");
+
+  describe("load", () => {
+    let localEnvMultiProvider: LocalEnvMultiProvider;
+
+    beforeEach(() => {
+      localEnvMultiProvider = new LocalEnvMultiProvider(workspaceFolder);
+      fs.emptyDirSync(workspaceFolder);
+    });
+
+    it("frontend", async () => {
+      const raw =
+        "\
+        BROWSER=a\n\
+        HTTPS=b\n\
+        MYENV1=1\n\
+        SSL_CRT_FILE=c\n\
+        SSL_KEY_FILE=d\n\
+        REACT_APP_TEAMSFX_ENDPOINT=e\n\
+        REACT_APP_START_LOGIN_PAGE_URL=f\n\
+        \n\
+        # ENV COMMENT\n\
+        REACT_APP_FUNC_ENDPOINT=g\n\
+        REACT_APP_FUNC_NAME=h\n\
+        REACT_APP_CLIENT_ID=i\n\
+        MYENV2=2\n";
+      const expected: LocalEnvs = {
+        teamsfxLocalEnvs: {
+          BROWSER: "a",
+          HTTPS: "b",
+          SSL_CRT_FILE: "c",
+          SSL_KEY_FILE: "d",
+          REACT_APP_TEAMSFX_ENDPOINT: "e",
+          REACT_APP_START_LOGIN_PAGE_URL: "f",
+          REACT_APP_FUNC_ENDPOINT: "g",
+          REACT_APP_FUNC_NAME: "h",
+          REACT_APP_CLIENT_ID: "i",
+        },
+        customizedLocalEnvs: {
+          MYENV1: "1",
+          MYENV2: "2",
+        },
+      };
+
+      const envFile = path.join(workspaceFolder, "tabs", ".env.teamsfx.local");
+      fs.createFileSync(envFile);
+      fs.writeFileSync(envFile, raw);
+
+      const actual = await localEnvMultiProvider.loadFrontendLocalEnvs(true, true);
+      chai.assert.deepEqual(actual, expected);
+    });
+
+    it("backend", async () => {
+      const raw =
+        "\
+      AzureWebJobsStorage=a\n\
+      FUNCTIONS_WORKER_RUNTIME=b\n\
+        MYENV1=1\n\
+        M365_AUTHORITY_HOST=c\n\
+        M365_TENANT_ID=d\n\
+        M365_CLIENT_ID=e\n\
+        M365_CLIENT_SECRET=f\n\
+        # ENV COMMENT\n\
+        \n\
+        IDENTITY_ID=g\n\
+        API_ENDPOINT=h\n\
+        M365_APPLICATION_ID_URI=i\n\
+        ALLOWED_APP_IDS=j\n\
+        MYENV2=2\n";
+      const expected: LocalEnvs = {
+        teamsfxLocalEnvs: {
+          AzureWebJobsStorage: "a",
+          FUNCTIONS_WORKER_RUNTIME: "b",
+          M365_AUTHORITY_HOST: "c",
+          M365_TENANT_ID: "d",
+          M365_CLIENT_ID: "e",
+          M365_CLIENT_SECRET: "f",
+          IDENTITY_ID: "g",
+          API_ENDPOINT: "h",
+          M365_APPLICATION_ID_URI: "i",
+          ALLOWED_APP_IDS: "j",
+        },
+        customizedLocalEnvs: {
+          MYENV1: "1",
+          MYENV2: "2",
+        },
+      };
+
+      const envFile = path.join(workspaceFolder, "api", ".env.teamsfx.local");
+      fs.createFileSync(envFile);
+      fs.writeFileSync(envFile, raw);
+
+      const actual = await localEnvMultiProvider.loadBackendLocalEnvs();
+      chai.assert.deepEqual(actual, expected);
+    });
+
+    it("bot", async () => {
+      const raw =
+        "\
+      BOT_ID=a\n\
+      BOT_PASSWORD=b\n\
+        MYENV1=1\n\
+        M365_CLIENT_ID=c\n\
+        \n\
+        M365_CLIENT_SECRET=d\n\
+        M365_TENANT_ID=e\n\
+        M365_AUTHORITY_HOST=f\n\
+        # ENV COMMENT\n\
+        INITIATE_LOGIN_ENDPOINT=g\n\
+        IDENTITY_ID=h\n\
+        API_ENDPOINT=i\n\
+        M365_APPLICATION_ID_URI=j\n\
+        MYENV2=2\n";
+      const expected: LocalEnvs = {
+        teamsfxLocalEnvs: {
+          BOT_ID: "a",
+          BOT_PASSWORD: "b",
+          M365_CLIENT_ID: "c",
+          M365_CLIENT_SECRET: "d",
+          M365_TENANT_ID: "e",
+          M365_AUTHORITY_HOST: "f",
+          INITIATE_LOGIN_ENDPOINT: "g",
+          IDENTITY_ID: "h",
+          API_ENDPOINT: "i",
+          M365_APPLICATION_ID_URI: "j",
+        },
+        customizedLocalEnvs: {
+          MYENV1: "1",
+          MYENV2: "2",
+        },
+      };
+
+      const envFile = path.join(workspaceFolder, "bot", ".env.teamsfx.local");
+      fs.createFileSync(envFile);
+      fs.writeFileSync(envFile, raw);
+
+      const actual = await localEnvMultiProvider.loadBotLocalEnvs(false);
+      chai.assert.deepEqual(actual, expected);
+    });
+  });
+
+  describe("save", () => {
+    let localEnvMultiProvider: LocalEnvMultiProvider;
+
+    beforeEach(() => {
+      localEnvMultiProvider = new LocalEnvMultiProvider(workspaceFolder);
+      fs.emptyDirSync(workspaceFolder);
+    });
+
+    it("save all", async () => {
+      const frontendEnvs: LocalEnvs = {
+        teamsfxLocalEnvs: {
+          npm_hello: "world",
+          F1: "a",
+          AA: "x",
+        },
+        customizedLocalEnvs: {
+          C1: "1",
+        },
+      };
+      const backendEnvs: LocalEnvs = {
+        teamsfxLocalEnvs: {
+          B1: "a",
+        },
+        customizedLocalEnvs: {},
+      };
+      const botEnvs: LocalEnvs = {
+        teamsfxLocalEnvs: {},
+        customizedLocalEnvs: {
+          C1: "1",
+        },
+      };
+
+      const expectedFrontendRaw =
+        "# Following variables are generated by TeamsFx" +
+        os.EOL +
+        "npm_hello=world" +
+        os.EOL +
+        "F1=a" +
+        os.EOL +
+        "AA=x" +
+        os.EOL +
+        os.EOL +
+        "# Following variables can be customized or you can add your owns" +
+        os.EOL +
+        "# FOO=BAR" +
+        os.EOL +
+        "C1=1" +
+        os.EOL;
+      const expectedBackendRaw =
+        "# Following variables are generated by TeamsFx" +
+        os.EOL +
+        "B1=a" +
+        os.EOL +
+        os.EOL +
+        "# Following variables can be customized or you can add your owns" +
+        os.EOL +
+        "# FOO=BAR" +
+        os.EOL;
+      const expectedBotRaw =
+        "# Following variables are generated by TeamsFx" +
+        os.EOL +
+        os.EOL +
+        "# Following variables can be customized or you can add your owns" +
+        os.EOL +
+        "# FOO=BAR" +
+        os.EOL +
+        "C1=1" +
+        os.EOL;
+
+      await localEnvMultiProvider.saveLocalEnvs(frontendEnvs, backendEnvs, botEnvs);
+
+      const actualFrontendRaw = fs.readFileSync(
+        path.join(workspaceFolder, "tabs", ".env.teamsfx.local"),
+        "utf8"
+      );
+      chai.assert.equal(expectedFrontendRaw, actualFrontendRaw);
+      const actualBackendRaw = fs.readFileSync(
+        path.join(workspaceFolder, "api", ".env.teamsfx.local"),
+        "utf8"
+      );
+      chai.assert.equal(expectedBackendRaw, actualBackendRaw);
+      const actualBotRaw = fs.readFileSync(
+        path.join(workspaceFolder, "bot", ".env.teamsfx.local"),
+        "utf8"
+      );
+      chai.assert.equal(expectedBotRaw, actualBotRaw);
+    });
+
+    it("save partial", async () => {
+      const frontendEnvs: LocalEnvs = {
+        teamsfxLocalEnvs: {
+          AA: "x",
+          npm_hello: "world",
+          F1: "a",
+        },
+        customizedLocalEnvs: {
+          C1: "1",
+        },
+      };
+
+      const expectedFrontendRaw =
+        "# Following variables are generated by TeamsFx" +
+        os.EOL +
+        "AA=x" +
+        os.EOL +
+        "npm_hello=world" +
+        os.EOL +
+        "F1=a" +
+        os.EOL +
+        os.EOL +
+        "# Following variables can be customized or you can add your owns" +
+        os.EOL +
+        "# FOO=BAR" +
+        os.EOL +
+        "C1=1" +
+        os.EOL;
+
+      await localEnvMultiProvider.saveLocalEnvs(frontendEnvs, undefined, undefined);
+
+      const actualFrontendRaw = fs.readFileSync(
+        path.join(workspaceFolder, "tabs", ".env.teamsfx.local"),
+        "utf8"
+      );
+      chai.assert.equal(expectedFrontendRaw, actualFrontendRaw);
+      chai.assert.isNotTrue(
+        fs.pathExistsSync(path.join(workspaceFolder, "api", ".env.teamsfx.local"))
+      );
+      chai.assert.isNotTrue(
+        fs.pathExistsSync(path.join(workspaceFolder, "bot", ".env.teamsfx.local"))
+      );
+    });
+  });
+
+  describe("init", () => {
+    let localEnvMultiProvider: LocalEnvMultiProvider;
+
+    beforeEach(() => {
+      localEnvMultiProvider = new LocalEnvMultiProvider(workspaceFolder);
+      fs.emptyDirSync(workspaceFolder);
+    });
+
+    it("frontend", () => {
+      const envs = localEnvMultiProvider.initFrontendLocalEnvs(false, false);
+      chai.assert.equal(Object.values(envs.teamsfxLocalEnvs).length, 2);
+      chai.assert.equal(Object.values(envs.customizedLocalEnvs).length, 0);
+    });
+
+    it("frontend + auth", () => {
+      const envs = localEnvMultiProvider.initFrontendLocalEnvs(false, true);
+      chai.assert.equal(Object.values(envs.teamsfxLocalEnvs).length, 5);
+      chai.assert.equal(Object.values(envs.customizedLocalEnvs).length, 0);
+    });
+
+    it("frontend + auth + backend", () => {
+      const envs = localEnvMultiProvider.initFrontendLocalEnvs(true, true);
+      chai.assert.equal(Object.values(envs.teamsfxLocalEnvs).length, 7);
+      chai.assert.equal(Object.values(envs.customizedLocalEnvs).length, 0);
+    });
+
+    it("backend", () => {
+      const envs = localEnvMultiProvider.initBackendLocalEnvs();
+      chai.assert.equal(Object.values(envs.teamsfxLocalEnvs).length, 10);
+      chai.assert.equal(Object.values(envs.customizedLocalEnvs).length, 4);
+    });
+
+    it("bot", () => {
+      const envs = localEnvMultiProvider.initBotLocalEnvs(false);
+      chai.assert.equal(Object.values(envs.teamsfxLocalEnvs).length, 10);
+      chai.assert.equal(Object.values(envs.customizedLocalEnvs).length, 4);
+    });
+
+    it("bot v1", () => {
+      const envs = localEnvMultiProvider.initBotLocalEnvs(true);
+      chai.assert.equal(Object.values(envs.teamsfxLocalEnvs).length, 2);
+      chai.assert.equal(Object.values(envs.customizedLocalEnvs).length, 0);
+    });
+  });
+});

--- a/packages/fx-core/tests/plugins/resource/localdebug/unit/localEnvMulti.test.ts
+++ b/packages/fx-core/tests/plugins/resource/localdebug/unit/localEnvMulti.test.ts
@@ -68,8 +68,8 @@ describe("LocalEnvProvider-MultiEnv", () => {
     it("backend", async () => {
       const raw =
         "\
-      AzureWebJobsStorage=a\n\
-      FUNCTIONS_WORKER_RUNTIME=b\n\
+        AzureWebJobsStorage=a\n\
+        FUNCTIONS_WORKER_RUNTIME=b\n\
         MYENV1=1\n\
         M365_AUTHORITY_HOST=c\n\
         M365_TENANT_ID=d\n\
@@ -112,8 +112,8 @@ describe("LocalEnvProvider-MultiEnv", () => {
     it("bot", async () => {
       const raw =
         "\
-      BOT_ID=a\n\
-      BOT_PASSWORD=b\n\
+        BOT_ID=a\n\
+        BOT_PASSWORD=b\n\
         MYENV1=1\n\
         M365_CLIENT_ID=c\n\
         \n\


### PR DESCRIPTION
This is a preparation for customized local debug, which is to generate `.env.teamsfx.local` for each component, then user can partial launch local service(s) or add customized environment variables.

- Only enabled for multi-env
- Add `.env.teamsfx.local` to git ignore
- Add unit tests