### PR TITLE
fix: remove active env from cli help

### DIFF
--- a/packages/cli/src/cmds/env.ts
+++ b/packages/cli/src/cmds/env.ts
@@ -40,8 +40,7 @@ export default class Env extends YargsCommand {
       description: `${this.subCommands.map((cmd) => cmd.commandHead).join("|")}`,
       type: "string",
       choices: this.subCommands.map((cmd) => cmd.commandHead),
-      // Action is not required because we support "teamsfx env" to show current active env.
-      require: false,
+      require: true,
     });
     this.subCommands.forEach((cmd) => {
       yargs.command(cmd.command, cmd.description, cmd.builder.bind(cmd), cmd.handler.bind(cmd));
@@ -56,8 +55,7 @@ export default class Env extends YargsCommand {
 class EnvAdd extends YargsCommand {
   public readonly commandHead = `add`;
   public readonly command = `${this.commandHead} <name>`;
-  public readonly description =
-    "Add a new environment by copying from current active environment or the specified environment.";
+  public readonly description = "Add a new environment by copying from the specified environment.";
   public params: { [_: string]: Options } = {};
 
   public builder(yargs: Argv): Argv<any> {


### PR DESCRIPTION
- `teamsfx env` requires following actions because there is no active env to show
- remove active env from cli help

E2E TEST: https://github.com/OfficeDev/TeamsFx/blob/f6f87441aa4176fabddb2feb3a60bd5983d971dc/packages/cli/tests/e2e/multienv/TestRemoteHappyPath.tests.ts#L38