### PR TITLE
test(scaffold): template ut fails when set preRelease env variable

### DIFF
--- a/packages/fx-core/tests/common/templateFetch.test.ts
+++ b/packages/fx-core/tests/common/templateFetch.test.ts
@@ -31,6 +31,10 @@ const timeout = 1000;
 
 describe("template-helper", () => {
   describe("Template Fetch Test", () => {
+    beforeEach(() => {
+      sinon.stub(templates, "preRelease").value("");
+    });
+
     afterEach(() => {
       sinon.restore();
     });


### PR DESCRIPTION
When setting TEAMSFX_TEMPLATE_PRERELEASE=alpha, scaffold lib always get template with version 0.0.0-alpha, which causes ut fail.