### PR TITLE
test(apim): change the add resource params in apim e2e test

### DIFF
--- a/packages/cli/tests/e2e/apim/TestCreateNewApim.tests.ts
+++ b/packages/cli/tests/e2e/apim/TestCreateNewApim.tests.ts
@@ -45,7 +45,7 @@ describe("Create a new API Management Service", function () {
       await ApimValidator.init(subscriptionId, AzureLogin, GraphLogin);
 
       result = await execAsyncWithRetry(
-        `teamsfx resource add azure-apim --subscription ${subscriptionId}`,
+        `teamsfx resource add azure-apim`,
         {
           cwd: projectPath,
           env: testProcessEnv,

--- a/packages/cli/tests/e2e/apim/TestImportApiIntoApim.tests.ts
+++ b/packages/cli/tests/e2e/apim/TestImportApiIntoApim.tests.ts
@@ -43,7 +43,7 @@ describe("Import API into API Management", function () {
       console.log(`Create new project. Error message: ${result.stderr}`);
 
       result = await execAsyncWithRetry(
-        `teamsfx resource add azure-apim --subscription ${subscriptionId}`,
+        `teamsfx resource add azure-apim`,
         {
           cwd: projectPath,
           env: testProcessEnv,


### PR DESCRIPTION
The parameters of add apim resource command is changed in API V2. Change the e2e test case.
Relative PR: https://github.com/OfficeDev/TeamsFx/pull/3252
E2E: https://github.com/OfficeDev/TeamsFx/actions/runs/1553705719
Detail: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_boards/board/t/Infrastructure%20Team/Stories/?workitem=12800701