### PR TITLE
chore: localdebug plugin to check insider flag instead of mocking it

### DIFF
--- a/packages/fx-core/tests/plugins/resource/localdebug/unit/index.test.ts
+++ b/packages/fx-core/tests/plugins/resource/localdebug/unit/index.test.ts
@@ -15,7 +15,6 @@ import { LocalDebugPluginInfo } from "../../../../../src/plugins/resource/locald
 import { LocalDebugPlugin } from "../../../../../src/plugins/resource/localdebug";
 import * as uuid from "uuid";
 import { newEnvInfo } from "../../../../../src/core/tools";
-import { FeatureFlagName } from "../../../../../src/common/constants";
 import { isMultiEnvEnabled } from "../../../../../src";
 chai.use(chaiAsPromised);
 
@@ -40,7 +39,6 @@ describe(LocalDebugPluginInfo.pluginName, () => {
   describe("scaffold", () => {
     let pluginContext: PluginContext;
     let plugin: LocalDebugPlugin;
-    let flagInsiderPreview: string | undefined;
 
     beforeEach(() => {
       pluginContext = {
@@ -51,11 +49,6 @@ describe(LocalDebugPluginInfo.pluginName, () => {
       } as PluginContext;
       plugin = new LocalDebugPlugin();
       fs.emptyDirSync(pluginContext.root);
-      flagInsiderPreview = process.env[FeatureFlagName.InsiderPreview];
-    });
-
-    afterEach(() => {
-      process.env[FeatureFlagName.InsiderPreview] = flagInsiderPreview;
     });
 
     const parameters1: TestParameter[] = [
@@ -486,6 +479,10 @@ describe(LocalDebugPluginInfo.pluginName, () => {
     });
 
     it("multi env", async () => {
+      if (!isMultiEnvEnabled()) {
+        // This feature only exists when insider preview is enabled
+        return;
+      }
       pluginContext.envInfo = newEnvInfo(
         undefined,
         undefined,
@@ -509,7 +506,6 @@ describe(LocalDebugPluginInfo.pluginName, () => {
 
       const packageJsonPath = path.resolve(__dirname, "../data/package.json");
       fs.writeFileSync(packageJsonPath, "{}");
-      process.env[FeatureFlagName.InsiderPreview] = "true";
 
       const result = await plugin.scaffold(pluginContext);
       chai.assert.isTrue(result.isOk());
@@ -558,7 +554,6 @@ describe(LocalDebugPluginInfo.pluginName, () => {
   describe("getLocalDebugEnvs", () => {
     let pluginContext: PluginContext;
     let plugin: LocalDebugPlugin;
-    let flagInsiderPreview: string | undefined;
 
     beforeEach(() => {
       pluginContext = {
@@ -569,14 +564,13 @@ describe(LocalDebugPluginInfo.pluginName, () => {
       } as PluginContext;
       plugin = new LocalDebugPlugin();
       fs.emptyDirSync(pluginContext.root);
-      flagInsiderPreview = process.env[FeatureFlagName.InsiderPreview];
-    });
-
-    afterEach(() => {
-      process.env[FeatureFlagName.InsiderPreview] = flagInsiderPreview;
     });
 
     it("multi-env", async () => {
+      if (!isMultiEnvEnabled()) {
+        // This feature only exists when insider preview is enabled
+        return;
+      }
       pluginContext.envInfo = newEnvInfo(
         undefined,
         undefined,
@@ -607,8 +601,6 @@ describe(LocalDebugPluginInfo.pluginName, () => {
       const botEnvPath = path.resolve(__dirname, "../data/bot/.env.teamsfx.local");
       fs.ensureFileSync(botEnvPath);
       fs.writeFileSync(botEnvPath, "FOO=BOT");
-
-      process.env[FeatureFlagName.InsiderPreview] = "true";
 
       const localEnvs = await plugin.getLocalDebugEnvs(pluginContext);
 


### PR DESCRIPTION
This is the prereqs of
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/12586858