### PR TITLE
test: make frontend plugin ut support insider preview

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -213,7 +213,8 @@ jobs:
           xvfb-run -a npx nyc mocha \
             "tests/core/**/*.test.ts" \
             "tests/plugins/resource/aad/**/*.test.ts" \
-            "tests/plugins/resource/simpleauth/**/*.test.ts"
+            "tests/plugins/resource/simpleauth/**/*.test.ts" \
+            "tests/plugins/resource/frontend/**/*.test.ts"
           cd -
 
           coverages="{}"

--- a/packages/fx-core/tests/plugins/resource/frontend/unit/config.test.ts
+++ b/packages/fx-core/tests/plugins/resource/frontend/unit/config.test.ts
@@ -56,12 +56,14 @@ describe("FrontendConfig", () => {
       );
     });
 
-    it("invalid storage name/id", async () => {
+    it("invalid storage name", async () => {
+      const invalidStorageName = "dangerous.com/";
       if (isArmSupportEnabled()) {
-        const invalidStorageResourceId = `/subscriptions/${uuid()}/resourceGroups/app-test-rg/providers/Microsoft.Storage/storageAccounts/dangerous.com%2F`;
+        const invalidStorageResourceId = `/subscriptions/${uuid()}/resourceGroups/app-test-rg/providers/Microsoft.Storage/storageAccounts/${encodeURIComponent(
+          invalidStorageName
+        )}`;
         pluginContext.config.set(FrontendConfigInfo.StorageResourceId, invalidStorageResourceId);
       } else {
-        const invalidStorageName = "dangerous.com/";
         pluginContext.config.set(FrontendConfigInfo.StorageName, invalidStorageName);
       }
       await assertRejected(

--- a/packages/fx-core/tests/plugins/resource/frontend/unit/config.test.ts
+++ b/packages/fx-core/tests/plugins/resource/frontend/unit/config.test.ts
@@ -5,6 +5,7 @@ import "mocha";
 import * as chai from "chai";
 import { PluginContext } from "@microsoft/teamsfx-api";
 import chaiAsPromised from "chai-as-promised";
+import { v4 as uuid } from "uuid";
 
 import { FrontendConfig } from "../../../../../src/plugins/resource/frontend/configs";
 import { FrontendConfigInfo } from "../../../../../src/plugins/resource/frontend/constants";
@@ -14,7 +15,7 @@ import {
   UnauthenticatedError,
 } from "../../../../../src/plugins/resource/frontend/resources/errors";
 import { TestHelper } from "../helper";
-import { newEnvInfo } from "../../../../../src";
+import { isArmSupportEnabled, newEnvInfo } from "../../../../../src";
 
 chai.use(chaiAsPromised);
 
@@ -55,9 +56,14 @@ describe("FrontendConfig", () => {
       );
     });
 
-    it("invalid storage name", async () => {
-      const invalidStorageName = "dangerous.com/";
-      pluginContext.config.set(FrontendConfigInfo.StorageName, invalidStorageName);
+    it("invalid storage name/id", async () => {
+      if (isArmSupportEnabled()) {
+        const invalidStorageResourceId = `/subscriptions/${uuid()}/resourceGroups/app-test-rg/providers/Microsoft.Storage/storageAccounts/dangerous.com%2F`;
+        pluginContext.config.set(FrontendConfigInfo.StorageResourceId, invalidStorageResourceId);
+      } else {
+        const invalidStorageName = "dangerous.com/";
+        pluginContext.config.set(FrontendConfigInfo.StorageName, invalidStorageName);
+      }
       await assertRejected(
         () => FrontendConfig.fromPluginContext(pluginContext),
         new InvalidStorageNameError().code

--- a/packages/fx-core/tests/plugins/resource/frontend/unit/index.test.ts
+++ b/packages/fx-core/tests/plugins/resource/frontend/unit/index.test.ts
@@ -24,6 +24,7 @@ import {
 } from "../../../../../src/plugins/resource/frontend/resources/errors";
 import { FrontendConfig } from "../../../../../src/plugins/resource/frontend/configs";
 import {
+  ArmOutput,
   AzureErrorCode,
   FrontendConfigInfo,
   FrontendPathInfo,
@@ -35,7 +36,7 @@ import { StorageAccounts } from "@azure/arm-storage";
 import { AzureLib } from "../../../../../src/plugins/resource/frontend/utils/azure-client";
 import * as core from "../../../../../src";
 import { EnvironmentUtils } from "../../../../../src/plugins/resource/frontend/utils/environment-utils";
-import { getTemplatesFolder } from "../../../../../src";
+import { getTemplatesFolder, isArmSupportEnabled, isMultiEnvEnabled } from "../../../../../src";
 import mock from "mock-fs";
 import * as path from "path";
 
@@ -101,6 +102,10 @@ describe("FrontendPlugin", () => {
   });
 
   describe("preProvision", () => {
+    if (isArmSupportEnabled()) {
+      // preProvision lifecycle is skipped with ARM
+      return;
+    }
     let frontendPlugin: FrontendPlugin;
     let pluginContext: PluginContext;
 
@@ -133,6 +138,10 @@ describe("FrontendPlugin", () => {
   });
 
   describe("provision", () => {
+    if (isArmSupportEnabled()) {
+      // provision lifecycle is skipped with ARM
+      return;
+    }
     let frontendPlugin: FrontendPlugin;
     let pluginContext: PluginContext;
 
@@ -207,7 +216,18 @@ describe("FrontendPlugin", () => {
 
     beforeEach(async () => {
       pluginContext = TestHelper.getFakePluginContext();
-      pluginContext.config.set(FrontendConfigInfo.Endpoint, TestHelper.storageEndpoint);
+      if (isMultiEnvEnabled()) {
+        sinon
+          .stub(AzureStorageClient.prototype, "enableStaticWebsite")
+          .returns(Promise.resolve(undefined));
+        TestHelper.mockArmOutput(
+          pluginContext,
+          ArmOutput.FrontendStorageResourceId,
+          TestHelper.storageResourceId
+        );
+      } else {
+        pluginContext.config.set(FrontendConfigInfo.Endpoint, TestHelper.storageEndpoint);
+      }
       frontendPlugin = new FrontendPlugin();
     });
 
@@ -232,6 +252,12 @@ describe("FrontendPlugin", () => {
     beforeEach(async () => {
       frontendPlugin = new FrontendPlugin();
       pluginContext = TestHelper.getFakePluginContext();
+      if (isArmSupportEnabled()) {
+        pluginContext.config.set(
+          FrontendConfigInfo.StorageResourceId,
+          TestHelper.storageResourceId
+        );
+      }
       sinon.stub(fs, "pathExists").resolves(true);
       sinon.stub(fs, "readFile").resolves(Buffer.from(""));
       sinon.stub(fs, "writeFile").resolves();
@@ -282,6 +308,12 @@ describe("FrontendPlugin", () => {
     beforeEach(async () => {
       frontendPlugin = new FrontendPlugin();
       pluginContext = TestHelper.getFakePluginContext();
+      if (isArmSupportEnabled()) {
+        pluginContext.config.set(
+          FrontendConfigInfo.StorageResourceId,
+          TestHelper.storageResourceId
+        );
+      }
       sinon.stub(AzureStorageClient.prototype, "getContainer").resolves({} as any);
       sinon.stub(AzureStorageClient.prototype, "deleteAllBlobs").resolves();
       sinon.stub(AzureStorageClient.prototype, "uploadFiles").resolves();

--- a/packages/fx-core/tests/plugins/resource/frontend/unit/index.test.ts
+++ b/packages/fx-core/tests/plugins/resource/frontend/unit/index.test.ts
@@ -36,7 +36,7 @@ import { StorageAccounts } from "@azure/arm-storage";
 import { AzureLib } from "../../../../../src/plugins/resource/frontend/utils/azure-client";
 import * as core from "../../../../../src";
 import { EnvironmentUtils } from "../../../../../src/plugins/resource/frontend/utils/environment-utils";
-import { getTemplatesFolder, isArmSupportEnabled, isMultiEnvEnabled } from "../../../../../src";
+import { getTemplatesFolder, isArmSupportEnabled } from "../../../../../src";
 import mock from "mock-fs";
 import * as path from "path";
 
@@ -216,7 +216,7 @@ describe("FrontendPlugin", () => {
 
     beforeEach(async () => {
       pluginContext = TestHelper.getFakePluginContext();
-      if (isMultiEnvEnabled()) {
+      if (isArmSupportEnabled()) {
         sinon
           .stub(AzureStorageClient.prototype, "enableStaticWebsite")
           .returns(Promise.resolve(undefined));


### PR DESCRIPTION
The unit test will run twice, one with TEAMSFX_INSIDER_PREVIEW=true and one without it. This PR make frontend plugin to support both cases.

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/12217265