### PR TITLE
fix: do not support url for icons

### DIFF
--- a/packages/fx-core/src/plugins/resource/appstudio/index.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/index.ts
@@ -152,7 +152,6 @@ export class AppStudioPlugin implements Plugin {
     if (validationResult.length > 0) {
       const errMessage = AppStudioError.ValidationFailedError.message(validationResult);
       ctx.logProvider?.error("Manifest Validation failed!");
-      ctx.ui?.showMessage("error", errMessage, false);
       const properties: { [key: string]: string } = this.appStudioPluginImpl.commonProperties;
       properties[TelemetryPropertyKey.validationResult] = validationResult.join("\n");
       const validationFailed = AppStudioResultFactory.UserError(

--- a/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
@@ -1164,14 +1164,12 @@ export class AppStudioPluginImpl {
         throw appDefinitionRes.error;
       }
       let appStudioToken = await ctx?.appStudioToken?.getAccessToken();
-      const colorIconContent =
-        manifest.icons.color && !manifest.icons.color.startsWith("https://")
-          ? (await fs.readFile(`${appDirectory}/${manifest.icons.color}`)).toString("base64")
-          : undefined;
-      const outlineIconContent =
-        manifest.icons.outline && !manifest.icons.outline.startsWith("https://")
-          ? (await fs.readFile(`${appDirectory}/${manifest.icons.outline}`)).toString("base64")
-          : undefined;
+      const colorIconContent = manifest.icons.color
+        ? (await fs.readFile(`${appDirectory}/${manifest.icons.color}`)).toString("base64")
+        : undefined;
+      const outlineIconContent = manifest.icons.outline
+        ? (await fs.readFile(`${appDirectory}/${manifest.icons.outline}`)).toString("base64")
+        : undefined;
       try {
         await AppStudioClient.updateApp(
           remoteTeamsAppId,


### PR DESCRIPTION
1) Avoid two info messages when validation failed

2) Check icons in manifest validation

![image](https://user-images.githubusercontent.com/71362691/144178605-aa33627d-ee19-43d7-b966-74d9648010f4.png)


E2E TEST: AzureAppHappyPath