### PR TITLE
fix(localdebug): fix task handler

### DIFF
--- a/packages/fx-core/src/plugins/solution/fx-solution/debug/util/tasks.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/debug/util/tasks.ts
@@ -221,10 +221,7 @@ function startBot(): Record<string, unknown> {
 function startNgrok(): Record<string, unknown> {
   return {
     label: "start ngrok",
-    type: ProductName,
-    command: "ngrok start",
-    isBackground: true,
-    dependsOn: ["bot npm install"],
+    dependsOn: ["bot npm install", `${ProductName}: ngrok start`],
   };
 }
 

--- a/packages/vscode-extension/src/debug/teamsfxTaskHandler.ts
+++ b/packages/vscode-extension/src/debug/teamsfxTaskHandler.ts
@@ -25,16 +25,7 @@ import { ExtensionSurvey } from "../utils/survey";
 import { TreatmentVariableValue } from "../exp/treatmentVariables";
 import { TeamsfxDebugConfiguration } from "./teamsfxDebugProvider";
 
-interface IRunningTeamsfxTask {
-  source: string;
-  name: string;
-  scope: vscode.WorkspaceFolder | vscode.TaskScope;
-}
-
-const allRunningTeamsfxTasks: Map<IRunningTeamsfxTask, number> = new Map<
-  IRunningTeamsfxTask,
-  number
->();
+const allRunningTeamsfxTasks: Map<string, number> = new Map<string, number>();
 const allRunningDebugSessions: Set<string> = new Set<string>();
 const activeNpmInstallTasks = new Set<string>();
 
@@ -47,6 +38,16 @@ const activeNpmInstallTasks = new Set<string>();
 let taskEndEventEmitter: vscode.EventEmitter<{ id: string; exitCode?: number }>;
 let taskStartEventEmitter: vscode.EventEmitter<string>;
 const trackedTasks = new Set<string>();
+
+function getTaskKey(task: vscode.Task): string {
+  if (task === undefined) {
+    return "";
+  }
+
+  // "source|name|scope"
+  const scope = (task.scope as vscode.WorkspaceFolder)?.uri?.toString() || task.scope?.toString();
+  return `${task.source}|${task.name}|${scope}`;
+}
 
 function isNpmInstallTask(task: vscode.Task): boolean {
   if (task) {
@@ -201,10 +202,7 @@ async function onDidStartTaskProcessHandler(event: vscode.TaskProcessStartEvent)
   if (ext.workspaceUri && isValidProject(ext.workspaceUri.fsPath)) {
     const task = event.execution.task;
     if (task.scope !== undefined && isTeamsfxTask(task)) {
-      allRunningTeamsfxTasks.set(
-        { source: task.source, name: task.name, scope: task.scope },
-        event.processId
-      );
+      allRunningTeamsfxTasks.set(getTaskKey(task), event.processId);
     } else if (isNpmInstallTask(task)) {
       try {
         ExtTelemetry.sendTelemetryEvent(TelemetryEvent.DebugNpmInstallStart, {
@@ -237,7 +235,7 @@ async function onDidEndTaskProcessHandler(event: vscode.TaskProcessEndEvent): Pr
   }
 
   if (task.scope !== undefined && isTeamsfxTask(task)) {
-    allRunningTeamsfxTasks.delete({ source: task.source, name: task.name, scope: task.scope });
+    allRunningTeamsfxTasks.delete(getTaskKey(task));
   } else if (isNpmInstallTask(task)) {
     try {
       activeNpmInstallTasks.delete(task.name);


### PR DESCRIPTION
Two fixes:
1. Update ngrok task to `teamsfx` source. The original one somehow could be recognized as `source: shell` so not correctly killed by task handler.
2. Use string as the key of `allRunningTeamsfxTasks`. The original one `IRunningTeamsfxTask` does not have `===` overload so the map is keeping increasing.