### PR TITLE
fix: potential fix to create project telemetry issue

### DIFF
--- a/packages/vscode-extension/src/commonlib/telemetry.ts
+++ b/packages/vscode-extension/src/commonlib/telemetry.ts
@@ -155,4 +155,8 @@ export class VSCodeTelemetryReporter extends vscode.Disposable implements Teleme
       this.reporter.sendTelemetryException(error, properties, measurements);
     }
   }
+
+  async dispose() {
+    await this.reporter.dispose();
+  }
 }

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -351,6 +351,7 @@ export async function createNewProjectHandler(args?: any[]): Promise<Result<any,
   ExtTelemetry.sendTelemetryEvent(TelemetryEvent.CreateProjectStart, getTriggerFromProperty(args));
   const result = await runCommand(Stage.create);
   if (result.isOk()) {
+    await ExtTelemetry.dispose();
     commands.executeCommand("vscode.openFolder", result.value);
   }
   return result;

--- a/packages/vscode-extension/src/telemetry/extTelemetry.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetry.ts
@@ -159,4 +159,8 @@ export namespace ExtTelemetry {
 
     reporter.sendTelemetryException(error, properties, measurements);
   }
+
+  export async function dispose() {
+    await reporter.dispose();
+  }
 }

--- a/packages/vscode-extension/test/unit/extension/handlers.test.ts
+++ b/packages/vscode-extension/test/unit/extension/handlers.test.ts
@@ -64,6 +64,7 @@ suite("handlers", () => {
       sinon.stub(handlers, "core").value(new MockCore());
       sinon.stub(ExtTelemetry, "sendTelemetryEvent");
       sinon.stub(ExtTelemetry, "sendTelemetryErrorEvent");
+      sinon.stub(ExtTelemetry, "dispose");
       const createProject = sinon.spy(handlers.core, "createProject");
       sinon.stub(vscode.commands, "executeCommand");
 


### PR DESCRIPTION
@chagong  @1openwindow @1yefuwang1 This is a potential fix to the create project issue since when 'openFolder' executed, the telemetry might not flashed.