### PR TITLE
fix: some telemetry events don't have correlation id

### DIFF
--- a/packages/vscode-extension/src/controls/webviewPanel.ts
+++ b/packages/vscode-extension/src/controls/webviewPanel.ts
@@ -86,7 +86,9 @@ export class WebviewPanel {
             vscode.env.openExternal(vscode.Uri.parse(msg.data));
             break;
           case Commands.CloneSampleApp:
-            await this.downloadSampleApp(msg);
+            Correlator.run(async () => {
+              await this.downloadSampleApp(msg);
+            });
             break;
           case Commands.DisplayCommands:
             vscode.commands.executeCommand("workbench.action.quickOpen", `>${msg.data}`);
@@ -110,7 +112,10 @@ export class WebviewPanel {
             });
             break;
           case Commands.CreateNewProject:
-            await runCommand(Stage.create);
+            await vscode.commands.executeCommand(
+              "fx-extension.create",
+              TelemetryTiggerFrom.Webview
+            );
             break;
           case Commands.SwitchPanel:
             WebviewPanel.createOrShow(msg.data);


### PR DESCRIPTION
Issue:
Some telemetry events from quick start page don't have a correlation id like create-project, download-sample

ADO item: 
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/11000095?src=WorkItemMention&src-action=artifact_link