### PR TITLE
fix(multi-env): workaround github exit code mystery

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -209,7 +209,7 @@ jobs:
         run: |
           export TEAMSFX_INSIDER_PREVIEW=true
           # replace with this eventually: xvfb-run -a npx lerna run test:unit
-          cd packages/fx-core && xvfb-run -a npx mocha "tests/core/**/*.test.ts" && cd -
+          cd packages/fx-core && xvfb-run -a npx nyc mocha "tests/core/**/*.test.ts" && cd -
 
           coverages="{}"
           for i in $(find . -name coverage-summary.json); do


### PR DESCRIPTION
- align multi-env test with original unit test to workaround github exit code issue. Github Action will not fail if the exit code is 15, 16 or 17(I don't know why, tested [here](https://github.com/OfficeDev/TeamsFx/pull/2678/checks?check_run_id=3936220989)). `nyc` will eat the error code returned by mocha (count of failed cases) and always return 1 on non-zero exit code of mocha
![image](https://user-images.githubusercontent.com/9698542/137867881-1bc3c9a7-73c3-4685-9f96-0f5c5b81fac0.png)
