### PR TITLE
chore(upgrade): enable codelens to view userdata in backup folder

### DIFF
--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -358,9 +358,7 @@ export async function activate(context: vscode.ExtensionContext) {
   const userDataSelector = {
     language: "plaintext",
     scheme: "file",
-    pattern: isMultiEnvEnabled()
-      ? `**/.${ConfigFolderName}/${StatesFolderName}/*.userdata`
-      : `**/.${ConfigFolderName}/*.userdata`,
+    pattern: "**/*.userdata",
   };
   const localDebugDataSelector = {
     language: "json",


### PR DESCRIPTION
Fix upgrade [bug 12554464 : Do not know what to do for original local debug resources ](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_dashboards/dashboard/8bb5e24b-9df9-44a7-b32d-6f073b8ce2f8).

**Mitigation**: 
As we already backed up original local debug config in `.backup` folder, they can check the previous local debug info in related config files (`env.default.json`, `local.env`, `default.userdata`), and clean up manually if needed. For secret data, we also support codelens to let user retrieve the previous app secret, e.g. AAD client secret, SQL password, etc.

![image](https://user-images.githubusercontent.com/10163840/142349880-7a31f781-d1f1-4fa8-a1f3-571ba81b14fb.png)
