### PR TITLE
fix(migration): migrate without import

### DIFF
--- a/packages/vscode-extension/src/migration/migrationHandler.ts
+++ b/packages/vscode-extension/src/migration/migrationHandler.ts
@@ -132,10 +132,6 @@ async function updateCodeInplace(
 ): Promise<Result<null, FxError>> {
   try {
     const sourceCode = (await fs.readFile(filePath)).toString();
-    // skip files that do not import Teams client SDK
-    if (!sourceCode.includes(constants.teamsClientSDKName)) {
-      return ok(null);
-    }
     vsCodeLogProvider.info(
       util.format(
         StringResources.vsc.migrateTeamsTabApp.updatingCode,

--- a/packages/vscode-extension/src/migration/migrationTool/ts/replaceTsSDK.ts
+++ b/packages/vscode-extension/src/migration/migrationTool/ts/replaceTsSDK.ts
@@ -13,6 +13,7 @@ import {
   Options,
   Collection,
   CallExpression,
+  Identifier,
 } from "jscodeshift";
 import { replaceFunction } from "./replaceFunction";
 import { replaceEnum } from "./replaceEnum";
@@ -24,6 +25,7 @@ import {
   replaceImport,
 } from "./replaceTsImport";
 import { replaceInterface } from "./replaceTsInterface";
+import * as constants from "../../constants";
 
 /**
  * core function to migrate sdk in a TypeScript file and would be called and executed
@@ -71,11 +73,34 @@ const transformTs: Transform = (file: FileInfo, api: API, options: Options): str
     teamsClientSDKTsImportEqualsDeclarationPaths
   );
 
+  // If there is
+  //   1. import * as microsoftTeams from "@microsoft/teams-js", or
+  //   2. import microsoftTeams from "@microsoft/teams-js", or
+  //   3. import "@microsoft/teams-js", or
+  //   4. import microsoftTeams = require("@microsoft/teams-js")
+  const hasImportDeclaration = importInfo.importEntireModuleInfo.some(
+    (info) => info.alias === constants.teamsClientSDKDefaultNamespace
+  );
+  const teamsClientSDKReferences = root
+    .find(Identifier)
+    .filter((p) => p.node.name === constants.teamsClientSDKDefaultNamespace);
+  if (!hasImportDeclaration && teamsClientSDKReferences.length > 0) {
+    // import * as microsoftTeams from "@microsoft/teams-js"
+    importInfo.importEntireModuleInfo.push({
+      type: "ImportNamespaceSpecifier",
+      alias: constants.teamsClientSDKDefaultNamespace,
+    });
+  }
+
   replaceFunction(j, root, importInfo);
 
   replaceInterface(j, root, importInfo);
 
   replaceEnum(j, root, importInfo);
+
+  if (!hasImportDeclaration && teamsClientSDKReferences.length > 0) {
+    importInfo.importEntireModuleInfo.pop();
+  }
 
   replaceImport(
     teamsClientSDKImportDeclarationPaths,

--- a/packages/vscode-extension/src/migration/migrationTool/ts/replaceTsSDK.ts
+++ b/packages/vscode-extension/src/migration/migrationTool/ts/replaceTsSDK.ts
@@ -56,18 +56,6 @@ const transformTs: Transform = (file: FileInfo, api: API, options: Options): str
     .find(CallExpression)
     .filter(isTeamsClientSDKTsImportCallExpression);
 
-  /**
-   * if there is no Teams Client SDK imported, nothing should be replaced
-   */
-  if (
-    teamsClientSDKImportDeclarationPaths.length == 0 &&
-    teamsClientSDKTsImportEqualsDeclarationPaths.length === 0 &&
-    teamsClientSDKRequireCallExpressionPaths.length === 0 &&
-    teamsClientSDKImportCallExpressionPaths.length === 0
-  ) {
-    return null;
-  }
-
   const importInfo = getTeamsClientSDKReferencePrefixes(
     teamsClientSDKImportDeclarationPaths,
     teamsClientSDKTsImportEqualsDeclarationPaths

--- a/packages/vscode-extension/test/unit/migration/data/js/others/replace-without-entire-import.input.js
+++ b/packages/vscode-extension/test/unit/migration/data/js/others/replace-without-entire-import.input.js
@@ -1,0 +1,7 @@
+import { appInitialization } from "@microsoft/teams-js";
+
+appInitialization.notifySuccess();
+
+microsoftTeams.initialize();
+
+msft.initialize();

--- a/packages/vscode-extension/test/unit/migration/data/js/others/replace-without-entire-import.output.js
+++ b/packages/vscode-extension/test/unit/migration/data/js/others/replace-without-entire-import.output.js
@@ -1,0 +1,7 @@
+import { app } from "@microsoft/teams-js";
+
+app.notifySuccess();
+
+microsoftTeams.app.initialize();
+
+msft.initialize();

--- a/packages/vscode-extension/test/unit/migration/data/ts/others/replace-without-entire-import.input.ts
+++ b/packages/vscode-extension/test/unit/migration/data/ts/others/replace-without-entire-import.input.ts
@@ -1,0 +1,21 @@
+import { appInitialization } from "@microsoft/teams-js";
+
+appInitialization.notifySuccess();
+
+microsoftTeams.initialize();
+
+msft.initialize();
+
+const x1: microsoftTeams.TaskInfo | undefined = undefined;
+const x2: msft.TaskInfo | undefined = undefined;
+
+async function f2(x: microsoftTeams.TaskInfo): Promise<microsoftTeams.TaskInfo> {
+  return x;
+}
+
+async function f1(x: msft.TaskInfo): Promise<msft.TaskInfo> {
+  return x;
+}
+
+microsoftTeams.TaskModuleDimension.Medium;
+msft.TaskModuleDimension.Medium;

--- a/packages/vscode-extension/test/unit/migration/data/ts/others/replace-without-entire-import.output.ts
+++ b/packages/vscode-extension/test/unit/migration/data/ts/others/replace-without-entire-import.output.ts
@@ -1,0 +1,21 @@
+import { app } from "@microsoft/teams-js";
+
+app.notifySuccess();
+
+microsoftTeams.app.initialize();
+
+msft.initialize();
+
+const x1: microsoftTeams.DialogInfo | undefined = undefined;
+const x2: msft.TaskInfo | undefined = undefined;
+
+async function f2(x: microsoftTeams.DialogInfo): Promise<microsoftTeams.DialogInfo> {
+  return x;
+}
+
+async function f1(x: msft.TaskInfo): Promise<msft.TaskInfo> {
+  return x;
+}
+
+microsoftTeams.DialogDimension.Medium;
+msft.TaskModuleDimension.Medium;


### PR DESCRIPTION
Fix [ADO 12577791](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/12577791).

If there is no import `microsoftTeams` declaration in the file but there are `microsoftTeams` references, then the references will also be migrated.

E2E TEST: AzureAppScaffold