### PR TITLE
fix: pass and convert env info

### DIFF
--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -1201,7 +1201,7 @@ interface ResourcePlugin {
     checkPermission?: (ctx: Context_2, inputs: InputsWithProjectPath, envInfo: DeepReadonly<EnvInfoV2>, tokenProvider: TokenProvider, userInfo: Json) => Promise<Result<Json, FxError>>;
     configureLocalResource?: (ctx: Context_2, inputs: Inputs, localSettings: Json, tokenProvider: TokenProvider) => Promise<Result<Void, FxError>>;
     configureResource?: (ctx: Context_2, inputs: ProvisionInputs, envInfo: DeepReadonly<EnvInfoV2>, tokenProvider: TokenProvider) => Promise<Result<ResourceProvisionOutput, FxError>>;
-    deploy?: (ctx: Context_2, inputs: DeploymentInputs, provisionOutputs: Json, tokenProvider: TokenProvider) => Promise<Result<Void, FxError>>;
+    deploy?: (ctx: Context_2, inputs: DeploymentInputs, envInfo: DeepReadonly<EnvInfoV2>, tokenProvider: TokenProvider) => Promise<Result<Void, FxError>>;
     // (undocumented)
     displayName: string;
     // (undocumented)
@@ -1435,7 +1435,7 @@ interface SolutionPlugin {
     // (undocumented)
     checkPermission?: (ctx: Context_2, inputs: InputsWithProjectPath, envInfo: DeepReadonly<EnvInfoV2>, tokenProvider: TokenProvider) => Promise<Result<Json, FxError>>;
     createEnv?: (ctx: Context_2, inputs: Inputs) => Promise<Result<Void, FxError>>;
-    deploy?: (ctx: Context_2, inputs: Inputs, provisionOutputs: Json, tokenProvider: TokenProvider) => Promise<Result<Void, FxError>>;
+    deploy?: (ctx: Context_2, inputs: Inputs, envInfo: DeepReadonly<EnvInfoV2>, tokenProvider: TokenProvider) => Promise<Result<Void, FxError>>;
     // (undocumented)
     displayName: string;
     executeUserTask?: (ctx: Context_2, inputs: Inputs, func: Func, localSettings: Json, envInfo: EnvInfoV2, tokenProvider: TokenProvider) => Promise<Result<unknown, FxError>>;

--- a/packages/api/src/v2/resourcePlugin.ts
+++ b/packages/api/src/v2/resourcePlugin.ts
@@ -154,7 +154,7 @@ export interface ResourcePlugin {
    *
    * @param {Context} ctx - plugin's runtime context shared by all lifecycles.
    * @param {DeploymentInputs} inputs - inputs injected by Toolkit runtime and solution.
-   * @param {Json} provisionOutputs - state containing provision outputs modeled after state.${env}.json
+   * @param {DeepReadonly<EnvInfoV2>} envInfo - a readonly view of environment info modeled after (config|state).${env}.json
    * @param {TokenProvider} tokenProvider - Token provider for Azure, AppStudio and m365
    */
   deploy?: (

--- a/packages/api/src/v2/resourcePlugin.ts
+++ b/packages/api/src/v2/resourcePlugin.ts
@@ -160,7 +160,7 @@ export interface ResourcePlugin {
   deploy?: (
     ctx: Context,
     inputs: DeploymentInputs,
-    provisionOutputs: Json,
+    envInfo: DeepReadonly<EnvInfoV2>,
     tokenProvider: TokenProvider
   ) => Promise<Result<Void, FxError>>;
 

--- a/packages/api/src/v2/solutionPlugin.ts
+++ b/packages/api/src/v2/solutionPlugin.ts
@@ -90,7 +90,7 @@ export interface SolutionPlugin {
   deploy?: (
     ctx: Context,
     inputs: Inputs,
-    provisionOutputs: Json,
+    envInfo: DeepReadonly<EnvInfoV2>,
     tokenProvider: TokenProvider
   ) => Promise<Result<Void, FxError>>;
 

--- a/packages/api/src/v2/solutionPlugin.ts
+++ b/packages/api/src/v2/solutionPlugin.ts
@@ -83,7 +83,7 @@ export interface SolutionPlugin {
    *
    * @param {Context} ctx - plugin's runtime context shared by all lifecycles.
    * @param {Inputs} inputs - system inputs
-   * @param {Json} provisionOutputs - provision outputs
+   * @param {DeepReadonly<EnvInfoV2>} envInfo - a readonly view of environment info modeled after (config|state).${env}.json
    * @param {TokenProvider} tokenProvider - Token providers for Azure, AppStudio and m365.
    *
    */

--- a/packages/fx-core/src/core/index.ts
+++ b/packages/fx-core/src/core/index.ts
@@ -564,7 +564,7 @@ export class FxCore implements Core {
         return await ctx.solutionV2.deploy(
           ctx.contextV2,
           inputs,
-          ctx.envInfoV2.state,
+          ctx.envInfoV2,
           this.tools.tokenProvider
         );
       else return ok(Void);

--- a/packages/fx-core/src/plugins/resource/apim/v2/index.ts
+++ b/packages/fx-core/src/plugins/resource/apim/v2/index.ts
@@ -114,7 +114,7 @@ export class ApimPluginV2 implements ResourcePlugin {
   async deploy(
     ctx: Context,
     inputs: DeploymentInputs,
-    provisionOutput: Json,
+    envInfo: DeepReadonly<v2.EnvInfoV2>,
     tokenProvider: TokenProvider
   ): Promise<Result<Void, FxError>> {
     // const questionRes = await this.plugin.getQuestions(
@@ -130,7 +130,7 @@ export class ApimPluginV2 implements ResourcePlugin {
     //     }
     //   }
     // }
-    return await deployAdapter(ctx, inputs, provisionOutput, tokenProvider, this.plugin);
+    return await deployAdapter(ctx, inputs, envInfo, tokenProvider, this.plugin);
   }
 
   async executeUserTask(

--- a/packages/fx-core/src/plugins/resource/appstudio/v2/index.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/v2/index.ts
@@ -42,6 +42,7 @@ import {
   getQuestionsAdapter,
   provisionResourceAdapter,
   scaffoldSourceCodeAdapter,
+  setEnvInfoV1ByStateV2,
 } from "../../utils4v2";
 
 @Service(ResourcePluginsV2.AppStudioPlugin)
@@ -127,6 +128,7 @@ export class AppStudioPluginV2 implements ResourcePlugin {
     tokenProvider: AppStudioTokenProvider
   ): Promise<Result<Void, FxError>> {
     const pluginContext: PluginContext = convert2PluginContext(this.plugin.name, ctx, inputs);
+    setEnvInfoV1ByStateV2(this.plugin.name, pluginContext, envInfo);
     pluginContext.appStudioToken = tokenProvider;
 
     // run question model for publish
@@ -140,13 +142,6 @@ export class AppStudioPluginV2 implements ResourcePlugin {
     //     }
     //   }
     // }
-    const configsOfOtherPlugins = new Map<string, ConfigMap>();
-    for (const key in envInfo.state) {
-      const output = envInfo.state[key];
-      const configMap = ConfigMap.fromJSON(output);
-      if (configMap) configsOfOtherPlugins.set(key, configMap);
-    }
-    pluginContext.envInfo = newEnvInfo(undefined, undefined, configsOfOtherPlugins);
     //TODO pass provisionInputConfig into config??
     const postRes = await this.plugin.publish(pluginContext);
     if (postRes.isErr()) {

--- a/packages/fx-core/src/plugins/resource/bot/v2/index.ts
+++ b/packages/fx-core/src/plugins/resource/bot/v2/index.ts
@@ -17,6 +17,7 @@ import {
 import {
   Context,
   DeploymentInputs,
+  DeepReadonly,
   ProvisionInputs,
   ResourcePlugin,
   ResourceProvisionOutput,
@@ -117,10 +118,10 @@ export class BotPluginV2 implements ResourcePlugin {
   async deploy(
     ctx: Context,
     inputs: DeploymentInputs,
-    provisionOutput: Json,
+    envInfo: DeepReadonly<v2.EnvInfoV2>,
     tokenProvider: TokenProvider
   ): Promise<Result<Void, FxError>> {
-    return await deployAdapter(ctx, inputs, provisionOutput, tokenProvider, this.plugin);
+    return await deployAdapter(ctx, inputs, envInfo, tokenProvider, this.plugin);
   }
 
   async executeUserTask(

--- a/packages/fx-core/src/plugins/resource/frontend/v2/index.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/v2/index.ts
@@ -16,6 +16,7 @@ import {
 import {
   Context,
   DeploymentInputs,
+  DeepReadonly,
   ProvisionInputs,
   ResourcePlugin,
   ResourceProvisionOutput,
@@ -87,10 +88,10 @@ export class FrontendPluginV2 implements ResourcePlugin {
   async deploy(
     ctx: Context,
     inputs: DeploymentInputs,
-    provisionOutput: Json,
+    envInfo: DeepReadonly<v2.EnvInfoV2>,
     tokenProvider: TokenProvider
   ): Promise<Result<Void, FxError>> {
-    return await deployAdapter(ctx, inputs, provisionOutput, tokenProvider, this.plugin);
+    return await deployAdapter(ctx, inputs, envInfo, tokenProvider, this.plugin);
   }
 
   async executeUserTask(

--- a/packages/fx-core/src/plugins/resource/function/v2/index.ts
+++ b/packages/fx-core/src/plugins/resource/function/v2/index.ts
@@ -88,10 +88,10 @@ export class FunctionPluginV2 implements ResourcePlugin {
   async deploy(
     ctx: Context,
     inputs: DeploymentInputs,
-    provisionOutput: Json,
+    envInfo: DeepReadonly<v2.EnvInfoV2>,
     tokenProvider: TokenProvider
   ): Promise<Result<Void, FxError>> {
-    return await deployAdapter(ctx, inputs, provisionOutput, tokenProvider, this.plugin);
+    return await deployAdapter(ctx, inputs, envInfo, tokenProvider, this.plugin);
   }
 
   async executeUserTask(

--- a/packages/fx-core/src/plugins/resource/spfx/v2/index.ts
+++ b/packages/fx-core/src/plugins/resource/spfx/v2/index.ts
@@ -11,7 +11,13 @@ import {
   Void,
   TokenProvider,
 } from "@microsoft/teamsfx-api";
-import { Context, DeploymentInputs, ResourcePlugin } from "@microsoft/teamsfx-api/build/v2";
+import {
+  Context,
+  DeploymentInputs,
+  DeepReadonly,
+  ResourcePlugin,
+  EnvInfoV2,
+} from "@microsoft/teamsfx-api/build/v2";
 import { Inject, Service } from "typedi";
 import { SpfxPlugin } from "../..";
 import {
@@ -49,9 +55,9 @@ export class SpfxPluginV2 implements ResourcePlugin {
   async deploy(
     ctx: Context,
     inputs: DeploymentInputs,
-    provisionOutput: Json,
+    envInfo: DeepReadonly<EnvInfoV2>,
     tokenProvider: TokenProvider
   ): Promise<Result<Void, FxError>> {
-    return await deployAdapter(ctx, inputs, provisionOutput, tokenProvider, this.plugin);
+    return await deployAdapter(ctx, inputs, envInfo, tokenProvider, this.plugin);
   }
 }

--- a/packages/fx-core/src/plugins/resource/utils4v2.ts
+++ b/packages/fx-core/src/plugins/resource/utils4v2.ts
@@ -271,7 +271,7 @@ export async function deployAdapter(
       return err(postRes.error);
     }
   }
-  setStateV2ByConfigMapInc(plugin.name, envInfo, pluginContext.config);
+  setStateV2ByConfigMapInc(plugin.name, envInfo.state, pluginContext.config);
   return ok(Void);
 }
 

--- a/packages/fx-core/src/plugins/resource/utils4v2.ts
+++ b/packages/fx-core/src/plugins/resource/utils4v2.ts
@@ -243,13 +243,13 @@ export async function configureResourceAdapter(
 export async function deployAdapter(
   ctx: Context,
   inputs: DeploymentInputs,
-  provisionOutput: Json,
+  envInfo: DeepReadonly<EnvInfoV2>,
   tokenProvider: TokenProvider,
   plugin: Plugin
 ): Promise<Result<Void, FxError>> {
   if (!plugin.deploy) return err(PluginHasNoTaskImpl(plugin.displayName, "deploy"));
   const pluginContext: PluginContext = convert2PluginContext(plugin.name, ctx, inputs);
-  setEnvInfoV1ByStateV2(plugin.name, pluginContext, provisionOutput);
+  setEnvInfoV1ByStateV2(plugin.name, pluginContext, envInfo);
   pluginContext.azureAccountProvider = tokenProvider.azureAccountProvider;
   pluginContext.graphTokenProvider = tokenProvider.graphTokenProvider;
   pluginContext.appStudioToken = tokenProvider.appStudioToken;
@@ -271,7 +271,7 @@ export async function deployAdapter(
       return err(postRes.error);
     }
   }
-  setStateV2ByConfigMapInc(plugin.name, provisionOutput, pluginContext.config);
+  setStateV2ByConfigMapInc(plugin.name, envInfo, pluginContext.config);
   return ok(Void);
 }
 
@@ -334,7 +334,7 @@ export async function executeUserTaskAdapter(
   pluginContext.azureAccountProvider = tokenProvider.azureAccountProvider;
   pluginContext.appStudioToken = tokenProvider.appStudioToken;
   pluginContext.graphTokenProvider = tokenProvider.graphTokenProvider;
-  setEnvInfoV1ByStateV2(plugin.name, pluginContext, envInfo.state);
+  setEnvInfoV1ByStateV2(plugin.name, pluginContext, envInfo);
   setLocalSettingsV1(pluginContext, localSettings);
   const res = await plugin.executeUserTask(func, pluginContext);
   if (res.isErr()) return err(res.error);
@@ -397,12 +397,12 @@ export function setStateV2ByConfigMapInc(pluginName: string, state: Json, config
 export function setEnvInfoV1ByStateV2(
   pluginName: string,
   pluginContext: PluginContext,
-  stateV2: Json
+  envInfoV2: EnvInfoV2
 ): void {
   const envInfo = newEnvInfo();
-  let stateV1: ConfigMap | undefined = ConfigMap.fromJSON(stateV2);
+  let stateV1: ConfigMap | undefined = ConfigMap.fromJSON(envInfoV2.state);
   if (!stateV1) {
-    throw InvalidStateError(pluginName, stateV2);
+    throw InvalidStateError(pluginName, envInfoV2.state);
   }
   stateV1 = flattenConfigMap(stateV1);
   let selfConfigMap: ConfigMap | undefined = stateV1.get(pluginName);
@@ -410,6 +410,8 @@ export function setEnvInfoV1ByStateV2(
     selfConfigMap = new ConfigMap();
     stateV1.set(pluginName, selfConfigMap);
   }
+  envInfo.envName = envInfoV2.envName;
+  envInfo.config = envInfoV2.config as EnvConfig;
   envInfo.state = stateV1;
   pluginContext.config = selfConfigMap;
   pluginContext.envInfo = envInfo;

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/deploy.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/deploy.ts
@@ -32,9 +32,10 @@ import {
 export async function deploy(
   ctx: v2.Context,
   inputs: Inputs,
-  provisionOutputs: Json,
+  envInfo: v2.DeepReadonly<v2.EnvInfoV2>,
   tokenProvider: TokenProvider
 ): Promise<Result<Void, FxError>> {
+  const provisionOutputs: Json = envInfo.state;
   const inAzureProject = isAzureProject(getAzureSolutionSettings(ctx));
   const provisioned = provisionOutputs[GLOBAL_CONFIG]["output"][
     SOLUTION_PROVISION_SUCCEEDED
@@ -79,7 +80,7 @@ export async function deploy(
               ...extractSolutionInputs(provisionOutputs[GLOBAL_CONFIG]["output"]),
               projectPath: inputs.projectPath!,
             },
-            provisionOutputs,
+            envInfo,
             tokenProvider
           ),
       };

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/solution.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/solution.ts
@@ -49,7 +49,7 @@ export class TeamsAppSolutionV2 implements v2.SolutionPlugin {
   deploy?: (
     ctx: v2.Context,
     inputs: Inputs,
-    provisionOutputs: Json,
+    envInfo: EnvInfoV2,
     tokenProvider: TokenProvider
   ) => Promise<Result<Void, FxError>> = deploy;
 

--- a/packages/fx-core/tests/plugins/resource/apiv2/utils4v2.test.ts
+++ b/packages/fx-core/tests/plugins/resource/apiv2/utils4v2.test.ts
@@ -100,7 +100,12 @@ describe("API V2 adapter", () => {
       plugin1: { k1: "v1" },
       plugin2: { k2: "v2" },
     };
-    setEnvInfoV1ByStateV2("plugin1", pluginContext, provisionOutputs);
+    const envInfo: EnvInfoV2 = {
+      envName: "default",
+      config: {},
+      state: provisionOutputs,
+    };
+    setEnvInfoV1ByStateV2("plugin1", pluginContext, envInfo);
     assert.equal(pluginContext.config.get("k1"), "v1");
     assert.equal((pluginContext.envInfo.state.get("plugin2") as ConfigMap).get("k2"), "v2");
   });

--- a/packages/fx-core/tests/plugins/resource/spfx/unit/v2lifecycle.test.ts
+++ b/packages/fx-core/tests/plugins/resource/spfx/unit/v2lifecycle.test.ts
@@ -11,7 +11,12 @@ import {
   ProjectSettings,
   Result,
 } from "@microsoft/teamsfx-api";
-import { Context, DeploymentInputs, SolutionInputs } from "@microsoft/teamsfx-api/build/v2";
+import {
+  Context,
+  EnvInfoV2,
+  DeploymentInputs,
+  SolutionInputs,
+} from "@microsoft/teamsfx-api/build/v2";
 import { assert } from "chai";
 import fs from "fs-extra";
 import "mocha";
@@ -111,12 +116,12 @@ describe("SPFX V2", () => {
     };
     const deployInputs: DeploymentInputs = { ...inputs, ...solutionInputs, projectPath: "./" };
     mockDeployThatAlwaysSucceed(pluginV1);
-    const res = await pluginV2.deploy(
-      context,
-      deployInputs,
-      { output: {}, secrets: {}, states: {} },
-      tools.tokenProvider
-    );
+    const envInfo: EnvInfoV2 = {
+      envName: "default",
+      config: {},
+      state: {},
+    };
+    const res = await pluginV2.deploy(context, deployInputs, envInfo, tools.tokenProvider);
     assert.isTrue(res.isOk());
   });
 });

--- a/packages/fx-core/tests/plugins/solution/solution.deploy.test.ts
+++ b/packages/fx-core/tests/plugins/solution/solution.deploy.test.ts
@@ -48,7 +48,7 @@ import { AadAppForTeamsPlugin, newEnvInfo } from "../../../src";
 import { ResourcePlugins } from "../../../src/plugins/solution/fx-solution/ResourcePluginContainer";
 import Container from "typedi";
 import { deploy } from "../../../src/plugins/solution/fx-solution/v2/deploy";
-import { ResourceProvisionOutput } from "@microsoft/teamsfx-api/build/v2";
+import { EnvInfoV2 } from "@microsoft/teamsfx-api/build/v2";
 import { LocalCrypto } from "../../../src/core/crypto";
 
 chai.use(chaiAsPromised);
@@ -269,10 +269,14 @@ describe("API v2 cases: deploy() for Azure projects", () => {
     const mockedInputs: Inputs = {
       platform: Platform.VSCode,
     };
-    const provisionOutput: Record<string, Json> = {
-      solution: { output: {}, secrets: {} },
+    const envInfo: EnvInfoV2 = {
+      envName: "default",
+      config: {},
+      state: {
+        solution: { output: {}, secrets: {} },
+      },
     };
-    const result = await deploy(mockedCtx, mockedInputs, provisionOutput, mockedTokenProvider);
+    const result = await deploy(mockedCtx, mockedInputs, envInfo, mockedTokenProvider);
     expect(result.isErr()).to.be.true;
     expect(result._unsafeUnwrapErr().name).equals(SolutionError.CannotDeployBeforeProvision);
   });
@@ -298,10 +302,14 @@ describe("API v2 cases: deploy() for Azure projects", () => {
     const mockedInputs: Inputs = {
       platform: Platform.VSCode,
     };
-    const provisionOutput: Record<string, Json> = {
-      solution: { output: { provisionSucceeded: true } },
+    const envInfo: EnvInfoV2 = {
+      envName: "default",
+      config: {},
+      state: {
+        solution: { output: { provisionSucceeded: true }, secrets: {} },
+      },
     };
-    const result = await deploy(mockedCtx, mockedInputs, provisionOutput, mockedTokenProvider);
+    const result = await deploy(mockedCtx, mockedInputs, envInfo, mockedTokenProvider);
     expect(result.isErr()).to.be.true;
     expect(result._unsafeUnwrapErr().name).equals(SolutionError.NoResourcePluginSelected);
   });
@@ -328,11 +336,15 @@ describe("API v2 cases: deploy() for Azure projects", () => {
       platform: Platform.VSCode,
     };
     mockedInputs[AzureSolutionQuestionNames.PluginSelectionDeploy] = [fehostPlugin.name];
-    const provisionOutput: Record<string, Json> = {
-      solution: { output: { provisionSucceeded: true } },
+    const envInfo: EnvInfoV2 = {
+      envName: "default",
+      config: {},
+      state: {
+        solution: { output: { provisionSucceeded: true }, secrets: {} },
+      },
     };
     mockDeployThatAlwaysSucceed(fehostPlugin);
-    const result = await deploy(mockedCtx, mockedInputs, provisionOutput, mockedTokenProvider);
+    const result = await deploy(mockedCtx, mockedInputs, envInfo, mockedTokenProvider);
 
     expect(result.isOk()).to.be.true;
   });


### PR DESCRIPTION
1) convert from v2 to v1 envInfo, should include config and envName
2) publishApplication with right envInfo

Test case passed:
1) Scaffold tab+bot project
2) Provision & deploy & publish
3) Create a new env
4) Provision & deploy & publish
5) Zip app package and select each environment