### PR TITLE
fix(local-debug): remove duplicate getLocalDebugEnvs

### DIFF
--- a/packages/cli/src/cmds/preview/commonUtils.ts
+++ b/packages/cli/src/cmds/preview/commonUtils.ts
@@ -187,10 +187,9 @@ export function createTaskStopCb(
   };
 }
 
-async function getLocalEnv(
+export async function getLocalEnv(
   core: FxCore,
-  workspaceFolder: string,
-  prefix = ""
+  workspaceFolder: string
 ): Promise<{ [key: string]: string } | undefined> {
   const localEnvFilePath: string = path.join(
     workspaceFolder,
@@ -225,6 +224,16 @@ async function getLocalEnv(
     env = dotenv.parse(contents);
   }
 
+  return env;
+}
+
+function getLocalEnvWithPrefix(
+  env: { [key: string]: string } | undefined,
+  prefix: string
+): { [key: string]: string } | undefined {
+  if (env === undefined) {
+    return undefined;
+  }
   const result: { [key: string]: string } = {};
   for (const key of Object.keys(env)) {
     if (key.startsWith(prefix) && env[key]) {
@@ -234,41 +243,33 @@ async function getLocalEnv(
   return Object.keys(result).length > 0 ? result : undefined;
 }
 
-export async function getFrontendLocalEnv(
-  core: FxCore,
-  workspaceFolder: string
-): Promise<{ [key: string]: string } | undefined> {
-  return getLocalEnv(core, workspaceFolder, constants.frontendLocalEnvPrefix);
+export function getFrontendLocalEnv(
+  env: { [key: string]: string } | undefined
+): { [key: string]: string } | undefined {
+  return getLocalEnvWithPrefix(env, constants.frontendLocalEnvPrefix);
 }
 
-export async function getBackendLocalEnv(
-  core: FxCore,
-  workspaceFolder: string
-): Promise<{ [key: string]: string } | undefined> {
-  return getLocalEnv(core, workspaceFolder, constants.backendLocalEnvPrefix);
+export function getBackendLocalEnv(
+  env: { [key: string]: string } | undefined
+): { [key: string]: string } | undefined {
+  return getLocalEnvWithPrefix(env, constants.backendLocalEnvPrefix);
 }
 
-export async function getAuthLocalEnv(
-  core: FxCore,
-  workspaceFolder: string
-): Promise<{ [key: string]: string } | undefined> {
+export function getAuthLocalEnv(
+  env: { [key: string]: string } | undefined
+): { [key: string]: string } | undefined {
   // SERVICE_PATH will also be included, but it has no side effect
-  return getLocalEnv(core, workspaceFolder, constants.authLocalEnvPrefix);
+  return getLocalEnvWithPrefix(env, constants.authLocalEnvPrefix);
 }
 
-export async function getAuthServicePath(
-  core: FxCore,
-  workspaceFolder: string
-): Promise<string | undefined> {
-  const result = await getLocalEnv(core, workspaceFolder);
-  return result ? result[constants.authServicePathEnvKey] : undefined;
+export function getAuthServicePath(env: { [key: string]: string } | undefined): string | undefined {
+  return env ? env[constants.authServicePathEnvKey] : undefined;
 }
 
-export async function getBotLocalEnv(
-  core: FxCore,
-  workspaceFolder: string
-): Promise<{ [key: string]: string } | undefined> {
-  return getLocalEnv(core, workspaceFolder, constants.botLocalEnvPrefix);
+export function getBotLocalEnv(
+  env: { [key: string]: string } | undefined
+): { [key: string]: string } | undefined {
+  return getLocalEnvWithPrefix(env, constants.botLocalEnvPrefix);
 }
 
 async function detectPortListeningImpl(port: number, host: string): Promise<boolean> {

--- a/packages/cli/src/cmds/preview/preview.ts
+++ b/packages/cli/src/cmds/preview/preview.ts
@@ -784,9 +784,11 @@ export default class Preview extends YargsCommand {
     dotnetChecker: DotnetChecker,
     funcToolChecker: FuncToolChecker
   ): Promise<Result<null, FxError>> {
+    const localEnv = await commonUtils.getLocalEnv(core, workspaceFolder);
+
     let frontendStartTask: Task | undefined;
     if (frontendRoot !== undefined) {
-      const env = await commonUtils.getFrontendLocalEnv(core, workspaceFolder);
+      const env = commonUtils.getFrontendLocalEnv(localEnv);
       frontendStartTask = new Task(
         constants.frontendStartTitle,
         true,
@@ -803,8 +805,8 @@ export default class Preview extends YargsCommand {
 
     let authStartTask: Task | undefined;
     if (frontendRoot !== undefined) {
-      const cwd = await commonUtils.getAuthServicePath(core, workspaceFolder);
-      const env = await commonUtils.getAuthLocalEnv(core, workspaceFolder);
+      const cwd = commonUtils.getAuthServicePath(localEnv);
+      const env = commonUtils.getAuthLocalEnv(localEnv);
       authStartTask = new Task(
         constants.authStartTitle,
         true,
@@ -823,7 +825,7 @@ export default class Preview extends YargsCommand {
     let backendStartTask: Task | undefined;
     let backendWatchTask: Task | undefined;
     if (backendRoot !== undefined) {
-      const env = await commonUtils.getBackendLocalEnv(core, workspaceFolder);
+      const env = commonUtils.getBackendLocalEnv(localEnv);
       const mergedEnv = commonUtils.mergeProcessEnv(env);
       const command =
         programmingLanguage === constants.ProgrammingLanguage.typescript
@@ -865,7 +867,7 @@ export default class Preview extends YargsCommand {
         programmingLanguage === constants.ProgrammingLanguage.typescript
           ? constants.botStartTsCommand
           : constants.botStartJsCommand;
-      const env = await commonUtils.getBotLocalEnv(core, workspaceFolder);
+      const env = commonUtils.getBotLocalEnv(localEnv);
       botStartTask = new Task(constants.botStartTitle, true, command, undefined, {
         shell: true,
         cwd: botRoot,

--- a/packages/vscode-extension/src/debug/commonUtils.ts
+++ b/packages/vscode-extension/src/debug/commonUtils.ts
@@ -6,16 +6,10 @@ import * as path from "path";
 import * as dotenv from "dotenv";
 import * as vscode from "vscode";
 import * as constants from "./constants";
-import {
-  ConfigFolderName,
-  Func,
-  InputConfigsFolderName,
-  PublishProfilesFolderName,
-} from "@microsoft/teamsfx-api";
+import { ConfigFolderName, Func, InputConfigsFolderName } from "@microsoft/teamsfx-api";
 import { core, getSystemInputs, showError } from "../handlers";
 import * as net from "net";
 import { ext } from "../extensionVariables";
-import { initializeFocusRects } from "@fluentui/utilities";
 import { isMultiEnvEnabled, isValidProject, isMigrateFromV1Project } from "@microsoft/teamsfx-core";
 
 export async function getProjectRoot(
@@ -27,7 +21,7 @@ export async function getProjectRoot(
   return projectExists ? projectRoot : undefined;
 }
 
-async function getLocalEnv(prefix = ""): Promise<{ [key: string]: string } | undefined> {
+export async function getLocalEnv(): Promise<{ [key: string]: string } | undefined> {
   if (!vscode.workspace.workspaceFolders) {
     return undefined;
   }
@@ -52,7 +46,16 @@ async function getLocalEnv(prefix = ""): Promise<{ [key: string]: string } | und
     const contents = await fs.readFile(localEnvFilePath);
     env = dotenv.parse(contents);
   }
+  return env;
+}
 
+function getLocalEnvWithPrefix(
+  env: { [key: string]: string } | undefined,
+  prefix: string
+): { [key: string]: string } | undefined {
+  if (env === undefined) {
+    return undefined;
+  }
   const result: { [key: string]: string } = {};
   for (const key of Object.keys(env)) {
     if (key.startsWith(prefix) && env[key]) {
@@ -62,26 +65,33 @@ async function getLocalEnv(prefix = ""): Promise<{ [key: string]: string } | und
   return Object.keys(result).length > 0 ? result : undefined;
 }
 
-export async function getFrontendLocalEnv(): Promise<{ [key: string]: string } | undefined> {
-  return getLocalEnv(constants.frontendLocalEnvPrefix);
+export function getFrontendLocalEnv(
+  env: { [key: string]: string } | undefined
+): { [key: string]: string } | undefined {
+  return getLocalEnvWithPrefix(env, constants.frontendLocalEnvPrefix);
 }
 
-export async function getBackendLocalEnv(): Promise<{ [key: string]: string } | undefined> {
-  return getLocalEnv(constants.backendLocalEnvPrefix);
+export function getBackendLocalEnv(
+  env: { [key: string]: string } | undefined
+): { [key: string]: string } | undefined {
+  return getLocalEnvWithPrefix(env, constants.backendLocalEnvPrefix);
 }
 
-export async function getAuthLocalEnv(): Promise<{ [key: string]: string } | undefined> {
+export function getAuthLocalEnv(
+  env: { [key: string]: string } | undefined
+): { [key: string]: string } | undefined {
   // SERVICE_PATH will also be included, but it has no side effect
-  return getLocalEnv(constants.authLocalEnvPrefix);
+  return getLocalEnvWithPrefix(env, constants.authLocalEnvPrefix);
 }
 
-export async function getAuthServicePath(): Promise<string | undefined> {
-  const result = await getLocalEnv();
-  return result ? result[constants.authServicePathEnvKey] : undefined;
+export function getAuthServicePath(env: { [key: string]: string } | undefined): string | undefined {
+  return env ? env[constants.authServicePathEnvKey] : undefined;
 }
 
-export async function getBotLocalEnv(): Promise<{ [key: string]: string } | undefined> {
-  return getLocalEnv(constants.botLocalEnvPrefix);
+export function getBotLocalEnv(
+  env: { [key: string]: string } | undefined
+): { [key: string]: string } | undefined {
+  return getLocalEnvWithPrefix(env, constants.botLocalEnvPrefix);
 }
 
 export async function isFxProject(folderPath: string): Promise<boolean> {


### PR DESCRIPTION
To fix https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/11033697.

Avoid calling getLocalDebugEnvs every time when getting frontend/backend/auth/bot envs.