### PR TITLE
fix: generate teams manifest first if provision has done

### DIFF
--- a/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
@@ -446,14 +446,20 @@ export class AppStudioPluginImpl {
       (isLocalDebug ? "local" : ctx.envInfo.envName) +
       `.json`;
     if (!(await fs.pathExists(manifestFileName))) {
-      return err(
-        AppStudioResultFactory.UserError(
-          AppStudioError.FileNotFoundError.name,
-          AppStudioError.FileNotFoundError.message(manifestFileName) +
-            " Run 'Provision in the cloud' first. Click Get Help to learn more about why you need to provision.",
-          HelpLinks.WhyNeedProvision
-        )
-      );
+      const isProvisionSucceeded = !!(ctx.envInfo.state
+        .get("solution")
+        ?.get(SOLUTION_PROVISION_SUCCEEDED) as boolean);
+      if (!isProvisionSucceeded) {
+        return err(
+          AppStudioResultFactory.UserError(
+            AppStudioError.FileNotFoundError.name,
+            AppStudioError.FileNotFoundError.message(manifestFileName) +
+              " Run 'Provision in the cloud' first. Click Get Help to learn more about why you need to provision.",
+            HelpLinks.WhyNeedProvision
+          )
+        );
+      }
+      await this.buildTeamsAppPackage(ctx, isLocalDebug);
     }
     const existingManifest = await fs.readJSON(manifestFileName);
     delete manifest.id;

--- a/packages/fx-core/tests/plugins/resource/appstudio/unit/updateManifest.test.ts
+++ b/packages/fx-core/tests/plugins/resource/appstudio/unit/updateManifest.test.ts
@@ -4,18 +4,22 @@
 import "mocha";
 import * as chai from "chai";
 import sinon from "sinon";
+import * as fs from "fs-extra";
 import { GLOBAL_CONFIG, newEnvInfo, SOLUTION_PROVISION_SUCCEEDED } from "../../../../../src";
-import { ConfigMap, PluginContext, TeamsAppManifest } from "@microsoft/teamsfx-api";
+import { ConfigMap, PluginContext } from "@microsoft/teamsfx-api";
 import { LocalCrypto } from "../../../../../src/core/crypto";
 import { AppStudioPluginImpl } from "../../../../../src/plugins/resource/appstudio/plugin";
 
 describe("Update manifest preview file", () => {
   let plugin: AppStudioPluginImpl;
   let ctx: PluginContext;
-  let manifest: TeamsAppManifest;
 
   beforeEach(async () => {
     sinon.restore();
+    const buildFolder = "../fx-core/tests/plugins/resource/appstudio/resources-multi-env/build";
+    if (await fs.pathExists(buildFolder)) {
+      await fs.remove(buildFolder);
+    }
     plugin = new AppStudioPluginImpl();
     ctx = {
       root: "../fx-core/tests/plugins/resource/appstudio/resources-multi-env",
@@ -27,14 +31,13 @@ describe("Update manifest preview file", () => {
       appName: "my app",
       projectId: "testid",
       solutionSettings: {
-        name: "azure",
+        name: "spfx",
         version: "1.0",
-        capabilities: ["Bot"],
+        capabilities: ["tab"],
         activeResourcePlugins: ["fx-resource-spfx"],
       },
     };
     ctx.envInfo.state.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
-    manifest = new TeamsAppManifest();
   });
 
   it("Generate manifest first if already provisioned", async () => {
@@ -43,6 +46,7 @@ describe("Update manifest preview file", () => {
     try {
       await plugin.updateManifest(ctx, false);
     } catch (e) {}
-    chai.assert(buildTeamsPackage.calledOnce);
+    chai.expect(buildTeamsPackage.calledOnce).to.be.true;
+    sinon.restore();
   });
 });

--- a/packages/fx-core/tests/plugins/resource/appstudio/unit/updateManifest.test.ts
+++ b/packages/fx-core/tests/plugins/resource/appstudio/unit/updateManifest.test.ts
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import "mocha";
+import * as chai from "chai";
+import sinon from "sinon";
+import { GLOBAL_CONFIG, newEnvInfo, SOLUTION_PROVISION_SUCCEEDED } from "../../../../../src";
+import { ConfigMap, PluginContext, TeamsAppManifest } from "@microsoft/teamsfx-api";
+import { LocalCrypto } from "../../../../../src/core/crypto";
+import { AppStudioPluginImpl } from "../../../../../src/plugins/resource/appstudio/plugin";
+
+describe("Update manifest preview file", () => {
+  let plugin: AppStudioPluginImpl;
+  let ctx: PluginContext;
+  let manifest: TeamsAppManifest;
+
+  beforeEach(async () => {
+    sinon.restore();
+    plugin = new AppStudioPluginImpl();
+    ctx = {
+      root: "../fx-core/tests/plugins/resource/appstudio/resources-multi-env",
+      envInfo: newEnvInfo(),
+      config: new ConfigMap(),
+      cryptoProvider: new LocalCrypto(""),
+    };
+    ctx.projectSettings = {
+      appName: "my app",
+      projectId: "testid",
+      solutionSettings: {
+        name: "azure",
+        version: "1.0",
+        capabilities: ["Bot"],
+        activeResourcePlugins: ["fx-resource-spfx"],
+      },
+    };
+    ctx.envInfo.state.get(GLOBAL_CONFIG)?.set(SOLUTION_PROVISION_SUCCEEDED, true);
+    manifest = new TeamsAppManifest();
+  });
+
+  it("Generate manifest first if already provisioned", async () => {
+    const buildTeamsPackage = sinon.stub(plugin, "buildTeamsAppPackage");
+
+    try {
+      await plugin.updateManifest(ctx, false);
+    } catch (e) {}
+    chai.assert(buildTeamsPackage.calledOnce);
+  });
+});


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/13415034
E2E TEST: will add later