### PR TITLE
fix: fix bicepChecker 401 error

### DIFF
--- a/packages/cli/src/commonlib/sharepointLogin.ts
+++ b/packages/cli/src/commonlib/sharepointLogin.ts
@@ -98,7 +98,7 @@ export class SharepointLogin extends login implements SharepointTokenProvider {
 
     if (accessToken.length > 0) {
       const response = await axios.get(GRAPH_TENANT_ENDPT, {
-        headers: { Authoriztaion: `Bearer ${accessToken}` },
+        headers: { Authorization: `Bearer ${accessToken}` },
       });
       return response.data.webUrl;
     }

--- a/packages/cli/src/commonlib/sharepointLogin.ts
+++ b/packages/cli/src/commonlib/sharepointLogin.ts
@@ -97,9 +97,9 @@ export class SharepointLogin extends login implements SharepointTokenProvider {
     const GRAPH_TENANT_ENDPT = "https://graph.microsoft.com/v1.0/sites/root?$select=webUrl";
 
     if (accessToken.length > 0) {
-      axios.defaults.headers.common.Authorization = `Bearer ${accessToken}`;
-
-      const response = await axios.get(GRAPH_TENANT_ENDPT);
+      const response = await axios.get(GRAPH_TENANT_ENDPT, {
+        headers: { Authoriztaion: `Bearer ${accessToken}` },
+      });
       return response.data.webUrl;
     }
     return "";

--- a/packages/cli/src/commonlib/sharepointLoginUserPassword.ts
+++ b/packages/cli/src/commonlib/sharepointLoginUserPassword.ts
@@ -99,7 +99,7 @@ export class SharepointTokenProviderUserPassword implements SharepointTokenProvi
 
     if (accessToken.length > 0) {
       const response = await axios.get(GRAPH_TENANT_ENDPT, {
-        headers: { Authoriztaion: `Bearer ${accessToken}` },
+        headers: { Authorization: `Bearer ${accessToken}` },
       });
       return response.data.webUrl;
     }

--- a/packages/cli/src/commonlib/sharepointLoginUserPassword.ts
+++ b/packages/cli/src/commonlib/sharepointLoginUserPassword.ts
@@ -98,9 +98,9 @@ export class SharepointTokenProviderUserPassword implements SharepointTokenProvi
     const GRAPH_TENANT_ENDPT = "https://graph.microsoft.com/v1.0/sites/root?$select=webUrl";
 
     if (accessToken.length > 0) {
-      axios.defaults.headers.common.Authorization = `Bearer ${accessToken}`;
-
-      const response = await axios.get(GRAPH_TENANT_ENDPT);
+      const response = await axios.get(GRAPH_TENANT_ENDPT, {
+        headers: { Authoriztaion: `Bearer ${accessToken}` },
+      });
       return response.data.webUrl;
     }
     return "";

--- a/packages/vscode-extension/src/commonlib/sharepointLogin.ts
+++ b/packages/vscode-extension/src/commonlib/sharepointLogin.ts
@@ -112,9 +112,9 @@ export class SharepointLogin extends login implements SharepointTokenProvider {
     const GRAPH_TENANT_ENDPT = "https://graph.microsoft.com/v1.0/sites/root?$select=webUrl";
 
     if (accessToken.length > 0) {
-      axios.defaults.headers.common.Authorization = `Bearer ${accessToken}`;
-
-      const response = await axios.get(GRAPH_TENANT_ENDPT);
+      const response = await axios.get(GRAPH_TENANT_ENDPT, {
+        headers: { Authoriztaion: `Bearer ${accessToken}` },
+      });
       return response.data.webUrl;
     }
     return "";

--- a/packages/vscode-extension/src/commonlib/sharepointLogin.ts
+++ b/packages/vscode-extension/src/commonlib/sharepointLogin.ts
@@ -113,7 +113,7 @@ export class SharepointLogin extends login implements SharepointTokenProvider {
 
     if (accessToken.length > 0) {
       const response = await axios.get(GRAPH_TENANT_ENDPT, {
-        headers: { Authoriztaion: `Bearer ${accessToken}` },
+        headers: { Authorization: `Bearer ${accessToken}` },
       });
       return response.data.webUrl;
     }


### PR DESCRIPTION
- Do not set axios.default because this will affect all axios instances globally
- SPFx sets a global `Authorization` headers, so when bicepChecker calls GitHub API (this is public API, and it does not need auth), it includes an Authorization header. GitHub will treat this as a invalid PAT and return a 401 error
- This will only happen in release package because SPFx login is in `vscode-extension` package and bicepChecker is in `core` package. After packaging, webpack will merge `axios` package in `vscode-extension` and `core` into one