### PR TITLE
fix: missing appid in cli for env related commands

### DIFF
--- a/packages/cli/src/cmds/deploy.ts
+++ b/packages/cli/src/cmds/deploy.ts
@@ -20,7 +20,7 @@ import {
 import activate from "../activate";
 import { YargsCommand } from "../yargsCommand";
 import { flattenNodes, getSystemInputs, toLocaleLowerCase } from "../utils";
-import CliTelemetry, { makeEnvProperty } from "../telemetry/cliTelemetry";
+import CliTelemetry, { makeEnvRelatedProperty } from "../telemetry/cliTelemetry";
 import {
   TelemetryEvent,
   TelemetryProperty,
@@ -108,14 +108,19 @@ export default class Deploy extends YargsCommand {
       }
       const result = await core.deployArtifacts(inputs);
       if (result.isErr()) {
-        CliTelemetry.sendTelemetryErrorEvent(TelemetryEvent.Deploy, result.error);
+        CliTelemetry.sendTelemetryErrorEvent(
+          TelemetryEvent.Deploy,
+          result.error,
+          makeEnvRelatedProperty(rootFolder, inputs)
+        );
+
         return err(result.error);
       }
     }
 
     CliTelemetry.sendTelemetryEvent(TelemetryEvent.Deploy, {
       [TelemetryProperty.Success]: TelemetrySuccess.Yes,
-      ...makeEnvProperty(inputs.env),
+      ...makeEnvRelatedProperty(rootFolder, inputs),
     });
     return ok(null);
   }

--- a/packages/cli/src/cmds/env.ts
+++ b/packages/cli/src/cmds/env.ts
@@ -20,7 +20,7 @@ import { WorkspaceNotSupported } from "./preview/errors";
 import HelpParamGenerator from "../helpParamGenerator";
 import activate from "../activate";
 import { getSystemInputs, isWorkspaceSupported } from "../utils";
