### PR TITLE
feat(core): support csharp on VS

### DIFF
--- a/packages/fx-core/src/core/question.ts
+++ b/packages/fx-core/src/core/question.ts
@@ -127,8 +127,11 @@ export const ProgrammingLanguageQuestion: SingleSelectQuestion = {
     { id: "typescript", label: "TypeScript" },
   ],
   dynamicOptions: (inputs: Inputs): StaticOptions => {
-    const cpas = inputs[CoreQuestionNames.Capabilities] as string[];
-    if (cpas.includes(TabSPFxItem.id)) return [{ id: "typescript", label: "TypeScript" }];
+    if (inputs.platform === Platform.VS) {
+      return [{ id: "csharp", label: "C#" }];
+    }
+    const caps = inputs[CoreQuestionNames.Capabilities] as string[];
+    if (caps.includes(TabSPFxItem.id)) return [{ id: "typescript", label: "TypeScript" }];
     return [
       { id: "javascript", label: "JavaScript" },
       { id: "typescript", label: "TypeScript" },

--- a/packages/fx-core/tests/core/question.test.ts
+++ b/packages/fx-core/tests/core/question.test.ts
@@ -1,0 +1,20 @@
+import "mocha";
+import chai from "chai";
+import { ProgrammingLanguageQuestion } from "../../src/core/question";
+import { Inputs, Platform } from "@microsoft/teamsfx-api";
+
+describe("Programming Language Questions", async () => {
+  it("should return csharp on VS platform", async () => {
+    chai.assert.isTrue(ProgrammingLanguageQuestion.dynamicOptions !== undefined);
+    if (ProgrammingLanguageQuestion.dynamicOptions === undefined) {
+      throw "unreachable";
+    }
+    const inputs: Inputs = { platform: Platform.VS };
+    const questions = await ProgrammingLanguageQuestion.dynamicOptions(inputs);
+    chai.assert.isTrue(questions !== undefined);
+    chai.assert.isArray(questions);
+    chai.assert.lengthOf(questions, 1);
+    chai.assert.property(questions[0], "id");
+    chai.assert.equal((questions[0] as any).id, "csharp");
+  });
+});


### PR DESCRIPTION
Adds programming language question to support csharp on VS.
Closes https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_sprints/taskboard/Teams%20Extensibility%20E2E%20Team/Microsoft%20Teams%20Extensibility/CY22-1.1?workitem=12962397