### PR TITLE
fix(env-tree): display subs id as fallback if subs name is missing

### DIFF
--- a/packages/vscode-extension/src/envTree.ts
+++ b/packages/vscode-extension/src/envTree.ts
@@ -265,7 +265,7 @@ async function appendSubscriptionAndResourceGroupNode(env: string): Promise<void
       const subscriptionTreeItem: TreeItem = {
         commandId: `fx-extension.environment.subscription.${env}`,
         contextValue: "openSubscriptionInPortal",
-        label: subscriptionInfo.subscriptionName,
+        label: subscriptionInfo.subscriptionName ?? subscriptionInfo.subscriptionId,
         icon: "key",
         isCustom: false,
         parent: "fx-extension.environment." + env,
@@ -344,7 +344,7 @@ async function checkAccountForEnvrironment(env: string): Promise<accountStatus |
           warnings.push(
             util.format(
               StringResources.vsc.commandsTreeViewProvider.azureAccountNotMatch,
-              subscriptionInfo?.subscriptionName
+              subscriptionInfo?.subscriptionName ?? subscriptionInfo?.subscriptionId
             )
           );
         }


### PR DESCRIPTION
As subscription name might not existing for old TeamsFx project, update the behavoir to display subscription id as fallback for this scenario.

![image](https://user-images.githubusercontent.com/15644078/143206779-967dc826-bb47-4250-8ecb-22e9bf3f07ac.png)

E2E TEST: only affect UI.
