### PR TITLE
fix: account azure sub update after selecting sub in provision state

### DIFF
--- a/packages/vscode-extension/src/accountTree.ts
+++ b/packages/vscode-extension/src/accountTree.ts
@@ -329,6 +329,7 @@ export async function registerAccountTreeHandler(): Promise<Result<Void, FxError
           ]);
           const subItem = await getSelectSubItem!(token);
           tools.treeProvider?.add([subItem[0]]);
+          await registerEnvTreeHandler();
         }
       } else if (status === "SigningIn") {
         tools.treeProvider?.refresh([

--- a/packages/vscode-extension/src/commonlib/azureLogin.ts
+++ b/packages/vscode-extension/src/commonlib/azureLogin.ts
@@ -348,7 +348,7 @@ export class AzureAccountManager extends login implements AzureAccountProvider {
             subscriptionName: item.subscription.displayName!,
             tenantId: item.session.tenantId,
           });
-          TreeViewManagerInstance.getTreeView("teamsfx-accounts")?.add([
+          TreeViewManagerInstance.getTreeView("teamsfx-accounts")?.refresh([
             {
               commandId: "fx-extension.selectSubscription",
               label: item.subscription.displayName!,


### PR DESCRIPTION
1. Update Azure sub in tree view after selecting subscription in provision state.
2. Update environment tree view after selecting subscription in provision state.

Fix: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/12460827

E2E TEST: Only affect UI