### PR TITLE
fix: errorType should not be changed if statusCode = undefined

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,8 +32,8 @@
 /packages/cli/tests/e2e/apim @XiaofuHuang @dooriya @kimizhu
 /packages/cli/tests/e2e/function @eriolchan @hund030 @IvanJobs
 /packages/cli/tests/e2e/frontend @hund030 @eriolchan @IvanJobs
-/packages/cli/tests/e2e/bot @IvanJobs @eriolchan @YitongFeng-git
-/packages/cli/tests/e2e/scaffold @hund030 @eriolchan @YitongFeng-git @IvanJobs
+/packages/cli/tests/e2e/bot @IvanJobs @eriolchan
+/packages/cli/tests/e2e/scaffold @hund030 @eriolchan @IvanJobs
 /packages/cli/tests/e2e/multienv @a1exwang @dooriya @qinezh @xiaolang124 @kimizhu
 /packages/cli/tests/e2e/keyvault @adashen @formulahendry @xzf0587
 /packages/cli/tests/unit/commonlib @kimizhu @swatDong @kuojianlu @a1exwang @qinezh @XiaofuHuang @xiaolang124 @meifans @dooriya
@@ -66,12 +66,12 @@
 /packages/fx-core/src/plugins/resource/spfx @HuihuiWu-Microsoft @nliu-ms @jayzhang
 /packages/fx-core/tests/plugins/resource/spfx @HuihuiWu-Microsoft @nliu-ms @jayzhang
 
-/packages/fx-core/src/plugins/resource/bot @IvanJobs @eriolchan @YitongFeng-git
-/packages/fx-core/tests/plugins/resource/bot @IvanJobs @eriolchan @YitongFeng-git
+/packages/fx-core/src/plugins/resource/bot @IvanJobs @eriolchan 
+/packages/fx-core/tests/plugins/resource/bot @IvanJobs @eriolchan 
 
-/templates/bot @YitongFeng-git @IvanJobs @eriolchan
-/templates/bot-msgext @YitongFeng-git @IvanJobs @eriolchan
-/templates/msgext @YitongFeng-git @IvanJobs @eriolchan
+/templates/bot @IvanJobs @eriolchan
+/templates/bot-msgext @IvanJobs @eriolchan
+/templates/msgext @IvanJobs @eriolchan
 
 /packages/fx-core/src/plugins/resource/frontend @hund030 @eriolchan @IvanJobs
 /packages/fx-core/tests/plugins/resource/frontend @hund030 @eriolchan @IvanJobs

--- a/packages/cli/tests/e2e/bot/CommandExecutionIsUserError.ts
+++ b/packages/cli/tests/e2e/bot/CommandExecutionIsUserError.ts
@@ -5,60 +5,59 @@
  * @author Ivan He <ruhe@microsoft.com>
  */
 
- import path from "path";
- import fs from "fs-extra";
- import * as chai from "chai";
+import path from "path";
+import fs from "fs-extra";
+import * as chai from "chai";
 
- import {
-   getSubscriptionId,
-   getTestFolder,
-   getUniqueAppName,
-   cleanUp,
-   setBotSkuNameToB1Bicep,
- } from "../commonUtils";
- import { environmentManager } from "@microsoft/teamsfx-core";
- import { CliHelper } from "../../commonlib/cliHelper";
- import { Capability, ResourceToDeploy } from "../../commonlib/constants";
+import {
+  getSubscriptionId,
+  getTestFolder,
+  getUniqueAppName,
+  cleanUp,
+  setBotSkuNameToB1Bicep,
+} from "../commonUtils";
+import { environmentManager } from "@microsoft/teamsfx-core";
+import { CliHelper } from "../../commonlib/cliHelper";
+import { Capability, ResourceToDeploy } from "../../commonlib/constants";
 import { ErrorType, PluginError } from "../../../../fx-core/src/plugins/resource/bot/errors";
