### PR TITLE
fix(localdebug): let v1 project to use old frontend port

### DIFF
--- a/docs/fx-core/localdebug-help.md
+++ b/docs/fx-core/localdebug-help.md
@@ -17,10 +17,10 @@ Some frequently asked questions are listed bellow.
 | --- | --- |
 | Tab | 53000, or 3000 (for Teams Toolkit version < 3.2.0) |
 | Auth | 55000. or 5000 (for Teams Toolkit version < 3.2.0) |
-| 7071 | Function |
-| 9229 | Node inspector for Function |
-| 3978 | Bot / Messaging Extension |
-| 9239 | Node inspector for Bot / Messaging Extension |
+| Function | 7071 |
+| Node inspector for Function | 9229 |
+| Bot / Messaging Extension | 3978 |
+| Node inspector for Bot / Messaging Extension | 9239 |
 
 ## What to do if some port is already in use?
 

--- a/packages/fx-core/src/common/local/localEnvProvider.ts
+++ b/packages/fx-core/src/common/local/localEnvProvider.ts
@@ -81,14 +81,15 @@ export class LocalEnvProvider {
 
   public async loadFrontendLocalEnvs(
     includeBackend: boolean,
-    includeAuth: boolean
+    includeAuth: boolean,
+    isMigrateFromV1: boolean
   ): Promise<LocalEnvs> {
     const envs = await this.loadLocalEnvFile(
       path.join(this.projectRoot, FolderName.Frontend, LocalEnvProvider.LocalEnvFileName),
       Object.values(EnvKeysFrontend)
     );
 
-    return envs ?? this.initFrontendLocalEnvs(includeBackend, includeAuth);
+    return envs ?? this.initFrontendLocalEnvs(includeBackend, includeAuth, isMigrateFromV1);
   }
 
   public async loadBackendLocalEnvs(): Promise<LocalEnvs> {
@@ -127,7 +128,11 @@ export class LocalEnvProvider {
     }
   }
 
-  public initFrontendLocalEnvs(includeBackend: boolean, includeAuth: boolean): LocalEnvs {
+  public initFrontendLocalEnvs(
+    includeBackend: boolean,
+    includeAuth: boolean,
+    isMigrateFromV1: boolean
+  ): LocalEnvs {
     const result: LocalEnvs = {
       teamsfxLocalEnvs: {},
       customizedLocalEnvs: {},
@@ -135,7 +140,10 @@ export class LocalEnvProvider {
 
     result.teamsfxLocalEnvs[EnvKeysFrontend.Browser] = "none";
     result.teamsfxLocalEnvs[EnvKeysFrontend.Https] = "true";
-    result.teamsfxLocalEnvs[EnvKeysFrontend.Port] = "53000";
+
+    if (!isMigrateFromV1) {
+      result.teamsfxLocalEnvs[EnvKeysFrontend.Port] = "53000";
+    }
 
     if (includeAuth) {
       result.teamsfxLocalEnvs[EnvKeysFrontend.TeamsFxEndpoint] = "";

--- a/packages/fx-core/src/common/local/portChecker.ts
+++ b/packages/fx-core/src/common/local/portChecker.ts
@@ -16,6 +16,7 @@ const loopbackAddressIPv4 = "127.0.0.1";
 const loopbackAddressIPv6 = "::1";
 const hosts = [allAddressIPv4, loopbackAddressIPv4, allAddressIPv6, loopbackAddressIPv6];
 
+const frontendPortsV1: [number, string[]][] = [[3000, hosts]];
 const frontendPorts: [number, string[]][] = [[53000, hosts]];
 const simpleAuthPorts: [number, string[]][] = [[55000, hosts]];
 const backendDebugPortRegex = /--inspect[\s]*=[\s"']*9229/im;
@@ -69,10 +70,12 @@ export async function getPortsInUse(
 
   const includeFrontend = ProjectSettingsHelper.includeFrontend(projectSettings);
   if (includeFrontend) {
-    ports.push(...frontendPorts);
     const migrateFromV1 = ProjectSettingsHelper.isMigrateFromV1(projectSettings);
     if (!migrateFromV1) {
+      ports.push(...frontendPorts);
       ports.push(...simpleAuthPorts);
+    } else {
+      ports.push(...frontendPortsV1);
     }
   }
 

--- a/packages/fx-core/tests/common/local/localEnvProvider.test.ts
+++ b/packages/fx-core/tests/common/local/localEnvProvider.test.ts
@@ -57,7 +57,7 @@ describe("LocalEnvProvider", () => {
       fs.createFileSync(envFile);
       fs.writeFileSync(envFile, raw);
 
-      const actual = await localEnvProvider.loadFrontendLocalEnvs(true, true);
+      const actual = await localEnvProvider.loadFrontendLocalEnvs(true, true, false);
       chai.assert.deepEqual(actual, expected);
     });
 
@@ -288,19 +288,19 @@ describe("LocalEnvProvider", () => {
     });
 
     it("frontend", () => {
-      const envs = localEnvProvider.initFrontendLocalEnvs(false, false);
+      const envs = localEnvProvider.initFrontendLocalEnvs(false, false, false);
       chai.assert.equal(Object.values(envs.teamsfxLocalEnvs).length, 3);
       chai.assert.equal(Object.values(envs.customizedLocalEnvs).length, 0);
     });
 
     it("frontend + auth", () => {
-      const envs = localEnvProvider.initFrontendLocalEnvs(false, true);
+      const envs = localEnvProvider.initFrontendLocalEnvs(false, true, false);
       chai.assert.equal(Object.values(envs.teamsfxLocalEnvs).length, 6);
       chai.assert.equal(Object.values(envs.customizedLocalEnvs).length, 0);
     });
 
     it("frontend + auth + backend", () => {
-      const envs = localEnvProvider.initFrontendLocalEnvs(true, true);
+      const envs = localEnvProvider.initFrontendLocalEnvs(true, true, false);
       chai.assert.equal(Object.values(envs.teamsfxLocalEnvs).length, 8);
       chai.assert.equal(Object.values(envs.customizedLocalEnvs).length, 0);
     });

--- a/packages/fx-core/tests/plugins/solution/debug/solution.debug.scaffolding.test.ts
+++ b/packages/fx-core/tests/plugins/solution/debug/solution.debug.scaffolding.test.ts
@@ -425,14 +425,14 @@ describe("solution.debug.scaffolding", () => {
         numConfigurations: 2,
         numCompounds: 2,
         numTasks: 5,
-        numLocalEnvs: 5,
+        numLocalEnvs: 4,
       },
       {
         programmingLanguage: "typescript",
         numConfigurations: 2,
         numCompounds: 2,
         numTasks: 5,
-        numLocalEnvs: 5,
+        numLocalEnvs: 4,
       },
     ];
     parameters6.forEach((parameter: TestParameter) => {


### PR DESCRIPTION
- let v1 project to use old frontend port 3000 rather than 53000
- fix help doc by the way

Tested v1 tab with SSO project with #3488 changes included.

Related: #3479 #3483 