### PR TITLE
fix(bot): aad error handling

### DIFF
--- a/packages/fx-core/src/plugins/resource/bot/aadRegistration.ts
+++ b/packages/fx-core/src/plugins/resource/bot/aadRegistration.ts
@@ -128,8 +128,8 @@ export class AADRegistration {
         ErrorType.User,
         errorDetail.name,
         errorDetail.message(...args),
+        [],
         error,
-        undefined,
         helpLink ?? errorDetail.helpLink
       );
     } else {


### PR DESCRIPTION
fix bug https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/12674401

After fix, the error log will be:
[2021-11-24T08:32:51.582Z] [Error] - code:BT.ProvisionError, message: Failed to provision 'AAD client secret'. Suggestions: Please check log in output channel and try to fix this issue. Please retry the current step., Request failed with status code 404, stack: Error: Request failed with status code 404
	at createError (D:\Work\TeamsFx\packages\fx-core\node_modules\axios\lib\core\createError.js:16:15)
	at settle (D:\Work\TeamsFx\packages\fx-core\node_modules\axios\lib\core\settle.js:17:12)
	at IncomingMessage.handleStreamEnd (D:\Work\TeamsFx\packages\fx-core\node_modules\axios\lib\adapters\http.js:269:11)
	at IncomingMessage.emit (events.js:327:22)
	at IncomingMessage.emit (domain.js:467:12)
	at endReadableNT (internal/streams/readable.js:1327:12)
	at processTicksAndRejections (internal/process/task_queues.js:80:21)