### PR TITLE
perf(scaffold): extend timeout and stop retry when timeout

### DIFF
--- a/packages/fx-core/src/common/templatesActions.ts
+++ b/packages/fx-core/src/common/templatesActions.ts
@@ -44,7 +44,7 @@ export interface ScaffoldAction {
 }
 
 const defaultTryLimits = 3;
-const defaultTimeoutInMs = 10000;
+const defaultTimeoutInMs = 30000;
 
 const missKeyErrorInfo = (key: string) => `Missing ${key} in template action.`;
 

--- a/packages/fx-core/src/common/templatesUtils.ts
+++ b/packages/fx-core/src/common/templatesUtils.ts
@@ -13,6 +13,8 @@ import { selectTag, templateURL } from "./templates";
 export const tagListUrl = config.tagListURL;
 export const templateFileExt = ".tpl";
 
+export const timeoutErrorCode = "ECONNABORTED";
+
 export async function sendRequestWithRetry<T>(
   requestFn: () => Promise<AxiosResponse<T>>,
   tryLimits: number
@@ -35,6 +37,10 @@ export async function sendRequestWithRetry<T>(
     } catch (e: any) {
       error = e;
       status = e?.response?.status;
+      if (e?.code === timeoutErrorCode) {
+        // Stop retry if request timeout
+        break;
+      }
     }
   }
 


### PR DESCRIPTION
1. 10 seconds timeout may be too short. Extend to 30s. 
1. And stop retry a timeout request, which seems helpless.