### PR TITLE
fix(multi-env): improve resource group permission error message

### DIFF
--- a/packages/fx-core/src/plugins/solution/fx-solution/commonQuestions.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/commonQuestions.ts
@@ -34,9 +34,9 @@ import {
   RESOURCE_GROUP_NAME,
   SolutionError,
   SolutionSource,
-  FailedToCheckResourceGroupExistence,
+  FailedToCheckResourceGroupExistenceError,
   SUBSCRIPTION_ID,
-  UnauthorizedToCheckResourceGroup,
+  UnauthorizedToCheckResourceGroupError,
 } from "./constants";
 import { v4 as uuidv4 } from "uuid";
 import { ResourceManagementClient } from "@azure/arm-resources";
@@ -702,11 +702,11 @@ function handleRestError<T>(
   // ARM API will return 403 with empty body when users does not have permission to access the resource group
   if (restError.statusCode === 403) {
     return err(
-      new UnauthorizedToCheckResourceGroup(resourceGroupName, subscriptionId, subscriptionName)
+      new UnauthorizedToCheckResourceGroupError(resourceGroupName, subscriptionId, subscriptionName)
     );
   } else {
     return err(
-      new FailedToCheckResourceGroupExistence(
+      new FailedToCheckResourceGroupExistenceError(
         restError,
         resourceGroupName,
         subscriptionId,
@@ -730,7 +730,7 @@ export async function checkResourceGroupExistence(
       return handleRestError(e, resourceGroupName, subscriptionId, subscriptionName);
     } else {
       return err(
-        new FailedToCheckResourceGroupExistence(
+        new FailedToCheckResourceGroupExistenceError(
           e,
           resourceGroupName,
           subscriptionId,

--- a/packages/fx-core/src/plugins/solution/fx-solution/commonQuestions.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/commonQuestions.ts
@@ -730,7 +730,7 @@ function handleRestError<T>(
   }
 }
 
-async function checkResourceGroupExistence(
+export async function checkResourceGroupExistence(
   rmClient: ResourceManagementClient,
   resourceGroupName: string,
   subscriptionId: string,

--- a/packages/fx-core/src/plugins/solution/fx-solution/constants.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/constants.ts
@@ -99,6 +99,7 @@ export enum SolutionError {
   FailedToGetResourceGroupInfoInputs = "FailedToGetResourceGroupInfoInputs",
   ResourceGroupNotFound = "ResourceGroupNotFound",
   SubscriptionNotFound = "SubscriptionNotFound",
+  Unauthorized = "Unauthorized",
   NotLoginToAzure = "NotLoginToAzure",
   AzureAccountExtensionNotInitialized = "AzureAccountExtensionNotInitialized",
   LocalTabEndpointMissing = "LocalTabEndpointMissing",

--- a/packages/fx-core/src/plugins/solution/fx-solution/constants.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/constants.ts
@@ -3,6 +3,7 @@
 // Licensed under the MIT license.
 
 import { UserError } from "@microsoft/teamsfx-api";
+import { RestError } from "@azure/ms-rest-js";
 
 /**
  * Void is used to construct Result<Void, FxError>.
@@ -92,14 +93,12 @@ export enum SolutionError {
   NoAppStudioToken = "NoAppStudioToken",
   NoTeamsAppTenantId = "NoTeamsAppTenantId",
   NoUserName = "NoUserName",
-  FailedToCheckResourceGroupExistence = "FailedToCheckResourceGroupExistence",
   FailedToCreateResourceGroup = "FailedToCreateResourceGroup",
   FailedToListResourceGroup = "FailedToListResourceGrouop",
   FailedToListResourceGroupLocation = "FailedToListResourceGroupLocation",
   FailedToGetResourceGroupInfoInputs = "FailedToGetResourceGroupInfoInputs",
   ResourceGroupNotFound = "ResourceGroupNotFound",
   SubscriptionNotFound = "SubscriptionNotFound",
-  Unauthorized = "Unauthorized",
   NotLoginToAzure = "NotLoginToAzure",
   AzureAccountExtensionNotInitialized = "AzureAccountExtensionNotInitialized",
   LocalTabEndpointMissing = "LocalTabEndpointMissing",
@@ -235,3 +234,51 @@ export enum SolutionTelemetrySuccess {
 
 export const SolutionTelemetryComponentName = "solution";
 export const SolutionSource = "Solution";
+
+export class UnauthorizedToCheckResourceGroup extends UserError {
+  constructor(resourceGroupName: string, subscriptionId: string, subscriptionName: string) {
+    const subscriptionInfoString =
+      subscriptionId + (subscriptionName.length > 0 ? `(${subscriptionName})` : "");
+    super(
+      new.target.name,
+      `Unauthorized to check the existence of resource group '${resourceGroupName}' in subscription '${subscriptionInfoString}'. Please check your Azure subscription.`,
+      SolutionSource
+    );
+  }
+}
+
+export class FailedToCheckResourceGroupExistence extends UserError {
+  constructor(
+    error: unknown,
+    resourceGroupName: string,
+    subscriptionId: string,
+    subscriptionName: string
+  ) {
+    const subscriptionInfoString =
+      subscriptionId + (subscriptionName.length > 0 ? `(${subscriptionName})` : "");
+    const baseErrorMessage = `Failed to check the existence of resource group '${resourceGroupName}' in subscription '${subscriptionInfoString}'`;
+
+    if (error instanceof RestError) {
+      // Avoid sensitive information like request headers in the error message.
+      const rawErrorString = JSON.stringify({
+        code: error.code,
+        statusCode: error.statusCode,
+        body: error.body,
+        name: error.name,
+        message: error.message,
+      });
+
+      super(new.target.name, `${baseErrorMessage}, error: '${rawErrorString}'`, SolutionSource);
+    } else if (error instanceof Error) {
+      // Reuse the original error object to prevent losing the stack info
+      error.message = `${baseErrorMessage}, error: '${error.message}'`;
+      super(error, SolutionSource, new.target.name);
+    } else {
+      super(
+        new.target.name,
+        `${baseErrorMessage}, error: '${JSON.stringify(error)}'`,
+        SolutionSource
+      );
+    }
+  }
+}

--- a/packages/fx-core/src/plugins/solution/fx-solution/constants.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/constants.ts
@@ -235,7 +235,7 @@ export enum SolutionTelemetrySuccess {
 export const SolutionTelemetryComponentName = "solution";
 export const SolutionSource = "Solution";
 
-export class UnauthorizedToCheckResourceGroup extends UserError {
+export class UnauthorizedToCheckResourceGroupError extends UserError {
   constructor(resourceGroupName: string, subscriptionId: string, subscriptionName: string) {
     const subscriptionInfoString =
       subscriptionId + (subscriptionName.length > 0 ? `(${subscriptionName})` : "");
@@ -247,7 +247,7 @@ export class UnauthorizedToCheckResourceGroup extends UserError {
   }
 }
 
-export class FailedToCheckResourceGroupExistence extends UserError {
+export class FailedToCheckResourceGroupExistenceError extends UserError {
   constructor(
     error: unknown,
     resourceGroupName: string,

--- a/packages/fx-core/tests/plugins/solution/solution.provision.test.ts
+++ b/packages/fx-core/tests/plugins/solution/solution.provision.test.ts
@@ -55,6 +55,8 @@ import {
   SolutionError,
   SOLUTION_PROVISION_SUCCEEDED,
   WEB_APPLICATION_INFO_SOURCE,
+  UnauthorizedToCheckResourceGroup,
+  FailedToCheckResourceGroupExistence,
 } from "../../../src/plugins/solution/fx-solution/constants";
 import {
   FRONTEND_DOMAIN,
@@ -1065,7 +1067,7 @@ describe("before provision() asking for resource group info", () => {
       );
       // Assert
       expect(result.isErr());
-      expect(result._unsafeUnwrapErr().name === SolutionError.Unauthorized);
+      expect(result._unsafeUnwrapErr()).instanceOf(UnauthorizedToCheckResourceGroup);
     });
 
     it("Network error", async () => {
@@ -1080,7 +1082,24 @@ describe("before provision() asking for resource group info", () => {
       );
       // Assert
       expect(result.isErr());
+      expect(result._unsafeUnwrapErr()).instanceOf(FailedToCheckResourceGroupExistence);
       expect(result._unsafeUnwrapErr().message).to.contain("MockNetworkError");
+    });
+
+    it("Non-Error thrown", async () => {
+      // Arrange
+      upstreamResult = new Err<boolean, Error>("UnexpectedUnknownError" as unknown as Error);
+      // Act
+      const result = await checkResourceGroupExistence(
+        mockRmClient,
+        mockResourceGroupName,
+        mockSubscriptionId,
+        mockSubscriptionName
+      );
+      // Assert
+      expect(result.isErr());
+      expect(result._unsafeUnwrapErr()).instanceOf(FailedToCheckResourceGroupExistence);
+      expect(result._unsafeUnwrapErr().message).to.contain("UnexpectedUnknownError");
     });
   });
 });

--- a/packages/fx-core/tests/plugins/solution/solution.provision.test.ts
+++ b/packages/fx-core/tests/plugins/solution/solution.provision.test.ts
@@ -55,8 +55,8 @@ import {
   SolutionError,
   SOLUTION_PROVISION_SUCCEEDED,
   WEB_APPLICATION_INFO_SOURCE,
-  UnauthorizedToCheckResourceGroup,
-  FailedToCheckResourceGroupExistence,
+  UnauthorizedToCheckResourceGroupError,
+  FailedToCheckResourceGroupExistenceError,
 } from "../../../src/plugins/solution/fx-solution/constants";
 import {
   FRONTEND_DOMAIN,
@@ -1067,7 +1067,7 @@ describe("before provision() asking for resource group info", () => {
       );
       // Assert
       expect(result.isErr());
-      expect(result._unsafeUnwrapErr()).instanceOf(UnauthorizedToCheckResourceGroup);
+      expect(result._unsafeUnwrapErr()).instanceOf(UnauthorizedToCheckResourceGroupError);
     });
 
     it("Network error", async () => {
@@ -1082,7 +1082,7 @@ describe("before provision() asking for resource group info", () => {
       );
       // Assert
       expect(result.isErr());
-      expect(result._unsafeUnwrapErr()).instanceOf(FailedToCheckResourceGroupExistence);
+      expect(result._unsafeUnwrapErr()).instanceOf(FailedToCheckResourceGroupExistenceError);
       expect(result._unsafeUnwrapErr().message).to.contain("MockNetworkError");
     });
 
@@ -1098,7 +1098,7 @@ describe("before provision() asking for resource group info", () => {
       );
       // Assert
       expect(result.isErr());
-      expect(result._unsafeUnwrapErr()).instanceOf(FailedToCheckResourceGroupExistence);
+      expect(result._unsafeUnwrapErr()).instanceOf(FailedToCheckResourceGroupExistenceError);
       expect(result._unsafeUnwrapErr().message).to.contain("UnexpectedUnknownError");
     });
   });

--- a/packages/fx-core/tests/plugins/solution/solution.provision.test.ts
+++ b/packages/fx-core/tests/plugins/solution/solution.provision.test.ts
@@ -42,6 +42,8 @@ import {
   Inputs,
   TokenProvider,
   v2,
+  Ok,
+  Err,
 } from "@microsoft/teamsfx-api";
 import * as sinon from "sinon";
 import fs, { PathLike } from "fs-extra";
@@ -87,7 +89,10 @@ import { AadAppForTeamsPlugin } from "../../../src/plugins/resource/aad";
 import { newEnvInfo } from "../../../src/core/tools";
 import { isArmSupportEnabled } from "../../../src/common/tools";
 import Container from "typedi";
-import { askResourceGroupInfo } from "../../../src/plugins/solution/fx-solution/commonQuestions";
+import {
+  askResourceGroupInfo,
+  checkResourceGroupExistence,
+} from "../../../src/plugins/solution/fx-solution/commonQuestions";
 import { ResourceManagementModels } from "@azure/arm-resources";
 import { CoreQuestionNames } from "../../../src/core/question";
 import { Subscriptions } from "@azure/arm-subscriptions";
@@ -973,6 +978,110 @@ describe("before provision() asking for resource group info", () => {
     expect(resourceGroupInfoResult._unsafeUnwrapErr().name).to.equal(
       SolutionError.FailedToListResourceGroup
     );
+  });
+
+  describe("checkResourceGroupExistence", () => {
+    const mockSubscriptionId = "3b8db46f-4298-458a-ac36-e04e7e66b68f";
+    const mockSubscriptionName = "Test Subscription";
+    const mockResourceGroupName = "mock-rg";
+    let upstreamResult: Result<boolean, Error> = new Ok<boolean, Error>(true);
+    let mockRmClient: ResourceManagementClient;
+
+    beforeEach(async () => {
+      const mockedCtx = mockCtxWithResourceGroupQuestions(false, mockResourceGroupName);
+      mocker
+        .stub(ResourceGroups.prototype, "checkExistence")
+        .callsFake(
+          async (
+            resourceGroupName: string,
+            options?: msRest.RequestOptionsBase
+          ): Promise<armResources.ResourceManagementModels.ResourceGroupsCheckExistenceResponse> => {
+            if (upstreamResult.isOk()) {
+              return {
+                body: upstreamResult.value,
+              } as armResources.ResourceManagementModels.ResourceGroupsCheckExistenceResponse;
+            } else {
+              throw upstreamResult.error;
+            }
+          }
+        );
+
+      mockedCtx.projectSettings = {
+        appName: "my app",
+        projectId: uuid.v4(),
+        solutionSettings: {
+          hostType: HostTypeOptionAzure.id,
+          name: "azure",
+          version: "1.0",
+          activeResourcePlugins: [],
+        },
+      };
+      const token = await mockedCtx.azureAccountProvider?.getAccountCredentialAsync();
+      expect(token).to.exist;
+      mockRmClient = new ResourceManagementClient(token!, mockSubscriptionId);
+    });
+
+    it("Exists", async () => {
+      // Arrange
+      upstreamResult = new Ok<boolean, Error>(true);
+      // Act
+      const result = await checkResourceGroupExistence(
+        mockRmClient,
+        mockResourceGroupName,
+        mockSubscriptionId,
+        mockSubscriptionName
+      );
+      // Assert
+      expect(result.isOk());
+      expect(result._unsafeUnwrap()).to.be.true;
+    });
+
+    it("Not exist", async () => {
+      // Arrange
+      upstreamResult = new Ok<boolean, Error>(false);
+      // Act
+      const result = await checkResourceGroupExistence(
+        mockRmClient,
+        mockResourceGroupName,
+        mockSubscriptionId,
+        mockSubscriptionName
+      );
+      // Assert
+      expect(result.isOk());
+      expect(result._unsafeUnwrap()).to.be.false;
+    });
+
+    it("Unauthorized", async () => {
+      // Arrange
+      upstreamResult = new Err<boolean, Error>(
+        new msRest.RestError("Unauthorized", "RestError", 403)
+      );
+      // Act
+      const result = await checkResourceGroupExistence(
+        mockRmClient,
+        mockResourceGroupName,
+        mockSubscriptionId,
+        mockSubscriptionName
+      );
+      // Assert
+      expect(result.isErr());
+      expect(result._unsafeUnwrapErr().name === SolutionError.Unauthorized);
+    });
+
+    it("Network error", async () => {
+      // Arrange
+      upstreamResult = new Err<boolean, Error>(new Error("MockNetworkError"));
+      // Act
+      const result = await checkResourceGroupExistence(
+        mockRmClient,
+        mockResourceGroupName,
+        mockSubscriptionId,
+        mockSubscriptionName
+      );
+      // Assert
+      expect(result.isErr());
+      expect(result._unsafeUnwrapErr().message).to.contain("MockNetworkError");
+    });
   });
 });
 


### PR DESCRIPTION
When selecting resource group before provision, and if the user does not have permission to acess current selected subscription, it will display a more user friendly error message.
![image](https://user-images.githubusercontent.com/9698542/141047125-3e397173-2411-42bd-84d4-7ec2848bbe83.png)

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/12545873