### PR TITLE
fix(apim): load subs from state.xx.json

### DIFF
--- a/packages/fx-core/src/plugins/resource/apim/config.ts
+++ b/packages/fx-core/src/plugins/resource/apim/config.ts
@@ -55,7 +55,7 @@ export interface ISolutionConfig {
   resourceGroupName: string;
   location: string;
   remoteTeamsAppId?: string | undefined;
-  subscriptionId?: string | undefined;
+  subscriptionId: string | undefined;
 }
 
 export class ApimPluginConfig implements IApimPluginConfig {
@@ -275,6 +275,12 @@ export class SolutionConfig implements ISolutionConfig {
     return this.configOfOtherPlugins
       .get(TeamsToolkitComponent.Solution)
       ?.get(SolutionConfigKeys.remoteTeamsAppId) as string;
+  }
+
+  get subscriptionId(): string | undefined {
+    return this.configOfOtherPlugins
+      .get(TeamsToolkitComponent.Solution)
+      ?.get(SolutionConfigKeys.subscriptionId) as string;
   }
 
   private checkAndGet(key: string): string {

--- a/packages/fx-core/src/plugins/resource/apim/constants.ts
+++ b/packages/fx-core/src/plugins/resource/apim/constants.ts
@@ -204,6 +204,7 @@ export class SolutionConfigKeys {
   public static readonly resourceGroupName: string = "resourceGroupName";
   public static readonly location: string = "location";
   public static readonly remoteTeamsAppId: string = "remoteTeamsAppId";
+  public static readonly subscriptionId: string = "subscriptionId";
 }
 
 export enum TeamsToolkitComponent {


### PR DESCRIPTION
Related PR: https://github.com/OfficeDev/TeamsFx/commit/1177a6238d52f1f1172091febd747323f4d5b9b2

Add the implementation of get subscriptionId from solution config.