### PR TITLE
fix: download sample twice will failed with progress bar hang

### DIFF
--- a/packages/fx-core/src/common/tools.ts
+++ b/packages/fx-core/src/common/tools.ts
@@ -290,7 +290,9 @@ export async function saveFilesRecursively(
           entry.entryName.split("/").includes(appFolder)
       )
       .map(async (entry) => {
-        const entryPath = entry.entryName.substring(entry.entryName.indexOf("/") + 1);
+        const entryPath = entry.entryName.substring(
+          entry.entryName.indexOf(appFolder) + appFolder.length
+        );
         const filePath = path.join(dstPath, entryPath);
         await fs.ensureDir(path.dirname(filePath));
         await fs.writeFile(filePath, entry.getData());

--- a/packages/fx-core/src/core/index.ts
+++ b/packages/fx-core/src/core/index.ts
@@ -1404,9 +1404,12 @@ export async function downloadSample(
     }
     const sample = samples[0];
     const url = sample.link as string;
-    const sampleAppPath = path.resolve(folder, sampleId);
+    let sampleAppPath = path.resolve(folder, sampleId);
     if ((await fs.pathExists(sampleAppPath)) && (await fs.readdir(sampleAppPath)).length > 0) {
-      throw ProjectFolderExistError(sampleAppPath);
+      let suffix = 1;
+      while (await fs.pathExists(sampleAppPath)) {
+        sampleAppPath = `${folder}/${sampleId}_${suffix++}`;
+      }
     }
     progress.next(`Downloading from ${url}`);
     const fetchRes = await fetchCodeZip(url);
@@ -1418,7 +1421,7 @@ export async function downloadSample(
       );
     }
     progress.next("Unzipping the sample package");
-    await saveFilesRecursively(new AdmZip(fetchRes.data), sampleId, folder);
+    await saveFilesRecursively(new AdmZip(fetchRes.data), sampleId, sampleAppPath);
     await downloadSampleHook(sampleId, sampleAppPath);
     progress.next("Update project settings");
     const loadInputs: Inputs = {


### PR DESCRIPTION
If sample app exists, will append suffix like <sample name>_1, <sample name>_2, ...


E2E TEST: hotfix, will add later