### PR TITLE
perf(template): add connection timeout for fetching templates

### DIFF
--- a/packages/fx-core/src/common/template-utils/templatesActions.ts
+++ b/packages/fx-core/src/common/template-utils/templatesActions.ts
@@ -43,8 +43,8 @@ export interface ScaffoldAction {
   run: (context: ScaffoldContext) => Promise<void>;
 }
 
-const defaultTryLimits = 3;
-const defaultTimeoutInMs = 10000;
+const defaultTryLimits = 1;
+const defaultTimeoutInMs = 30000;
 
 const missKeyErrorInfo = (key: string) => `Missing ${key} in template action.`;
 

--- a/packages/fx-core/src/common/template-utils/templatesUtils.ts
+++ b/packages/fx-core/src/common/template-utils/templatesUtils.ts
@@ -51,9 +51,16 @@ export async function sendRequestWithTimeout<T>(
   const timeout = setTimeout(() => {
     source.cancel();
   }, timeoutInMs);
-  const res = await sendRequestWithRetry(() => requestFn(source.token), tryLimits);
-  clearTimeout(timeout);
-  return res;
+  try {
+    const res = await sendRequestWithRetry(() => requestFn(source.token), tryLimits);
+    clearTimeout(timeout);
+    return res;
+  } catch (err: unknown) {
+    if (axios.isCancel(err)) {
+      throw new Error("Request timeout");
+    }
+    throw err;
+  }
 }
 
 export async function fetchTemplateTagList(


### PR DESCRIPTION
The timeout parameter in axios is a response timeout, which throw an error when server doesn't response in time. While what we need is a connection timeout, which throw an error when the request doesn't end in time.

## How was this change tested
1. Replace template url with 1GB size test file download link.
2. Run scaffold, plugin takes more than 2 minutes to download the test file.
```
[2022-01-20T03:01:26.038Z] [Info] - [fx-resource-frontend-hosting] Retrieving template from 'https://speed.hetzner.de/1GB.bin'.
[2022-01-20T03:03:59.687Z] [Info] - [fx-resource-frontend-hosting] Error: Invalid or unsupported zip format. No END header found
[2022-01-20T03:03:59.689Z] [Info] - [fx-resource-frontend-hosting] Failed to retrieve latest template from GitHub. Using local template instead.
```
3. Add the changes.
4. Run scaffold, plugin takes 30 seconds but request timeout, and fallback to using local templates.
```
[2022-01-19T08:53:27.252Z] [Info] - [fx-resource-frontend-hosting] Retrieving template from 'https://speed.hetzner.de/1GB.bin'.
[2022-01-19T08:53:57.254Z] [Info] - [fx-resource-frontend-hosting] Error: Request timeout
[2022-01-19T08:53:57.255Z] [Info] - [fx-resource-frontend-hosting] Failed to retrieve latest template from GitHub. Using local template instead.
```