### PR TITLE
fix: select capability can go back

### DIFF
--- a/packages/api/src/qm/visitor.ts
+++ b/packages/api/src/qm/visitor.ts
@@ -89,7 +89,7 @@ const questionVisitor = async function (
   totalSteps?: number
 ): Promise<Result<InputResult<any>, FxError>> {
   if (inputs[question.name] !== undefined) {
-    return ok({ type: "success", result: inputs[question.name] });
+    return ok({ type: "skip", result: inputs[question.name] });
   }
   if (question.type === "func") {
     try {


### PR DESCRIPTION
Fix the P0 bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_sprints/taskboard/Teams%20Extensibility%20E2E%20Team/Microsoft%20Teams%20Extensibility/CY22-1.1?workitem=13023698

Root cause: actually there's an invisible question for creating new project. So the current step for select capability is 2 and back button is available.