### PR TITLE
chore: add more info for subscription item in env tree view

### DIFF
--- a/packages/vscode-extension/src/envTree.ts
+++ b/packages/vscode-extension/src/envTree.ts
@@ -255,6 +255,7 @@ async function appendSubscriptionAndResourceGroupNode(env: string): Promise<void
   ) {
     const envSubItems: TreeItem[] = [];
     const subscriptionInfo = await getSubscriptionInfoFromEnv(env);
+
     if (subscriptionInfo) {
       const subscriptionTreeItem: TreeItem = {
         commandId: `fx-extension.environment.subscription.${env}`,
@@ -265,7 +266,11 @@ async function appendSubscriptionAndResourceGroupNode(env: string): Promise<void
           isMarkdown: false,
           value: `'${env}' environment is provisioned in Azure subscription '${
             subscriptionInfo.subscriptionName ?? subscriptionInfo.subscriptionId
-          }'`,
+          }'${
+            subscriptionInfo.subscriptionName
+              ? " (ID: " + subscriptionInfo.subscriptionId + ")"
+              : ""
+          }`,
         },
         icon: "key",
         isCustom: false,

--- a/packages/vscode-extension/src/envTree.ts
+++ b/packages/vscode-extension/src/envTree.ts
@@ -260,6 +260,13 @@ async function appendSubscriptionAndResourceGroupNode(env: string): Promise<void
         commandId: `fx-extension.environment.subscription.${env}`,
         contextValue: "openSubscriptionInPortal",
         label: subscriptionInfo.subscriptionName ?? subscriptionInfo.subscriptionId,
+        description: subscriptionInfo.subscriptionId,
+        tooltip: {
+          isMarkdown: false,
+          value: `'${env}' environment is provisioned in Azure subscription '${
+            subscriptionInfo.subscriptionName ?? subscriptionInfo.subscriptionId
+          }'`,
+        },
         icon: "key",
         isCustom: false,
         parent: "fx-extension.environment." + env,

--- a/packages/vscode-extension/src/envTree.ts
+++ b/packages/vscode-extension/src/envTree.ts
@@ -264,13 +264,18 @@ async function appendSubscriptionAndResourceGroupNode(env: string): Promise<void
         description: subscriptionInfo.subscriptionId,
         tooltip: {
           isMarkdown: false,
-          value: `'${env}' environment is provisioned in Azure subscription '${
-            subscriptionInfo.subscriptionName ?? subscriptionInfo.subscriptionId
-          }'${
-            subscriptionInfo.subscriptionName
-              ? " (ID: " + subscriptionInfo.subscriptionId + ")"
-              : ""
-          }`,
+          value: subscriptionInfo.subscriptionName
+            ? util.format(
+                StringResources.vsc.envTree.subscriptionTooltip,
+                env,
+                subscriptionInfo.subscriptionName,
+                subscriptionInfo.subscriptionId
+              )
+            : util.format(
+                StringResources.vsc.envTree.subscriptionTooltipWithoutName,
+                env,
+                subscriptionInfo.subscriptionId
+              ),
         },
         icon: "key",
         isCustom: false,

--- a/packages/vscode-extension/src/resources/Strings.json
+++ b/packages/vscode-extension/src/resources/Strings.json
@@ -206,6 +206,10 @@
       "sideloadingMessage": "[Teams Toolkit] Your Microsoft 365 tenant admin hasn't enabled sideloading permission for your account. You can't install your app to Teams! Please applying for a Microsoft 365 developer tenant by joining Microsoft developer program or contact your tenant admin to resolve the issue.",
       "sideloadingJoinM365": "Join M365 Developer Program"
     },
+    "envTree": {
+      "subscriptionTooltip": "'%s' environment is provisioned in Azure subscription '%s' (ID: %s)",
+      "subscriptionTooltipWithoutName": "'%s' environment is provisioned in Azure subscription '%s'"
+    },
     "qm": {
       "emptySelection": "select option is empty",
       "ok": "ok (Enter)",


### PR DESCRIPTION
Fix bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/12607395
- Add subscription id info as the tree item description for each subscription node.
- Add tooltip for subscription node (user can mouse over to see more info about this node)

![image](https://user-images.githubusercontent.com/10163840/144990813-19e44c73-8a38-4436-9e40-f63cb2db680a.png)
