### PR TITLE
fix(bot): remove useless output value botServiceName

### DIFF
--- a/packages/fx-core/templates/plugins/resource/bot/bicep/provision.template.bicep
+++ b/packages/fx-core/templates/plugins/resource/bot/bicep/provision.template.bicep
@@ -13,7 +13,6 @@ output botOutput object = {
   siteName: botProvision.outputs.botWebAppName
   validDomain: botProvision.outputs.botDomain
   appServicePlanName: botProvision.outputs.appServicePlanName
-  botChannelRegName: botProvision.outputs.botServiceName
   botWebAppResourceId: botProvision.outputs.botWebAppResourceId
   siteEndpoint: botProvision.outputs.botWebAppEndpoint
 }

--- a/packages/fx-core/tests/plugins/resource/bot/unit/expectedBicepFiles/provision.result.bicep
+++ b/packages/fx-core/tests/plugins/resource/bot/unit/expectedBicepFiles/provision.result.bicep
@@ -13,7 +13,6 @@ output botOutput object = {
   siteName: botProvision.outputs.botWebAppName
   validDomain: botProvision.outputs.botDomain
   appServicePlanName: botProvision.outputs.appServicePlanName
-  botChannelRegName: botProvision.outputs.botServiceName
   botWebAppResourceId: botProvision.outputs.botWebAppResourceId
   siteEndpoint: botProvision.outputs.botWebAppEndpoint
 }


### PR DESCRIPTION
[change botChannelRegistration property name in state.xxx.json](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/12614801)