### PR TITLE
chore: add migrate v1 retired notification

### DIFF
--- a/packages/fx-core/src/common/projectSettingsValidator.ts
+++ b/packages/fx-core/src/common/projectSettingsValidator.ts
@@ -32,7 +32,7 @@ export function validateProjectSettings(projectSettings: ProjectSettings): strin
   }
 
   if (projectSettings?.solutionSettings?.migrateFromV1) {
-    return "The project migrated from v1 is only supported in the Teams Toolkit prior to V3.4.0.";
+    return "The project created before v2.0.0 is only supported in the Teams Toolkit before v3.4.0.";
   }
 
   return undefined;

--- a/packages/fx-core/src/common/projectSettingsValidator.ts
+++ b/packages/fx-core/src/common/projectSettingsValidator.ts
@@ -30,6 +30,11 @@ export function validateProjectSettings(projectSettings: ProjectSettings): strin
   if (validateRes) {
     return `solutionSettings.activeResourcePlugins validation failed: ${validateRes}`;
   }
+
+  if (projectSettings?.solutionSettings?.migrateFromV1) {
+    return "The project migrated from v1 is only supported in the Teams Toolkit prior to V3.4.0.";
+  }
+
   return undefined;
 }
 

--- a/packages/fx-core/src/core/tools.ts
+++ b/packages/fx-core/src/core/tools.ts
@@ -40,20 +40,6 @@ export function isValidProject(workspacePath?: string): boolean {
   }
 }
 
-// TODO: used to show migrate v1 retired notification
-export async function isMigrateFromV1Project(workspacePath?: string): Promise<boolean> {
-  if (!workspacePath) return false;
-  try {
-    const confFolderPath = path.resolve(workspacePath, `.${ConfigFolderName}`, "configs");
-    const settingsFile = path.resolve(confFolderPath, ProjectSettingsFileName);
-    const projectSettings: ProjectSettings = await fs.readJson(settingsFile);
-    if (validateSettings(projectSettings)) return false;
-    return !!projectSettings?.solutionSettings?.migrateFromV1;
-  } catch (e) {
-    return false;
-  }
-}
-
 export function newEnvInfo(
   envName?: string,
   config?: EnvConfig,


### PR DESCRIPTION
The treeview of project migrated from v1:
![image](https://user-images.githubusercontent.com/49138419/155454220-2b2ce36a-d46e-4130-9838-01db3d95c416.png)

The notification of F5 / Add resource / Provision / Deploy......
![image](https://user-images.githubusercontent.com/49138419/155454292-dac2d686-db23-45d6-a623-1c15d9072350.png)
