### PR TITLE
fix: local debug configuration

### DIFF
--- a/packages/fx-core/src/plugins/resource/appstudio/errors.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/errors.ts
@@ -72,7 +72,8 @@ export class AppStudioError {
 
   public static readonly GetLocalDebugConfigFailedError = {
     name: "GetLocalDebugConfigFailed",
-    message: (error: any) => `Missing configuration data for manifest. ${error.message}`,
+    message: (error: any) =>
+      `Missing configuration data for manifest. You may need to run 'Local debug' first. ${error.message}`,
   };
 
   public static readonly GetRemoteConfigFailedError = {

--- a/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
@@ -1710,25 +1710,25 @@ export class AppStudioPluginImpl {
         },
         localSettings: {
           frontend: {
-            tabEndpoint: endpoint ?? "{{{localSettings.frontend.tabEndpoint}}}",
+            tabEndpoint: endpoint ? endpoint : "{{{localSettings.frontend.tabEndpoint}}}",
           },
           auth: {
-            clientId:
-              ctx.localSettings?.auth?.get(LocalSettingsAuthKeys.ClientId) ??
-              "{{localSettings.auth.clientId}}",
-            applicationIdUris:
-              ctx.localSettings?.auth?.get(LocalSettingsAuthKeys.ApplicationIdUris) ??
-              "{{{localSettings.auth.applicationIdUris}}}",
+            clientId: ctx.localSettings?.auth?.get(LocalSettingsAuthKeys.ClientId)
+              ? ctx.localSettings?.auth?.get(LocalSettingsAuthKeys.ClientId)
+              : "{{localSettings.auth.clientId}}",
+            applicationIdUris: ctx.localSettings?.auth?.get(LocalSettingsAuthKeys.ApplicationIdUris)
+              ? ctx.localSettings?.auth?.get(LocalSettingsAuthKeys.ApplicationIdUris)
+              : "{{{localSettings.auth.applicationIdUris}}}",
           },
           teamsApp: {
-            teamsAppId:
-              ctx.localSettings?.teamsApp?.get(LocalSettingsTeamsAppKeys.TeamsAppId) ??
-              "{{localSettings.teamsApp.teamsAppId}}",
+            teamsAppId: ctx.localSettings?.teamsApp?.get(LocalSettingsTeamsAppKeys.TeamsAppId)
+              ? ctx.localSettings?.teamsApp?.get(LocalSettingsTeamsAppKeys.TeamsAppId)
+              : "{{localSettings.teamsApp.teamsAppId}}",
           },
           bot: {
-            botId:
-              ctx.localSettings?.bot?.get(LocalSettingsBotKeys.BotId) ??
-              "{{localSettings.bot.botId}}",
+            botId: ctx.localSettings?.bot?.get(LocalSettingsBotKeys.BotId)
+              ? ctx.localSettings?.bot?.get(LocalSettingsBotKeys.BotId)
+              : "{{localSettings.bot.botId}}",
           },
         },
       };


### PR DESCRIPTION
double question mark only works for undefined and null values. 

local settings configuration entry return empty string instead. 

![image](https://user-images.githubusercontent.com/71362691/143183623-a82e98be-4031-4487-88f7-be4560cda226.png)