### PR TITLE
fix: spfx deploy cause 401 error

### DIFF
--- a/packages/cli/src/commonlib/sharepointLogin.ts
+++ b/packages/cli/src/commonlib/sharepointLogin.ts
@@ -58,7 +58,9 @@ export class SharepointLogin extends login implements SharepointTokenProvider {
    * Get team access token
    */
   async getAccessToken(showDialog = true): Promise<string | undefined> {
+    let isFirstLogin = false;
     if (!SharepointLogin.codeFlowInstance) {
+      isFirstLogin = true;
       try {
         const scopes = await this.getScopes(showDialog);
         if (!scopes) {
@@ -76,7 +78,7 @@ export class SharepointLogin extends login implements SharepointTokenProvider {
     }
 
     await SharepointLogin.codeFlowInstance.reloadCache();
-    if (!SharepointLogin.codeFlowInstance.account) {
+    if (!isFirstLogin) {
       try {
         const scopes = await this.getScopes(showDialog);
         if (!scopes) {

--- a/packages/vscode-extension/src/commonlib/sharepointLogin.ts
+++ b/packages/vscode-extension/src/commonlib/sharepointLogin.ts
@@ -90,16 +90,14 @@ export class SharepointLogin extends login implements SharepointTokenProvider {
     }
 
     await SharepointLogin.codeFlowInstance.reloadCache();
-    if (!SharepointLogin.codeFlowInstance.account) {
-      try {
-        const scopes = await this.getScopes(showDialog);
-        if (!scopes) {
-          return undefined;
-        }
-        SharepointLogin.codeFlowInstance.scopes = scopes;
-      } catch (error) {
-        throw error;
+    try {
+      const scopes = await this.getScopes(showDialog);
+      if (!scopes) {
+        return undefined;
       }
+      SharepointLogin.codeFlowInstance.scopes = scopes;
+    } catch (error) {
+      throw error;
     }
     const accessToken = SharepointLogin.codeFlowInstance.getToken();
     return accessToken;

--- a/packages/vscode-extension/src/commonlib/sharepointLogin.ts
+++ b/packages/vscode-extension/src/commonlib/sharepointLogin.ts
@@ -72,7 +72,9 @@ export class SharepointLogin extends login implements SharepointTokenProvider {
    * Get sharepoint access token
    */
   async getAccessToken(showDialog = true): Promise<string | undefined> {
+    let isFirstLogin = false;
     if (!SharepointLogin.codeFlowInstance) {
+      isFirstLogin = true;
       try {
         const scopes = await this.getScopes(showDialog);
         if (!scopes) {
@@ -90,15 +92,18 @@ export class SharepointLogin extends login implements SharepointTokenProvider {
     }
 
     await SharepointLogin.codeFlowInstance.reloadCache();
-    try {
-      const scopes = await this.getScopes(showDialog);
-      if (!scopes) {
-        return undefined;
+    if (!isFirstLogin) {
+      try {
+        const scopes = await this.getScopes(showDialog);
+        if (!scopes) {
+          return undefined;
+        }
+        SharepointLogin.codeFlowInstance.scopes = scopes;
+      } catch (error) {
+        throw error;
       }
-      SharepointLogin.codeFlowInstance.scopes = scopes;
-    } catch (error) {
-      throw error;
     }
+
     const accessToken = SharepointLogin.codeFlowInstance.getToken();
     return accessToken;
   }


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/12587039?src=WorkItemMention&src-action=artifact_link

Root cause:
The scope is not updated if sharepoint.getAccessToken() called before user switch account.

E2E TEST: the token provider implementation for e2e is not the same with product code