### PR TITLE
feat(env-checker): support node16 for non-function/non-spfx projects

### DIFF
--- a/.github/workflows/env-checker-ci-schedule.yml
+++ b/.github/workflows/env-checker-ci-schedule.yml
@@ -20,7 +20,7 @@ jobs:
       # macos-latest is 10.15. We need to test 11 as well.
       matrix: # TODO: add more versions and cases where Node.js do not exist
         os: [windows-latest, macos-latest, macos-11, ubuntu-latest]
-        node-version: [10, 12, 14]
+        node-version: [12, 14, 16]
         func-version: [none, 2, 3]
         dotnet-version: [none, 3.1.x, 5.0.x]
       max-parallel: 30

--- a/docs/vscode-extension/envchecker-help.md
+++ b/docs/vscode-extension/envchecker-help.md
@@ -17,7 +17,9 @@ Please Note:
 
 Please refer to [nodejs.org](https://nodejs.org/) to download and install the supported versions:
 
-- For `Azure` hosting, please refer to the supported versions [here](#nodenotsupportedazure-hosting).
+- For `Azure` hosting projects:
+    - If your project does not contain Azure Functions, please refer to the supported versions [here](#nodenotsupportedazure-hosting).
+    - If your project contains Azure Functions, please refer to the supported versions [here](#nodenotsupportedazure-functions).
 - For `SPFx` hosting, please refer to the supported versions [here](#nodenotsupportedspfx-hosting).
 
 **NOTE**: Please restart all your Visual Studio Code instances after the installation is finished.
@@ -49,7 +51,12 @@ Please refer to [the official website](https://docs.microsoft.com/en-us/azure/az
 As the Teams Toolkit project is implemented by `Node.js`, it's required to install the npm pacakges and run the project in local. 
 
 ### Mitigation
-Please refer to [nodejs.org](https://nodejs.org/) to install the right version: currently only LTS versions (v10, v12 and v14) are supported by Teams Toolkit, and `Node v14` would be recommended to be installed.
+Please refer to [nodejs.org](https://nodejs.org/) to install the right version: currently only LTS versions (v10, v12, v14 and v16) are supported by Teams Toolkit that does not containing Azure Functions or SPFx, and `Node v14` would be recommended to be installed.
+
+**NOTE**: Please restart all your Visual Studio Code instances after the installation is finished.
+
+### Mitigation
+Please refer to [nodejs.org](https://nodejs.org/) to install the right version: currently only LTS versions (v10, v12 and v14) are supported by Teams Toolkit for projects containing Azure Functions and `Node v14` would be recommended to be installed.
 
 **NOTE**: Please restart all your Visual Studio Code instances after the installation is finished.
 
@@ -57,7 +64,16 @@ Please refer to [nodejs.org](https://nodejs.org/) to install the right version: 
 ### Notification Message
 > Node.js (*node_version*) is not in the supported version list (v10, v12, v14).
 
-When `Azure` is selected as the hosting type, only LTS versions (v10, v12 and v14) of Node.js are supported by Teams Toolkit currently, please make sure the installed Node.js meets this requirement. In addition, **Node v14 (LTS)** would be recommended to be installed.
+When `Azure` is selected as the hosting type and the project does not contain Azure Functions, only LTS versions (v10, v12, v14 and v16) of Node.js are supported by Teams Toolkit currently, please make sure the installed Node.js meets this requirement. In addition, **Node v14 (LTS)** would be recommended to be installed.
+
+### Mitigation
+Please refer to [the guide](#how-to-install-nodejs) to install `Node.js`.
+
+## NodeNotSupported(Azure Functions)
+### Notification Message
+> Node.js (*node_version*) is not in the supported version list (v10, v12, v14).
+
+When `Azure` is selected as the hosting type and the project contains Azure Functions, only LTS versions (v10, v12 and v14) of Node.js are supported by Teams Toolkit currently, please make sure the installed Node.js meets this requirement. In addition, **Node v14 (LTS)** would be recommended to be installed.
 
 ### Mitigation
 Please refer to [the guide](#how-to-install-nodejs) to install `Node.js`.

--- a/docs/vscode-extension/envchecker-help.md
+++ b/docs/vscode-extension/envchecker-help.md
@@ -6,8 +6,8 @@ Teams Toolkit will help to check if the required dependencies are installed.
 
 Current required dependencies:
 
-* [Node.js](https://nodejs.org/en/download/).
-* [.NET SDK](https://dotnet.microsoft.com/download): To start simpleAuth service for local debugging and install the customized function binding extension.
+* [Node.js](https://nodejs.org/en/about/releases/).
+* [.NET SDK](https://dotnet.microsoft.com/download/): To start simpleAuth service for local debugging and install the customized function binding extension.
 
 Please Note:
 - For `Node.js`, Teams Toolkit will check its existence, and provide with the link to users where and how to install.
@@ -15,12 +15,13 @@ Please Note:
 
 ## How to install Node.js?
 
-Please refer to [nodejs.org](https://nodejs.org/) to download and install the supported versions:
+Please refer to [the official site](https://nodejs.org/en/about/releases/) to download and install the supported versions:
 
-- For `Azure` hosting projects:
-    - If your project does not contain Azure Functions, please refer to the supported versions [here](#nodenotsupportedazure-hosting).
-    - If your project contains Azure Functions, please refer to the supported versions [here](#nodenotsupportedazure-functions).
-- For `SPFx` hosting, please refer to the supported versions [here](#nodenotsupportedspfx-hosting).
+| Project type | Node.js LTS versions | Details |
+| -- | -- | -- |
+| Azure hosting projects without Functions | 10, 12, **14 (recommended)**, 16 | All Node.js LTS [versions](#nodenotsupportedazure-hosting) |
+| Azure hosting projects with Functions | 10, 12, **14 (recommended)** | Refer to the details [here](#nodenotsupportedazure-functions) |
+| SPFx hosting projects | 10, 12, **14 (recommended)** | Refer to the details [here](#nodenotsupportedspfx-hosting) |
 
 **NOTE**: Please restart all your Visual Studio Code instances after the installation is finished.
 
@@ -51,18 +52,18 @@ Please refer to [the official website](https://docs.microsoft.com/en-us/azure/az
 As the Teams Toolkit project is implemented by `Node.js`, it's required to install the npm pacakges and run the project in local. 
 
 ### Mitigation
-Please refer to [nodejs.org](https://nodejs.org/) to install the right version: currently only LTS versions (v10, v12, v14 and v16) are supported by Teams Toolkit that does not containing Azure Functions or SPFx, and `Node v14` would be recommended to be installed.
+Please refer to [the official website](https://nodejs.org/en/about/releases/) to install the right version: currently only LTS versions (v10, v12, v14 and v16) are supported by Teams Toolkit that does not containing Azure Functions or SPFx, and `Node v14` would be recommended to be installed.
 
 **NOTE**: Please restart all your Visual Studio Code instances after the installation is finished.
 
 ### Mitigation
-Please refer to [nodejs.org](https://nodejs.org/) to install the right version: currently only LTS versions (v10, v12 and v14) are supported by Teams Toolkit for projects containing Azure Functions and `Node v14` would be recommended to be installed.
+Please refer to [the official website](https://nodejs.org/en/about/releases/) to install the right version: currently only LTS versions (v10, v12 and v14) are supported by Teams Toolkit for projects containing Azure Functions and `Node v14` would be recommended to be installed.
 
 **NOTE**: Please restart all your Visual Studio Code instances after the installation is finished.
 
 ## NodeNotSupported(Azure hosting)
 ### Notification Message
-> Node.js (*node_version*) is not in the supported version list (v10, v12, v14).
+> Node.js (*node_version*) is not in the supported version list (v10, v12, v14, v16).
 
 When `Azure` is selected as the hosting type and the project does not contain Azure Functions, only LTS versions (v10, v12, v14 and v16) of Node.js are supported by Teams Toolkit currently, please make sure the installed Node.js meets this requirement. In addition, **Node v14 (LTS)** would be recommended to be installed.
 

--- a/packages/vscode-extension/src/debug/depsChecker/azureNodeChecker.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/azureNodeChecker.ts
@@ -2,8 +2,15 @@ import { DepsCheckerEvent, nodeNotFoundHelpLink, nodeNotSupportedForAzureHelpLin
 import { NodeChecker } from "./nodeChecker";
 
 export class AzureNodeChecker extends NodeChecker {
-  protected readonly _supportedVersions = ["10", "12", "14"];
   protected readonly _nodeNotFoundHelpLink = nodeNotFoundHelpLink;
   protected readonly _nodeNotSupportedHelpLink = nodeNotSupportedForAzureHelpLink;
   protected readonly _nodeNotSupportedEvent = DepsCheckerEvent.nodeNotSupportedForAzure;
+
+  protected async getSupportedVersions(): Promise<string[]> {
+    if (await this._adapter.hasTeamsfxBackend()) {
+      return ["10", "12", "14"];
+    } else {
+      return ["10", "12", "14", "16"];
+    }
+  }
 }

--- a/packages/vscode-extension/src/debug/depsChecker/azureNodeChecker.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/azureNodeChecker.ts
@@ -1,10 +1,23 @@
-import { DepsCheckerEvent, nodeNotFoundHelpLink, nodeNotSupportedForAzureHelpLink } from "./common";
+import {
+  DepsCheckerEvent,
+  nodeNotFoundHelpLink,
+  nodeNotSupportedForAzureHelpLink,
+  nodeNotSupportedForFunctionsHelpLink,
+} from "./common";
+
 import { NodeChecker } from "./nodeChecker";
 
 export class AzureNodeChecker extends NodeChecker {
   protected readonly _nodeNotFoundHelpLink = nodeNotFoundHelpLink;
-  protected readonly _nodeNotSupportedHelpLink = nodeNotSupportedForAzureHelpLink;
   protected readonly _nodeNotSupportedEvent = DepsCheckerEvent.nodeNotSupportedForAzure;
+
+  protected async getNodeNotSupportedHelpLink(): Promise<string> {
+    if (await this._adapter.hasTeamsfxBackend()) {
+      return nodeNotSupportedForFunctionsHelpLink;
+    } else {
+      return nodeNotSupportedForAzureHelpLink;
+    }
+  }
 
   protected async getSupportedVersions(): Promise<string[]> {
     if (await this._adapter.hasTeamsfxBackend()) {

--- a/packages/vscode-extension/src/debug/depsChecker/common.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/common.ts
@@ -28,6 +28,7 @@ export const defaultHelpLink = "https://aka.ms/teamsfx-envchecker-help";
 
 export const nodeNotFoundHelpLink = `${defaultHelpLink}#nodenotfound`;
 export const nodeNotSupportedForAzureHelpLink = `${defaultHelpLink}#nodenotsupportedazure-hosting`;
+export const nodeNotSupportedForFunctionsHelpLink = `${defaultHelpLink}#nodenotsupportedazure-functions`;
 export const nodeNotSupportedForSPFxHelpLink = `${defaultHelpLink}#nodenotsupportedspfx-hosting`;
 
 export const dotnetExplanationHelpLink = `${defaultHelpLink}#overall`;

--- a/packages/vscode-extension/src/debug/depsChecker/nodeChecker.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/nodeChecker.ts
@@ -15,13 +15,13 @@ class NodeVersion {
 }
 
 export abstract class NodeChecker implements IDepsChecker {
-  protected abstract readonly _supportedVersions: string[];
   protected abstract readonly _nodeNotSupportedHelpLink: string;
   protected abstract readonly _nodeNotFoundHelpLink: string;
   protected abstract readonly _nodeNotSupportedEvent: DepsCheckerEvent;
+  protected abstract getSupportedVersions(): Promise<string[]>;
 
   private readonly _telemetry: IDepsTelemetry;
-  private readonly _adapter: IDepsAdapter;
+  protected readonly _adapter: IDepsAdapter;
   private readonly _logger: IDepsLogger;
 
   constructor(adapter: IDepsAdapter, logger: IDepsLogger, telemetry: IDepsTelemetry) {
@@ -35,8 +35,10 @@ export abstract class NodeChecker implements IDepsChecker {
   }
 
   public async isInstalled(): Promise<boolean> {
+    const supportedVersions = await this.getSupportedVersions();
+
     this._logger.debug(
-      `NodeChecker checking for supported versions: '${JSON.stringify(this._supportedVersions)}'`
+      `NodeChecker checking for supported versions: '${JSON.stringify(supportedVersions)}'`
     );
 
     const currentVersion = await getInstalledNodeVersion();
@@ -45,8 +47,8 @@ export abstract class NodeChecker implements IDepsChecker {
       throw new NodeNotFoundError(Messages.NodeNotFound, this._nodeNotFoundHelpLink);
     }
 
-    if (!NodeChecker.isVersionSupported(this._supportedVersions, currentVersion)) {
-      const supportedVersions = this._supportedVersions.map((v) => "v" + v).join(" ,");
+    if (!NodeChecker.isVersionSupported(supportedVersions, currentVersion)) {
+      const supportedVersionsString = supportedVersions.map((v) => "v" + v).join(" ,");
       this._telemetry.sendUserErrorEvent(
         this._nodeNotSupportedEvent,
         `Node.js ${currentVersion.version} is not supported.`
@@ -55,7 +57,7 @@ export abstract class NodeChecker implements IDepsChecker {
         Messages.NodeNotSupported.split("@CurrentVersion")
           .join(currentVersion.version)
           .split("@SupportedVersions")
-          .join(supportedVersions),
+          .join(supportedVersionsString),
         this._nodeNotSupportedHelpLink
       );
     }
@@ -70,7 +72,7 @@ export abstract class NodeChecker implements IDepsChecker {
   public async getDepsInfo(): Promise<DepsInfo> {
     return {
       name: NodeName,
-      supportedVersions: this._supportedVersions,
+      supportedVersions: await this.getSupportedVersions(),
       details: new Map<string, string>(),
     };
   }

--- a/packages/vscode-extension/src/debug/depsChecker/nodeChecker.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/nodeChecker.ts
@@ -15,10 +15,10 @@ class NodeVersion {
 }
 
 export abstract class NodeChecker implements IDepsChecker {
-  protected abstract readonly _nodeNotSupportedHelpLink: string;
   protected abstract readonly _nodeNotFoundHelpLink: string;
   protected abstract readonly _nodeNotSupportedEvent: DepsCheckerEvent;
   protected abstract getSupportedVersions(): Promise<string[]>;
+  protected abstract getNodeNotSupportedHelpLink(): Promise<string>;
 
   private readonly _telemetry: IDepsTelemetry;
   protected readonly _adapter: IDepsAdapter;
@@ -58,7 +58,7 @@ export abstract class NodeChecker implements IDepsChecker {
           .join(currentVersion.version)
           .split("@SupportedVersions")
           .join(supportedVersionsString),
-        this._nodeNotSupportedHelpLink
+        await this.getNodeNotSupportedHelpLink()
       );
     }
 

--- a/packages/vscode-extension/src/debug/depsChecker/spfxNodeChecker.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/spfxNodeChecker.ts
@@ -2,8 +2,11 @@ import { DepsCheckerEvent, nodeNotFoundHelpLink, nodeNotSupportedForSPFxHelpLink
 import { NodeChecker } from "./nodeChecker";
 
 export class SPFxNodeChecker extends NodeChecker {
-  protected readonly _supportedVersions: string[] = ["10", "12", "14"];
   protected readonly _nodeNotFoundHelpLink = nodeNotFoundHelpLink;
   protected readonly _nodeNotSupportedHelpLink = nodeNotSupportedForSPFxHelpLink;
   protected readonly _nodeNotSupportedEvent = DepsCheckerEvent.nodeNotSupportedForSPFx;
+
+  protected async getSupportedVersions(): Promise<string[]> {
+    return ["10", "12", "14"];
+  }
 }

--- a/packages/vscode-extension/src/debug/depsChecker/spfxNodeChecker.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/spfxNodeChecker.ts
@@ -3,8 +3,11 @@ import { NodeChecker } from "./nodeChecker";
 
 export class SPFxNodeChecker extends NodeChecker {
   protected readonly _nodeNotFoundHelpLink = nodeNotFoundHelpLink;
-  protected readonly _nodeNotSupportedHelpLink = nodeNotSupportedForSPFxHelpLink;
   protected readonly _nodeNotSupportedEvent = DepsCheckerEvent.nodeNotSupportedForSPFx;
+
+  protected async getNodeNotSupportedHelpLink(): Promise<string> {
+    return nodeNotSupportedForSPFxHelpLink;
+  }
 
   protected async getSupportedVersions(): Promise<string[]> {
     return ["10", "12", "14"];

--- a/packages/vscode-extension/test/integration/envChecker/cases/node.ts
+++ b/packages/vscode-extension/test/integration/envChecker/cases/node.ts
@@ -8,11 +8,10 @@ import { DepsChecker } from "../../../../src/debug/depsChecker/checker";
 import { TestAdapter } from "../adapters/testAdapter";
 import { TestLogger } from "../adapters/testLogger";
 import { TestTelemetry } from "../adapters/testTelemetry";
-import { ConfigFolderName } from "@microsoft/teamsfx-api";
-import { isLinux } from "../../../../src/utils/commonUtils";
 import { AzureNodeChecker } from "../../../../src/debug/depsChecker/azureNodeChecker";
 
-const azureSupportedNodeVersions = ["10", "12", "14"];
+const functionsSupportedNodeVersions = ["10", "12", "14"];
+const azureSupportedNodeVersions = ["10", "12", "14", "16"];
 
 function createTestChecker(
   hasTeamsfxBackend: boolean,
@@ -38,11 +37,23 @@ function createTestChecker(
 suite("NodeChecker E2E Test", async () => {
   test("Node supported version is installed", async function (this: Mocha.Context) {
     const nodeVersion = await nodeUtils.getNodeVersion();
-    if (!(nodeVersion != null && azureSupportedNodeVersions.includes(nodeVersion))) {
+    if (!(nodeVersion != null && functionsSupportedNodeVersions.includes(nodeVersion))) {
       this.skip();
     }
 
     const [checker, _] = createTestChecker(true);
+
+    const shouldContinue = await checker.resolve();
+    chai.assert.isTrue(shouldContinue);
+  });
+
+  test("Node supported version is installed for tab-only projects", async function (this: Mocha.Context) {
+    const nodeVersion = await nodeUtils.getNodeVersion();
+    if (!(nodeVersion != null && azureSupportedNodeVersions.includes(nodeVersion))) {
+      this.skip();
+    }
+
+    const [checker, _] = createTestChecker(false);
 
     const shouldContinue = await checker.resolve();
     chai.assert.isTrue(shouldContinue);
@@ -61,7 +72,7 @@ suite("NodeChecker E2E Test", async () => {
 
   test("Node unsupported version is installed, and the user clicks continue", async function (this: Mocha.Context) {
     const nodeVersion = await nodeUtils.getNodeVersion();
-    if (!(nodeVersion != null && !azureSupportedNodeVersions.includes(nodeVersion))) {
+    if (!(nodeVersion != null && !functionsSupportedNodeVersions.includes(nodeVersion))) {
       this.skip();
     }
 
@@ -73,7 +84,7 @@ suite("NodeChecker E2E Test", async () => {
 
   test("Node unsupported version is installed, and the user clicks cancel", async function (this: Mocha.Context) {
     const nodeVersion = await nodeUtils.getNodeVersion();
-    if (!(nodeVersion != null && !azureSupportedNodeVersions.includes(nodeVersion))) {
+    if (!(nodeVersion != null && !functionsSupportedNodeVersions.includes(nodeVersion))) {
       this.skip();
     }
 


### PR DESCRIPTION
- For non-function/non-spfx projects, support Node.js 16 LTS
- Update the documents accordingly

See the rendered document at [here](https://github.com/OfficeDev/TeamsFx/blob/aochengwang/feat/node16/docs/vscode-extension/envchecker-help.md#nodenotsupportedazure-functions)

env-checker test result: https://github.com/OfficeDev/TeamsFx/actions/runs/1525007470
M1 for https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/12196596/