### PR TITLE
chore(telemetry): fill createdFrom when upgrading

### DIFF
--- a/packages/fx-core/src/core/middleware/projectMigrator.ts
+++ b/packages/fx-core/src/core/middleware/projectMigrator.ts
@@ -884,6 +884,11 @@ async function ensureProjectSettings(
     settings.defaultFunctionName =
       settings.defaultFunctionName || envDefault[PluginNames.FUNC]?.[defaultFunctionName];
   }
+  if (!settings.createdFrom) {
+    // We won't know the exact version when the project is created.
+    // But we know it is from core <1.0 (extension < 3.0).
+    settings.createdFrom = "<1.0";
+  }
   settings.version = "2.0.0";
   await fs.writeFile(projectSettingPath, JSON.stringify(settings, null, 4), {
     encoding: "UTF-8",


### PR DESCRIPTION
this is to prevent GDPR classification error making it indistinguishable to know whether it is from v2 or v3

Tested migrate happy path