### PR TITLE
fix(multi-env): send correct project id before migration

### DIFF
--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -434,7 +434,7 @@ export function getProjectId(rootfolder: string | undefined): any {
 
     // Also try reading from the old project location to support `ProjectMigratorMW` telemetry.
     // While doing migration, sending telemetry will call this `getProjectId()` function.
-    // But before migration done, the settings file will be in the old path.
+    // But before migration done, the settings file is still in the old location.
     const settingsFilePathOld = getConfigPath(rootfolder, "settings.json");
     try {
       const settings = fs.readJsonSync(settingsFilePathOld);

--- a/packages/vscode-extension/src/utils/commonUtils.ts
+++ b/packages/vscode-extension/src/utils/commonUtils.ts
@@ -139,7 +139,7 @@ export function getProjectId(): string | undefined {
 
       // Also try reading from the old project location to support `ProjectMigratorMW` telemetry.
       // While doing migration, sending telemetry will call this `getProjectId()` function.
-      // But before migration done, the settings file will be in the old path.
+      // But before migration done, the settings file is still in the old location.
       const settingsJson = JSON.parse(fs.readFileSync(settingsJsonPathOld, "utf8"));
       return settingsJson.projectId;
     } else {

--- a/packages/vscode-extension/src/utils/commonUtils.ts
+++ b/packages/vscode-extension/src/utils/commonUtils.ts
@@ -121,19 +121,32 @@ export function getTeamsAppIdByEnv(env: string) {
 export function getProjectId(): string | undefined {
   try {
     const ws = ext.workspaceUri.fsPath;
+    const settingsJsonPathNew = path.join(
+      ws,
+      `.${ConfigFolderName}`,
+      InputConfigsFolderName,
+      ProjectSettingsFileName
+    );
+    const settingsJsonPathOld = path.join(ws, `.${ConfigFolderName}/settings.json`);
 
-    if (isValidProject(ws)) {
-      const settingsJsonPath = path.join(
-        ws,
+    if (isMultiEnvEnabled()) {
+      // Do not check validity of project in multi-env.
+      // Before migration, `isValidProject()` is false, but we still need to send `project-id` telemetry property.
+      try {
+        const settingsJson = JSON.parse(fs.readFileSync(settingsJsonPathNew, "utf8"));
+        return settingsJson.projectId;
+      } catch (e) {}
 
-        isMultiEnvEnabled()
-          ? `.${ConfigFolderName}/${InputConfigsFolderName}/${ProjectSettingsFileName}`
-          : `.${ConfigFolderName}/settings.json`
-      );
-
-      const settingsJson = JSON.parse(fs.readFileSync(settingsJsonPath, "utf8"));
-
+      // Also try reading from the old project location to support `ProjectMigratorMW` telemetry.
+      // While doing migration, sending telemetry will call this `getProjectId()` function.
+      // But before migration done, the settings file will be in the old path.
+      const settingsJson = JSON.parse(fs.readFileSync(settingsJsonPathOld, "utf8"));
       return settingsJson.projectId;
+    } else {
+      if (isValidProject(ws)) {
+        const settingsJson = JSON.parse(fs.readFileSync(settingsJsonPathOld, "utf8"));
+        return settingsJson.projectId;
+      }
     }
   } catch (e) {
     return undefined;


### PR DESCRIPTION
When users enable `TEAMSFX_INSIDER_PREVIEW` and open an old project, the `project-id` property in telemetry is not correctly sent. This is because `getProjectId()` will incorrectly assume this is a new project and retrieve `project-id` from the new location.

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/12525703


E2E TESTS: https://github.com/OfficeDev/TeamsFx/blob/dev/packages/cli/tests/e2e/multienv/TestRemoteHappyPath.tests.ts