### PR TITLE
chore(core): add feature flag for vs calling cli

### DIFF
--- a/packages/fx-core/src/common/constants.ts
+++ b/packages/fx-core/src/common/constants.ts
@@ -39,4 +39,5 @@ export class FeatureFlagName {
   static readonly APIV2 = "TEAMSFX_APIV2";
   static readonly InsiderPreview = "TEAMSFX_INSIDER_PREVIEW";
   static readonly rootDirectory = "TEAMSFX_ROOT_DIRECTORY";
+  static readonly VSCallingCLI = "VS_CALLING_CLI";
 }

--- a/packages/fx-core/src/core/index.ts
+++ b/packages/fx-core/src/core/index.ts
@@ -141,14 +141,23 @@ export interface CoreHookContext extends HookContext {
   localSettings?: Json;
 }
 
-// API V2 feature flag
-export function isV2() {
-  const flag = process.env[FeatureFlagName.APIV2];
+function featureFlagEnabled(flagName: string): boolean {
+  const flag = process.env[flagName];
   if (flag !== undefined && flag.toLowerCase() === "true") {
     return true;
   } else {
     return false;
   }
+}
+
+// API V2 feature flag
+export function isV2() {
+  return featureFlagEnabled(FeatureFlagName.APIV2);
+}
+
+// On VS calling CLI, interactive questions need to be skipped.
+export function isVsCallingCli() {
+  return featureFlagEnabled(FeatureFlagName.VSCallingCLI);
 }
 
 export let Logger: LogProvider;


### PR DESCRIPTION
Add feature flag for further development on VS extension calling CLI.
closes https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_sprints/taskboard/Teams%20Extensibility%20E2E%20Team/Microsoft%20Teams%20Extensibility/CY21-11.1?workitem=12525135