### PR TITLE
feat(env-config): add empty variables to env config for existing app

### DIFF
--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -510,6 +510,26 @@ export interface ErrorOptionBase {
 }
 
 // @public (undocumented)
+export interface ExistingAppConfig {
+    // (undocumented)
+    isCreatedFromExistingApp: boolean;
+    // (undocumented)
+    newAppTypes: ExistingTeamsAppType[];
+}
+
+// @public (undocumented)
+export enum ExistingTeamsAppType {
+    // (undocumented)
+    Bot = 2,
+    // (undocumented)
+    ConfigurableTab = 1,
+    // (undocumented)
+    MessageExtension = 3,
+    // (undocumented)
+    StaticTab = 0
+}
+
+// @public (undocumented)
 export interface ExpServiceProvider {
     // (undocumented)
     getTreatmentVariableAsync<T extends boolean | number | string>(configId: string, name: string, checkCache?: boolean): Promise<T | undefined>;
@@ -790,6 +810,8 @@ export interface InputResult<T> {
 export interface Inputs extends Json {
     // (undocumented)
     env?: string;
+    // (undocumented)
+    existingAppConfig?: ExistingAppConfig;
     // (undocumented)
     existingResources?: string[];
     // (undocumented)

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -231,6 +231,20 @@ export interface Inputs extends Json {
   env?: string;
   projectId?: string;
   existingResources?: string[];
+  existingAppConfig?: ExistingAppConfig;
+}
+
+// configs for existing app building
+export interface ExistingAppConfig {
+  isCreatedFromExistingApp: boolean;
+  newAppTypes: ExistingTeamsAppType[];
+}
+
+export enum ExistingTeamsAppType {
+  StaticTab, // scopes: personal tab
+  ConfigurableTab, // scopes: team/group chat
+  Bot,
+  MessageExtension,
 }
 
 export interface ProjectConfig {

--- a/packages/fx-core/src/common/constants.ts
+++ b/packages/fx-core/src/common/constants.ts
@@ -60,3 +60,13 @@ export class FeatureFlagName {
   static readonly rootDirectory = "TEAMSFX_ROOT_DIRECTORY";
   static readonly VSCallingCLI = "VS_CALLING_CLI";
 }
+
+export class ManifestVariables {
+  static readonly DeveloperWebsiteUrl = "developerWebsiteUrl";
+  static readonly DeveloperPrivacyUrl = "developerPrivacyUrl";
+  static readonly DeveloperTermsOfUseUrl = "developerTermsOfUseUrl";
+  static readonly TabContentUrl = "tabContentUrl";
+  static readonly TabWebsiteUrl = "tabWebsiteUrl";
+  static readonly TabConfigurationUrl = "tabConfigurationUrl";
+  static readonly BotId = "botId";
+}


### PR DESCRIPTION
For existing app, add some pre-defined variables to the default env config during scaffolding. Here's an example of config.dev.json while creating tab app from an existing app:

```json
{
    "$schema": "https://aka.ms/teamsfx-env-config-schema",
    "description": "You can customize the TeamsFx config for different environments. Visit https://aka.ms/teamsfx-env-config to learn more about this.",
    "manifest": {
        "appName": {
            "short": "myapp",
            "full": "Full name for my app"
        },
        "developerWebsiteUrl": "",
        "developerPrivacyUrl": "",
        "developerTermsOfUseUrl": "",
        "tabContentUrl": "",
        "tabWebsiteUrl": ""
    }
}
```