### PR TITLE
chore: add keyvault reference identity for keyvault support

### DIFF
--- a/packages/fx-core/templates/plugins/resource/bot/bicep/botProvision.template.bicep
+++ b/packages/fx-core/templates/plugins/resource/bot/bicep/botProvision.template.bicep
@@ -34,7 +34,7 @@ resource botServiceMsTeamsChannel 'Microsoft.BotService/botServices/channels@202
   }
 }
 
-resource serverfarm 'Microsoft.Web/serverfarms@2021-01-01' = {
+resource serverfarm 'Microsoft.Web/serverfarms@2021-02-01' = {
   kind: 'app'
   location: resourceGroup().location
   name: serverfarmsName
@@ -43,12 +43,13 @@ resource serverfarm 'Microsoft.Web/serverfarms@2021-01-01' = {
   }
 }
 
-resource webApp 'Microsoft.Web/sites@2021-01-01' = {
+resource webApp 'Microsoft.Web/sites@2021-02-01' = {
   kind: 'app'
   location: resourceGroup().location
   name: webAppName
   properties: {
     serverFarmId: serverfarm.id
+    keyVaultReferenceIdentity: userAssignedIdentityId
     siteConfig: {
       appSettings: [
         {

--- a/packages/fx-core/templates/plugins/resource/function/bicep/functionProvision.template.bicep
+++ b/packages/fx-core/templates/plugins/resource/function/bicep/functionProvision.template.bicep
@@ -7,7 +7,7 @@ var serverfarmsName = contains(provisionParameters, 'functionServerfarmsName') ?
 var functionAppName = contains(provisionParameters, 'functionWebappName') ? provisionParameters['functionWebappName'] : '${resourceBaseName}-function-webapp'
 var storageName = contains(provisionParameters, 'functionStorageName') ? provisionParameters['functionStorageName'] : 'functionstg${uniqueString(resourceBaseName)}'
 
-resource serverfarms 'Microsoft.Web/serverfarms@2021-01-15' = {
+resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   kind: 'functionapp'
   location: resourceGroup().location
@@ -16,12 +16,13 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-01-15' = {
   }
 }
 
-resource functionApp 'Microsoft.Web/sites@2021-01-15' = {
+resource functionApp 'Microsoft.Web/sites@2021-02-01' = {
   name: functionAppName
   kind: 'functionapp'
   location: resourceGroup().location
   properties: {
     serverFarmId: serverfarms.id
+    keyVaultReferenceIdentity: userAssignedIdentityId
     siteConfig: {
       appSettings: [
         {

--- a/packages/fx-core/templates/plugins/resource/simpleauth/bicep/simpleAuthProvision.template.v2.bicep
+++ b/packages/fx-core/templates/plugins/resource/simpleauth/bicep/simpleAuthProvision.template.v2.bicep
@@ -7,7 +7,7 @@ var serverFarmsName = contains(provisionParameters, 'simpleAuthServerFarmsName')
 var webAppName = contains(provisionParameters, 'simpleAuthWebAppName') ? provisionParameters['simpleAuthWebAppName'] : '${resourceBaseName}-simpleAuth-webapp'
 var simpelAuthPackageUri = contains(provisionParameters, 'simpleAuthPackageUri') ? provisionParameters['simpleAuthPackageUri'] : 'https://github.com/OfficeDev/TeamsFx/releases/download/simpleauth@0.1.0/Microsoft.TeamsFx.SimpleAuth_0.1.0.zip'
 
-resource serverFarms 'Microsoft.Web/serverfarms@2020-06-01' = {
+resource serverFarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverFarmsName
   location: resourceGroup().location
   sku: {
@@ -16,12 +16,13 @@ resource serverFarms 'Microsoft.Web/serverfarms@2020-06-01' = {
   kind: 'app'
 }
 
-resource webApp 'Microsoft.Web/sites@2020-06-01' = {
+resource webApp 'Microsoft.Web/sites@2021-02-01' = {
   kind: 'app'
   name: webAppName
   location: resourceGroup().location
   properties: {
     serverFarmId: serverFarms.id
+    keyVaultReferenceIdentity: userAssignedIdentityId
   }
   identity: {
     type: 'UserAssigned'
@@ -31,7 +32,7 @@ resource webApp 'Microsoft.Web/sites@2020-06-01' = {
   }
 }
 
-resource simpleAuthDeploy 'Microsoft.Web/sites/extensions@2021-01-15' = {
+resource simpleAuthDeploy 'Microsoft.Web/sites/extensions@2021-02-01' = {
   parent: webApp
   name: 'MSDeploy'
   properties: {

--- a/packages/fx-core/tests/plugins/resource/bot/unit/expectedBicepFiles/botProvision.result.bicep
+++ b/packages/fx-core/tests/plugins/resource/bot/unit/expectedBicepFiles/botProvision.result.bicep
@@ -34,7 +34,7 @@ resource botServiceMsTeamsChannel 'Microsoft.BotService/botServices/channels@202
   }
 }
 
-resource serverfarm 'Microsoft.Web/serverfarms@2021-01-01' = {
+resource serverfarm 'Microsoft.Web/serverfarms@2021-02-01' = {
   kind: 'app'
   location: resourceGroup().location
   name: serverfarmsName
@@ -43,12 +43,13 @@ resource serverfarm 'Microsoft.Web/serverfarms@2021-01-01' = {
   }
 }
 
-resource webApp 'Microsoft.Web/sites@2021-01-01' = {
+resource webApp 'Microsoft.Web/sites@2021-02-01' = {
   kind: 'app'
   location: resourceGroup().location
   name: webAppName
   properties: {
     serverFarmId: serverfarm.id
+    keyVaultReferenceIdentity: userAssignedIdentityId
     siteConfig: {
       appSettings: [
         {

--- a/packages/fx-core/tests/plugins/resource/function/unit/expectedBicepFiles/functionProvision.result.bicep
+++ b/packages/fx-core/tests/plugins/resource/function/unit/expectedBicepFiles/functionProvision.result.bicep
@@ -7,7 +7,7 @@ var serverfarmsName = contains(provisionParameters, 'functionServerfarmsName') ?
 var functionAppName = contains(provisionParameters, 'functionWebappName') ? provisionParameters['functionWebappName'] : '${resourceBaseName}-function-webapp'
 var storageName = contains(provisionParameters, 'functionStorageName') ? provisionParameters['functionStorageName'] : 'functionstg${uniqueString(resourceBaseName)}'
 
-resource serverfarms 'Microsoft.Web/serverfarms@2021-01-15' = {
+resource serverfarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverfarmsName
   kind: 'functionapp'
   location: resourceGroup().location
@@ -16,12 +16,13 @@ resource serverfarms 'Microsoft.Web/serverfarms@2021-01-15' = {
   }
 }
 
-resource functionApp 'Microsoft.Web/sites@2021-01-15' = {
+resource functionApp 'Microsoft.Web/sites@2021-02-01' = {
   name: functionAppName
   kind: 'functionapp'
   location: resourceGroup().location
   properties: {
     serverFarmId: serverfarms.id
+    keyVaultReferenceIdentity: userAssignedIdentityId
     siteConfig: {
       appSettings: [
         {

--- a/packages/fx-core/tests/plugins/resource/simpleauth/unit/expectedBicepFiles/simpleAuthProvision.result.v2.bicep
+++ b/packages/fx-core/tests/plugins/resource/simpleauth/unit/expectedBicepFiles/simpleAuthProvision.result.v2.bicep
@@ -7,7 +7,7 @@ var serverFarmsName = contains(provisionParameters, 'simpleAuthServerFarmsName')
 var webAppName = contains(provisionParameters, 'simpleAuthWebAppName') ? provisionParameters['simpleAuthWebAppName'] : '${resourceBaseName}-simpleAuth-webapp'
 var simpelAuthPackageUri = contains(provisionParameters, 'simpleAuthPackageUri') ? provisionParameters['simpleAuthPackageUri'] : 'https://github.com/OfficeDev/TeamsFx/releases/download/simpleauth@0.1.0/Microsoft.TeamsFx.SimpleAuth_0.1.0.zip'
 
-resource serverFarms 'Microsoft.Web/serverfarms@2020-06-01' = {
+resource serverFarms 'Microsoft.Web/serverfarms@2021-02-01' = {
   name: serverFarmsName
   location: resourceGroup().location
   sku: {
@@ -16,12 +16,13 @@ resource serverFarms 'Microsoft.Web/serverfarms@2020-06-01' = {
   kind: 'app'
 }
 
-resource webApp 'Microsoft.Web/sites@2020-06-01' = {
+resource webApp 'Microsoft.Web/sites@2021-02-01' = {
   kind: 'app'
   name: webAppName
   location: resourceGroup().location
   properties: {
     serverFarmId: serverFarms.id
+    keyVaultReferenceIdentity: userAssignedIdentityId
   }
   identity: {
     type: 'UserAssigned'
@@ -31,7 +32,7 @@ resource webApp 'Microsoft.Web/sites@2020-06-01' = {
   }
 }
 
-resource simpleAuthDeploy 'Microsoft.Web/sites/extensions@2021-01-15' = {
+resource simpleAuthDeploy 'Microsoft.Web/sites/extensions@2021-02-01' = {
   parent: webApp
   name: 'MSDeploy'
   properties: {


### PR DESCRIPTION
Due to a service issue of Azure Web App / Function, we cannot config keyvault reference identity via Azure Web App / Function config API. We need to add keyvault reference identity in advance so users can adopt the key vault feature smoothly. @formulahendry will work with Azure support team on the issue we found.

Changes:
1. Use latest service API version
2. Config Azure Web App / Function to use user assigned identity to access keyvault