### PR TITLE
chore(template): add graph client as dependency

### DIFF
--- a/templates/function-base/js/default/package.json
+++ b/templates/function-base/js/default/package.json
@@ -5,6 +5,7 @@
         "start": "npx func start"
     },
     "dependencies": {
+        "@microsoft/microsoft-graph-client": "^3.0.0",
         "@microsoft/teamsfx": "^0.3.0",
         "isomorphic-fetch": "^3.0.0"
     }

--- a/templates/function-base/ts/default/package.json
+++ b/templates/function-base/ts/default/package.json
@@ -9,7 +9,7 @@
     },
     "dependencies": {
         "@azure/functions": "^1.2.2",
-        "@microsoft/microsoft-graph-client": "^2.2.1",
+        "@microsoft/microsoft-graph-client": "^3.0.0",
         "@microsoft/teamsfx": "^0.3.0",
         "isomorphic-fetch": "^3.0.0"
     },

--- a/templates/tab/js/default/package.json
+++ b/templates/tab/js/default/package.json
@@ -4,6 +4,7 @@
     "private": true,
     "dependencies": {
         "@fluentui/react-northstar": "^0.54.0",
+        "@microsoft/microsoft-graph-client": "^3.0.0",
         "@microsoft/teams-js": "^1.9.0",
         "@microsoft/teamsfx": "^0.3.0",
         "axios": "^0.21.1",

--- a/templates/tab/ts/default/package.json
+++ b/templates/tab/ts/default/package.json
@@ -4,6 +4,7 @@
     "private": true,
     "dependencies": {
         "@fluentui/react-northstar": "^0.54.0",
+        "@microsoft/microsoft-graph-client": "^3.0.0",
         "@microsoft/teams-js": "^1.9.0",
         "@microsoft/teamsfx": "^0.3.0",
         "axios": "^0.21.1",


### PR DESCRIPTION
Explicitly add `@microsoft/microsoft-graph-client` as dependency because SDK makes it as peer dependency.