### PR TITLE
fix: popup and error log when backup fails

### DIFF
--- a/packages/fx-core/src/core/middleware/projectMigrator.ts
+++ b/packages/fx-core/src/core/middleware/projectMigrator.ts
@@ -327,6 +327,8 @@ async function migrateToArmAndMultiEnv(ctx: CoreHookContext): Promise<void> {
       sendTelemetryEvent(Component.core, TelemetryEvent.ProjectMigratorMigrateArm);
     }
   } catch (err) {
+    const core = ctx.self as FxCore;
+    core.tools.logProvider.error(`[core] Failed to upgrade project, error: '${err}'`);
     await handleError(projectPath, ctx, backupFolder);
     throw err;
   }
@@ -375,7 +377,13 @@ async function handleError(
   ctx: CoreHookContext,
   backupFolder: string | undefined
 ) {
-  await cleanup(projectPath, backupFolder);
+  try {
+    await cleanup(projectPath, backupFolder);
+  } catch (e) {
+    // try my best to cleanup
+    const core = ctx.self as FxCore;
+    core.tools.logProvider.error(`[core] Failed to cleanup the backup, error: '${e}'`);
+  }
   const core = ctx.self as FxCore;
   core.tools.ui
     .showMessage(


### PR DESCRIPTION
When the upgrade process fails in the backup stage, there will be no popup message or error log at all. Fix https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/12674853/

The new behavior:
![image](https://user-images.githubusercontent.com/9698542/143217311-54966846-b29e-44e4-a82e-b6e6f23ca435.png)
