### PR TITLE
feat(dotnet): updateArmTemplate

### DIFF
--- a/packages/fx-core/src/plugins/resource/frontend/dotnet/constants.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/dotnet/constants.ts
@@ -66,4 +66,9 @@ export class WebappBicep {
   static readonly webappEndpoint = "provisionOutputs.webappOutput.value.endpoint";
   static readonly webappResourceId = "provisionOutputs.webappOutput.value.resourceId";
   static readonly webappDomain = "provisionOutputs.webappOutput.value.domain";
+  static readonly Reference = {
+    webappResourceId: WebappBicep.webappResourceId,
+    endpoint: WebappBicep.webappEndpoint,
+    domain: WebappBicep.webappDomain,
+  };
 }

--- a/packages/fx-core/templates/plugins/resource/webapp/bicep/provision.template.bicep
+++ b/packages/fx-core/templates/plugins/resource/webapp/bicep/provision.template.bicep
@@ -11,5 +11,6 @@ output webappOutput object = {
   teamsFxPluginId: 'fx-resource-frontend-hosting'
   domain: webappProvision.outputs.domain
   endpoint: webappProvision.outputs.endpoint
+  indexPath: webappProvision.outputs.indexPath
   webAppResourceId: webappProvision.outputs.resourceId
 }

--- a/packages/fx-core/templates/plugins/resource/webapp/bicep/webappConfiguration.template.bicep
+++ b/packages/fx-core/templates/plugins/resource/webapp/bicep/webappConfiguration.template.bicep
@@ -23,7 +23,7 @@ var webappDomain = provisionOutputs.webappOutput.value.domain
 var webappEndpoint = provisionOutputs.webappOutput.value.endpoint
 
 {{#if (contains "fx-resource-bot" plugins) }}
-var botId = provisionParameters['botAadAppClientId']
+var botAadAppClientId = provisionParameters['botAadAppClientId']
   {{#if (contains "fx-resource-key-vault" plugins) }}
 var botAadAppClientSecret = \{{fx-resource-key-vault.References.botClientSecretReference}}
   {{else}}
@@ -32,7 +32,7 @@ var botAadAppClientSecret = provisionParameters['botAadAppClientSecret']
 {{/if}}
 
 {{#if (contains "fx-resource-bot" plugins) }}
-var m365ApplicationIdUri = 'api://${webappDomain}/botid-${botId}'
+var m365ApplicationIdUri = 'api://${webappDomain}/botid-${botAadAppClientId}'
 {{else}}
 var m365ApplicationIdUri = 'api://${webappDomain}/${m365ClientId}'
 {{/if}}

--- a/packages/fx-core/templates/plugins/resource/webapp/bicep/webappProvision.template.bicep
+++ b/packages/fx-core/templates/plugins/resource/webapp/bicep/webappProvision.template.bicep
@@ -45,3 +45,4 @@ var siteDomain = webApp.properties.defaultHostName
 output resourceId string = webApp.id
 output endpoint string = 'https://${siteDomain}'
 output domain string = siteDomain
+output indexPath string = ''


### PR DESCRIPTION
`UpdateArmTemplate` will be called when a new capability/resource added.
For example:
1. Create a project with tab capability -> `scaffold` and `generateArmTemplate` of frontend plugin is called.
2. Add capability bot -> `updateArmTemplate` of frontend plugin is called.