### PR TITLE
fix: click m365 account will trigger sign in logic

### DIFF
--- a/packages/vscode-extension/src/accountTree.ts
+++ b/packages/vscode-extension/src/accountTree.ts
@@ -29,6 +29,7 @@ import * as util from "util";
 import * as StringResources from "./resources/Strings.json";
 import { StringContext } from "./utils/stringContext";
 import { registerEnvTreeHandler } from "./envTree";
+import { TreeViewCommand } from "./treeview/commandsTreeViewProvider";
 
 export async function getSubscriptionId(): Promise<string | undefined> {
   const subscriptionInfo = await AzureAccountManager.getSelectedSubscription();
@@ -183,6 +184,11 @@ export async function registerAccountTreeHandler(): Promise<Result<Void, FxError
   };
 
   const signinM365Callback = async (args?: any[]): Promise<Result<null, FxError>> => {
+    if (args && args.length > 1) {
+      const command: TreeViewCommand = args[1];
+      if (command && command.contextValue === "signedinM365") return ok(null);
+    }
+
     tools.telemetryReporter?.sendTelemetryEvent(TelemetryEvent.LoginClick, {
       [TelemetryProperty.TriggerFrom]:
         args && args.length > 0 ? TelemetryTiggerFrom.TreeView : TelemetryTiggerFrom.CommandPalette,
@@ -208,6 +214,11 @@ export async function registerAccountTreeHandler(): Promise<Result<Void, FxError
   };
 
   const signinAzureCallback = async (args?: any[]): Promise<Result<null, FxError>> => {
+    if (args && args.length > 1) {
+      const command: TreeViewCommand = args[1];
+      if (command && command.contextValue === "signedinAzure") return ok(null);
+    }
+
     if (AzureAccountManager.getAccountInfo() === undefined) {
       tools.telemetryReporter?.sendTelemetryEvent(TelemetryEvent.LoginClick, {
         [TelemetryProperty.TriggerFrom]:

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -814,7 +814,7 @@ function getTriggerFromProperty(args?: any[]) {
     return { [TelemetryProperty.TriggerFrom]: TelemetryTiggerFrom.CommandPalette };
   }
 
-  switch (args.toString()) {
+  switch (args[0].toString()) {
     case TelemetryTiggerFrom.TreeView:
       return { [TelemetryProperty.TriggerFrom]: TelemetryTiggerFrom.TreeView };
     case TelemetryTiggerFrom.Webview:

--- a/packages/vscode-extension/src/treeview/commandsTreeViewProvider.ts
+++ b/packages/vscode-extension/src/treeview/commandsTreeViewProvider.ts
@@ -319,7 +319,7 @@ export class TreeViewCommand extends vscode.TreeItem {
       this.command = {
         title: label,
         command: commandId,
-        arguments: [[CommandsTreeViewProvider.TreeViewFlag]],
+        arguments: [CommandsTreeViewProvider.TreeViewFlag, this],
       };
     }
   }


### PR DESCRIPTION
ADO: 
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/12401147
Issue:
the signInAzure(M365)Callback will be triggered when user click related tree item even if user already sign in. This will introduce performance issue on collaborator feature. 
E2E TEST: Only affect UI