### PR TITLE
chore(multi-env): refine account warning UI in tree view

### DIFF
--- a/packages/vscode-extension/src/envTree.ts
+++ b/packages/vscode-extension/src/envTree.ts
@@ -19,6 +19,7 @@ import {
   LocalSettingsProvider,
 } from "@microsoft/teamsfx-core";
 import * as vscode from "vscode";
+import * as util from "util";
 import { CommandsTreeViewProvider } from "./treeview/commandsTreeViewProvider";
 import TreeViewManagerInstance from "./treeview/treeViewManager";
 import * as StringResources from "./resources/Strings.json";
@@ -40,6 +41,11 @@ let environmentTreeProvider: CommandsTreeViewProvider;
 let collaboratorsRecordCache: Record<string, TreeItem[]> = {};
 let permissionCache: Record<string, boolean> = {};
 const mutex = new Mutex();
+
+interface accountStatus {
+  isOk: boolean;
+  warnings: string[];
+}
 
 export async function registerEnvTreeHandler(
   forceUpdateCollaboratorList = true
@@ -67,6 +73,17 @@ export async function registerEnvTreeHandler(
         showEnvList.push(item);
         const provisionSucceeded = await getProvisionSucceedFromEnv(item);
         const isLocal = item === LocalEnvironmentName;
+
+        const accountStatusResult = await CheckAccountForEnvrironment(item);
+        let envIcon = provisionSucceeded ? "folder-active" : "symbol-folder";
+        const isIconCustom: boolean = isLocal ? false : !accountStatusResult.isOk;
+        let accountTip = "";
+
+        if (item !== LocalEnvironmentName && !accountStatusResult.isOk) {
+          envIcon = "warning";
+          accountTip = formatWarningMessages(accountStatusResult.warnings);
+        }
+
         environmentTreeProvider.add([
           {
             commandId: "fx-extension.environment." + item,
@@ -78,8 +95,12 @@ export async function registerEnvTreeHandler(
               : provisionSucceeded
               ? "environment-provisioned"
               : "environment",
-            icon: provisionSucceeded ? "folder-active" : "symbol-folder",
-            isCustom: false,
+            icon: envIcon,
+            tooltip: {
+              isMarkdown: false,
+              value: accountTip,
+            },
+            isCustom: isIconCustom,
             expanded: isLocal ? undefined : true,
           },
         ]);
@@ -246,7 +267,7 @@ async function getSubscriptionAndResourceGroupNode(env: string): Promise<TreeIte
     environmentTreeProvider.findCommand("fx-extension.environment." + env) &&
     env !== LocalEnvironmentName
   ) {
-    let envSubItems: TreeItem[] = [];
+    const envSubItems: TreeItem[] = [];
     const subscriptionInfo = await getSubscriptionInfoFromEnv(env);
     if (subscriptionInfo) {
       const subscriptionTreeItem: TreeItem = {
@@ -273,19 +294,6 @@ async function getSubscriptionAndResourceGroupNode(env: string): Promise<TreeIte
 
         envSubItems.push(resourceGroupTreeItem);
       }
-
-      const warningItem = await checkSubscriptionPermission(env, subscriptionInfo.subscriptionId);
-      if (warningItem) {
-        envSubItems = [warningItem].concat(envSubItems);
-      }
-    }
-
-    const m365TenantId = await getM365TenantFromEnv(env);
-    if (m365TenantId) {
-      const warningItem = await checkM365Permission(env, m365TenantId);
-      if (warningItem) {
-        envSubItems = [warningItem].concat(envSubItems);
-      }
     }
 
     return envSubItems;
@@ -294,18 +302,65 @@ async function getSubscriptionAndResourceGroupNode(env: string): Promise<TreeIte
   return [];
 }
 
-function checkAzureAccountStatus(env: string): TreeItem | undefined {
-  if (AzureAccountManager.getAccountInfo() === undefined) {
-    return {
-      commandId: `fx-extension.environment.checkAzureAccount.${env}`,
-      label: StringResources.vsc.commandsTreeViewProvider.noAzureAccountSignedIn,
-      icon: "warning",
-      isCustom: true,
-      parent: `fx-extension.environment.${env}`,
-    };
+function formatWarningMessages(warnings: string[]): string {
+  let warningMessage = "";
+  if (warnings.length > 1) {
+    const formatedWarnings = warnings.map((warning) => "> ".concat(warning));
+    warningMessage = formatedWarnings.join("\n");
   } else {
-    return undefined;
+    warningMessage = warnings[0];
   }
+
+  return warningMessage;
+}
+async function CheckAccountForEnvrironment(env: string): Promise<accountStatus> {
+  let checkResult = true;
+  const warnings: string[] = [];
+
+  // Check M365 account status
+  const loginStatus = await AppStudioLogin.getInstance().getStatus();
+  if (loginStatus.status == signedIn) {
+    // Signed account doesn't match
+    const m365TenantId = await getM365TenantFromEnv(env);
+    if ((loginStatus.accountInfo as any).tid !== m365TenantId) {
+      checkResult = false;
+      warnings.push(StringResources.vsc.commandsTreeViewProvider.m365AccountNotMatch);
+    }
+  } else {
+    // Not signed in
+    checkResult = false;
+    warnings.push(StringResources.vsc.commandsTreeViewProvider.m365AccountNotSignedIn);
+  }
+
+  // Check Azure account status
+  if (AzureAccountManager.getAccountInfo() !== undefined) {
+    const subscriptions: SubscriptionInfo[] = await AzureAccountManager.listSubscriptions();
+    const subscriptionInfo = await getSubscriptionInfoFromEnv(env);
+    const provisionedSubId = subscriptionInfo?.subscriptionId;
+
+    if (provisionedSubId) {
+      const targetSub = subscriptions.find(
+        (sub) => sub.subscriptionId === subscriptionInfo?.subscriptionId
+      );
+      if (targetSub === undefined) {
+        checkResult = false;
+        warnings.push(
+          util.format(
+            StringResources.vsc.commandsTreeViewProvider.azureAccountNotMatch,
+            subscriptionInfo?.subscriptionName
+          )
+        );
+      }
+    }
+  } else {
+    checkResult = false;
+    warnings.push(StringResources.vsc.commandsTreeViewProvider.azureAccountNotSignedIn);
+  }
+
+  return {
+    isOk: checkResult,
+    warnings: warnings,
+  };
 }
 
 async function checkSubscriptionPermission(
@@ -328,38 +383,6 @@ async function checkSubscriptionPermission(
         label: StringResources.vsc.commandsTreeViewProvider.azureAccountNotMatch,
         tooltip: {
           value: StringResources.vsc.commandsTreeViewProvider.noSubscriptionFoundInAzureAccount,
-          isMarkdown: false,
-        },
-        icon: "warning",
-        isCustom: true,
-        parent: `fx-extension.environment.${env}`,
-      };
-
-      return warningTreeItem;
-    }
-  }
-
-  return undefined;
-}
-
-async function checkM365Permission(
-  env: string,
-  m365TenantId: string
-): Promise<TreeItem | undefined> {
-  const loginStatus = await AppStudioLogin.getInstance().getStatus();
-  if (loginStatus.status === signedIn) {
-    let checkSucceeded = false;
-
-    if ((loginStatus.accountInfo as any).tid === m365TenantId) {
-      checkSucceeded = true;
-    }
-
-    if (!checkSucceeded) {
-      const warningTreeItem: TreeItem = {
-        commandId: `fx-extension.environment.${env}.checkM365Tenant`,
-        label: StringResources.vsc.commandsTreeViewProvider.m365AccountNotMatch,
-        tooltip: {
-          value: StringResources.vsc.commandsTreeViewProvider.m365TenantNotMatch,
           isMarkdown: false,
         },
         icon: "warning",

--- a/packages/vscode-extension/src/resources/Strings.json
+++ b/packages/vscode-extension/src/resources/Strings.json
@@ -77,7 +77,7 @@
       "grantPermissionWarning": "You need to handle Azure resource permissions manually on Azure Portal.",
       "m365AccountNotSignedIn": "No M365 account signed in. Please sign in to M365.",
       "m365TenantNotMatch": "The M365 tenant id(which is used to provision before) does not match the current account.",
-      "m365AccountNotMatch": "The signed in M365 account does not match the M365 tenant used in previous provision. Please sign out and sign in with correct M365 Account.",
+      "m365AccountNotMatch": "The signed in M365 account does not match the M365 tenant used in previous provision. Please sign out and sign in with correct M365 account.",
       "azureAccountNotSignedIn": "No Azure account signed in. Please sign in to Azure.",
       "azureAccountNotMatch": "The signed in Azure account does not have permission to access the subscription '%s' used in previous provision. Please sign out and sign in with correct Azure account."
     },

--- a/packages/vscode-extension/src/resources/Strings.json
+++ b/packages/vscode-extension/src/resources/Strings.json
@@ -77,7 +77,7 @@
       "grantPermissionWarning": "You need to handle Azure resource permissions manually on Azure Portal.",
       "m365AccountNotSignedIn": "No M365 account signed in. Please sign in to M365.",
       "m365TenantNotMatch": "The M365 tenant id(which is used to provision before) does not match the current account.",
-      "m365AccountNotMatch": "The signed in M365 account does not match the M365 tenant used in previous provision. Please sign out and sign in with connrect M365 Account.",
+      "m365AccountNotMatch": "The signed in M365 account does not match the M365 tenant used in previous provision. Please sign out and sign in with correct M365 Account.",
       "azureAccountNotSignedIn": "No Azure account signed in. Please sign in to Azure.",
       "azureAccountNotMatch": "The signed in Azure account does not have permission to access the subscription '%s' used in previous provision. Please sign out and sign in with correct Azure account."
     },

--- a/packages/vscode-extension/src/resources/Strings.json
+++ b/packages/vscode-extension/src/resources/Strings.json
@@ -75,10 +75,11 @@
       "previewACDesciption": "Preview and author Adaptive Cards directly in Visual Studio Code",
       "grantPermissionSucceeded": "Added account: '%s' to the environment '%s' as a collaborator.",
       "grantPermissionWarning": "You need to handle Azure resource permissions manually on Azure Portal.",
-      "noM365AccountSignedIn": "No M365 account signed in. Please sign in to M365.",
+      "m365AccountNotSignedIn": "No M365 account signed in. Please sign in to M365.",
       "m365TenantNotMatch": "The M365 tenant id(which is used to provision before) does not match the current account.",
-      "azureAccountNotMatch": "The Azure account does not match.",
-      "m365AccountNotMatch": "The M365 account does not match."
+      "m365AccountNotMatch": "The signed in M365 account does not match the M365 tenant used in previous provision. Please sign out and sign in with connrect M365 Account.",
+      "azureAccountNotSignedIn": "No Azure account signed in. Please sign in to Azure.",
+      "azureAccountNotMatch": "The signed in Azure account does not have permission to access the subscription '%s' used in previous provision. Please sign out and sign in with correct Azure account."
     },
     "handlers": {
       "concurrentTriggerTask": "Task '%s' is still running. Wait for it to complete before starting another task.",


### PR DESCRIPTION
Remove warning nodes under env node, and show warning messages when user hover mouse to the env node.

![image](https://user-images.githubusercontent.com/10163840/142591359-b81467f2-2f14-48a6-9675-b76cd876e9c4.png)

![image](https://user-images.githubusercontent.com/10163840/142592126-9560f4b2-c6ef-4100-9a75-41ecc9f27385.png)

