### PR TITLE
chore: add tenant id for multi-env telemetry events

### DIFF
--- a/packages/cli/src/cmds/publish.ts
+++ b/packages/cli/src/cmds/publish.ts
@@ -7,7 +7,7 @@ import { Argv, Options } from "yargs";
 import { FxError, err, ok, Result, Platform, Func, Stage, Inputs } from "@microsoft/teamsfx-api";
 import activate from "../activate";
 import { YargsCommand } from "../yargsCommand";
-import { argsToInputs, getTeamsAppIdByEnv } from "../utils";
+import { argsToInputs, getTeamsAppTelemetryInfoByEnv } from "../utils";
 import CliTelemetry, { makeEnvRelatedProperty } from "../telemetry/cliTelemetry";
 import {
   TelemetryEvent,
@@ -58,9 +58,10 @@ export default class Publish extends YargsCommand {
     if (answers[manifestFolderParamName] && answers["teams-app-id"]) {
       properties[TelemetryProperty.AppId] = answers["teams-app-id"];
     } else if (answers.projectPath && answers.env) {
-      const appId = getTeamsAppIdByEnv(answers.projectPath, answers.env);
-      if (appId) {
-        properties[TelemetryProperty.AppId] = appId;
+      const appInfo = getTeamsAppTelemetryInfoByEnv(answers.projectPath, answers.env);
+      if (appInfo) {
+        properties[TelemetryProperty.AppId] = appInfo.appId;
+        properties[TelemetryProperty.TenantId] = appInfo.tenantId;
       }
     }
 

--- a/packages/cli/src/cmds/publish.ts
+++ b/packages/cli/src/cmds/publish.ts
@@ -50,6 +50,18 @@ export default class Publish extends YargsCommand {
       return err(result.error);
     }
 
+    const core = result.value;
+    if (answers[manifestFolderParamName] && answers["teams-app-id"]) {
+      answers.platform = Platform.VS;
+      const func: Func = {
+        namespace: "fx-solution-azure",
+        method: "VSpublish",
+      };
+      result = await core.executeUserTask!(func, answers);
+    } else {
+      result = await core.publishApplication(answers);
+    }
+
     // For VS, use appid from `answers['teams-app-id']`, for other cases, use appid from config files in projectPath
     const properties: { [key: string]: string } = {};
     if (answers.env) {
@@ -65,17 +77,6 @@ export default class Publish extends YargsCommand {
       }
     }
 
-    const core = result.value;
-    if (answers[manifestFolderParamName] && answers["teams-app-id"]) {
-      answers.platform = Platform.VS;
-      const func: Func = {
-        namespace: "fx-solution-azure",
-        method: "VSpublish",
-      };
-      result = await core.executeUserTask!(func, answers);
-    } else {
-      result = await core.publishApplication(answers);
-    }
     if (result.isErr()) {
       CliTelemetry.sendTelemetryErrorEvent(TelemetryEvent.Publish, result.error, properties);
       return err(result.error);

--- a/packages/cli/src/telemetry/cliTelemetry.ts
+++ b/packages/cli/src/telemetry/cliTelemetry.ts
@@ -11,7 +11,7 @@ import {
 } from "./cliTelemetryEvents";
 import { FxError, Inputs, UserError } from "@microsoft/teamsfx-api";
 import { getHashedEnv } from "@microsoft/teamsfx-core";
-import { getSettingsVersion, getTeamsAppIdByEnv } from "../utils";
+import { getSettingsVersion, getTeamsAppTelemetryInfoByEnv } from "../utils";
 
 export function makeEnvRelatedProperty(
   projectDir: string,
@@ -20,9 +20,10 @@ export function makeEnvRelatedProperty(
   const properties: { [key: string]: string } = {};
   if (inputs.env) {
     properties[TelemetryProperty.Env] = getHashedEnv(inputs.env);
-    const appId = getTeamsAppIdByEnv(projectDir, inputs.env);
-    if (appId) {
-      properties[TelemetryProperty.AppId] = appId;
+    const appInfo = getTeamsAppTelemetryInfoByEnv(projectDir, inputs.env);
+    if (appInfo) {
+      properties[TelemetryProperty.AppId] = appInfo.appId;
+      properties[TelemetryProperty.TenantId] = appInfo.tenantId;
     }
   }
   return properties;

--- a/packages/cli/src/telemetry/cliTelemetryEvents.ts
+++ b/packages/cli/src/telemetry/cliTelemetryEvents.ts
@@ -79,6 +79,7 @@ export enum TelemetryProperty {
   ProjectId = "project-id",
   CorrelationId = "correlation-id",
   AppId = "appid",
+  TenantId = "tenant-id",
   UserId = "hashed-userid",
   AccountType = "account-type",
   Success = "success",

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -319,12 +319,24 @@ export function isWorkspaceSupported(workspace: string): boolean {
   return true;
 }
 
-export function getTeamsAppIdByEnv(projectDir: string, env: string): string | undefined {
+export interface TeamsAppTelemetryInfo {
+  appId: string;
+  tenantId: string;
+}
+
+export function getTeamsAppTelemetryInfoByEnv(
+  projectDir: string,
+  env: string
+): TeamsAppTelemetryInfo | undefined {
   try {
     if (isWorkspaceSupported(projectDir)) {
       const result = environmentManager.getEnvStateFilesPath(env, projectDir);
       const envJson = JSON.parse(fs.readFileSync(result.envState, "utf8"));
-      return envJson[PluginNames.APPST].teamsAppId;
+      const appstudioState = envJson[PluginNames.APPST];
+      return {
+        appId: appstudioState.teamsAppId,
+        tenantId: appstudioState.tenantId,
+      };
     }
   } catch (e) {
     return undefined;

--- a/packages/cli/tests/unit/utils.tests.ts
+++ b/packages/cli/tests/unit/utils.tests.ts
@@ -506,7 +506,7 @@ describe("Utils Tests", function () {
     });
 
     it("Invalid State File", async () => {
-      const result = getTeamsAppTelemetryInfoByEnv(invalidProjectDir, env);
+      const result = getTeamsAppTelemetryInfoByEnv(invalidStateProjectDir, env);
       expect(result).equals(undefined);
     });
 

--- a/packages/cli/tests/unit/utils.tests.ts
+++ b/packages/cli/tests/unit/utils.tests.ts
@@ -34,7 +34,7 @@ import {
   sleep,
   toLocaleLowerCase,
   toYargsOptions,
-  getTeamsAppIdByEnv,
+  getTeamsAppTelemetryInfoByEnv,
 } from "../../src/utils";
 import * as utils from "../../src/utils";
 import { expect } from "./utils";
@@ -446,7 +446,7 @@ describe("Utils Tests", function () {
     });
   });
 
-  describe("getTeamsAppIdByEnv", async () => {
+  describe("getTeamsAppTelemetryInfoByEnv", async () => {
     const sandbox = sinon.createSandbox();
     const env = "dev";
     const invalidProjectDir = "invaldProjectDir";
@@ -467,6 +467,7 @@ describe("Utils Tests", function () {
       programmingLanguage: "javascript",
     };
     const teamsAppId = "teamsAppId";
+    const tenantId = "tenantId";
 
     before(() => {
       sandbox.stub(fs, "existsSync").callsFake((path: fs.PathLike) => {
@@ -484,6 +485,7 @@ describe("Utils Tests", function () {
           return JSON.stringify({
             [PluginNames.APPST]: {
               teamsAppId: teamsAppId,
+              tenantId: tenantId,
             },
           });
         } else if (file.includes(invalidStateProjectDir) && file.includes(`state.${env}.json`)) {
@@ -499,18 +501,18 @@ describe("Utils Tests", function () {
     });
 
     it("Invalid Project Dir", async () => {
-      const result = getTeamsAppIdByEnv(invalidProjectDir, env);
+      const result = getTeamsAppTelemetryInfoByEnv(invalidProjectDir, env);
       expect(result).equals(undefined);
     });
 
     it("Invalid State File", async () => {
-      const result = getTeamsAppIdByEnv(invalidProjectDir, env);
+      const result = getTeamsAppTelemetryInfoByEnv(invalidProjectDir, env);
       expect(result).equals(undefined);
     });
 
     it("Valid State File", async () => {
-      const result = getTeamsAppIdByEnv(validProjectDir, env);
-      expect(result).equals(teamsAppId);
+      const result = getTeamsAppTelemetryInfoByEnv(validProjectDir, env);
+      expect(result).deep.equals({ appId: teamsAppId, tenantId: tenantId });
     });
   });
 

--- a/packages/vscode-extension/src/debug/commonUtils.ts
+++ b/packages/vscode-extension/src/debug/commonUtils.ts
@@ -9,7 +9,7 @@ import * as constants from "./constants";
 import { ConfigFolderName, UserError } from "@microsoft/teamsfx-api";
 import VsCodeLogInstance from "../commonlib/log";
 import { ExtTelemetry } from "../telemetry/extTelemetry";
-import { getTeamsAppIdByEnv } from "../utils/commonUtils";
+import { getTeamsAppTelemetryInfoByEnv } from "../utils/commonUtils";
 import { core, getSystemInputs, showError } from "../handlers";
 import { ext } from "../extensionVariables";
 import { LocalEnvManager, FolderName } from "@microsoft/teamsfx-core";
@@ -130,8 +130,8 @@ export async function getDebugConfig(
       }
 
       // load env state
-      const remoteId = getTeamsAppIdByEnv(env!);
-      if (remoteId === undefined) {
+      const appInfo = getTeamsAppTelemetryInfoByEnv(env!);
+      if (appInfo === undefined) {
         throw new UserError({
           name: "MissingTeamsAppId",
           message: `No teams app found in ${env} environment. Run Provision to ensure teams app is created.`,
@@ -139,7 +139,7 @@ export async function getDebugConfig(
         });
       }
 
-      return { appId: remoteId as string, env: env };
+      return { appId: appInfo.appId as string, env: env };
     }
   } catch (error: any) {
     showError(error);

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -832,7 +832,7 @@ async function processResult(
     envProperty[TelemetryProperty.Env] = getHashedEnv(inputs.env);
     const appInfo = getTeamsAppTelemetryInfoByEnv(inputs.env);
     if (appInfo) {
-      envProperty[TelemetryProperty.AapId] = appInfo.appId;
+      envProperty[TelemetryProperty.AppId] = appInfo.appId;
       envProperty[TelemetryProperty.TenantId] = appInfo.tenantId;
     }
   }

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -97,7 +97,7 @@ import {
   getProvisionSucceedFromEnv,
   getResourceGroupNameFromEnv,
   getSubscriptionInfoFromEnv,
-  getTeamsAppIdByEnv,
+  getTeamsAppTelemetryInfoByEnv,
   isSPFxProject,
 } from "./utils/commonUtils";
 import * as fs from "fs-extra";
@@ -830,7 +830,11 @@ async function processResult(
 
   if (inputs?.env) {
     envProperty[TelemetryProperty.Env] = getHashedEnv(inputs.env);
-    envProperty[TelemetryProperty.AapId] = getTeamsAppIdByEnv(inputs.env);
+    const appInfo = getTeamsAppTelemetryInfoByEnv(inputs.env);
+    if (appInfo) {
+      envProperty[TelemetryProperty.AapId] = appInfo.appId;
+      envProperty[TelemetryProperty.TenantId] = appInfo.tenantId;
+    }
   }
   if (eventName == TelemetryEvent.CreateProject && inputs?.projectId) {
     createProperty[TelemetryProperty.NewProjectId] = inputs?.projectId;

--- a/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
@@ -156,6 +156,7 @@ export enum TelemetryProperty {
   ProjectId = "project-id",
   CorrelationId = "correlation-id",
   AapId = "appid",
+  TenantId = "tenant-id",
   UserId = "hashed-userid",
   AccountType = "account-type",
   TriggerFrom = "trigger-from",

--- a/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
@@ -155,7 +155,7 @@ export enum TelemetryProperty {
   Component = "component",
   ProjectId = "project-id",
   CorrelationId = "correlation-id",
-  AapId = "appid",
+  AppId = "appid",
   TenantId = "tenant-id",
   UserId = "hashed-userid",
   AccountType = "account-type",

--- a/packages/vscode-extension/src/utils/commonUtils.ts
+++ b/packages/vscode-extension/src/utils/commonUtils.ts
@@ -62,15 +62,24 @@ export function isLinux() {
   return os.type() === "Linux";
 }
 
+export interface TeamsAppTelemetryInfo {
+  appId: string;
+  tenantId: string;
+}
+
 // Only used for telemetry when multi-env is enabled
-export function getTeamsAppIdByEnv(env: string) {
+export function getTeamsAppTelemetryInfoByEnv(env: string): TeamsAppTelemetryInfo | undefined {
   try {
     const ws = ext.workspaceUri.fsPath;
 
     if (isValidProject(ws)) {
       const result = environmentManager.getEnvStateFilesPath(env, ws);
       const envJson = JSON.parse(fs.readFileSync(result.envState, "utf8"));
-      return envJson[PluginNames.APPST].teamsAppId;
+      const aadState = envJson[PluginNames.APPST];
+      return {
+        appId: aadState.teamsAppId,
+        tenantId: aadState.tenantId,
+      };
     }
   } catch (e) {
     return undefined;

--- a/packages/vscode-extension/src/utils/commonUtils.ts
+++ b/packages/vscode-extension/src/utils/commonUtils.ts
@@ -75,10 +75,10 @@ export function getTeamsAppTelemetryInfoByEnv(env: string): TeamsAppTelemetryInf
     if (isValidProject(ws)) {
       const result = environmentManager.getEnvStateFilesPath(env, ws);
       const envJson = JSON.parse(fs.readFileSync(result.envState, "utf8"));
-      const aadState = envJson[PluginNames.APPST];
+      const appstudioState = envJson[PluginNames.APPST];
       return {
-        appId: aadState.teamsAppId,
-        tenantId: aadState.tenantId,
+        appId: appstudioState.teamsAppId,
+        tenantId: appstudioState.tenantId,
       };
     }
   } catch (e) {


### PR DESCRIPTION
All 'end events' related to multi-env and teams app from extension and cli now contains 'tenant-id' property. This is for calculating OKR goals.

vscode:
![image](https://user-images.githubusercontent.com/9698542/155078743-1f163fec-390e-4d10-8434-d8c82a40fe37.png)
cli:
![image](https://user-images.githubusercontent.com/9698542/155084820-4f35d741-f38f-481c-9399-e14ff41e773f.png)


https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/13249760/