### PR TITLE
fix(multi-env): make error message clear when running teamsfx config before provision

### DIFF
--- a/packages/cli/src/cmds/config.ts
+++ b/packages/cli/src/cmds/config.ts
@@ -25,7 +25,13 @@ import {
   TelemetrySuccess,
 } from "../telemetry/cliTelemetryEvents";
 import activate from "../activate";
-import { NonTeamsFxProjectFolder, ConfigNameNotFound, EnvNotSpecified } from "../error";
+import {
+  NonTeamsFxProjectFolder,
+  ConfigNameNotFound,
+  EnvNotSpecified,
+  ConfigNotFoundError,
+  EnvNotProvisioned,
+} from "../error";
 import * as constants from "../constants";
 
 const GlobalOptions = new Set([
@@ -176,7 +182,6 @@ export class ConfigGet extends YargsCommand {
     option?: string
   ): Promise<Result<null, FxError>> {
     let found = false;
-    // TODO: check file not found error before provision
     const result = await readProjectSecrets(rootFolder, env);
     if (result.isErr()) {
       CliTelemetry.sendTelemetryErrorEvent(TelemetryEvent.ConfigGet, result.error);
@@ -275,7 +280,8 @@ export class ConfigSet extends YargsCommand {
       } else {
         env = environmentManager.getDefaultEnvName();
       }
-      const inProject = (await readEnvJsonFile(rootFolder, env)).isOk();
+
+      const inProject = readSettingsFileSync(rootFolder).isOk();
       // project config
       if (inProject) {
         const projectResult = await this.setProjectConfig(rootFolder, args.option, args.value, env);

--- a/packages/cli/src/error.ts
+++ b/packages/cli/src/error.ts
@@ -3,7 +3,16 @@
 
 "use strict";
 
-import { returnSystemError, returnUserError, SystemError, UserError } from "@microsoft/teamsfx-api";
+import {
+  ConfigFolderName,
+  EnvNamePlaceholder,
+  EnvStateFileNameTemplate,
+  returnSystemError,
+  returnUserError,
+  StatesFolderName,
+  SystemError,
+  UserError,
+} from "@microsoft/teamsfx-api";
 import { isMultiEnvEnabled } from "@microsoft/teamsfx-core";
 
 import * as constants from "./constants";
@@ -152,5 +161,15 @@ export class EnvNotFound extends UserError {
 export class EnvNotProvisioned extends UserError {
   constructor(env: string) {
     super(new.target.name, `The environment "${env}" is not provisioned`, constants.cliSource);
+  }
+}
+
+export class UserdataNotFound extends UserError {
+  constructor(env: string) {
+    super(
+      new.target.name,
+      `The userdata file ".${ConfigFolderName}/${StatesFolderName}/${env}.userdata" is not found. Please try to provision in the "${env}" envrionment`,
+      constants.cliSource
+    );
   }
 }

--- a/packages/cli/tests/unit/cmds/config.tests.ts
+++ b/packages/cli/tests/unit/cmds/config.tests.ts
@@ -384,6 +384,14 @@ describe("Config Set Command Check", () => {
       logs.push(message);
     });
     sandbox
+      .stub(Utils, "readSettingsFileSync")
+      .callsFake((rootFolder: string): Result<any, FxError> => {
+        if (rootFolder.endsWith("testProjectFolder")) {
+          return ok({});
+        }
+        return err(NonTeamsFxProjectFolder());
+      });
+    sandbox
       .stub(Utils, "readEnvJsonFile")
       .callsFake(async (rootFolder: string): Promise<Result<any, FxError>> => {
         if (rootFolder.endsWith("testProjectFolder")) {

--- a/packages/cli/tests/unit/utils.tests.ts
+++ b/packages/cli/tests/unit/utils.tests.ts
@@ -353,7 +353,11 @@ describe("Utils Tests", function () {
 
     it("Fake Path", async () => {
       const result = await readProjectSecrets("fake", environmentManager.getDefaultEnvName());
-      expect(result.isOk() ? result.value : result.error.name).equals("ConfigNotFound");
+      if (isMultiEnvEnabled()) {
+        expect(result.isOk() ? result.value : result.error.name).equals("UserdataNotFound");
+      } else {
+        expect(result.isOk() ? result.value : result.error.name).equals("ConfigNotFound");
+      }
     });
   });
 


### PR DESCRIPTION
```
>  teamsfx config set key value --env dev                                   15:32:33
(✖) [TeamsfxCLI.UserdataNotFound]: The userdata file ".fx/states/dev.userdata" is not found. Please try to provision in the "dev" envrionment

> teamsfx config get --env dev                                             15:35:22
{}
(✖) [TeamsfxCLI.UserdataNotFound]: The userdata file ".fx/states/dev.userdata" is not found. Please try to provision in the "dev" envrionment

```


E2E TEST: https://github.com/OfficeDev/TeamsFx/blob/84b4cbf2229fc06e97b411bd15655f5247e66626/packages/cli/tests/e2e/multienv/TestRemoteHappyPath.tests.ts#L38