### PR TITLE
fix: block debug before extension activated

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -58,8 +58,6 @@
     "onCommand:fx-extension.openAppManagement",
     "onCommand:fx-extension.openBotManagement",
     "onCommand:fx-extension.openReportIssues",
-    "onCommand:fx-extension.validate-dependencies",
-    "onCommand:fx-extension.pre-debug-check",
     "onCommand:fx-extension.migrateV1Project",
     "onCommand:workbench.action.tasks.runTask",
     "workspaceContains:**/.fx/*",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -61,6 +61,7 @@
     "onCommand:fx-extension.validate-dependencies",
     "onCommand:fx-extension.pre-debug-check",
     "onCommand:fx-extension.migrateV1Project",
+    "onCommand:workbench.action.tasks.runTask",
     "workspaceContains:**/.fx/*",
     "onView:teamsfx",
     "onView:teamsfx-accounts",


### PR DESCRIPTION
To fix: (1) https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/12361074 and (2) #2594.

(1) can be stably reproduced, but (2) is hard to be reproduced.

From my test, task provider will not be called before activation finished. (1) can be definitely solved and we expect (2) can also be solved. See references below for more details.

References:
https://github.com/platformio/platformio-vscode-ide/issues/89#issuecomment-392447277