### PR TITLE
chore(multi-env): rename profile to state

### DIFF
--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -327,7 +327,7 @@ export interface EnvMeta {
 export const EnvNamePlaceholder = "@envName";
 
 // @public (undocumented)
-export const EnvProfileFileNameTemplate: string;
+export const EnvStateFileNameTemplate: string;
 
 // @public (undocumented)
 export interface ErrorOptionBase {
@@ -999,9 +999,6 @@ type ProvisionInputs = Inputs & SolutionInputs & {
     projectPath: string;
 };
 
-// @public (undocumented)
-export const PublishProfilesFolderName = "publishProfiles";
-
 // @public
 export class QTreeNode {
     constructor(data: Question | Group);
@@ -1303,6 +1300,9 @@ export enum Stage {
     // (undocumented)
     userTask = "userTask"
 }
+
+// @public (undocumented)
+export const StatesFolderName = "states";
 
 // @public
 export type StaticOptions = string[] | OptionItem[];

--- a/packages/api/src/constants.ts
+++ b/packages/api/src/constants.ts
@@ -5,11 +5,11 @@
 export const ConfigFolderName = "fx";
 export const AppPackageFolderName = "appPackage";
 export const InputConfigsFolderName = "configs";
-export const PublishProfilesFolderName = "publishProfiles";
+export const StatesFolderName = "states";
 export const ProjectSettingsFileName = "projectSettings.json";
 export const EnvNamePlaceholder = "@envName";
 export const EnvConfigFileNameTemplate = `config.${EnvNamePlaceholder}.json`;
-export const EnvProfileFileNameTemplate = `profile.${EnvNamePlaceholder}.json`;
+export const EnvStateFileNameTemplate = `state.${EnvNamePlaceholder}.json`;
 export const LocalEnvironmentName = "local";
 export const ProductName = "teamsfx";
 export const ArchiveFolderName = ".archive";

--- a/packages/cli/src/cmds/resource.ts
+++ b/packages/cli/src/cmds/resource.ts
@@ -43,15 +43,15 @@ async function checkAndReadEnvJson(
   if (!envsResult.value.includes(env)) {
     return err(new EnvNotFound(env));
   }
-  const envProfilePathResult = environmentManager.getEnvProfileFilesPath(env, rootFolder);
-  if (!existsSync(envProfilePathResult.envProfile)) {
+  const envStatePathResult = environmentManager.getEnvStateFilesPath(env, rootFolder);
+  if (!existsSync(envStatePathResult.envState)) {
     return err(new EnvNotProvisioned(env));
   }
   try {
-    const result = readJson(envProfilePathResult.envProfile);
+    const result = readJson(envStatePathResult.envState);
     return ok(result);
   } catch (error) {
-    return err(InvalidEnvFile("Failed to read env profile", envProfilePathResult.envProfile));
+    return err(InvalidEnvFile("Failed to read env state", envStatePathResult.envState));
   }
 }
 

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -24,10 +24,10 @@ import {
   Inputs,
   Platform,
   Colors,
-  PublishProfilesFolderName,
+  StatesFolderName,
   EnvNamePlaceholder,
   ProjectSettingsFileName,
-  EnvProfileFileNameTemplate,
+  EnvStateFileNameTemplate,
   InputConfigsFolderName,
 } from "@microsoft/teamsfx-api";
 
@@ -145,8 +145,8 @@ export function getEnvFilePath(
     path.join(
       projectFolder,
       `.${ConfigFolderName}`,
-      PublishProfilesFolderName,
-      EnvProfileFileNameTemplate.replace(EnvNamePlaceholder, env)
+      StatesFolderName,
+      EnvStateFileNameTemplate.replace(EnvNamePlaceholder, env)
     )
   );
 }
@@ -172,9 +172,7 @@ export function getSecretFilePath(
     return ok(path.join(projectRoot, `.${ConfigFolderName}`, `default.userdata`));
   }
 
-  return ok(
-    path.join(projectRoot, `.${ConfigFolderName}`, PublishProfilesFolderName, `${env}.userdata`)
-  );
+  return ok(path.join(projectRoot, `.${ConfigFolderName}`, StatesFolderName, `${env}.userdata`));
 }
 
 export async function readEnvJsonFile(

--- a/packages/cli/tests/e2e/commonUtils.ts
+++ b/packages/cli/tests/e2e/commonUtils.ts
@@ -4,10 +4,10 @@
 import {
   ConfigFolderName,
   EnvNamePlaceholder,
-  EnvProfileFileNameTemplate,
+  EnvStateFileNameTemplate,
   FxError,
   InputConfigsFolderName,
-  PublishProfilesFolderName,
+  StatesFolderName,
   Result,
   ok,
 } from "@microsoft/teamsfx-api";
@@ -81,8 +81,8 @@ function getEnvFilePathSuffix(isMultiEnvEnabled: boolean, envName: string) {
   if (isMultiEnvEnabled) {
     return path.join(
       ".fx",
-      PublishProfilesFolderName,
-      EnvProfileFileNameTemplate.replace(EnvNamePlaceholder, envName)
+      StatesFolderName,
+      EnvStateFileNameTemplate.replace(EnvNamePlaceholder, envName)
     );
   } else {
     return envFilePathSuffix;
@@ -321,12 +321,12 @@ export async function loadContext(projectPath: string, env: string): Promise<Res
     path.join(
       projectPath,
       `.${ConfigFolderName}`,
-      PublishProfilesFolderName,
-      EnvProfileFileNameTemplate.replace(EnvNamePlaceholder, env)
+      StatesFolderName,
+      EnvStateFileNameTemplate.replace(EnvNamePlaceholder, env)
     )
   );
   const userdataContent = await fs.readFile(
-    path.join(projectPath, `.${ConfigFolderName}`, PublishProfilesFolderName, `${env}.userdata`),
+    path.join(projectPath, `.${ConfigFolderName}`, StatesFolderName, `${env}.userdata`),
     "utf8"
   );
   const userdata = deserializeDict(userdataContent);

--- a/packages/cli/tests/e2e/multienv/TestRemoteHappyPath.tests.ts
+++ b/packages/cli/tests/e2e/multienv/TestRemoteHappyPath.tests.ts
@@ -34,8 +34,8 @@ import {
   Result,
   ok,
   ConfigFolderName,
-  PublishProfilesFolderName,
-  EnvProfileFileNameTemplate,
+  StatesFolderName,
+  EnvStateFileNameTemplate,
   EnvNamePlaceholder,
   AppPackageFolderName,
 } from "@microsoft/teamsfx-api";

--- a/packages/fx-core/src/common/telemetry.ts
+++ b/packages/fx-core/src/common/telemetry.ts
@@ -68,7 +68,7 @@ export enum Component {
 export enum CustomizeResourceGroupType {
   CommandLine = "command-line",
   EnvConfig = "env-config",
-  EnvProfile = "env-profile",
+  EnvState = "env-state",
   InteractiveCreateDefault = "interactive-create-default",
   InteractiveCreateCustomized = "interactive-create-customized",
   InteractiveUseExisting = "interactive-use-existing",

--- a/packages/fx-core/src/core/environment.ts
+++ b/packages/fx-core/src/core/environment.ts
@@ -5,12 +5,12 @@ import {
   ConfigFolderName,
   ConfigMap,
   CryptoProvider,
-  EnvProfileFileNameTemplate,
+  EnvStateFileNameTemplate,
   EnvConfig,
   err,
   FxError,
   ok,
-  PublishProfilesFolderName,
+  StatesFolderName,
   Result,
   SystemError,
   InputConfigsFolderName,
@@ -45,17 +45,16 @@ import { isMultiEnvEnabled } from "../common";
 import Ajv from "ajv";
 import * as draft6MetaSchema from "ajv/dist/refs/json-schema-draft-06.json";
 import * as envConfigSchema from "@microsoft/teamsfx-api/build/schemas/envConfig.json";
-import { InvalidProjectSettingsFileError } from ".";
 
-export interface EnvProfileFiles {
-  envProfile: string;
+export interface EnvStateFiles {
+  envState: string;
   userDataFile: string;
 }
 
 class EnvironmentManager {
   public readonly envNameRegex = /^[\w\d-_]+$/;
   public readonly envConfigNameRegex = /^config\.(?<envName>[\w\d-_]+)\.json$/i;
-  public readonly envProfileNameRegex = /^profile\.(?<envName>[\w\d-_]+)\.json$/i;
+  public readonly envStateNameRegex = /^state\.(?<envName>[\w\d-_]+)\.json$/i;
 
   private readonly defaultEnvName = "default";
   private readonly defaultEnvNameNew = "dev";
@@ -87,12 +86,12 @@ class EnvironmentManager {
       return err(configResult.error);
     }
 
-    const profileResult = await this.loadEnvProfile(projectPath, envName, cryptoProvider);
-    if (profileResult.isErr()) {
-      return err(profileResult.error);
+    const stateResult = await this.loadEnvState(projectPath, envName, cryptoProvider);
+    if (stateResult.isErr()) {
+      return err(stateResult.error);
     }
 
-    return ok({ envName, config: configResult.value, profile: profileResult.value });
+    return ok({ envName, config: configResult.value, profile: stateResult.value });
   }
 
   public newEnvConfigData(appName: string): EnvConfig {
@@ -136,7 +135,7 @@ class EnvironmentManager {
     return ok(envConfigPath);
   }
 
-  public async writeEnvProfile(
+  public async writeEnvState(
     envData: Map<string, any> | Json,
     projectPath: string,
     cryptoProvider: CryptoProvider,
@@ -146,13 +145,13 @@ class EnvironmentManager {
       return err(PathNotExistError(projectPath));
     }
 
-    const envProfilesFolder = this.getEnvProfilesFolder(projectPath);
-    if (!(await fs.pathExists(envProfilesFolder))) {
-      await fs.ensureDir(envProfilesFolder);
+    const envStatesFolder = this.getEnvStatesFolder(projectPath);
+    if (!(await fs.pathExists(envStatesFolder))) {
+      await fs.ensureDir(envStatesFolder);
     }
 
     envName = envName ?? this.getDefaultEnvName();
-    const envFiles = this.getEnvProfileFilesPath(envName, projectPath);
+    const envFiles = this.getEnvStateFilesPath(envName, projectPath);
 
     const data = envData instanceof Map ? mapToJson(envData) : envData;
     const secrets = sperateSecretData(data);
@@ -162,13 +161,13 @@ class EnvironmentManager {
     }
 
     try {
-      await fs.writeFile(envFiles.envProfile, JSON.stringify(data, null, 4));
+      await fs.writeFile(envFiles.envState, JSON.stringify(data, null, 4));
       await fs.writeFile(envFiles.userDataFile, serializeDict(secrets));
     } catch (error) {
       return err(WriteFileError(error));
     }
 
-    return ok(envFiles.envProfile);
+    return ok(envFiles.envState);
   }
 
   public async listEnvConfigs(projectPath: string): Promise<Result<Array<string>, FxError>> {
@@ -220,17 +219,17 @@ class EnvironmentManager {
     return path.resolve(basePath, EnvConfigFileNameTemplate.replace(EnvNamePlaceholder, envName));
   }
 
-  public getEnvProfileFilesPath(envName: string, projectPath: string): EnvProfileFiles {
-    const basePath = this.getEnvProfilesFolder(projectPath);
-    const envProfile = path.resolve(
+  public getEnvStateFilesPath(envName: string, projectPath: string): EnvStateFiles {
+    const basePath = this.getEnvStatesFolder(projectPath);
+    const envState = path.resolve(
       basePath,
       isMultiEnvEnabled()
-        ? EnvProfileFileNameTemplate.replace(EnvNamePlaceholder, envName)
+        ? EnvStateFileNameTemplate.replace(EnvNamePlaceholder, envName)
         : `env.${envName}.json`
     );
     const userDataFile = path.resolve(basePath, `${envName}.userdata`);
 
-    return { envProfile, userDataFile };
+    return { envState: envState, userDataFile };
   }
 
   private async loadEnvConfig(
@@ -262,25 +261,25 @@ class EnvironmentManager {
     return err(InvalidEnvConfigError(envName, JSON.stringify(validate.errors)));
   }
 
-  private async loadEnvProfile(
+  private async loadEnvState(
     projectPath: string,
     envName: string,
     cryptoProvider: CryptoProvider
   ): Promise<Result<Map<string, any>, FxError>> {
-    const envFiles = this.getEnvProfileFilesPath(envName, projectPath);
+    const envFiles = this.getEnvStateFilesPath(envName, projectPath);
     const userDataResult = await this.loadUserData(envFiles.userDataFile, cryptoProvider);
     if (userDataResult.isErr()) {
       return err(userDataResult.error);
     }
     const userData = userDataResult.value;
 
-    if (!(await fs.pathExists(envFiles.envProfile))) {
+    if (!(await fs.pathExists(envFiles.envState))) {
       const data = new Map<string, any>([[GLOBAL_CONFIG, new ConfigMap()]]);
 
       return ok(data);
     }
 
-    const envData = await readJson(envFiles.envProfile);
+    const envData = await readJson(envFiles.envState);
 
     mergeSerectData(userData, envData);
     const data = objectToMap(envData);
@@ -301,13 +300,13 @@ class EnvironmentManager {
     return path.resolve(projectPath, `.${ConfigFolderName}`);
   }
 
-  private getPublishProfilesFolder(projectPath: string): string {
-    return path.resolve(this.getConfigFolder(projectPath), PublishProfilesFolderName);
+  private getStatesFolder(projectPath: string): string {
+    return path.resolve(this.getConfigFolder(projectPath), StatesFolderName);
   }
 
-  private getEnvProfilesFolder(projectPath: string): string {
+  private getEnvStatesFolder(projectPath: string): string {
     return isMultiEnvEnabled()
-      ? this.getPublishProfilesFolder(projectPath)
+      ? this.getStatesFolder(projectPath)
       : this.getConfigFolder(projectPath);
   }
 

--- a/packages/fx-core/src/core/index.ts
+++ b/packages/fx-core/src/core/index.ts
@@ -26,7 +26,7 @@ import {
   Platform,
   ProjectConfig,
   ProjectSettings,
-  PublishProfilesFolderName,
+  StatesFolderName,
   QTreeNode,
   Result,
   RunnableTask,
@@ -1303,7 +1303,7 @@ export async function createBasicFolderStructure(inputs: Inputs): Promise<Result
         ? [
             "node_modules",
             `.${ConfigFolderName}/${InputConfigsFolderName}/${localSettingsFileName}`,
-            `.${ConfigFolderName}/${PublishProfilesFolderName}/*.userdata`,
+            `.${ConfigFolderName}/${StatesFolderName}/*.userdata`,
             ".DS_Store",
             `${ArchiveFolderName}`,
             `${ArchiveLogFileName}`,

--- a/packages/fx-core/src/core/middleware/envInfoWriter.ts
+++ b/packages/fx-core/src/core/middleware/envInfoWriter.ts
@@ -56,16 +56,16 @@ async function writeEnvInfo(ctx: CoreHookContext, skip: boolean) {
     if (isMultiEnvEnabled() && provisionOutputs[PluginNames.LDEBUG]) {
       delete provisionOutputs[PluginNames.LDEBUG];
     }
-    const envProfilePath = await environmentManager.writeEnvProfile(
+    const envStatePath = await environmentManager.writeEnvState(
       provisionOutputs,
       inputs.projectPath,
       ctx.contextV2!.cryptoProvider,
       envInfoV2.envName
     );
 
-    if (envProfilePath.isOk()) {
+    if (envStatePath.isOk()) {
       const core = ctx.self as FxCore;
-      core.tools.logProvider.debug(`[core] persist env profile: ${envProfilePath.value}`);
+      core.tools.logProvider.debug(`[core] persist env profile: ${envStatePath.value}`);
     }
   } else {
     const solutionContext = ctx.solutionContext;
@@ -76,16 +76,16 @@ async function writeEnvInfo(ctx: CoreHookContext, skip: boolean) {
       solutionContext.envInfo.profile.delete(PluginNames.LDEBUG);
     }
 
-    const envProfilePath = await environmentManager.writeEnvProfile(
+    const envStatePath = await environmentManager.writeEnvState(
       solutionContext.envInfo.profile,
       inputs.projectPath,
       solutionContext.cryptoProvider,
       solutionContext.envInfo.envName
     );
 
-    if (envProfilePath.isOk()) {
+    if (envStatePath.isOk()) {
       const core = ctx.self as FxCore;
-      core.tools.logProvider.debug(`[core] persist env profile: ${envProfilePath.value}`);
+      core.tools.logProvider.debug(`[core] persist env state: ${envStatePath.value}`);
     }
   }
 }

--- a/packages/fx-core/src/core/middleware/projectMigrator.ts
+++ b/packages/fx-core/src/core/middleware/projectMigrator.ts
@@ -12,7 +12,7 @@ import {
   Platform,
   ProjectSettings,
   ProjectSettingsFileName,
-  PublishProfilesFolderName,
+  StatesFolderName,
   returnSystemError,
   TeamsAppManifest,
 } from "@microsoft/teamsfx-api";
@@ -253,9 +253,7 @@ async function migrateToArmAndMultiEnv(ctx: CoreHookContext): Promise<void> {
 }
 
 async function migrateMultiEnv(projectPath: string): Promise<void> {
-  const { fx, fxConfig, templateAppPackage, fxPublishProfile } = await getMultiEnvFolders(
-    projectPath
-  );
+  const { fx, fxConfig, templateAppPackage, fxState } = await getMultiEnvFolders(projectPath);
   const {
     hasFrontend,
     hasBackend,
@@ -326,11 +324,11 @@ async function migrateMultiEnv(projectPath: string): Promise<void> {
   }
 
   if (hasProvision) {
-    const devProfile = path.join(fxPublishProfile, "profile.dev.json");
-    const devUserData = path.join(fxPublishProfile, "dev.userdata");
-    await fs.copy(path.join(fx, "new.env.default.json"), devProfile);
+    const devState = path.join(fxState, "state.dev.json");
+    const devUserData = path.join(fxState, "dev.userdata");
+    await fs.copy(path.join(fx, "new.env.default.json"), devState);
     await fs.copy(path.join(fx, "default.userdata"), devUserData);
-    await removeExpiredFields(devProfile, devUserData);
+    await removeExpiredFields(devState, devUserData);
   }
 }
 
@@ -448,10 +446,10 @@ async function getMultiEnvFolders(projectPath: string): Promise<any> {
   const fx = path.join(projectPath, `.${ConfigFolderName}`);
   const fxConfig = path.join(fx, InputConfigsFolderName);
   const templateAppPackage = path.join(projectPath, "templates", AppPackageFolderName);
-  const fxPublishProfile = path.join(fx, PublishProfilesFolderName);
+  const fxState = path.join(fx, StatesFolderName);
   await fs.ensureDir(fxConfig);
   await fs.ensureDir(templateAppPackage);
-  return { fx, fxConfig, templateAppPackage, fxPublishProfile };
+  return { fx, fxConfig, templateAppPackage, fxState };
 }
 
 async function backup(projectPath: string): Promise<void> {
@@ -518,12 +516,10 @@ async function getAppName(projectSettingPath: string): Promise<string> {
 }
 
 async function cleanup(projectPath: string): Promise<void> {
-  const { _, fxConfig, templateAppPackage, fxPublishProfile } = await getMultiEnvFolders(
-    projectPath
-  );
+  const { _, fxConfig, templateAppPackage, fxState } = await getMultiEnvFolders(projectPath);
   await fs.remove(fxConfig);
   await fs.remove(templateAppPackage);
-  await fs.remove(fxPublishProfile);
+  await fs.remove(fxState);
   await fs.remove(path.join(templateAppPackage, ".."));
   if (await fs.pathExists(path.join(fxConfig, "..", "new.env.default.json"))) {
     await fs.remove(path.join(fxConfig, "..", "new.env.default.json"));

--- a/packages/fx-core/src/core/middleware/projectUpgrader.ts
+++ b/packages/fx-core/src/core/middleware/projectUpgrader.ts
@@ -1,7 +1,7 @@
 import { Middleware, NextFunction } from "@feathersjs/hooks";
 import {
   ConfigFolderName,
-  PublishProfilesFolderName,
+  StatesFolderName,
   err,
   FxError,
   Inputs,
@@ -12,7 +12,7 @@ import {
   SystemError,
   ProjectSettingsFileName,
   InputConfigsFolderName,
-  EnvProfileFileNameTemplate,
+  EnvStateFileNameTemplate,
 } from "@microsoft/teamsfx-api";
 import * as fs from "fs-extra";
 import * as path from "path";
@@ -90,24 +90,21 @@ export async function upgradeContext(ctx: CoreHookContext): Promise<Result<undef
   const confFolderPath = isMultiEnvEnabled()
     ? path.resolve(inputs.projectPath, `.${ConfigFolderName}`, InputConfigsFolderName)
     : path.resolve(inputs.projectPath, `.${ConfigFolderName}`);
-  const publishProfilesFolderPath = path.resolve(
+  const statesFolderPath = path.resolve(
     inputs.projectPath,
     `.${ConfigFolderName}`,
-    PublishProfilesFolderName
+    StatesFolderName
   );
 
   const defaultEnvName = environmentManager.getDefaultEnvName();
 
   const contextPath = isMultiEnvEnabled()
-    ? path.resolve(
-        publishProfilesFolderPath,
-        EnvProfileFileNameTemplate.replace("@envName", defaultEnvName)
-      )
+    ? path.resolve(statesFolderPath, EnvStateFileNameTemplate.replace("@envName", defaultEnvName))
     : path.resolve(confFolderPath, `env.${defaultEnvName}.json`);
 
   const userDataPath = path.resolve(confFolderPath, `${defaultEnvName}.userdata`);
 
-  // For the multi env scenario, profile.{envName}.json and {envName}.userdata are not created when scaffolding
+  // For the multi env scenario, state.{envName}.json and {envName}.userdata are not created when scaffolding
   // These projects must be the new projects, so skip upgrading.
   if (isMultiEnvEnabled()) {
     try {

--- a/packages/fx-core/src/plugins/resource/aad/constants.ts
+++ b/packages/fx-core/src/plugins/resource/aad/constants.ts
@@ -272,6 +272,6 @@ export class TemplatePathInfo {
 export class ConfigFilePath {
   static readonly Default = "env.default.json";
   static readonly LocalSettings = "localSettings.json";
-  static readonly Profile = (env: string) => `profile.${env}.json`;
+  static readonly State = (env: string) => `state.${env}.json`;
   static readonly Input = (env: string) => `config.${env}.json`;
 }

--- a/packages/fx-core/src/plugins/resource/aad/utils/common.ts
+++ b/packages/fx-core/src/plugins/resource/aad/utils/common.ts
@@ -47,7 +47,7 @@ export class Utils {
       if (isLocalDebug) {
         return ConfigFilePath.LocalSettings;
       } else {
-        return ConfigFilePath.Profile(ctx.envInfo.envName);
+        return ConfigFilePath.State(ctx.envInfo.envName);
       }
     } else {
       return ConfigFilePath.Default;

--- a/packages/fx-core/src/plugins/solution/fx-solution/commonQuestions.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/commonQuestions.ts
@@ -488,7 +488,7 @@ async function askCommonQuestions(
       }
 
       telemetryProperties[TelemetryProperty.CustomizeResourceGroupType] =
-        CustomizeResourceGroupType.EnvProfile;
+        CustomizeResourceGroupType.EnvState;
     } catch (e) {
       return err(
         returnUserError(e, SolutionSource, SolutionError.FailedToCheckResourceGroupExistence)

--- a/packages/fx-core/tests/core/environment.test.ts
+++ b/packages/fx-core/tests/core/environment.test.ts
@@ -58,7 +58,7 @@ describe("APIs of Environment Manager", () => {
   };
   const invalidEnvConfigData = {};
 
-  const envProfileDataObj = new Map([
+  const envStateDataObj = new Map([
     [
       "solution",
       {
@@ -68,10 +68,10 @@ describe("APIs of Environment Manager", () => {
     ],
   ]);
 
-  const envProfileDataWithoutCredential = {
+  const envStateDataWithoutCredential = {
     key: "value",
   };
-  const envProfileDataWithCredential = {
+  const envStateDataWithCredential = {
     solution: {
       teamsAppTenantId: "{{solution.teamsAppTenantId}}",
       key: "value",
@@ -167,7 +167,7 @@ describe("APIs of Environment Manager", () => {
     });
   });
 
-  describe("Load Environment Profile File", () => {
+  describe("Load Environment State File", () => {
     const userData = {
       "solution.teamsAppTenantId": encryptedSecret,
     };
@@ -188,8 +188,8 @@ describe("APIs of Environment Manager", () => {
       sandbox.restore();
     });
 
-    it("no userdata: load environment profile without target env", async () => {
-      await mockEnvProfiles(projectPath, envProfileDataWithoutCredential);
+    it("no userdata: load environment state without target env", async () => {
+      await mockEnvStates(projectPath, envStateDataWithoutCredential);
 
       const actualEnvDataResult = await environmentManager.loadEnvInfo(
         projectPath,
@@ -197,15 +197,15 @@ describe("APIs of Environment Manager", () => {
         undefined
       );
       if (actualEnvDataResult.isErr()) {
-        assert.fail("Error ocurrs while loading environment profile.");
+        assert.fail("Error ocurrs while loading environment state.");
       }
 
       const envInfo = actualEnvDataResult.value;
-      assert.equal(envInfo.profile.get("key"), envProfileDataWithoutCredential.key);
+      assert.equal(envInfo.profile.get("key"), envStateDataWithoutCredential.key);
     });
 
-    it("no userdata: load environment profile with target env", async () => {
-      await mockEnvProfiles(projectPath, envProfileDataWithoutCredential, targetEnvName);
+    it("no userdata: load environment state with target env", async () => {
+      await mockEnvStates(projectPath, envStateDataWithoutCredential, targetEnvName);
 
       const actualEnvDataResult = await environmentManager.loadEnvInfo(
         projectPath,
@@ -213,15 +213,15 @@ describe("APIs of Environment Manager", () => {
         targetEnvName
       );
       if (actualEnvDataResult.isErr()) {
-        assert.fail("Error ocurrs while loading environment profile.");
+        assert.fail("Error ocurrs while loading environment state.");
       }
 
       const envInfo = actualEnvDataResult.value;
-      assert.equal(envInfo.profile.get("key"), envProfileDataWithoutCredential.key);
+      assert.equal(envInfo.profile.get("key"), envStateDataWithoutCredential.key);
     });
 
-    it("with userdata: load environment profile without target env", async () => {
-      await mockEnvProfiles(projectPath, envProfileDataWithCredential, undefined, userData);
+    it("with userdata: load environment state without target env", async () => {
+      await mockEnvStates(projectPath, envStateDataWithCredential, undefined, userData);
 
       const actualEnvDataResult = await environmentManager.loadEnvInfo(
         projectPath,
@@ -229,20 +229,17 @@ describe("APIs of Environment Manager", () => {
         undefined
       );
       if (actualEnvDataResult.isErr()) {
-        assert.fail("Error ocurrs while loading environment profile.");
+        assert.fail("Error ocurrs while loading environment state.");
       }
 
       const envInfo = actualEnvDataResult.value;
-      const expectedSolutionConfig = envProfileDataWithCredential.solution as Record<
-        string,
-        string
-      >;
+      const expectedSolutionConfig = envStateDataWithCredential.solution as Record<string, string>;
       assert.equal(envInfo.profile.get("solution").get("teamsAppTenantId"), decryptedValue);
       assert.equal(envInfo.profile.get("solution").get("key"), expectedSolutionConfig.key);
     });
 
-    it("with userdata: load environment profile with target env", async () => {
-      await mockEnvProfiles(projectPath, envProfileDataWithCredential, targetEnvName, userData);
+    it("with userdata: load environment state with target env", async () => {
+      await mockEnvStates(projectPath, envStateDataWithCredential, targetEnvName, userData);
 
       const actualEnvDataResult = await environmentManager.loadEnvInfo(
         projectPath,
@@ -250,20 +247,17 @@ describe("APIs of Environment Manager", () => {
         targetEnvName
       );
       if (actualEnvDataResult.isErr()) {
-        assert.fail("Error ocurrs while loading environment profile.");
+        assert.fail("Error ocurrs while loading environment state.");
       }
 
       const envInfo = actualEnvDataResult.value;
-      const expectedSolutionConfig = envProfileDataWithCredential.solution as Record<
-        string,
-        string
-      >;
+      const expectedSolutionConfig = envStateDataWithCredential.solution as Record<string, string>;
       assert.equal(envInfo.profile.get("solution").get("teamsAppTenantId"), decryptedValue);
       assert.equal(envInfo.profile.get("solution").get("key"), expectedSolutionConfig.key);
     });
 
-    it("with userdata (has checksum): load environment profile without target env", async () => {
-      await mockEnvProfiles(projectPath, envProfileDataWithCredential, undefined, {
+    it("with userdata (has checksum): load environment state without target env", async () => {
+      await mockEnvStates(projectPath, envStateDataWithCredential, undefined, {
         ...userData,
         _checksum: "81595a4344a4345ecfd90232f9e3540ce2b72e50745b3b83adc484c8e5055a33",
       });
@@ -274,20 +268,17 @@ describe("APIs of Environment Manager", () => {
         undefined
       );
       if (actualEnvDataResult.isErr()) {
-        assert.fail("Error ocurrs while loading environment profile.");
+        assert.fail("Error ocurrs while loading environment state.");
       }
 
       const envInfo = actualEnvDataResult.value;
-      const expectedSolutionConfig = envProfileDataWithCredential.solution as Record<
-        string,
-        string
-      >;
+      const expectedSolutionConfig = envStateDataWithCredential.solution as Record<string, string>;
       assert.equal(envInfo.profile.get("solution").get("teamsAppTenantId"), decryptedValue);
       assert.equal(envInfo.profile.get("solution").get("key"), expectedSolutionConfig.key);
     });
 
-    it("with userdata (legacy project): load environment profile with target env", async () => {
-      await mockEnvProfiles(projectPath, envProfileDataWithCredential, targetEnvName, userData);
+    it("with userdata (legacy project): load environment state with target env", async () => {
+      await mockEnvStates(projectPath, envStateDataWithCredential, targetEnvName, userData);
 
       const actualEnvDataResult = await environmentManager.loadEnvInfo(
         projectPath,
@@ -295,22 +286,19 @@ describe("APIs of Environment Manager", () => {
         targetEnvName
       );
       if (actualEnvDataResult.isErr()) {
-        assert.fail("Error ocurrs while loading environment profile.");
+        assert.fail("Error ocurrs while loading environment state.");
       }
 
       const envInfo = actualEnvDataResult.value;
-      const expectedSolutionConfig = envProfileDataWithCredential.solution as Record<
-        string,
-        string
-      >;
+      const expectedSolutionConfig = envStateDataWithCredential.solution as Record<string, string>;
       assert.equal(envInfo.profile.get("solution").get("teamsAppTenantId"), decryptedValue);
       assert.equal(envInfo.profile.get("solution").get("key"), expectedSolutionConfig.key);
     });
 
-    it("environment profile doesn't exist", async () => {
+    it("Environment state doesn't exist", async () => {
       const actualEnvDataResult = await environmentManager.loadEnvInfo(projectPath, cryptoProvider);
       if (actualEnvDataResult.isErr()) {
-        assert.fail("Error ocurrs while loading environment profile.");
+        assert.fail("Error ocurrs while loading environment state.");
       }
       assert.equal(actualEnvDataResult.value.envName, "default");
     });
@@ -369,7 +357,7 @@ describe("APIs of Environment Manager", () => {
     });
   });
 
-  describe("Write Environment Profile", () => {
+  describe("Write Environment State", () => {
     before(async () => {
       sandbox.stub(tools, "dataNeedEncryption").returns(true);
       sandbox.stub(fs, "pathExists").resolves(true);
@@ -387,53 +375,53 @@ describe("APIs of Environment Manager", () => {
       sandbox.restore();
     });
 
-    it("no userdata: write environment profile without target env", async () => {
-      await environmentManager.writeEnvProfile(
-        tools.objectToMap(envProfileDataWithoutCredential),
+    it("no userdata: write environment state without target env", async () => {
+      await environmentManager.writeEnvState(
+        tools.objectToMap(envStateDataWithoutCredential),
         projectPath,
         cryptoProvider
       );
-      const envFiles = environmentManager.getEnvProfileFilesPath("default", projectPath);
+      const envFiles = environmentManager.getEnvStateFilesPath("default", projectPath);
 
-      const expectedEnvProfileContent = JSON.stringify(envProfileDataWithoutCredential, null, 4);
+      const expectedEnvStateContent = JSON.stringify(envStateDataWithoutCredential, null, 4);
       assert.equal(
-        formatContent(fileMap.get(envFiles.envProfile)),
-        formatContent(expectedEnvProfileContent)
+        formatContent(fileMap.get(envFiles.envState)),
+        formatContent(expectedEnvStateContent)
       );
       assert.equal(fileMap.get(envFiles.userDataFile), "");
     });
 
-    it("no userdata: write environment profile with target env", async () => {
-      await environmentManager.writeEnvProfile(
-        tools.objectToMap(envProfileDataWithoutCredential),
+    it("no userdata: write environment state with target env", async () => {
+      await environmentManager.writeEnvState(
+        tools.objectToMap(envStateDataWithoutCredential),
         projectPath,
         cryptoProvider,
         targetEnvName
       );
-      const envFiles = environmentManager.getEnvProfileFilesPath(targetEnvName, projectPath);
+      const envFiles = environmentManager.getEnvStateFilesPath(targetEnvName, projectPath);
 
-      const expectedEnvProfileContent = JSON.stringify(envProfileDataWithoutCredential, null, 4);
+      const expectedEnvStateContent = JSON.stringify(envStateDataWithoutCredential, null, 4);
       assert.equal(
-        formatContent(fileMap.get(envFiles.envProfile)),
-        formatContent(expectedEnvProfileContent)
+        formatContent(fileMap.get(envFiles.envState)),
+        formatContent(expectedEnvStateContent)
       );
       assert.equal(fileMap.get(envFiles.userDataFile), "");
     });
 
-    it("with userdata: write environment profile without target env", async () => {
-      await environmentManager.writeEnvProfile(
-        envProfileDataObj,
+    it("with userdata: write environment state without target env", async () => {
+      await environmentManager.writeEnvState(
+        envStateDataObj,
         projectPath,
         cryptoProvider,
         undefined
       );
-      const envFiles = environmentManager.getEnvProfileFilesPath("default", projectPath);
+      const envFiles = environmentManager.getEnvStateFilesPath("default", projectPath);
 
-      const expectedEnvProfileContent = JSON.stringify(envProfileDataWithCredential, null, 4);
+      const expectedEnvStateContent = JSON.stringify(envStateDataWithCredential, null, 4);
       const expectedUserDataFileContent = `solution.teamsAppTenantId=${encryptedSecret}\n_checksum=81595a4344a4345ecfd90232f9e3540ce2b72e50745b3b83adc484c8e5055a33`;
       assert.equal(
-        formatContent(fileMap.get(envFiles.envProfile)),
-        formatContent(expectedEnvProfileContent)
+        formatContent(fileMap.get(envFiles.envState)),
+        formatContent(expectedEnvStateContent)
       );
       assert.equal(
         formatContent(fileMap.get(envFiles.userDataFile)),
@@ -441,20 +429,20 @@ describe("APIs of Environment Manager", () => {
       );
     });
 
-    it("with userdata: write environment profile with target env", async () => {
-      await environmentManager.writeEnvProfile(
-        envProfileDataObj,
+    it("with userdata: write environment state with target env", async () => {
+      await environmentManager.writeEnvState(
+        envStateDataObj,
         projectPath,
         cryptoProvider,
         targetEnvName
       );
-      const envFiles = environmentManager.getEnvProfileFilesPath(targetEnvName, projectPath);
+      const envFiles = environmentManager.getEnvStateFilesPath(targetEnvName, projectPath);
 
-      const expectedEnvProfileContent = JSON.stringify(envProfileDataWithCredential, null, 4);
+      const expectedEnvStateContent = JSON.stringify(envStateDataWithCredential, null, 4);
       const expectedUserDataFileContent = `solution.teamsAppTenantId=${encryptedSecret}\n_checksum=81595a4344a4345ecfd90232f9e3540ce2b72e50745b3b83adc484c8e5055a33`;
       assert.equal(
-        formatContent(fileMap.get(envFiles.envProfile)),
-        formatContent(expectedEnvProfileContent)
+        formatContent(fileMap.get(envFiles.envState)),
+        formatContent(expectedEnvStateContent)
       );
       assert.equal(
         formatContent(fileMap.get(envFiles.userDataFile)),
@@ -510,7 +498,7 @@ describe("APIs of Environment Manager", () => {
       ]);
     });
 
-    it("no env profile found", async () => {
+    it("no env state found", async () => {
       const envNamesResult = await environmentManager.listEnvConfigs(projectPath);
       if (envNamesResult.isErr()) {
         assert.fail("Fail to get the list of env configs.");
@@ -549,17 +537,17 @@ describe("APIs of Environment Manager", () => {
   });
 });
 
-async function mockEnvProfiles(
+async function mockEnvStates(
   projectPath: string,
-  envProfileData: Json,
+  envStateData: Json,
   envName?: string,
   userData?: Record<string, string>
 ) {
   envName = envName ?? environmentManager.getDefaultEnvName();
-  const envFiles = environmentManager.getEnvProfileFilesPath(envName, projectPath);
+  const envFiles = environmentManager.getEnvStateFilesPath(envName, projectPath);
 
-  await fs.ensureFile(envFiles.envProfile);
-  await fs.writeJson(envFiles.envProfile, envProfileData);
+  await fs.ensureFile(envFiles.envState);
+  await fs.writeJson(envFiles.envState, envStateData);
 
   if (userData) {
     await fs.ensureFile(envFiles.userDataFile);

--- a/packages/fx-core/tests/core/middleware/EnvInfoMW.test.ts
+++ b/packages/fx-core/tests/core/middleware/EnvInfoMW.test.ts
@@ -147,9 +147,9 @@ describe("Middleware - EnvInfoWriterMW, EnvInfoLoaderMW", async () => {
         sandbox.stub(fs, "pathExists").resolves(true);
         const envName = environmentManager.getDefaultEnvName();
         const envConfigFile = environmentManager.getEnvConfigPath(envName, projectPath);
-        const envFiles = environmentManager.getEnvProfileFilesPath(envName, projectPath);
+        const envFiles = environmentManager.getEnvStateFilesPath(envName, projectPath);
         const userdataFile = envFiles.userDataFile;
-        const envJsonFile = envFiles.envProfile;
+        const envJsonFile = envFiles.envState;
         const confFolderPath = path.resolve(projectPath, `.${ConfigFolderName}`);
         const settingsFiles = [
           path.resolve(confFolderPath, "settings.json"),

--- a/packages/vscode-extension/src/commonlib/common/constant.ts
+++ b/packages/vscode-extension/src/commonlib/common/constant.ts
@@ -12,4 +12,4 @@ export const loggingIn = "LoggingIn";
 
 export const subscriptionInfoFile = "subscriptionInfo.json";
 export const envDefaultJsonFile = "env.default.json";
-export const profileDefaultJsonFile = "profile.dev.json";
+export const stateDefaultJsonFile = "state.dev.json";

--- a/packages/vscode-extension/src/error.ts
+++ b/packages/vscode-extension/src/error.ts
@@ -16,7 +16,7 @@ export enum ExtensionErrors {
   FolderAlreadyExist = "FolderAlreadyExist",
   InvalidProject = "InvalidProject",
   FetchSampleError = "FetchSampleError",
-  OpenEnvProfileError = "OpenEnvProfileError",
-  EnvProfileNotFoundError = "EnvProfileNotFoundError",
+  OpenEnvStateError = "OpenEnvStateError",
+  EnvStateNotFoundError = "EnvStateNotFoundError",
   NoWorkspaceError = "NoWorkSpaceError",
 }

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -27,11 +27,7 @@ import {
 import { TreatmentVariableValue, TreatmentVariables } from "./exp/treatmentVariables";
 import { enableMigrateV1 } from "./utils/migrateV1";
 import { isTeamsfx, syncFeatureFlags } from "./utils/commonUtils";
-import {
-  ConfigFolderName,
-  InputConfigsFolderName,
-  PublishProfilesFolderName,
-} from "@microsoft/teamsfx-api";
+import { ConfigFolderName, InputConfigsFolderName, StatesFolderName } from "@microsoft/teamsfx-api";
 import { ExtensionUpgrade } from "./utils/upgrade";
 import { registerEnvTreeHandler } from "./envTree";
 import { getWorkspacePath } from "./handlers";
@@ -268,7 +264,7 @@ export async function activate(context: vscode.ExtensionContext) {
     language: "plaintext",
     scheme: "file",
     pattern: isMultiEnvEnabled()
-      ? `**/.${ConfigFolderName}/${PublishProfilesFolderName}/*.userdata`
+      ? `**/.${ConfigFolderName}/${StatesFolderName}/*.userdata`
       : `**/.${ConfigFolderName}/*.userdata`,
   };
   const localDebugDataSelector = {

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -982,7 +982,7 @@ export async function viewEnvironment(env: string): Promise<Result<Void, FxError
         },
         (error: any) => {
           const openEnvError = new SystemError(
-            ExtensionErrors.OpenEnvProfileError,
+            ExtensionErrors.OpenEnvStateError,
             util.format(StringResources.vsc.handlers.openEnvFailed, env),
             ExtensionSource,
             undefined,
@@ -1000,7 +1000,7 @@ export async function viewEnvironment(env: string): Promise<Result<Void, FxError
       );
     } else {
       const noEnvError = new UserError(
-        ExtensionErrors.EnvProfileNotFoundError,
+        ExtensionErrors.EnvStateNotFoundError,
         util.format(StringResources.vsc.handlers.findEnvFailed, env),
         ExtensionSource
       );

--- a/packages/vscode-extension/src/utils/commonUtils.ts
+++ b/packages/vscode-extension/src/utils/commonUtils.ts
@@ -18,8 +18,8 @@ import {
   ConfigFolderName,
   InputConfigsFolderName,
   ProjectSettingsFileName,
-  EnvProfileFileNameTemplate,
-  PublishProfilesFolderName,
+  EnvStateFileNameTemplate,
+  StatesFolderName,
   EnvNamePlaceholder,
   Json,
   SubscriptionInfo,
@@ -327,9 +327,9 @@ async function getProvisionResultJson(env: string): Promise<Json | undefined> {
 
       isMultiEnvEnabled()
         ? path.join(
-            PublishProfilesFolderName,
+            StatesFolderName,
 
-            EnvProfileFileNameTemplate.replace(EnvNamePlaceholder, env)
+            EnvStateFileNameTemplate.replace(EnvNamePlaceholder, env)
           )
         : envDefaultJsonFile
     );


### PR DESCRIPTION
PR changes:
1. Rename the folder `publishProfiles` to `states`.
2. Rename the publish profile file `profile.<env>.json` to `state.<env>.json`.
3. Rename some variables from `profile` to `state`. 

Please note, the renaming of `envInfo.profile` will be covered in another separated PR.

work item: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/11012592