### PR TITLE
fix: move get status to immediate call logic

### DIFF
--- a/packages/vscode-extension/src/commonlib/common/login.ts
+++ b/packages/vscode-extension/src/commonlib/common/login.ts
@@ -16,8 +16,8 @@ export abstract class login {
     immediateCall = true
   ): Promise<boolean> {
     this.statusChangeMap.set(name, statusChange);
-    const loginStatus: LoginStatus = await this.getStatus();
     if (immediateCall) {
+      const loginStatus: LoginStatus = await this.getStatus();
       statusChange(loginStatus.status, loginStatus.token, loginStatus.accountInfo);
     }
     return true;


### PR DESCRIPTION
1. Fix open share point login page unexpected when open a project.

Fix bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/12674790/