### PR TITLE
fix: ok button for single select doesn't work

### DIFF
--- a/packages/vscode-extension/src/qm/vsc_ui.ts
+++ b/packages/vscode-extension/src/qm/vsc_ui.ts
@@ -190,7 +190,10 @@ export class VsCodeUI implements UserInteraction {
             }),
             quickPick.onDidTriggerButton((button) => {
               if (button === QuickInputButtons.Back) resolve(ok({ type: "back" }));
-              else onDidAccept();
+              else {
+                quickPick.selectedItems = quickPick.activeItems;
+                onDidAccept();
+              }
             })
           );
 


### PR DESCRIPTION
ADO:
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/12470841
Issue:
click ok button for single select control doesn't work
Root cause:
This issue is introduced by https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/11033114. when there's no valid selection for matching, we shouldn't select the first option by default. It's weird that when using enter key, the selected item is currently active item, but when using ok button, the selected item is null. So I assign active item to selected item before onDidAccept event to fix the issue
E2E TEST: Only affect UI