### PR TITLE
chore: deprecated the function to check if Go Production features enabled

### DIFF
--- a/packages/fx-core/src/common/tools.ts
+++ b/packages/fx-core/src/common/tools.ts
@@ -423,10 +423,16 @@ export function isFeatureFlagEnabled(featureFlagName: string, defaultValue = fal
   }
 }
 
+/**
+ * @deprecated This method will be removed in 12/20/2021, please help do the code clean before the date.
+ */
 export function isMultiEnvEnabled(): boolean {
   return isFeatureFlagEnabled(FeatureFlagName.InsiderPreview, true);
 }
 
+/**
+ * @deprecated This method will be removed in 12/20/2021, please help do the code clean before the date.
+ */
 export function isArmSupportEnabled(): boolean {
   return isFeatureFlagEnabled(FeatureFlagName.InsiderPreview, true);
 }
@@ -435,6 +441,9 @@ export function isBicepEnvCheckerEnabled(): boolean {
   return isFeatureFlagEnabled(FeatureFlagName.BicepEnvCheckerEnable, true);
 }
 
+/**
+ * @deprecated This method will be removed in 12/20/2021, please help do the code clean before the date.
+ */
 export function isRemoteCollaborateEnabled(): boolean {
   return isFeatureFlagEnabled(FeatureFlagName.InsiderPreview, true);
 }


### PR DESCRIPTION
Mark below function as deprecated to reminder code owner to do code clean, and an email will be sent separately for more details:
* isMultiEnvEnabled()
* isArmSupportEnabled()
* isRemoteCollaborateEnabled()

All places referenced these functions will be marked as deprecated in VS Code:
![image](https://user-images.githubusercontent.com/15644078/145544402-4c0b9f29-e243-468f-8dbd-f31f84710b0d.png)
