### PR TITLE
fix(dotnet): add capability generate broken biceps

### DIFF
--- a/packages/fx-core/src/plugins/resource/frontend/dotnet/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/dotnet/plugin.ts
@@ -46,6 +46,7 @@ import { ArmTemplateResult } from "../../../../common/armInterface";
 import { PluginImpl } from "../interface";
 import { ProgressHelper } from "../utils/progress-helper";
 import { WebappDeployProgress as DeployProgress } from "./resources/steps";
+import { BotOptionItem, TabOptionItem } from "../../../solution/fx-solution/question";
 
 type Site = WebSiteManagementModels.Site;
 
@@ -123,6 +124,13 @@ export class DotnetPluginImpl implements PluginImpl {
   }
 
   public async generateArmTemplates(ctx: PluginContext): Promise<TeamsFxResult> {
+    if (
+      ctx.answers?.existingCapabilities?.includes(BotOptionItem.id) ||
+      ctx.answers?.existingCapabilities?.includes(TabOptionItem.id)
+    ) {
+      return ok({} as ArmTemplateResult);
+    }
+
     Logger.info(Messages.StartGenerateArmTemplates);
 
     const bicepTemplateDirectory = PathInfo.bicepTemplateFolder(getTemplatesFolder());


### PR DESCRIPTION
Create new project with bot capability -> add tab -> provision -> deploy -> preview
Create new project with tab capability -> add bot -> provision -> deploy -> preview
Both cases pass. But user code may be replaced after adding capability.

E2E TEST: CLI does not support csharp scenario yet.