### PR TITLE
fix(local debug): remove simple auth related local settings when simple auth plugin is not activated

### DIFF
--- a/packages/fx-core/src/common/localSettingsConstants.ts
+++ b/packages/fx-core/src/common/localSettingsConstants.ts
@@ -15,6 +15,9 @@ export const LocalSettingsAuthKeys = Object.freeze({
   OauthAuthority: "oauthAuthority",
   OauthHost: "oauthHost",
   ApplicationIdUris: "applicationIdUris",
+});
+
+export const LocalSettingsSimpleAuthKeys = Object.freeze({
   SimpleAuthFilePath: "simpleAuthFilePath",
   SimpleAuthEnvironmentVariableParams: "SimpleAuthEnvironmentVariableParams",
   SimpleAuthServiceEndpoint: "AuthServiceEndpoint",

--- a/packages/fx-core/src/common/localSettingsProvider.ts
+++ b/packages/fx-core/src/common/localSettingsProvider.ts
@@ -18,6 +18,7 @@ import {
   LocalSettingsFrontendKeys,
   LocalSettingsTeamsAppKeys,
   LocalSettingsEncryptKeys,
+  LocalSettingsSimpleAuthKeys,
 } from "./localSettingsConstants";
 
 export const localSettingsFileName = "localSettings.json";
@@ -33,7 +34,8 @@ export class LocalSettingsProvider {
     includeFrontend: boolean,
     includeBackend: boolean,
     includeBotOrMessageExtension: boolean,
-    migrateFromV1 = false
+    migrateFromV1 = false,
+    includeSimpleAuth = false
   ): LocalSettings {
     // initialize Teams app related config for local debug.
     const teamsAppLocalConfig = new ConfigMap();
@@ -45,7 +47,7 @@ export class LocalSettingsProvider {
     };
 
     if (!migrateFromV1) {
-      localSettings.auth = this.initSimpleAuth();
+      localSettings.auth = this.initAuth(includeSimpleAuth);
     }
 
     // initialize frontend and simple auth local settings.
@@ -70,7 +72,8 @@ export class LocalSettingsProvider {
     includeFrontend: boolean,
     includeBackend: boolean,
     includeBotOrMessageExtension: boolean,
-    migrateFromV1 = false
+    migrateFromV1 = false,
+    includeSimpleAuth = false
   ): Json {
     const localSettings: Json = {
       teamsApp: {
@@ -80,7 +83,7 @@ export class LocalSettingsProvider {
     };
 
     if (!migrateFromV1) {
-      localSettings.auth = this.initSimpleAuth().toJSON();
+      localSettings.auth = this.initAuth(includeSimpleAuth).toJSON();
     }
 
     // initialize frontend and simple auth local settings.
@@ -277,12 +280,19 @@ export class LocalSettingsProvider {
     return localSettingsJson;
   }
 
-  initSimpleAuth(): ConfigMap {
-    // simple auth is only required by frontend
+  initAuth(includeSimpleAuth = false): ConfigMap {
     const authLocalConfig = new ConfigMap();
     const keys = Object.values(LocalSettingsAuthKeys);
     for (const key of keys) {
       authLocalConfig.set(key, "");
+    }
+
+    // If simple auth is activated, add simple auth related configs.
+    if (includeSimpleAuth) {
+      const simpleAuthKeys = Object.values(LocalSettingsSimpleAuthKeys);
+      for (const key of simpleAuthKeys) {
+        authLocalConfig.set(key, "");
+      }
     }
 
     return authLocalConfig;

--- a/packages/fx-core/src/core/middleware/localSettingsLoader.ts
+++ b/packages/fx-core/src/core/middleware/localSettingsLoader.ts
@@ -10,6 +10,7 @@ import { PluginNames } from "../../plugins/solution/fx-solution/constants";
 import { getActivatedResourcePlugins } from "../../plugins/solution/fx-solution/ResourcePluginContainer";
 import { ObjectIsUndefinedError } from "../error";
 import { shouldIgnored } from "./projectSettingsLoader";
+import { IsSimpleAuthEnabled } from "../../common/tools";
 
 export const LocalSettingsLoaderMW: Middleware = async (
   ctx: CoreHookContext,
@@ -39,6 +40,7 @@ export const LocalSettingsLoaderMW: Middleware = async (
     const hasFrontend = selectedPlugins?.some((plugin) => plugin.name === PluginNames.FE);
     const hasBackend = selectedPlugins?.some((plugin) => plugin.name === PluginNames.FUNC);
     const hasBot = selectedPlugins?.some((plugin) => plugin.name === PluginNames.BOT);
+    const hasSimpleAuth = IsSimpleAuthEnabled(ctx.projectSettings);
 
     const localSettingsProvider = new LocalSettingsProvider(inputs.projectPath);
     let exists = await fs.pathExists(localSettingsProvider.localSettingsFilePath);
@@ -53,7 +55,12 @@ export const LocalSettingsLoaderMW: Middleware = async (
     if (exists) {
       ctx.localSettings = await localSettingsProvider.loadV2(ctx.contextV2?.cryptoProvider);
     } else {
-      ctx.localSettings = localSettingsProvider.initV2(hasFrontend, hasBackend, hasBot);
+      ctx.localSettings = localSettingsProvider.initV2(
+        hasFrontend,
+        hasBackend,
+        hasBot,
+        hasSimpleAuth
+      );
     }
     if (ctx.solutionContext) {
       if (exists) {
@@ -64,7 +71,8 @@ export const LocalSettingsLoaderMW: Middleware = async (
         ctx.solutionContext.localSettings = localSettingsProvider.init(
           hasFrontend,
           hasBackend,
-          hasBot
+          hasBot,
+          hasSimpleAuth
         );
       }
     }

--- a/packages/fx-core/src/plugins/resource/simpleauth/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/simpleauth/plugin.ts
@@ -13,7 +13,7 @@ import * as fs from "fs-extra";
 import { getTemplatesFolder } from "../../../folder";
 import { ArmTemplateResult } from "../../../common/armInterface";
 import { isMultiEnvEnabled } from "../../../common";
-import { LocalSettingsAuthKeys } from "../../../common/localSettingsConstants";
+import { LocalSettingsSimpleAuthKeys } from "../../../common/localSettingsConstants";
 import { Bicep, ConstantString } from "../../../common/constants";
 import { getActivatedV2ResourcePlugins } from "../../solution/fx-solution/ResourcePluginContainer";
 import { NamedArmResourcePluginAdaptor } from "../../solution/fx-solution/v2/adaptor";
@@ -27,7 +27,10 @@ export class SimpleAuthPluginImpl {
 
     const simpleAuthFilePath = Utils.getSimpleAuthFilePath();
     if (isMultiEnvEnabled()) {
-      ctx.localSettings?.auth?.set(LocalSettingsAuthKeys.SimpleAuthFilePath, simpleAuthFilePath);
+      ctx.localSettings?.auth?.set(
+        LocalSettingsSimpleAuthKeys.SimpleAuthFilePath,
+        simpleAuthFilePath
+      );
     } else {
       ctx.config.set(Constants.SimpleAuthPlugin.configKeys.filePath, simpleAuthFilePath);
     }
@@ -51,7 +54,7 @@ export class SimpleAuthPluginImpl {
 
     if (isMultiEnvEnabled()) {
       ctx.localSettings?.auth?.set(
-        LocalSettingsAuthKeys.SimpleAuthEnvironmentVariableParams,
+        LocalSettingsSimpleAuthKeys.SimpleAuthEnvironmentVariableParams,
         configArray.join(" ")
       );
     } else {

--- a/packages/fx-core/tests/core/middleware/LocalSettingsLoaderMW.test.ts
+++ b/packages/fx-core/tests/core/middleware/LocalSettingsLoaderMW.test.ts
@@ -165,7 +165,10 @@ describe("Middleware - LocalSettingsLoaderMW, ContextInjectorMW: part 2", () => 
       async other(inputs: Inputs, ctx?: CoreHookContext): Promise<Result<any, FxError>> {
         assert.isTrue(ctx !== undefined);
         if (ctx) {
-          assert.deepEqual(ctx.localSettings, localSettingsProvider.initV2(true, false, false));
+          assert.deepEqual(
+            ctx.localSettings,
+            localSettingsProvider.initV2(true, false, false, true, true)
+          );
         }
         assert.isTrue(ctx?.solutionContext !== undefined);
         assert.isTrue(ctx?.solutionContext?.localSettings !== undefined);

--- a/packages/fx-core/tests/plugins/resource/simpleauth/unit/index.test.ts
+++ b/packages/fx-core/tests/plugins/resource/simpleauth/unit/index.test.ts
@@ -24,7 +24,10 @@ import {
   mockSolutionUpdateArmTemplates,
 } from "../../util";
 import { isMultiEnvEnabled } from "../../../../../src";
-import { LocalSettingsAuthKeys } from "../../../../../src/common/localSettingsConstants";
+import {
+  LocalSettingsAuthKeys,
+  LocalSettingsSimpleAuthKeys,
+} from "../../../../../src/common/localSettingsConstants";
 import { getAllowedAppIds } from "../../../../../src/common/tools";
 import {
   AzureResourceKeyVault,
@@ -71,7 +74,7 @@ describe("simpleAuthPlugin", () => {
     let filePath: string;
     if (isMultiEnvEnabled()) {
       filePath = pluginContext.localSettings?.auth?.get(
-        LocalSettingsAuthKeys.SimpleAuthFilePath
+        LocalSettingsSimpleAuthKeys.SimpleAuthFilePath
       ) as string;
     } else {
       filePath = pluginContext.config.get(Constants.SimpleAuthPlugin.configKeys.filePath) as string;
@@ -84,7 +87,7 @@ describe("simpleAuthPlugin", () => {
     if (isMultiEnvEnabled()) {
       chai.assert.strictEqual(
         pluginContext.localSettings?.auth?.get(
-          LocalSettingsAuthKeys.SimpleAuthEnvironmentVariableParams
+          LocalSettingsSimpleAuthKeys.SimpleAuthEnvironmentVariableParams
         ),
         expectedEnvironmentVariableParams
       );


### PR DESCRIPTION
related bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_queries/edit/13051456/?triage=true