### PR TITLE
chore: add multi-env test to nyc coverage calculation

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -41,7 +41,11 @@ jobs:
         id: unit-test
         shell: bash
         run: |
+          # make sure the coverage data is cleaned
+          rm -rf .nyc_output
           xvfb-run -a npx lerna run test:unit
+          TEAMSFX_INSIDER_PREVIEW=true xvfb-run -a npx lerna run test:unit
+
           coverages="{}"
           for i in $(find . -name coverage-summary.json); do
             coverages=$(echo $coverages | jq -rc --arg package $(basename $(dirname $(dirname $i))) --argjson total $(jq -cr '.total' $i) '.[$package]= $total')
@@ -79,7 +83,10 @@ jobs:
         id: unit-test
         shell: bash
         run: |
+          rm -rf .nyc_output
           xvfb-run -a npx lerna run test:unit
+          TEAMSFX_INSIDER_PREVIEW=true xvfb-run -a npx lerna run test:unit
+
           coverages="{}"
           for i in $(find . -name coverage-summary.json); do
             coverages=$(echo $coverages | jq -rc --arg package $(basename $(dirname $(dirname $i))) --argjson total $(jq -cr '.total' $i) '.[$package]= $total')
@@ -176,64 +183,3 @@ jobs:
             --entity PartitionKey=TeamsFx RowKey=${{ github.run_id }}_fx-core_fx-solution Package=solution/fx-solution GitBranch=${{ github.ref }} Type=unit_test LinesPct=$(get_pct solution/fx-solution 'Lines') BranchesPct=$(get_pct solution/fx-solution 'Branches') StatementsPct=$(get_pct solution/fx-solution 'Statements') FunctionsPct=$(get_pct solution/fx-solution 'Functions') \
             --if-exists replace \
             --table-name TestCoverage
-
-  multi-env-test:
-    if: ${{ github.event_name == 'pull_request' }}
-    runs-on: ubuntu-latest
-    outputs:
-      coverages: ${{ steps.unit-test.outputs.coverages }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.head_ref }}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
-
-      - name: Setup node
-        uses: actions/setup-node@v2.1.2
-        with:
-          node-version: 14
-
-      - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 3.1.x
-
-      - name: Setup project
-        run: |
-          npm run setup
-
-      - name: Unit Test
-        id: unit-test
-        shell: bash
-        run: |
-          export TEAMSFX_INSIDER_PREVIEW=true
-          # replace with this eventually: xvfb-run -a npx lerna run test:unit
-          cd packages/fx-core
-          xvfb-run -a npx nyc mocha \
-            "tests/core/**/*.test.ts" \
-            "tests/plugins/resource/appstudio/**/*.test.ts" \
-            "tests/plugins/resource/bot/**/*.test.ts" \
-            "tests/plugins/resource/function/**/*.test.ts" \
-            "tests/plugins/resource/sql/**/*.test.ts" \
-            "tests/plugins/resource/aad/**/*.test.ts" \
-            "tests/plugins/resource/simpleauth/**/*.test.ts" \
-            "tests/plugins/resource/frontend/**/*.test.ts" \
-            "tests/plugins/resource/localdebug/**/*.test.ts" \
-            "tests/plugins/solution/*.test.ts"
-          cd -
-
-          cd packages/cli
-          xvfb-run -a npm run test:unit
-          cd -
-
-          cd packages/vscode-extension
-          xvfb-run -a npm run test:unit
-          cd -
-
-          coverages="{}"
-          for i in $(find . -name coverage-summary.json); do
-            coverages=$(echo $coverages | jq -rc --arg package $(basename $(dirname $(dirname $i))) --argjson total $(jq -cr '.total' $i) '.[$package]= $total')
-          done  
-          echo $coverages
-          echo "::set-output name=coverages::$coverages"

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -23,7 +23,7 @@
     "prepare": "npm run build",
     "lint:fix": "eslint \"src/**/*.ts\" \"tests/**/*.ts\" --fix",
     "doc": "typedoc",
-    "test:unit": "nyc mocha --no-timeouts --require ts-node/register \"tests/**/*.ts\"",
+    "test:unit": "nyc --no-clean mocha --no-timeouts --require ts-node/register \"tests/**/*.ts\"",
     "prepublishOnly": "npm run test:unit && npm run build",
     "precommit": "lint-staged"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,7 +22,7 @@
     "test:e2e:parallel": "mocha --parallel --reporter @mochajs/json-file-reporter \"tests/e2e/**/*.tests.ts\"",
     "test:e2e:smoke": "mocha --reporter @mochajs/json-file-reporter \"tests/e2e/smoke/*.tests.ts\"",
     "test:e2e:others": "mocha --reporter @mochajs/json-file-reporter \"tests/e2e/{,!(smoke)}/*.tests.ts\"",
-    "test:unit": "nyc mocha \"tests/unit/**/*.tests.ts\"",
+    "test:unit": "nyc --no-clean mocha \"tests/unit/**/*.tests.ts\"",
     "check-format": "prettier --list-different --config .prettierrc.json --ignore-path .prettierignore \"{src,tests}/**/*.ts\" \"*.{js,json}\"",
     "format": "prettier --write --config .prettierrc.json --ignore-path .prettierignore \"{src,tests}/**/*.ts\" \"*.{js,json}\"",
     "lint:fix": "eslint \"src/**/*.ts\" \"tests/**/*.ts\" --fix",

--- a/packages/fx-core/package.json
+++ b/packages/fx-core/package.json
@@ -18,7 +18,7 @@
     "test:appstudio": "nyc mocha \"tests/plugins/resource/appstudio/**/*.test.ts\"",
     "test:spfx": "nyc mocha \"tests/plugins/resource/spfx/**/*.test.ts\"",
     "test:apim": "nyc mocha \"tests/plugins/resource/apim/**/*.test.ts\"",
-    "test:unit": "nyc mocha \"tests/**/*.test.ts\"",
+    "test:unit": "nyc --no-clean mocha \"tests/**/*.test.ts\"",
     "test:solution": "nyc mocha \"tests/plugins/solution/*.test.ts\"",
     "test:core": "nyc mocha \"tests/core/*.test.ts\"",
     "test:core-mw": "nyc mocha \"tests/core/middleware/*.test.ts\"",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -34,7 +34,7 @@
     "test:node": "npm run build:test && npm run unit-test:node && npm run e2e-test:node",
     "test": "npm run test:unit && npm run test:e2e",
     "unit-test:browser": "karma start --single-run --glob=./dist-test/index.unit.browser.js",
-    "unit-test:node": "nyc mocha --no-timeouts -r test/mocha.env.ts --require ts-node/register \"test/unit/node/**/*.spec.ts\" \"test/unit/*.spec.ts\"",
+    "unit-test:node": "nyc --no-clean mocha --no-timeouts -r test/mocha.env.ts --require ts-node/register \"test/unit/node/**/*.spec.ts\" \"test/unit/*.spec.ts\"",
     "test:unit": "npm run build:test && npm run unit-test:node && npm run unit-test:browser",
     "ui-test": "mocha --no-timeouts -r test/mocha.env.ts -r ts-node/register test/ui/**/*.spec.ts --exit",
     "precommit": "lint-staged",


### PR DESCRIPTION
Run unit test with and without TEAMSFX_INSIDER_PREVIEW but without cleaning up coverage data so the final coverage report will be the union of both test runs.

It is to make the coverage calculation more accurate to prevent coverage drop when changing multi-env code. This will increase the global coverage by about 5% https://github.com/OfficeDev/TeamsFx/runs/4006014856?check_suite_focus=true.