### PR TITLE
chore(localdebug): add local debug correlation id

### DIFF
--- a/packages/vscode-extension/src/debug/commonUtils.ts
+++ b/packages/vscode-extension/src/debug/commonUtils.ts
@@ -3,6 +3,7 @@
 
 import * as fs from "fs-extra";
 import * as path from "path";
+import * as uuid from "uuid";
 import * as dotenv from "dotenv";
 import * as vscode from "vscode";
 import * as constants from "./constants";
@@ -395,4 +396,19 @@ export async function loadTeamsFxDevScript(componentRoot: string): Promise<strin
   } else {
     return undefined;
   }
+}
+
+// Helper functions for local debug correlation-id, only used for telemetry
+let localDebugCorrelationId: string | undefined = undefined;
+export function startLocalDebugSession(): string {
+  localDebugCorrelationId = uuid.v4();
+  return getLocalDebugSessionId();
+}
+
+export function endLocalDebugSession() {
+  localDebugCorrelationId = undefined;
+}
+
+export function getLocalDebugSessionId(): string {
+  return localDebugCorrelationId || "undefined";
 }

--- a/packages/vscode-extension/src/debug/commonUtils.ts
+++ b/packages/vscode-extension/src/debug/commonUtils.ts
@@ -410,5 +410,5 @@ export function endLocalDebugSession() {
 }
 
 export function getLocalDebugSessionId(): string {
-  return localDebugCorrelationId || "undefined";
+  return localDebugCorrelationId || "no-session-id";
 }

--- a/packages/vscode-extension/src/debug/teamsfxDebugProvider.ts
+++ b/packages/vscode-extension/src/debug/teamsfxDebugProvider.ts
@@ -39,6 +39,10 @@ export class TeamsfxDebugProvider implements vscode.DebugConfigurationProvider {
           return debugConfiguration;
         }
 
+        // Attach correlation-id to DebugConfiguration so concurrent debug sessions are correctly handled in this stage.
+        // For backend and bot debug sessions, debugConfiguration.url is undefined so we need to set correlation id early.
+        debugConfiguration.teamsfxCorrelationId = commonUtils.getLocalDebugSessionId();
+
         if (debugConfiguration.url === undefined) {
           return debugConfiguration;
         }
@@ -74,8 +78,6 @@ export class TeamsfxDebugProvider implements vscode.DebugConfigurationProvider {
           isLocalSideloadingConfiguration ? localTeamsAppIdPlaceholder : teamsAppIdPlaceholder,
           debugConfig.appId
         );
