### PR TITLE
fix: make getLocalDebugEnvs readonly operation

### DIFF
--- a/packages/fx-core/src/plugins/resource/localdebug/util/localService.ts
+++ b/packages/fx-core/src/plugins/resource/localdebug/util/localService.ts
@@ -8,6 +8,10 @@ import * as os from "os";
 import * as path from "path";
 import { ConfigFolderName } from "@microsoft/teamsfx-api";
 
+export function getAuthServiceFolder(): string {
+  return `${os.homedir()}/.${ConfigFolderName}/localauth`;
+}
+
 export async function prepareLocalAuthService(zipPath: string): Promise<string> {
   const toolkitHome = `${os.homedir()}/.${ConfigFolderName}`;
   const zipFolder = path.dirname(zipPath);

--- a/packages/fx-core/tests/plugins/resource/localdebug/unit/index.test.ts
+++ b/packages/fx-core/tests/plugins/resource/localdebug/unit/index.test.ts
@@ -64,14 +64,14 @@ describe(LocalDebugPluginInfo.pluginName, () => {
         numConfigurations: 5,
         numCompounds: 2,
         numTasks: 9,
-        numLocalEnvs: isMultiEnvEnabled() ? 29 : 30,
+        numLocalEnvs: isMultiEnvEnabled() ? 30 : 30,
       },
       {
         programmingLanguage: "typescript",
         numConfigurations: 5,
         numCompounds: 2,
         numTasks: 9,
-        numLocalEnvs: isMultiEnvEnabled() ? 29 : 30,
+        numLocalEnvs: isMultiEnvEnabled() ? 30 : 30,
       },
     ];
     parameters1.forEach((parameter: TestParameter) => {
@@ -127,14 +127,14 @@ describe(LocalDebugPluginInfo.pluginName, () => {
         numConfigurations: 4,
         numCompounds: 2,
         numTasks: 6,
-        numLocalEnvs: isMultiEnvEnabled() ? 15 : 16,
+        numLocalEnvs: isMultiEnvEnabled() ? 16 : 16,
       },
       {
         programmingLanguage: "typescript",
         numConfigurations: 4,
         numCompounds: 2,
         numTasks: 6,
-        numLocalEnvs: isMultiEnvEnabled() ? 15 : 16,
+        numLocalEnvs: isMultiEnvEnabled() ? 16 : 16,
       },
     ];
     parameters2.forEach((parameter) => {
@@ -239,14 +239,14 @@ describe(LocalDebugPluginInfo.pluginName, () => {
         numConfigurations: 6,
         numCompounds: 2,
         numTasks: 12,
-        numLocalEnvs: isMultiEnvEnabled() ? 41 : 44,
+        numLocalEnvs: isMultiEnvEnabled() ? 42 : 44,
       },
       {
         programmingLanguage: "typescript",
         numConfigurations: 6,
         numCompounds: 2,
         numTasks: 12,
-        numLocalEnvs: isMultiEnvEnabled() ? 41 : 44,
+        numLocalEnvs: isMultiEnvEnabled() ? 42 : 44,
       },
     ];
     parameters4.forEach((parameter) => {
@@ -303,14 +303,14 @@ describe(LocalDebugPluginInfo.pluginName, () => {
         numConfigurations: 5,
         numCompounds: 2,
         numTasks: 9,
-        numLocalEnvs: isMultiEnvEnabled() ? 27 : 30,
+        numLocalEnvs: isMultiEnvEnabled() ? 28 : 30,
       },
       {
         programmingLanguage: "typescript",
         numConfigurations: 5,
         numCompounds: 2,
         numTasks: 9,
-        numLocalEnvs: isMultiEnvEnabled() ? 27 : 30,
+        numLocalEnvs: isMultiEnvEnabled() ? 28 : 30,
       },
     ];
     parameters5.forEach((parameter) => {

--- a/packages/fx-core/tests/plugins/resource/localdebug/unit/localService.test.ts
+++ b/packages/fx-core/tests/plugins/resource/localdebug/unit/localService.test.ts
@@ -11,7 +11,10 @@ import * as fs from "fs-extra";
 import os from "os";
 import * as path from "path";
 
-import { prepareLocalAuthService } from "../../../../../src/plugins/resource/localdebug/util/localService";
+import {
+  getAuthServiceFolder,
+  prepareLocalAuthService,
+} from "../../../../../src/plugins/resource/localdebug/util/localService";
 import { ConfigFolderName } from "@microsoft/teamsfx-api";
 
 chai.use(chaiAsPromised);
@@ -86,6 +89,11 @@ describe("localService", () => {
       chai.assert.isFalse(
         fs.pathExistsSync(`${fakeHomeDir}/.${ConfigFolderName}/localauth/test.dll`)
       );
+    });
+
+    it("auth service folder", () => {
+      const localAuthFolder = getAuthServiceFolder();
+      chai.assert.equal(localAuthFolder, `${fakeHomeDir}/.${ConfigFolderName}/localauth`);
     });
   });
 });


### PR DESCRIPTION
Make `getLocalDebugEnvs` a read-only operation so it could be called before `localDebug`.
(This fixes ADO bug 12514524)