### PR TITLE
fix: add retry as a workaround for unstable App Studio API

### DIFF
--- a/packages/fx-core/src/plugins/resource/appstudio/appStudio.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/appStudio.ts
@@ -8,7 +8,7 @@ import { AppStudioError } from "./errors";
 import { IPublishingAppDenition } from "./interfaces/IPublishingAppDefinition";
 import { AppStudioResultFactory } from "./results";
 import { getAppStudioEndpoint } from "../../..";
-import { Constants, ErrorMessages } from "./constants";
+import { Constants, ErrorMessages, RETRY_INTERVAL, RETRY_MAX_TIMES } from "./constants";
 import { sleep } from "../spfx/utils/utils";
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -126,7 +126,7 @@ export namespace AppStudioClient {
     const requester = createRequesterWithToken(appStudioToken);
     let retry = 0;
     let response = null;
-    while (response == null && retry < 10) {
+    while (response == null && retry < RETRY_MAX_TIMES) {
       try {
         response = await requester.get(`/api/appdefinitions/${teamsAppId}`);
         if (response && response.data) {
@@ -139,7 +139,7 @@ export namespace AppStudioClient {
         );
         retry++;
       }
-      await sleep(30000);
+      await sleep(RETRY_INTERVAL);
     }
     const errorMessage = `Cannot get the app definition with app ID ${teamsAppId}, after retry ${retry} times.`;
     await logProvider?.error(errorMessage);
@@ -190,7 +190,7 @@ export namespace AppStudioClient {
       }
       let retry = 0;
       let response = null;
-      while (response == null && retry < 10) {
+      while (response == null && retry < RETRY_MAX_TIMES) {
         try {
           response = await requester.post(
             `/api/appdefinitions/${teamsAppId}/override`,
@@ -202,13 +202,13 @@ export namespace AppStudioClient {
           }
         } catch (e: any) {
           logProvider?.warning(
-            `Cannot get the app definition with app ID ${teamsAppId}, due to status: ${e.response?.status}, ${e.name}: ${e.message}, retry: ${retry} times.`
+            `Update app definition: cannot get the app definition with app ID ${teamsAppId}, due to status: ${e.response?.status}, ${e.name}: ${e.message}, retry: ${retry} times.`
           );
           retry++;
         }
-        await sleep(30000);
+        await sleep(RETRY_INTERVAL);
       }
-      const errorMessage = `Cannot get the app definition with app ID ${teamsAppId}, after retry ${retry} times.`;
+      const errorMessage = `Update app definition: cannot get the app definition with app ID ${teamsAppId}, after retry ${retry} times.`;
       await logProvider?.error(errorMessage);
       throw new Error(errorMessage);
     }

--- a/packages/fx-core/src/plugins/resource/appstudio/constants.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/constants.ts
@@ -45,6 +45,8 @@ export const DEFAULT_COLOR_PNG_FILENAME = "color.png";
 export const DEFAULT_OUTLINE_PNG_FILENAME = "outline.png";
 export const MANIFEST_RESOURCES = "resources";
 export const APP_PACKAGE_FOLDER_FOR_MULTI_ENV = "templates/appPackage";
+export const RETRY_INTERVAL = 30000;
+export const RETRY_MAX_TIMES = 6;
 /**
  * Config Keys that are useful for remote collaboration
  */

--- a/packages/fx-core/src/plugins/resource/appstudio/constants.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/constants.ts
@@ -45,8 +45,6 @@ export const DEFAULT_COLOR_PNG_FILENAME = "color.png";
 export const DEFAULT_OUTLINE_PNG_FILENAME = "outline.png";
 export const MANIFEST_RESOURCES = "resources";
 export const APP_PACKAGE_FOLDER_FOR_MULTI_ENV = "templates/appPackage";
-export const RETRY_INTERVAL = 30000;
-export const RETRY_MAX_TIMES = 6;
 /**
  * Config Keys that are useful for remote collaboration
  */


### PR DESCRIPTION
Most of the cases retry 1 or 2 times can work.
![image](https://user-images.githubusercontent.com/71362691/144992673-51a9d0fc-e359-436b-9d23-f7656f140c75.png)

![image](https://user-images.githubusercontent.com/71362691/144996386-fd0e0bda-c1d4-4096-90ef-7a4276c88655.png)


But retry cannot resolve all the cases:
![image](https://user-images.githubusercontent.com/71362691/144995812-9dfbf56c-756a-4488-880d-60613545788e.png)
