### PR TITLE
feat(env-checker): add support for .NET 6.0

### DIFF
--- a/.github/workflows/env-checker-ci-schedule.yml
+++ b/.github/workflows/env-checker-ci-schedule.yml
@@ -22,7 +22,7 @@ jobs:
         os: [windows-latest, macos-latest, macos-11, ubuntu-latest]
         node-version: [12, 14, 16]
         func-version: [none, 2, 3]
-        dotnet-version: [none, 3.1.x, 5.0.x]
+        dotnet-version: [none, 3.1.x, 5.0.x, 6.0.x]
       max-parallel: 30
 
     runs-on: ${{ matrix.os }}

--- a/docs/vscode-extension/envchecker-help.md
+++ b/docs/vscode-extension/envchecker-help.md
@@ -27,11 +27,14 @@ Please refer to [the official site](https://nodejs.org/en/about/releases/) to do
 
 ## How to install .NET SDK?
 
-Please refer to [the official website](https://dotnet.microsoft.com/download) to download and install the supported versions: `.NET 5.0 SDK` or `.NET Core 3.1 SDK`.
+Please refer to [the official website](https://dotnet.microsoft.com/download) to download and install the supported versions:
+
+| Platform | .NET versions |
+| -- | -- |
+| Windows, macOS (x64), Linux | **.NET Core 3.1 SDK (recommended)**, .NET 5.0 SDK, .NET 6.0 SDK  |
+| macOS (arm64) | .NET 6.0 SDK |
 
 **NOTE**: Please restart all your Visual Studio Code instances after the installation is finished.
-
-**NOTE for M1 Mac Users**: Currently neither `.NET 5.0 SDK` or `.NET Core 3.1 SDK` supports M1 Mac (see [this GitHub issue](https://github.com/dotnet/core/issues/4879)).
 
 ## How to install Azure Functions Core Tools?
 

--- a/packages/cli/src/cmds/preview/depsChecker/common.ts
+++ b/packages/cli/src/cmds/preview/depsChecker/common.ts
@@ -23,6 +23,10 @@ export function isLinux(): boolean {
   return os.type() === "Linux";
 }
 
+export function isArm64(): boolean {
+  return os.arch() === "arm64";
+}
+
 // help links
 export const defaultHelpLink = "https://aka.ms/teamsfx-envchecker-help";
 

--- a/packages/cli/src/cmds/preview/depsChecker/dotnetChecker.ts
+++ b/packages/cli/src/cmds/preview/depsChecker/dotnetChecker.ts
@@ -18,7 +18,9 @@ import { DepsInfo, IDepsAdapter, IDepsChecker, IDepsLogger, IDepsTelemetry } fro
 import {
   DepsCheckerEvent,
   dotnetFailToInstallHelpLink,
+  isArm64,
   isLinux,
+  isMacOS,
   isWindows,
   Messages,
   TelemtryMessages,
@@ -39,7 +41,7 @@ export enum DotnetVersion {
 export const DotnetCoreSDKName = ".NET Core SDK";
 export type DotnetSDK = { version: string; path: string };
 
-export const installVersion = DotnetVersion.v31;
+export const installVersion = isMacOS() && isArm64() ? DotnetVersion.v60 : DotnetVersion.v31;
 export const supportedVersions = [DotnetVersion.v31, DotnetVersion.v50, DotnetVersion.v60];
 const installedNameWithVersion = `${DotnetCoreSDKName} (v${DotnetVersion.v31})`;
 

--- a/packages/cli/src/cmds/preview/depsChecker/dotnetChecker.ts
+++ b/packages/cli/src/cmds/preview/depsChecker/dotnetChecker.ts
@@ -33,13 +33,14 @@ export enum DotnetVersion {
   v21 = "2.1",
   v31 = "3.1",
   v50 = "5.0",
+  v60 = "6.0",
 }
 
 export const DotnetCoreSDKName = ".NET Core SDK";
 export type DotnetSDK = { version: string; path: string };
 
 export const installVersion = DotnetVersion.v31;
-export const supportedVersions = [DotnetVersion.v31, DotnetVersion.v50];
+export const supportedVersions = [DotnetVersion.v31, DotnetVersion.v50, DotnetVersion.v60];
 const installedNameWithVersion = `${DotnetCoreSDKName} (v${DotnetVersion.v31})`;
 
 export class DotnetChecker implements IDepsChecker {

--- a/packages/fx-core/src/plugins/resource/function/utils/depsChecker/common.ts
+++ b/packages/fx-core/src/plugins/resource/function/utils/depsChecker/common.ts
@@ -23,6 +23,10 @@ export function isLinux(): boolean {
   return os.type() === "Linux";
 }
 
+export function isArm64(): boolean {
+  return os.arch() === "arm64";
+}
+
 // help links
 export const defaultHelpLink = "https://aka.ms/teamsfx-envchecker-help";
 

--- a/packages/fx-core/src/plugins/resource/function/utils/depsChecker/dotnetChecker.ts
+++ b/packages/fx-core/src/plugins/resource/function/utils/depsChecker/dotnetChecker.ts
@@ -18,7 +18,9 @@ import { DepsInfo, IDepsAdapter, IDepsChecker, IDepsLogger, IDepsTelemetry } fro
 import {
   DepsCheckerEvent,
   dotnetFailToInstallHelpLink,
+  isArm64,
   isLinux,
+  isMacOS,
   isWindows,
   Messages,
   TelemtryMessages,
@@ -39,7 +41,7 @@ export enum DotnetVersion {
 export const DotnetCoreSDKName = ".NET Core SDK";
 export type DotnetSDK = { version: string; path: string };
 
-export const installVersion = DotnetVersion.v31;
+export const installVersion = isMacOS() && isArm64() ? DotnetVersion.v60 : DotnetVersion.v31;
 export const supportedVersions = [DotnetVersion.v31, DotnetVersion.v50, DotnetVersion.v60];
 const installedNameWithVersion = `${DotnetCoreSDKName} (v${DotnetVersion.v31})`;
 

--- a/packages/fx-core/src/plugins/resource/function/utils/depsChecker/dotnetChecker.ts
+++ b/packages/fx-core/src/plugins/resource/function/utils/depsChecker/dotnetChecker.ts
@@ -33,13 +33,14 @@ export enum DotnetVersion {
   v21 = "2.1",
   v31 = "3.1",
   v50 = "5.0",
+  v60 = "6.0",
 }
 
 export const DotnetCoreSDKName = ".NET Core SDK";
 export type DotnetSDK = { version: string; path: string };
 
 export const installVersion = DotnetVersion.v31;
-export const supportedVersions = [DotnetVersion.v31, DotnetVersion.v50];
+export const supportedVersions = [DotnetVersion.v31, DotnetVersion.v50, DotnetVersion.v60];
 const installedNameWithVersion = `${DotnetCoreSDKName} (v${DotnetVersion.v31})`;
 
 export class DotnetChecker implements IDepsChecker {

--- a/packages/vscode-extension/src/debug/depsChecker/common.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/common.ts
@@ -23,6 +23,10 @@ export function isLinux(): boolean {
   return os.type() === "Linux";
 }
 
+export function isArm64(): boolean {
+  return os.arch() === "arm64";
+}
+
 // help links
 export const defaultHelpLink = "https://aka.ms/teamsfx-envchecker-help";
 

--- a/packages/vscode-extension/src/debug/depsChecker/dotnetChecker.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/dotnetChecker.ts
@@ -18,7 +18,9 @@ import { DepsInfo, IDepsAdapter, IDepsChecker, IDepsLogger, IDepsTelemetry } fro
 import {
   DepsCheckerEvent,
   dotnetFailToInstallHelpLink,
+  isArm64,
   isLinux,
+  isMacOS,
   isWindows,
   Messages,
   TelemtryMessages,
@@ -39,7 +41,7 @@ export enum DotnetVersion {
 export const DotnetCoreSDKName = ".NET Core SDK";
 export type DotnetSDK = { version: string; path: string };
 
-export const installVersion = DotnetVersion.v31;
+export const installVersion = isMacOS() && isArm64() ? DotnetVersion.v60 : DotnetVersion.v31;
 export const supportedVersions = [DotnetVersion.v31, DotnetVersion.v50, DotnetVersion.v60];
 const installedNameWithVersion = `${DotnetCoreSDKName} (v${DotnetVersion.v31})`;
 

--- a/packages/vscode-extension/src/debug/depsChecker/dotnetChecker.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/dotnetChecker.ts
@@ -33,13 +33,14 @@ export enum DotnetVersion {
   v21 = "2.1",
   v31 = "3.1",
   v50 = "5.0",
+  v60 = "6.0",
 }
 
 export const DotnetCoreSDKName = ".NET Core SDK";
 export type DotnetSDK = { version: string; path: string };
 
 export const installVersion = DotnetVersion.v31;
-export const supportedVersions = [DotnetVersion.v31, DotnetVersion.v50];
+export const supportedVersions = [DotnetVersion.v31, DotnetVersion.v50, DotnetVersion.v60];
 const installedNameWithVersion = `${DotnetCoreSDKName} (v${DotnetVersion.v31})`;
 
 export class DotnetChecker implements IDepsChecker {


### PR DESCRIPTION
Support .NET 6.0 in env checker. Code and documents updated.

Tested tab+function project.

Tested on M1

[.NET support matrix for M1 mac](https://docs.microsoft.com/en-us/dotnet/core/install/macos#whats-supported)

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/12600126