### PR TITLE
chore: install win64 for pack server bits.

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           node-version: 14
 
-      - name: Install Win64
+      - name: Install wine64
         run: |
           sudo apt install wine64 -y
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -59,6 +59,10 @@ jobs:
         with:
           node-version: 14
 
+      - name: Install Win64
+        run: |
+          sudo apt install wine64 -y
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:


### PR DESCRIPTION
pack server bits need win64, and test success once installed.