### PR TITLE
fix(multi-env): fix teamsfx env list and teamsfx env add

### DIFF
--- a/packages/cli/src/cmds/env.ts
+++ b/packages/cli/src/cmds/env.ts
@@ -30,18 +30,12 @@ import { EnvNodeNoCreate } from "../constants";
 
 export default class Env extends YargsCommand {
   public readonly commandHead = `env`;
-  public readonly command = `${this.commandHead} [action]`;
+  public readonly command = `${this.commandHead} <action>`;
   public readonly description = "Manage environments.";
 
   public readonly subCommands: YargsCommand[] = [new EnvAdd(), new EnvList()];
 
   public builder(yargs: Argv): Argv<any> {
-    yargs.options("action", {
-      description: `${this.subCommands.map((cmd) => cmd.commandHead).join("|")}`,
-      type: "string",
-      choices: this.subCommands.map((cmd) => cmd.commandHead),
-      require: true,
-    });
     this.subCommands.forEach((cmd) => {
       yargs.command(cmd.command, cmd.description, cmd.builder.bind(cmd), cmd.handler.bind(cmd));
     });


### PR DESCRIPTION
`teamsfx env list` previously required `action` option be set, but apparently there is no `action` option in the `list` command.

Use `<>` instead of `[]` to make the `action` option in `teamsfx env` command a required option. This aligns with other commands like `teamsfx config` and `teamsfx permission` 

E2E TEST https://github.com/OfficeDev/TeamsFx/blob/d3ab1f1be30620255343538fb1839bec273613f1/packages/cli/tests/e2e/multienv/TestRemoteHappyPath.tests.ts#L38

e2e test result: https://github.com/OfficeDev/TeamsFx/actions/runs/1424222811