### PR TITLE
fix: unexpected select-env window pop-up

### DIFF
--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -273,6 +273,8 @@ async function getIsFromSample() {
 async function getSettingsVersion(): Promise<string | undefined> {
   if (core) {
     const input = getSystemInputs();
+    input.ignoreEnvInfo = true;
+
     // TODO: from the experience of 'is-from-sample':
     // in some circumstances, getProjectConfig() returns undefined even projectSettings.json is valid.
     // This is a workaround to prevent that. We can change to the following code after the root cause is found.


### PR DESCRIPTION
Fix bug: https://dev.azure.com/msazure/Microsoft%20Teams%20Extensibility/_workitems/edit/12783952