### PR TITLE
feat: change activate() to accept projectSettings instead of solutionSettings

### DIFF
--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -1315,7 +1315,7 @@ export type ResourceConfigs = ResourceTemplates;
 
 // @public
 interface ResourcePlugin {
-    activate(solutionSettings: AzureSolutionSettings): boolean;
+    activate(projectSettings: ProjectSettings): boolean;
     // (undocumented)
     checkPermission?: (ctx: Context_2, inputs: InputsWithProjectPath, envInfo: DeepReadonly<EnvInfoV2>, tokenProvider: TokenProvider, userInfo: Json) => Promise<Result<Json, FxError>>;
     configureLocalResource?: (ctx: Context_2, inputs: Inputs, localSettings: Json, tokenProvider: TokenProvider) => Promise<Result<Void, FxError>>;

--- a/packages/api/src/v2/resourcePlugin.ts
+++ b/packages/api/src/v2/resourcePlugin.ts
@@ -4,7 +4,7 @@
 import { Result } from "neverthrow";
 import { FxError } from "../error";
 import { Func, QTreeNode } from "../qm/question";
-import { AzureSolutionSettings, Inputs, Json, Void } from "../types";
+import { ProjectSettings, Inputs, Json, Void } from "../types";
 import { AppStudioTokenProvider, TokenProvider } from "../utils";
 import {
   Context,
@@ -53,13 +53,13 @@ export interface ResourcePlugin {
 
   /**
    * A resource plugin can decide whether it needs to be activated when the Toolkit initializes
-   * based on solution settings.
+   * based on project settings.
    *
-   * @param solutionSettings solution settings
+   * @param projectSettings project settings
    *
    * @returns whether to be activated
    */
-  activate(solutionSettings: AzureSolutionSettings): boolean;
+  activate(projectSettings: ProjectSettings): boolean;
 
   /**
    * Called by Toolkit when creating a new project or adding a new resource.

--- a/packages/fx-core/src/core/middleware/projectMigrator.ts
+++ b/packages/fx-core/src/core/middleware/projectMigrator.ts
@@ -1044,7 +1044,7 @@ async function generateArmTemplatesFiles(ctx: CoreHookContext) {
     throw SolutionConfigError();
   }
   minorCtx.solutionContext = result.value;
-  const settings = minorCtx.projectSettings?.solutionSettings as AzureSolutionSettings;
+  const settings = minorCtx.projectSettings as ProjectSettings;
   const activePlugins = getActivatedV2ResourcePlugins(settings).map(
     (p) => new NamedArmResourcePluginAdaptor(p)
   );

--- a/packages/fx-core/src/plugins/resource/aad/v2/index.ts
+++ b/packages/fx-core/src/plugins/resource/aad/v2/index.ts
@@ -11,6 +11,7 @@ import {
   TokenProvider,
   Void,
   v2,
+  ProjectSettings,
 } from "@microsoft/teamsfx-api";
 import {
   Context,
@@ -42,7 +43,8 @@ export class AadPluginV2 implements ResourcePlugin {
   @Inject(ResourcePlugins.AadPlugin)
   plugin!: AadAppForTeamsPlugin;
 
-  activate(solutionSettings: AzureSolutionSettings): boolean {
+  activate(projectSettings: ProjectSettings): boolean {
+    const solutionSettings = projectSettings.solutionSettings as AzureSolutionSettings;
     return this.plugin.activate(solutionSettings);
   }
 

--- a/packages/fx-core/src/plugins/resource/apim/managers/apimManager.ts
+++ b/packages/fx-core/src/plugins/resource/apim/managers/apimManager.ts
@@ -158,8 +158,7 @@ export class ApimManager {
   }
 
   public async updateArmTemplates(ctx: PluginContext): Promise<ArmTemplateResult> {
-    const azureSolutionSettings = ctx.projectSettings!.solutionSettings as AzureSolutionSettings;
-    const plugins = getActivatedV2ResourcePlugins(azureSolutionSettings).map(
+    const plugins = getActivatedV2ResourcePlugins(ctx.projectSettings!).map(
       (p) => new NamedArmResourcePluginAdaptor(p)
     );
     const pluginCtx = { plugins: plugins.map((obj) => obj.name) };
@@ -182,8 +181,7 @@ export class ApimManager {
   }
 
   public async generateArmTemplates(ctx: PluginContext): Promise<ArmTemplateResult> {
-    const azureSolutionSettings = ctx.projectSettings!.solutionSettings as AzureSolutionSettings;
-    const plugins = getActivatedV2ResourcePlugins(azureSolutionSettings).map(
+    const plugins = getActivatedV2ResourcePlugins(ctx.projectSettings!).map(
       (p) => new NamedArmResourcePluginAdaptor(p)
     );
     const pluginCtx = { plugins: plugins.map((obj) => obj.name) };

--- a/packages/fx-core/src/plugins/resource/apim/v2/index.ts
+++ b/packages/fx-core/src/plugins/resource/apim/v2/index.ts
@@ -9,6 +9,7 @@ import {
   FxError,
   Inputs,
   Json,
+  ProjectSettings,
   QTreeNode,
   Result,
   Stage,
@@ -52,7 +53,8 @@ export class ApimPluginV2 implements ResourcePlugin {
   @Inject(ResourcePlugins.ApimPlugin)
   plugin!: ApimPlugin;
 
-  activate(solutionSettings: AzureSolutionSettings): boolean {
+  activate(projectSettings: ProjectSettings): boolean {
+    const solutionSettings = projectSettings.solutionSettings as AzureSolutionSettings;
     return this.plugin.activate(solutionSettings);
   }
 

--- a/packages/fx-core/src/plugins/resource/appstudio/v2/index.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/v2/index.ts
@@ -12,6 +12,7 @@ import {
   Json,
   ok,
   PluginContext,
+  ProjectSettings,
   QTreeNode,
   Result,
   TokenProvider,
@@ -52,7 +53,8 @@ export class AppStudioPluginV2 implements ResourcePlugin {
   @Inject(ResourcePlugins.AppStudioPlugin)
   plugin!: AppStudioPlugin;
 
-  activate(solutionSettings: AzureSolutionSettings): boolean {
+  activate(projectSettings: ProjectSettings): boolean {
+    const solutionSettings = projectSettings.solutionSettings as AzureSolutionSettings;
     return this.plugin.activate(solutionSettings);
   }
 

--- a/packages/fx-core/src/plugins/resource/bot/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/bot/plugin.ts
@@ -163,8 +163,7 @@ export class TeamsBotImpl {
 
   public async updateArmTemplates(ctx: PluginContext): Promise<FxResult> {
     Logger.info(Messages.UpdatingArmTemplatesBot);
-    const azureSolutionSettings = ctx.projectSettings!.solutionSettings as AzureSolutionSettings;
-    const plugins = getActivatedV2ResourcePlugins(azureSolutionSettings).map(
+    const plugins = getActivatedV2ResourcePlugins(ctx.projectSettings!).map(
       (p) => new NamedArmResourcePluginAdaptor(p)
     );
     const pluginCtx = { plugins: plugins.map((obj) => obj.name) };
@@ -190,8 +189,7 @@ export class TeamsBotImpl {
 
   public async generateArmTemplates(ctx: PluginContext): Promise<FxResult> {
     Logger.info(Messages.GeneratingArmTemplatesBot);
-    const azureSolutionSettings = ctx.projectSettings!.solutionSettings as AzureSolutionSettings;
-    const plugins = getActivatedV2ResourcePlugins(azureSolutionSettings).map(
+    const plugins = getActivatedV2ResourcePlugins(ctx.projectSettings!).map(
       (p) => new NamedArmResourcePluginAdaptor(p)
     );
     const pluginCtx = { plugins: plugins.map((obj) => obj.name) };

--- a/packages/fx-core/src/plugins/resource/bot/v2/index.ts
+++ b/packages/fx-core/src/plugins/resource/bot/v2/index.ts
@@ -8,6 +8,7 @@ import {
   FxError,
   Inputs,
   Json,
+  ProjectSettings,
   QTreeNode,
   Result,
   TokenProvider,
@@ -48,7 +49,8 @@ export class BotPluginV2 implements ResourcePlugin {
   @Inject(ResourcePlugins.BotPlugin)
   plugin!: TeamsBot;
 
-  activate(solutionSettings: AzureSolutionSettings): boolean {
+  activate(projectSettings: ProjectSettings): boolean {
+    const solutionSettings = projectSettings.solutionSettings as AzureSolutionSettings;
     return this.plugin.activate(solutionSettings);
   }
 

--- a/packages/fx-core/src/plugins/resource/frontend/dotnet/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/dotnet/plugin.ts
@@ -111,8 +111,7 @@ export class DotnetPluginImpl implements PluginImpl {
       WebappBicepFile.configurationTemplateFileName
     );
 
-    const solutionSettings = ctx.projectSettings!.solutionSettings as AzureSolutionSettings;
-    const plugins = getActivatedV2ResourcePlugins(solutionSettings).map(
+    const plugins = getActivatedV2ResourcePlugins(ctx.projectSettings!).map(
       (p) => new NamedArmResourcePluginAdaptor(p)
     );
     const pluginCtx = { plugins: plugins.map((obj) => obj.name) };

--- a/packages/fx-core/src/plugins/resource/frontend/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/plugin.ts
@@ -142,8 +142,7 @@ export class FrontendPluginImpl implements PluginImpl {
 
   public async generateArmTemplates(ctx: PluginContext): Promise<TeamsFxResult> {
     Logger.info(Messages.StartGenerateArmTemplates(PluginInfo.DisplayName));
-    const azureSolutionSettings = ctx.projectSettings!.solutionSettings as AzureSolutionSettings;
-    const plugins = getActivatedV2ResourcePlugins(azureSolutionSettings).map(
+    const plugins = getActivatedV2ResourcePlugins(ctx.projectSettings!).map(
       (p) => new NamedArmResourcePluginAdaptor(p)
     );
     const pluginCtx = { plugins: plugins.map((obj) => obj.name) };

--- a/packages/fx-core/src/plugins/resource/frontend/v2/index.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/v2/index.ts
@@ -8,6 +8,7 @@ import {
   FxError,
   Inputs,
   Json,
+  ProjectSettings,
   Result,
   TokenProvider,
   v2,
@@ -46,7 +47,8 @@ export class FrontendPluginV2 implements ResourcePlugin {
   @Inject(ResourcePlugins.FrontendPlugin)
   plugin!: FrontendPlugin;
 
-  activate(solutionSettings: AzureSolutionSettings): boolean {
+  activate(projectSettings: ProjectSettings): boolean {
+    const solutionSettings = projectSettings.solutionSettings as AzureSolutionSettings;
     return this.plugin.activate(solutionSettings);
   }
 

--- a/packages/fx-core/src/plugins/resource/function/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/function/plugin.ts
@@ -606,8 +606,7 @@ export class FunctionPluginImpl {
       "function",
       "bicep"
     );
-    const azureSolutionSettings = ctx.projectSettings!.solutionSettings as AzureSolutionSettings;
-    const plugins = getActivatedV2ResourcePlugins(azureSolutionSettings).map(
+    const plugins = getActivatedV2ResourcePlugins(ctx.projectSettings!).map(
       (p) => new NamedArmResourcePluginAdaptor(p)
     );
     const configFuncTemplateFilePath = path.join(
@@ -638,8 +637,7 @@ export class FunctionPluginImpl {
       "function",
       "bicep"
     );
-    const azureSolutionSettings = ctx.projectSettings!.solutionSettings as AzureSolutionSettings;
-    const plugins = getActivatedV2ResourcePlugins(azureSolutionSettings).map(
+    const plugins = getActivatedV2ResourcePlugins(ctx.projectSettings!).map(
       (p) => new NamedArmResourcePluginAdaptor(p)
     );
 

--- a/packages/fx-core/src/plugins/resource/function/v2/index.ts
+++ b/packages/fx-core/src/plugins/resource/function/v2/index.ts
@@ -8,6 +8,7 @@ import {
   FxError,
   Inputs,
   Json,
+  ProjectSettings,
   QTreeNode,
   Result,
   TokenProvider,
@@ -47,7 +48,8 @@ export class FunctionPluginV2 implements ResourcePlugin {
   @Inject(ResourcePlugins.FunctionPlugin)
   plugin!: FunctionPlugin;
 
-  activate(solutionSettings: AzureSolutionSettings): boolean {
+  activate(projectSettings: ProjectSettings): boolean {
+    const solutionSettings = projectSettings.solutionSettings as AzureSolutionSettings;
     return this.plugin.activate(solutionSettings);
   }
 

--- a/packages/fx-core/src/plugins/resource/identity/index.ts
+++ b/packages/fx-core/src/plugins/resource/identity/index.ts
@@ -121,8 +121,7 @@ export class IdentityPlugin implements Plugin {
   }
 
   public async generateArmTemplates(ctx: PluginContext): Promise<Result> {
-    const azureSolutionSettings = ctx.projectSettings!.solutionSettings as AzureSolutionSettings;
-    const plugins = getActivatedV2ResourcePlugins(azureSolutionSettings).map(
+    const plugins = getActivatedV2ResourcePlugins(ctx.projectSettings!).map(
       (p) => new NamedArmResourcePluginAdaptor(p)
     );
     const pluginCtx = { plugins: plugins.map((obj) => obj.name) };

--- a/packages/fx-core/src/plugins/resource/identity/v2/index.ts
+++ b/packages/fx-core/src/plugins/resource/identity/v2/index.ts
@@ -6,6 +6,7 @@ import {
   FxError,
   Inputs,
   Json,
+  ProjectSettings,
   Result,
   TokenProvider,
   v2,
@@ -35,7 +36,8 @@ export class IdentityPluginV2 implements ResourcePlugin {
   @Inject(ResourcePlugins.IdentityPlugin)
   plugin!: IdentityPlugin;
 
-  activate(solutionSettings: AzureSolutionSettings): boolean {
+  activate(projectSettings: ProjectSettings): boolean {
+    const solutionSettings = projectSettings.solutionSettings as AzureSolutionSettings;
     return this.plugin.activate(solutionSettings);
   }
   async provisionResource(

--- a/packages/fx-core/src/plugins/resource/keyvault/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/keyvault/plugin.ts
@@ -16,8 +16,7 @@ export class KeyVaultPluginImpl {
   public async generateArmTemplates(
     ctx: PluginContext
   ): Promise<Result<ArmTemplateResult, FxError>> {
-    const azureSolutionSettings = ctx.projectSettings!.solutionSettings as AzureSolutionSettings;
-    const plugins = getActivatedV2ResourcePlugins(azureSolutionSettings).map(
+    const plugins = getActivatedV2ResourcePlugins(ctx.projectSettings!).map(
       (p) => new NamedArmResourcePluginAdaptor(p)
     );
     const pluginCtx = { plugins: plugins.map((obj) => obj.name) };

--- a/packages/fx-core/src/plugins/resource/keyvault/v2/index.ts
+++ b/packages/fx-core/src/plugins/resource/keyvault/v2/index.ts
@@ -1,7 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { AzureSolutionSettings, FxError, Inputs, Result, v2 } from "@microsoft/teamsfx-api";
+import {
+  AzureSolutionSettings,
+  FxError,
+  Inputs,
+  ProjectSettings,
+  Result,
+  v2,
+} from "@microsoft/teamsfx-api";
 import { Context, ResourcePlugin } from "@microsoft/teamsfx-api/build/v2";
 import { Inject, Service } from "typedi";
 import { KeyVaultPlugin } from "..";
@@ -19,7 +26,8 @@ export class KeyVaultPluginV2 implements ResourcePlugin {
   @Inject(ResourcePlugins.KeyVaultPlugin)
   plugin!: KeyVaultPlugin;
 
-  activate(solutionSettings: AzureSolutionSettings): boolean {
+  activate(projectSettings: ProjectSettings): boolean {
+    const solutionSettings = projectSettings.solutionSettings as AzureSolutionSettings;
     const azureResources = solutionSettings.azureResources || [];
     return (
       solutionSettings.hostType === HostTypeOptionAzure.id &&

--- a/packages/fx-core/src/plugins/resource/localdebug/v2/index.ts
+++ b/packages/fx-core/src/plugins/resource/localdebug/v2/index.ts
@@ -9,6 +9,7 @@ import {
   Inputs,
   Json,
   ok,
+  ProjectSettings,
   Result,
   TokenProvider,
   v2,
@@ -37,7 +38,8 @@ export class LocalDebugPluginV2 implements ResourcePlugin {
   displayName = "LocalDebug";
   @Inject(ResourcePlugins.LocalDebugPlugin)
   plugin!: LocalDebugPlugin;
-  activate(solutionSettings: AzureSolutionSettings): boolean {
+  activate(projectSettings: ProjectSettings): boolean {
+    const solutionSettings = projectSettings.solutionSettings as AzureSolutionSettings;
     return this.plugin.activate(solutionSettings);
   }
 

--- a/packages/fx-core/src/plugins/resource/simpleauth/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/simpleauth/plugin.ts
@@ -116,8 +116,7 @@ export class SimpleAuthPluginImpl {
   public async updateArmTemplates(ctx: PluginContext): Promise<Result<ArmTemplateResult, FxError>> {
     TelemetryUtils.init(ctx);
     Utils.addLogAndTelemetry(ctx.logProvider, Messages.StartUpdateArmTemplates);
-    const azureSolutionSettings = ctx.projectSettings!.solutionSettings as AzureSolutionSettings;
-    const plugins = getActivatedV2ResourcePlugins(azureSolutionSettings).map(
+    const plugins = getActivatedV2ResourcePlugins(ctx.projectSettings!).map(
       (p) => new NamedArmResourcePluginAdaptor(p)
     );
     const pluginCtx = { plugins: plugins.map((obj) => obj.name) };
@@ -154,8 +153,7 @@ export class SimpleAuthPluginImpl {
   ): Promise<Result<ArmTemplateResult, FxError>> {
     TelemetryUtils.init(ctx);
     Utils.addLogAndTelemetry(ctx.logProvider, Messages.StartGenerateArmTemplates);
-    const azureSolutionSettings = ctx.projectSettings!.solutionSettings as AzureSolutionSettings;
-    const plugins = getActivatedV2ResourcePlugins(azureSolutionSettings).map(
+    const plugins = getActivatedV2ResourcePlugins(ctx.projectSettings!).map(
       (p) => new NamedArmResourcePluginAdaptor(p)
     );
     const pluginCtx = { plugins: plugins.map((obj) => obj.name) };

--- a/packages/fx-core/src/plugins/resource/simpleauth/v2/index.ts
+++ b/packages/fx-core/src/plugins/resource/simpleauth/v2/index.ts
@@ -6,6 +6,7 @@ import {
   FxError,
   Inputs,
   Json,
+  ProjectSettings,
   Result,
   TokenProvider,
   v2,
@@ -32,7 +33,8 @@ export class SimpleAuthPluginV2 implements v2.ResourcePlugin {
   displayName = "Simple Auth";
   @Inject(ResourcePlugins.SimpleAuthPlugin)
   plugin!: SimpleAuthPlugin;
-  activate(solutionSettings: AzureSolutionSettings): boolean {
+  activate(projectSettings: ProjectSettings): boolean {
+    const solutionSettings = projectSettings.solutionSettings as AzureSolutionSettings;
     return this.plugin.activate(solutionSettings);
   }
 

--- a/packages/fx-core/src/plugins/resource/spfx/v2/index.ts
+++ b/packages/fx-core/src/plugins/resource/spfx/v2/index.ts
@@ -10,6 +10,7 @@ import {
   Result,
   Void,
   TokenProvider,
+  ProjectSettings,
 } from "@microsoft/teamsfx-api";
 import {
   Context,
@@ -37,7 +38,8 @@ export class SpfxPluginV2 implements ResourcePlugin {
   @Inject(ResourcePlugins.SpfxPlugin)
   plugin!: SpfxPlugin;
 
-  activate(solutionSettings: AzureSolutionSettings): boolean {
+  activate(projectSettings: ProjectSettings): boolean {
+    const solutionSettings = projectSettings.solutionSettings as AzureSolutionSettings;
     return this.plugin.activate(solutionSettings);
   }
 

--- a/packages/fx-core/src/plugins/resource/sql/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/sql/plugin.ts
@@ -271,8 +271,7 @@ export class SqlPluginImpl {
   }
 
   public async generateArmTemplates(ctx: PluginContext): Promise<Result<any, FxError>> {
-    const azureSolutionSettings = ctx.projectSettings!.solutionSettings as AzureSolutionSettings;
-    const plugins = getActivatedV2ResourcePlugins(azureSolutionSettings).map(
+    const plugins = getActivatedV2ResourcePlugins(ctx.projectSettings!).map(
       (p) => new NamedArmResourcePluginAdaptor(p)
     );
     const pluginCtx = { plugins: plugins.map((obj) => obj.name) };

--- a/packages/fx-core/src/plugins/resource/sql/v2/index.ts
+++ b/packages/fx-core/src/plugins/resource/sql/v2/index.ts
@@ -5,6 +5,7 @@ import {
   AzureSolutionSettings,
   FxError,
   Inputs,
+  ProjectSettings,
   QTreeNode,
   Result,
   TokenProvider,
@@ -38,7 +39,8 @@ export class SqlPluginV2 implements ResourcePlugin {
   @Inject(ResourcePlugins.SqlPlugin)
   plugin!: SqlPlugin;
 
-  activate(solutionSettings: AzureSolutionSettings): boolean {
+  activate(projectSettings: ProjectSettings): boolean {
+    const solutionSettings = projectSettings.solutionSettings as AzureSolutionSettings;
     return this.plugin.activate(solutionSettings);
   }
 

--- a/packages/fx-core/src/plugins/solution/fx-solution/ResourcePluginContainer.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/ResourcePluginContainer.ts
@@ -1,6 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { v2, AzureSolutionSettings, Plugin, returnUserError } from "@microsoft/teamsfx-api";
+import {
+  v2,
+  AzureSolutionSettings,
+  Plugin,
+  returnUserError,
+  ProjectSettings,
+} from "@microsoft/teamsfx-api";
 import "reflect-metadata";
 import { Container } from "typedi";
 import { SolutionError, SolutionSource } from "./constants";
@@ -110,14 +116,14 @@ export function getActivatedResourcePlugins(solutionSettings: AzureSolutionSetti
 
 /**
  * return activated resource plugin according to solution settings
- * @param solutionSettings Azure solution settings
+ * @param projectSettings project settings
  * @returns activated resource plugins
  */
 export function getActivatedV2ResourcePlugins(
-  solutionSettings: AzureSolutionSettings
+  projectSettings: ProjectSettings
 ): v2.ResourcePlugin[] {
   const activatedPlugins = getAllV2ResourcePlugins().filter(
-    (p) => p.activate && p.activate(solutionSettings) === true
+    (p) => p.activate && p.activate(projectSettings) === true
   );
   if (activatedPlugins.length === 0) {
     throw returnUserError(

--- a/packages/fx-core/src/plugins/solution/fx-solution/arm.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/arm.ts
@@ -802,9 +802,8 @@ async function doGenerateArmTemplate(
   ctx: SolutionContext,
   selectedPlugins: NamedArmResourcePlugin[]
 ): Promise<Result<any, FxError>> {
-  const azureSolutionSettings = ctx.projectSettings?.solutionSettings as AzureSolutionSettings;
   const baseName = generateResourceBaseName(ctx.projectSettings!.appName, ctx.envInfo!.envName);
-  const plugins = getActivatedV2ResourcePlugins(azureSolutionSettings).map(
+  const plugins = getActivatedV2ResourcePlugins(ctx.projectSettings!).map(
     (p) => new NamedArmResourcePluginAdaptor(p)
   ); // This function ensures return result won't be empty
   const bicepOrchestrationTemplate = new BicepOrchestrationContent(
@@ -1258,8 +1257,7 @@ function generateBicepModuleConfigFilePath(moduleFileName: string) {
 }
 
 function expandParameterPlaceholders(ctx: SolutionContext, parameterContent: string): string {
-  const azureSolutionSettings = ctx.projectSettings?.solutionSettings as AzureSolutionSettings;
-  const plugins = getActivatedV2ResourcePlugins(azureSolutionSettings).map(
+  const plugins = getActivatedV2ResourcePlugins(ctx.projectSettings!).map(
     (p) => new NamedArmResourcePluginAdaptor(p)
   ); // This function ensures return result won't be empty
   const stateVariables: Record<string, Record<string, any>> = {};

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/checkPermission.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/checkPermission.ts
@@ -91,9 +91,7 @@ async function executeCheckPermissionV2(
   tokenProvider: TokenProvider,
   userInfo: IUserList
 ): Promise<[ResourcePermission[], Err<any, FxError>[]]> {
-  const plugins = getActivatedV2ResourcePlugins(
-    ctx.projectSetting?.solutionSettings as AzureSolutionSettings
-  );
+  const plugins = getActivatedV2ResourcePlugins(ctx.projectSetting);
 
   const thunks: NamedThunk<Json>[] = plugins
     .filter((plugin) => !!plugin.checkPermission)

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/deploy.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/deploy.ts
@@ -64,7 +64,7 @@ export async function deploy(
     );
   }
 
-  const plugins = getSelectedPlugins(getAzureSolutionSettings(ctx));
+  const plugins = getSelectedPlugins(ctx.projectSetting);
   const thunks: NamedThunk<Json>[] = plugins
     .filter((plugin) => !isUndefined(plugin.deploy) && optionsToDeploy.includes(plugin.name))
     .map((plugin) => {

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/executeUserTask.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/executeUserTask.ts
@@ -361,7 +361,7 @@ export async function addCapability(
 
   // 7. update solution settings
   solutionSettings.capabilities = Array.from(newCapabilitySet);
-  reloadV2Plugins(solutionSettings);
+  reloadV2Plugins(ctx.projectSetting);
 
   // 8. scaffold and update arm
   const pluginsToScaffold = Array.from(pluginNamesToScaffold).map((name) =>
@@ -556,7 +556,7 @@ export async function addResource(
   // 7. update solution settings
   addedResources.forEach((r) => newResourceSet.add(r));
   solutionSettings.azureResources = Array.from(newResourceSet);
-  reloadV2Plugins(solutionSettings);
+  reloadV2Plugins(ctx.projectSetting);
 
   // 8. scaffold and update arm
   if (pluginsToScaffold.length > 0 || pluginsToDoArm.length > 0) {

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/generateResourceTemplate.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/generateResourceTemplate.ts
@@ -10,8 +10,7 @@ export async function generateResourceTemplate(
   inputs: Inputs
 ): Promise<Result<Json, FxError>> {
   const legacyContext = new ScaffoldingContextAdapter([ctx, inputs]);
-  const azureSolutionSettings = getAzureSolutionSettings(ctx);
-  const plugins = getSelectedPlugins(azureSolutionSettings).map(
+  const plugins = getSelectedPlugins(ctx.projectSetting).map(
     (plugin) => new NamedArmResourcePluginAdaptor(plugin)
   );
   const armResult = await armV2.generateArmTemplate(legacyContext, plugins);
@@ -24,8 +23,7 @@ export async function generateResourceTemplateForPlugins(
   plugins: v2.ResourcePlugin[]
 ): Promise<Result<Json, FxError>> {
   showUpdateArmTemplateNotice(ctx.userInteraction);
-  const azureSolutionSettings = getAzureSolutionSettings(ctx);
-  const allPlugins = getActivatedV2ResourcePlugins(azureSolutionSettings);
+  const allPlugins = getActivatedV2ResourcePlugins(ctx.projectSetting);
   const armResult = await arm.generateArmTemplate(ctx, inputs, allPlugins, plugins);
   return armResult;
 }

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/getQuestions.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/getQuestions.ts
@@ -224,7 +224,7 @@ export async function getQuestions(
     }
     let plugins: v2.ResourcePlugin[] = [];
     if (isDynamicQuestion) {
-      plugins = getSelectedPlugins(solutionSettings);
+      plugins = getSelectedPlugins(ctx.projectSetting);
     } else {
       plugins = getAllV2ResourcePlugins();
       node.addChild(new QTreeNode(AskSubscriptionQuestion));
@@ -256,7 +256,7 @@ export async function getQuestions(
     }
     let plugins: v2.ResourcePlugin[] = [];
     if (isDynamicQuestion) {
-      plugins = getSelectedPlugins(solutionSettings);
+      plugins = getSelectedPlugins(ctx.projectSetting);
     } else {
       plugins = getAllV2ResourcePlugins();
     }
@@ -317,7 +317,7 @@ export async function getQuestions(
     }
     let plugins: v2.ResourcePlugin[] = [];
     if (isDynamicQuestion) {
-      plugins = getSelectedPlugins(solutionSettings);
+      plugins = getSelectedPlugins(ctx.projectSetting);
     } else {
       plugins = getAllV2ResourcePlugins();
     }

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/grantPermission.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/grantPermission.ts
@@ -342,9 +342,7 @@ async function executeGrantPermissionsV2(
   tokenProvider: TokenProvider,
   userInfo: IUserList
 ): Promise<[ResourcePermission[], Err<any, FxError>[]]> {
-  const plugins = getActivatedV2ResourcePlugins(
-    ctx.projectSetting?.solutionSettings as AzureSolutionSettings
-  );
+  const plugins = getActivatedV2ResourcePlugins(ctx.projectSetting);
 
   const thunks: NamedThunk<Json>[] = plugins
     .filter((plugin) => !!plugin.grantPermission)

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/provision.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/provision.ts
@@ -135,7 +135,7 @@ export async function provisionResource(
 
   const solutionInputs = extractSolutionInputs(newEnvInfo.state[GLOBAL_CONFIG]["output"]);
 
-  const plugins = getSelectedPlugins(azureSolutionSettings);
+  const plugins = getSelectedPlugins(ctx.projectSetting);
   const provisionThunks = plugins
     .filter((plugin) => !isUndefined(plugin.provisionResource))
     .map((plugin) => {

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/provisionLocal.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/provisionLocal.ts
@@ -69,7 +69,7 @@ export async function provisionLocalResource(
     return new v2.FxFailure(m365TenantMatches.error);
   }
 
-  const plugins: v2.ResourcePlugin[] = getSelectedPlugins(azureSolutionSettings);
+  const plugins: v2.ResourcePlugin[] = getSelectedPlugins(ctx.projectSetting);
   const provisionLocalResourceThunks = plugins
     .filter((plugin) => !isUndefined(plugin.provisionLocalResource))
     .map((plugin) => {

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/publish.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/publish.ts
@@ -43,7 +43,7 @@ export async function publishApplication(
     );
   }
 
-  const plugins = getSelectedPlugins(getAzureSolutionSettings(ctx));
+  const plugins = getSelectedPlugins(ctx.projectSetting);
   const thunks = plugins
     .filter((plugin) => !isUndefined(plugin.publishApplication))
     .map((plugin) => {

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/scaffolding.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/scaffolding.ts
@@ -60,7 +60,7 @@ export async function scaffoldSourceCode(
   const solutionSettings: AzureSolutionSettings = getAzureSolutionSettings(ctx);
   const fillinRes = fillInSolutionSettings(solutionSettings, inputs);
   if (fillinRes.isErr()) return err(fillinRes.error);
-  const plugins = getSelectedPlugins(solutionSettings);
+  const plugins = getSelectedPlugins(ctx.projectSetting);
 
   let thunks: NamedThunk<Void>[] = plugins
     .filter((plugin) => !!plugin.scaffoldSourceCode)

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/utils.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/utils.ts
@@ -14,6 +14,7 @@ import {
   SolutionContext,
   Plugin,
   AppStudioTokenProvider,
+  ProjectSettings,
 } from "@microsoft/teamsfx-api";
 import { LocalSettingsTeamsAppKeys } from "../../../../common/localSettingsConstants";
 import { getStrings, isMultiEnvEnabled } from "../../../../common/tools";
@@ -40,8 +41,10 @@ import { PluginsWithContext } from "../solution";
 import { getPluginContext } from "../utils/util";
 import * as util from "util";
 
-export function getSelectedPlugins(azureSettings: AzureSolutionSettings): v2.ResourcePlugin[] {
-  const plugins = getActivatedV2ResourcePlugins(azureSettings);
+export function getSelectedPlugins(projectSettings: ProjectSettings): v2.ResourcePlugin[] {
+  const azureSettings: AzureSolutionSettings =
+    projectSettings.solutionSettings as AzureSolutionSettings;
+  const plugins = getActivatedV2ResourcePlugins(projectSettings);
   azureSettings.activeResourcePlugins = plugins.map((p) => p.name);
   return plugins;
 }
@@ -76,8 +79,10 @@ export function extractSolutionInputs(record: Json): v2.SolutionInputs {
   };
 }
 
-export function reloadV2Plugins(solutionSettings: AzureSolutionSettings): v2.ResourcePlugin[] {
-  const res = getActivatedV2ResourcePlugins(solutionSettings);
+export function reloadV2Plugins(projectSettings: ProjectSettings): v2.ResourcePlugin[] {
+  const solutionSettings: AzureSolutionSettings =
+    projectSettings.solutionSettings as AzureSolutionSettings;
+  const res = getActivatedV2ResourcePlugins(projectSettings);
   solutionSettings.activeResourcePlugins = res.map((p) => p.name);
   return res;
 }


### PR DESCRIPTION
Plugin's activate() used to have type `(SolutionSettings) => boolean`. But SolutionSettings alone is not enough for VS scenario, where plugins need to be aware of the project settings in order to decide whether to actiavte.

Related task: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_sprints/taskboard/Teams%20Extensibility%20E2E%20Team/Microsoft%20Teams%20Extensibility/CY22-1.1?workitem=13012232