### PR TITLE
fix: spfx local debug concurrency error

### DIFF
--- a/packages/fx-core/src/plugins/solution/fx-solution/debug/util/tasks.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/debug/util/tasks.ts
@@ -130,7 +130,7 @@ export function generateSpfxTasks(): Record<string, unknown>[] {
     {
       label: "prepare dev env",
       dependsOn: ["prepare local environment", "gulp serve"],
-      dependsOrder: "parallel",
+      dependsOrder: "sequence",
     },
     {
       label: "Terminate All Tasks",


### PR DESCRIPTION
ADO:
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_sprints/taskboard/Teams%20Extensibility%20E2E%20Team/Microsoft%20Teams%20Extensibility/CY21-12.3?workitem=12873660
Root cause:
When F5, both pre debug check and validate dependency handlers will be executed. The two handlers will call APIs of core which will cause concurrency error. So I change the order to 'sequence' instead of 'parallel' to avoid the lock fail issue.
E2E TEST: only for extension