### PR TITLE
chore: remove the flag to work on Toolkit v2

### DIFF
--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -59,5 +59,4 @@ export const deployPluginNodeName = "deploy-plugin";
 
 export class FeatureFlags {
   static readonly InsiderPreview = "__TEAMSFX_INSIDER_PREVIEW";
-  static readonly RollbackToTeamsToolkitV2 = "TEAMSFX_ROLLBACK_TO_TEAMS_TOOLKIT_V2";
 }

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -551,10 +551,7 @@ export function isFeatureFlagEnabled(featureFlagName: string, defaultValue = fal
 }
 
 export function isRemoteCollaborationEnabled(): boolean {
-  return (
-    !isFeatureFlagEnabled(FeatureFlags.RollbackToTeamsToolkitV2, false) &&
-    isFeatureFlagEnabled(FeatureFlags.InsiderPreview, true)
-  );
+  return isFeatureFlagEnabled(FeatureFlags.InsiderPreview, true);
 }
 
 export function getAllFeatureFlags(): string[] | undefined {

--- a/packages/fx-core/src/common/constants.ts
+++ b/packages/fx-core/src/common/constants.ts
@@ -55,7 +55,6 @@ export class FeatureFlagName {
   static readonly APIV2 = "TEAMSFX_APIV2";
   // This will default to true and this environment is only for tests. It does not expose to user.
   static readonly InsiderPreview = "__TEAMSFX_INSIDER_PREVIEW";
-  static readonly RollbackToTeamsToolkitV2 = "TEAMSFX_ROLLBACK_TO_TEAMS_TOOLKIT_V2";
   static readonly rootDirectory = "TEAMSFX_ROOT_DIRECTORY";
   static readonly VSCallingCLI = "VS_CALLING_CLI";
 }

--- a/packages/fx-core/src/common/tools.ts
+++ b/packages/fx-core/src/common/tools.ts
@@ -424,17 +424,11 @@ export function isFeatureFlagEnabled(featureFlagName: string, defaultValue = fal
 }
 
 export function isMultiEnvEnabled(): boolean {
-  return (
-    !isFeatureFlagEnabled(FeatureFlagName.RollbackToTeamsToolkitV2, false) &&
-    isFeatureFlagEnabled(FeatureFlagName.InsiderPreview, true)
-  );
+  return isFeatureFlagEnabled(FeatureFlagName.InsiderPreview, true);
 }
 
 export function isArmSupportEnabled(): boolean {
-  return (
-    !isFeatureFlagEnabled(FeatureFlagName.RollbackToTeamsToolkitV2, false) &&
-    isFeatureFlagEnabled(FeatureFlagName.InsiderPreview, true)
-  );
+  return isFeatureFlagEnabled(FeatureFlagName.InsiderPreview, true);
 }
 
 export function isBicepEnvCheckerEnabled(): boolean {
@@ -442,10 +436,7 @@ export function isBicepEnvCheckerEnabled(): boolean {
 }
 
 export function isRemoteCollaborateEnabled(): boolean {
-  return (
-    !isFeatureFlagEnabled(FeatureFlagName.RollbackToTeamsToolkitV2, false) &&
-    isFeatureFlagEnabled(FeatureFlagName.InsiderPreview, true)
-  );
+  return isFeatureFlagEnabled(FeatureFlagName.InsiderPreview, true);
 }
 
 export function getRootDirectory(): string {

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -783,11 +783,6 @@
       {
         "title": "Teams Toolkit",
         "properties": {
-          "fx-extension.(Obsolete)WorkOnTeamsToolkitV2ProjectConfigurationFiles": {
-            "type": "boolean",
-            "description": "Temporarily work on Teams Toolkit V2 project configuration files. This setting is obsolete and will be removed soon. (Requires reload of VS Code)",
-            "default": false
-          },
           "fx-extension.validateNode": {
             "type": "boolean",
             "description": "Ensure Node.js is installed.",

--- a/packages/vscode-extension/src/constants.ts
+++ b/packages/vscode-extension/src/constants.ts
@@ -1,7 +1,6 @@
 export const CONFIGURATION_PREFIX = "fx-extension";
 export enum ConfigurationKey {
   BicepEnvCheckerEnable = "validateBicep",
-  RollbackToTeamsToolkitV2 = "(Obsolete)WorkOnTeamsToolkitV2ProjectConfigurationFiles",
   RootDirectory = "defaultProjectRootDirectory",
 }
 

--- a/packages/vscode-extension/src/utils/commonUtils.ts
+++ b/packages/vscode-extension/src/utils/commonUtils.ts
@@ -242,10 +242,6 @@ export function getConfiguration(key: string): boolean {
 }
 
 export function syncFeatureFlags() {
-  process.env["TEAMSFX_ROLLBACK_TO_TEAMS_TOOLKIT_V2"] = getConfiguration(
-    ConfigurationKey.RollbackToTeamsToolkitV2
-  ).toString();
-
   process.env["TEAMSFX_BICEP_ENV_CHECKER_ENABLE"] = getConfiguration(
     ConfigurationKey.BicepEnvCheckerEnable
   ).toString();
@@ -257,7 +253,6 @@ export function syncFeatureFlags() {
 
 export class FeatureFlags {
   static readonly InsiderPreview = "__TEAMSFX_INSIDER_PREVIEW";
-  static readonly RollbackToTeamsToolkitV2 = "TEAMSFX_ROLLBACK_TO_TEAMS_TOOLKIT_V2";
   static readonly TelemetryTest = "TEAMSFX_TELEMETRY_TEST";
 }
 


### PR DESCRIPTION
Remove the feature flag added as a workaround for upgrade failure, related PR: https://github.com/OfficeDev/TeamsFx/pull/3050