### PR TITLE
refactor(localdebug): support migrate v1 scaffold local debug settings

### DIFF
--- a/packages/fx-core/src/plugins/resource/localdebug/index.ts
+++ b/packages/fx-core/src/plugins/resource/localdebug/index.ts
@@ -39,10 +39,6 @@ export class LocalDebugPlugin implements Plugin {
   }
 
   public async executeUserTask(func: Func, ctx: PluginContext): Promise<Result<any, FxError>> {
-    if (func.method === "migrateV1Project") {
-      return await this.scaffold(ctx);
-    }
-
     return ok(undefined);
   }
 }

--- a/packages/fx-core/src/plugins/solution/fx-solution/debug/error.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/debug/error.ts
@@ -20,7 +20,7 @@ export function ConfigLocalDebugSettingsError(error: any): SystemError {
 export function NgrokTunnelNotConnected(): UserError {
   return returnUserError(
     new Error("Ngrok tunnel is not connected. Check your network settings and try again."),
-    "localdebug-plugin",
+    SolutionSource,
     "NgrokTunnelNotConnected",
     "https://aka.ms/teamsfx-localdebug"
   );
@@ -31,7 +31,7 @@ export function LocalBotEndpointNotConfigured(): UserError {
     new Error(
       'Local bot endpoint is not configured. Set "fx-resource-local-debug.localBotEndpoint" in ".fx/default.user.data" and try again.'
     ),
-    "localdebug-plugin",
+    SolutionSource,
     "LocalBotEndpointNotConfigured"
   );
 }
@@ -39,7 +39,15 @@ export function LocalBotEndpointNotConfigured(): UserError {
 export function InvalidLocalBotEndpointFormat(localBotEndpoint: string): UserError {
   return returnUserError(
     new Error(`Local bot endpoint format is invalid: ${localBotEndpoint}.`),
-    "localdebug-plugin",
+    SolutionSource,
     "InvalidLocalBotEndpointFormat"
+  );
+}
+
+export function ScaffoldLocalDebugSettingsV1Error(): SystemError {
+  return returnSystemError(
+    new Error("Failed to convert api v1 context to v2 context."),
+    SolutionSource,
+    "ScaffoldLocalDebugSettingsV1Error"
   );
 }

--- a/packages/fx-core/src/plugins/solution/fx-solution/debug/provisionLocal.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/debug/provisionLocal.ts
@@ -57,7 +57,7 @@ export async function setupLocalDebugSettings(
     auth: includeAuth ? "true" : "false",
     "skip-ngrok": skipNgrok ? "true" : "false",
   };
-  TelemetryUtils.init(ctx);
+  TelemetryUtils.init(ctx.telemetryReporter);
   TelemetryUtils.sendStartEvent(TelemetryEventName.setupLocalDebugSettings, telemetryProperties);
 
   try {
@@ -160,7 +160,7 @@ export async function configLocalDebugSettings(
     auth: includeAuth ? "true" : "false",
     "trust-development-certificate": trustDevCert + "",
   };
-  TelemetryUtils.init(ctx);
+  TelemetryUtils.init(ctx.telemetryReporter);
   TelemetryUtils.sendStartEvent(TelemetryEventName.configLocalDebugSettings, telemetryProperties);
 
   try {

--- a/packages/fx-core/src/plugins/solution/fx-solution/debug/scaffolding.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/debug/scaffolding.ts
@@ -35,7 +35,7 @@ export async function scaffoldLocalDebugSettings(
   inputs: Inputs,
   localSettings?: Json
 ): Promise<Result<Void, FxError>> {
-  return _scaffoldLocalDebugSettings(
+  return await _scaffoldLocalDebugSettings(
     ctx.projectSetting,
     inputs,
     ctx.telemetryReporter,
@@ -51,7 +51,7 @@ export async function scaffoldLocalDebugSettingsV1(
   if (!ctx.projectSettings || !ctx.answers || !ctx.telemetryReporter || !ctx.logProvider) {
     return err(ScaffoldLocalDebugSettingsV1Error());
   }
-  return _scaffoldLocalDebugSettings(
+  return await _scaffoldLocalDebugSettings(
     ctx.projectSettings,
     ctx.answers,
     ctx.telemetryReporter,

--- a/packages/fx-core/src/plugins/solution/fx-solution/debug/util/telemetry.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/debug/util/telemetry.ts
@@ -49,7 +49,7 @@ export class TelemetryUtils {
     if (TelemetryUtils.localAppId) {
       properties[TelemetryPropertyKey.appId] = TelemetryUtils.localAppId;
     }
-    TelemetryUtils.telemetryReporter?.sendTelemetryEvent(
+    TelemetryUtils.telemetryReporter.sendTelemetryEvent(
       `${eventName}-start`,
       properties,
       measurements
@@ -70,7 +70,7 @@ export class TelemetryUtils {
       properties[TelemetryPropertyKey.appId] = TelemetryUtils.localAppId;
     }
     properties[TelemetryPropertyKey.success] = TelemetryPropertyValue.success;
-    TelemetryUtils.telemetryReporter?.sendTelemetryErrorEvent(
+    TelemetryUtils.telemetryReporter.sendTelemetryErrorEvent(
       eventName,
       properties,
       measurements,
@@ -100,7 +100,7 @@ export class TelemetryUtils {
     }
     properties[TelemetryPropertyKey.errorCode] = `${err.source}.${err.name}`;
     properties[TelemetryPropertyKey.errorMessage] = err.message;
-    TelemetryUtils.telemetryReporter?.sendTelemetryErrorEvent(
+    TelemetryUtils.telemetryReporter.sendTelemetryErrorEvent(
       eventName,
       properties,
       measurements,

--- a/packages/fx-core/src/plugins/solution/fx-solution/debug/util/telemetry.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/debug/util/telemetry.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 "use strict";
 
+import { TelemetryReporter } from "@microsoft/teamsfx-api";
 import { Json, LocalSettings, SystemError, UserError, v2 } from "@microsoft/teamsfx-api";
 import { SolutionTelemetryComponentName } from "../../constants";
 
@@ -22,17 +23,17 @@ enum TelemetryPropertyValue {
 }
 
 export enum TelemetryEventName {
-  scaffoldLocalDebugSettings = "scaffoldLocalDebugSettings",
-  setupLocalDebugSettings = "setupLocalDebugSettings",
-  configLocalDebugSettings = "configLocalDebugSettings",
+  scaffoldLocalDebugSettings = "scaffold-local-debug-settings",
+  setupLocalDebugSettings = "setup-local-debug-settings",
+  configLocalDebugSettings = "config-local-debug-settings",
 }
 
 export class TelemetryUtils {
-  static ctx: v2.Context;
+  static telemetryReporter: TelemetryReporter;
   static localAppId: string | undefined;
 
-  public static init(ctx: v2.Context, localSettings?: LocalSettings | Json) {
-    TelemetryUtils.ctx = ctx;
+  public static init(telemetryReporter: TelemetryReporter, localSettings?: Json) {
+    TelemetryUtils.telemetryReporter = telemetryReporter;
     TelemetryUtils.localAppId = localSettings?.teamsApp?.teamsAppId;
   }
 
@@ -48,7 +49,7 @@ export class TelemetryUtils {
     if (TelemetryUtils.localAppId) {
       properties[TelemetryPropertyKey.appId] = TelemetryUtils.localAppId;
     }
-    TelemetryUtils.ctx.telemetryReporter?.sendTelemetryEvent(
+    TelemetryUtils.telemetryReporter?.sendTelemetryEvent(
       `${eventName}-start`,
       properties,
       measurements
@@ -69,7 +70,7 @@ export class TelemetryUtils {
       properties[TelemetryPropertyKey.appId] = TelemetryUtils.localAppId;
     }
     properties[TelemetryPropertyKey.success] = TelemetryPropertyValue.success;
-    TelemetryUtils.ctx.telemetryReporter?.sendTelemetryErrorEvent(
+    TelemetryUtils.telemetryReporter?.sendTelemetryErrorEvent(
       eventName,
       properties,
       measurements,
@@ -99,7 +100,7 @@ export class TelemetryUtils {
     }
     properties[TelemetryPropertyKey.errorCode] = `${err.source}.${err.name}`;
     properties[TelemetryPropertyKey.errorMessage] = err.message;
-    TelemetryUtils.ctx.telemetryReporter?.sendTelemetryErrorEvent(
+    TelemetryUtils.telemetryReporter?.sendTelemetryErrorEvent(
       eventName,
       properties,
       measurements,

--- a/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
@@ -35,6 +35,7 @@ import {
   SystemError,
   TeamsAppManifest,
   UserError,
+  v2,
 } from "@microsoft/teamsfx-api";
 import axios from "axios";
 import * as fs from "fs-extra";
@@ -149,7 +150,7 @@ import { listCollaborator } from "./v2/listCollaborator";
 import { scaffoldReadme } from "./v2/scaffolding";
 import { TelemetryEvent, TelemetryProperty } from "../../../common/telemetry";
 import { LOCAL_TENANT_ID, REMOTE_TEAMS_APP_TENANT_ID } from ".";
-import { ResourceManagementClient } from "@azure/arm-resources";
+import { scaffoldLocalDebugSettingsV1 } from "./debug/scaffolding";
 
 export type LoadedPlugin = Plugin;
 export type PluginsWithContext = [LoadedPlugin, PluginContext];
@@ -342,6 +343,11 @@ export class TeamsAppSolution implements Solution {
 
     const solutionSettings = settingsRes.value;
     const selectedPlugins = await this.reloadPlugins(solutionSettings);
+
+    const scaffoldLocalDebugSettingResult = await scaffoldLocalDebugSettingsV1(ctx);
+    if (scaffoldLocalDebugSettingResult.isErr()) {
+      return scaffoldLocalDebugSettingResult;
+    }
 
     const results: Result<any, FxError>[] = await Promise.all<Result<any, FxError>>(
       selectedPlugins.map<Promise<Result<any, FxError>>>((migratePlugin) => {


### PR DESCRIPTION
Migrate v1 should use the local debug settings scaffolding logic in the solution. 