### PR TITLE
refactor(api): add new platform enum item for onboarding blazor plugin

### DIFF
--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -902,12 +902,14 @@ export enum Platform {
     // (undocumented)
     VS = "vs",
     // (undocumented)
+    VS_CALL_CLI = "vs_call_cli",
+    // (undocumented)
     VSCode = "vsc"
 }
 
 // @public
 interface Plugin_2 {
-    activate(solutionSettings: AzureSolutionSettings): boolean;
+    activate(solutionSettings: AzureSolutionSettings, platform?: Platform): boolean;
     callFunc?: (func: Func, ctx: PluginContext) => Promise<Result<any, FxError>>;
     // (undocumented)
     checkPermission?: (ctx: PluginContext, userInfo: Record<string, any>) => Promise<Result<any, FxError>>;

--- a/packages/api/src/constants.ts
+++ b/packages/api/src/constants.ts
@@ -27,6 +27,7 @@ export enum Platform {
   CLI = "cli",
   VS = "vs",
   CLI_HELP = "cli_help",
+  VS_CALL_CLI = "vs_call_cli", // The first version of VS extension will call CLI. We assign it a special platform different from VS and CLI.
 }
 
 export const StaticPlatforms = [Platform.VS, Platform.CLI_HELP];

--- a/packages/api/src/plugin.ts
+++ b/packages/api/src/plugin.ts
@@ -5,7 +5,7 @@
 import { Context, PluginContext } from "./context";
 import { Result } from "neverthrow";
 import { FxError } from "./error";
-import { Stage } from "./constants";
+import { Stage, Platform } from "./constants";
 import { Func, QTreeNode } from "./qm";
 import { AzureSolutionSettings } from "./types";
 /**
@@ -20,7 +20,7 @@ export interface Plugin {
    * resource plugin decide whether it need to be activated
    * @param solutionSettings solution settings
    */
-  activate(solutionSettings: AzureSolutionSettings): boolean;
+  activate(solutionSettings: AzureSolutionSettings, platform?: Platform): boolean;
 
   /**
    * prerequisiteCheck will check the whether required software has been installed. e.g. dotnet runtime of a required version.


### PR DESCRIPTION
closes https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_sprints/taskboard/Teams%20Extensibility%20E2E%20Team/Microsoft%20Teams%20Extensibility/CY21-11.1?workitem=12517463

In VS extension, identiy plugin should not be activated. So the activate() method needs to know in which platform it is operating.