### PR TITLE
fix(localdebug): use better ports for frontend and auth

### DIFF
--- a/packages/cli/src/cmds/preview/constants.ts
+++ b/packages/cli/src/cmds/preview/constants.ts
@@ -120,8 +120,8 @@ const loopbackAddressIPv6 = "::1";
 const hosts = [allAddressIPv4, loopbackAddressIPv4, allAddressIPv6, loopbackAddressIPv6];
 
 export const frontendPorts: [number, string[]][] = [
-  [3000, hosts],
-  [5000, hosts],
+  [53000, hosts],
+  [55000, hosts],
 ];
 export const backendPorts: [number, string[]][] = [[7071, hosts]];
 export const botPorts: [number, string[]][] = [[3978, hosts]];

--- a/packages/fx-core/src/common/local/constants.ts
+++ b/packages/fx-core/src/common/local/constants.ts
@@ -62,6 +62,7 @@ export const LocalEnvCertKeys = Object.freeze({
 export const LocalEnvFrontendKeys = Object.freeze({
   Browser: "FRONTEND_BROWSER",
   Https: "FRONTEND_HTTPS",
+  Port: "FRONTEND_PORT",
   TeamsFxEndpoint: "FRONTEND_REACT_APP_TEAMSFX_ENDPOINT",
   LoginUrl: "FRONTEND_REACT_APP_START_LOGIN_PAGE_URL",
   FuncEndpoint: "FRONTEND_REACT_APP_FUNC_ENDPOINT",

--- a/packages/fx-core/src/common/local/localEnvProvider.ts
+++ b/packages/fx-core/src/common/local/localEnvProvider.ts
@@ -16,6 +16,7 @@ export interface LocalEnvs {
 export const EnvKeysFrontend = Object.freeze({
   Browser: "BROWSER",
   Https: "HTTPS",
+  Port: "Port",
   SslCrtFile: "SSL_CRT_FILE",
   SslKeyFile: "SSL_KEY_FILE",
   TeamsFxEndpoint: "REACT_APP_TEAMSFX_ENDPOINT",
@@ -134,6 +135,7 @@ export class LocalEnvProvider {
 
     result.teamsfxLocalEnvs[EnvKeysFrontend.Browser] = "none";
     result.teamsfxLocalEnvs[EnvKeysFrontend.Https] = "true";
+    result.teamsfxLocalEnvs[EnvKeysFrontend.Port] = "53000";
 
     if (includeAuth) {
       result.teamsfxLocalEnvs[EnvKeysFrontend.TeamsFxEndpoint] = "";

--- a/packages/fx-core/src/common/local/localSettingsHelper.ts
+++ b/packages/fx-core/src/common/local/localSettingsHelper.ts
@@ -87,6 +87,7 @@ export async function convertToLocalEnvs(
     localEnvs[LocalEnvFrontendKeys.Https] = frontendConfigs?.get(
       LocalSettingsFrontendKeys.Https
     ) as string;
+    localEnvs[LocalEnvFrontendKeys.Port] = "53000";
 
     if (includeAuth) {
       // frontend local envs

--- a/packages/fx-core/src/plugins/solution/fx-solution/debug/provisionLocal.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/debug/provisionLocal.ts
@@ -72,14 +72,14 @@ export async function setupLocalDebugSettings(
       if (vscEnv === VsCodeEnv.codespaceBrowser || vscEnv === VsCodeEnv.codespaceVsCode) {
         const codespaceName = await getCodespaceName();
 
-        localTabEndpoint = getCodespaceUrl(codespaceName, 3000);
+        localTabEndpoint = getCodespaceUrl(codespaceName, 53000);
         localTabDomain = new URL(localTabEndpoint).host;
-        localAuthEndpoint = getCodespaceUrl(codespaceName, 5000);
+        localAuthEndpoint = getCodespaceUrl(codespaceName, 55000);
         localFuncEndpoint = getCodespaceUrl(codespaceName, 7071);
       } else {
         localTabDomain = "localhost";
-        localTabEndpoint = "https://localhost:3000";
-        localAuthEndpoint = "http://localhost:5000";
+        localTabEndpoint = "https://localhost:53000";
+        localAuthEndpoint = "http://localhost:55000";
         localFuncEndpoint = "http://localhost:7071";
       }
 
@@ -190,6 +190,8 @@ export async function configLocalDebugSettings(
       const localAuthPackagePath = localSettings?.auth?.simpleAuthFilePath as string;
 
       if (includeFrontend) {
+        frontendEnvs!.teamsfxLocalEnvs[EnvKeysFrontend.Port] = "53000";
+
         if (includeAuth) {
           frontendEnvs!.teamsfxLocalEnvs[EnvKeysFrontend.TeamsFxEndpoint] = localAuthEndpoint;
           frontendEnvs!.teamsfxLocalEnvs[

--- a/packages/fx-core/tests/common/local/localEnvManager.test.ts
+++ b/packages/fx-core/tests/common/local/localEnvManager.test.ts
@@ -34,7 +34,7 @@ describe("LocalEnvManager", () => {
     },
     frontend: {
       tabDomain: "localhost",
-      tabEndpoint: "https://localhost:3000",
+      tabEndpoint: "https://localhost:53000",
     },
   };
   const projectPath = path.resolve(__dirname, "data");
@@ -226,7 +226,7 @@ describe("LocalEnvManager", () => {
       chai.assert.equal(localSettings!.auth.clientSecret, "password-placeholder");
       chai.assert.isDefined(localSettings!.frontend);
       chai.assert.equal(localSettings!.frontend.tabDomain, "localhost");
-      chai.assert.equal(localSettings!.frontend.tabEndpoint, "https://localhost:3000");
+      chai.assert.equal(localSettings!.frontend.tabEndpoint, "https://localhost:53000");
     });
 
     it("missing field", async () => {

--- a/packages/fx-core/tests/common/local/localEnvProvider.test.ts
+++ b/packages/fx-core/tests/common/local/localEnvProvider.test.ts
@@ -289,19 +289,19 @@ describe("LocalEnvProvider", () => {
 
     it("frontend", () => {
       const envs = localEnvProvider.initFrontendLocalEnvs(false, false);
-      chai.assert.equal(Object.values(envs.teamsfxLocalEnvs).length, 2);
+      chai.assert.equal(Object.values(envs.teamsfxLocalEnvs).length, 3);
       chai.assert.equal(Object.values(envs.customizedLocalEnvs).length, 0);
     });
 
     it("frontend + auth", () => {
       const envs = localEnvProvider.initFrontendLocalEnvs(false, true);
-      chai.assert.equal(Object.values(envs.teamsfxLocalEnvs).length, 5);
+      chai.assert.equal(Object.values(envs.teamsfxLocalEnvs).length, 6);
       chai.assert.equal(Object.values(envs.customizedLocalEnvs).length, 0);
     });
 
     it("frontend + auth + backend", () => {
       const envs = localEnvProvider.initFrontendLocalEnvs(true, true);
-      chai.assert.equal(Object.values(envs.teamsfxLocalEnvs).length, 7);
+      chai.assert.equal(Object.values(envs.teamsfxLocalEnvs).length, 8);
       chai.assert.equal(Object.values(envs.customizedLocalEnvs).length, 0);
     });
 

--- a/packages/fx-core/tests/common/local/localSettingsHelper.test.ts
+++ b/packages/fx-core/tests/common/local/localSettingsHelper.test.ts
@@ -46,7 +46,7 @@ describe("localSettingsHelper", () => {
       },
       frontend: {
         tabDomain: "localhost",
-        tabEndpoint: "https://localhost:3000",
+        tabEndpoint: "https://localhost:53000",
       },
     };
     const projectPath = path.resolve(__dirname, "data");
@@ -58,10 +58,10 @@ describe("localSettingsHelper", () => {
       const localEnvs = await convertToLocalEnvs(projectPath, projectSettings0, localSettings0);
 
       chai.assert.isDefined(localEnvs);
-      chai.assert.equal(Object.keys(localEnvs).length, 16);
+      chai.assert.equal(Object.keys(localEnvs).length, 17);
       chai.assert.equal(
         localEnvs["FRONTEND_REACT_APP_START_LOGIN_PAGE_URL"],
-        "https://localhost:3000/auth-start.html"
+        "https://localhost:53000/auth-start.html"
       );
       chai.assert.equal(
         localEnvs["FRONTEND_REACT_APP_CLIENT_ID"],
@@ -77,7 +77,7 @@ describe("localSettingsHelper", () => {
         localEnvs["AUTH_OAUTH_AUTHORITY"],
         "https://login.microsoftonline.com/22222222-2222-2222-2222-222222222222"
       );
-      chai.assert.equal(localEnvs["AUTH_TAB_APP_ENDPOINT"], "https://localhost:3000");
+      chai.assert.equal(localEnvs["AUTH_TAB_APP_ENDPOINT"], "https://localhost:53000");
     });
 
     it(".env.teamsfx.local", async () => {

--- a/packages/fx-core/tests/core/localSettings.test.ts
+++ b/packages/fx-core/tests/core/localSettings.test.ts
@@ -69,7 +69,7 @@ describe("LocalSettings provider APIs", () => {
     it("should incremental init if localSettings exists", async () => {
       let localSettings: Json | undefined;
       localSettings = localSettingsProvider.initV2(true, false, false);
-      const updateValue = "http://localhost:5000";
+      const updateValue = "http://localhost:55000";
       localSettings.auth.AuthServiceEndpoint = updateValue;
 
       await localSettingsProvider.saveJson(localSettings);
@@ -148,7 +148,7 @@ describe("LocalSettings provider APIs", () => {
   describe("load localSettings", () => {
     it("should load after save", async () => {
       const localSettings = localSettingsProvider.init(true, true, true);
-      const updateValue = "http://localhost:5000";
+      const updateValue = "http://localhost:55000";
       localSettings.auth?.set(LocalSettingsAuthKeys.SimpleAuthServiceEndpoint, updateValue);
 
       await localSettingsProvider.save(localSettings);

--- a/packages/fx-core/tests/plugins/solution/debug/solution.debug.scaffolding.test.ts
+++ b/packages/fx-core/tests/plugins/solution/debug/solution.debug.scaffolding.test.ts
@@ -56,14 +56,14 @@ describe("solution.debug.scaffolding", () => {
         numConfigurations: 5,
         numCompounds: 2,
         numTasks: 9,
-        numLocalEnvs: 30,
+        numLocalEnvs: 31,
       },
       {
         programmingLanguage: "typescript",
         numConfigurations: 5,
         numCompounds: 2,
         numTasks: 9,
-        numLocalEnvs: 30,
+        numLocalEnvs: 31,
       },
     ];
     parameters1.forEach((parameter: TestParameter) => {
@@ -117,14 +117,14 @@ describe("solution.debug.scaffolding", () => {
         numConfigurations: 4,
         numCompounds: 2,
         numTasks: 6,
-        numLocalEnvs: 16,
+        numLocalEnvs: 17,
       },
       {
         programmingLanguage: "typescript",
         numConfigurations: 4,
         numCompounds: 2,
         numTasks: 6,
-        numLocalEnvs: 16,
+        numLocalEnvs: 17,
       },
     ];
     parameters2.forEach((parameter) => {
@@ -225,14 +225,14 @@ describe("solution.debug.scaffolding", () => {
         numConfigurations: 6,
         numCompounds: 2,
         numTasks: 12,
-        numLocalEnvs: 42,
+        numLocalEnvs: 43,
       },
       {
         programmingLanguage: "typescript",
         numConfigurations: 6,
         numCompounds: 2,
         numTasks: 12,
-        numLocalEnvs: 42,
+        numLocalEnvs: 43,
       },
     ];
     parameters4.forEach((parameter) => {
@@ -287,14 +287,14 @@ describe("solution.debug.scaffolding", () => {
         numConfigurations: 5,
         numCompounds: 2,
         numTasks: 9,
-        numLocalEnvs: 28,
+        numLocalEnvs: 29,
       },
       {
         programmingLanguage: "typescript",
         numConfigurations: 5,
         numCompounds: 2,
         numTasks: 9,
-        numLocalEnvs: 28,
+        numLocalEnvs: 29,
       },
     ];
     parameters5.forEach((parameter) => {
@@ -425,14 +425,14 @@ describe("solution.debug.scaffolding", () => {
         numConfigurations: 2,
         numCompounds: 2,
         numTasks: 5,
-        numLocalEnvs: 4,
+        numLocalEnvs: 5,
       },
       {
         programmingLanguage: "typescript",
         numConfigurations: 2,
         numCompounds: 2,
         numTasks: 5,
-        numLocalEnvs: 4,
+        numLocalEnvs: 5,
       },
     ];
     parameters6.forEach((parameter: TestParameter) => {

--- a/packages/vscode-extension/src/debug/constants.ts
+++ b/packages/vscode-extension/src/debug/constants.ts
@@ -46,8 +46,8 @@ const loopbackAddressIPv4 = "127.0.0.1";
 const loopbackAddressIPv6 = "::1";
 const hosts = [allAddressIPv4, loopbackAddressIPv4, allAddressIPv6, loopbackAddressIPv6];
 
-export const frontendPorts: [number, string[]][] = [[3000, hosts]];
-export const simpleAuthPorts: [number, string[]][] = [[5000, hosts]];
+export const frontendPorts: [number, string[]][] = [[53000, hosts]];
+export const simpleAuthPorts: [number, string[]][] = [[55000, hosts]];
 export const backendDebugPortRegex = /--inspect[\s]*=[\s"']*9229/im;
 export const backendDebugPorts: [number, string[]][] = [[9229, hosts]];
 export const backendServicePortRegex = /--port[\s"']*7071/im;


### PR DESCRIPTION
3000 -> 53000
5000 -> 55000

Changes in `.fx/configs/localSettings.json`:
```json
{
    "auth": {
        "AuthServiceEndpoint": "http://localhost:55000",
    },
    "frontend": {
        "tabEndpoint": "https://localhost:53000"
    }
}
```

Changes in `tabs/.env.teamsfx.local`:
```
Port=53000
```

Documentation related changes will be included in the another PR.