### PR TITLE
fix: bicepChecker will stuck on write error

### DIFF
--- a/packages/fx-core/src/plugins/solution/fx-solution/utils/depsChecker/bicepChecker.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/utils/depsChecker/bicepChecker.ts
@@ -184,12 +184,11 @@ class BicepChecker {
 
     const bicepReader: Readable = axiosResponse.data;
     const bicepWriter: Writable = fs.createWriteStream(installDir);
-    try {
-      await this.writeBicepBits(bicepWriter, bicepReader);
-      fs.chmodSync(installDir, 0o755);
-    } finally {
-      await this.closeStream(bicepWriter);
-    }
+    // https://nodejs.org/api/fs.html#fscreatewritestreampath-options
+    // on 'error' or 'finish' the file descriptor will be closed automatically
+    // calling writer.end() again will hang
+    await this.writeBicepBits(bicepWriter, bicepReader);
+    fs.chmodSync(installDir, 0o755);
   }
 
   private async writeBicepBits(writer: Writable, reader: Readable): Promise<void> {
@@ -199,12 +198,6 @@ class BicepChecker {
         if (err) reject(err);
         else resolve();
       });
-    });
-  }
-
-  private async closeStream(writer: Writable): Promise<void> {
-    return new Promise((resolve: (value: void) => void): void => {
-      writer.end(() => resolve());
     });
   }
 


### PR DESCRIPTION
The bug is: when it fails to write to `.fx/bin/bicep/bicep` (e.g. no permission or no space), the provision will be stuck forever.

Remove this defensive `writer.end()` because it will stuck on error

This is a possible node.js bug: https://github.com/nodejs/node/issues/40851