### PR TITLE
chore: support resolving secret value from environment variables

### DIFF
--- a/packages/fx-core/src/core/environment.ts
+++ b/packages/fx-core/src/core/environment.ts
@@ -38,18 +38,19 @@ import {
   ModifiedSecretError,
 } from "..";
 import { GLOBAL_CONFIG } from "../plugins/solution/fx-solution/constants";
-import { readJson } from "../common/fileUtils";
 import { Component, sendTelemetryErrorEvent, TelemetryEvent } from "../common/telemetry";
-import { isMultiEnvEnabled } from "../common";
+import { compileHandlebarsTemplateString, isMultiEnvEnabled } from "../common";
 import Ajv from "ajv";
 import * as draft6MetaSchema from "ajv/dist/refs/json-schema-draft-06.json";
 import * as envConfigSchema from "@microsoft/teamsfx-api/build/schemas/envConfig.json";
-import Mustache from "mustache";
+import { ConstantString } from "../common/constants";
 
 export interface EnvStateFiles {
   envState: string;
   userDataFile: string;
 }
+
+export const envPrefix = "$env:";
 
 class EnvironmentManager {
   public readonly envNameRegex = /^[\w\d-_]+$/;
@@ -249,10 +250,15 @@ class EnvironmentManager {
     const validate = this.ajv.compile<EnvConfig>(envConfigSchema);
     let data;
     try {
-      data = await fs.readJson(envConfigPath);
+      data = await fs.readFile(envConfigPath, ConstantString.UTF8Encoding);
+
+      // resolve environment variables
+      data = this.expandEnvironmentVariables(data);
+      data = JSON.parse(data);
     } catch (error) {
       return err(InvalidEnvConfigError(envName, `Failed to read env config JSON: ${error}`));
     }
+
     if (validate(data)) {
       return ok(data);
     }
@@ -287,6 +293,19 @@ class EnvironmentManager {
     const data = objectToMap(resultJson);
 
     return ok(data);
+  }
+
+  private expandEnvironmentVariables(templateContent: string): string {
+    if (!templateContent) {
+      return templateContent;
+    }
+
+    const envVars: Record<string, any> = {};
+    Object.entries(process.env).forEach(([key, value]) => {
+      envVars[envPrefix + key] = value;
+    });
+
+    return compileHandlebarsTemplateString(templateContent, envVars);
   }
 
   private getEnvNameFromPath(filePath: string): string | null {

--- a/packages/fx-core/src/core/environment.ts
+++ b/packages/fx-core/src/core/environment.ts
@@ -50,7 +50,7 @@ export interface EnvStateFiles {
   userDataFile: string;
 }
 
-export const envPrefix = "$env:";
+export const envPrefix = "$env.";
 
 class EnvironmentManager {
   public readonly envNameRegex = /^[\w\d-_]+$/;
@@ -300,12 +300,7 @@ class EnvironmentManager {
       return templateContent;
     }
 
-    const envVars: Record<string, any> = {};
-    Object.entries(process.env).forEach(([key, value]) => {
-      envVars[envPrefix + key] = value;
-    });
-
-    return compileHandlebarsTemplateString(templateContent, envVars);
+    return compileHandlebarsTemplateString(templateContent, { $env: process.env });
   }
 
   private getEnvNameFromPath(filePath: string): string | null {

--- a/packages/fx-core/tests/core/environment.test.ts
+++ b/packages/fx-core/tests/core/environment.test.ts
@@ -20,6 +20,7 @@ import {
 } from "@microsoft/teamsfx-api";
 import { environmentManager } from "../../src/core/environment";
 import * as tools from "../../src/common/tools";
+import mockedEnv, { RestoreFn } from "mocked-env";
 import { isMultiEnvEnabled } from "../../src/common/tools";
 import sinon from "sinon";
 
@@ -58,6 +59,20 @@ describe("APIs of Environment Manager", () => {
     },
   };
   const invalidEnvConfigData = {};
+
+  const envConfigDataWithSecret = {
+    manifest: {
+      appName: {
+        short: appName,
+      },
+    },
+    auth: {
+      accessAsUserScopeId: "test-scope-id",
+      clientId: "test-client-id",
+      clientSecret: "{{$env:MOCKED_CLIENT_SECRET}}",
+      objectId: "test-object-id",
+    },
+  };
 
   const envStateDataObj = new Map([
     [
@@ -152,6 +167,33 @@ describe("APIs of Environment Manager", () => {
       } else {
         assert.fail("Failed to get expected error.");
       }
+    });
+
+    it("load environment config file with secret data", async () => {
+      const secretValue = "mocked secret value";
+      const mockedEnvRestore = mockedEnv({
+        MOCKED_CLIENT_SECRET: secretValue,
+      });
+
+      const envName = "test";
+      await mockEnvConfigs(projectPath, envConfigDataWithSecret, envName);
+
+      const actualEnvDataResult = await environmentManager.loadEnvInfo(
+        projectPath,
+        cryptoProvider,
+        envName
+      );
+
+      if (actualEnvDataResult.isErr()) {
+        assert.fail("Error occurs while loading environment config.");
+      }
+
+      const envConfigInfo = actualEnvDataResult.value;
+      assert.equal(envConfigInfo.envName, envName);
+      const actualValue = envConfigInfo.config.auth?.clientSecret;
+      assert.equal(actualValue, secretValue);
+
+      mockedEnvRestore();
     });
 
     it("load non existent env name", async () => {

--- a/packages/fx-core/tests/core/environment.test.ts
+++ b/packages/fx-core/tests/core/environment.test.ts
@@ -18,7 +18,7 @@ import {
   ok,
   Result,
 } from "@microsoft/teamsfx-api";
-import { environmentManager } from "../../src/core/environment";
+import { environmentManager, envPrefix } from "../../src/core/environment";
 import * as tools from "../../src/common/tools";
 import mockedEnv, { RestoreFn } from "mocked-env";
 import { isMultiEnvEnabled } from "../../src/common/tools";
@@ -69,7 +69,7 @@ describe("APIs of Environment Manager", () => {
     auth: {
       accessAsUserScopeId: "test-scope-id",
       clientId: "test-client-id",
-      clientSecret: "{{$env:MOCKED_CLIENT_SECRET}}",
+      clientSecret: `{{${envPrefix}MOCKED_CLIENT_SECRET}}`,
       objectId: "test-object-id",
     },
   };

--- a/packages/fx-core/tests/core/middleware/EnvInfoMW.test.ts
+++ b/packages/fx-core/tests/core/middleware/EnvInfoMW.test.ts
@@ -174,6 +174,7 @@ describe("Middleware - EnvInfoWriterMW, EnvInfoLoaderMW", async () => {
         sandbox.stub<any, any>(fs, "readFile").callsFake(async (file: string) => {
           if (userdataFile === file) return content;
           if (envJsonFile === file) return fileMap.get(envJsonFile);
+          if (envConfigFile === file) return JSON.stringify(envInfoV1.config);
           return {};
         });
         const configsFolder = environmentManager.getEnvConfigsFolder(projectPath);


### PR DESCRIPTION
In current multi-env design, user may need to config some secret value in the `config.<env>.json` file, such as AAD client secret, bot app secret, as well as some other user customized secret data.

To prevent check-in the credential into the project's repo, we are now supporting resolving the credential in env config from environment variables, you can define your config like this:
```json
{
   "clientId": "{{$env.my_env_name}}"
}
```