### PR TITLE
fix: check auth port for frontend only

### DIFF
--- a/packages/vscode-extension/src/debug/commonUtils.ts
+++ b/packages/vscode-extension/src/debug/commonUtils.ts
@@ -252,11 +252,12 @@ export async function getPortsInUse(): Promise<number[]> {
     const frontendRoot = await getProjectRoot(workspacePath, constants.frontendFolderName);
     if (frontendRoot) {
       ports.push(...constants.frontendPorts);
+      const migrateFromV1 = await isMigrateFromV1Project(workspacePath);
+      if (!migrateFromV1) {
+        ports.push(...constants.simpleAuthPorts);
+      }
     }
-    const migrateFromV1 = await isMigrateFromV1Project(workspacePath);
-    if (!migrateFromV1) {
-      ports.push(...constants.simpleAuthPorts);
-    }
+
     const backendRoot = await getProjectRoot(workspacePath, constants.backendFolderName);
     if (backendRoot) {
       ports.push(...constants.backendServicePorts);


### PR DESCRIPTION
To fix https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/12411167
Check auth port for frontend only.