### PR TITLE
fix: add no subscriptions warning to tree view

### DIFF
--- a/packages/vscode-extension/src/accountTree.ts
+++ b/packages/vscode-extension/src/accountTree.ts
@@ -64,15 +64,33 @@ export async function registerAccountTreeHandler(): Promise<Result<Void, FxError
       );
       let icon = "";
       let contextValue = "selectSubscription";
+      const valid = await isValid();
       if (activeSubscriptionId === undefined || activeSubscription === undefined) {
         selectSubLabel = util.format(
           StringResources.vsc.accountTree.totalSubscriptions,
           subscriptions.length
         );
         icon = "subscriptions";
-
         if (subscriptions.length === 0) {
           contextValue = "emptySubscription";
+          selectSubLabel = StringResources.vsc.accountTree.noSubscriptions;
+          return [
+            {
+              commandId: "fx-extension.selectSubscription",
+              label: selectSubLabel,
+              callback: () => {
+                return Promise.resolve(ok(null));
+              },
+              parent: "fx-extension.signinAzure",
+              contextValue: valid ? contextValue : "invalidFxProject",
+              icon: "warning",
+              tooltip: {
+                isMarkdown: false,
+                value: StringResources.vsc.accountTree.noSubscriptionsTooltip,
+              },
+            },
+            true,
+          ];
         }
 
         if (subscriptions.length === 1) {
@@ -84,7 +102,6 @@ export async function registerAccountTreeHandler(): Promise<Result<Void, FxError
         selectSubLabel = activeSubscription.subscriptionName;
         icon = "subscriptionSelected";
       }
-      const valid = await isValid();
       return [
         {
           commandId: "fx-extension.selectSubscription",

--- a/packages/vscode-extension/src/resources/Strings.json
+++ b/packages/vscode-extension/src/resources/Strings.json
@@ -192,6 +192,8 @@
       "cancelMessage": "userCancelled"
     },
     "accountTree": {
+      "noSubscriptions": "No subscriptions discovered",
+      "noSubscriptionsTooltip": "You have no subscriptions. You can't provision or deploy your resources to Azure!",
       "totalSubscriptions": "%d subscriptions discovered",
       "signingInM365": "M365: Signing in...",
       "signingInAzure": "Azure: Signing in...",


### PR DESCRIPTION
1. Add warning to account tree when login with an Azure account with no subscriptions.

![image](https://user-images.githubusercontent.com/13211513/145342681-62f7f9c5-2851-46a0-bf38-e35e1ddc159b.png)

fix: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/12588918/