### PR TITLE
fix: set REMOTE_TEAMS_APP_TENANT_ID for spfx

### DIFF
--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/provision.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/provision.ts
@@ -264,6 +264,12 @@ export async function provisionResource(
     const update = combineRecords(configureResourceResult.output);
     _.assign(newEnvInfo.state, update);
     newEnvInfo.state[GLOBAL_CONFIG]["output"][SOLUTION_PROVISION_SUCCEEDED] = true;
+    if (!isAzureProject(azureSolutionSettings)) {
+      const appStudioTokenJson = await tokenProvider.appStudioToken.getJsonObject();
+      newEnvInfo.state[GLOBAL_CONFIG]["output"][REMOTE_TEAMS_APP_TENANT_ID] = (
+        appStudioTokenJson as any
+      ).tid;
+    }
     return new v2.FxSuccess(newEnvInfo.state);
   }
 }


### PR DESCRIPTION
The fix of this bug https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/12807393
was accidentally deleted on main(https://github.com/OfficeDev/TeamsFx/commit/0f4eb4bdb8267a207a8a7cc6fede100543ecc765#diff-27f77cc037519b1cc57ac5f3c9b27a7e4b82db198830bdc1231b77aab121180aL266)  Restore it.