### PR TITLE
chore(upgrade): add extension setting as workaround for upgrade failure

### DIFF
--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -59,4 +59,5 @@ export const deployPluginNodeName = "deploy-plugin";
 
 export class FeatureFlags {
   static readonly InsiderPreview = "__TEAMSFX_INSIDER_PREVIEW";
+  static readonly RollbackToToolkitV2 = "TEAMSFX_ROLLBACK_TO_TOOLKIT_V2";
 }

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -59,5 +59,5 @@ export const deployPluginNodeName = "deploy-plugin";
 
 export class FeatureFlags {
   static readonly InsiderPreview = "__TEAMSFX_INSIDER_PREVIEW";
-  static readonly RollbackToToolkitV2 = "TEAMSFX_ROLLBACK_TO_TOOLKIT_V2";
+  static readonly RollbackToTeamsToolkitV2 = "TEAMSFX_ROLLBACK_TO_TEAMS_TOOLKIT_V2";
 }

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -531,7 +531,10 @@ export function isFeatureFlagEnabled(featureFlagName: string, defaultValue = fal
 }
 
 export function isRemoteCollaborationEnabled(): boolean {
-  return isFeatureFlagEnabled(FeatureFlags.InsiderPreview, false);
+  return (
+    !isFeatureFlagEnabled(FeatureFlags.RollbackToToolkitV2, false) &&
+    isFeatureFlagEnabled(FeatureFlags.InsiderPreview, true)
+  );
 }
 
 export function getAllFeatureFlags(): string[] | undefined {

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -532,7 +532,7 @@ export function isFeatureFlagEnabled(featureFlagName: string, defaultValue = fal
 
 export function isRemoteCollaborationEnabled(): boolean {
   return (
-    !isFeatureFlagEnabled(FeatureFlags.RollbackToToolkitV2, false) &&
+    !isFeatureFlagEnabled(FeatureFlags.RollbackToTeamsToolkitV2, false) &&
     isFeatureFlagEnabled(FeatureFlags.InsiderPreview, true)
   );
 }

--- a/packages/fx-core/src/common/constants.ts
+++ b/packages/fx-core/src/common/constants.ts
@@ -52,6 +52,7 @@ export class FeatureFlagName {
   static readonly APIV2 = "TEAMSFX_APIV2";
   // This will default to true and this environment is only for tests. It does not expose to user.
   static readonly InsiderPreview = "__TEAMSFX_INSIDER_PREVIEW";
+  static readonly RollbackToToolkitV2 = "TEAMSFX_ROLLBACK_TO_TOOLKIT_V2";
   static readonly rootDirectory = "TEAMSFX_ROOT_DIRECTORY";
   static readonly VSCallingCLI = "VS_CALLING_CLI";
 }

--- a/packages/fx-core/src/common/constants.ts
+++ b/packages/fx-core/src/common/constants.ts
@@ -52,7 +52,7 @@ export class FeatureFlagName {
   static readonly APIV2 = "TEAMSFX_APIV2";
   // This will default to true and this environment is only for tests. It does not expose to user.
   static readonly InsiderPreview = "__TEAMSFX_INSIDER_PREVIEW";
-  static readonly RollbackToToolkitV2 = "TEAMSFX_ROLLBACK_TO_TOOLKIT_V2";
+  static readonly RollbackToTeamsToolkitV2 = "TEAMSFX_ROLLBACK_TO_TEAMS_TOOLKIT_V2";
   static readonly rootDirectory = "TEAMSFX_ROOT_DIRECTORY";
   static readonly VSCallingCLI = "VS_CALLING_CLI";
 }

--- a/packages/fx-core/src/common/tools.ts
+++ b/packages/fx-core/src/common/tools.ts
@@ -417,14 +417,14 @@ export function isFeatureFlagEnabled(featureFlagName: string, defaultValue = fal
 
 export function isMultiEnvEnabled(): boolean {
   return (
-    !isFeatureFlagEnabled(FeatureFlagName.RollbackToToolkitV2, false) &&
+    !isFeatureFlagEnabled(FeatureFlagName.RollbackToTeamsToolkitV2, false) &&
     isFeatureFlagEnabled(FeatureFlagName.InsiderPreview, true)
   );
 }
 
 export function isArmSupportEnabled(): boolean {
   return (
-    !isFeatureFlagEnabled(FeatureFlagName.RollbackToToolkitV2, false) &&
+    !isFeatureFlagEnabled(FeatureFlagName.RollbackToTeamsToolkitV2, false) &&
     isFeatureFlagEnabled(FeatureFlagName.InsiderPreview, true)
   );
 }
@@ -435,7 +435,7 @@ export function isBicepEnvCheckerEnabled(): boolean {
 
 export function isRemoteCollaborateEnabled(): boolean {
   return (
-    !isFeatureFlagEnabled(FeatureFlagName.RollbackToToolkitV2, false) &&
+    !isFeatureFlagEnabled(FeatureFlagName.RollbackToTeamsToolkitV2, false) &&
     isFeatureFlagEnabled(FeatureFlagName.InsiderPreview, true)
   );
 }

--- a/packages/fx-core/src/common/tools.ts
+++ b/packages/fx-core/src/common/tools.ts
@@ -416,11 +416,17 @@ export function isFeatureFlagEnabled(featureFlagName: string, defaultValue = fal
 }
 
 export function isMultiEnvEnabled(): boolean {
-  return isFeatureFlagEnabled(FeatureFlagName.InsiderPreview, true);
+  return (
+    !isFeatureFlagEnabled(FeatureFlagName.RollbackToToolkitV2, false) &&
+    isFeatureFlagEnabled(FeatureFlagName.InsiderPreview, true)
+  );
 }
 
 export function isArmSupportEnabled(): boolean {
-  return isFeatureFlagEnabled(FeatureFlagName.InsiderPreview, true);
+  return (
+    !isFeatureFlagEnabled(FeatureFlagName.RollbackToToolkitV2, false) &&
+    isFeatureFlagEnabled(FeatureFlagName.InsiderPreview, true)
+  );
 }
 
 export function isBicepEnvCheckerEnabled(): boolean {
@@ -428,7 +434,10 @@ export function isBicepEnvCheckerEnabled(): boolean {
 }
 
 export function isRemoteCollaborateEnabled(): boolean {
-  return isFeatureFlagEnabled(FeatureFlagName.InsiderPreview, true);
+  return (
+    !isFeatureFlagEnabled(FeatureFlagName.RollbackToToolkitV2, false) &&
+    isFeatureFlagEnabled(FeatureFlagName.InsiderPreview, true)
+  );
 }
 
 export function getRootDirectory(): string {

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -821,7 +821,7 @@
       {
         "title": "Teams Toolkit",
         "properties": {
-          "fx-extension.rollbackToToolkitV2": {
+          "fx-extension.rollbackToTeamsToolkitV2": {
             "type": "boolean",
             "description": "Rollback to Teams Toolkit v2. Notice the setting will be obsolete and removed soon. (requires reload of VS Code)",
             "default": false

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -821,6 +821,11 @@
       {
         "title": "Teams Toolkit",
         "properties": {
+          "fx-extension.rollbackToToolkitV2": {
+            "type": "boolean",
+            "description": "Rollback to Teams Toolkit v2. Notice the setting will be obsolete and removed soon. (requires reload of VS Code)",
+            "default": false
+          },
           "fx-extension.validateNode": {
             "type": "boolean",
             "description": "Ensure Node.js is installed.",

--- a/packages/vscode-extension/src/constants.ts
+++ b/packages/vscode-extension/src/constants.ts
@@ -1,7 +1,7 @@
 export const CONFIGURATION_PREFIX = "fx-extension";
 export enum ConfigurationKey {
   BicepEnvCheckerEnable = "validateBicep",
-  RollbackToToolkitV2 = "rollbackToToolkitV2",
+  RollbackToTeamsToolkitV2 = "rollbackToTeamsToolkitV2",
   RootDirectory = "defaultProjectRootDirectory",
 }
 

--- a/packages/vscode-extension/src/constants.ts
+++ b/packages/vscode-extension/src/constants.ts
@@ -1,6 +1,7 @@
 export const CONFIGURATION_PREFIX = "fx-extension";
 export enum ConfigurationKey {
   BicepEnvCheckerEnable = "validateBicep",
+  RollbackToToolkitV2 = "rollbackToToolkitV2",
   RootDirectory = "defaultProjectRootDirectory",
 }
 

--- a/packages/vscode-extension/src/utils/commonUtils.ts
+++ b/packages/vscode-extension/src/utils/commonUtils.ts
@@ -242,6 +242,10 @@ export function getConfiguration(key: string): boolean {
 }
 
 export function syncFeatureFlags() {
+  process.env["TEAMSFX_ROLLBACK_TO_TOOLKIT_V2"] = getConfiguration(
+    ConfigurationKey.RollbackToToolkitV2
+  ).toString();
+
   process.env["TEAMSFX_BICEP_ENV_CHECKER_ENABLE"] = getConfiguration(
     ConfigurationKey.BicepEnvCheckerEnable
   ).toString();
@@ -253,7 +257,7 @@ export function syncFeatureFlags() {
 
 export class FeatureFlags {
   static readonly InsiderPreview = "__TEAMSFX_INSIDER_PREVIEW";
-
+  static readonly RollbackToToolkitV2 = "TEAMSFX_ROLLBACK_TO_TOOLKIT_V2";
   static readonly TelemetryTest = "TEAMSFX_TELEMETRY_TEST";
 }
 

--- a/packages/vscode-extension/src/utils/commonUtils.ts
+++ b/packages/vscode-extension/src/utils/commonUtils.ts
@@ -242,8 +242,8 @@ export function getConfiguration(key: string): boolean {
 }
 
 export function syncFeatureFlags() {
-  process.env["TEAMSFX_ROLLBACK_TO_TOOLKIT_V2"] = getConfiguration(
-    ConfigurationKey.RollbackToToolkitV2
+  process.env["TEAMSFX_ROLLBACK_TO_TEAMS_TOOLKIT_V2"] = getConfiguration(
+    ConfigurationKey.RollbackToTeamsToolkitV2
   ).toString();
 
   process.env["TEAMSFX_BICEP_ENV_CHECKER_ENABLE"] = getConfiguration(
@@ -257,7 +257,7 @@ export function syncFeatureFlags() {
 
 export class FeatureFlags {
   static readonly InsiderPreview = "__TEAMSFX_INSIDER_PREVIEW";
-  static readonly RollbackToToolkitV2 = "TEAMSFX_ROLLBACK_TO_TOOLKIT_V2";
+  static readonly RollbackToTeamsToolkitV2 = "TEAMSFX_ROLLBACK_TO_TEAMS_TOOLKIT_V2";
   static readonly TelemetryTest = "TEAMSFX_TELEMETRY_TEST";
 }
 


### PR DESCRIPTION
This is a workaround only for upgrade failure and plan to be removed soon. As for the accurate date to remove it, it will depend on the upgrade failure rate from BI report.

<img src="https://user-images.githubusercontent.com/15644078/142789726-11bc61d4-db70-4380-89e5-6dbeae3d838e.png" width=600>