### PR TITLE
fix: get status will wait for azure account extension initialization

### DIFF
--- a/packages/vscode-extension/src/commonlib/azureLogin.ts
+++ b/packages/vscode-extension/src/commonlib/azureLogin.ts
@@ -379,6 +379,8 @@ export class AzureAccountManager extends login implements AzureAccountProvider {
 
   async getStatus(): Promise<LoginStatus> {
     const azureAccount = this.getAzureAccount();
+    // add this to make sure Azure Account Extension has fully initialized
+    await azureAccount.waitForSubscriptions();
     if (azureAccount.status === loggedIn) {
       const credential = await this.doGetAccountCredentialAsync();
       const token = await credential?.getToken();


### PR DESCRIPTION

1. Azure get status will wait Azure Account extension initialization.

Fix: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/12783666