### PR TITLE
fix: only notify azure sign in status for valid teamsfx project

### DIFF
--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -154,18 +154,21 @@ export async function activate(): Promise<Result<Void, FxError>> {
     }
 
     const telemetry = ExtTelemetry.reporter;
-    AzureAccountManager.setStatusChangeMap(
-      "successfully-sign-in-azure",
-      (status, token, accountInfo) => {
-        if (status === signedIn) {
-          window.showInformationMessage(StringResources.vsc.handlers.azureSignIn);
-        } else if (status === signedOut) {
-          window.showInformationMessage(StringResources.vsc.handlers.azureSignOut);
-        }
-        return Promise.resolve();
-      },
-      false
-    );
+    if (validProject) {
+      AzureAccountManager.setStatusChangeMap(
+        "successfully-sign-in-azure",
+        (status, token, accountInfo) => {
+          if (status === signedIn) {
+            window.showInformationMessage(StringResources.vsc.handlers.azureSignIn);
+          } else if (status === signedOut) {
+            window.showInformationMessage(StringResources.vsc.handlers.azureSignOut);
+          }
+          return Promise.resolve();
+        },
+        false
+      );
+    }
+
     let appstudioLogin: AppStudioTokenProvider = AppStudioTokenInstance;
     const vscodeEnv = detectVsCodeEnv();
     if (vscodeEnv === VsCodeEnv.codespaceBrowser || vscodeEnv === VsCodeEnv.codespaceVsCode) {


### PR DESCRIPTION
This fix is part of https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/13506162

E2E TEST: only for extension