### PR TITLE
fix(env-checker): fallback to use hardcoded bicep version if Github API fails

### DIFF
--- a/packages/fx-core/src/plugins/solution/fx-solution/utils/depsChecker/bicepChecker.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/utils/depsChecker/bicepChecker.ts
@@ -30,7 +30,6 @@ import {
 import { performance } from "perf_hooks";
 import { sendErrorTelemetryThenReturnError } from "../util";
 import { isBicepEnvCheckerEnabled } from "../../../../../common/tools";
-import { sendTelemetryEvent } from "../../../../../common/telemetry";
 
 export const BicepName = "Bicep";
 export const installVersion = "v0.4";

--- a/packages/fx-core/src/plugins/solution/fx-solution/utils/depsChecker/bicepChecker.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/utils/depsChecker/bicepChecker.ts
@@ -33,11 +33,13 @@ import { isBicepEnvCheckerEnabled } from "../../../../../common/tools";
 
 export const BicepName = "Bicep";
 export const installVersion = "v0.4";
+export const fallbackInstallVersion = "v0.4.1008";
 export const supportedVersions: Array<string> = [installVersion];
 
 const displayBicepName = `${BicepName} (${installVersion})`;
 const timeout = 5 * 60 * 1000;
 const source = "bicep-envchecker";
+const bicepReleaseApiUrl = "https://api.github.com/repos/Azure/bicep/releases";
 
 export async function ensureBicep(ctx: SolutionContext): Promise<string> {
   const bicepChecker = new BicepChecker(ctx.logProvider, ctx.telemetryReporter);
@@ -156,16 +158,32 @@ class BicepChecker {
   }
 
   private async doInstallBicep(): Promise<void> {
-    const response: AxiosResponse<Array<{ tag_name: string }>> = await this._axios.get(
-      "https://api.github.com/repos/Azure/bicep/releases",
-      {
-        headers: { Accept: "application/vnd.github.v3+json" },
-      }
-    );
-    const selectedVersion: string = response.data
-      .map((t) => t.tag_name)
-      .filter(this.isVersionSupported)
-      .sort((v1, v2) => v2.localeCompare(v1))[0];
+    let selectedVersion: string;
+    try {
+      const response: AxiosResponse<Array<{ tag_name: string }>> = await this._axios.get(
+        bicepReleaseApiUrl,
+        {
+          headers: { Accept: "application/vnd.github.v3+json" },
+        }
+      );
+      selectedVersion = response.data
+        .map((t) => t.tag_name)
+        .filter(this.isVersionSupported)
+        .sort((v1, v2) => v2.localeCompare(v1))[0];
+    } catch (e) {
+      // GitHub public API has a limit of 60 requests per hour per IP
+      // If it fails to retrieve the latest version, just use a known version.
+      selectedVersion = fallbackInstallVersion;
+      this._logger?.debug(
+        Messages.failToRetriveBicepReleaseVersions
+          .split("@GithubUrl")
+          .join(bicepReleaseApiUrl)
+          .split("@BicepVersion")
+          .join(fallbackInstallVersion)
+          .split("@Error")
+          .join(`${e}`)
+      );
+    }
     const installDir = this.getBicepExecPath();
 
     await this._logger?.info(

--- a/packages/fx-core/src/plugins/solution/fx-solution/utils/depsChecker/bicepChecker.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/utils/depsChecker/bicepChecker.ts
@@ -30,6 +30,7 @@ import {
 import { performance } from "perf_hooks";
 import { sendErrorTelemetryThenReturnError } from "../util";
 import { isBicepEnvCheckerEnabled } from "../../../../../common/tools";
+import { sendTelemetryEvent } from "../../../../../common/telemetry";
 
 export const BicepName = "Bicep";
 export const installVersion = "v0.4";
@@ -174,14 +175,9 @@ class BicepChecker {
       // GitHub public API has a limit of 60 requests per hour per IP
       // If it fails to retrieve the latest version, just use a known version.
       selectedVersion = fallbackInstallVersion;
-      this._logger?.debug(
-        Messages.failToRetriveBicepReleaseVersions
-          .split("@GithubUrl")
-          .join(bicepReleaseApiUrl)
-          .split("@BicepVersion")
-          .join(fallbackInstallVersion)
-          .split("@Error")
-          .join(`${e}`)
+      this._telemetry?.sendTelemetryEvent(
+        DepsCheckerEvent.bicepFailedToRetrieveGithubReleaseVersions,
+        { [TelemetryMeasurement.ErrorMessage]: `${e}` }
       );
     }
     const installDir = this.getBicepExecPath();

--- a/packages/fx-core/src/plugins/solution/fx-solution/utils/depsChecker/common.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/utils/depsChecker/common.ts
@@ -31,7 +31,6 @@ export const Messages = {
   learnMoreButtonText: "Learn more",
 
   downloadBicep: `Downloading and installing the portable version of @NameVersion, which will be installed to @InstallDir and will not affect your environment.`,
-  failToRetriveBicepReleaseVersions: `Failed to retrieve bicep release versions from '@GithubUrl', using default version '@BicepVersion'. Error = '@Error'`,
   finishInstallBicep: `Successfully installed @NameVersion.`,
   failToInstallBicep: `Failed to install @NameVersion`,
   failToInstallBicepOutputVSC: `Failed to install @NameVersion. please read this wiki(@HelpLink) to install @NameVersion manually and restart Visual Studio Code.`,
@@ -49,6 +48,7 @@ export enum DepsCheckerEvent {
   bicepInstallScriptCompleted = "bicep-install-script-completed",
   bicepInstallScriptError = "bicep-install-script-error",
   bicepValidationError = "bicep-validation-error",
+  bicepFailedToRetrieveGithubReleaseVersions = "bicep-failed-to-retrieve-github-release-versions",
 
   clickLearnMore = "env-checker-click-learn-more",
   clickCancel = "env-checker-click-cancel",
@@ -64,4 +64,5 @@ export enum TelemetryMeasurement {
   OSArch = "os-arch",
   OSRelease = "os-release",
   Component = "component",
+  ErrorMessage = "error-message",
 }

--- a/packages/fx-core/src/plugins/solution/fx-solution/utils/depsChecker/common.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/utils/depsChecker/common.ts
@@ -31,6 +31,7 @@ export const Messages = {
   learnMoreButtonText: "Learn more",
 
   downloadBicep: `Downloading and installing the portable version of @NameVersion, which will be installed to @InstallDir and will not affect your environment.`,
+  failToRetriveBicepReleaseVersions: `Failed to retrieve bicep release versions from '@GithubUrl', using default version '@BicepVersion'. Error = '@Error'`,
   finishInstallBicep: `Successfully installed @NameVersion.`,
   failToInstallBicep: `Failed to install @NameVersion`,
   failToInstallBicepOutputVSC: `Failed to install @NameVersion. please read this wiki(@HelpLink) to install @NameVersion manually and restart Visual Studio Code.`,


### PR DESCRIPTION
- Unauthenticated GitHub API call has a limit of 60 requests per hour per IP. It is easily hit. If the API fails, fallback to use a hard-coded version of bicep

Tested by changing hosts file

