### PR TITLE
fix: create app catalog

### DIFF
--- a/packages/fx-core/resource/strings.json
+++ b/packages/fx-core/resource/strings.json
@@ -54,7 +54,7 @@
       "buildNotice": "SharePoint package successfully built at %s.",
       "deployNotice": "SharePoint package %s has been successfully deployed to [%s](%s).",
       "deployFailedNotice": "You don't have permission to upload and deploy package to App Catalog %s, please use site admin account, or you can get your own free Microsoft 365 tenant from [M365 developer program](https://developer.microsoft.com/en-us/microsoft-365/dev-program)",
-      "createAppCatalogNotice": "There is no tenant app catalog under %s, do you want to create one?"
+      "createAppCatalogNotice": "There is no tenant app catalog under %s, you can Read more about how to create app catalog site."
     }
   }
 }

--- a/packages/fx-core/src/plugins/resource/spfx/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/spfx/plugin.ts
@@ -1,6 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { PluginContext, FxError, Result, ok, Platform, Colors, err } from "@microsoft/teamsfx-api";
+import {
+  PluginContext,
+  FxError,
+  Result,
+  ok,
+  Platform,
+  Colors,
+  err,
+  UserCancelError,
+} from "@microsoft/teamsfx-api";
 import * as uuid from "uuid";
 import lodash from "lodash";
 import * as fs from "fs-extra";
@@ -275,7 +284,6 @@ export class SPFxPluginImpl {
           "warn",
           util.format(getStrings().plugins.SPFx.createAppCatalogNotice, tenant.value),
           true,
-          "OK",
           Constants.READ_MORE
         );
         const confirm = res?.isOk() ? res.value : undefined;
@@ -305,7 +313,7 @@ export class SPFxPluginImpl {
             break;
           case Constants.READ_MORE:
             ctx.ui?.openUrl(Constants.CREATE_APP_CATALOG_GUIDE);
-            break;
+            return ok(UserCancelError);
           default:
             return ok(undefined);
         }

--- a/packages/fx-core/src/plugins/resource/spfx/spoClient.ts
+++ b/packages/fx-core/src/plugins/resource/spfx/spoClient.ts
@@ -80,6 +80,6 @@ export namespace SPOClient {
 
   export async function createAppCatalog(spoToken: string): Promise<any> {
     const requester = createRequesterWithToken(spoToken);
-    await requester.post(`/_api/web/EnsureTenantAppCatalog(callerId='teamsdev'`);
+    await requester.post(`/_api/web/EnsureTenantAppCatalog(callerId='teamsdev')`);
   }
 }

--- a/packages/fx-core/src/plugins/resource/spfx/utils/constants.ts
+++ b/packages/fx-core/src/plugins/resource/spfx/utils/constants.ts
@@ -6,8 +6,8 @@ export class Constants {
   public static readonly MAX_ALIAS_LENGTH = 40;
   public static readonly MAX_BUNDLE_NAME_LENGTH = 64;
   public static readonly CALLED_ID = "teamsdev";
-  public static readonly APP_CATALOG_REFRESH_TIME = 2000;
-  public static readonly APP_CATALOG_MAX_TIMES = 30;
+  public static readonly APP_CATALOG_REFRESH_TIME = 10000;
+  public static readonly APP_CATALOG_MAX_TIMES = 12;
   public static readonly PLUGIN_NAME = "SPFx";
   public static readonly PLUGIN_DEV_NAME = "fx-resource-spfx";
   public static readonly BUILD_SHAREPOINT_PACKAGE = "Build SharePoint Package";

--- a/packages/fx-core/src/plugins/resource/spfx/utils/utils.ts
+++ b/packages/fx-core/src/plugins/resource/spfx/utils/utils.ts
@@ -74,3 +74,7 @@ export class Utils {
     return axiosInstance;
   }
 }
+
+export async function sleep(ms: number) {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
If tenant app catalog doesn't exist, we will call ensure `Ensure App Catalog` API to create one.

But it requires some time to take effect.
![image](https://user-images.githubusercontent.com/71362691/143435686-75465816-0b60-4280-83f6-cbbe29ec67f3.png)

https://docs.microsoft.com/en-us/sharepoint/dev/sp-add-ins/retrieve-tenant-app-catalog-url-rest



So we just disabled automatic app catalog creation for the user, give doc to let user manually create tenant app catalog.
![image](https://user-images.githubusercontent.com/71362691/143435535-c93e2d9a-cd65-423a-a93c-71cf943deda3.png)
