### PR TITLE
fix: local manifest migration

### DIFF
--- a/packages/fx-core/src/core/middleware/projectMigrator.ts
+++ b/packages/fx-core/src/core/middleware/projectMigrator.ts
@@ -47,7 +47,7 @@ import {
   HostTypeOptionSPFx,
   MessageExtensionItem,
 } from "../../plugins/solution/fx-solution/question";
-import { createLocalManifest, createManifest } from "../../plugins/resource/appstudio/plugin";
+import { createManifest } from "../../plugins/resource/appstudio/plugin";
 import { loadSolutionContext } from "./envInfoLoader";
 import { ResourcePlugins } from "../../common/constants";
 import { getActivatedResourcePlugins } from "../../plugins/solution/fx-solution/ResourcePluginContainer";
@@ -57,6 +57,7 @@ import {
   MANIFEST_TEMPLATE,
   REMOTE_MANIFEST,
 } from "../../plugins/resource/appstudio/constants";
+import { getLocalAppName } from "../../plugins/resource/appstudio/utils/utils";
 import {
   Component,
   ProjectMigratorGuideStatus,
@@ -380,7 +381,7 @@ async function generateLocalTemplate(manifestString: string) {
   const manifest: TeamsAppManifest = JSON.parse(manifestString);
   manifest.name.full =
     (manifest.name.full ? manifest.name.full : manifest.name.short) + "-local-debug";
-  manifest.name.short = manifest.name.short.substr(0, 18) + "-local-debug";
+  manifest.name.short = getLocalAppName(manifest.name.short);
   manifest.id = "{{localSettings.teamsApp.teamsAppId}}";
   return manifest;
 }
@@ -474,17 +475,7 @@ async function migrateMultiEnv(projectPath: string): Promise<void> {
   }
 
   // generate manifest.local.template.json
-  // TODO: use generateLocalTemplate instead of create
-  const localManifest: TeamsAppManifest = migrateFromV1
-    ? await generateLocalTemplate(JSON.stringify(manifest))
-    : await createLocalManifest(
-        appName,
-        hasFrontend,
-        hasBotCapability,
-        hasMessageExtensionCapability,
-        isSPFx,
-        false
-      );
+  const localManifest: TeamsAppManifest = await generateLocalTemplate(JSON.stringify(manifest));
   const targetLocalManifestFile = path.join(templateAppPackage, MANIFEST_LOCAL);
   await fs.writeFile(targetLocalManifestFile, JSON.stringify(localManifest, null, 4));
 

--- a/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
@@ -105,7 +105,7 @@ import { v4 } from "uuid";
 import isUUID from "validator/lib/isUUID";
 import { ResourcePermission, TeamsAppAdmin } from "../../../common/permissionInterface";
 import Mustache from "mustache";
-import { getCustomizedKeys, replaceConfigValue } from "./utils/utils";
+import { getCustomizedKeys, getLocalAppName, replaceConfigValue } from "./utils/utils";
 import { TelemetryPropertyKey } from "./utils/telemetry";
 
 export class AppStudioPluginImpl {
@@ -201,13 +201,7 @@ export class AppStudioPluginImpl {
       const manifestString = Mustache.render(JSON.stringify(manifest), view);
       manifest = JSON.parse(manifestString);
     } else {
-      const suffix = "-local-debug";
-      let appName = ctx.projectSettings!.appName;
-      if (suffix.length + appName.length <= TEAMS_APP_SHORT_NAME_MAX_LENGTH) {
-        appName = appName + suffix;
-      }
-      manifest.name.short = appName;
-
+      manifest.name.short = getLocalAppName(ctx.projectSettings!.appName);
       manifest.id = localTeamsAppID ?? "";
 
       if (manifest.configurableTabs) {
@@ -1723,14 +1717,9 @@ export class AppStudioPluginImpl {
     const appDefinition = this.convertToAppDefinition(updatedManifest, false);
 
     if (isLocalDebug && !isMultiEnvEnabled()) {
-      const suffix = "-local-debug";
-      if (
-        suffix.length + (appDefinition.shortName ? appDefinition.shortName.length : 0) <=
-        TEAMS_APP_SHORT_NAME_MAX_LENGTH
-      ) {
-        appDefinition.shortName = appDefinition.shortName + suffix;
-        appDefinition.appName = appDefinition.shortName;
-      }
+      const appName = getLocalAppName(appDefinition.shortName ?? "");
+      appDefinition.shortName = appName;
+      appDefinition.appName = appName;
     }
 
     return ok([appDefinition, updatedManifest]);

--- a/packages/fx-core/src/plugins/resource/appstudio/utils/utils.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/utils/utils.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+import { TEAMS_APP_SHORT_NAME_MAX_LENGTH } from "../constants";
 
 export function replaceConfigValue(config: string, id: string, value: string): string {
   if (config && id && value) {
@@ -30,4 +31,12 @@ export function getCustomizedKeys(prefix: string, manifest: any): string[] {
     }
   }
   return keys;
+}
+
+export function getLocalAppName(appName: string): string {
+  const suffix = "-local-debug";
+  if (suffix.length + appName.length <= TEAMS_APP_SHORT_NAME_MAX_LENGTH) {
+    appName = appName + suffix;
+  }
+  return appName;
 }


### PR DESCRIPTION
1) Generate local manifest template from manifest.source.json, rather than creating a new one.

2) get local app name