### PR TITLE
test(multi-env): make unit test of aad and simpleauth plugins support multi-env

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -209,7 +209,12 @@ jobs:
         run: |
           export TEAMSFX_INSIDER_PREVIEW=true
           # replace with this eventually: xvfb-run -a npx lerna run test:unit
-          cd packages/fx-core && xvfb-run -a npx nyc mocha "tests/core/**/*.test.ts" && cd -
+          cd packages/fx-core
+          xvfb-run -a npx nyc mocha \
+            "tests/core/**/*.test.ts"
+            "tests/plugins/resource/aad/**/*.test.ts"
+            "tests/plugins/resource/simpleauth/**/*.test.ts"
+          cd -
 
           coverages="{}"
           for i in $(find . -name coverage-summary.json); do

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -211,8 +211,8 @@ jobs:
           # replace with this eventually: xvfb-run -a npx lerna run test:unit
           cd packages/fx-core
           xvfb-run -a npx nyc mocha \
-            "tests/core/**/*.test.ts"
-            "tests/plugins/resource/aad/**/*.test.ts"
+            "tests/core/**/*.test.ts" \
+            "tests/plugins/resource/aad/**/*.test.ts" \
             "tests/plugins/resource/simpleauth/**/*.test.ts"
           cd -
 

--- a/packages/fx-core/tests/plugins/resource/aad/helper.ts
+++ b/packages/fx-core/tests/plugins/resource/aad/helper.ts
@@ -25,8 +25,10 @@ import jwt_decode from "jwt-decode";
 import { Utils } from "../../../../src/plugins/resource/aad/utils/common";
 import { MockUserInteraction } from "../../../core/utils";
 import { DEFAULT_PERMISSION_REQUEST } from "../../../../src/plugins/solution/fx-solution/constants";
-import { newEnvInfo } from "../../../../src";
+import { isMultiEnvEnabled, newEnvInfo } from "../../../../src";
 import { IUserList } from "../../../../src/plugins/resource/appstudio/interfaces/IAppDefinition";
+import { ARM_TEMPLATE_OUTPUT } from "../../../../src/plugins/solution/fx-solution/constants";
+import { SOLUTION } from "../../../../src/plugins/resource/appstudio/constants";
 
 const permissions = '[{"resource": "Microsoft Graph","delegated": ["User.Read"],"application":[]}]';
 const permissionsWrong =
@@ -231,6 +233,11 @@ export function mockProvisionResult(context: PluginContext, isLocalDebug = false
     Utils.addLocalDebugPrefix(isLocalDebug, ConfigKeys.clientSecret),
     faker.datatype.uuid()
   );
