### PR TITLE
fix(collaboration): warning message not show when list failed

### DIFF
--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -1115,7 +1115,7 @@ export async function listAllCollaborators(envs: string[]): Promise<Record<strin
           [TelemetryProperty.Success]: TelemetrySuccess.Yes,
         });
       } else {
-        throw userList.error;
+        throw userList.error.error;
       }
     } catch (e) {
       ExtTelemetry.sendTelemetryErrorEvent(TelemetryEvent.ListCollaborator, e);


### PR DESCRIPTION
If we open a old project with invalid config, then warning message of collaborator list will not show:
![image](https://user-images.githubusercontent.com/5545529/137676648-8cf7e316-a153-4cd3-9ab6-5d7c2195f4e3.png)

After fix:
![image](https://user-images.githubusercontent.com/5545529/137677754-3b024629-3170-472a-b896-73c5c99d1e9c.png)

