### PR TITLE
chore(local debug): get env for func task

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -628,26 +628,11 @@
       {
         "type": "teamsfx",
         "required": [
-          "command",
-          "component"
+          "command"
         ],
         "properties": {
           "command": {
-            "type": "string",
-            "description": "The command to be executed on a teamsfx component.",
-            "enum": [
-              "dev",
-              "watch"
-            ]
-          },
-          "component": {
-            "type": "string",
-            "description": "The teamsfx component.",
-            "enum": [
-              "frontend",
-              "backend",
-              "bot"
-            ]
+            "type": "string"
           }
         }
       }

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -491,6 +491,11 @@
         "enablement": "never"
       },
       {
+        "command": "fx-extension.append-func-path",
+        "title": "Teams - Append Func Path Environment Variable",
+        "enablement": "never"
+      },
+      {
         "command": "fx-extension.pre-debug-check",
         "title": "Teams - Pre Debug Check",
         "enablement": "never"

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -491,8 +491,8 @@
         "enablement": "never"
       },
       {
-        "command": "fx-extension.append-func-path",
-        "title": "Teams - Append Func Path Environment Variable",
+        "command": "fx-extension.get-func-path",
+        "title": "Teams - Get Func Path for Environment Variable",
         "enablement": "never"
       },
       {

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -146,6 +146,12 @@ export async function activate(context: vscode.ExtensionContext) {
   );
   context.subscriptions.push(validatePrerequisitesCmd);
 
+  // Referenced by tasks.json
+  const appendFuncPathCmd = vscode.commands.registerCommand("fx-extension.append-func-path", () =>
+    Correlator.run(handlers.appendFuncPathHandler)
+  );
+  context.subscriptions.push(appendFuncPathCmd);
+
   // 1.8 pre debug check command (hide from UI)
   const preDebugCheckCmd = vscode.commands.registerCommand("fx-extension.pre-debug-check", () =>
     Correlator.runWithId(getLocalDebugSessionId(), handlers.preDebugCheckHandler)

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -147,10 +147,10 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(validatePrerequisitesCmd);
 
   // Referenced by tasks.json
-  const appendFuncPathCmd = vscode.commands.registerCommand("fx-extension.append-func-path", () =>
-    Correlator.run(handlers.appendFuncPathHandler)
+  const getFuncPathCmd = vscode.commands.registerCommand("fx-extension.get-func-path", () =>
+    Correlator.run(handlers.getFuncPathHandler)
   );
-  context.subscriptions.push(appendFuncPathCmd);
+  context.subscriptions.push(getFuncPathCmd);
 
   // 1.8 pre debug check command (hide from UI)
   const preDebugCheckCmd = vscode.commands.registerCommand("fx-extension.pre-debug-check", () =>

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -927,7 +927,7 @@ export async function backendExtensionsInstallHandler(): Promise<string | undefi
  * Get func binary path to be referenced by task definition.
  * Usage like ${env:PATH}${command:...} so need to include delimiter as well
  */
-export async function appendFuncPathHandler(): Promise<string> {
+export async function getFuncPathHandler(): Promise<string> {
   try {
     const vscodeDepsChecker = new VSCodeDepsChecker(vscodeLogger, vscodeTelemetry);
     const funcStatus = await vscodeDepsChecker.getDepsStatus(DepsType.FuncCoreTools);

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -16,6 +16,7 @@ import {
 import {
   AppPackageFolderName,
   AppStudioTokenProvider,
+  assembleError,
   AzureSolutionSettings,
   BuildFolderName,
   ConcurrentError,
@@ -920,6 +921,24 @@ export async function backendExtensionsInstallHandler(): Promise<string | undefi
       }
     }
   }
+}
+
+/**
+ * Get func binary path to be referenced by task definition.
+ * Usage like ${env:PATH}${command:...} so need to include delimiter as well
+ */
+export async function appendFuncPathHandler(): Promise<string> {
+  try {
+    const vscodeDepsChecker = new VSCodeDepsChecker(vscodeLogger, vscodeTelemetry);
+    const funcStatus = await vscodeDepsChecker.getDepsStatus(DepsType.FuncCoreTools);
+    if (funcStatus?.details?.binFolders !== undefined) {
+      return `${path.delimiter}${funcStatus.details.binFolders.join(path.delimiter)}`;
+    }
+  } catch (error: any) {
+    showError(assembleError(error));
+  }
+
+  return "";
 }
 
 /**


### PR DESCRIPTION
Add a new hidden command `fx-extension.append-func-path` to be used by tasks.json.

``` json
{
  "label": "start",
  "type": "shell",
  "command": "func start",
  "options": {
    "env": {
      "PATH": "${env:PATH}${command:fx-extension.append-func-path}"
    }
  }
}
```