### PR TITLE
chore: compatible with 0.10.0 azure account extension

### DIFF
--- a/packages/vscode-extension/src/commonlib/azureLogin.ts
+++ b/packages/vscode-extension/src/commonlib/azureLogin.ts
@@ -21,6 +21,7 @@ import { LoginFailureError } from "./codeFlowLogin";
 import * as vscode from "vscode";
 import * as identity from "@azure/identity";
 import {
+  initializing,
   loggedIn,
   loggedOut,
   loggingIn,
@@ -379,8 +380,11 @@ export class AzureAccountManager extends login implements AzureAccountProvider {
 
   async getStatus(): Promise<LoginStatus> {
     const azureAccount = this.getAzureAccount();
-    // add this to make sure Azure Account Extension has fully initialized
-    await azureAccount.waitForSubscriptions();
+    if (this.checkVersion()) {
+      // add this to make sure Azure Account Extension has fully initialized
+      // this will wait for login finish when version >= 0.10.0, so loggingIn status will be ignored
+      await azureAccount.waitForSubscriptions();
+    }
     if (azureAccount.status === loggedIn) {
       const credential = await this.doGetAccountCredentialAsync();
       const token = await credential?.getToken();
@@ -408,27 +412,54 @@ export class AzureAccountManager extends login implements AzureAccountProvider {
       }
     }
     azureAccount.onStatusChanged(async (event) => {
-      if (AzureAccountManager.currentStatus === "Initializing") {
-        AzureAccountManager.currentStatus = event;
-        if (AzureAccountManager.currentStatus === "LoggedIn") {
-          const subscriptioninfo = await this.readSubscription();
-          if (subscriptioninfo) {
-            this.setSubscription(subscriptioninfo.subscriptionId);
+      if (this.checkVersion()) {
+        if (AzureAccountManager.currentStatus === "Initializing") {
+          AzureAccountManager.currentStatus = event;
+          if (AzureAccountManager.currentStatus === "LoggedIn") {
+            const subscriptioninfo = await this.readSubscription();
+            if (subscriptioninfo) {
+              this.setSubscription(subscriptioninfo.subscriptionId);
+            }
           }
+          return;
         }
-        return;
-      }
-      AzureAccountManager.currentStatus = event;
-      if (event === loggedOut) {
-        if (AzureAccountManager.statusChange !== undefined) {
-          await AzureAccountManager.statusChange(signedOut, undefined, undefined);
+        AzureAccountManager.currentStatus = event;
+        if (event === loggedOut) {
+          if (AzureAccountManager.statusChange !== undefined) {
+            await AzureAccountManager.statusChange(signedOut, undefined, undefined);
+          }
+          await this.notifyStatus();
+        } else if (event === loggedIn) {
+          await this.updateLoginStatus();
+          await this.notifyStatus();
+        } else if (event === loggingIn) {
+          await this.notifyStatus();
         }
-        await this.notifyStatus();
-      } else if (event === loggedIn) {
-        await this.updateLoginStatus();
-        await this.notifyStatus();
-      } else if (event === loggingIn) {
-        await this.notifyStatus();
+      } else {
+        if (AzureAccountManager.currentStatus === initializing) {
+          if (event === loggedIn) {
+            const subscriptioninfo = await this.readSubscription();
+            if (subscriptioninfo) {
+              this.setSubscription(subscriptioninfo.subscriptionId);
+            }
+            AzureAccountManager.currentStatus = event;
+          } else if (event === loggedOut) {
+            AzureAccountManager.currentStatus = event;
+          }
+          return;
+        }
+        AzureAccountManager.currentStatus = event;
+        if (event === loggedOut) {
+          if (AzureAccountManager.statusChange !== undefined) {
+            await AzureAccountManager.statusChange(signedOut, undefined, undefined);
+          }
+          await this.notifyStatus();
+        } else if (event === loggedIn) {
+          await this.updateLoginStatus();
+          await this.notifyStatus();
+        } else if (event === loggingIn) {
+          await this.notifyStatus();
+        }
       }
     });
   }
@@ -563,6 +594,19 @@ export class AzureAccountManager extends login implements AzureAccountProvider {
       return subscriptionFile;
     } else {
       return undefined;
+    }
+  }
+
+  checkVersion(): boolean {
+    try {
+      const version: string =
+        vscode.extensions.getExtension<AzureAccount>("ms-vscode.azure-account")!.packageJSON
+          .version;
+      const versionDetail = version.split(".");
+      return parseInt(versionDetail[1]) < 10;
+    } catch (e) {
+      VsCodeLogInstance.error("[Get Azure extension] " + e.message);
+      return false;
     }
   }
 }

--- a/packages/vscode-extension/src/commonlib/azureLogin.ts
+++ b/packages/vscode-extension/src/commonlib/azureLogin.ts
@@ -380,7 +380,7 @@ export class AzureAccountManager extends login implements AzureAccountProvider {
 
   async getStatus(): Promise<LoginStatus> {
     const azureAccount = this.getAzureAccount();
-    if (this.checkVersion()) {
+    if (this.isLegacyVersion()) {
       // add this to make sure Azure Account Extension has fully initialized
       // this will wait for login finish when version >= 0.10.0, so loggingIn status will be ignored
       await azureAccount.waitForSubscriptions();
@@ -412,7 +412,7 @@ export class AzureAccountManager extends login implements AzureAccountProvider {
       }
     }
     azureAccount.onStatusChanged(async (event) => {
-      if (this.checkVersion()) {
+      if (this.isLegacyVersion()) {
         if (AzureAccountManager.currentStatus === "Initializing") {
           AzureAccountManager.currentStatus = event;
           if (AzureAccountManager.currentStatus === "LoggedIn") {
@@ -597,7 +597,7 @@ export class AzureAccountManager extends login implements AzureAccountProvider {
     }
   }
 
-  checkVersion(): boolean {
+  isLegacyVersion(): boolean {
     try {
       const version: string =
         vscode.extensions.getExtension<AzureAccount>("ms-vscode.azure-account")!.packageJSON

--- a/packages/vscode-extension/src/commonlib/azureLogin.ts
+++ b/packages/vscode-extension/src/commonlib/azureLogin.ts
@@ -603,7 +603,7 @@ export class AzureAccountManager extends login implements AzureAccountProvider {
         vscode.extensions.getExtension<AzureAccount>("ms-vscode.azure-account")!.packageJSON
           .version;
       const versionDetail = version.split(".");
-      return parseInt(versionDetail[1]) < 10;
+      return parseInt(versionDetail[0]) === 0 && parseInt(versionDetail[1]) < 10;
     } catch (e) {
       VsCodeLogInstance.error("[Get Azure extension] " + e.message);
       return false;

--- a/packages/vscode-extension/src/commonlib/common/constant.ts
+++ b/packages/vscode-extension/src/commonlib/common/constant.ts
@@ -9,6 +9,7 @@ export const signingIn = "SigningIn";
 export const loggedOut = "LoggedOut";
 export const loggedIn = "LoggedIn";
 export const loggingIn = "LoggingIn";
+export const initializing = "Initializing";
 
 export const subscriptionInfoFile = "subscriptionInfo.json";
 export const envDefaultJsonFile = "env.default.json";


### PR DESCRIPTION
1.Status change logic when version<0.10.0
Initializing->loggedIn/loggedOut

Status change logic when version==0.10.0
Initializing->loggingIn->loggedIn/loggedOut

2.```azureAccount.waitForSubscriptions()``` will wait for login finish when version==0.10.0.