### PR TITLE
refactor(localdebug): getNpmInstallLog

### DIFF
--- a/packages/fx-core/src/common/index.ts
+++ b/packages/fx-core/src/common/index.ts
@@ -5,5 +5,6 @@
 export * from "./tools";
 export * from "./correlator";
 export * from "./globalState";
+export * from "./local/localEnvManager";
 export * from "./permissionInterface";
 export * from "./samples";

--- a/packages/fx-core/src/common/local/localEnvManager.ts
+++ b/packages/fx-core/src/common/local/localEnvManager.ts
@@ -13,6 +13,7 @@ import {
 import * as fs from "fs-extra";
 import * as path from "path";
 
+import { getNpmInstallLogInfo, NpmInstallLogInfo } from "./npmLogHelper";
 import { LocalSettingsProvider } from "../localSettingsProvider";
 import { waitSeconds } from "../tools";
 import { LocalCrypto } from "../../core/crypto";
@@ -27,7 +28,9 @@ class LocalEnvManager {
 
   public async getLocalDebugEnvs() {}
 
-  public async getNpmInstallLogInfo() {}
+  public async getNpmInstallLogInfo(): Promise<NpmInstallLogInfo | undefined> {
+    return await getNpmInstallLogInfo();
+  }
 
   public async getPortsInUse() {}
 

--- a/packages/fx-core/src/common/local/npmLogHelper.ts
+++ b/packages/fx-core/src/common/local/npmLogHelper.ts
@@ -1,0 +1,101 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+"use strict";
+
+import * as fs from "fs-extra";
+import * as path from "path";
+
+import { cpUtils } from "../deps-checker/util/cpUtils";
+
+export interface NpmInstallLogInfo {
+  logFile: string;
+  timestamp: Date;
+  nodeVersion: string | undefined;
+  npmVersion: string | undefined;
+  cwd: string | undefined;
+  exitCode: number | undefined;
+  errorMessage: Array<string> | undefined;
+}
+
+async function getNpmCachePath(): Promise<string | undefined> {
+  try {
+    const result = await cpUtils.executeCommand(
+      undefined,
+      undefined,
+      undefined,
+      "npm config get cache"
+    );
+    return result.trim();
+  } catch (error) {
+    return undefined;
+  }
+}
+
+async function getLatestNpmLogFile(npmLogPath: string): Promise<string | undefined> {
+  const files = await fs.readdir(npmLogPath);
+  if (files.length === 0) {
+    return undefined;
+  }
+  const latestNpmLogFile = files.reduce((previous, current, index, array) => {
+    return previous > current ? previous : current;
+  });
+  return path.join(npmLogPath, latestNpmLogFile);
+}
+
+export async function getNpmInstallLogInfo(): Promise<NpmInstallLogInfo | undefined> {
+  try {
+    const npmCachePath = await getNpmCachePath();
+    if (npmCachePath === undefined || !(await fs.pathExists(npmCachePath))) {
+      return undefined;
+    }
+    const npmLogFolder = path.join(npmCachePath, "_logs");
+    if (!(await fs.pathExists(npmLogFolder))) {
+      return undefined;
+    }
+    const latestNpmLogFile = await getLatestNpmLogFile(npmLogFolder);
+    if (latestNpmLogFile === undefined) {
+      return undefined;
+    }
+    const latestNpmLogFileName = path.basename(latestNpmLogFile);
+    const str = latestNpmLogFileName.replace(/_/g, ":");
+    const timestamp = new Date(`${str.slice(0, 19)}.${str.slice(20, 24)}`);
+    const log = (await fs.readFile(latestNpmLogFile)).toString();
+
+    const nodePattern = /\d+\s+verbose\s+node\s+(v.*)/;
+    const nodeResult = log.match(nodePattern);
+    const nodeVersion = nodeResult ? nodeResult[1].trim() : undefined;
+
+    const npmPattern = /\d+\s+verbose\s+npm\s+(v.*)/;
+    const npmResult = log.match(npmPattern);
+    const npmVersion = npmResult ? npmResult[1].trim() : undefined;
+
+    const cwdPattern = /\d+\s+verbose\s+cwd\s+(.*)/;
+    const cwdResult = log.match(cwdPattern);
+    const cwd = cwdResult ? cwdResult[1].trim() : undefined;
+
+    const exitCodePattern = /\d+\s+verbose\s+exit\s+\[\s+(-?\d+),\s+.*]/;
+    const exitCodeResult = log.match(exitCodePattern);
+    const exitCode = exitCodeResult ? Number(exitCodeResult[1]) : undefined;
+
+    const errorPattern = /\d+\s+error\s+.*/g;
+    const errorResults = log.match(errorPattern);
+    const errorMessage = errorResults
+      ? errorResults.map((value, index, array) => {
+          return value.trim();
+        })
+      : undefined;
+
+    const npmInstallLogInfo: NpmInstallLogInfo = {
+      logFile: latestNpmLogFile,
+      timestamp,
+      nodeVersion,
+      npmVersion,
+      cwd,
+      exitCode,
+      errorMessage,
+    };
+    return npmInstallLogInfo;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/fx-core/tests/common/local/npmLogHelper.test.ts
+++ b/packages/fx-core/tests/common/local/npmLogHelper.test.ts
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import "mocha";
+import * as chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+import * as fs from "fs-extra";
+import * as path from "path";
+import * as sinon from "sinon";
+
+import { getNpmInstallLogInfo } from "../../../src/common/local/npmLogHelper";
+import { cpUtils } from "../../../src/common/deps-checker/util/cpUtils";
+
+chai.use(chaiAsPromised);
+
+describe("npmLogHelper", () => {
+  describe("getNpmInstallLogInfo()", () => {
+    const npmCachePath = path.resolve(__dirname, "data/npm-cache");
+    const npmLogPath = path.resolve(npmCachePath, "_logs");
+    const npmErrorLogRaw =
+      "\
+1 verbose cwd cwd-placeholder\n\
+2 verbose node vnode-version-placeholder\n\
+3 verbose npm  vnpm-version-placeholder\n\
+4 error error1\n\
+5 error error2\n\
+6 error error3\n\
+7 verbose exit [ 1234, true ]\n\
+    ";
+
+    beforeEach(() => {
+      sinon.restore();
+      fs.ensureDirSync(npmLogPath);
+      fs.emptyDirSync(npmLogPath);
+    });
+
+    it("happy path", async () => {
+      await fs.writeFile(
+        path.join(npmLogPath, "2021-12-02T20_21_12_020Z-debug.log"),
+        npmErrorLogRaw
+      );
+      sinon.stub(cpUtils, "executeCommand").resolves(npmCachePath);
+
+      const logInfo = await getNpmInstallLogInfo();
+
+      chai.assert.isDefined(logInfo);
+      chai.assert.equal(logInfo!.timestamp.getUTCFullYear(), 2021);
+      chai.assert.equal(logInfo!.cwd, "cwd-placeholder");
+      chai.assert.equal(logInfo!.nodeVersion, "vnode-version-placeholder");
+      chai.assert.equal(logInfo!.npmVersion, "vnpm-version-placeholder");
+      chai.assert.equal(logInfo!.exitCode, 1234);
+      chai.assert.deepEqual(logInfo!.errorMessage, [
+        "4 error error1",
+        "5 error error2",
+        "6 error error3",
+      ]);
+    });
+
+    it("no log file", async () => {
+      sinon.stub(cpUtils, "executeCommand").resolves(npmCachePath);
+
+      const logInfo = await getNpmInstallLogInfo();
+
+      chai.assert.isUndefined(logInfo);
+    });
+
+    it("invalid log file name", async () => {
+      await fs.writeFile(path.join(npmLogPath, "invalid.invalid"), npmErrorLogRaw);
+      sinon.stub(cpUtils, "executeCommand").resolves(npmCachePath);
+
+      const logInfo = await getNpmInstallLogInfo();
+
+      chai.assert.isDefined(logInfo);
+      chai.assert.isNaN(logInfo!.timestamp.getTime());
+      chai.assert.equal(logInfo!.cwd, "cwd-placeholder");
+      chai.assert.equal(logInfo!.nodeVersion, "vnode-version-placeholder");
+      chai.assert.equal(logInfo!.npmVersion, "vnpm-version-placeholder");
+      chai.assert.equal(logInfo!.exitCode, 1234);
+      chai.assert.deepEqual(logInfo!.errorMessage, [
+        "4 error error1",
+        "5 error error2",
+        "6 error error3",
+      ]);
+    });
+
+    it("get latest log file", async () => {
+      await fs.writeFile(
+        path.join(npmLogPath, "2021-12-02T20_21_12_020Z-debug.log"),
+        npmErrorLogRaw
+      );
+      await fs.writeFile(path.join(npmLogPath, "2099-12-31T23_59_59_000Z-debug.log"), "no error");
+      sinon.stub(cpUtils, "executeCommand").resolves(npmCachePath);
+
+      const logInfo = await getNpmInstallLogInfo();
+
+      chai.assert.isDefined(logInfo);
+      chai.assert.equal(logInfo!.timestamp.getUTCFullYear(), 2099);
+      chai.assert.isUndefined(logInfo!.cwd);
+      chai.assert.isUndefined(logInfo!.nodeVersion);
+      chai.assert.isUndefined(logInfo!.npmVersion);
+    });
+  });
+});


### PR DESCRIPTION
Add `getNpmInstallLogInfo()` to `LocalEnvManager`, as well as unit tests.
Export `LocalEnvManager` so it can be used by vsc/cli.