### PR TITLE
feat(local debug): add dev:teamsfx script to new projects

### DIFF
--- a/templates/bot/js/default/package.json
+++ b/templates/bot/js/default/package.json
@@ -9,6 +9,8 @@
   "license": "MIT",
   "main": "index.js",
   "scripts": {
+    "dev:teamsfx": "env-cmd --silent -f .env.teamsfx.local npm run dev",
+    "dev": "nodemon --inspect=9239 --signal SIGINT ./index.js",
     "start": "node ./index.js",
     "watch": "nodemon ./index.js"
   },
@@ -20,6 +22,7 @@
     "restify": "~8.5.1"
   },
   "devDependencies": {
+    "env-cmd": "^10.1.0",
     "nodemon": "^2.0.7"
   }
 }

--- a/templates/bot/ts/default/package.json
+++ b/templates/bot/ts/default/package.json
@@ -6,6 +6,8 @@
   "license": "MIT",
   "main": "./lib/index.js",
   "scripts": {
+    "dev:teamsfx": "env-cmd --silent -f .env.teamsfx.local npm run dev",
+    "dev": "nodemon --exec node --inspect=9239 --signal SIGINT -r ts-node/register ./index.ts",
     "build": "tsc --build && shx cp -r ./adaptiveCards ./lib/",
     "start": "node ./lib/index.js",
     "test": "echo \"Error: no test specified\" && exit 1",
@@ -24,6 +26,7 @@
   },
   "devDependencies": {
     "@types/restify": "8.4.2",
+    "env-cmd": "^10.1.0",
     "ts-node": "~9.1.1",
     "typescript": "~3.9.2",
     "nodemon": "^2.0.7",

--- a/templates/function-base/js/default/package.json
+++ b/templates/function-base/js/default/package.json
@@ -2,10 +2,15 @@
     "name": "teamsfx-template-api",
     "version": "1.0.0",
     "scripts": {
+        "dev:teamsfx": "env-cmd --silent -f .env.teamsfx.local npm run dev",
+        "dev": "func start --javascript --language-worker=\"--inspect=9229\" --port \"7071\" --cors \"*\"",
         "start": "npx func start"
     },
     "dependencies": {
         "@microsoft/teamsfx": "^0.4.0",
         "isomorphic-fetch": "^3.0.0"
+    },
+    "devDependencies": {
+        "env-cmd": "^10.1.0"
     }
 }

--- a/templates/function-base/ts/default/package.json
+++ b/templates/function-base/ts/default/package.json
@@ -2,6 +2,9 @@
     "name": "teamsfx-template-api",
     "version": "1.0.0",
     "scripts": {
+        "dev:teamsfx": "env-cmd --silent -f .env.teamsfx.local npm run dev",
+        "dev": "func start --typescript --language-worker=\"--inspect=9229\" --port \"7071\" --cors \"*\"",
+        "watch:teamsfx": "tsc --watch",
         "build": "tsc",
         "watch": "tsc -w",
         "prestart": "npm run build",
@@ -14,6 +17,7 @@
         "isomorphic-fetch": "^3.0.0"
     },
     "devDependencies": {
+        "env-cmd": "^10.1.0",
         "typescript": "^3.3.3"
     }
 }

--- a/templates/msgext/js/default/package.json
+++ b/templates/msgext/js/default/package.json
@@ -9,6 +9,8 @@
   "license": "MIT",
   "main": "index.js",
   "scripts": {
+    "dev:teamsfx": "env-cmd --silent -f .env.teamsfx.local npm run dev",
+    "dev": "nodemon --inspect=9239 --signal SIGINT ./index.js",
     "start": "node ./index.js",
     "watch": "nodemon ./index.js"
   },
@@ -19,6 +21,7 @@
     "html-entities": "^1.3.1"
   },
   "devDependencies": {
+    "env-cmd": "^10.1.0",
     "nodemon": "^2.0.7"
   }
 }

--- a/templates/msgext/ts/default/package.json
+++ b/templates/msgext/ts/default/package.json
@@ -6,6 +6,8 @@
   "license": "MIT",
   "main": "./lib/index.js",
   "scripts": {
+    "dev:teamsfx": "env-cmd --silent -f .env.teamsfx.local npm run dev",
+    "dev": "nodemon --exec node --inspect=9239 --signal SIGINT -r ts-node/register ./index.ts",
     "build": "tsc --build",
     "start": "node ./lib/index.js",
     "test": "echo \"Error: no test specified\" && exit 1",
@@ -23,6 +25,7 @@
   },
   "devDependencies": {
     "@types/restify": "8.4.2",
+    "env-cmd": "^10.1.0",
     "typescript": "~3.9.2",
     "nodemon": "^2.0.7",
     "ts-node": "~9.1.1"

--- a/templates/tab/js/default/package.json
+++ b/templates/tab/js/default/package.json
@@ -18,6 +18,7 @@
     "env-cmd": "^10.1.0"
   },
   "scripts": {
+    "dev:teamsfx": "env-cmd --silent -f .env.teamsfx.local npm run start",
     "start": "react-scripts start",
     "build": "react-scripts build",
     "build:teamsfx": "cross-env-shell \"env-cmd -f .env.teamsfx.${TEAMS_FX_ENV} npm run build\"",

--- a/templates/tab/ts/default/package.json
+++ b/templates/tab/ts/default/package.json
@@ -24,6 +24,7 @@
     "typescript": "^4.1.2"
   },
   "scripts": {
+    "dev:teamsfx": "env-cmd --silent -f .env.teamsfx.local npm run start",
     "start": "react-scripts start",
     "build": "react-scripts build",
     "build:teamsfx": "cross-env-shell \"env-cmd -f .env.teamsfx.${TEAMS_FX_ENV} npm run build\"",


### PR DESCRIPTION
The new `dev:teamsfx` script will be used by F5 to launch local services. Adjust templates to prepare those scripts.