-import CliTelemetry, { makeEnvProperty } from "../telemetry/cliTelemetry";
+import CliTelemetry, { makeEnvRelatedProperty } from "../telemetry/cliTelemetry";
 import {
   TelemetryEvent,
   TelemetryProperty,
@@ -93,12 +93,17 @@ class EnvAdd extends YargsCommand {
 
     const result = await fxCore.createEnv(inputs);
     if (result.isErr()) {
+      CliTelemetry.sendTelemetryErrorEvent(
+        TelemetryEvent.CreateNewEnvironment,
+        result.error,
+        makeEnvRelatedProperty(projectDir, inputs)
+      );
       return err(result.error);
     }
 
     CliTelemetry.sendTelemetryEvent(TelemetryEvent.CreateNewEnvironment, {
       [TelemetryProperty.Success]: TelemetrySuccess.Yes,
-      ...makeEnvProperty(inputs.env),
+      ...makeEnvRelatedProperty(projectDir, inputs),
     });
 
     return ok(null);
@@ -144,6 +149,7 @@ class EnvList extends YargsCommand {
 
     const envResult = await environmentManager.listEnvConfigs(projectDir);
     if (envResult.isErr()) {
+      CliTelemetry.sendTelemetryErrorEvent(TelemetryEvent.EnvList, envResult.error);
       return err(envResult.error);
     }
 

--- a/packages/cli/src/cmds/manifest.ts
+++ b/packages/cli/src/cmds/manifest.ts
@@ -9,7 +9,7 @@ import { FxError, err, ok, Result, Func, Inputs } from "@microsoft/teamsfx-api";
 import activate from "../activate";
 import { YargsCommand } from "../yargsCommand";
 import { getSystemInputs, toLocaleLowerCase } from "../utils";
-import CliTelemetry, { makeEnvProperty } from "../telemetry/cliTelemetry";
+import CliTelemetry, { makeEnvRelatedProperty } from "../telemetry/cliTelemetry";
 import {
   TelemetryEvent,
   TelemetryProperty,
@@ -76,14 +76,19 @@ class ManifestValidate extends YargsCommand {
       inputs = getSystemInputs(rootFolder, args.env as any);
       const result = await core.executeUserTask!(func, inputs);
       if (result.isErr()) {
-        CliTelemetry.sendTelemetryErrorEvent(TelemetryEvent.ValidateManifest, result.error);
+        CliTelemetry.sendTelemetryErrorEvent(
+          TelemetryEvent.ValidateManifest,
+          result.error,
+          makeEnvRelatedProperty(rootFolder, inputs)
+        );
+
         return err(result.error);
       }
     }
 
     CliTelemetry.sendTelemetryEvent(TelemetryEvent.ValidateManifest, {
       [TelemetryProperty.Success]: TelemetrySuccess.Yes,
-      ...makeEnvProperty(inputs.env),
+      ...makeEnvRelatedProperty(rootFolder, inputs),
     });
     return ok(null);
   }
@@ -121,14 +126,19 @@ class ManifestUpdate extends YargsCommand {
       inputs = getSystemInputs(rootFolder, args.env as any);
       const result = await core.executeUserTask!(func, inputs);
       if (result.isErr()) {
-        CliTelemetry.sendTelemetryErrorEvent(TelemetryEvent.UpdateManifest, result.error);
+        CliTelemetry.sendTelemetryErrorEvent(
+          TelemetryEvent.UpdateManifest,
+          result.error,
+          makeEnvRelatedProperty(rootFolder, inputs)
+        );
+
         return err(result.error);
       }
     }
 
     CliTelemetry.sendTelemetryEvent(TelemetryEvent.UpdateManifest, {
       [TelemetryProperty.Success]: TelemetrySuccess.Yes,
-      ...makeEnvProperty(inputs.env),
+      ...makeEnvRelatedProperty(rootFolder, inputs),
     });
     return ok(null);
   }

--- a/packages/cli/src/cmds/package.ts
+++ b/packages/cli/src/cmds/package.ts
@@ -9,7 +9,7 @@ import { FxError, err, ok, Result, Func, Stage, Inputs } from "@microsoft/teamsf
 import activate from "../activate";
 import { YargsCommand } from "../yargsCommand";
 import { getSystemInputs } from "../utils";
-import CliTelemetry, { makeEnvProperty } from "../telemetry/cliTelemetry";
+import CliTelemetry, { makeEnvRelatedProperty } from "../telemetry/cliTelemetry";
 import {
   TelemetryEvent,
   TelemetryProperty,
@@ -48,14 +48,19 @@ export default class Package extends YargsCommand {
       inputs = getSystemInputs(rootFolder, args.env as any);
       const result = await core.executeUserTask!(func, inputs);
       if (result.isErr()) {
-        CliTelemetry.sendTelemetryErrorEvent(TelemetryEvent.Build, result.error);
+        CliTelemetry.sendTelemetryErrorEvent(
+          TelemetryEvent.Build,
+          result.error,
+          makeEnvRelatedProperty(rootFolder, inputs)
+        );
+
         return err(result.error);
       }
     }
 
     CliTelemetry.sendTelemetryEvent(TelemetryEvent.Build, {
       [TelemetryProperty.Success]: TelemetrySuccess.Yes,
-      ...makeEnvProperty(inputs.env),
+      ...makeEnvRelatedProperty(rootFolder, inputs),
     });
     return ok(null);
   }

--- a/packages/cli/src/cmds/provision.ts
+++ b/packages/cli/src/cmds/provision.ts
@@ -11,7 +11,7 @@ import { FxError, err, ok, Result, Stage } from "@microsoft/teamsfx-api";
 import activate from "../activate";
 import { getSystemInputs, setSubscriptionId } from "../utils";
 import { YargsCommand } from "../yargsCommand";
-import CliTelemetry, { makeEnvProperty } from "../telemetry/cliTelemetry";
+import CliTelemetry, { makeEnvRelatedProperty } from "../telemetry/cliTelemetry";
 import {
   TelemetryEvent,
   TelemetryProperty,
@@ -70,14 +70,18 @@ export default class Provision extends YargsCommand {
     {
       const result = await core.provisionResources(inputs);
       if (result.isErr()) {
-        CliTelemetry.sendTelemetryErrorEvent(TelemetryEvent.Provision, result.error);
+        CliTelemetry.sendTelemetryErrorEvent(
+          TelemetryEvent.Provision,
+          result.error,
+          makeEnvRelatedProperty(rootFolder, inputs)
+        );
         return err(result.error);
       }
     }
 
     CliTelemetry.sendTelemetryEvent(TelemetryEvent.Provision, {
       [TelemetryProperty.Success]: TelemetrySuccess.Yes,
-      ...makeEnvProperty(inputs.env),
+      ...makeEnvRelatedProperty(rootFolder, inputs),
     });
     return ok(null);
   }

--- a/packages/cli/src/cmds/publish.ts
+++ b/packages/cli/src/cmds/publish.ts
@@ -7,14 +7,15 @@ import { Argv, Options } from "yargs";
 import { FxError, err, ok, Result, Platform, Func, Stage, Inputs } from "@microsoft/teamsfx-api";
 import activate from "../activate";
 import { YargsCommand } from "../yargsCommand";
-import { argsToInputs } from "../utils";
-import CliTelemetry, { makeEnvProperty } from "../telemetry/cliTelemetry";
+import { argsToInputs, getTeamsAppIdByEnv } from "../utils";
+import CliTelemetry, { makeEnvRelatedProperty } from "../telemetry/cliTelemetry";
 import {
   TelemetryEvent,
   TelemetryProperty,
   TelemetrySuccess,
 } from "../telemetry/cliTelemetryEvents";
 import HelpParamGenerator from "../helpParamGenerator";
+import { getHashedEnv } from "@microsoft/teamsfx-core";
 
 export default class Publish extends YargsCommand {
   public readonly commandHead = `publish`;
@@ -49,6 +50,20 @@ export default class Publish extends YargsCommand {
       return err(result.error);
     }
 
+    // For VS, use appid from `answers['teams-app-id']`, for other cases, use appid from config files in projectPath
+    const properties: { [key: string]: string } = {};
+    if (answers.env) {
+      properties[TelemetryProperty.Env] = getHashedEnv(answers.env);
+    }
+    if (answers[manifestFolderParamName] && answers["teams-app-id"]) {
+      properties[TelemetryProperty.AppId] = answers["teams-app-id"];
+    } else if (answers.projectPath && answers.env) {
+      const appId = getTeamsAppIdByEnv(answers.projectPath, answers.env);
+      if (appId) {
+        properties[TelemetryProperty.AppId] = appId;
+      }
+    }
+
     const core = result.value;
     if (answers[manifestFolderParamName] && answers["teams-app-id"]) {
       answers.platform = Platform.VS;
@@ -61,14 +76,15 @@ export default class Publish extends YargsCommand {
       result = await core.publishApplication(answers);
     }
     if (result.isErr()) {
-      CliTelemetry.sendTelemetryErrorEvent(TelemetryEvent.Publish, result.error);
+      CliTelemetry.sendTelemetryErrorEvent(TelemetryEvent.Publish, result.error, properties);
       return err(result.error);
     }
 
     CliTelemetry.sendTelemetryEvent(TelemetryEvent.Publish, {
       [TelemetryProperty.Success]: TelemetrySuccess.Yes,
-      ...makeEnvProperty(answers.env),
+      ...properties,
     });
+
     return ok(null);
   }
 }

--- a/packages/cli/src/telemetry/cliTelemetry.ts
+++ b/packages/cli/src/telemetry/cliTelemetry.ts
@@ -9,14 +9,23 @@ import {
   TelemetrySuccess,
   TelemetryErrorType,
 } from "./cliTelemetryEvents";
-import { FxError, UserError } from "@microsoft/teamsfx-api";
+import { FxError, Inputs, UserError } from "@microsoft/teamsfx-api";
 import { getHashedEnv } from "@microsoft/teamsfx-core";
-import { getSettingsVersion, getTeamsAppId } from "../utils";
+import { getSettingsVersion, getTeamsAppIdByEnv } from "../utils";
 
-export function makeEnvProperty(
-  env: string | undefined
-): { [TelemetryProperty.Env]: string } | undefined {
-  return env ? { [TelemetryProperty.Env]: getHashedEnv(env) } : undefined;
+export function makeEnvRelatedProperty(
+  projectDir: string,
+  inputs: Inputs
+): { [key: string]: string } {
+  const properties: { [key: string]: string } = {};
+  if (inputs.env) {
+    properties[TelemetryProperty.Env] = getHashedEnv(inputs.env);
+    const appId = getTeamsAppIdByEnv(projectDir, inputs.env);
+    if (appId) {
+      properties[TelemetryProperty.AppId] = appId;
+    }
+  }
+  return properties;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -59,7 +68,6 @@ export class CliTelemetry {
       properties[TelemetryProperty.Component] = TelemetryComponentType;
     }
 
-    properties[TelemetryProperty.AppId] = getTeamsAppId(CliTelemetry.rootFolder);
     const settingsVersion = getSettingsVersion(CliTelemetry.rootFolder);
     if (settingsVersion !== undefined) {
       properties[TelemetryProperty.SettingsVersion] = settingsVersion;
@@ -85,7 +93,6 @@ export class CliTelemetry {
       properties[TelemetryProperty.Component] = TelemetryComponentType;
     }
 
-    properties[TelemetryProperty.AppId] = getTeamsAppId(CliTelemetry.rootFolder);
     const settingsVersion = getSettingsVersion(CliTelemetry.rootFolder);
     if (settingsVersion !== undefined) {
       properties[TelemetryProperty.SettingsVersion] = settingsVersion;
@@ -119,7 +126,6 @@ export class CliTelemetry {
       properties[TelemetryProperty.Component] = TelemetryComponentType;
     }
 
-    properties[TelemetryProperty.AppId] = getTeamsAppId(CliTelemetry.rootFolder);
     const settingsVersion = getSettingsVersion(CliTelemetry.rootFolder);
     if (settingsVersion !== undefined) {
       properties[TelemetryProperty.SettingsVersion] = settingsVersion;

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -40,6 +40,8 @@ import {
   localSettingsFileName,
   FxCore,
   isSPFxProject,
+  PluginNames,
+  isValidProject,
 } from "@microsoft/teamsfx-core";
 import { WorkspaceNotSupported } from "./cmds/preview/errors";
 
@@ -317,21 +319,16 @@ export function isWorkspaceSupported(workspace: string): boolean {
   return true;
 }
 
-// Only used when multi-env is disabled
-export function getTeamsAppId(rootfolder: string | undefined): any {
-  if (!rootfolder) {
+export function getTeamsAppIdByEnv(projectDir: string, env: string): string | undefined {
+  try {
+    if (isWorkspaceSupported(projectDir)) {
+      const result = environmentManager.getEnvStateFilesPath(env, projectDir);
+      const envJson = JSON.parse(fs.readFileSync(result.envState, "utf8"));
+      return envJson[PluginNames.APPST].teamsAppId;
+    }
+  } catch (e) {
     return undefined;
   }
-
-  if (isWorkspaceSupported(rootfolder)) {
-    const result = readEnvJsonFileSync(rootfolder, environmentManager.getDefaultEnvName());
-    if (result.isErr()) {
-      return undefined;
-    }
-    return result.value.solution.remoteTeamsAppId;
-  }
-
-  return undefined;
 }
 
 // Only used for telemetry

--- a/packages/cli/tests/unit/telemetry/cliTelemetry.tests.ts
+++ b/packages/cli/tests/unit/telemetry/cliTelemetry.tests.ts
@@ -43,7 +43,6 @@ describe("Telemetry", function () {
 
   it("sendTelemetryEvent", () => {
     sandbox.stub(UserSettings, "getTelemetrySetting").returns(ok(false));
-    sandbox.stub(Utils, "getTeamsAppId").returns(undefined);
     sandbox
       .stub(CliTelemetryReporter.prototype, "sendTelemetryEvent")
       .callsFake((eventName: string, properties?: any) => {
@@ -61,7 +60,6 @@ describe("Telemetry", function () {
 
     before(() => {
       sandbox.stub(UserSettings, "getTelemetrySetting").returns(ok(false));
-      sandbox.stub(Utils, "getTeamsAppId").returns(undefined);
       sandbox
         .stub(CliTelemetryReporter.prototype, "sendTelemetryErrorEvent")
         .callsFake((eventName: string, properties?: any) => {
@@ -99,7 +97,6 @@ describe("Telemetry", function () {
 
   it("sendTelemetryException", () => {
     sandbox.stub(UserSettings, "getTelemetrySetting").returns(ok(false));
-    sandbox.stub(Utils, "getTeamsAppId").returns(undefined);
     sandbox
       .stub(CliTelemetryReporter.prototype, "sendTelemetryException")
       .callsFake((error: Error, properties?: any) => {


### PR DESCRIPTION
1. for all env related commands, add "appid" telemetry property in the end event. 
2. fix the missing error event in env.ts
3. add related UT

1 is not need before multi-env because telemetry reporter handled this logic. But after multi-env, not all (e.g. the "start" events) events have appid (from the bussiness logic) and the telemetry reporter cannot handle this logic. It will be handled by lifecycle function callers.

This issue has already been fixed in vscode-extension before 3.0 release.

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/12962338/