### PR TITLE
fix: generate correct localSettings.json using initV2()

### DIFF
--- a/packages/fx-core/package.json
+++ b/packages/fx-core/package.json
@@ -21,6 +21,7 @@
     "test:apim": "nyc mocha \"tests/plugins/resource/apim/**/*.test.ts\"",
     "test:keyvault": "nyc mocha \"tests/plugins/resource/keyvault/**/*.test.ts\"",
     "test:unit": "nyc --no-clean mocha \"tests/**/*.test.ts\"",
+    "test:common": "nyc --no-clean mocha \"tests/common/*.test.ts\"",
     "test:solution": "nyc mocha \"tests/plugins/solution/*.test.ts\"",
     "test:solution:debug": "nyc mocha \"tests/plugins/solution/debug/*.test.ts\"",
     "test:core": "nyc mocha \"tests/core/**/*.test.ts\"",

--- a/packages/fx-core/src/common/localSettingsProvider.ts
+++ b/packages/fx-core/src/common/localSettingsProvider.ts
@@ -69,7 +69,12 @@ export class LocalSettingsProvider {
     return localSettings;
   }
 
-  public initV2(includeFrontend: boolean, includeBackend: boolean, includeBot: boolean): Json {
+  public initV2(
+    includeFrontend: boolean,
+    includeBackend: boolean,
+    includeBotOrMessageExtension: boolean,
+    migrateFromV1 = false
+  ): Json {
     const localSettings: Json = {
       teamsApp: {
         [LocalSettingsTeamsAppKeys.TenantId]: "",
@@ -77,10 +82,13 @@ export class LocalSettingsProvider {
       },
     };
 
+    if (!migrateFromV1) {
+      localSettings.auth = this.initSimpleAuth().toJSON();
+    }
+
     // initialize frontend and simple auth local settings.
     if (includeFrontend) {
       localSettings.frontend = this.initFrontend().toJSON();
-      localSettings.auth = this.initSimpleAuth().toJSON();
     }
 
     // initialize backend local settings.
@@ -89,7 +97,7 @@ export class LocalSettingsProvider {
     }
 
     // initialize bot local settings.
-    if (includeBot) {
+    if (includeBotOrMessageExtension) {
       localSettings.bot = this.initBot().toJSON();
     }
 
@@ -250,11 +258,14 @@ export class LocalSettingsProvider {
     return localSettings;
   }
 
-  private convertToLocalSettingsJson(localSettings: LocalSettings): Json {
+  convertToLocalSettingsJson(localSettings: LocalSettings): Json {
     const localSettingsJson: Json = {
       teamsApp: localSettings.teamsApp?.toJSON(),
-      auth: localSettings.auth?.toJSON(),
     };
+
+    if (localSettings.auth) {
+      localSettingsJson["auth"] = localSettings.auth?.toJSON();
+    }
 
     if (localSettings.frontend) {
       localSettingsJson["frontend"] = localSettings.frontend.toJSON();

--- a/packages/fx-core/tests/common/localSettingsProvider.test.ts
+++ b/packages/fx-core/tests/common/localSettingsProvider.test.ts
@@ -1,0 +1,30 @@
+import { Json, LocalSettings } from "@microsoft/teamsfx-api";
+import { assert } from "chai";
+import "mocha";
+import { LocalSettingsProvider } from "../../src/common/localSettingsProvider";
+
+describe("LocalSettingsProvider's init() and initV2()", () => {
+  it("should produce same output when given same input", () => {
+    const localSettings = new LocalSettingsProvider("./");
+    // init() and initV2() both have 4 bool parameters. There are 2^4 = 16 combinations
+    for (let i = 0; i < 15; i++) {
+      const includeFrontend = !!(i & 1);
+      const includeBackend = !!((i >> 1) & 1);
+      const includeBotOrMessageExtension = !!((i >> 2) & 1);
+      const migrateFromV1 = !!((i >> 3) & 1);
+      const initOutput = localSettings.init(
+        includeFrontend,
+        includeBackend,
+        includeBotOrMessageExtension,
+        migrateFromV1
+      );
+      const initV2Output = localSettings.initV2(
+        includeFrontend,
+        includeBackend,
+        includeBotOrMessageExtension,
+        migrateFromV1
+      );
+      assert.deepEqual(initV2Output, localSettings.convertToLocalSettingsJson(initOutput));
+    }
+  });
+});

--- a/packages/fx-core/tests/common/localSettingsProvider.test.ts
+++ b/packages/fx-core/tests/common/localSettingsProvider.test.ts
@@ -1,4 +1,3 @@
-import { Json, LocalSettings } from "@microsoft/teamsfx-api";
 import { assert } from "chai";
 import "mocha";
 import { LocalSettingsProvider } from "../../src/common/localSettingsProvider";

--- a/packages/fx-core/tests/core/localSettings.test.ts
+++ b/packages/fx-core/tests/core/localSettings.test.ts
@@ -97,6 +97,7 @@ describe("LocalSettings provider APIs", () => {
       const localSettings = localSettingsProvider.initV2(hasFrontend, hasBackend, hasBot);
       chai.assert.isDefined(localSettings.frontend);
       chai.assert.isDefined(localSettings.backend);
+      chai.assert.isDefined(localSettings.auth);
       chai.assert.isUndefined(localSettings.bot);
     });
 
@@ -105,9 +106,10 @@ describe("LocalSettings provider APIs", () => {
       hasBackend = false;
       hasBot = false;
 
-      const localSettings = localSettingsProvider.init(hasFrontend, hasBackend, hasBot);
+      const localSettings = localSettingsProvider.initV2(hasFrontend, hasBackend, hasBot);
       chai.assert.isDefined(localSettings.frontend);
       chai.assert.isUndefined(localSettings.backend);
+      chai.assert.isDefined(localSettings.auth);
       chai.assert.isUndefined(localSettings.bot);
     });
 
@@ -116,9 +118,10 @@ describe("LocalSettings provider APIs", () => {
       hasBackend = false;
       hasBot = true;
 
-      const localSettings = localSettingsProvider.init(hasFrontend, hasBackend, hasBot);
+      const localSettings = localSettingsProvider.initV2(hasFrontend, hasBackend, hasBot);
       chai.assert.isUndefined(localSettings.frontend);
       chai.assert.isUndefined(localSettings.backend);
+      chai.assert.isDefined(localSettings.auth);
       chai.assert.isDefined(localSettings.bot);
     });
   });


### PR DESCRIPTION
fixes https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_sprints/taskboard/Teams%20Extensibility%20E2E%20Team/Microsoft%20Teams%20Extensibility/CY21-12.2?workitem=12873343

For bot-only projects, LocalSettingsProvider.initV2() doesn't generate "auth" key. This PR fixes it.
