### PR TITLE
chore: prepare custom local tasks

### DIFF
--- a/packages/fx-core/src/common/local/taskDefinition.ts
+++ b/packages/fx-core/src/common/local/taskDefinition.ts
@@ -19,65 +19,6 @@ export interface ITaskDefinition {
   env?: { [key: string]: string };
 }
 
-// This type of task executes npm script of each component.
-export class NpmTaskDefinition {
-  private static command(isWatchTask: boolean): string {
-    return isWatchTask ? "npm run watch:teamsfx" : "npm run dev:teamsfx";
-  }
-
-  private static nameSuffix(isWatchTask: boolean): string {
-    return isWatchTask ? "watch" : "dev";
-  }
-
-  static frontend(workspaceFolder: string, isWatchTask: boolean): ITaskDefinition {
-    return {
-      name: `frontend ${NpmTaskDefinition.nameSuffix(isWatchTask)}`,
-      command: NpmTaskDefinition.command(isWatchTask),
-      cwd: path.join(workspaceFolder, FolderName.Frontend),
-      execOptions: {
-        needShell: true,
-      },
-      isBackground: true,
-    };
-  }
-
-  static backend(
-    workspaceFolder: string,
-    isWatchTask: boolean,
-    funcBinFolders: string[] | undefined
-  ): ITaskDefinition {
-    return {
-      name: `backend ${NpmTaskDefinition.nameSuffix(isWatchTask)}`,
-      command: NpmTaskDefinition.command(isWatchTask),
-      cwd: path.join(workspaceFolder, FolderName.Function),
-      execOptions: {
-        needShell: true,
-      },
-      isBackground: true,
-      env: funcBinFolders
-        ? {
-            // put portable func at the end since func checker prefers global func
-            PATH: `${process.env.PATH ?? ""}${path.delimiter}${funcBinFolders.join(
-              path.delimiter
-            )}`,
-          }
-        : undefined,
-    };
-  }
-
-  static bot(workspaceFolder: string, isWatchTask: boolean): ITaskDefinition {
-    return {
-      name: `bot ${NpmTaskDefinition.nameSuffix(isWatchTask)}`,
-      command: NpmTaskDefinition.command(isWatchTask),
-      cwd: path.join(workspaceFolder, FolderName.Bot),
-      execOptions: {
-        needShell: true,
-      },
-      isBackground: true,
-    };
-  }
-}
-
 export class TaskDefinition {
   static frontendStart(workspaceFolder: string): ITaskDefinition {
     return {

--- a/packages/vscode-extension/src/debug/teamsfxTaskHandler.ts
+++ b/packages/vscode-extension/src/debug/teamsfxTaskHandler.ts
@@ -58,7 +58,6 @@ function isNpmInstallTask(task: vscode.Task): boolean {
 
 function isTeamsfxTask(task: vscode.Task): boolean {
   // teamsfx: xxx start / xxx watch
-  // teamsfx: dev / watch
   if (task) {
     if (
       task.source === ProductName &&
@@ -75,10 +74,15 @@ function isTeamsfxTask(task: vscode.Task): boolean {
       return (
         command !== undefined &&
         (command.trim().toLocaleLowerCase().endsWith("start") ||
-          command.trim().toLocaleLowerCase().endsWith("watch") ||
-          command.trim().toLowerCase() === "dev" ||
-          command.trim().toLowerCase() === "watch")
+          command.trim().toLocaleLowerCase().endsWith("watch"))
       );
+    }
+
+    // dev:teamsfx and watch:teamsfx
+    const commandLine: string | undefined =
+      task.execution && (<vscode.ShellExecution>task.execution).commandLine;
+    if (commandLine !== undefined) {
+      return /(npm|yarn)[\s]+(run )?[\s]*(dev|watch):teamsfx/i.test(commandLine);
     }
   }
 

--- a/packages/vscode-extension/src/debug/teamsfxTaskHandler.ts
+++ b/packages/vscode-extension/src/debug/teamsfxTaskHandler.ts
@@ -79,8 +79,12 @@ function isTeamsfxTask(task: vscode.Task): boolean {
     }
 
     // dev:teamsfx and watch:teamsfx
-    const commandLine: string | undefined =
-      task.execution && (<vscode.ShellExecution>task.execution).commandLine;
+    let commandLine: string | undefined;
+    if (task.execution && <vscode.ShellExecution>task.execution) {
+      const execution = <vscode.ShellExecution>task.execution;
+      commandLine =
+        execution.commandLine || `${execution.command} ${(execution.args || []).join(" ")}`;
+    }
     if (commandLine !== undefined) {
       return /(npm|yarn)[\s]+(run )?[\s]*(dev|watch):teamsfx/i.test(commandLine);
     }

--- a/packages/vscode-extension/src/debug/teamsfxTaskProvider.ts
+++ b/packages/vscode-extension/src/debug/teamsfxTaskProvider.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as path from "path";
 import * as vscode from "vscode";
 
 import * as constants from "./constants";
@@ -15,12 +14,11 @@ import VsCodeLogInstance from "../commonlib/log";
 import { detectVsCodeEnv, showError } from "../handlers";
 import { ExtTelemetry } from "../telemetry/extTelemetry";
 import {
-  NpmTaskDefinition,
-  TaskDefinition,
-  ITaskDefinition,
   DepsType,
+  ITaskDefinition,
+  ProgrammingLanguage,
+  TaskDefinition,
 } from "@microsoft/teamsfx-core";
-import { ProgrammingLanguage } from "@microsoft/teamsfx-core";
 
 export class TeamsfxTaskProvider implements vscode.TaskProvider {
   public static readonly type: string = ProductName;
@@ -103,101 +101,8 @@ export class TeamsfxTaskProvider implements vscode.TaskProvider {
     task: vscode.Task,
     token?: vscode.CancellationToken | undefined
   ): Promise<vscode.Task | undefined> {
-    // Resolve "dev" and "watch" tasks
-    if (vscode.workspace.workspaceFolders) {
-      const workspaceFolder: vscode.WorkspaceFolder = vscode.workspace.workspaceFolders[0];
-      const workspacePath: string = workspaceFolder.uri.fsPath;
-      if (!(await commonUtils.isFxProject(workspacePath))) {
-        VsCodeLogInstance.error(
-          `No ${TeamsfxTaskProvider.type} project. Cannot resolve ${TeamsfxTaskProvider.type} task.`
-        );
-        return undefined;
-      }
-
-      const command: string | undefined = task.definition.command;
-      if (!command || (command?.toLowerCase() !== "dev" && command?.toLowerCase() !== "watch")) {
-        VsCodeLogInstance.error(
-          `Missing or wrong 'command' field in ${TeamsfxTaskProvider.type} task.`
-        );
-
-        return undefined;
-      }
-
-      const component: string | undefined = task.definition.component;
-      if (
-        !component ||
-        (component?.toLowerCase() !== "frontend" &&
-          component?.toLowerCase() !== "backend" &&
-          component?.toLowerCase() !== "bot")
-      ) {
-        VsCodeLogInstance.error(
-          `Missing or wrong 'component' field in ${TeamsfxTaskProvider.type} task.`
-        );
-        return undefined;
-      }
-
-      if (
-        task.scope !== undefined &&
-        task.scope !== vscode.TaskScope.Global &&
-        task.scope !== vscode.TaskScope.Workspace
-      ) {
-        let problemMatcher: string;
-        const isWatchTask = command.toLowerCase() === "watch";
-        let taskDefinition: ITaskDefinition | undefined = undefined;
-        if (component?.toLowerCase() === "frontend") {
-          taskDefinition = NpmTaskDefinition.frontend(workspacePath, isWatchTask);
-          problemMatcher = isWatchTask
-            ? constants.tscWatchProblemMatcher
-            : constants.frontendProblemMatcher;
-        } else if (component?.toLowerCase() === "backend") {
-          problemMatcher = isWatchTask
-            ? constants.tscWatchProblemMatcher
-            : constants.backendProblemMatcher;
-
-          // prepare PATH to execute `func`
-          const depsChecker = new VSCodeDepsChecker(vscodeLogger, vscodeTelemetry);
-          const funcCoreTools = await depsChecker.getDepsStatus(DepsType.FuncCoreTools);
-          // const funcBinFolders = funcCoreTools.details.binFolders;
-          taskDefinition = NpmTaskDefinition.backend(
-            workspacePath,
-            isWatchTask,
-            funcCoreTools.details.binFolders
-          );
-        } else if (component?.toLowerCase() === "bot") {
-          problemMatcher = isWatchTask
-            ? constants.tscWatchProblemMatcher
-            : constants.botProblemMatcher;
-          taskDefinition = NpmTaskDefinition.bot(workspacePath, isWatchTask);
-        } else {
-          VsCodeLogInstance.error(
-            `Missing or wrong 'component' field in ${TeamsfxTaskProvider.type} task.`
-          );
-          return undefined;
-        }
-
-        const resolvedTask = new vscode.Task(
-          task.definition,
-          task.scope,
-          task.name,
-          TeamsfxTaskProvider.type,
-          new vscode.ShellExecution(taskDefinition.command, {
-            cwd: taskDefinition.cwd,
-            env: taskDefinition.env,
-          }),
-          problemMatcher
-        );
-        resolvedTask.isBackground = taskDefinition?.isBackground;
-        return resolvedTask;
-      } else {
-        VsCodeLogInstance.error(`No task scope. Cannot resolve ${TeamsfxTaskProvider.type} task.`);
-        return undefined;
-      }
-    } else {
-      VsCodeLogInstance.error(
-        `No workspace open. Cannot resolve ${TeamsfxTaskProvider.type} task.`
-      );
-      return undefined;
-    }
+    // Return undefined since all tasks are provided and fully resolved
+    return undefined;
   }
 
   private async createFrontendStartTask(

--- a/packages/vscode-extension/test/unit/localdebug/teamsfxTaskProvider.test.ts
+++ b/packages/vscode-extension/test/unit/localdebug/teamsfxTaskProvider.test.ts
@@ -2,34 +2,15 @@
 // Licensed under the MIT license.
 
 import * as chai from "chai";
-import * as sinon from "sinon";
-import * as path from "path";
 import * as vscode from "vscode";
 
-import * as commonUtils from "../../../src/debug/commonUtils";
 import { TeamsfxTaskProvider } from "../../../src/debug/teamsfxTaskProvider";
 
 suite("[debug > teamsfxTaskProvider]", () => {
   const taskProvider = new TeamsfxTaskProvider();
   const testWorkspaceFolder = {} as vscode.WorkspaceFolder;
   suite("resolveTask", () => {
-    test("frontend dev", async () => {
-      sinon.stub(vscode.workspace, "workspaceFolders").value([
-        {
-          uri: vscode.Uri.file("test"),
-          name: "test",
-          index: 0,
-        } as vscode.WorkspaceFolder,
-      ]);
-      sinon.stub(commonUtils, "isFxProject").callsFake(async (folderPath: string) => {
-        return true;
-      });
-      sinon
-        .stub(commonUtils, "getProjectRoot")
-        .callsFake(async (folderPath: string, folderName: string) => {
-          return path.join(folderPath, folderName);
-        });
-
+    test("no task", async () => {
       const inputTask = new vscode.Task(
         {
           type: "teamsfx",
@@ -41,186 +22,7 @@ suite("[debug > teamsfxTaskProvider]", () => {
         "teamsfx"
       );
       const resolvedTask = await taskProvider.resolveTask(inputTask);
-      chai.expect(resolvedTask).not.to.be.undefined;
-      chai.expect(resolvedTask!.name).equals("frontend dev");
-      chai.expect(resolvedTask!.problemMatchers).eql(["$teamsfx-frontend-watch"]);
-      chai.expect(resolvedTask!.isBackground).true;
-
-      sinon.restore();
-    });
-
-    test("backend dev", async () => {
-      sinon.stub(vscode.workspace, "workspaceFolders").value([
-        {
-          uri: vscode.Uri.file("test"),
-          name: "test",
-          index: 0,
-        } as vscode.WorkspaceFolder,
-      ]);
-      sinon.stub(commonUtils, "isFxProject").callsFake(async (folderPath: string) => {
-        return true;
-      });
-      sinon
-        .stub(commonUtils, "getProjectRoot")
-        .callsFake(async (folderPath: string, folderName: string) => {
-          return path.join(folderPath, folderName);
-        });
-
-      const inputTask = new vscode.Task(
-        {
-          type: "teamsfx",
-          command: "dev",
-          component: "backend",
-        },
-        testWorkspaceFolder,
-        "backend dev",
-        "teamsfx"
-      );
-      const resolvedTask = await taskProvider.resolveTask(inputTask);
-      chai.expect(resolvedTask).not.to.be.undefined;
-      chai.expect(resolvedTask!.name).equals("backend dev");
-      chai.expect(resolvedTask!.problemMatchers).eql(["$teamsfx-backend-watch"]);
-      chai.expect(resolvedTask!.isBackground).true;
-
-      sinon.restore();
-    });
-
-    test("bot dev", async () => {
-      sinon.stub(vscode.workspace, "workspaceFolders").value([
-        {
-          uri: vscode.Uri.file("test"),
-          name: "test",
-          index: 0,
-        } as vscode.WorkspaceFolder,
-      ]);
-      sinon.stub(commonUtils, "isFxProject").callsFake(async (folderPath: string) => {
-        return true;
-      });
-      sinon
-        .stub(commonUtils, "getProjectRoot")
-        .callsFake(async (folderPath: string, folderName: string) => {
-          return path.join(folderPath, folderName);
-        });
-
-      const inputTask = new vscode.Task(
-        {
-          type: "teamsfx",
-          command: "dev",
-          component: "bot",
-        },
-        testWorkspaceFolder,
-        "bot dev",
-        "teamsfx"
-      );
-      const resolvedTask = await taskProvider.resolveTask(inputTask);
-      chai.expect(resolvedTask).not.to.be.undefined;
-      chai.expect(resolvedTask!.name).equals("bot dev");
-      chai.expect(resolvedTask!.problemMatchers).eql(["$teamsfx-bot-watch"]);
-      chai.expect(resolvedTask!.isBackground).true;
-
-      sinon.restore();
-    });
-
-    test("bot watch", async () => {
-      sinon.stub(vscode.workspace, "workspaceFolders").value([
-        {
-          uri: vscode.Uri.file("test"),
-          name: "test",
-          index: 0,
-        } as vscode.WorkspaceFolder,
-      ]);
-      sinon.stub(commonUtils, "isFxProject").callsFake(async (folderPath: string) => {
-        return true;
-      });
-      sinon
-        .stub(commonUtils, "getProjectRoot")
-        .callsFake(async (folderPath: string, folderName: string) => {
-          return path.join(folderPath, folderName);
-        });
-
-      const inputTask = new vscode.Task(
-        {
-          type: "teamsfx",
-          command: "watch",
-          component: "bot",
-        },
-        testWorkspaceFolder,
-        "bot watch",
-        "teamsfx"
-      );
-      const resolvedTask = await taskProvider.resolveTask(inputTask);
-      chai.expect(resolvedTask).not.to.be.undefined;
-      chai.expect(resolvedTask!.name).equals("bot watch");
-      chai.expect(resolvedTask!.problemMatchers).eql(["$tsc-watch"]);
-      chai.expect(resolvedTask!.isBackground).true;
-
-      sinon.restore();
-    });
-
-    test("invalid command", async () => {
-      sinon.stub(vscode.workspace, "workspaceFolders").value([
-        {
-          uri: vscode.Uri.file("test"),
-          name: "test",
-          index: 0,
-        } as vscode.WorkspaceFolder,
-      ]);
-      sinon.stub(commonUtils, "isFxProject").callsFake(async (folderPath: string) => {
-        return true;
-      });
-      sinon
-        .stub(commonUtils, "getProjectRoot")
-        .callsFake(async (folderPath: string, folderName: string) => {
-          return path.join(folderPath, folderName);
-        });
-
-      const inputTask = new vscode.Task(
-        {
-          type: "teamsfx",
-          command: "try", // invalid
-          component: "frontend",
-        },
-        testWorkspaceFolder,
-        "frontend try",
-        "teamsfx"
-      );
-      const resolvedTask = await taskProvider.resolveTask(inputTask);
       chai.expect(resolvedTask).to.be.undefined;
-
-      sinon.restore();
-    });
-
-    test("invalid component", async () => {
-      sinon.stub(vscode.workspace, "workspaceFolders").value([
-        {
-          uri: vscode.Uri.file("test"),
-          name: "test",
-          index: 0,
-        } as vscode.WorkspaceFolder,
-      ]);
-      sinon.stub(commonUtils, "isFxProject").callsFake(async (folderPath: string) => {
-        return true;
-      });
-      sinon
-        .stub(commonUtils, "getProjectRoot")
-        .callsFake(async (folderPath: string, folderName: string) => {
-          return path.join(folderPath, folderName);
-        });
-
-      const inputTask = new vscode.Task(
-        {
-          type: "teamsfx",
-          command: "dev",
-          component: "try", // invalid
-        },
-        testWorkspaceFolder,
-        "try dev",
-        "teamsfx"
-      );
-      const resolvedTask = await taskProvider.resolveTask(inputTask);
-      chai.expect(resolvedTask).to.be.undefined;
-
-      sinon.restore();
     });
   });
 });


### PR DESCRIPTION
To be transparent, directly expose `npm run xxx` shell task in tasks.json, so extension only needs to handle such tasks, no need to provide/resolve such tasks.