### PR TITLE
fix(migration): correct comment location

### DIFF
--- a/packages/vscode-extension/test/unit/migration/data/js/others/replace-getContext-commentLine.input.js
+++ b/packages/vscode-extension/test/unit/migration/data/js/others/replace-getContext-commentLine.input.js
@@ -1,0 +1,10 @@
+import * as microsoftTeams from "@microsoft/teams-js";
+function myFunc() {
+    const result = microsoftTeams.getContext(123);
+    if (1 === 1) {
+        let x = undefined;
+        x = microsoftTeams.getContext(123);
+        microsoftTeams.getContext(123);
+    }
+}
+microsoftTeams.getContext(123);

--- a/packages/vscode-extension/test/unit/migration/data/js/others/replace-getContext-commentLine.output.js
+++ b/packages/vscode-extension/test/unit/migration/data/js/others/replace-getContext-commentLine.output.js
@@ -1,0 +1,18 @@
+import * as microsoftTeams from "@microsoft/teams-js";
+function myFunc() {
+    //TODO: Convert callback to promise, for more info, please refer to https://aka.ms/teamsfx-callback-to-promise.
+    //TODO: Change the context interface, for more info, please refer to https://aka.ms/teamsfx-context-mapping.
+    const result = microsoftTeams.app.getContext(123);
+    if (1 === 1) {
+        let x = undefined;
+        //TODO: Convert callback to promise, for more info, please refer to https://aka.ms/teamsfx-callback-to-promise.
+        //TODO: Change the context interface, for more info, please refer to https://aka.ms/teamsfx-context-mapping.
+        x = microsoftTeams.app.getContext(123);
+        //TODO: Convert callback to promise, for more info, please refer to https://aka.ms/teamsfx-callback-to-promise.
+        //TODO: Change the context interface, for more info, please refer to https://aka.ms/teamsfx-context-mapping.
+        microsoftTeams.app.getContext(123);
+    }
+}
+//TODO: Convert callback to promise, for more info, please refer to https://aka.ms/teamsfx-callback-to-promise.
+//TODO: Change the context interface, for more info, please refer to https://aka.ms/teamsfx-context-mapping.
+microsoftTeams.app.getContext(123);

--- a/packages/vscode-extension/test/unit/migration/data/ts/others/replace-getContext-commentLine.input.ts
+++ b/packages/vscode-extension/test/unit/migration/data/ts/others/replace-getContext-commentLine.input.ts
@@ -1,0 +1,10 @@
+import * as microsoftTeams from "@microsoft/teams-js";
+function myFunc() {
+    const result = microsoftTeams.getContext(123);
+    if (1 === 1) {
+        let x = undefined;
+        x = microsoftTeams.getContext(123);
+        microsoftTeams.getContext(123);
+    }
+}
+microsoftTeams.getContext(123);

--- a/packages/vscode-extension/test/unit/migration/data/ts/others/replace-getContext-commentLine.output.ts
+++ b/packages/vscode-extension/test/unit/migration/data/ts/others/replace-getContext-commentLine.output.ts
@@ -1,0 +1,18 @@
+import * as microsoftTeams from "@microsoft/teams-js";
+function myFunc() {
+    //TODO: Convert callback to promise, for more info, please refer to https://aka.ms/teamsfx-callback-to-promise.
+    //TODO: Change the context interface, for more info, please refer to https://aka.ms/teamsfx-context-mapping.
+    const result = microsoftTeams.app.getContext(123);
+    if (1 === 1) {
+        let x = undefined;
+        //TODO: Convert callback to promise, for more info, please refer to https://aka.ms/teamsfx-callback-to-promise.
+        //TODO: Change the context interface, for more info, please refer to https://aka.ms/teamsfx-context-mapping.
+        x = microsoftTeams.app.getContext(123);
+        //TODO: Convert callback to promise, for more info, please refer to https://aka.ms/teamsfx-callback-to-promise.
+        //TODO: Change the context interface, for more info, please refer to https://aka.ms/teamsfx-context-mapping.
+        microsoftTeams.app.getContext(123);
+    }
+}
+//TODO: Convert callback to promise, for more info, please refer to https://aka.ms/teamsfx-callback-to-promise.
+//TODO: Change the context interface, for more info, please refer to https://aka.ms/teamsfx-context-mapping.
+microsoftTeams.app.getContext(123);


### PR DESCRIPTION
Fix [ADO-12494034](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/12494034/)
Detect parent node of the line start, so comment will be put at previous line. Tests added.

E2E TEST: AzureAppScaffold