### PR TITLE
feat: remove ab test logic and keep create from sample option

### DIFF
--- a/packages/vscode-extension/src/exp/treatmentVariables.ts
+++ b/packages/vscode-extension/src/exp/treatmentVariables.ts
@@ -2,10 +2,8 @@ export class TreatmentVariables {
   public static readonly VSCodeConfig = "vscode";
   public static readonly EmbeddedSurvey = "embeddedsurvey";
   public static readonly CustomizeTreeview = "customizetreeview";
-  public static readonly RemoveCreateFromSample = "removecreatefromsample";
 }
 
 export class TreatmentVariableValue {
   public static isEmbeddedSurvey: boolean | undefined = undefined;
-  public static removeCreateFromSample: boolean | undefined = undefined;
 }

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -77,13 +77,6 @@ export async function activate(context: vscode.ExtensionContext) {
       TreatmentVariables.EmbeddedSurvey,
       true
     )) as boolean | undefined;
-  TreatmentVariableValue.removeCreateFromSample = (await exp
-    .getExpService()
-    .getTreatmentVariableAsync(
-      TreatmentVariables.VSCodeConfig,
-      TreatmentVariables.RemoveCreateFromSample,
-      true
-    )) as boolean | undefined;
 
   // 1.1 Register the creating command.
   const createCmd = vscode.commands.registerCommand("fx-extension.create", (...args) =>

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -586,10 +586,6 @@ export async function runCommand(
 
     switch (stage) {
       case Stage.create: {
-        if (TreatmentVariableValue.removeCreateFromSample) {
-          inputs["scratch"] = inputs["scratch"] ?? "yes";
-          inputs.projectId = inputs.projectId ?? uuid.v4();
-        }
         const tmpResult = await core.createProject(inputs);
         if (tmpResult.isErr()) {
           result = err(tmpResult.error);


### PR DESCRIPTION
According to the telemetry data and discussion with Zhen & Jaeyong, will keep the create from sample option to avoid sample engagement decrease.

ADO: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/13413556

E2E TEST: feature discarded and no ux change