### PR TITLE
chore(multi-env): core unittest supports multi-env

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -207,7 +207,7 @@ jobs:
         id: unit-test
         shell: bash
         run: |
-          export TEAMSFX_PRIVATE_PREVIEW=true
+          export TEAMSFX_INSIDER_PREVIEW=true
           # replace with this eventually: xvfb-run -a npx lerna run test:unit
           cd packages/fx-core && xvfb-run -a npx mocha "tests/core/**/*.test.ts" && cd -
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -176,3 +176,44 @@ jobs:
             --entity PartitionKey=TeamsFx RowKey=${{ github.run_id }}_fx-core_fx-solution Package=solution/fx-solution GitBranch=${{ github.ref }} Type=unit_test LinesPct=$(get_pct solution/fx-solution 'Lines') BranchesPct=$(get_pct solution/fx-solution 'Branches') StatementsPct=$(get_pct solution/fx-solution 'Statements') FunctionsPct=$(get_pct solution/fx-solution 'Functions') \
             --if-exists replace \
             --table-name TestCoverage
+
+  multi-env-test:
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    outputs:
+      coverages: ${{ steps.unit-test.outputs.coverages }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+
+      - name: Setup node
+        uses: actions/setup-node@v2.1.2
+        with:
+          node-version: 14
+
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.x
+
+      - name: Setup project
+        run: |
+          npm run setup
+
+      - name: Unit Test
+        id: unit-test
+        shell: bash
+        run: |
+          export TEAMSFX_PRIVATE_PREVIEW=true
+          # replace with this eventually: xvfb-run -a npx lerna run test:unit
+          cd packages/fx-core && xvfb-run -a npx mocha "tests/core/**/*.test.ts" && cd -
+
+          coverages="{}"
+          for i in $(find . -name coverage-summary.json); do
+            coverages=$(echo $coverages | jq -rc --arg package $(basename $(dirname $(dirname $i))) --argjson total $(jq -cr '.total' $i) '.[$package]= $total')
+          done  
+          echo $coverages
+          echo "::set-output name=coverages::$coverages"

--- a/packages/fx-core/src/common/tools.ts
+++ b/packages/fx-core/src/common/tools.ts
@@ -31,7 +31,7 @@ import * as uuid from "uuid";
 import { getResourceFolder } from "../folder";
 import { ConstantString, FeatureFlagName } from "./constants";
 import * as crypto from "crypto";
-import { FailedToParseResourceIdError } from "..";
+import { FailedToParseResourceIdError } from "../core/error";
 
 Handlebars.registerHelper("contains", (value, array, options) => {
   array = array instanceof Array ? array : [array];

--- a/packages/fx-core/src/core/middleware/projectUpgrader.ts
+++ b/packages/fx-core/src/core/middleware/projectUpgrader.ts
@@ -102,7 +102,10 @@ export async function upgradeContext(ctx: CoreHookContext): Promise<Result<undef
     ? path.resolve(statesFolderPath, EnvStateFileNameTemplate.replace("@envName", defaultEnvName))
     : path.resolve(confFolderPath, `env.${defaultEnvName}.json`);
 
-  const userDataPath = path.resolve(confFolderPath, `${defaultEnvName}.userdata`);
+  const userDataPath = path.resolve(
+    isMultiEnvEnabled() ? statesFolderPath : confFolderPath,
+    `${defaultEnvName}.userdata`
+  );
 
   // For the multi env scenario, state.{envName}.json and {envName}.userdata are not created when scaffolding
   // These projects must be the new projects, so skip upgrading.

--- a/packages/fx-core/tests/core/core.test.ts
+++ b/packages/fx-core/tests/core/core.test.ts
@@ -148,6 +148,10 @@ describe("Core basic APIs", () => {
   });
 
   describe("migrateV1", () => {
+    if (commonTools.isMultiEnvEnabled()) {
+      // TODO: add multi-env test case after migrateV1 for mult-env implemented
+      return;
+    }
     let mockedEnvRestore: RestoreFn;
     beforeEach(() => {
       mockedEnvRestore = mockedEnv({ TEAMSFX_APIV2: "false" });

--- a/packages/fx-core/tests/core/environment.test.ts
+++ b/packages/fx-core/tests/core/environment.test.ts
@@ -41,7 +41,7 @@ class MockCrypto implements CryptoProvider {
   }
 }
 
-describe("APIs of Environment Manager without Multi Env", () => {
+describe("APIs of Environment Manager", () => {
   const sandbox = sinon.createSandbox();
   const appName = randomAppName();
   const projectPath = path.resolve(os.tmpdir(), appName);

--- a/packages/fx-core/tests/core/environment.test.ts
+++ b/packages/fx-core/tests/core/environment.test.ts
@@ -20,6 +20,7 @@ import {
 } from "@microsoft/teamsfx-api";
 import { environmentManager } from "../../src/core/environment";
 import * as tools from "../../src/common/tools";
+import { isMultiEnvEnabled } from "../../src/common/tools";
 import sinon from "sinon";
 
 class MockCrypto implements CryptoProvider {
@@ -40,7 +41,7 @@ class MockCrypto implements CryptoProvider {
   }
 }
 
-describe("APIs of Environment Manager", () => {
+describe("APIs of Environment Manager without Multi Env", () => {
   const sandbox = sinon.createSandbox();
   const appName = randomAppName();
   const projectPath = path.resolve(os.tmpdir(), appName);
@@ -79,10 +80,10 @@ describe("APIs of Environment Manager", () => {
   };
 
   describe("Load Environment Config File", () => {
-    before(async () => {
-      sandbox.stub(tools, "isMultiEnvEnabled").returns(true);
-    });
-
+    // environment config exists only in multi-env
+    if (!isMultiEnvEnabled()) {
+      return;
+    }
     beforeEach(async () => {
       await fs.ensureDir(projectPath);
     });
@@ -190,6 +191,9 @@ describe("APIs of Environment Manager", () => {
 
     it("no userdata: load environment state without target env", async () => {
       await mockEnvStates(projectPath, envStateDataWithoutCredential);
+      if (isMultiEnvEnabled()) {
+        await mockEnvConfigs(projectPath, validEnvConfigData, targetEnvName);
+      }
 
       const actualEnvDataResult = await environmentManager.loadEnvInfo(
         projectPath,
@@ -197,7 +201,8 @@ describe("APIs of Environment Manager", () => {
         undefined
       );
       if (actualEnvDataResult.isErr()) {
-        assert.fail("Error ocurrs while loading environment state.");
+        // just throw the error so we get the error message and stack
+        throw actualEnvDataResult.error;
       }
 
       const envInfo = actualEnvDataResult.value;
@@ -206,6 +211,9 @@ describe("APIs of Environment Manager", () => {
 
     it("no userdata: load environment state with target env", async () => {
       await mockEnvStates(projectPath, envStateDataWithoutCredential, targetEnvName);
+      if (isMultiEnvEnabled()) {
+        await mockEnvConfigs(projectPath, validEnvConfigData, targetEnvName);
+      }
 
       const actualEnvDataResult = await environmentManager.loadEnvInfo(
         projectPath,
@@ -213,7 +221,7 @@ describe("APIs of Environment Manager", () => {
         targetEnvName
       );
       if (actualEnvDataResult.isErr()) {
-        assert.fail("Error ocurrs while loading environment state.");
+        throw actualEnvDataResult.error;
       }
 
       const envInfo = actualEnvDataResult.value;
@@ -222,6 +230,9 @@ describe("APIs of Environment Manager", () => {
 
     it("with userdata: load environment state without target env", async () => {
       await mockEnvStates(projectPath, envStateDataWithCredential, undefined, userData);
+      if (isMultiEnvEnabled()) {
+        await mockEnvConfigs(projectPath, validEnvConfigData, targetEnvName);
+      }
 
       const actualEnvDataResult = await environmentManager.loadEnvInfo(
         projectPath,
@@ -229,7 +240,7 @@ describe("APIs of Environment Manager", () => {
         undefined
       );
       if (actualEnvDataResult.isErr()) {
-        assert.fail("Error ocurrs while loading environment state.");
+        throw actualEnvDataResult.error;
       }
 
       const envInfo = actualEnvDataResult.value;
@@ -240,6 +251,9 @@ describe("APIs of Environment Manager", () => {
 
     it("with userdata: load environment state with target env", async () => {
       await mockEnvStates(projectPath, envStateDataWithCredential, targetEnvName, userData);
+      if (isMultiEnvEnabled()) {
+        await mockEnvConfigs(projectPath, validEnvConfigData, targetEnvName);
+      }
 
       const actualEnvDataResult = await environmentManager.loadEnvInfo(
         projectPath,
@@ -247,7 +261,7 @@ describe("APIs of Environment Manager", () => {
         targetEnvName
       );
       if (actualEnvDataResult.isErr()) {
-        assert.fail("Error ocurrs while loading environment state.");
+        throw actualEnvDataResult.error;
       }
 
       const envInfo = actualEnvDataResult.value;
@@ -261,6 +275,9 @@ describe("APIs of Environment Manager", () => {
         ...userData,
         _checksum: "81595a4344a4345ecfd90232f9e3540ce2b72e50745b3b83adc484c8e5055a33",
       });
+      if (isMultiEnvEnabled()) {
+        await mockEnvConfigs(projectPath, validEnvConfigData, targetEnvName);
+      }
 
       const actualEnvDataResult = await environmentManager.loadEnvInfo(
         projectPath,
@@ -268,7 +285,7 @@ describe("APIs of Environment Manager", () => {
         undefined
       );
       if (actualEnvDataResult.isErr()) {
-        assert.fail("Error ocurrs while loading environment state.");
+        throw actualEnvDataResult.error;
       }
 
       const envInfo = actualEnvDataResult.value;
@@ -279,6 +296,9 @@ describe("APIs of Environment Manager", () => {
 
     it("with userdata (legacy project): load environment state with target env", async () => {
       await mockEnvStates(projectPath, envStateDataWithCredential, targetEnvName, userData);
+      if (isMultiEnvEnabled()) {
+        await mockEnvConfigs(projectPath, validEnvConfigData, targetEnvName);
+      }
 
       const actualEnvDataResult = await environmentManager.loadEnvInfo(
         projectPath,
@@ -286,7 +306,7 @@ describe("APIs of Environment Manager", () => {
         targetEnvName
       );
       if (actualEnvDataResult.isErr()) {
-        assert.fail("Error ocurrs while loading environment state.");
+        throw actualEnvDataResult.error;
       }
 
       const envInfo = actualEnvDataResult.value;
@@ -296,11 +316,14 @@ describe("APIs of Environment Manager", () => {
     });
 
     it("Environment state doesn't exist", async () => {
+      if (isMultiEnvEnabled()) {
+        await mockEnvConfigs(projectPath, validEnvConfigData, targetEnvName);
+      }
       const actualEnvDataResult = await environmentManager.loadEnvInfo(projectPath, cryptoProvider);
       if (actualEnvDataResult.isErr()) {
-        assert.fail("Error ocurrs while loading environment state.");
+        throw actualEnvDataResult.error;
       }
-      assert.equal(actualEnvDataResult.value.envName, "default");
+      assert.equal(actualEnvDataResult.value.envName, environmentManager.getDefaultEnvName());
     });
   });
 
@@ -328,11 +351,7 @@ describe("APIs of Environment Manager", () => {
         assert.fail("Failed to write environment config.");
       }
 
-      const expectedContent = JSON.stringify(envConfig, null, 4);
-      assert.equal(
-        formatContent(fileMap.get(envConfigPathResult.value)),
-        formatContent(expectedContent)
-      );
+      assert.deepEqual(JSON.parse(fileMap.get(envConfigPathResult.value)), envConfig);
     });
 
     it("write environment config with target env", async () => {
@@ -381,13 +400,13 @@ describe("APIs of Environment Manager", () => {
         projectPath,
         cryptoProvider
       );
-      const envFiles = environmentManager.getEnvStateFilesPath("default", projectPath);
+      const envFiles = environmentManager.getEnvStateFilesPath(
+        environmentManager.getDefaultEnvName(),
+        projectPath
+      );
 
       const expectedEnvStateContent = JSON.stringify(envStateDataWithoutCredential, null, 4);
-      assert.equal(
-        formatContent(fileMap.get(envFiles.envState)),
-        formatContent(expectedEnvStateContent)
-      );
+      assert.deepEqual(JSON.parse(fileMap.get(envFiles.envState)), envStateDataWithoutCredential);
       assert.equal(fileMap.get(envFiles.userDataFile), "");
     });
 
@@ -415,14 +434,13 @@ describe("APIs of Environment Manager", () => {
         cryptoProvider,
         undefined
       );
-      const envFiles = environmentManager.getEnvStateFilesPath("default", projectPath);
-
-      const expectedEnvStateContent = JSON.stringify(envStateDataWithCredential, null, 4);
-      const expectedUserDataFileContent = `solution.teamsAppTenantId=${encryptedSecret}\n_checksum=81595a4344a4345ecfd90232f9e3540ce2b72e50745b3b83adc484c8e5055a33`;
-      assert.equal(
-        formatContent(fileMap.get(envFiles.envState)),
-        formatContent(expectedEnvStateContent)
+      const envFiles = environmentManager.getEnvStateFilesPath(
+        environmentManager.getDefaultEnvName(),
+        projectPath
       );
+
+      const expectedUserDataFileContent = `solution.teamsAppTenantId=${encryptedSecret}\n_checksum=81595a4344a4345ecfd90232f9e3540ce2b72e50745b3b83adc484c8e5055a33`;
+      assert.deepEqual(JSON.parse(fileMap.get(envFiles.envState)), envStateDataWithCredential);
       assert.equal(
         formatContent(fileMap.get(envFiles.userDataFile)),
         formatContent(expectedUserDataFileContent)

--- a/packages/fx-core/tests/core/hooks.test.ts
+++ b/packages/fx-core/tests/core/hooks.test.ts
@@ -154,7 +154,6 @@ describe("Middleware - others", () => {
 
         async upgrade(inputs: Inputs, ctx?: CoreHookContext): Promise<Result<any, FxError>> {
           assert.equal(userData["fx-resource-aad-app-for-teams.local_clientId"], "local_clientId");
-          console.log(userData);
           assert.equal(userData["solution.localDebugTeamsAppId"], "teamsAppId");
           assert.equal(
             (envJson["solution"] as any)["localDebugTeamsAppId"],

--- a/packages/fx-core/tests/core/hooks.test.ts
+++ b/packages/fx-core/tests/core/hooks.test.ts
@@ -9,19 +9,24 @@ import {
   CryptoProvider,
   EnvConfig,
   EnvInfo,
+  EnvNamePlaceholder,
+  EnvStateFileNameTemplate,
   Err,
   err,
   FxError,
+  InputConfigsFolderName,
   Inputs,
   Json,
   Ok,
   ok,
   Platform,
+  ProjectSettingsFileName,
   Result,
   SingleSelectConfig,
   SingleSelectResult,
   SolutionContext,
   Stage,
+  StatesFolderName,
   Tools,
   UserCancelError,
 } from "@microsoft/teamsfx-api";
@@ -75,10 +80,30 @@ describe("Middleware - others", () => {
     const inputs: Inputs = { platform: Platform.VSCode };
     inputs.projectPath = path.join(os.tmpdir(), appName);
     const envName = environmentManager.getDefaultEnvName();
-    const confFolderPath = path.resolve(inputs.projectPath, `.${ConfigFolderName}`);
-    const settingsFile = path.resolve(confFolderPath, "settings.json");
-    const envJsonFile = path.resolve(confFolderPath, `env.${envName}.json`);
-    const userDataFile = path.resolve(confFolderPath, `${envName}.userdata`);
+    const confFolderPath = path.resolve(
+      inputs.projectPath,
+      commonTools.isMultiEnvEnabled()
+        ? path.resolve(`.${ConfigFolderName}`, InputConfigsFolderName)
+        : `.${ConfigFolderName}`
+    );
+    const statesFolderPath = path.resolve(
+      inputs.projectPath,
+      `.${ConfigFolderName}`,
+      StatesFolderName
+    );
+    const settingsFile = path.resolve(
+      confFolderPath,
+      commonTools.isMultiEnvEnabled() ? ProjectSettingsFileName : "settings.json"
+    );
+    const envJsonFile = commonTools.isMultiEnvEnabled()
+      ? path.resolve(
+          statesFolderPath,
+          EnvStateFileNameTemplate.replace(EnvNamePlaceholder, envName)
+        )
+      : path.resolve(confFolderPath, `env.${envName}.json`);
+    const userDataFile = commonTools.isMultiEnvEnabled()
+      ? path.resolve(statesFolderPath, `${envName}.userdata`)
+      : path.resolve(confFolderPath, `${envName}.userdata`);
 
     function MockFunctions() {
       sandbox.stub<any, any>(fs, "readJson").callsFake(async (file: string) => {
@@ -97,6 +122,13 @@ describe("Middleware - others", () => {
       sandbox.stub<any, any>(fs, "readFile").callsFake(async (file: string) => {
         if (userDataFile === file) return serializeDict(userData);
         return {};
+      });
+      sandbox.stub<any, any>(fs, "stat").callsFake(async (file: string) => {
+        if ([settingsFile, envJsonFile, userDataFile].includes(file)) {
+          return {};
+        } else {
+          throw new Error("file not found");
+        }
       });
     }
 
@@ -122,6 +154,7 @@ describe("Middleware - others", () => {
 
         async upgrade(inputs: Inputs, ctx?: CoreHookContext): Promise<Result<any, FxError>> {
           assert.equal(userData["fx-resource-aad-app-for-teams.local_clientId"], "local_clientId");
+          console.log(userData);
           assert.equal(userData["solution.localDebugTeamsAppId"], "teamsAppId");
           assert.equal(
             (envJson["solution"] as any)["localDebugTeamsAppId"],

--- a/packages/fx-core/tests/core/localSettings.test.ts
+++ b/packages/fx-core/tests/core/localSettings.test.ts
@@ -2,7 +2,12 @@ import "mocha";
 import * as chai from "chai";
 import * as fs from "fs-extra";
 import * as path from "path";
-import { ConfigFolderName, Json, LocalSettings } from "@microsoft/teamsfx-api";
+import {
+  ConfigFolderName,
+  InputConfigsFolderName,
+  Json,
+  LocalSettings,
+} from "@microsoft/teamsfx-api";
 import { LocalSettingsProvider } from "../../src/common/localSettingsProvider";
 import {
   LocalSettingsAuthKeys,
@@ -12,10 +17,16 @@ import {
   LocalSettingsTeamsAppKeys,
 } from "../../src/common/localSettingsConstants";
 import { assert } from "console";
+import { isMultiEnvEnabled } from "../../src/common/tools";
 
 describe("LocalSettings provider APIs", () => {
   const workspaceFolder = path.resolve(__dirname, "./data/");
-  const testFilePath = path.resolve(__dirname, `./data/.${ConfigFolderName}/localSettings.json`);
+  const testFilePath = path.resolve(
+    __dirname,
+    `./data/.${ConfigFolderName}/${
+      isMultiEnvEnabled() ? InputConfigsFolderName : ""
+    }/localSettings.json`
+  );
 
   let hasFrontend: boolean;
   let hasBackend: boolean;


### PR DESCRIPTION
The whole plan is to make the unit test support both multi-env enabled/disabled cases. And then run the unit test twice: with TEAMSFX_INSIDER_PREVIEW and without.

- fix the unit test so the it can pass with multi-env enabled in fx-core
  - use deepEqual to compare JSON because the key order of JSON.stringify is not [in any particular order](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify)
  - throw the error instead of `assert.fail` so we can know the actual stack and error message when the test fails 
- fix a projectMigrator bug
- fix loop import in core