### PR TITLE
fix(telemetry): send appid for telemetry events

### DIFF
--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -73,7 +73,12 @@ import * as commonUtils from "./debug/commonUtils";
 import { ExtensionErrors, ExtensionSource } from "./error";
 import { WebviewPanel } from "./controls/webviewPanel";
 import * as constants from "./debug/constants";
-import { anonymizeFilePaths, isSPFxProject, syncFeatureFlags } from "./utils/commonUtils";
+import {
+  anonymizeFilePaths,
+  getTeamsAppIdByEnv,
+  isSPFxProject,
+  syncFeatureFlags,
+} from "./utils/commonUtils";
 import * as fs from "fs-extra";
 import * as vscode from "vscode";
 import { DepsChecker } from "./debug/depsChecker/checker";
@@ -573,6 +578,9 @@ async function processResult(
   const envProperty: { [key: string]: string } = {};
   if (inputs?.env) {
     envProperty[TelemetryProperty.Env] = getHashedEnv(inputs.env);
+    if (isMultiEnvEnabled()) {
+      envProperty[TelemetryProperty.AapId] = getTeamsAppIdByEnv(inputs.env);
+    }
   }
 
   if (result.isErr()) {

--- a/packages/vscode-extension/src/telemetry/extTelemetry.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetry.ts
@@ -14,6 +14,7 @@ import {
 import * as extensionPackage from "../../package.json";
 import { FxError, Stage, UserError } from "@microsoft/teamsfx-api";
 import { getIsExistingUser, getTeamsAppId } from "../utils/commonUtils";
+import { isMultiEnvEnabled } from "@microsoft/teamsfx-core";
 
 export namespace ExtTelemetry {
   export let reporter: VSCodeTelemetryReporter;
@@ -79,7 +80,9 @@ export namespace ExtTelemetry {
       properties[TelemetryProperty.Component] = TelemetryComponentType;
     }
 
-    properties[TelemetryProperty.AapId] = getTeamsAppId();
+    if (!isMultiEnvEnabled()) {
+      properties[TelemetryProperty.AapId] = getTeamsAppId();
+    }
 
     const isExistingUser = getIsExistingUser();
     properties[TelemetryProperty.IsExistingUser] = isExistingUser ? isExistingUser : "";
@@ -106,7 +109,9 @@ export namespace ExtTelemetry {
       properties[TelemetryProperty.Component] = TelemetryComponentType;
     }
 
-    properties[TelemetryProperty.AapId] = getTeamsAppId();
+    if (!isMultiEnvEnabled()) {
+      properties[TelemetryProperty.AapId] = getTeamsAppId();
+    }
 
     const isExistingUser = getIsExistingUser();
     properties[TelemetryProperty.IsExistingUser] = isExistingUser ? isExistingUser : "";
@@ -143,7 +148,9 @@ export namespace ExtTelemetry {
       properties[TelemetryProperty.Component] = TelemetryComponentType;
     }
 
-    properties[TelemetryProperty.AapId] = getTeamsAppId();
+    if (!isMultiEnvEnabled()) {
+      properties[TelemetryProperty.AapId] = getTeamsAppId();
+    }
 
     const isExistingUser = getIsExistingUser();
     properties[TelemetryProperty.IsExistingUser] = isExistingUser ? isExistingUser : "";

--- a/packages/vscode-extension/src/utils/commonUtils.ts
+++ b/packages/vscode-extension/src/utils/commonUtils.ts
@@ -111,6 +111,21 @@ export function getTeamsAppId() {
   }
 }
 
+// Only used for telemetry when multi-env is enabled
+export function getTeamsAppIdByEnv(env: string) {
+  try {
+    const ws = ext.workspaceUri.fsPath;
+
+    if (isValidProject(ws)) {
+      const result = environmentManager.getEnvProfileFilesPath(env, ws);
+      const envJson = JSON.parse(fs.readFileSync(result.envProfile, "utf8"));
+      return envJson[PluginNames.APPST].teamsAppId;
+    }
+  } catch (e) {
+    return undefined;
+  }
+}
+
 export function getProjectId(): string | undefined {
   try {
     const ws = ext.workspaceUri.fsPath;


### PR DESCRIPTION
- when multi-env is enabled, the appid property is not sent.
- Only affect cases when multi-env is enabled

tested provision telemetry with/without feature flag