### PR TITLE
fix: move .env.teamsfx.local to template

### DIFF
--- a/packages/fx-core/src/plugins/resource/localdebug/index.ts
+++ b/packages/fx-core/src/plugins/resource/localdebug/index.ts
@@ -201,16 +201,6 @@ export class LocalDebugPlugin implements Plugin {
             ctx.config.set(LocalDebugConfigKeys.SkipNgrok, "false");
             ctx.config.set(LocalDebugConfigKeys.LocalBotEndpoint, "");
           }
-        } else {
-          // multi-env, prepare .env.teamsfx.local
-          const localEnvMultiProvider = new LocalEnvMultiProvider(ctx.root);
-          await localEnvMultiProvider.saveLocalEnvs(
-            includeFrontend
-              ? localEnvMultiProvider.initFrontendLocalEnvs(includeBackend, includeAuth)
-              : undefined,
-            includeBackend ? localEnvMultiProvider.initBackendLocalEnvs() : undefined,
-            includeBot ? localEnvMultiProvider.initBotLocalEnvs(isMigrateFromV1) : undefined
-          );
         }
 
         if (includeBackend) {


### PR DESCRIPTION
Move initial .env.teamsfx.local to template (template change will be another PR) to avoid conflict with component plugins.