### PR TITLE
feat(blazor): support arm

### DIFF
--- a/packages/fx-core/src/plugins/resource/frontend/blazor/enum.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/blazor/enum.ts
@@ -13,6 +13,7 @@ export enum BlazorConfigKey {
   webAppEndpoint = "webAppEndpoint",
   webAppDomain = "webAppDomain",
   projectFilePath = "projectFilePath",
+  webAppResourceId = "webAppResourceId",
 
   /* Intermediate */
   site = "site",

--- a/packages/fx-core/src/plugins/resource/frontend/index.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/index.ts
@@ -16,6 +16,7 @@ import { ErrorFactory, TeamsFxResult } from "./error-factory";
 import {
   ErrorType,
   FrontendPluginError,
+  NotImplemented,
   UnhandledErrorCode,
   UnhandledErrorMessage,
 } from "./resources/errors";
@@ -49,7 +50,7 @@ export class FrontendPlugin implements Plugin, ArmResourcePlugin {
 
   public async scaffold(ctx: PluginContext): Promise<TeamsFxResult> {
     if (isVsCallingCli()) {
-      return ok(undefined);
+      throw new NotImplemented();
     }
     FrontendPlugin.setContext(ctx);
     return this.runWithErrorHandling(ctx, TelemetryEvent.Scaffold, () =>
@@ -112,7 +113,7 @@ export class FrontendPlugin implements Plugin, ArmResourcePlugin {
 
   public async generateArmTemplates(ctx: PluginContext): Promise<TeamsFxResult> {
     if (isVsCallingCli()) {
-      return ok(undefined);
+      throw new NotImplemented();
     }
 
     FrontendPlugin.setContext(ctx);

--- a/packages/fx-core/src/plugins/resource/frontend/index.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/index.ts
@@ -22,7 +22,7 @@ import {
 } from "./resources/errors";
 import { Logger } from "./utils/logger";
 import { ProgressHelper } from "./utils/progress-helper";
-import { TelemetryEvent } from "./constants";
+import { FrontendPluginInfo, TelemetryEvent } from "./constants";
 import { TelemetryHelper } from "./utils/telemetry-helper";
 import { HostTypeOptionAzure, TabOptionItem } from "../../solution/fx-solution/question";
 import { Service } from "typedi";
@@ -31,6 +31,7 @@ import { isArmSupportEnabled, isVsCallingCli } from "../../..";
 import { ArmResourcePlugin } from "../../../common/armInterface";
 import "./v2";
 import { BlazorPluginImpl } from "./blazor/plugin";
+import { BlazorPluginInfo } from "./blazor/constants";
 
 @Service(ResourcePlugins.FrontendPlugin)
 export class FrontendPlugin implements Plugin, ArmResourcePlugin {
@@ -45,7 +46,10 @@ export class FrontendPlugin implements Plugin, ArmResourcePlugin {
 
   private static setContext(ctx: PluginContext): void {
     Logger.setLogger(ctx.logProvider);
-    TelemetryHelper.setContext(ctx);
+    TelemetryHelper.setContext(
+      ctx,
+      isVsCallingCli() ? BlazorPluginInfo.pluginName : FrontendPluginInfo.PluginName
+    );
   }
 
   public async scaffold(ctx: PluginContext): Promise<TeamsFxResult> {

--- a/packages/fx-core/src/plugins/resource/frontend/resources/errors.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/resources/errors.ts
@@ -340,6 +340,12 @@ export class MigrateV1ProjectError extends FrontendPluginError {
   }
 }
 
+export class NotImplemented extends FrontendPluginError {
+  constructor() {
+    super(ErrorType.System, "NotImplemented", "Not Implemented", []);
+  }
+}
+
 export class UserTaskNotImplementedError extends FrontendPluginError {
   constructor(taskName: string) {
     super(

--- a/packages/fx-core/src/plugins/resource/frontend/utils/telemetry-helper.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/utils/telemetry-helper.ts
@@ -13,13 +13,15 @@ import { FrontendPluginError } from "../resources/errors";
 
 export class TelemetryHelper {
   private static ctx?: PluginContext;
+  private static component?: string;
 
-  static setContext(ctx: PluginContext): void {
+  static setContext(ctx: PluginContext, component?: string): void {
     this.ctx = ctx;
+    this.component = component;
   }
 
   private static fillCommonProperty(properties: { [key: string]: string }): void {
-    properties[TelemetryKey.Component] = FrontendPluginInfo.PluginName;
+    properties[TelemetryKey.Component] = this.component ?? FrontendPluginInfo.PluginName;
     properties[TelemetryKey.AppId] =
       (this.ctx?.envInfo.state
         .get(DependentPluginInfo.SolutionPluginName)


### PR DESCRIPTION
For blazor scenario, we do scaffolding in VS extension, so we don't need to implement `generateArmTemplate` in blazor plugin, just update the arm bicep files in scaffold templates.
E2E TEST: https://github.com/OfficeDev/TeamsFx/blob/bb110600e8feccf400fb050598f7ff7b4e62d32f/packages/cli/tests/e2e/blazor/TestDeployBlazor.tests.ts#L6