### PR TITLE
chore: update rc template deps sync up with sdk

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -117,6 +117,12 @@ jobs:
               git push -d origin $(git tag --points-at HEAD | grep templates | grep rc)
           fi
       
+      - name: sync up templates deps with sdk version for RC
+        if: ${{ contains(steps.version-change.outputs.CHANGED, '@microsoft/teamsfx') && !contains(steps.version-change.outputs.CHANGED, 'templates@') && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && github.event.inputs.preid == 'rc' }}
+        run: |
+          node sdk-sync-up-version.js
+        working-directory: ./.github/scripts
+      
       - name: generate templates
         run: |
           curl -sSL https://git.io/get-mo -o mo && chmod +x mo && sudo mv mo /usr/local/bin/
@@ -250,12 +256,6 @@ jobs:
         if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev' && github.event.inputs.preid == 'alpha')}}
         run: |
           npx lerna publish from-package --dist-tag=alpha --yes --allow-branch dev
-
-      - name: sync up templates deps with sdk version for RC
-        if: ${{ contains(steps.version-change.outputs.CHANGED, '@microsoft/teamsfx') && !contains(steps.version-change.outputs.CHANGED, 'templates@') && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && github.event.inputs.preid == 'rc' }}
-        run: |
-          node sdk-sync-up-version.js
-        working-directory: ./.github/scripts
 
       - name: update cli ai key
         if: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.preid == 'stable'||github.event.inputs.preid == 'rc') }}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "install-eslint": "cd packages/eslint-config && npm install",
     "lint:staged": "lerna run lint:staged --stream",
     "lint": "lerna run lint --stream",
-    "manual-version:rc": "lerna version --preid=rc --no-push --no-changelog --no-private --ignore-scripts",
+    "manual-version:rc": "lerna version --preid=rc --no-push --no-changelog --ignore-scripts",
     "prepare": "husky install"
   },
   "devDependencies": {


### PR DESCRIPTION
1. templates alpha need to update daily
2. templates rc need to update every rc release
3. templates stable no need to update every stable release since sdk deps is semver as ^
4. sync up templates deps in rc will make code change on main branch, this will let template auto release rc and stable. which is not reasonable.
5. so template sync up script will be ignore at rc release, and separate as a single action later.
6. actually, once template bump up version on stable release, the rc version also sync up with sdk.