- 
- describe("Error type should be expected", function () {
-   const testFolder = getTestFolder();
-   const subscription = getSubscriptionId();
-   const appName = getUniqueAppName();
-   const projectPath = path.resolve(testFolder, appName);
-   const env = environmentManager.getDefaultEnvName();
- 
-   after(async () => {
-     await cleanUp(appName, projectPath, true, true, false, true);
-   });
- 
-   it(`CommandExecutionError should be in UserError`, async function () {
-     // Create new bot project
-     await CliHelper.createProjectWithCapability(appName, testFolder, Capability.Bot);
- 
-     // Provision
-     await setBotSkuNameToB1Bicep(projectPath, env);
-     await CliHelper.setSubscription(subscription, projectPath);
-     await CliHelper.provisionProject(projectPath);
- 
-     // Make CommandExecutionError
-     // Make `package.json` invalid, so CommandExecutionError would occur when running `npm install`.
-     const packageJsonPath = path.join(projectPath, "bot", "package.json");
-     if (! await fs.pathExists(packageJsonPath)) {
-        chai.assert.fail(`${packageJsonPath} is not found.`);
-     }
-     await fs.writeFile(packageJsonPath, "any invalid json");
-     // deploy
-     try {
-        await CliHelper.deployProject(ResourceToDeploy.Bot, projectPath);
-     } catch (e) {
-        chai.assert.isTrue(e instanceof PluginError);
-        chai.assert.isTrue(e.ErrorType == ErrorType.User);
-        return ;
-     }
- 
-     // Assert
-     chai.assert.fail("Should not reach here!!!");
-   });
- });
- 
+
+describe("Error type should be expected", function () {
+  const testFolder = getTestFolder();
+  const subscription = getSubscriptionId();
+  const appName = getUniqueAppName();
+  const projectPath = path.resolve(testFolder, appName);
+  const env = environmentManager.getDefaultEnvName();
+
+  after(async () => {
+    await cleanUp(appName, projectPath, true, true, false, true);
+  });
+
+  it(`CommandExecutionError should be in UserError`, async function () {
+    // Create new bot project
+    await CliHelper.createProjectWithCapability(appName, testFolder, Capability.Bot);
+
+    // Provision
+    await setBotSkuNameToB1Bicep(projectPath, env);
+    await CliHelper.setSubscription(subscription, projectPath);
+    await CliHelper.provisionProject(projectPath);
+
+    // Make CommandExecutionError
+    // Make `package.json` invalid, so CommandExecutionError would occur when running `npm install`.
+    const packageJsonPath = path.join(projectPath, "bot", "package.json");
+    if (!(await fs.pathExists(packageJsonPath))) {
+      chai.assert.fail(`${packageJsonPath} is not found.`);
+    }
+    await fs.writeFile(packageJsonPath, "any invalid json");
+    // deploy
+    try {
+      await CliHelper.deployProject(ResourceToDeploy.Bot, projectPath);
+    } catch (e) {
+      chai.assert.isTrue(e instanceof PluginError);
+      chai.assert.isTrue(e.ErrorType == ErrorType.User);
+      return;
+    }
+
+    // Assert
+    chai.assert.fail("Should not reach here!!!");
+  });
+});

