### PR TITLE
chore: update e2e case author

### DIFF
--- a/packages/cli/tests/e2e/bot/ProvisionResourceProjectWithNewBot.tests.ts
+++ b/packages/cli/tests/e2e/bot/ProvisionResourceProjectWithNewBot.tests.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 /**
- * @author Yitong Feng <yitong.feng@microsoft.com>
+ * @author Ivan He <ruhe@microsoft.com>
  */
 
 import fs from "fs-extra";


### PR DESCRIPTION
a very quick update of e2e case author.

FYI: grep -r "yitong.feng" under packages, nothing filtered out.