### PR TITLE
chore: add customized manifest keys for multi-env telemetry

### DIFF
--- a/packages/fx-core/src/plugins/resource/appstudio/index.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/index.ts
@@ -86,10 +86,17 @@ export class AppStudioPlugin implements Plugin {
     TelemetryUtils.sendStartEvent(TelemetryEventName.provision);
     const remoteTeamsAppId = await this.appStudioPluginImpl.provision(ctx);
     if (remoteTeamsAppId.isErr()) {
-      TelemetryUtils.sendErrorEvent(TelemetryEventName.provision, remoteTeamsAppId.error);
+      TelemetryUtils.sendErrorEvent(
+        TelemetryEventName.provision,
+        remoteTeamsAppId.error,
+        this.appStudioPluginImpl.commonProperties
+      );
       return remoteTeamsAppId;
     } else {
-      TelemetryUtils.sendSuccessEvent(TelemetryEventName.provision);
+      TelemetryUtils.sendSuccessEvent(
+        TelemetryEventName.provision,
+        this.appStudioPluginImpl.commonProperties
+      );
       return ok(remoteTeamsAppId.value);
     }
   }
@@ -120,7 +127,7 @@ export class AppStudioPlugin implements Plugin {
       const errMessage = AppStudioError.ValidationFailedError.message(validationResult);
       ctx.logProvider?.error("Manifest Validation failed!");
       ctx.ui?.showMessage("error", errMessage, false);
-      const properties: { [key: string]: string } = {};
+      const properties: { [key: string]: string } = this.appStudioPluginImpl.commonProperties;
       properties[TelemetryPropertyKey.validationResult] = validationResult.join("\n");
       const validationFailed = AppStudioResultFactory.UserError(
         AppStudioError.ValidationFailedError.name,
@@ -135,7 +142,10 @@ export class AppStudioPlugin implements Plugin {
     }
     const validationSuccess = "Manifest Validation succeed!";
     ctx.ui?.showMessage("info", validationSuccess, false);
-    TelemetryUtils.sendSuccessEvent(TelemetryEventName.validateManifest);
+    TelemetryUtils.sendSuccessEvent(
+      TelemetryEventName.validateManifest,
+      this.appStudioPluginImpl.commonProperties
+    );
     return validationpluginResult;
   }
 
@@ -174,10 +184,17 @@ export class AppStudioPlugin implements Plugin {
         { content: " built successfully!", color: Colors.BRIGHT_WHITE },
       ];
       ctx.ui?.showMessage("info", builtSuccess, false);
-      TelemetryUtils.sendSuccessEvent(TelemetryEventName.buildTeamsPackage);
+      TelemetryUtils.sendSuccessEvent(
+        TelemetryEventName.buildTeamsPackage,
+        this.appStudioPluginImpl.commonProperties
+      );
       return ok(appPackagePath);
     } catch (error) {
-      TelemetryUtils.sendErrorEvent(TelemetryEventName.buildTeamsPackage, error);
+      TelemetryUtils.sendErrorEvent(
+        TelemetryEventName.buildTeamsPackage,
+        error,
+        this.appStudioPluginImpl.commonProperties
+      );
       return err(
         AppStudioResultFactory.UserError(
           AppStudioError.TeamsPackageBuildError.name,
@@ -255,7 +272,7 @@ export class AppStudioPlugin implements Plugin {
         `Success: ${result.name} successfully published to the [admin portal](${Constants.TEAMS_ADMIN_PORTAL}). Once approved, your app will be available for your organization.`,
         false
       );
-      const properties: { [key: string]: string } = {};
+      const properties: { [key: string]: string } = this.appStudioPluginImpl.commonProperties;
       properties[TelemetryPropertyKey.updateExistingApp] = String(result.update);
       properties[TelemetryPropertyKey.publishedAppId] = String(result.id);
       TelemetryUtils.sendSuccessEvent(TelemetryEventName.publish, properties);
@@ -268,7 +285,11 @@ export class AppStudioPlugin implements Plugin {
         }
         const innerError = error.innerError ? `innerError: ${error.innerError}` : "";
         error.message = `${error.message} ${innerError}`;
-        TelemetryUtils.sendErrorEvent(TelemetryEventName.publish, error);
+        TelemetryUtils.sendErrorEvent(
+          TelemetryEventName.publish,
+          error,
+          this.appStudioPluginImpl.commonProperties
+        );
         return err(error);
       } else {
         const publishFailed = new SystemError(
@@ -279,7 +300,11 @@ export class AppStudioPlugin implements Plugin {
           undefined,
           error
         );
-        TelemetryUtils.sendErrorEvent(TelemetryEventName.publish, publishFailed);
+        TelemetryUtils.sendErrorEvent(
+          TelemetryEventName.publish,
+          publishFailed,
+          this.appStudioPluginImpl.commonProperties
+        );
         return err(publishFailed);
       }
     }

--- a/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
@@ -112,9 +112,12 @@ import { v4 } from "uuid";
 import isUUID from "validator/lib/isUUID";
 import { ResourcePermission, TeamsAppAdmin } from "../../../common/permissionInterface";
 import Mustache from "mustache";
-import { replaceConfigValue } from "./utils/utils";
+import { getCustomizedKeys, replaceConfigValue } from "./utils/utils";
+import { TelemetryPropertyKey } from "./utils/telemetry";
 
 export class AppStudioPluginImpl {
+  public commonProperties: { [key: string]: string } = {};
+
   public async getAppDefinitionAndUpdate(
     ctx: PluginContext,
     isLocalDebug: boolean,
@@ -1698,6 +1701,10 @@ export class AppStudioPluginImpl {
     ).toString();
 
     if (isMultiEnvEnabled()) {
+      const customizedKeys = getCustomizedKeys("", JSON.parse(manifest));
+      this.commonProperties = {
+        [TelemetryPropertyKey.customizedKeys]: JSON.stringify(customizedKeys),
+      };
       const view = {
         config: ctx.envInfo.config,
         state: {

--- a/packages/fx-core/src/plugins/resource/appstudio/utils/telemetry.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/utils/telemetry.ts
@@ -20,6 +20,7 @@ export enum TelemetryPropertyKey {
   success = "success",
   appId = "appid",
   publishedAppId = "published-app-id",
+  customizedKeys = "customized-manifest-keys",
 }
 
 enum TelemetryPropertyValue {

--- a/packages/fx-core/src/plugins/resource/appstudio/utils/utils.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/utils/utils.ts
@@ -10,3 +10,24 @@ export function replaceConfigValue(config: string, id: string, value: string): s
   }
   return config;
 }
+
+export function getCustomizedKeys(prefix: string, manifest: any): string[] {
+  let keys: string[] = [];
+  for (const key in manifest) {
+    if (manifest.hasOwnProperty(key)) {
+      const value = manifest[key];
+      if (typeof value === "object") {
+        if (Array.isArray(value)) {
+          value.map((item, index) => {
+            keys = keys.concat(getCustomizedKeys(`${prefix}.${key}[${index}]`, item));
+          });
+        } else {
+          keys = keys.concat(getCustomizedKeys(`${prefix}.${key}`, value));
+        }
+      } else if (typeof value === "string" && value.startsWith("{{config.manifest")) {
+        keys.push(`${prefix}.${key}`);
+      }
+    }
+  }
+  return keys;
+}


### PR DESCRIPTION
For multi-env, users may add some customized placeholders in manifest template, in a format of {{config.manifest.xx}}

Add these keys to telemetry properties to give more insights.