### PR TITLE
chore: isMultiEnvEnabled() always returns true

### DIFF
--- a/packages/fx-core/src/common/tools.ts
+++ b/packages/fx-core/src/common/tools.ts
@@ -438,7 +438,7 @@ export function isFeatureFlagEnabled(featureFlagName: string, defaultValue = fal
  * @deprecated Please DO NOT use this method any more, it will be removed in near future.
  */
 export function isMultiEnvEnabled(): boolean {
-  return isFeatureFlagEnabled(FeatureFlagName.InsiderPreview, true);
+  return true;
 }
 
 /**

--- a/packages/fx-core/tests/core/middleware/ProjectSettingsWriterMW.test.ts
+++ b/packages/fx-core/tests/core/middleware/ProjectSettingsWriterMW.test.ts
@@ -91,21 +91,9 @@ describe("Middleware - ProjectSettingsWriterMW", () => {
       myMethod: [ContextInjectorMW, ProjectSettingsWriterMW],
     });
     const my = new MyClass();
-    let mockedEnvRestore = mockedEnv({ __TEAMSFX_INSIDER_PREVIEW: "false" });
-    {
-      await my.myMethod(inputs);
-      const content: string = fileMap.get(settingsFileV1);
-      const settingsInFile = JSON.parse(content);
-      assert.deepEqual(mockProjectSettings, settingsInFile);
-    }
-    mockedEnvRestore();
-    mockedEnvRestore = mockedEnv({ __TEAMSFX_INSIDER_PREVIEW: "true" });
-    {
-      await my.myMethod(inputs);
-      const content: string = fileMap.get(settingsFileV2);
-      const settingsInFile = JSON.parse(content);
-      assert.deepEqual(mockProjectSettings, settingsInFile);
-    }
-    mockedEnvRestore();
+    await my.myMethod(inputs);
+    const content: string = fileMap.get(settingsFileV2);
+    const settingsInFile = JSON.parse(content);
+    assert.deepEqual(mockProjectSettings, settingsInFile);
   });
 });

--- a/packages/fx-core/tests/plugins/solution/solution.provision.test.ts
+++ b/packages/fx-core/tests/plugins/solution/solution.provision.test.ts
@@ -480,13 +480,7 @@ describe("provision() happy path for SPFx projects", () => {
     mocker.restore();
   });
 
-  it("should succeed if app studio returns successfully", () =>
-    provisionSpfxProjectShouldSucceed(false));
-
-  it("should succeed if insider feature flag enabled", () =>
-    provisionSpfxProjectShouldSucceed(true));
-
-  async function provisionSpfxProjectShouldSucceed(insiderEnabled = false): Promise<void> {
+  it("should succeed if insider feature flag enabled", async () => {
     const solution = new TeamsAppSolution();
     const mockedCtx = mockSolutionContext();
     mockedCtx.root = "./tests/plugins/resource/appstudio/spfx-resources/";
@@ -500,9 +494,6 @@ describe("provision() happy path for SPFx projects", () => {
         activeResourcePlugins: [spfxPlugin.name, appStudioPlugin.name],
       },
     };
-    mocker.stub(process, "env").get(() => {
-      return { __TEAMSFX_INSIDER_PREVIEW: insiderEnabled.toString() };
-    });
 
     expect(mockedCtx.envInfo.state.get(GLOBAL_CONFIG)?.get(SOLUTION_PROVISION_SUCCEEDED)).to.be
       .undefined;
@@ -512,17 +503,11 @@ describe("provision() happy path for SPFx projects", () => {
     expect(mockedCtx.envInfo.state.get(GLOBAL_CONFIG)?.get(SOLUTION_PROVISION_SUCCEEDED)).to.be
       .true;
 
-    if (insiderEnabled) {
-      expect(mockedCtx.envInfo.state.get("fx-resource-appstudio")?.get("teamsAppId")).equals(
-        mockedAppDef.teamsAppId
-      );
-    } else {
-      expect(mockedCtx.envInfo.state.get(GLOBAL_CONFIG)?.get(REMOTE_TEAMS_APP_ID)).equals(
-        mockedAppDef.teamsAppId
-      );
-    }
+    expect(mockedCtx.envInfo.state.get("fx-resource-appstudio")?.get("teamsAppId")).equals(
+      mockedAppDef.teamsAppId
+    );
     expect(solution.runningState).equals(SolutionRunningState.Idle);
-  }
+  });
 });
 
 function mockAzureProjectDeps(


### PR DESCRIPTION
Update the return value of `isMultiEnvEnabled` to be `true` and fix several failed test cases.