### PR TITLE
chore(localdebug): add log when trust local cert skipped or failed

### DIFF
--- a/packages/fx-core/src/common/local/localCertificateManager.ts
+++ b/packages/fx-core/src/common/local/localCertificateManager.ts
@@ -3,13 +3,21 @@
 "use strict";
 
 import * as fs from "fs-extra";
-import { ConfigFolderName, LogProvider, UserInteraction } from "@microsoft/teamsfx-api";
+import {
+  ConfigFolderName,
+  LogProvider,
+  UserInteraction,
+  FxError,
+  returnUserError,
+  UserCancelError,
+} from "@microsoft/teamsfx-api";
 import { asn1, md, pki } from "node-forge";
 import * as os from "os";
 import { v4 as uuidv4 } from "uuid";
 
 import { LocalDebugCertificate } from "./constants";
 import * as ps from "./process";
+import { CoreSource } from "../../core/error";
 
 const installText = "Install";
 const learnMoreText = "Learn More";
@@ -27,6 +35,7 @@ export interface LocalCertificate {
   certPath: string;
   keyPath: string;
   isTrusted?: boolean;
+  error?: FxError;
 }
 
 export class LocalCertificateManager {
@@ -79,8 +88,8 @@ export class LocalCertificateManager {
           // already trusted
           localCert.isTrusted = true;
         } else {
-          localCert.isTrusted = await this.trustCertificate(
-            localCert.certPath,
+          await this.trustCertificate(
+            localCert,
             certThumbprint,
             LocalDebugCertificate.FriendlyName
           );
@@ -89,6 +98,7 @@ export class LocalCertificateManager {
     } catch (error: any) {
       this.logger?.warning(`Failed to setup certificate. Error: ${error}`);
       localCert.isTrusted = false;
+      localCert.error = returnUserError(error, CoreSource, "SetupCertificateError", learnMoreUrl);
     } finally {
       return localCert;
     }
@@ -276,41 +286,52 @@ export class LocalCertificateManager {
   }
 
   private async trustCertificate(
-    certPath: string,
+    localCert: LocalCertificate,
     thumbprint: string,
     friendlyName: string
-  ): Promise<boolean | undefined> {
+  ): Promise<void> {
     try {
       if (os.type() === "Windows_NT") {
         if (!(await this.waitForUserConfirm())) {
-          return false;
+          localCert.isTrusted = false;
+          localCert.error = UserCancelError;
+          return;
         }
 
-        const installCertCommand = `(Import-Certificate -FilePath '${certPath}' -CertStoreLocation Cert:\\CurrentUser\\Root)[0].Thumbprint`;
+        const installCertCommand = `(Import-Certificate -FilePath '${localCert.certPath}' -CertStoreLocation Cert:\\CurrentUser\\Root)[0].Thumbprint`;
         const thumbprint = (await ps.execPowerShell(installCertCommand)).trim();
 
         const friendlyNameCommand = `(Get-ChildItem -Path Cert:\\CurrentUser\\Root\\${thumbprint}).FriendlyName='${friendlyName}'`;
         await ps.execPowerShell(friendlyNameCommand);
 
-        return true;
+        localCert.isTrusted = true;
+        return;
       } else if (os.type() === "Darwin") {
         if (!(await this.waitForUserConfirm())) {
-          return false;
+          localCert.isTrusted = false;
+          localCert.error = UserCancelError;
+          return;
         }
 
         await ps.execShell(
-          `security add-trusted-cert -p ssl -k "${os.homedir()}/Library/Keychains/login.keychain-db" "${certPath}"`
+          `security add-trusted-cert -p ssl -k "${os.homedir()}/Library/Keychains/login.keychain-db" "${
+            localCert.certPath
+          }"`
         );
 
-        return true;
+        localCert.isTrusted = true;
+        return;
       } else {
         // TODO: Linux
-        return undefined;
+        localCert.isTrusted = undefined;
+        return;
       }
-    } catch (error) {
+    } catch (error: any) {
       // treat any error as install failure, to not block the main progress
       this.logger?.warning(`Failed to install certificate. Error: ${error}`);
-      return false;
+      localCert.isTrusted = false;
+      localCert.error = returnUserError(error, CoreSource, "TrustCertificateError", learnMoreUrl);
+      return;
     }
   }
 

--- a/packages/fx-core/src/common/local/localEnvManager.ts
+++ b/packages/fx-core/src/common/local/localEnvManager.ts
@@ -25,7 +25,7 @@ import { LocalCrypto } from "../../core/crypto";
 import { CoreSource, ReadFileError } from "../../core/error";
 import { DepsType } from "../deps-checker/depsChecker";
 import { ProjectSettingsHelper } from "./projectSettingsHelper";
-import { LocalCertificateManager } from "./localCertificateManager";
+import { LocalCertificate, LocalCertificateManager } from "./localCertificateManager";
 
 export class LocalEnvManager {
   private readonly logger: LogProvider | undefined;
@@ -128,10 +128,11 @@ export class LocalEnvManager {
     });
   }
 
-  public async resolveLocalCertificate(trustDevCert: boolean): Promise<boolean | undefined> {
-    const certManager = new LocalCertificateManager(this.ui, this.logger);
-    const localCert = await certManager.setupCertificate(trustDevCert);
-    return localCert.isTrusted;
+  public async resolveLocalCertificate(trustDevCert: boolean): Promise<LocalCertificate> {
+    // Do not print any log in LocalCertificateManager, use the error message returned instead.
+    const certManager = new LocalCertificateManager(this.ui);
+    const res = await certManager.setupCertificate(trustDevCert);
+    return res;
   }
 
   // Retry logic when reading project config files in case of read-write conflict

--- a/packages/vscode-extension/src/debug/depsChecker/doctorConstant.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/doctorConstant.ts
@@ -4,6 +4,7 @@
 export const doctorConstant = {
   Tick: "√",
   Cross: "×",
+  Exclamation: "!",
   WhiteSpace: "   ",
   NodeNotFound: `Cannot find Node.js.`,
   NodeNotSupported: `Node.js (@CurrentVersion) is not in the supported version list (@SupportedVersions).`,

--- a/packages/vscode-extension/src/debug/prerequisitesHandler.ts
+++ b/packages/vscode-extension/src/debug/prerequisitesHandler.ts
@@ -54,6 +54,7 @@ import { doctorConstant } from "./depsChecker/doctorConstant";
 import { runTask } from "./teamsfxTaskHandler";
 import { vscodeHelper } from "./depsChecker/vscodeHelper";
 import { taskEndEventEmitter, trackedTasks } from "./teamsfxTaskHandler";
+import { trustDevCertHelpLink } from "./constants";
 
 interface CheckResult {
   checker: string;

--- a/packages/vscode-extension/src/debug/prerequisitesHandler.ts
+++ b/packages/vscode-extension/src/debug/prerequisitesHandler.ts
@@ -324,7 +324,7 @@ async function resolveLocalCertificate(localEnvManager: LocalEnvManager): Promis
     if (typeof localCertResult.isTrusted === "undefined") {
       result = ResultStatus.warn;
       error = returnUserError(
-        new Error("Skip to trust local certificate."),
+        new Error("Skip trusting local certificate."),
         ExtensionSource,
         "SkipTrustDevCertError",
         trustDevCertHelpLink

--- a/packages/vscode-extension/src/debug/prerequisitesHandler.ts
+++ b/packages/vscode-extension/src/debug/prerequisitesHandler.ts
@@ -493,7 +493,7 @@ async function handleCheckResults(results: CheckResult[]): Promise<void> {
 function outputCheckResultError(result: CheckResult, output: vscode.OutputChannel) {
   if (result.error) {
     let message: string = result.error.message;
-    if (message.startsWith("User Cancel")) {
+    if (result.checker === "M365 Account" && message.startsWith("User Cancel")) {
       message = doctorConstant.SignInCancelled;
     }
 


### PR DESCRIPTION
When generate dev cert is failed:
![image](https://user-images.githubusercontent.com/49138419/152939361-7623d5b4-742f-473e-a41f-7b6d30ca5c36.png)

When trust dev cert is skipped (Linux / vscode settings):
![image](https://user-images.githubusercontent.com/49138419/152939595-ae76c303-d1a5-40a1-bdf4-a62c8518101c.png)

When user cancelled trust certification:
![image](https://user-images.githubusercontent.com/49138419/152939815-7ee5f05e-16ec-46a9-8767-f025df0ac2f0.png)
PS: change user cancel error message in PR: https://github.com/OfficeDev/TeamsFx/pull/3866