--- a/packages/cli/tests/e2e/bot/CommandExecutionIsUserError.ts
+++ b/packages/cli/tests/e2e/bot/CommandExecutionIsUserError.ts
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * @author Ivan He <ruhe@microsoft.com>
+ */
+
+ import path from "path";
+ import fs from "fs-extra";
+ import * as chai from "chai";
+
+ import {
+   getSubscriptionId,
+   getTestFolder,
+   getUniqueAppName,
+   cleanUp,
+   setBotSkuNameToB1Bicep,
+ } from "../commonUtils";
+ import { environmentManager } from "@microsoft/teamsfx-core";
+ import { CliHelper } from "../../commonlib/cliHelper";
+ import { Capability, ResourceToDeploy } from "../../commonlib/constants";
+import { ErrorType, PluginError } from "../../../../fx-core/src/plugins/resource/bot/errors";
+ 
+ describe("Error type should be expected", function () {
+   const testFolder = getTestFolder();
+   const subscription = getSubscriptionId();
+   const appName = getUniqueAppName();
+   const projectPath = path.resolve(testFolder, appName);
+   const env = environmentManager.getDefaultEnvName();
+ 
+   after(async () => {
+     await cleanUp(appName, projectPath, true, true, false, true);
+   });
+ 
+   it(`CommandExecutionError should be in UserError`, async function () {
+     // Create new bot project
+     await CliHelper.createProjectWithCapability(appName, testFolder, Capability.Bot);
+ 
+     // Provision
+     await setBotSkuNameToB1Bicep(projectPath, env);
+     await CliHelper.setSubscription(subscription, projectPath);
+     await CliHelper.provisionProject(projectPath);
+ 
+     // Make CommandExecutionError
+     // Make `package.json` invalid, so CommandExecutionError would occur when running `npm install`.
+     const packageJsonPath = path.join(projectPath, "bot", "package.json");
+     if (! await fs.pathExists(packageJsonPath)) {
+        chai.assert.fail(`${packageJsonPath} is not found.`);
+     }
+     await fs.writeFile(packageJsonPath, "any invalid json");
+     // deploy
+     try {
+        await CliHelper.deployProject(ResourceToDeploy.Bot, projectPath);
+     } catch (e) {
+        chai.assert.isTrue(e instanceof PluginError);
+        chai.assert.isTrue(e.ErrorType == ErrorType.User);
+        return ;
+     }
+ 
+     // Assert
+     chai.assert.fail("Should not reach here!!!");
+   });
+ });
+ 

