### PR TITLE
perf(collaboration): show warning message when tenant id is empty

### DIFF
--- a/packages/fx-core/resource/strings.json
+++ b/packages/fx-core/resource/strings.json
@@ -57,7 +57,12 @@
     "ProvisionFinishNotice": "[%s] Provison finished!",
     "DeployStartNotice": "[%s] Deployment start.",
     "SelectedPluginsToDeployNotice": "[%s] Selected plugins to deploy: %s",
-    "PublishStartNotice": "[%s] Publish start."
+    "PublishStartNotice": "[%s] Publish start.",
+    "Collaboration": {
+      "ListCollaboratorsSuccess": "List M365 Teams App%s owners success, you can view it in Teams Toolkit output window",
+      "WithAadApp": "(With AAD App)",
+      "FailedToListCollaborators": "Failed to list Teams App owners for the project.\nError details: \n"
+    }
   },
   "plugins": {
     "SPFx": {

--- a/packages/fx-core/src/common/permissionInterface.ts
+++ b/packages/fx-core/src/common/permissionInterface.ts
@@ -12,6 +12,7 @@ export enum CollaborationState {
   OK = "OK",
   NotProvisioned = "NotProvisioned",
   M365TenantNotMatch = "M365TenantNotMatch",
+  EmptyM365Tenant = "EmptyM365Tenant",
   SolutionIsNotIdle = "SolutionIsNotIdle",
   m365AccountNotSignedIn = "M365AccountNotSignedIn",
   ERROR = "ERROR",

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/listCollaborator.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/listCollaborator.ts
@@ -25,6 +25,7 @@ import {
   CollaborationState,
   Collaborator,
   getHashedEnv,
+  getStrings,
   ListCollaboratorResult,
   TeamsAppAdmin,
 } from "../../../../common";
@@ -48,6 +49,7 @@ import { getPluginAndContextArray } from "./utils";
 import { Container } from "typedi";
 import { flattenConfigMap } from "../../../resource/utils4v2";
 import { REMOTE_TEAMS_APP_TENANT_ID } from "..";
+import * as util from "util";
 
 export async function executeListCollaboratorV2(
   ctx: v2.Context,
@@ -190,7 +192,7 @@ async function listCollaboratorImpl(
 
   let errorMsg = "";
   if (errors.length > 0) {
-    errorMsg += `Failed to list Teams App owners for the project.\nError details: \n`;
+    errorMsg += getStrings().solution.Collaboration.FailedToListCollaborators;
     for (const fxError of errors) {
       errorMsg += fxError.error.message + "\n";
     }
@@ -280,9 +282,12 @@ async function listCollaboratorImpl(
     } else if (platform === Platform.VSCode) {
       ui?.showMessage(
         "info",
-        `List M365 Teams App${
-          !CollaborationUtil.isSpfxProject(param.ctx) ? "(With AAD App)" : ""
-        } owners success, you can view it in Teams Toolkit output window`,
+        util.format(
+          getStrings().solution.Collaboration.ListCollaboratorsSuccess,
+          CollaborationUtil.isSpfxProject(param.ctx)
+            ? getStrings().solution.Collaboration.WithAadApp
+            : ""
+        ),
         false
       );
       logProvider?.info(message);

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/listCollaborator.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/listCollaborator.ts
@@ -190,7 +190,7 @@ async function listCollaboratorImpl(
 
   let errorMsg = "";
   if (errors.length > 0) {
-    errorMsg += `Failed to list collaborator for the project.\n Error details: \n`;
+    errorMsg += `Failed to list Teams App owners for the project.\nError details: \n`;
     for (const fxError of errors) {
       errorMsg += fxError.error.message + "\n";
     }
@@ -278,6 +278,13 @@ async function listCollaboratorImpl(
     if (platform === Platform.CLI) {
       ui?.showMessage("info", message, false);
     } else if (platform === Platform.VSCode) {
+      ui?.showMessage(
+        "info",
+        `List M365 Teams App${
+          CollaborationUtil.isSpfxProject(param.ctx) ? "(With AAD App)" : ""
+        } owners success, you can view it in Teams Toolkit output window`,
+        false
+      );
       logProvider?.info(message);
     }
   }

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/listCollaborator.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/listCollaborator.ts
@@ -281,7 +281,7 @@ async function listCollaboratorImpl(
       ui?.showMessage(
         "info",
         `List M365 Teams App${
-          CollaborationUtil.isSpfxProject(param.ctx) ? "(With AAD App)" : ""
+          !CollaborationUtil.isSpfxProject(param.ctx) ? "(With AAD App)" : ""
         } owners success, you can view it in Teams Toolkit output window`,
         false
       );

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -675,7 +675,13 @@ async function checkCollaborationState(env: string): Promise<Result<any, FxError
     const tokenJsonObject = await AppStudioTokenInstance.getJsonObject(true);
     if (tokenJsonObject) {
       const m365TenantId = await getM365TenantFromEnv(env);
-      if (m365TenantId && tokenJsonObject.tid !== m365TenantId) {
+      if (!m365TenantId) {
+        return ok({
+          state: CollaborationState.EmptyM365Tenant,
+          message: StringResources.vsc.commandsTreeViewProvider.emptyM365Tenant,
+        });
+      }
+      if (tokenJsonObject.tid !== m365TenantId) {
         return ok({
           state: CollaborationState.M365TenantNotMatch,
           message: StringResources.vsc.commandsTreeViewProvider.m365TenantNotMatch,
@@ -1323,7 +1329,7 @@ export async function openResourceGroupInPortal(env: string): Promise<Result<Voi
   }
 }
 
-export async function grantPermission(env: string): Promise<Result<Void, FxError>> {
+export async function grantPermission(env: string): Promise<Result<any, FxError>> {
   let result: Result<any, FxError> = ok(Void);
   ExtTelemetry.sendTelemetryEvent(TelemetryEvent.GrantPermissionStart);
 

--- a/packages/vscode-extension/src/resources/Strings.json
+++ b/packages/vscode-extension/src/resources/Strings.json
@@ -76,6 +76,7 @@
       "grantPermissionSucceeded": "Added account: '%s' to the environment '%s' as a collaborator.",
       "grantPermissionWarning": "You need to handle Azure resource permissions manually on Azure Portal.",
       "m365AccountNotSignedIn": "No M365 account signed in. Please sign in to M365.",
+      "emptyM365Tenant": "Tenant id from environment state file is empty, please re-provision and try again",
       "m365TenantNotMatch": "The M365 tenant id(which is used to provision before) does not match the current account.",
       "m365AccountNotMatch": "The signed in M365 account does not match the M365 tenant used in previous provision. Please sign out and sign in with correct M365 account.",
       "azureAccountNotSignedIn": "No Azure account signed in. Please sign in to Azure.",

--- a/packages/vscode-extension/src/utils/commonUtils.ts
+++ b/packages/vscode-extension/src/utils/commonUtils.ts
@@ -281,7 +281,7 @@ export async function getM365TenantFromEnv(env: string): Promise<string | undefi
     return undefined;
   }
 
-  return provisionResult?.[PluginNames.AAD]?.tenantId;
+  return provisionResult?.[PluginNames.SOLUTION]?.teamsAppTenantId;
 }
 
 export async function getResourceGroupNameFromEnv(env: string): Promise<string | undefined> {

--- a/packages/vscode-extension/test/unit/extension/handlers.test.ts
+++ b/packages/vscode-extension/test/unit/extension/handlers.test.ts
@@ -407,7 +407,28 @@ suite("handlers", () => {
 
       const result = await handlers.grantPermission("env");
       chai.expect(result.isOk()).equals(true);
-      sinon.restore();
+    });
+
+    test("grant permission with empty tenant id", async () => {
+      sinon.stub(handlers, "core").value(new MockCore());
+      const sendTelemetryEvent = sinon.stub(ExtTelemetry, "sendTelemetryEvent");
+      const sendTelemetryErrorEvent = sinon.stub(ExtTelemetry, "sendTelemetryErrorEvent");
+      sinon.stub(commonUtils, "getProvisionSucceedFromEnv").resolves(true);
+      sinon.stub(AppStudioTokenInstance, "getJsonObject").resolves({
+        tid: "fake-tenant-id",
+      });
+      sinon.stub(commonUtils, "getM365TenantFromEnv").callsFake(async (env: string) => {
+        return "";
+      });
+
+      const result = await handlers.grantPermission("env");
+
+      if (result.isErr()) {
+        throw new Error("Unexpected error: " + result.error.message);
+      }
+
+      chai.expect(result.isOk()).equals(true);
+      chai.expect(result.value.state === CollaborationState.EmptyM365Tenant);
     });
 
     test("list all collaborators: with user", async () => {
@@ -441,7 +462,6 @@ suite("handlers", () => {
       );
       chai.assert.equal(result["env"][0].icon, "person");
       chai.assert.equal(result["env"][0].isCustom, false);
-      sinon.restore();
     });
 
     test("list collaborator: with error", async () => {
@@ -471,7 +491,6 @@ suite("handlers", () => {
       chai.assert.equal(result["env"][0].commandId, "fx-extension.listcollaborator.env");
       chai.assert.equal(result["env"][0].icon, "warning");
       chai.assert.equal(result["env"][0].isCustom, true);
-      sinon.restore();
     });
 
     test("list collaborator: with empty user info", async () => {
@@ -501,7 +520,6 @@ suite("handlers", () => {
       chai.assert.equal(result["env"][0].commandId, "fx-extension.listcollaborator.env");
       chai.assert.equal(result["env"][0].icon, "warning");
       chai.assert.equal(result["env"][0].isCustom, true);
-      sinon.restore();
     });
 
     test("check permission: with both permission", async () => {
@@ -532,7 +550,6 @@ suite("handlers", () => {
 
       const result = await handlers.checkPermission("env");
       chai.assert.equal(result, true);
-      sinon.restore();
     });
 
     test("check permission: without permission", async () => {
@@ -563,7 +580,6 @@ suite("handlers", () => {
 
       const result = await handlers.checkPermission("env");
       chai.assert.equal(result, false);
-      sinon.restore();
     });
 
     test("check permission: throw error without permission", async () => {
@@ -574,7 +590,6 @@ suite("handlers", () => {
 
       const result = await handlers.checkPermission("env");
       chai.assert.equal(result, false);
-      sinon.restore();
     });
 
     test("edit manifest template: local", async () => {
@@ -594,7 +609,6 @@ suite("handlers", () => {
           "undefined/templates/appPackage/manifest.local.template.json" as any
         )
       );
-      sinon.restore();
     });
 
     test("edit manifest template: remote", async () => {
@@ -614,7 +628,6 @@ suite("handlers", () => {
           "undefined/templates/appPackage/manifest.remote.template.json" as any
         )
       );
-      sinon.restore();
     });
   });
 });


### PR DESCRIPTION
- Will show warning message instead of tenant id not match:
![image](https://user-images.githubusercontent.com/5545529/149467918-32382381-a1ae-4c26-8365-2700a206973b.png)

- Format and update list collaborator failed message:
![image](https://user-images.githubusercontent.com/5545529/149468771-3e66d67a-7015-4770-9230-0b7591b2b41f.png)

- Show message box when list collaborator success:
![image](https://user-images.githubusercontent.com/5545529/149469060-f00823b1-069b-4b10-b8cd-9f4abe285f1b.png)

