### PR TITLE
chore(sdk): move teams-js sdk to peer dependency

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -87,6 +87,7 @@
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
     "@microsoft/api-documenter": "^7.12.4",
     "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/teams-js": "^1.9.0",
     "@rollup/plugin-commonjs": "^13.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -66,7 +66,6 @@
     "@azure/identity": "^2.0.1",
     "@azure/msal-node": "~1.1.0",
     "@microsoft/microsoft-graph-client": "^2.2.1",
-    "@microsoft/teams-js": "^1.9.0",
     "axios": "^0.24.0",
     "botbuilder": ">=4.15.0-rc0 <5.0.0",
     "botbuilder-core": ">=4.15.0-rc0 <5.0.0",
@@ -76,6 +75,9 @@
     "tedious": "^14.0.0",
     "tslib": "^2.0.0",
     "uuid": "^8.3.2"
+  },
+  "peerDependencies": {
+    "@microsoft/teams-js": "^1.9.0"
   },
   "devDependencies": {
     "@azure/arm-sql": "^7.0.2",

--- a/packages/sdk/rollup.base.config.js
+++ b/packages/sdk/rollup.base.config.js
@@ -14,7 +14,7 @@ import { terser } from "rollup-plugin-terser";
 
 const pkg = require("./package.json");
 const input = pkg.module;
-const depNames = Object.keys(pkg.dependencies);
+const depNames = Object.keys(Object.assign({}, pkg.dependencies, pkg.peerDependencies));
 const devDepNames = Object.keys(pkg.devDependencies);
 const production = process.env.NODE_ENV === "production";
 

--- a/templates/tab/js/default/package.json
+++ b/templates/tab/js/default/package.json
@@ -4,7 +4,7 @@
     "private": true,
     "dependencies": {
         "@fluentui/react-northstar": "^0.54.0",
-        "@microsoft/teams-js": "^1.6.0",
+        "@microsoft/teams-js": "^1.9.0",
         "@microsoft/teamsfx": "^0.3.0",
         "axios": "^0.21.1",
         "classnames": "^2.3.1",

--- a/templates/tab/ts/default/package.json
+++ b/templates/tab/ts/default/package.json
@@ -4,7 +4,7 @@
     "private": true,
     "dependencies": {
         "@fluentui/react-northstar": "^0.54.0",
-        "@microsoft/teams-js": "^1.6.0",
+        "@microsoft/teams-js": "^1.9.0",
         "@microsoft/teamsfx": "^0.3.0",
         "axios": "^0.21.1",
         "classnames": "^2.3.1",


### PR DESCRIPTION
Related bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/12514687