### PR TITLE
fix(localdebug): improve npm install task error handler

### DIFF
--- a/packages/vscode-extension/src/debug/constants.ts
+++ b/packages/vscode-extension/src/debug/constants.ts
@@ -19,6 +19,7 @@ export const authLocalEnvPrefix = "AUTH_";
 export const authServicePathEnvKey = "AUTH_SERVICE_PATH";
 export const botLocalEnvPrefix = "BOT_";
 
+export const issueChooseLink = "https://github.com/OfficeDev/TeamsFx/issues/new/choose";
 export const issueLink = "https://github.com/OfficeDev/TeamsFx/issues/new?";
 export const issueTemplate = `
 **Describe the bug**


### PR DESCRIPTION
- use issue template choice link when getting npm log fails
- fix replacing workspace folder logic

If user updates `cwd` of npm install tasks in tasks.json like to an absolute path, the original replacing logic will be wrong.