### PR TITLE
fix: block user from wrong app name

### DIFF
--- a/packages/fx-core/src/core/question.ts
+++ b/packages/fx-core/src/core/question.ts
@@ -16,6 +16,7 @@ import * as fs from "fs-extra";
 import * as os from "os";
 import { environmentManager } from "./environment";
 import { sampleProvider } from "../common";
+import { getRootDirectory } from "..";
 
 export enum CoreQuestionNames {
   AppName = "app-name",
@@ -42,8 +43,6 @@ export const QuestionAppName: TextInputQuestion = {
   title: "Application name",
   validation: {
     validFunc: async (input: string, previousInputs?: Inputs): Promise<string | undefined> => {
-      const folder = previousInputs![CoreQuestionNames.Folder] as string;
-      if (!folder) return undefined;
       const schema = {
         pattern: ProjectNamePattern,
       };
@@ -52,7 +51,7 @@ export const QuestionAppName: TextInputQuestion = {
       if (validateResult.errors && validateResult.errors.length > 0) {
         return "Application name must start with a letter and can only contain letters and digits.";
       }
-      const projectPath = path.resolve(folder, appName);
+      const projectPath = path.resolve(getRootDirectory(), appName);
       const exists = await fs.pathExists(projectPath);
       if (exists) return `Path exists: ${projectPath}. Select a different application name.`;
       return undefined;

--- a/packages/fx-core/tests/core/other.test.ts
+++ b/packages/fx-core/tests/core/other.test.ts
@@ -24,6 +24,7 @@ import {
   isFeatureFlagEnabled,
   isMultiEnvEnabled,
 } from "../../src/common/tools";
+import * as tools from "../../src/common/tools";
 import {
   ContextUpgradeError,
   FetchSampleError,
@@ -52,9 +53,7 @@ describe("Other test case", () => {
   });
   it("question: QuestionAppName validation", async () => {
     const inputs: Inputs = { platform: Platform.VSCode };
-    const folder = os.tmpdir();
     let appName = "1234";
-    inputs.folder = folder;
 
     let validRes = await (QuestionAppName.validation as FuncValidation<string>).validFunc(
       appName,
@@ -67,6 +66,8 @@ describe("Other test case", () => {
     );
 
     appName = randomAppName();
+    const folder = os.tmpdir();
+    sandbox.stub(tools, "getRootDirectory").returns(folder);
     const projectPath = path.resolve(folder, appName);
 
     sandbox.stub<any, any>(fs, "pathExists").withArgs(projectPath).resolves(true);

--- a/packages/fx-core/tests/core/other.test.ts
+++ b/packages/fx-core/tests/core/other.test.ts
@@ -23,6 +23,7 @@ import {
   isArmSupportEnabled,
   isFeatureFlagEnabled,
   isMultiEnvEnabled,
+  getRootDirectory,
 } from "../../src/common/tools";
 import * as tools from "../../src/common/tools";
 import {
@@ -264,5 +265,28 @@ describe("Other test case", () => {
     assert.isTrue(res2.isErr());
     const res3 = parseTeamsAppTenantId({ abd: "123" });
     assert.isTrue(res3.isErr());
+  });
+
+  it("getRootDirectory", () => {
+    let restore = mockedEnv({
+      [FeatureFlagName.rootDirectory]: undefined,
+    });
+
+    assert.equal(getRootDirectory(), path.join(os.homedir(), "TeamsApps"));
+    restore();
+
+    restore = mockedEnv({
+      [FeatureFlagName.rootDirectory]: "",
+    });
+
+    assert.equal(getRootDirectory(), path.join(os.homedir(), "TeamsApps"));
+    restore();
+
+    restore = mockedEnv({
+      [FeatureFlagName.rootDirectory]: os.tmpdir(),
+    });
+
+    assert.equal(getRootDirectory(), os.tmpdir());
+    restore();
   });
 });


### PR DESCRIPTION
ADO:
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/12517688

before:
![app-name-before](https://user-images.githubusercontent.com/73154171/140848680-1e2b14cd-f259-40fa-a89c-e077d3397da4.gif)


after:
![app-name-after](https://user-images.githubusercontent.com/73154171/140848465-18e1b9c4-2349-40cd-ac59-d22f7864be62.gif)

E2E TEST: only UI affected
