### PR TITLE
chore: set correct error code for arm deployment

### DIFF
--- a/packages/fx-core/src/plugins/solution/fx-solution/arm.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/arm.ts
@@ -608,11 +608,11 @@ export async function deployArmTemplates(ctx: SolutionContext): Promise<Result<v
       result = err(error);
     } else if (error instanceof Error) {
       result = err(
-        returnUserError(error, SolutionSource, SolutionError.FailedToDeployArmTemplatesToAzure)
+        returnSystemError(error, SolutionSource, SolutionError.FailedToDeployArmTemplatesToAzure)
       );
     } else {
       result = err(
-        returnUserError(
+        returnSystemError(
           new Error(JSON.stringify(error)),
           SolutionSource,
           SolutionError.FailedToDeployArmTemplatesToAzure
@@ -662,9 +662,21 @@ export async function deployArmTemplatesV3(
       );
     }
   } catch (error) {
-    result = err(
-      returnUserError(error, SolutionSource, SolutionError.FailedToDeployArmTemplatesToAzure)
-    );
+    if (error instanceof UserError || error instanceof SystemError) {
+      result = err(error);
+    } else if (error instanceof Error) {
+      result = err(
+        returnSystemError(error, SolutionSource, SolutionError.FailedToDeployArmTemplatesToAzure)
+      );
+    } else {
+      result = err(
+        returnSystemError(
+          new Error(JSON.stringify(error)),
+          SolutionSource,
+          SolutionError.FailedToDeployArmTemplatesToAzure
+        )
+      );
+    }
     sendErrorTelemetryThenReturnError(
       SolutionTelemetryEvent.ArmDeployment,
       result.error,

--- a/packages/fx-core/src/plugins/solution/fx-solution/arm.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/arm.ts
@@ -17,6 +17,7 @@ import {
   returnSystemError,
   returnUserError,
   SolutionContext,
+  SystemError,
   UserError,
   v2,
   v3,
@@ -603,9 +604,21 @@ export async function deployArmTemplates(ctx: SolutionContext): Promise<Result<v
       );
     }
   } catch (error) {
-    result = err(
-      returnUserError(error, SolutionSource, SolutionError.FailedToDeployArmTemplatesToAzure)
-    );
+    if (error instanceof UserError || error instanceof SystemError) {
+      result = err(error);
+    } else if (error instanceof Error) {
+      result = err(
+        returnUserError(error, SolutionSource, SolutionError.FailedToDeployArmTemplatesToAzure)
+      );
+    } else {
+      result = err(
+        returnUserError(
+          new Error(JSON.stringify(error)),
+          SolutionSource,
+          SolutionError.FailedToDeployArmTemplatesToAzure
+        )
+      );
+    }
     sendErrorTelemetryThenReturnError(
       SolutionTelemetryEvent.ArmDeployment,
       result.error,

--- a/packages/fx-core/tests/plugins/solution/solution.arm.test.ts
+++ b/packages/fx-core/tests/plugins/solution/solution.arm.test.ts
@@ -799,8 +799,7 @@ describe("Deploy ARM Template to Azure", () => {
     // Assert
     chai.assert.isTrue(result.isErr());
     const error = (result as Err<void, FxError>).error;
-    chai.assert.strictEqual(error.name, "FailedToDeployArmTemplatesToAzure");
-    chai.assert.strictEqual(error.innerError.name, "ParameterFileNotExist");
+    chai.assert.strictEqual(error.name, "ParameterFileNotExist");
     expect(error.message)
       .to.be.a("string")
       .that.contains("azure.parameters.default.json does not exist.");


### PR DESCRIPTION
currently all telemetries set the error code to ArmDeploymentFailed, update the code to set correct error code in telemetry, like BicepInstallFailed.