### PR TITLE
fix(collaboration): fix tree view not refresh after provision

### DIFF
--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -706,7 +706,7 @@ function showWarningMessageWithProvisionButton(message: string): void {
     .showWarningMessage(message, StringResources.vsc.handlers.provisionResourcesButton)
     .then((result) => {
       if (result === StringResources.vsc.handlers.provisionResourcesButton) {
-        return runCommand(Stage.provision);
+        return Correlator.run(provisionHandler);
       }
     });
 }


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/13070653

Use `Correlator.run(provisionHandler)` instead of `runCommand(Stage.provision)` directly, which will refresh the tree view after provision