### PR TITLE
fix(multi-env): make error message clearer when checking resource group

### DIFF
--- a/packages/fx-core/src/plugins/solution/fx-solution/commonQuestions.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/commonQuestions.ts
@@ -438,6 +438,7 @@ async function askCommonQuestions(
     );
     if (!maybeResourceGroupInfo) {
       // Currently we do not support creating resource group from command line arguments
+
       return err(
         returnUserError(
           new Error(
@@ -490,8 +491,17 @@ async function askCommonQuestions(
       telemetryProperties[TelemetryProperty.CustomizeResourceGroupType] =
         CustomizeResourceGroupType.EnvProfile;
     } catch (e) {
+      let error;
+      const errorMessage = `Failed to check the existence of the resource group '${resourceGroupNameFromProfile}', error: '${e}'`;
+      if (e instanceof Error) {
+        // reuse the original error object to prevent losing the stack info
+        e.message = errorMessage;
+        error = e;
+      } else {
+        error = new Error(errorMessage);
+      }
       return err(
-        returnUserError(e, SolutionSource, SolutionError.FailedToCheckResourceGroupExistence)
+        returnUserError(error, SolutionSource, SolutionError.FailedToCheckResourceGroupExistence)
       );
     }
   } else if (ctx.answers && ctx.ui) {


### PR DESCRIPTION
Currently, on failure to check resource group existence, the error message of Azure js SDK is empty string in some cases. This will make the error message unclear to the users. Wrap the error message to make it clearer.

New behavior("test error" is my fake error message) 
![image](https://user-images.githubusercontent.com/9698542/137686538-dd1bb83f-c95d-49e9-a370-40a95576fb8f.png)

Old behavior:
![image](https://user-images.githubusercontent.com/9698542/137686745-9631a9b6-636c-45d6-9872-1c491f19c122.png)


Fix https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/12371313/