+  if (isMultiEnvEnabled()) {
+    const solutionProfile = context.envInfo.state.get(SOLUTION) ?? {};
+    solutionProfile[ConfigKeysOfOtherPlugin.frontendHostingDomain] = "frontendDomain";
+    context.envInfo.state.set(SOLUTION, solutionProfile);
+  }
 }
 
 export function mockTokenProvider(): AppStudioTokenProvider {

--- a/packages/fx-core/tests/plugins/resource/aad/unit/index.test.ts
+++ b/packages/fx-core/tests/plugins/resource/aad/unit/index.test.ts
@@ -101,7 +101,7 @@ describe("AadAppForTeamsPlugin: CI", () => {
     const provision = await plugin.provision(context);
     chai.assert.isTrue(provision.isOk());
 
-    mockProvisionResult(context);
+    mockProvisionResult(context, false, false);
     const setAppId = plugin.setApplicationInContext(context);
     chai.assert.isTrue(setAppId.isErr());
 
@@ -112,6 +112,7 @@ describe("AadAppForTeamsPlugin: CI", () => {
     const provisionSecond = await plugin.provision(context);
     chai.assert.isTrue(provisionSecond.isOk());
 
+    mockProvisionResult(context, false, true);
     const setAppIdSecond = plugin.setApplicationInContext(context);
     chai.assert.isTrue(setAppIdSecond.isOk());
 

--- a/packages/fx-core/tests/plugins/resource/simpleauth/unit/index.test.ts
+++ b/packages/fx-core/tests/plugins/resource/simpleauth/unit/index.test.ts
@@ -8,7 +8,7 @@ import * as sinon from "sinon";
 import * as path from "path";
 
 import { SimpleAuthPlugin } from "../../../../../src/plugins/resource/simpleauth/index";
-import { TestHelper } from "../helper";
+import { mockArmOutput, TestHelper } from "../helper";
 import { Constants } from "../../../../../src/plugins/resource/simpleauth/constants";
 import * as msRestNodeAuth from "@azure/ms-rest-nodeauth";
 import * as fs from "fs-extra";
@@ -20,6 +20,8 @@ import { PluginContext } from "@microsoft/teamsfx-api";
 import * as uuid from "uuid";
 import { ConstantString, mockSolutionUpdateArmTemplates } from "../../util";
 import { TeamsClientId } from "../../../../../src/common/constants";
+import { isMultiEnvEnabled } from "../../../../../src";
+import { LocalSettingsAuthKeys } from "../../../../../src/common/localSettingsConstants";
 
 chai.use(chaiAsPromised);
 
@@ -58,16 +60,30 @@ describe("simpleAuthPlugin", () => {
     await simpleAuthPlugin.postLocalDebug(pluginContext);
 
     // Assert
-    const filePath = pluginContext.config.get(
-      Constants.SimpleAuthPlugin.configKeys.filePath
-    ) as string;
+    let filePath: string;
+    if (isMultiEnvEnabled()) {
+      filePath = pluginContext.localSettings?.auth?.get(
+        LocalSettingsAuthKeys.SimpleAuthFilePath
+      ) as string;
+    } else {
+      filePath = pluginContext.config.get(Constants.SimpleAuthPlugin.configKeys.filePath) as string;
+    }
     chai.assert.isOk(filePath);
     chai.assert.isTrue(await fs.pathExists(filePath));
     const expectedEnvironmentVariableParams = `CLIENT_ID="mock-local-clientId" CLIENT_SECRET="mock-local-clientSecret" OAUTH_AUTHORITY="https://login.microsoftonline.com/mock-teamsAppTenantId" IDENTIFIER_URI="mock-local-applicationIdUris" ALLOWED_APP_IDS="${TeamsClientId.MobileDesktop};${TeamsClientId.Web}" TAB_APP_ENDPOINT="https://endpoint.mock" AAD_METADATA_ADDRESS="https://login.microsoftonline.com/mock-teamsAppTenantId/v2.0/.well-known/openid-configuration"`;
-    chai.assert.strictEqual(
-      pluginContext.config.get(Constants.SimpleAuthPlugin.configKeys.environmentVariableParams),
-      expectedEnvironmentVariableParams
-    );
+    if (isMultiEnvEnabled()) {
+      chai.assert.strictEqual(
+        pluginContext.localSettings?.auth?.get(
+          LocalSettingsAuthKeys.SimpleAuthEnvironmentVariableParams
+        ),
+        expectedEnvironmentVariableParams
+      );
+    } else {
+      chai.assert.strictEqual(
+        pluginContext.config.get(Constants.SimpleAuthPlugin.configKeys.environmentVariableParams),
+        expectedEnvironmentVariableParams
+      );
+    }
   });
 
   it("generate arm templates: only simple auth plugin", async function () {
@@ -241,8 +257,9 @@ describe("simpleAuthPlugin", () => {
 
   it("provision", async function () {
     // Arrange
+    const webAppUrl = faker.internet.url();
     const webApp = {
-      endpoint: faker.internet.url(),
+      endpoint: webAppUrl,
       skuName: "B1",
     };
     sinon.stub(WebAppClient.prototype, "createWebApp").resolves(webApp);
@@ -251,6 +268,7 @@ describe("simpleAuthPlugin", () => {
 
     // Act
     const provisionResult = await simpleAuthPlugin.provision(pluginContext);
+    mockArmOutput(pluginContext, webAppUrl);
     const postProvisionResult = await simpleAuthPlugin.postProvision(pluginContext);
 
     // Assert


### PR DESCRIPTION
The test will run twice, one with TEAMSFX_INSIDER_PREVIEW and one without it. This PR fixes the cases with TEAMSFX_INSIDER_PREVIEW=true