### PR TITLE
fix(solution): do not check m365 account in Azure projects

### DIFF
--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/deploy.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/deploy.ts
@@ -55,24 +55,24 @@ export async function deploy(
     );
   }
 
-  const appStudioTokenJson = await tokenProvider.appStudioToken.getJsonObject();
+  if (!inAzureProject) {
+    const appStudioTokenJson = await tokenProvider.appStudioToken.getJsonObject();
 
-  if (appStudioTokenJson) {
-    const checkM365 = await checkM365Tenant({ version: 2, data: envInfo }, appStudioTokenJson);
-    if (checkM365.isErr()) {
-      return checkM365;
+    if (appStudioTokenJson) {
+      const checkM365 = await checkM365Tenant({ version: 2, data: envInfo }, appStudioTokenJson);
+      if (checkM365.isErr()) {
+        return checkM365;
+      }
+    } else {
+      return err(
+        new SystemError(
+          SolutionError.NoAppStudioToken,
+          "App Studio json is undefined",
+          SolutionSource
+        )
+      );
     }
   } else {
-    return err(
-      new SystemError(
-        SolutionError.NoAppStudioToken,
-        "App Studio json is undefined",
-        SolutionSource
-      )
-    );
-  }
-
-  if (isAzureProject(getAzureSolutionSettings(ctx))) {
     const checkAzure = await checkSubscription(
       { version: 2, data: envInfo },
       tokenProvider.azureAccountProvider


### PR DESCRIPTION
Fixes https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/13698661?src=WorkItemMention&src-action=artifact_link

E2E TEST: not needed since unit test cases are added.