### PR TITLE
chore: use secret file jenkins

### DIFF
--- a/docs/cicd/jenkins-cd-template.Jenkinsfile
+++ b/docs/cicd/jenkins-cd-template.Jenkinsfile
@@ -53,7 +53,7 @@ pipeline {
 
         // We suggest to do the `npx teamsfx provision` step manually or in a separate pipeline. The following steps are for your reference.
         // After provisioning, you should commit .fx/env.default.json into the repository.
-        // You should save the content of .fx/default.userdata into credentials (https://www.jenkins.io/doc/book/using/using-credentials/) which can be refered by the stage with name 'Generate default.userdata'. 
+        // You should upload .fx/default.userdata into credentials (https://www.jenkins.io/doc/book/using/using-credentials/) in type of `Secret file` which can be refered by the stage with name 'Generate default.userdata'. 
         // stage('Provision hosting environment') {
         //     steps {
         //         sh 'npx teamsfx provision --subscription ${AZURE_SUBSCRIPTION_ID}'
@@ -79,7 +79,7 @@ pipeline {
                 USERDATA_CONTENT = credentials('USERDATA_CONTENT')
             }
             steps {
-                sh '[ ! -z "${USERDATA_CONTENT}" ] && echo "${USERDATA_CONTENT}" > .fx/default.userdata'
+                sh '[ ! -z "${USERDATA_CONTENT}" ] && cp ${USERDATA_CONTENT} .fx/default.userdata'
             }
         }
 

--- a/docs/cicd_insider/jenkins-cd-template.Jenkinsfile
+++ b/docs/cicd_insider/jenkins-cd-template.Jenkinsfile
@@ -58,7 +58,7 @@ pipeline {
 
         // We suggest to do the `npx teamsfx provision` step manually or in a separate pipeline. The following steps are for your reference.
         // After provisioning, you should commit necessary files under .fx into the repository.
-        // You should copy content of .fx/states/${TEAMSFX_ENV_NAME}.userdata into credentials (https://www.jenkins.io/doc/book/using/using-credentials/) which can be refered by the stage with name 'Generate userdata'. 
+        // You should upload .fx/states/${TEAMSFX_ENV_NAME}.userdata into credentials (https://www.jenkins.io/doc/book/using/using-credentials/) in type of `Secret file` which can be refered by the stage with name 'Generate userdata'. 
         // stage('Provision hosting environment') {
         //     environment {
         //         TEAMSFX_BICEP_ENV_CHECKER_ENABLE = 'true'
@@ -87,7 +87,7 @@ pipeline {
                 USERDATA_CONTENT = credentials('USERDATA_CONTENT')
             }
             steps {
-                sh '[ ! -z "${USERDATA_CONTENT}" ] && echo "${USERDATA_CONTENT}" > .fx/states/${TEAMSFX_ENV_NAME}.userdata'
+                sh '[ ! -z "${USERDATA_CONTENT}" ] && cp ${USERDATA_CONTENT} .fx/states/${TEAMSFX_ENV_NAME}.userdata'
             }
         }
 


### PR DESCRIPTION
Jenkins credentials got multiple types which including 
1. Secret text
2. Secret file

Currently, we use the type of Secret text to store the content of userdata file, but it may cause some bugs since jenkins will replace some but not all  \n  with space.

The type of Secret file is a better solution in Jenkins to store userdata, so change it.