### PR TITLE
perf(aad): update AAD activate logic to allow Tab without AAD

### DIFF
--- a/packages/fx-core/src/plugins/resource/aad/constants.ts
+++ b/packages/fx-core/src/plugins/resource/aad/constants.ts
@@ -85,8 +85,6 @@ export class Plugins {
   static localDebug = "fx-resource-local-debug";
   static solution = "solution";
   static auth = "auth";
-  static apim = "apim";
-  static function = "function";
 }
 
 export class ConfigKeys {

--- a/packages/fx-core/src/plugins/resource/aad/constants.ts
+++ b/packages/fx-core/src/plugins/resource/aad/constants.ts
@@ -85,6 +85,8 @@ export class Plugins {
   static localDebug = "fx-resource-local-debug";
   static solution = "solution";
   static auth = "auth";
+  static apim = "apim";
+  static function = "function";
 }
 
 export class ConfigKeys {

--- a/packages/fx-core/src/plugins/resource/aad/index.ts
+++ b/packages/fx-core/src/plugins/resource/aad/index.ts
@@ -35,7 +35,13 @@ export class AadAppForTeamsPlugin implements Plugin {
     if (solutionSettings?.migrateFromV1) {
       return false;
     }
-    return solutionSettings.hostType === HostTypeOptionAzure.id;
+    return (
+      solutionSettings.hostType === HostTypeOptionAzure.id &&
+      (solutionSettings.activeResourcePlugins == undefined ||
+        solutionSettings.activeResourcePlugins.includes(Plugins.pluginNameComplex) ||
+        solutionSettings.azureResources.includes(Plugins.function) ||
+        solutionSettings.azureResources.includes(Plugins.apim))
+    );
   }
 
   public pluginImpl: AadAppForTeamsImpl = new AadAppForTeamsImpl();

--- a/packages/fx-core/src/plugins/resource/aad/index.ts
+++ b/packages/fx-core/src/plugins/resource/aad/index.ts
@@ -38,11 +38,11 @@ export class AadAppForTeamsPlugin implements Plugin {
     return (
       solutionSettings.hostType === HostTypeOptionAzure.id &&
       // For scaffold, activeResourecPlugins is undefined
-      (solutionSettings.activeResourcePlugins == undefined ||
-        solutionSettings.activeResourcePlugins.includes(Plugins.pluginNameComplex) ||
+      (!solutionSettings.activeResourcePlugins ||
+        solutionSettings.activeResourcePlugins?.includes(Plugins.pluginNameComplex) ||
         // When adding function and apim as azure resources, AAD should be activated.
-        solutionSettings.azureResources.includes(Plugins.function) ||
-        solutionSettings.azureResources.includes(Plugins.apim))
+        solutionSettings.azureResources?.includes(Plugins.function) ||
+        solutionSettings.azureResources?.includes(Plugins.apim))
     );
   }
 

--- a/packages/fx-core/src/plugins/resource/aad/index.ts
+++ b/packages/fx-core/src/plugins/resource/aad/index.ts
@@ -39,10 +39,7 @@ export class AadAppForTeamsPlugin implements Plugin {
       solutionSettings.hostType === HostTypeOptionAzure.id &&
       // For scaffold, activeResourecPlugins is undefined
       (!solutionSettings.activeResourcePlugins ||
-        solutionSettings.activeResourcePlugins?.includes(Plugins.pluginNameComplex) ||
-        // When adding function and apim as azure resources, AAD should be activated.
-        solutionSettings.azureResources?.includes(Plugins.function) ||
-        solutionSettings.azureResources?.includes(Plugins.apim))
+        solutionSettings.activeResourcePlugins?.includes(Plugins.pluginNameComplex))
     );
   }
 

--- a/packages/fx-core/src/plugins/resource/aad/index.ts
+++ b/packages/fx-core/src/plugins/resource/aad/index.ts
@@ -37,8 +37,10 @@ export class AadAppForTeamsPlugin implements Plugin {
     }
     return (
       solutionSettings.hostType === HostTypeOptionAzure.id &&
+      // For scaffold, activeResourecPlugins is undefined
       (solutionSettings.activeResourcePlugins == undefined ||
         solutionSettings.activeResourcePlugins.includes(Plugins.pluginNameComplex) ||
+        // When adding function and apim as azure resources, AAD should be activated.
         solutionSettings.azureResources.includes(Plugins.function) ||
         solutionSettings.azureResources.includes(Plugins.apim))
     );

--- a/packages/fx-core/tests/plugins/solution/solution.grantPermission.test.ts
+++ b/packages/fx-core/tests/plugins/solution/solution.grantPermission.test.ts
@@ -22,7 +22,10 @@ import {
   SolutionError,
   SOLUTION_PROVISION_SUCCEEDED,
 } from "../../../src/plugins/solution/fx-solution/constants";
-import { HostTypeOptionAzure } from "../../../src/plugins/solution/fx-solution/question";
+import {
+  HostTypeOptionAzure,
+  HostTypeOptionSPFx,
+} from "../../../src/plugins/solution/fx-solution/question";
 import * as uuid from "uuid";
 import sinon from "sinon";
 import { EnvConfig, MockGraphTokenProvider } from "../resource/apim/testUtil";
@@ -389,7 +392,7 @@ describe("grantPermission() for Teamsfx projects", () => {
       appName: "my app",
       projectId: uuid.v4(),
       solutionSettings: {
-        hostType: HostTypeOptionAzure.id,
+        hostType: HostTypeOptionSPFx.id,
         name: "azure",
         version: "1.0",
         activeResourcePlugins: [
@@ -453,6 +456,6 @@ describe("grantPermission() for Teamsfx projects", () => {
     if (result.isErr()) {
       chai.assert.fail("result is error");
     }
-    expect(result.value.permissions!.length).equal(2);
+    expect(result.value.permissions!.length).equal(1);
   });
 });


### PR DESCRIPTION
Now provision and deploy works with some changes to the tempalte:
1. remove aad from active plugins
2. remove webApplicationInfo in teams app manifest.
TODO：add aad plugin when adding function/apim in solution