### PR TITLE
fix: change v1 localSettingsProvider to use v1 save

### DIFF
--- a/packages/fx-core/src/plugins/resource/localdebug/index.ts
+++ b/packages/fx-core/src/plugins/resource/localdebug/index.ts
@@ -699,11 +699,11 @@ export class LocalDebugPlugin implements Plugin {
         includeBackend,
         includeBot
       );
-      await localSettingsProvider.saveJson(ctx.localSettings);
+      await localSettingsProvider.save(ctx.localSettings);
     } else {
       // Initialize a local settings on scaffolding
       ctx.localSettings = localSettingsProvider.init(includeFrontend, includeBackend, includeBot);
-      await localSettingsProvider.saveJson(ctx.localSettings);
+      await localSettingsProvider.save(ctx.localSettings);
     }
   }
 }


### PR DESCRIPTION
1. Fix the problem that the initial content in ```localSettings.json``` is empty.