### PR TITLE
docs: add sessionStorage notice

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -14,6 +14,8 @@ Use the library to:
 
 ## Getting started
 
+> Important: Please be advised that access tokens are stored in sessionStorage for you by default. This can make it possible for malicious code in your app (or code pasted into a console on your page) to access APIs at the same privilege level as your client application. Please ensure you only request the minimum necessary scopes from your client application, and perform any sensitive operations from server side code that your client has to authenticate with.
+
 TeamsFx SDK is pre-configured in scaffolded project using Teams Toolkit extension for Visual Studio and vscode, or the `teamsfx` cli from the `teamsfx-cli` npm package.
 Please check the [README](https://github.com/OfficeDev/TeamsFx/blob/main/packages/vscode-extension/README.md) to see how to create a Teams App project.
 

--- a/packages/sdk/src/credential/teamsUserCredential.browser.ts
+++ b/packages/sdk/src/credential/teamsUserCredential.browser.ts
@@ -236,6 +236,7 @@ export class TeamsUserCredential implements TokenCredential {
 
         const tokenResult: AccessTokenResult = response.data;
         const key = await this.getAccessTokenCacheKey(scopesStr);
+        // Important: tokens are stored in sessionStorage, read more here: https://aka.ms/teamsfx-session-storage-notice
         this.setTokenCache(key, {
           token: tokenResult.access_token,
           expiresOnTimestamp: tokenResult.expires_on,

--- a/packages/sdk/src/credential/teamsUserCredential.browser.ts
+++ b/packages/sdk/src/credential/teamsUserCredential.browser.ts
@@ -132,7 +132,7 @@ export class TeamsUserCredential implements TokenCredential {
   /**
    * Get access token from credential.
    *
-   * Important: Graph access tokens are stored in sessionStorage, read more here: https://aka.ms/teamsfx-session-storage-notice
+   * Important: Access tokens are stored in sessionStorage, read more here: https://aka.ms/teamsfx-session-storage-notice
    *
    * @example
    * ```typescript

--- a/packages/sdk/src/credential/teamsUserCredential.browser.ts
+++ b/packages/sdk/src/credential/teamsUserCredential.browser.ts
@@ -132,6 +132,8 @@ export class TeamsUserCredential implements TokenCredential {
   /**
    * Get access token from credential.
    *
+   * Important: Graph access tokens are stored in sessionStorage, read more here: https://aka.ms/teamsfx-session-storage-notice
+   *
    * @example
    * ```typescript
    * await credential.getToken([]) // Get SSO token using empty string array

--- a/templates/tab/js/default/README.md
+++ b/templates/tab/js/default/README.md
@@ -1,5 +1,7 @@
 # How to use this Teams Tab app HelloWorld app
 
+> Important: Please be advised that access tokens are stored in sessionStorage for you by default. This can make it possible for malicious code in your app (or code pasted into a console on your page) to access APIs at the same privilege level as your client application. Please ensure you only request the minimum necessary scopes from your client application, and perform any sensitive operations from server side code that your client has to authenticate with.
+
 Microsoft Teams supports the ability to run web-based UI inside "custom tabs" that users can install either for just themselves (personal tabs) or within a team or group chat context.
 
 ## Prerequisites

--- a/templates/tab/js/default/src/components/sample/lib/useGraph.js
+++ b/templates/tab/js/default/src/components/sample/lib/useGraph.js
@@ -21,6 +21,7 @@ export function useGraph(asyncFunc, options) {
     async () => {
       const credential = new TeamsUserCredential();
       await credential.login(scope);
+      // Important: tokens are stored in sessionStorage, read more here: https://aka.ms/teamsfx-session-storage-notice
       const graph = createMicrosoftGraphClient(credential, scope);
       return await asyncFunc(graph);
     },

--- a/templates/tab/ts/default/README.md
+++ b/templates/tab/ts/default/README.md
@@ -1,5 +1,7 @@
 # How to use this Teams Tab app HelloWorld app
 
+> Important: Please be advised that access tokens are stored in sessionStorage for you by default. This can make it possible for malicious code in your app (or code pasted into a console on your page) to access APIs at the same privilege level as your client application. Please ensure you only request the minimum necessary scopes from your client application, and perform any sensitive operations from server side code that your client has to authenticate with.
+
 Microsoft Teams supports the ability to run web-based UI inside "custom tabs" that users can install either for just themselves (personal tabs) or within a team or group chat context.
 
 ## Prerequisites

--- a/templates/tab/ts/default/src/components/sample/lib/useGraph.ts
+++ b/templates/tab/ts/default/src/components/sample/lib/useGraph.ts
@@ -25,6 +25,7 @@ export function useGraph<T>(
     async () => {
       const credential = new TeamsUserCredential();
       await credential.login(scope);
+      // Important: tokens are stored in sessionStorage, read more here: https://aka.ms/teamsfx-session-storage-notice
       const graph = createMicrosoftGraphClient(credential, scope);
       return await asyncFunc(graph);
     },


### PR DESCRIPTION
@zhenyasav , could you help provide the helper link target URL, I will update it in aka service: https://aka.ms/teamsfx-session-storage-notice


Related task: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_sprints/taskboard/AuthAndData/Microsoft%20Teams%20Extensibility/CY21-12.1?workitem=12699312