-        // attach correlation-id to DebugConfiguration so concurrent debug sessions are correctly handled in this stage.
-        debugConfiguration.teamsfxCorrelationId = commonUtils.getLocalDebugSessionId();
 
         const accountHintPlaceholder = "${account-hint}";
         const isaccountHintConfiguration: boolean = (debugConfiguration.url as string).includes(

--- a/packages/vscode-extension/src/debug/teamsfxTaskHandler.ts
+++ b/packages/vscode-extension/src/debug/teamsfxTaskHandler.ts
@@ -406,7 +406,8 @@ export function registerTeamsfxTaskAndDebugEvents(): void {
   ext.context.subscriptions.push(
     vscode.debug.onDidStartDebugSession((event: vscode.DebugSession) =>
       Correlator.runWithId(
-        event.configuration.teamsfxCorrelationId || "undefined",
+        // fallback to retrieve correlation id from the global variable.
+        event.configuration.teamsfxCorrelationId || getLocalDebugSessionId(),
         onDidStartDebugSessionHandler,
         event
       )
@@ -415,7 +416,7 @@ export function registerTeamsfxTaskAndDebugEvents(): void {
   ext.context.subscriptions.push(
     vscode.debug.onDidTerminateDebugSession((event: vscode.DebugSession) =>
       Correlator.runWithId(
-        event.configuration.teamsfxCorrelationId || "undefined",
+        event.configuration.teamsfxCorrelationId || getLocalDebugSessionId(),
         onDidTerminateDebugSessionHandler,
         event
       )

--- a/packages/vscode-extension/src/debug/teamsfxTaskHandler.ts
+++ b/packages/vscode-extension/src/debug/teamsfxTaskHandler.ts
@@ -4,12 +4,17 @@
 import { ProductName } from "@microsoft/teamsfx-api";
 import * as vscode from "vscode";
 
-import { getLocalTeamsAppId, loadTeamsFxDevScript } from "./commonUtils";
+import {
+  endLocalDebugSession,
+  getLocalDebugSessionId,
+  getLocalTeamsAppId,
+  loadTeamsFxDevScript,
+} from "./commonUtils";
 import { ext } from "../extensionVariables";
 import { ExtTelemetry } from "../telemetry/extTelemetry";
 import { TelemetryEvent, TelemetryProperty } from "../telemetry/extTelemetryEvents";
 import { getTeamsAppId } from "../utils/commonUtils";
-import { getHashedEnv, isValidProject } from "@microsoft/teamsfx-core";
+import { Correlator, getHashedEnv, isValidProject } from "@microsoft/teamsfx-core";
 import { getNpmInstallLogInfo } from "./npmLogHandler";
 import * as path from "path";
 import { errorDetail, issueLink, issueTemplate } from "./constants";
@@ -376,17 +381,44 @@ function onDidTerminateDebugSessionHandler(event: vscode.DebugSession): void {
     }
 
     allRunningDebugSessions.delete(event.id);
+    if (allRunningDebugSessions.size == 0) {
+      endLocalDebugSession();
+    }
     allRunningTeamsfxTasks.clear();
   }
 }
 
 export function registerTeamsfxTaskAndDebugEvents(): void {
-  ext.context.subscriptions.push(vscode.tasks.onDidStartTaskProcess(onDidStartTaskProcessHandler));
-  ext.context.subscriptions.push(vscode.tasks.onDidEndTaskProcess(onDidEndTaskProcessHandler));
   ext.context.subscriptions.push(
-    vscode.debug.onDidStartDebugSession(onDidStartDebugSessionHandler)
+    vscode.tasks.onDidStartTaskProcess((event: vscode.TaskProcessStartEvent) =>
+      Correlator.runWithId(getLocalDebugSessionId(), onDidStartTaskProcessHandler, event)
+    )
+  );
+
+  ext.context.subscriptions.push(
+    vscode.tasks.onDidEndTaskProcess((event: vscode.TaskProcessEndEvent) =>
+      Correlator.runWithId(getLocalDebugSessionId(), onDidEndTaskProcessHandler, event)
+    )
+  );
+
+  // debug session handler use correlation-id from event.configuration.teamsfxCorrelationId
+  // to minimize concurrent debug session affecting correlation-id
+  ext.context.subscriptions.push(
+    vscode.debug.onDidStartDebugSession((event: vscode.DebugSession) =>
+      Correlator.runWithId(
+        event.configuration.teamsfxCorrelationId || "undefined",
+        onDidStartDebugSessionHandler,
+        event
+      )
+    )
   );
   ext.context.subscriptions.push(
-    vscode.debug.onDidTerminateDebugSession(onDidTerminateDebugSessionHandler)
+    vscode.debug.onDidTerminateDebugSession((event: vscode.DebugSession) =>
+      Correlator.runWithId(
+        event.configuration.teamsfxCorrelationId || "undefined",
+        onDidTerminateDebugSessionHandler,
+        event
+      )
+    )
   );
 }

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -48,6 +48,7 @@ import { ExtensionUpgrade } from "./utils/upgrade";
 import { registerEnvTreeHandler } from "./envTree";
 import { getWorkspacePath } from "./handlers";
 import { localSettingsJsonName } from "./debug/constants";
+import { getLocalDebugSessionId, startLocalDebugSession } from "./debug/commonUtils";
 
 export let VS_CODE_UI: VsCodeUI;
 
@@ -134,28 +135,30 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(cicdGuideCmd);
 
   // 1.7 validate dependencies command (hide from UI)
+  // localdebug session starts from environment checker
   const validateDependenciesCmd = vscode.commands.registerCommand(
     "fx-extension.validate-dependencies",
-    () => Correlator.run(handlers.validateDependenciesHandler)
+    () => Correlator.runWithId(startLocalDebugSession(), handlers.validateDependenciesHandler)
   );
   context.subscriptions.push(validateDependenciesCmd);
 
+  // localdebug session starts from environment checker
   const validateSpfxDependenciesCmd = vscode.commands.registerCommand(
     "fx-extension.validate-spfx-dependencies",
-    () => Correlator.run(handlers.validateSpfxDependenciesHandler)
+    () => Correlator.runWithId(startLocalDebugSession(), handlers.validateSpfxDependenciesHandler)
   );
   context.subscriptions.push(validateSpfxDependenciesCmd);
 
   // 1.8 pre debug check command (hide from UI)
   const preDebugCheckCmd = vscode.commands.registerCommand("fx-extension.pre-debug-check", () =>
-    Correlator.run(handlers.preDebugCheckHandler)
+    Correlator.runWithId(getLocalDebugSessionId(), handlers.preDebugCheckHandler)
   );
   context.subscriptions.push(preDebugCheckCmd);
 
   // 1.9 Register backend extensions install command (hide from UI)
   const backendExtensionsInstallCmd = vscode.commands.registerCommand(
     "fx-extension.backend-extensions-install",
-    () => Correlator.run(handlers.backendExtensionsInstallHandler)
+    () => Correlator.runWithId(getLocalDebugSessionId(), handlers.backendExtensionsInstallHandler)
   );
   context.subscriptions.push(backendExtensionsInstallCmd);
 


### PR DESCRIPTION
localdebug contains several parts in TaskProvider, DebugProvider and several command handlers.
- the correlation id life cycle is defined as follows:
    - starts from the start of env-checker
    - ends when all the teamsfx debug sessions end or another debug session starts

Implementation:
1. For env-checker/task providers/preDebugCheck/DebugProvider, use a global variable to store correlation id (assuming at most one debug session at anytime)
2. For onDidStart/TerminateDebugSessionHandler, use event.configuration.teamsfxCorrelationId. So concurrent issue will not happen in this stage

Stage 2 is longer than stage 1, so maybe stage 1 is less likely to encounter concurrent issue.

#### Tested tab local debug happy path (timestamp from latest to earliest):
![image](https://user-images.githubusercontent.com/9698542/145349950-6db1925c-d86e-43fd-90a3-067d9065213a.png)

#### Tab+Function happy path (multiple debug sessions are correctly handled):
![image](https://user-images.githubusercontent.com/9698542/145360877-4f295fe1-f639-4f0c-9e0d-dc55e83cd160.png)

#### Cancel local debug in env checker multiple times
![image](https://user-images.githubusercontent.com/9698542/145350265-da4a838a-bafa-43ed-8995-866c43cb7f55.png)

#### Concurrent run in debug stage (note that correlation-id of the debug-stop event is still correct):
![image](https://user-images.githubusercontent.com/9698542/145351173-86b7f374-8d10-4775-8293-817ac1af8182.png)
