### PR TITLE
fix(local debug): remove IDENTITY_ID from backend and bot local envs

### DIFF
--- a/packages/fx-core/src/plugins/resource/localdebug/localEnvMulti.ts
+++ b/packages/fx-core/src/plugins/resource/localdebug/localEnvMulti.ts
@@ -32,7 +32,6 @@ export const EnvKeysBackend = Object.freeze({
   TenantId: "M365_TENANT_ID",
   ClientId: "M365_CLIENT_ID",
   ClientSecret: "M365_CLIENT_SECRET",
-  IdentityId: "IDENTITY_ID",
   ApiEndpoint: "API_ENDPOINT",
   ApplicationIdUri: "M365_APPLICATION_ID_URI",
   AllowedAppIds: "ALLOWED_APP_IDS",
@@ -53,7 +52,6 @@ export const EnvKeysBot = Object.freeze({
   TenantID: "M365_TENANT_ID",
   OauthAuthority: "M365_AUTHORITY_HOST",
   LoginEndpoint: "INITIATE_LOGIN_ENDPOINT",
-  IdentityId: "IDENTITY_ID",
   ApiEndpoint: "API_ENDPOINT",
   ApplicationIdUri: "M365_APPLICATION_ID_URI",
 });
@@ -177,7 +175,6 @@ export class LocalEnvMultiProvider {
     result.teamsfxLocalEnvs[EnvKeysBackend.TenantId] = "";
     result.teamsfxLocalEnvs[EnvKeysBackend.ClientId] = "";
     result.teamsfxLocalEnvs[EnvKeysBackend.ClientSecret] = "";
-    result.teamsfxLocalEnvs[EnvKeysBackend.IdentityId] = "";
     result.teamsfxLocalEnvs[EnvKeysBackend.ApiEndpoint] = "";
     result.teamsfxLocalEnvs[EnvKeysBackend.ApplicationIdUri] = "";
     result.teamsfxLocalEnvs[EnvKeysBackend.AllowedAppIds] = "";
@@ -207,7 +204,6 @@ export class LocalEnvMultiProvider {
       result.teamsfxLocalEnvs[EnvKeysBot.TenantID] = "";
       result.teamsfxLocalEnvs[EnvKeysBot.OauthAuthority] = "";
       result.teamsfxLocalEnvs[EnvKeysBot.LoginEndpoint] = "";
-      result.teamsfxLocalEnvs[EnvKeysBot.IdentityId] = "";
       result.teamsfxLocalEnvs[EnvKeysBot.ApiEndpoint] = "";
       result.teamsfxLocalEnvs[EnvKeysBot.ApplicationIdUri] = "";
 

--- a/packages/fx-core/tests/plugins/resource/localdebug/unit/localEnvMulti.test.ts
+++ b/packages/fx-core/tests/plugins/resource/localdebug/unit/localEnvMulti.test.ts
@@ -77,7 +77,6 @@ describe("LocalEnvProvider-MultiEnv", () => {
         M365_CLIENT_SECRET=f\n\
         # ENV COMMENT\n\
         \n\
-        IDENTITY_ID=g\n\
         API_ENDPOINT=h\n\
         M365_APPLICATION_ID_URI=i\n\
         ALLOWED_APP_IDS=j\n\
@@ -90,7 +89,6 @@ describe("LocalEnvProvider-MultiEnv", () => {
           M365_TENANT_ID: "d",
           M365_CLIENT_ID: "e",
           M365_CLIENT_SECRET: "f",
-          IDENTITY_ID: "g",
           API_ENDPOINT: "h",
           M365_APPLICATION_ID_URI: "i",
           ALLOWED_APP_IDS: "j",
@@ -122,7 +120,6 @@ describe("LocalEnvProvider-MultiEnv", () => {
         M365_AUTHORITY_HOST=f\n\
         # ENV COMMENT\n\
         INITIATE_LOGIN_ENDPOINT=g\n\
-        IDENTITY_ID=h\n\
         API_ENDPOINT=i\n\
         M365_APPLICATION_ID_URI=j\n\
         MYENV2=2\n";
@@ -135,7 +132,6 @@ describe("LocalEnvProvider-MultiEnv", () => {
           M365_TENANT_ID: "e",
           M365_AUTHORITY_HOST: "f",
           INITIATE_LOGIN_ENDPOINT: "g",
-          IDENTITY_ID: "h",
           API_ENDPOINT: "i",
           M365_APPLICATION_ID_URI: "j",
         },
@@ -315,13 +311,13 @@ describe("LocalEnvProvider-MultiEnv", () => {
 
     it("backend", () => {
       const envs = localEnvMultiProvider.initBackendLocalEnvs();
-      chai.assert.equal(Object.values(envs.teamsfxLocalEnvs).length, 10);
+      chai.assert.equal(Object.values(envs.teamsfxLocalEnvs).length, 9);
       chai.assert.equal(Object.values(envs.customizedLocalEnvs).length, 4);
     });
 
     it("bot", () => {
       const envs = localEnvMultiProvider.initBotLocalEnvs(false);
-      chai.assert.equal(Object.values(envs.teamsfxLocalEnvs).length, 10);
+      chai.assert.equal(Object.values(envs.teamsfxLocalEnvs).length, 9);
       chai.assert.equal(Object.values(envs.customizedLocalEnvs).length, 4);
     });
 


### PR DESCRIPTION
- remove IDENTITY_ID from backend and bot local envs since it is useless

Fix https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/12711181.

E2E TEST: https://github.com/OfficeDev/TeamsFx-UI-Test/blob/main/src/ui-test/localdebug/localdebug-tabbotfunc.test.ts#L11