### PR TITLE
fix: always show local in env tree

### DIFF
--- a/packages/vscode-extension/src/envTree.ts
+++ b/packages/vscode-extension/src/envTree.ts
@@ -66,9 +66,7 @@ export async function registerEnvTreeHandler(
       }
       showEnvList.splice(0);
 
-      const envNames = (await localSettingsExists(workspacePath))
-        ? [LocalEnvironmentName].concat(envNamesResult.value)
-        : envNamesResult.value;
+      const envNames = [LocalEnvironmentName].concat(envNamesResult.value);
       for (const item of envNames) {
         showEnvList.push(item);
         const provisionSucceeded = await getProvisionSucceedFromEnv(item);
@@ -239,11 +237,6 @@ function generateCollaboratorParentNode(env: string): TreeItem {
     parent: "fx-extension.environment." + env,
     expanded: false,
   };
-}
-
-async function localSettingsExists(projectRoot: string): Promise<boolean> {
-  const provider = new LocalSettingsProvider(projectRoot);
-  return await fs.pathExists(provider.localSettingsFilePath);
 }
 
 async function appendSubscriptionAndResourceGroupNode(env: string): Promise<void> {


### PR DESCRIPTION
Display `local` in env tree no matter the `localSettings.json` exist or not.

Bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/12664790/

E2E TEST: only affect UI