### PR TITLE
fix(dotnet): dotnet project file path as project setting 

### DIFF
--- a/packages/fx-core/src/plugins/resource/frontend/dotnet/constants.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/dotnet/constants.ts
@@ -37,6 +37,7 @@ export class DotnetPathInfo {
   static readonly bicepTemplateFolder = (templateFolder: string) =>
     path.join(templateFolder, "plugins", "resource", "webapp", "bicep");
   static readonly TemplateFolderName = "dotnet";
+  static readonly projectFilename = (projectName: string): string => `${projectName}.csproj`;
 }
 
 export class DotnetCommands {

--- a/packages/fx-core/src/plugins/resource/frontend/dotnet/resources/errors.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/dotnet/resources/errors.ts
@@ -48,6 +48,12 @@ export class DotnetPluginError extends FrontendPluginError {
   }
 }
 
+export class NoProjectSettingError extends DotnetPluginError {
+  constructor() {
+    super(ErrorType.System, "NoProjectSettingError", "Failed to load project setting", []);
+  }
+}
+
 export class FetchConfigError extends DotnetPluginError {
   constructor(key: string) {
     super(ErrorType.User, "FetchConfigError", `Failed to find ${key} from configuration`, [

--- a/packages/fx-core/src/plugins/resource/frontend/dotnet/resources/templateInfo.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/dotnet/resources/templateInfo.ts
@@ -29,7 +29,10 @@ export class TemplateInfo {
   static readonly version = templatesVersion;
 }
 
-export function generateTemplateInfos(selectedCapabilities: string[], ctx: PluginContext) {
+export function generateTemplateInfos(
+  selectedCapabilities: string[],
+  ctx: PluginContext
+): TemplateInfo[] {
   const projectName = ctx.projectSettings!.appName;
   const templateVariable: TemplateVariable = { BlazorAppServer: projectName };
   const templateInfoList: TemplateInfo[] = [];


### PR DESCRIPTION
Dotnet plugin need to parse project file to get current runtime and build the project depends on the csproj file. So we drop project file path in project setting when scaffolding.
E2E TEST: will add e2e test later.