### PR TITLE
perf(collaboration): auto input default user email when grant permission

### DIFF
--- a/packages/cli/tests/unit/help.tests.ts
+++ b/packages/cli/tests/unit/help.tests.ts
@@ -1,28 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as sinon from "sinon";
 import { Stage, SystemError } from "@microsoft/teamsfx-api";
 
 import HelpParamGenerator from "../../src/helpParamGenerator";
 import { expect } from "./utils";
 import { sqlPasswordConfirmQuestionName } from "../../src/constants";
-import appStudioLogin from "../../src/commonlib/appStudioLogin";
 
 describe("Help Parameter Tests", function () {
-  const sandbox = sinon.createSandbox();
-
-  before(() => {
-    sandbox.stub(appStudioLogin, "getJsonObject").resolves({ upn: "fakeUserPrincipalName" });
-  });
-
   beforeEach(async () => {
     const result = await HelpParamGenerator.initializeQuestionsForHelp();
     expect(result.isOk() ? result.value : result.error).to.be.true;
-  });
-
-  after(() => {
-    sandbox.restore();
   });
 
   it("No Initalized Error", () => {

--- a/packages/cli/tests/unit/help.tests.ts
+++ b/packages/cli/tests/unit/help.tests.ts
@@ -1,16 +1,28 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import * as sinon from "sinon";
 import { Stage, SystemError } from "@microsoft/teamsfx-api";
 
 import HelpParamGenerator from "../../src/helpParamGenerator";
 import { expect } from "./utils";
 import { sqlPasswordConfirmQuestionName } from "../../src/constants";
+import appStudioLogin from "../../src/commonlib/appStudioLogin";
 
 describe("Help Parameter Tests", function () {
+  const sandbox = sinon.createSandbox();
+
+  before(() => {
+    sandbox.stub(appStudioLogin, "getJsonObject").resolves({ upn: "fakeUserPrincipalName" });
+  });
+
   beforeEach(async () => {
     const result = await HelpParamGenerator.initializeQuestionsForHelp();
     expect(result.isOk() ? result.value : result.error).to.be.true;
+  });
+
+  after(() => {
+    sandbox.restore();
   });
 
   it("No Initalized Error", () => {

--- a/packages/fx-core/src/plugins/solution/fx-solution/question.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/question.ts
@@ -256,21 +256,31 @@ export const AskSubscriptionQuestion: FuncQuestion = {
   },
 };
 
-export const GetUserEmailQuestion: TextInputQuestion = {
-  name: "email",
-  type: "text",
-  title: "Add owner to Teams/AAD app for the account under the same M365 tenant (email)",
-  validation: {
-    validFunc: (input: string, previousInputs?: Inputs): string | undefined => {
-      if (!input || input.trim() === "") {
-        return "Email address cannot be null or empty";
-      }
+export function getUserEmailQuestion(currentUserEmail: string): TextInputQuestion {
+  const defaultUserEmail = "[UserName]@" + currentUserEmail.split("@")[1];
+  return {
+    name: "email",
+    type: "text",
+    title: "Add owner to Teams/AAD app for the account under the same M365 tenant (email)",
+    default: defaultUserEmail,
+    validation: {
+      validFunc: (input: string, previousInputs?: Inputs): string | undefined => {
+        if (!input || input.trim() === "") {
+          return "Email address cannot be null or empty";
+        }
 
-      const re = /\S+@\S+\.\S+/;
-      if (!re.test(input)) {
-        return "Email address is not valid";
-      }
-      return undefined;
+        input = input.trim();
+
+        if (input === defaultUserEmail) {
+          return "Please change [UserName] to the real user name";
+        }
+
+        const re = /\S+@\S+\.\S+/;
+        if (!re.test(input)) {
+          return "Email address is not valid";
+        }
+        return undefined;
+      },
     },
-  },
-};
+  };
+}

--- a/packages/fx-core/src/plugins/solution/fx-solution/question.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/question.ts
@@ -257,7 +257,10 @@ export const AskSubscriptionQuestion: FuncQuestion = {
 };
 
 export function getUserEmailQuestion(currentUserEmail: string): TextInputQuestion {
-  const defaultUserEmail = "[UserName]@" + currentUserEmail.split("@")[1];
+  let defaultUserEmail = "";
+  if (currentUserEmail && currentUserEmail.indexOf("@") > 0) {
+    defaultUserEmail = "[UserName]@" + currentUserEmail.split("@")[1];
+  }
   return {
     name: "email",
     type: "text",

--- a/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
@@ -115,9 +115,9 @@ import {
   HostTypeOptionAzure,
   MessageExtensionItem,
   TabOptionItem,
-  GetUserEmailQuestion,
   TabSPFxItem,
   AzureResourceKeyVault,
+  getUserEmailQuestion,
 } from "./question";
 import {
   getActivatedResourcePlugins,
@@ -1168,7 +1168,8 @@ export class TeamsAppSolution implements Solution {
         }
       }
     } else if (stage === Stage.grantPermission) {
-      node.addChild(new QTreeNode(GetUserEmailQuestion));
+      const appStudioTokenJson = await ctx.appStudioToken?.getJsonObject();
+      node.addChild(new QTreeNode(getUserEmailQuestion((appStudioTokenJson as any).upn)));
     }
     return ok(node);
   }

--- a/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
@@ -1168,8 +1168,10 @@ export class TeamsAppSolution implements Solution {
         }
       }
     } else if (stage === Stage.grantPermission) {
-      const appStudioTokenJson = await ctx.appStudioToken?.getJsonObject();
-      node.addChild(new QTreeNode(getUserEmailQuestion((appStudioTokenJson as any)?.upn)));
+      if (isDynamicQuestion) {
+        const appStudioTokenJson = await ctx.appStudioToken?.getJsonObject();
+        node.addChild(new QTreeNode(getUserEmailQuestion((appStudioTokenJson as any)?.upn)));
+      }
     }
     return ok(node);
   }

--- a/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
@@ -1169,7 +1169,7 @@ export class TeamsAppSolution implements Solution {
       }
     } else if (stage === Stage.grantPermission) {
       const appStudioTokenJson = await ctx.appStudioToken?.getJsonObject();
-      node.addChild(new QTreeNode(getUserEmailQuestion((appStudioTokenJson as any).upn)));
+      node.addChild(new QTreeNode(getUserEmailQuestion((appStudioTokenJson as any)?.upn)));
     }
     return ok(node);
   }

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/getQuestions.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/getQuestions.ts
@@ -34,7 +34,7 @@ import {
   createAddAzureResourceQuestion,
   createV1CapabilityQuestion,
   DeployPluginSelectQuestion,
-  GetUserEmailQuestion,
+  getUserEmailQuestion,
   MessageExtensionItem,
   TabOptionItem,
   TabSPFxItem,
@@ -333,7 +333,8 @@ export async function getQuestions(
       }
     }
   } else if (stage === Stage.grantPermission) {
-    node.addChild(new QTreeNode(GetUserEmailQuestion));
+    const jsonObject = await tokenProvider.appStudioToken.getJsonObject();
+    node.addChild(new QTreeNode(getUserEmailQuestion((jsonObject as any).upn)));
   }
   return ok(node);
 }

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/getQuestions.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/getQuestions.ts
@@ -333,8 +333,10 @@ export async function getQuestions(
       }
     }
   } else if (stage === Stage.grantPermission) {
-    const jsonObject = await tokenProvider.appStudioToken.getJsonObject();
-    node.addChild(new QTreeNode(getUserEmailQuestion((jsonObject as any).upn)));
+    if (isDynamicQuestion) {
+      const jsonObject = await tokenProvider.appStudioToken.getJsonObject();
+      node.addChild(new QTreeNode(getUserEmailQuestion((jsonObject as any).upn)));
+    }
   }
   return ok(node);
 }

--- a/packages/fx-core/tests/plugins/solution/util.ts
+++ b/packages/fx-core/tests/plugins/solution/util.ts
@@ -322,7 +322,9 @@ export class MockedAppStudioProvider implements AppStudioTokenProvider {
     return "fakeToken";
   }
   async getJsonObject(showDialog?: boolean): Promise<Record<string, unknown>> {
-    return {};
+    return {
+      upn: "fakeUserPrincipalName@fake.com",
+    };
   }
   async signout(): Promise<boolean> {
     return true;


### PR DESCRIPTION
When click grant permission, it will auto input default user email:
![1](https://user-images.githubusercontent.com/5545529/149287365-2ca62914-ccb8-4778-8878-ff71a3d38ce9.png)

If user forget to update this default email, it will show tips:
![2](https://user-images.githubusercontent.com/5545529/149287505-f5443e0e-e1c9-4bab-8248-ce78a51d09a7.png)

