### PR TITLE
refactor: get capability from manifest, rather than project settings

### DIFF
--- a/packages/fx-core/src/plugins/resource/appstudio/manifestTemplate.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/manifestTemplate.ts
@@ -91,7 +91,7 @@ export async function init(
 
 export async function loadManifest(
   projectRoot: string,
-  isLocalDebug: boolean
+  isLocalDebug = false
 ): Promise<Result<TeamsAppManifest, FxError>> {
   const manifestFilePath = await getManifestTemplatePath(projectRoot, isLocalDebug);
   if (!(await fs.pathExists(manifestFilePath))) {
@@ -136,6 +136,34 @@ export async function saveManifest(
   const manifestFilePath = await getManifestTemplatePath(projectRoot, isLocalDebug);
   await fs.writeFile(manifestFilePath, JSON.stringify(manifest, null, 4));
   return ok(manifestFilePath);
+}
+
+/**
+ * Only works for manifest.template.json
+ * @param projectRoot
+ * @returns
+ */
+export async function getCapabilities(projectRoot: string): Promise<Result<string[], FxError>> {
+  if (!isConfigUnifyEnabled()) return ok([]);
+
+  const manifestRes = await loadManifest(projectRoot);
+  if (manifestRes.isErr()) {
+    return err(manifestRes.error);
+  }
+  const capabilities: string[] = [];
+  if (manifestRes.value.staticTabs && manifestRes.value.staticTabs!.length > 0) {
+    capabilities.push("staticTab");
+  }
+  if (manifestRes.value.configurableTabs && manifestRes.value.configurableTabs!.length > 0) {
+    capabilities.push("configurableTab");
+  }
+  if (manifestRes.value.bots && manifestRes.value.bots!.length > 0) {
+    capabilities.push("Bot");
+  }
+  if (manifestRes.value.composeExtensions) {
+    capabilities.push("MessageExtension");
+  }
+  return ok(capabilities);
 }
 
 export async function capabilityExceedLimit(

--- a/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
@@ -93,7 +93,7 @@ import {
 import { TelemetryPropertyKey } from "./utils/telemetry";
 import _ from "lodash";
 import { HelpLinks, ResourcePlugins } from "../../../common/constants";
-import { getManifestTemplatePath, loadManifest } from "./manifestTemplate";
+import { getCapabilities, getManifestTemplatePath, loadManifest } from "./manifestTemplate";
 
 export class AppStudioPluginImpl {
   public commonProperties: { [key: string]: string } = {};
@@ -1444,9 +1444,13 @@ export class AppStudioPluginImpl {
     // Bot only project, without frontend hosting
     let endpoint = tabEndpoint;
     let indexPath = tabIndexPath;
-    const solutionSettings: AzureSolutionSettings = ctx.projectSettings
-      ?.solutionSettings as AzureSolutionSettings;
-    const hasFrontend = solutionSettings.capabilities.includes(TabOptionItem.id);
+
+    const capabilities = await getCapabilities(ctx.root);
+    if (capabilities.isErr()) {
+      return err(capabilities.error);
+    }
+    const hasFrontend =
+      capabilities.value.includes("staticTab") || capabilities.value.includes("configurableTab");
     if (!endpoint && !hasFrontend) {
       endpoint = DEFAULT_DEVELOPER_WEBSITE_URL;
       indexPath = "";


### PR DESCRIPTION
Test with miniapp, provision succeed.