### PR TITLE
fix(migratev1): send telemetry after migrate v1 success

### DIFF
--- a/packages/fx-core/src/core/middleware/migrateConditionHandler.ts
+++ b/packages/fx-core/src/core/middleware/migrateConditionHandler.ts
@@ -24,7 +24,4 @@ export const MigrateConditionHandlerMW: Middleware = async (
   }
 
   await next();
-  if (ctx.result?.isOk()) {
-    await ctx?.self.tools.ui.reload?.();
-  }
 };

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -373,10 +373,8 @@ export async function migrateV1ProjectHandler(args?: any[]): Promise<Result<any,
     getTriggerFromProperty(args)
   );
   const result = await runCommand(Stage.migrateV1);
-  await vscode.commands.executeCommand("setContext", "fx-extension.sidebarWelcome.treeview", true);
-  await vscode.commands.executeCommand("setContext", "fx-extension.sidebarWelcome.default", false);
   if (result.isOk()) {
-    commands.executeCommand("vscode.openFolder", result.value);
+    commands.executeCommand("workbench.action.reloadWindow", result.value);
   }
   return result;
 }


### PR DESCRIPTION
Move reload command to vscode-extension to send telemetry after migrating success.
Detail: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_boards/board/t/Infrastructure%20Team/Stories/?workitem=12783805