--- a/packages/fx-core/src/plugins/resource/bot/errors.ts
+++ b/packages/fx-core/src/plugins/resource/bot/errors.ts
@@ -57,7 +57,7 @@ export class PluginError extends Error {
     if (helpLink) this.helpLink = helpLink;
 
     const statusCode = this.innerError.response?.status;
-    if (!statusCode) return ;
+    if (!statusCode) return;
     if (
       statusCode >= Constants.statusCodeUserError &&
       statusCode < Constants.statusCodeServerError

--- a/packages/fx-core/src/plugins/resource/bot/errors.ts
+++ b/packages/fx-core/src/plugins/resource/bot/errors.ts
@@ -57,8 +57,8 @@ export class PluginError extends Error {
     if (helpLink) this.helpLink = helpLink;
 
     const statusCode = this.innerError.response?.status;
+    if (!statusCode) return ;
     if (
-      statusCode &&
       statusCode >= Constants.statusCodeUserError &&
       statusCode < Constants.statusCodeServerError
     ) {

--- a/packages/fx-core/src/plugins/resource/bot/errors.ts
+++ b/packages/fx-core/src/plugins/resource/bot/errors.ts
@@ -18,10 +18,12 @@ function resolveInnerError(target: PluginError, helpLinkMap: Map<string, string>
   if (!target.innerError) return;
 
   const statusCode = target.innerError.response?.status;
-  if (statusCode && statusCode >= Constants.statusCodeUserError && statusCode < Constants.statusCodeServerError) {
-    target.errorType = ErrorType.User;
-  } else {
-    target.errorType = ErrorType.System;
+  if (statusCode) {
+    if (statusCode >= Constants.statusCodeUserError && statusCode < Constants.statusCodeServerError) {
+      target.errorType = ErrorType.User;
+    } else {
+      target.errorType = ErrorType.System;
+    }
   }
 
   const errorCode = target.innerError.response?.data?.error?.code;

--- a/packages/fx-core/src/plugins/resource/bot/errors.ts
+++ b/packages/fx-core/src/plugins/resource/bot/errors.ts
@@ -23,10 +23,7 @@ function InferInnerError(target: PluginError, helpLinkMap: Map<string, string>):
 
   const statusCode = target.innerError.response?.status;
   if (!statusCode) return;
-  if (
-    statusCode >= Constants.statusCodeUserError &&
-    statusCode < Constants.statusCodeServerError
-  ) {
+  if (statusCode >= Constants.statusCodeUserError && statusCode < Constants.statusCodeServerError) {
     target.errorType = ErrorType.User;
   } else {
     target.errorType = ErrorType.System;

--- a/packages/fx-core/src/plugins/resource/bot/errors.ts
+++ b/packages/fx-core/src/plugins/resource/bot/errors.ts
@@ -14,10 +14,12 @@ export enum ErrorType {
   System,
 }
 
-function InferInnerError(target: PluginError, helpLinkMap: Map<string, string>): void {
+function resolveInnerError(target: PluginError, helpLinkMap: Map<string, string>): void {
   if (!target.innerError) return;
 
   const errorCode = target.innerError.response?.data?.error?.code;
+  if (!errorCode) return;
+
   const helpLink = helpLinkMap.get(errorCode);
   if (helpLink) target.helpLink = helpLink;
 
@@ -108,14 +110,14 @@ export class AADAppCheckingError extends PluginError {
 export class CreateAADAppError extends PluginError {
   constructor(innerError?: any) {
     super(ErrorType.User, CreateAppError.name, CreateAppError.message(), [], innerError);
-    InferInnerError(this, GraphErrorCodes);
+    resolveInnerError(this, GraphErrorCodes);
   }
 }
 
 export class CreateAADSecretError extends PluginError {
   constructor(innerError?: any) {
     super(ErrorType.User, CreateSecretError.name, CreateSecretError.message(), [], innerError);
-    InferInnerError(this, GraphErrorCodes);
+    resolveInnerError(this, GraphErrorCodes);
   }
 }
 

--- a/packages/fx-core/src/plugins/resource/bot/errors.ts
+++ b/packages/fx-core/src/plugins/resource/bot/errors.ts
@@ -17,18 +17,17 @@ export enum ErrorType {
 function resolveInnerError(target: PluginError, helpLinkMap: Map<string, string>): void {
   if (!target.innerError) return;
 
-  const errorCode = target.innerError.response?.data?.error?.code;
-  if (!errorCode) return;
-
-  const helpLink = helpLinkMap.get(errorCode);
-  if (helpLink) target.helpLink = helpLink;
-
   const statusCode = target.innerError.response?.status;
-  if (!statusCode) return;
-  if (statusCode >= Constants.statusCodeUserError && statusCode < Constants.statusCodeServerError) {
+  if (statusCode && statusCode >= Constants.statusCodeUserError && statusCode < Constants.statusCodeServerError) {
     target.errorType = ErrorType.User;
   } else {
     target.errorType = ErrorType.System;
+  }
+
+  const errorCode = target.innerError.response?.data?.error?.code;
+  if (errorCode) {
+    const helpLink = helpLinkMap.get(errorCode);
+    if (helpLink) target.helpLink = helpLink;
   }
 }
 

--- a/packages/fx-core/src/plugins/resource/bot/errors.ts
+++ b/packages/fx-core/src/plugins/resource/bot/errors.ts
@@ -19,7 +19,7 @@ function resolveInnerError(target: PluginError, helpLinkMap: Map<string, string>
 
   const statusCode = target.innerError.response?.status;
   if (statusCode) {
-    if (statusCode >= Constants.statusCodeUserError && statusCode < Constants.statusCodeServerError) {
+    if (statusCode >= 400 && statusCode < 500) {
       target.errorType = ErrorType.User;
     } else {
       target.errorType = ErrorType.System;

--- a/packages/fx-core/tests/plugins/resource/bot/unit/errors.test.ts
+++ b/packages/fx-core/tests/plugins/resource/bot/unit/errors.test.ts
@@ -79,12 +79,12 @@ describe("Test Errors", () => {
           status: 500,
           data: {
             error: {
-              code: "SomeCode"
-            }
-          }
-        }
+              code: "SomeCode",
+            },
+          },
+        },
       });
-      
+
       // Assert
       chai.assert.isTrue(myError instanceof PluginError);
       chai.assert.isTrue(myError.errorType == ErrorType.System);
@@ -109,12 +109,12 @@ describe("Test Errors", () => {
           status: 500,
           data: {
             error: {
-              code: "SomeCode"
-            }
-          }
-        }
+              code: "SomeCode",
+            },
+          },
+        },
       });
-      
+
       // Assert
       chai.assert.isTrue(myError instanceof PluginError);
       chai.assert.isTrue(myError.errorType == ErrorType.System);

--- a/packages/fx-core/tests/plugins/resource/bot/unit/errors.test.ts
+++ b/packages/fx-core/tests/plugins/resource/bot/unit/errors.test.ts
@@ -87,7 +87,7 @@ describe("Test Errors", () => {
       
       // Assert
       chai.assert.isTrue(myError instanceof PluginError);
-      chai.assert.isTrue(myError.errorType = ErrorType.System);
+      chai.assert.isTrue(myError.errorType == ErrorType.System);
     });
   });
 
@@ -117,7 +117,7 @@ describe("Test Errors", () => {
       
       // Assert
       chai.assert.isTrue(myError instanceof PluginError);
-      chai.assert.isTrue(myError.errorType = ErrorType.System);
+      chai.assert.isTrue(myError.errorType == ErrorType.System);
     });
   });
 

--- a/packages/fx-core/tests/plugins/resource/bot/unit/errors.test.ts
+++ b/packages/fx-core/tests/plugins/resource/bot/unit/errors.test.ts
@@ -70,6 +70,25 @@ describe("Test Errors", () => {
       // Assert
       chai.assert.isTrue(myError instanceof PluginError);
     });
+
+    it("[InferInnerError] expect errorType change to SystemError", () => {
+      // Arrange
+      // Act
+      const myError = new CreateAADAppError({
+        response: {
+          status: 500,
+          data: {
+            error: {
+              code: "SomeCode"
+            }
+          }
+        }
+      });
+      
+      // Assert
+      chai.assert.isTrue(myError instanceof PluginError);
+      chai.assert.isTrue(myError.errorType = ErrorType.System);
+    });
   });
 
   describe("CreateAADSecretError", () => {
@@ -80,6 +99,25 @@ describe("Test Errors", () => {
 
       // Assert
       chai.assert.isTrue(myError instanceof PluginError);
+    });
+
+    it("[InferInnerError] expect errorType change to SystemError", () => {
+      // Arrange
+      // Act
+      const myError = new CreateAADSecretError({
+        response: {
+          status: 500,
+          data: {
+            error: {
+              code: "SomeCode"
+            }
+          }
+        }
+      });
+      
+      // Assert
+      chai.assert.isTrue(myError instanceof PluginError);
+      chai.assert.isTrue(myError.errorType = ErrorType.System);
     });
   });
 

--- a/packages/fx-core/tests/plugins/resource/bot/unit/errors.test.ts
+++ b/packages/fx-core/tests/plugins/resource/bot/unit/errors.test.ts
@@ -71,7 +71,7 @@ describe("Test Errors", () => {
       chai.assert.isTrue(myError instanceof PluginError);
     });
 
-    it("[InferInnerError] expect errorType change to SystemError", () => {
+    it("[InferInnerError] expect errorType changes to SystemError", () => {
       // Arrange
       // Act
       const myError = new CreateAADAppError({
@@ -101,7 +101,7 @@ describe("Test Errors", () => {
       chai.assert.isTrue(myError instanceof PluginError);
     });
 
-    it("[InferInnerError] expect errorType change to SystemError", () => {
+    it("[InferInnerError] expect errorType changes to SystemError", () => {
       // Arrange
       // Act
       const myError = new CreateAADSecretError({


### PR DESCRIPTION
to finish: https://dev.azure.com/msazure/Microsoft%20Teams%20Extensibility/_workitems/edit/13026392

errorType shouldn't be changed if statusCode = undefined, instead, respect the original errorType.

+ update code owners also.
1. Refactor inferInnerError as a external function.
2. Infer Graph Error in CreateAADError and CreateAADSecretError by need.
3. Add UT and E2E cases.

E2E TEST: https://github.com/OfficeDev/TeamsFx/blob/b9b0d58ec78d29044008cd64b49cb6c2406b9ba5/packages/cli/tests/e2e/bot/CommandExecutionIsUserError.ts#L35