### PR TITLE
fix: ignore format uri

### DIFF
--- a/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
@@ -109,7 +109,7 @@ export class AppStudioPluginImpl {
   private readonly ajv;
 
   constructor() {
-    this.ajv = new Ajv({ strictSchema: false });
+    this.ajv = new Ajv({ formats: { uri: true } });
   }
 
   public async getAppDefinitionAndUpdate(


### PR DESCRIPTION
Manifest schema has an undefined format uri
![image](https://user-images.githubusercontent.com/71362691/151319186-3df50b46-dd40-4558-9407-438e5b49f5cc.png)

Ignore this format to avoid cli errors.
Reference: https://ajv.js.org/packages/ajv-formats.html#options
