### PR TITLE
chore: scaffold from local code for debug purpose

### DIFF
--- a/packages/fx-core/src/common/templatesActions.ts
+++ b/packages/fx-core/src/common/templatesActions.ts
@@ -73,8 +73,16 @@ export const fetchTemplateZipFromSourceCode: ScaffoldAction = {
       return;
     }
 
-    if (!context.group || !context.lang || !context.scenario) {
-      return;
+    if (!context.group) {
+      throw new Error(missKeyErrorInfo("group"));
+    }
+
+    if (!context.lang) {
+      throw new Error(missKeyErrorInfo("lang"));
+    }
+
+    if (!context.scenario) {
+      throw new Error(missKeyErrorInfo("scenario"));
     }
 
     //! This path only works in debug mode
@@ -88,11 +96,7 @@ export const fetchTemplateZipFromSourceCode: ScaffoldAction = {
     );
 
     const zip = new AdmZip();
-    try {
-      zip.addLocalFolder(templateSourceCodePath);
-    } catch {
-      return;
-    }
+    zip.addLocalFolder(templateSourceCodePath);
 
     context.zip = zip;
   },


### PR DESCRIPTION
How to use this action:
1. Set DEBUG_TEMPLATE=true to your environment variables.
1. Add your changes in templates source code.
2. cd to vscode-extension folder.
3. F5 to local debug and create new project.
4. The `FetchTemplateZipFromSourceCode` action will get template from the source code that you just changed.

* `FetchTemplatesUrlWithTag`, `FetchTemplatesZipFromUrl`, `FetchTemplateZipFromLocal`, these actions are skipped.
* Since bot's and message extension's templates are generated during CD pipeline, we can't debug those code with this action.