### PR TITLE
fix: skip creating rg when if it exists

### DIFF
--- a/packages/fx-core/src/plugins/solution/fx-solution/commonQuestions.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/commonQuestions.ts
@@ -200,8 +200,17 @@ export async function askResourceGroupInfo(
   defaultResourceGroupName: string
 ): Promise<Result<ResourceGroupInfo, FxError>> {
   if (!isMultiEnvEnabled()) {
+    let exists = false;
+    try {
+      const checkRes = await rmClient.resourceGroups.checkExistence(defaultResourceGroupName);
+      exists = !!checkRes.body;
+    } catch (error) {
+      ctx.logProvider?.warning(
+        `Failed to check resource group existence ${defaultResourceGroupName}, assume non-existent, error '${error}'`
+      );
+    }
     return ok({
-      createNewResourceGroup: true,
+      createNewResourceGroup: !exists,
       name: defaultResourceGroupName,
       location: DefaultResourceGroupLocation,
     });


### PR DESCRIPTION
Prevent overwriting resource group if it exists when provisioning. Fixes #2777 

Tested. After a successful provision, the resource group tag is not overwritten.
![image](https://user-images.githubusercontent.com/9698542/139366013-0fe284c4-4041-4c65-8b4a-a4614fd045f2.png)

E2E TEST: https://github.com/OfficeDev/TeamsFx/actions/runs/1397525184