### PR TITLE
chore(release): bump cli for repub

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/teamsfx-cli",
-  "version": "0.7.1",
+  "version": "0.7.1-rc.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/teamsfx-cli",
-  "version": "0.7.0",
+  "version": "0.7.1-rc.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/teamsfx-cli",
-  "version": "0.7.1-rc.0",
+  "version": "0.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/teamsfx-cli",
-  "version": "0.7.0",
+  "version": "0.7.1-rc.0",
   "author": "Microsoft Corporation",
   "description": "",
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/teamsfx-cli",
-  "version": "0.7.1-rc.0",
+  "version": "0.7.1",
   "author": "Microsoft Corporation",
   "description": "",
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/teamsfx-cli",
-  "version": "0.7.1",
+  "version": "0.7.1-rc.0",
   "author": "Microsoft Corporation",
   "description": "",
   "license": "MIT",

--- a/packages/vscode-extension/package-lock.json
+++ b/packages/vscode-extension/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ms-teams-vscode-extension",
-  "version": "2.8.0",
+  "version": "2.8.0-rc.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/vscode-extension/package-lock.json
+++ b/packages/vscode-extension/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ms-teams-vscode-extension",
-  "version": "2.8.1",
+  "version": "2.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/vscode-extension/package-lock.json
+++ b/packages/vscode-extension/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ms-teams-vscode-extension",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "ms-teams-vscode-extension",
   "displayName": "Teams Toolkit (Preview)",
   "description": "Create, debug, and deploy Teams apps with Teams Toolkit",
-  "version": "2.8.0",
+  "version": "2.8.0-rc.4",
   "publisher": "TeamsDevApp",
   "author": "Microsoft Corporation",
   "icon": "media/teams.png",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "ms-teams-vscode-extension",
   "displayName": "Teams Toolkit (Preview)",
   "description": "Create, debug, and deploy Teams apps with Teams Toolkit",
-  "version": "2.8.1",
+  "version": "2.8.0",
   "publisher": "TeamsDevApp",
   "author": "Microsoft Corporation",
   "icon": "media/teams.png",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "ms-teams-vscode-extension",
   "displayName": "Teams Toolkit (Preview)",
   "description": "Create, debug, and deploy Teams apps with Teams Toolkit",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "publisher": "TeamsDevApp",
   "author": "Microsoft Corporation",
   "icon": "media/teams.png",


### PR DESCRIPTION
bump cli version from 0.7.0 to 0.7.1 since we cannot publish 0.7.0 for the second time.

- @microsoft/teamsfx-cli: 0.7.1-rc.0 => 0.7.1
- ms-teams-vscode-extension: 2.8.0-rc.4 => 2.8.0