### PR TITLE
perf(solution): update solution to separate AAD

### DIFF
--- a/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
@@ -1651,6 +1651,9 @@ export class TeamsAppSolution implements Solution {
     const pluginsToDoArm: LoadedPlugin[] = [];
     const azureResource = Array.from(settings.azureResources || []);
     if (addFunc || ((addSQL || addApim) && !alreadyHaveFunction)) {
+      if (!settings.activeResourcePlugins?.includes(PluginNames.AAD)) {
+        settings.activeResourcePlugins.push(PluginNames.AAD);
+      }
       pluginsToScaffold.push(functionPlugin);
       if (!azureResource.includes(AzureResourceFunction.id)) {
         azureResource.push(AzureResourceFunction.id);

--- a/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
@@ -1651,9 +1651,6 @@ export class TeamsAppSolution implements Solution {
     const pluginsToDoArm: LoadedPlugin[] = [];
     const azureResource = Array.from(settings.azureResources || []);
     if (addFunc || ((addSQL || addApim) && !alreadyHaveFunction)) {
-      if (!settings.activeResourcePlugins?.includes(PluginNames.AAD)) {
-        settings.activeResourcePlugins.push(PluginNames.AAD);
-      }
       pluginsToScaffold.push(functionPlugin);
       if (!azureResource.includes(AzureResourceFunction.id)) {
         azureResource.push(AzureResourceFunction.id);

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/executeUserTask.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/executeUserTask.ts
@@ -58,6 +58,7 @@ import { AppStudioPluginV3 } from "../../../resource/appstudio/v3";
 import { BuiltInResourcePluginNames } from "../v3/constants";
 import { isVSProject, OperationNotSupportedForExistingAppError } from "../../../../core";
 import { TeamsAppSolutionNameV2 } from "./constants";
+import { PluginNames } from "../constants";
 export async function executeUserTask(
   ctx: v2.Context,
   inputs: Inputs,
@@ -535,6 +536,11 @@ export async function addResource(
   let scaffoldApim = false;
   // 4. check Function
   if (addFunc) {
+    // AAD plugin needs to be activated when adding function.
+    // Since APIM also have dependency on Function, will only add depenedency here.
+    if (!solutionSettings.activeResourcePlugins?.includes(PluginNames.AAD)) {
+      solutionSettings.activeResourcePlugins?.push(PluginNames.AAD);
+    }
     const functionPlugin = Container.get<v2.ResourcePlugin>(ResourcePluginsV2.FunctionPlugin);
     pluginsToScaffold.push(functionPlugin);
     if (!alreadyHaveFunction) {

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/provisionLocal.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/provisionLocal.ts
@@ -110,16 +110,6 @@ export async function provisionLocalResource(
       if (result.isErr()) {
         return new v2.FxPartialSuccess(localSettings, result.error);
       }
-    } else {
-      if (!ctx.projectSetting.solutionSettings!.migrateFromV1) {
-        return new v2.FxFailure(
-          returnSystemError(
-            new Error("AAD plugin not selected or executeUserTask is undefined"),
-            SolutionSource,
-            SolutionError.InternelError
-          )
-        );
-      }
     }
   }
 


### PR DESCRIPTION
1. remove error when local debug does not contain AAD plugin
2. add aad plugin if not exists in active plugins when adding function

TODO: hardcoded aad plugin is not removed in registerTeamsAppAndAad since it is not used now.