### PR TITLE
chore(upgrade): save change log into correct folder

### DIFF
--- a/packages/fx-core/src/core/middleware/projectMigrator.ts
+++ b/packages/fx-core/src/core/middleware/projectMigrator.ts
@@ -354,9 +354,11 @@ async function generateUpgradeReport(ctx: CoreHookContext) {
   try {
     const inputs = ctx.arguments[ctx.arguments.length - 1] as Inputs;
     const projectPath = inputs.projectPath as string;
-    const target = path.join(projectPath, ".backup", upgradeReportName);
-    const source = path.resolve(path.join(getResourceFolder(), upgradeReportName));
-    await fs.copyFile(source, target);
+    if (backupFolder) {
+      const target = path.join(projectPath, backupFolder, upgradeReportName);
+      const source = path.resolve(path.join(getResourceFolder(), upgradeReportName));
+      await fs.copyFile(source, target);
+    }
   } catch (error) {
     // do nothing
   }


### PR DESCRIPTION
if `.backup` already existed in user's project, then upgrade changelog should be saved into `.teamsfx.backup`. 