### PR TITLE
chore: prepare func checker for custom local debug

### DIFF
--- a/packages/cli/src/cmds/preview/depsChecker/funcToolChecker.ts
+++ b/packages/cli/src/cmds/preview/depsChecker/funcToolChecker.ts
@@ -86,12 +86,14 @@ export class FuncToolChecker implements IDepsChecker {
       // to avoid "func -v" and "func new" work well, but "func start" fail.
       hasSentinel = await fs.pathExists(FuncToolChecker.getSentinelPath());
 
-      // delete func.ps1 when checking portable function
-      for (const funcFolder in this.getPortableFuncBinFolders()) {
-        const funcPath = path.join(funcFolder, "func.ps1");
-        if (await fs.pathExists(funcPath)) {
-          await this._logger.debug(`deleting func.ps1 from ${funcPath}`);
-          await fs.remove(funcPath);
+      if (isWindows()) {
+        // delete func.ps1 when checking portable function
+        for (const funcFolder of this.getPortableFuncBinFolders()) {
+          const funcPath = path.join(funcFolder, "func.ps1");
+          if (await fs.pathExists(funcPath)) {
+            await this._logger.debug(`deleting func.ps1 from ${funcPath}`);
+            await fs.remove(funcPath);
+          }
         }
       }
     } catch (error) {
@@ -306,7 +308,7 @@ export class FuncToolChecker implements IDepsChecker {
         }
 
         // delete func.ps1 for portable version as well
-        for (const funcFolder in this.getPortableFuncBinFolders()) {
+        for (const funcFolder of this.getPortableFuncBinFolders()) {
           const funcPath = path.join(funcFolder, "func.ps1");
           if (await fs.pathExists(funcPath)) {
             await this._logger.debug(`deleting func.ps1 from ${funcPath}`);

--- a/packages/cli/src/cmds/preview/depsChecker/funcToolChecker.ts
+++ b/packages/cli/src/cmds/preview/depsChecker/funcToolChecker.ts
@@ -85,6 +85,15 @@ export class FuncToolChecker implements IDepsChecker {
         portableFuncVersion !== null && supportedVersions.includes(portableFuncVersion);
       // to avoid "func -v" and "func new" work well, but "func start" fail.
       hasSentinel = await fs.pathExists(FuncToolChecker.getSentinelPath());
+
+      // delete func.ps1 when checking portable function
+      for (const funcFolder in this.getPortableFuncBinFolders()) {
+        const funcPath = path.join(funcFolder, "func.ps1");
+        if (await fs.pathExists(funcPath)) {
+          await this._logger.debug(`deleting func.ps1 from ${funcPath}`);
+          await fs.remove(funcPath);
+        }
+      }
     } catch (error) {
       // do nothing
       return false;

--- a/packages/cli/src/cmds/preview/depsChecker/funcToolChecker.ts
+++ b/packages/cli/src/cmds/preview/depsChecker/funcToolChecker.ts
@@ -190,6 +190,13 @@ export class FuncToolChecker implements IDepsChecker {
     return "npx azure-functions-core-tools@3";
   }
 
+  public getPortableFuncBinFolders(): string[] {
+    return [
+      FuncToolChecker.getDefaultInstallPath(), // npm 6 (windows) https://github.com/npm/cli/issues/3489
+      path.join(FuncToolChecker.getDefaultInstallPath(), "node_modules", ".bin"),
+    ];
+  }
+
   private async queryFuncVersion(path: string): Promise<FuncVersion | null> {
     const output = await cpUtils.executeCommand(
       undefined,
@@ -287,6 +294,15 @@ export class FuncToolChecker implements IDepsChecker {
         if (await fs.pathExists(funcPSScript)) {
           await this._logger.debug(`deleting func.ps1 from ${funcPSScript}`);
           await fs.remove(funcPSScript);
+        }
+
+        // delete func.ps1 for portable version as well
+        for (const funcFolder in this.getPortableFuncBinFolders()) {
+          const funcPath = path.join(funcFolder, "func.ps1");
+          if (await fs.pathExists(funcPath)) {
+            await this._logger.debug(`deleting func.ps1 from ${funcPath}`);
+            await fs.remove(funcPath);
+          }
         }
       }
     } catch (error) {

--- a/packages/vscode-extension/src/debug/depsChecker/funcToolChecker.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/funcToolChecker.ts
@@ -86,12 +86,14 @@ export class FuncToolChecker implements IDepsChecker {
       // to avoid "func -v" and "func new" work well, but "func start" fail.
       hasSentinel = await fs.pathExists(FuncToolChecker.getSentinelPath());
 
-      // delete func.ps1 when checking portable function
-      for (const funcFolder in this.getPortableFuncBinFolders()) {
-        const funcPath = path.join(funcFolder, "func.ps1");
-        if (await fs.pathExists(funcPath)) {
-          await this._logger.debug(`deleting func.ps1 from ${funcPath}`);
-          await fs.remove(funcPath);
+      if (isWindows()) {
+        // delete func.ps1 when checking portable function
+        for (const funcFolder of this.getPortableFuncBinFolders()) {
+          const funcPath = path.join(funcFolder, "func.ps1");
+          if (await fs.pathExists(funcPath)) {
+            await this._logger.debug(`deleting func.ps1 from ${funcPath}`);
+            await fs.remove(funcPath);
+          }
         }
       }
     } catch (error) {
@@ -306,7 +308,7 @@ export class FuncToolChecker implements IDepsChecker {
         }
 
         // delete func.ps1 for portable version as well
-        for (const funcFolder in this.getPortableFuncBinFolders()) {
+        for (const funcFolder of this.getPortableFuncBinFolders()) {
           const funcPath = path.join(funcFolder, "func.ps1");
           if (await fs.pathExists(funcPath)) {
             await this._logger.debug(`deleting func.ps1 from ${funcPath}`);

--- a/packages/vscode-extension/src/debug/depsChecker/funcToolChecker.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/funcToolChecker.ts
@@ -85,6 +85,15 @@ export class FuncToolChecker implements IDepsChecker {
         portableFuncVersion !== null && supportedVersions.includes(portableFuncVersion);
       // to avoid "func -v" and "func new" work well, but "func start" fail.
       hasSentinel = await fs.pathExists(FuncToolChecker.getSentinelPath());
+
+      // delete func.ps1 when checking portable function
+      for (const funcFolder in this.getPortableFuncBinFolders()) {
+        const funcPath = path.join(funcFolder, "func.ps1");
+        if (await fs.pathExists(funcPath)) {
+          await this._logger.debug(`deleting func.ps1 from ${funcPath}`);
+          await fs.remove(funcPath);
+        }
+      }
     } catch (error) {
       // do nothing
       return false;

--- a/packages/vscode-extension/src/debug/depsChecker/funcToolChecker.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/funcToolChecker.ts
@@ -190,6 +190,13 @@ export class FuncToolChecker implements IDepsChecker {
     return "npx azure-functions-core-tools@3";
   }
 
+  public getPortableFuncBinFolders(): string[] {
+    return [
+      FuncToolChecker.getDefaultInstallPath(), // npm 6 (windows) https://github.com/npm/cli/issues/3489
+      path.join(FuncToolChecker.getDefaultInstallPath(), "node_modules", ".bin"),
+    ];
+  }
+
   private async queryFuncVersion(path: string): Promise<FuncVersion | null> {
     const output = await cpUtils.executeCommand(
       undefined,
@@ -287,6 +294,15 @@ export class FuncToolChecker implements IDepsChecker {
         if (await fs.pathExists(funcPSScript)) {
           await this._logger.debug(`deleting func.ps1 from ${funcPSScript}`);
           await fs.remove(funcPSScript);
+        }
+
+        // delete func.ps1 for portable version as well
+        for (const funcFolder in this.getPortableFuncBinFolders()) {
+          const funcPath = path.join(funcFolder, "func.ps1");
+          if (await fs.pathExists(funcPath)) {
+            await this._logger.debug(`deleting func.ps1 from ${funcPath}`);
+            await fs.remove(funcPath);
+          }
         }
       }
     } catch (error) {


### PR DESCRIPTION
- Expose bin folder so that `func` can be used directly from cmd
- Delete `func.ps1` for portable installation as well

@a1exwang @meifans - please help review