### PR TITLE
feat: allow user to manually update manifest file

### DIFF
--- a/packages/fx-core/src/plugins/resource/appstudio/errors.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/errors.ts
@@ -181,4 +181,10 @@ export class AppStudioError {
     name: "UpdateManifestCancelled",
     message: (name: string) => `Update manifest with ID ${name} has been cancelled.`,
   };
+
+  public static readonly UpdateManifestWithInvalidAppError = {
+    name: "UpdateManifestWithInvalidAppError",
+    message: (appId: string) =>
+      `Cannot find teams app with id ${appId}. You must run local debug or provision first before updating manifest to Teams platform`,
+  };
 }

--- a/packages/fx-core/src/plugins/resource/appstudio/errors.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/errors.ts
@@ -65,6 +65,11 @@ export class AppStudioError {
     message: (errors: string[]) => `Validation error: \n ${errors.join("\n")}`,
   };
 
+  public static readonly UpdateManifestError = {
+    name: "UpdateManifestFailed",
+    message: (error: any) => (error.message ? error.message : "Update Teams App manifest failed!"),
+  };
+
   public static readonly GetLocalDebugConfigFailedError = {
     name: "GetLocalDebugConfigFailed",
     message: (domain: string, doProvision: boolean) =>
@@ -170,5 +175,10 @@ export class AppStudioError {
   public static readonly TeamsAppNotFoundError = {
     name: "TeamsAppNotFound",
     message: (appId: string) => `Cannot found teams app with id ${appId}`,
+  };
+
+  public static readonly UpdateManifestCancelError = {
+    name: "UpdateManifestCancelled",
+    message: (name: string) => `Update manifest with ID ${name} has been cancelled.`,
   };
 }

--- a/packages/fx-core/src/plugins/resource/appstudio/index.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/index.ts
@@ -236,6 +236,46 @@ export class AppStudioPlugin implements Plugin {
   }
 
   /**
+   * Update manifest file
+   */
+  public async updateManifest(
+    ctx: PluginContext,
+    isLocalDebug: boolean
+  ): Promise<Result<Void, FxError>> {
+    TelemetryUtils.init(ctx);
+    TelemetryUtils.sendStartEvent(TelemetryEventName.updateManifest);
+
+    try {
+      const res = await this.appStudioPluginImpl.updateManifest(ctx, isLocalDebug);
+      if (res.isErr()) {
+        TelemetryUtils.sendErrorEvent(
+          TelemetryEventName.updateManifest,
+          res.error,
+          this.appStudioPluginImpl.commonProperties
+        );
+        return ok(Void);
+      }
+      TelemetryUtils.sendSuccessEvent(
+        TelemetryEventName.updateManifest,
+        this.appStudioPluginImpl.commonProperties
+      );
+      return ok(Void);
+    } catch (error) {
+      TelemetryUtils.sendErrorEvent(
+        TelemetryEventName.updateManifest,
+        error,
+        this.appStudioPluginImpl.commonProperties
+      );
+      return err(
+        AppStudioResultFactory.SystemError(
+          AppStudioError.UpdateManifestError.name,
+          AppStudioError.UpdateManifestError.message(error)
+        )
+      );
+    }
+  }
+
+  /**
    * Publish the app to Teams App Catalog
    * @param {PluginContext} ctx
    * @returns {string[]} - Teams App ID in Teams app catalog
@@ -449,6 +489,8 @@ export class AppStudioPlugin implements Plugin {
     } else if (func.method === "getManifestTemplatePath") {
       const filePath = await this.appStudioPluginImpl.getManifestTemplatePath(ctx.root);
       return ok(filePath);
+    } else if (func.method === "updateManifest") {
+      return await this.updateManifest(ctx, func.params && func.params.envName === "local");
     }
     return err(
       new SystemError(

--- a/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
@@ -544,7 +544,7 @@ export class AppStudioPluginImpl {
       appDefinition,
       appStudioToken!,
       isLocalDebug,
-      !isLocalDebug,
+      false,
       appDirectory,
       teamsAppId,
       ctx.logProvider

--- a/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
@@ -107,6 +107,7 @@ import { ResourcePermission, TeamsAppAdmin } from "../../../common/permissionInt
 import Mustache from "mustache";
 import { getCustomizedKeys, getLocalAppName, replaceConfigValue } from "./utils/utils";
 import { TelemetryPropertyKey } from "./utils/telemetry";
+import _ from "lodash";
 
 export class AppStudioPluginImpl {
   public commonProperties: { [key: string]: string } = {};
@@ -441,6 +442,116 @@ export class AppStudioPluginImpl {
       }
     }
     return ok(await AppStudioClient.validateManifest(manifestString, appStudioToken!));
+  }
+
+  public async updateManifest(
+    ctx: PluginContext,
+    isLocalDebug: boolean
+  ): Promise<Result<string, FxError>> {
+    const teamsAppId = await this.getTeamsAppId(ctx, isLocalDebug);
+    let manifest: TeamsAppManifest;
+    let manifestString: string;
+    const appDirectory = await getAppDirectory(ctx.root);
+    const manifestPath = await this.getManifestTemplatePath(ctx.root, isLocalDebug);
+    const manifestResult = await this.reloadManifestAndCheckRequiredFields(manifestPath);
+    if (manifestResult.isErr()) {
+      throw manifestResult;
+    } else {
+      manifestString = JSON.stringify(manifestResult.value);
+    }
+
+    let appDefinition: IAppDefinition;
+    if (isSPFxProject(ctx.projectSettings)) {
+      let view: any;
+      if (isLocalDebug) {
+        view = {
+          localSettings: {
+            teamsApp: {
+              teamsAppId: teamsAppId,
+            },
+          },
+        };
+      } else {
+        view = {
+          config: ctx.envInfo.config,
+          state: {
+            "fx-resource-appstudio": {
+              teamsAppId: teamsAppId,
+            },
+          },
+        };
+      }
+
+      manifestString = Mustache.render(manifestString, view);
+      manifest = JSON.parse(manifestString);
+      appDefinition = this.convertToAppDefinition(manifest, false);
+    } else {
+      const appManifest = await this.getAppDefinitionAndManifest(ctx, isLocalDebug);
+      if (appManifest.isErr()) {
+        ctx.logProvider?.error("[Teams Toolkit] Update manifest failed!");
+        const isProvisionSucceeded = !!(ctx.envInfo.state
+          .get("solution")
+          ?.get(SOLUTION_PROVISION_SUCCEEDED) as boolean);
+        if (
+          appManifest.error.name === AppStudioError.GetRemoteConfigFailedError.name &&
+          !isProvisionSucceeded
+        ) {
+          throw AppStudioResultFactory.UserError(
+            AppStudioError.GetRemoteConfigError.name,
+            AppStudioError.GetRemoteConfigError.message("Update manifest failed")
+          );
+        } else {
+          throw appManifest.error;
+        }
+      }
+      [appDefinition] = appManifest.value;
+      manifest = appManifest.value[1];
+    }
+
+    const manifestFileName =
+      `${ctx.root}/${BuildFolderName}/${AppPackageFolderName}/manifest.` +
+      (isLocalDebug ? "local" : ctx.envInfo.envName) +
+      `.json`;
+    const existingManifest = await fs.readJSON(manifestFileName);
+    if (!_.isEqual(manifest, existingManifest)) {
+      const res = await ctx.ui?.showMessage(
+        "warn",
+        "Your configuration has been updated, do you want to regenerate the manifest file and upload?",
+        true,
+        "Regenerate and upload"
+      );
+      if (!(res?.isOk() && res.value === "Regenerate and upload")) {
+        const error = AppStudioResultFactory.UserError(
+          AppStudioError.UpdateManifestCancelError.name,
+          AppStudioError.UpdateManifestCancelError.message(manifest.name.short)
+        );
+        return err(error);
+      }
+      this.buildTeamsAppPackage(ctx, isLocalDebug);
+    }
+
+    const appStudioToken = await ctx?.appStudioToken?.getAccessToken();
+    const result = await this.updateApp(
+      ctx,
+      appDefinition,
+      appStudioToken!,
+      false,
+      false,
+      appDirectory,
+      teamsAppId,
+      ctx.logProvider
+    );
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    ctx.logProvider?.info(`Teams app updated: ${result.value}`);
+    ctx.ui?.showMessage(
+      "info",
+      `Successfully updated manifest for [${manifest.name.short}]`,
+      false
+    );
+    return ok(teamsAppId);
   }
 
   public async migrateV1Project(ctx: PluginContext): Promise<{ enableAuth: boolean }> {

--- a/packages/fx-core/src/plugins/resource/appstudio/utils/telemetry.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/utils/telemetry.ts
@@ -36,6 +36,7 @@ export enum TelemetryEventName {
   buildTeamsPackage = "build",
   publish = "publish",
   migrateV1Project = "migrate-v1-project",
+  updateManifest = "update-manifest",
   provision = "provision",
   checkPermission = "check-permission",
   grantPermission = "grant-permission",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -552,7 +552,7 @@
       },
       {
         "command": "fx-extension.updatePreviewFile",
-        "title": "Teams: Update manifest file",
+        "title": "Teams: Update manifest to Teams platform",
         "icon": "$(cloud-upload)",
         "enablement": "fx-extension.isMultiEnvEnabled"
       },

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -301,6 +301,11 @@
           "command": "fx-extension.openPreviewFile",
           "when": "resourceFilename == manifest.local.template.json || resourceFilename == manifest.remote.template.json",
           "group": "navigation"
+        },
+        {
+          "command": "fx-extension.updatePreviewFile",
+          "when": "resourceFilename =~ /manifest.[\\w]*.json/ && resourceDirname =~ /build/ && fx-extension.isMultiEnvEnabled",
+          "group": "navigation"
         }
       ],
       "commandPalette": [
@@ -544,6 +549,12 @@
         "command": "fx-extension.openSchema",
         "title": "Open manifest schema",
         "icon": "$(file-code)"
+      },
+      {
+        "command": "fx-extension.updatePreviewFile",
+        "title": "Teams: Update manifest file",
+        "icon": "$(cloud-upload)",
+        "enablement": "fx-extension.isMultiEnvEnabled"
       },
       {
         "command": "fx-extension.migrateV1Project",

--- a/packages/vscode-extension/src/codeLensProvider.ts
+++ b/packages/vscode-extension/src/codeLensProvider.ts
@@ -97,6 +97,14 @@ export class ManifestTemplateCodeLensProvider implements vscode.CodeLensProvider
   public provideCodeLenses(
     document: vscode.TextDocument
   ): vscode.ProviderResult<vscode.CodeLens[]> {
+    if (document.fileName.endsWith("template.json")) {
+      return this.computeTemplateCodeLenses(document);
+    } else {
+      return this.computePreviewCodeLenses(document);
+    }
+  }
+
+  private computeTemplateCodeLenses(document: vscode.TextDocument) {
     const codeLenses: vscode.CodeLens[] = [];
     const command = {
       title: "📝Preview",
@@ -147,6 +155,17 @@ export class ManifestTemplateCodeLensProvider implements vscode.CodeLensProvider
       }
     }
 
+    return codeLenses;
+  }
+
+  private computePreviewCodeLenses(document: vscode.TextDocument) {
+    const codeLenses: vscode.CodeLens[] = [];
+    const command = {
+      title: "🔄Update",
+      command: "fx-extension.updatePreviewFile",
+      arguments: [{ fsPath: document.fileName }, TelemetryTiggerFrom.CodeLens],
+    };
+    codeLenses.push(new vscode.CodeLens(new vscode.Range(0, 0, 0, 0), command));
     return codeLenses;
   }
 }

--- a/packages/vscode-extension/src/codeLensProvider.ts
+++ b/packages/vscode-extension/src/codeLensProvider.ts
@@ -161,7 +161,7 @@ export class ManifestTemplateCodeLensProvider implements vscode.CodeLensProvider
   private computePreviewCodeLenses(document: vscode.TextDocument) {
     const codeLenses: vscode.CodeLens[] = [];
     const command = {
-      title: "🔄Update",
+      title: "Update to Teams platform",
       command: "fx-extension.updatePreviewFile",
       arguments: [{ fsPath: document.fileName }, TelemetryTiggerFrom.CodeLens],
     };

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -37,6 +37,7 @@ import {
   StatesFolderName,
   AdaptiveCardsFolderName,
   AppPackageFolderName,
+  BuildFolderName,
 } from "@microsoft/teamsfx-api";
 import { ExtensionUpgrade } from "./utils/upgrade";
 import { registerEnvTreeHandler } from "./envTree";
@@ -279,6 +280,12 @@ export async function activate(context: vscode.ExtensionContext) {
   );
   context.subscriptions.push(openConfigCmd);
 
+  const updateManifestCmd = vscode.commands.registerCommand(
+    "fx-extension.updatePreviewFile",
+    (...args) => Correlator.run(handlers.updatePreviewManifest, args)
+  );
+  context.subscriptions.push(updateManifestCmd);
+
   const createNewEnvironment = vscode.commands.registerCommand(
     "fx-extension.addEnvironment",
     (...args) => Correlator.run(handlers.createNewEnvironment, args)
@@ -408,6 +415,11 @@ export async function activate(context: vscode.ExtensionContext) {
     scheme: "file",
     pattern: `**/manifest.*.template.json`,
   };
+  const manifestPreviewSelector = {
+    language: "json",
+    scheme: "file",
+    pattern: `**/${BuildFolderName}/${AppPackageFolderName}/manifest.*.json`,
+  };
 
   context.subscriptions.push(
     vscode.languages.registerCodeLensProvider(userDataSelector, codelensProvider)
@@ -424,6 +436,12 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.languages.registerCodeLensProvider(
       manifestTemplateSelecctor,
+      manifestTemplateCodeLensProvider
+    )
+  );
+  context.subscriptions.push(
+    vscode.languages.registerCodeLensProvider(
+      manifestPreviewSelector,
       manifestTemplateCodeLensProvider
     )
   );

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -622,7 +622,8 @@ export function detectVsCodeEnv(): VsCodeEnv {
 export async function runUserTask(
   func: Func,
   eventName: string,
-  ignoreEnvInfo: boolean
+  ignoreEnvInfo: boolean,
+  envName?: string
 ): Promise<Result<any, FxError>> {
   let result: Result<any, FxError> = ok(null);
   let inputs: Inputs | undefined;
@@ -634,6 +635,7 @@ export async function runUserTask(
 
     inputs = getSystemInputs();
     inputs.ignoreEnvInfo = ignoreEnvInfo;
+    inputs.env = envName;
     result = await core.executeUserTask(func, inputs);
   } catch (e) {
     result = wrapError(e);
@@ -895,6 +897,10 @@ function getTriggerFromProperty(args?: any[]) {
       return { [TelemetryProperty.TriggerFrom]: TelemetryTiggerFrom.TreeView };
     case TelemetryTiggerFrom.Webview:
       return { [TelemetryProperty.TriggerFrom]: TelemetryTiggerFrom.Webview };
+    case TelemetryTiggerFrom.CodeLens:
+      return { [TelemetryProperty.TriggerFrom]: TelemetryTiggerFrom.CodeLens };
+    case TelemetryTiggerFrom.EditorTitle:
+      return { [TelemetryProperty.TriggerFrom]: TelemetryTiggerFrom.EditorTitle };
     case TelemetryTiggerFrom.Other:
       return { [TelemetryProperty.TriggerFrom]: TelemetryTiggerFrom.Other };
     default:
@@ -1906,6 +1912,38 @@ export async function openConfigFile() {
   ExtTelemetry.sendTelemetryEvent(TelemetryEvent.OpenManifestConfig, {
     [TelemetryProperty.Success]: TelemetrySuccess.Yes,
   });
+}
+
+export async function updatePreviewManifest(args: any[]) {
+  ExtTelemetry.sendTelemetryEvent(
+    TelemetryEvent.UpdatePreviewManifestStart,
+    getTriggerFromProperty(args && args.length > 1 ? [args[1]] : undefined)
+  );
+  let env: string | undefined;
+  if (args && args.length > 0) {
+    const segments = args[0].fsPath.split(".");
+    env = segments[segments.length - 2];
+  }
+
+  if (env && env !== "local") {
+    const inputs = getSystemInputs();
+    inputs.env = env;
+    await core.activateEnv(inputs);
+  }
+  const func: Func = {
+    namespace: "fx-solution-azure/fx-resource-appstudio",
+    method: "updateManifest",
+    params: {
+      envName: env,
+    },
+  };
+
+  return await runUserTask(
+    func,
+    TelemetryEvent.UpdatePreviewManifest,
+    env && env === "local" ? true : false,
+    env
+  );
 }
 
 export async function signOutAzure(isFromTreeView: boolean) {

--- a/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
@@ -34,6 +34,9 @@ export enum TelemetryEvent {
   ValidateManifestStart = "validate-manifest-start",
   ValidateManifest = "validate-manifest",
 
+  UpdatePreviewManifestStart = "update-preview-manifest-start",
+  UpdatePreviewManifest = "update-preview-manifest",
+
   getManifestTemplatePath = "get-manifest-path",
 
   BuildStart = "build-start",
@@ -198,6 +201,7 @@ export enum TelemetryTiggerFrom {
   TreeView = "TreeView",
   Webview = "Webview",
   CodeLens = "CodeLens",
+  EditorTitle = "EditorTitle",
   Other = "Other",
   Unknow = "Unknow",
 }


### PR DESCRIPTION
User can update manifest file manually from editor context menu/preview file codelens/command palette.
For the former two scenarios, update current manifest. For  command palette, ask user to select env to update
![update manifest ](https://user-images.githubusercontent.com/73154171/142156660-84811be1-e3f4-4bc8-8b5e-52aa6977465a.gif)
