### PR TITLE
chore: add created-from telemetry property for bi data

### DIFF
--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -997,7 +997,7 @@ export interface ProjectSettings {
     // (undocumented)
     appName: string;
     // (undocumented)
-    createdFrom?: string | undefined;
+    createdFrom?: string;
     // (undocumented)
     defaultFunctionName?: string;
     // (undocumented)

--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -997,6 +997,8 @@ export interface ProjectSettings {
     // (undocumented)
     appName: string;
     // (undocumented)
+    createdFrom?: string | undefined;
+    // (undocumented)
     defaultFunctionName?: string;
     // (undocumented)
     isFromSample?: boolean;

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -143,6 +143,7 @@ export interface ProjectSettings {
   defaultFunctionName?: string;
   solutionSettings: SolutionSettings;
   isFromSample?: boolean;
+  createdFrom?: string | undefined;
 }
 
 /**

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -143,7 +143,7 @@ export interface ProjectSettings {
   defaultFunctionName?: string;
   solutionSettings: SolutionSettings;
   isFromSample?: boolean;
-  createdFrom?: string | undefined;
+  createdFrom?: string;
 }
 
 /**

--- a/packages/cli/src/telemetry/cliTelemetry.ts
+++ b/packages/cli/src/telemetry/cliTelemetry.ts
@@ -11,7 +11,7 @@ import {
 } from "./cliTelemetryEvents";
 import { FxError, UserError } from "@microsoft/teamsfx-api";
 import { getHashedEnv } from "@microsoft/teamsfx-core";
-import { getTeamsAppId } from "../utils";
+import { getCreatedFrom, getTeamsAppId } from "../utils";
 
 export function makeEnvProperty(
   env: string | undefined
@@ -60,6 +60,10 @@ export class CliTelemetry {
     }
 
     properties[TelemetryProperty.AppId] = getTeamsAppId(CliTelemetry.rootFolder);
+    const createdFrom = getCreatedFrom(CliTelemetry.rootFolder);
+    if (createdFrom !== undefined) {
+      properties[TelemetryProperty.CreatedFrom] = createdFrom;
+    }
 
     CliTelemetry.reporter
       .withRootFolder(CliTelemetry.rootFolder)
@@ -82,6 +86,10 @@ export class CliTelemetry {
     }
 
     properties[TelemetryProperty.AppId] = getTeamsAppId(CliTelemetry.rootFolder);
+    const createdFrom = getCreatedFrom(CliTelemetry.rootFolder);
+    if (createdFrom !== undefined) {
+      properties[TelemetryProperty.CreatedFrom] = createdFrom;
+    }
 
     properties[TelemetryProperty.Success] = TelemetrySuccess.No;
     if (error instanceof UserError) {
@@ -112,6 +120,10 @@ export class CliTelemetry {
     }
 
     properties[TelemetryProperty.AppId] = getTeamsAppId(CliTelemetry.rootFolder);
+    const createdFrom = getCreatedFrom(CliTelemetry.rootFolder);
+    if (createdFrom !== undefined) {
+      properties[TelemetryProperty.CreatedFrom] = createdFrom;
+    }
 
     CliTelemetry.reporter
       .withRootFolder(CliTelemetry.rootFolder)

--- a/packages/cli/src/telemetry/cliTelemetryEvents.ts
+++ b/packages/cli/src/telemetry/cliTelemetryEvents.ts
@@ -96,6 +96,7 @@ export enum TelemetryProperty {
   ListAllCollaborators = "list-all-collaborators",
   FeatureFlags = "feature-flags",
   Env = "env",
+  CreatedFrom = "created-from",
 }
 
 export enum TelemetrySuccess {

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -362,6 +362,24 @@ export function getTeamsAppId(rootfolder: string | undefined): any {
   return undefined;
 }
 
+// Only used for telemetry
+export function getCreatedFrom(rootFolder: string | undefined): string | undefined {
+  if (!rootFolder) {
+    return undefined;
+  }
+  try {
+    if (isWorkspaceSupported(rootFolder)) {
+      const result = readSettingsFileSync(rootFolder);
+      if (result.isOk()) {
+        return result.value.createdFrom;
+      }
+    }
+  } catch (e) {
+    // ignore errors for telemetry
+  }
+  return undefined;
+}
+
 export function getLocalTeamsAppId(rootfolder: string | undefined): any {
   if (!rootfolder) {
     return undefined;

--- a/packages/fx-core/src/core/index.ts
+++ b/packages/fx-core/src/core/index.ts
@@ -172,6 +172,7 @@ export let TOOLS: Tools;
 export class FxCore implements Core {
   tools: Tools;
   isFromSample?: boolean;
+  createdFrom?: string;
 
   constructor(tools: Tools) {
     this.tools = tools;

--- a/packages/fx-core/src/core/index.ts
+++ b/packages/fx-core/src/core/index.ts
@@ -130,6 +130,10 @@ import {
 import { flattenConfigJson, newEnvInfo } from "./tools";
 import { LocalCrypto } from "./crypto";
 import { SupportV1ConditionMW } from "./middleware/supportV1ConditionHandler";
+// TODO: For package.json,
+// use require instead of import because of core building/packaging method.
+// Using import will cause the build folder structure to change.
+const corePackage = require("../../package.json");
 
 export interface CoreHookContext extends HookContext {
   projectSettings?: ProjectSettings;
@@ -245,6 +249,7 @@ export class FxCore implements Core {
       if (basicFolderRes.isErr()) {
         return err(basicFolderRes.error);
       }
+
       const projectSettings: ProjectSettings = {
         appName: appName,
         projectId: inputs.projectId ? inputs.projectId : uuid.v4(),
@@ -254,6 +259,7 @@ export class FxCore implements Core {
         },
         version: getProjectSettingsVersion(),
         isFromSample: false,
+        createdFrom: corePackage.version,
       };
       ctx.projectSettings = projectSettings;
       if (multiEnv) {

--- a/packages/fx-core/src/core/middleware/projectSettingsLoader.ts
+++ b/packages/fx-core/src/core/middleware/projectSettingsLoader.ts
@@ -66,6 +66,7 @@ export const ProjectSettingsLoaderMW: Middleware = async (
 
     ctx.projectSettings = projectSettings;
     (ctx.self as FxCore).isFromSample = projectSettings.isFromSample === true;
+    (ctx.self as FxCore).createdFrom = projectSettings.createdFrom;
     if (isV2()) {
       (ctx.self as FxCore).tools.cryptoProvider = new LocalCrypto(projectSettings.projectId);
       ctx.contextV2 = createV2Context(ctx.self as FxCore, projectSettings);

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -222,6 +222,7 @@ export async function activate(): Promise<Result<Void, FxError>> {
     await openSampleReadmeHandler();
     await postUpgrade();
     ExtTelemetry.isFromSample = await getIsFromSample();
+    ExtTelemetry.createdFrom = await getCreatedFrom();
 
     if (workspacePath) {
       // refresh env tree when env config files added or deleted.
@@ -264,6 +265,19 @@ async function getIsFromSample() {
     await core.getProjectConfig(input);
 
     return core.isFromSample;
+  }
+  return undefined;
+}
+
+// only used for telemetry
+async function getCreatedFrom(): Promise<string | undefined> {
+  if (core) {
+    const input = getSystemInputs();
+    const projectConfig = await core.getProjectConfig(input);
+    // ignore errors for telemetry
+    if (projectConfig.isOk()) {
+      return projectConfig.value?.settings?.createdFrom;
+    }
   }
   return undefined;
 }

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -273,11 +273,16 @@ async function getIsFromSample() {
 async function getCreatedFrom(): Promise<string | undefined> {
   if (core) {
     const input = getSystemInputs();
-    const projectConfig = await core.getProjectConfig(input);
+    // TODO: from the experience of 'is-from-sample':
+    // in some circumstances, getProjectConfig() returns undefined even projectSettings.json is valid.
+    // This is a workaround to prevent that. We can change to the following code after the root cause is found.
+    // const projectConfig = await core.getProjectConfig(input);
     // ignore errors for telemetry
-    if (projectConfig.isOk()) {
-      return projectConfig.value?.settings?.createdFrom;
-    }
+    // if (projectConfig.isOk()) {
+    //   return projectConfig.value?.settings?.createdFrom;
+    // }
+    await core.getProjectConfig(input);
+    return core.createdFrom;
   }
   return undefined;
 }

--- a/packages/vscode-extension/src/telemetry/extTelemetry.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetry.ts
@@ -21,6 +21,7 @@ export namespace ExtTelemetry {
   export let hasSentTelemetry = false;
   /* eslint-disable prefer-const */
   export let isFromSample: boolean | undefined = undefined;
+  export let createdFrom: string | undefined = undefined;
 
   export function setHasSentTelemetry(eventName: string) {
     if (eventName === "query-expfeature") return;
@@ -34,6 +35,7 @@ export namespace ExtTelemetry {
   export class Reporter extends vscode.Disposable {
     constructor(ctx: vscode.ExtensionContext) {
       super(() => reporter.dispose());
+
       reporter = new VSCodeTelemetryReporter(
         extensionPackage.aiKey,
         extensionPackage.version,
@@ -90,6 +92,9 @@ export namespace ExtTelemetry {
     if (isFromSample != undefined) {
       properties![TelemetryProperty.IsFromSample] = isFromSample.toString();
     }
+    if (createdFrom != undefined) {
+      properties![TelemetryProperty.CreatedFrom] = createdFrom.toString();
+    }
 
     reporter.sendTelemetryEvent(eventName, properties, measurements);
   }
@@ -131,6 +136,9 @@ export namespace ExtTelemetry {
     if (isFromSample != undefined) {
       properties![TelemetryProperty.IsFromSample] = isFromSample.toString();
     }
+    if (createdFrom != undefined) {
+      properties![TelemetryProperty.CreatedFrom] = createdFrom.toString();
+    }
 
     reporter.sendTelemetryErrorEvent(eventName, properties, measurements, errorProps);
   }
@@ -157,6 +165,9 @@ export namespace ExtTelemetry {
 
     if (isFromSample != undefined) {
       properties![TelemetryProperty.IsFromSample] = isFromSample.toString();
+    }
+    if (createdFrom != undefined) {
+      properties![TelemetryProperty.CreatedFrom] = createdFrom.toString();
     }
 
     reporter.sendTelemetryException(error, properties, measurements);

--- a/packages/vscode-extension/src/telemetry/extTelemetry.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetry.ts
@@ -92,7 +92,7 @@ export namespace ExtTelemetry {
     if (isFromSample != undefined) {
       properties![TelemetryProperty.IsFromSample] = isFromSample.toString();
     }
-    if (createdFrom != undefined) {
+    if (createdFrom !== undefined) {
       properties![TelemetryProperty.CreatedFrom] = createdFrom.toString();
     }
 
@@ -136,7 +136,7 @@ export namespace ExtTelemetry {
     if (isFromSample != undefined) {
       properties![TelemetryProperty.IsFromSample] = isFromSample.toString();
     }
-    if (createdFrom != undefined) {
+    if (createdFrom !== undefined) {
       properties![TelemetryProperty.CreatedFrom] = createdFrom.toString();
     }
 
@@ -166,7 +166,7 @@ export namespace ExtTelemetry {
     if (isFromSample != undefined) {
       properties![TelemetryProperty.IsFromSample] = isFromSample.toString();
     }
-    if (createdFrom != undefined) {
+    if (createdFrom !== undefined) {
       properties![TelemetryProperty.CreatedFrom] = createdFrom.toString();
     }
 

--- a/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
@@ -189,6 +189,7 @@ export enum TelemetryProperty {
   SourceEnv = "sourceEnv",
   TargetEnv = "targetEnv",
   IsFromSample = "is-from-sample",
+  CreatedFrom = "created-from",
   UpdateFailedFiles = "update-failed-files",
 }
 


### PR DESCRIPTION
- add created-from property to telemetry events so BI report will not need to aggregate all projects and some hacky methods to determine at what version the project is created
- BI reports for old projects will still use the old method
- create-from property is core's package version, because we cannot get extension/cli version from core. toolkit/cli version can be determined because they have 1:1 mapping
- its implementation is similar to is-from-sample
- ut added

tested local debug happy path and packaged version:

![CopyQ VDTdZl](https://user-images.githubusercontent.com/9698542/144544035-8b7d8530-b73e-40ee-9c4e-d62d991f9d75.png)
![CopyQ AgAnJO](https://user-images.githubusercontent.com/9698542/144544045-17bb1073-01d8-4ca4-b658-44859930143c.png)

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/12690560/