### PR TITLE
chore: remove invalid recommended extension

### DIFF
--- a/packages/vscode-extension/.vscode/extensions.json
+++ b/packages/vscode-extension/.vscode/extensions.json
@@ -1,5 +1,5 @@
 {
   // See http://go.microsoft.com/fwlink/?LinkId=827846
   // for the documentation about the extensions.json format
-  "recommendations": ["dbaeumer.vscode-eslint", "eamodio.tsl-problem-matcher"]
+  "recommendations": ["dbaeumer.vscode-eslint"]
 }


### PR DESCRIPTION
Remove the invalid recommended vscode extension to avoid warning every time opening the project:

![image](https://user-images.githubusercontent.com/15644078/142796545-3e3938f2-11b7-46f7-aa25-9a8122ffba0e.png)
