### PR TITLE
chore(flag): add feature flag for incremental app building

### DIFF
--- a/packages/fx-core/src/common/constants.ts
+++ b/packages/fx-core/src/common/constants.ts
@@ -62,7 +62,7 @@ export class FeatureFlagName {
   static readonly InsiderPreview = "__TEAMSFX_INSIDER_PREVIEW";
   static readonly rootDirectory = "TEAMSFX_ROOT_DIRECTORY";
   static readonly VSCallingCLI = "VS_CALLING_CLI";
-  static readonly ConfigUnify = "TEAMSFX_CONFIG_UNIFY";
+  static readonly EnableIncrementalAppBuilding = "TEAMSFX_INCREMENTAL_APP";
   static readonly AadManifest = "TEAMSFX_AAD_MANIFEST";
   static readonly DebugTemplate = "TEAMSFX_DEBUG_TEMPLATE";
 }

--- a/packages/fx-core/src/common/constants.ts
+++ b/packages/fx-core/src/common/constants.ts
@@ -62,7 +62,8 @@ export class FeatureFlagName {
   static readonly InsiderPreview = "__TEAMSFX_INSIDER_PREVIEW";
   static readonly rootDirectory = "TEAMSFX_ROOT_DIRECTORY";
   static readonly VSCallingCLI = "VS_CALLING_CLI";
-  static readonly EnableIncrementalAppBuilding = "TEAMSFX_INCREMENTAL_APP";
+  static readonly ConfigUnify = "TEAMSFX_CONFIG_UNIFY";
+  static readonly EnableInitApp = "TEAMSFX_INIT_APP";
   static readonly AadManifest = "TEAMSFX_AAD_MANIFEST";
   static readonly DebugTemplate = "TEAMSFX_DEBUG_TEMPLATE";
 }

--- a/packages/fx-core/src/common/tools.ts
+++ b/packages/fx-core/src/common/tools.ts
@@ -378,7 +378,11 @@ export function isBicepEnvCheckerEnabled(): boolean {
 }
 
 export function isConfigUnifyEnabled(): boolean {
-  return isFeatureFlagEnabled(FeatureFlagName.EnableIncrementalAppBuilding, false);
+  return isFeatureFlagEnabled(FeatureFlagName.ConfigUnify, false);
+}
+
+export function isInitAppEnabled(): boolean {
+  return isFeatureFlagEnabled(FeatureFlagName.EnableInitApp, false);
 }
 
 export function isAadManifestEnabled(): boolean {

--- a/packages/fx-core/src/common/tools.ts
+++ b/packages/fx-core/src/common/tools.ts
@@ -378,7 +378,7 @@ export function isBicepEnvCheckerEnabled(): boolean {
 }
 
 export function isConfigUnifyEnabled(): boolean {
-  return isFeatureFlagEnabled(FeatureFlagName.ConfigUnify, false);
+  return isFeatureFlagEnabled(FeatureFlagName.EnableIncrementalAppBuilding, false);
 }
 
 export function isAadManifestEnabled(): boolean {

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -794,7 +794,7 @@
         "properties": {
           "fx-extension.defaultProjectRootDirectory": {
             "type": "string",
-            "description": "Set the default root directory for creating new teams app project. By default, the root directory is ${homeDir}/TeamsApps. (requries reload of VS Code)",
+            "description": "Set the default root directory for creating new teams app project. By default, the root directory is ${homeDir}/TeamsApps. (requires reload of VS Code)",
             "default": "${homeDir}/TeamsApps"
           },
           "fx-extension.automaticNpmInstall": {
@@ -846,6 +846,17 @@
               "ngrok": true,
               "devCert": true
             }
+          }
+        }
+      },
+      {
+        "title": "Experimental Features",
+        "order": 3,
+        "properties": {
+          "fx-extension.enableIncrementalAppBuilding": {
+            "type": "boolean",
+            "description": "Enable incremental app building and unify the local & remote configs. (requires reload of VS Code)",
+            "default": false
           }
         }
       }

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -853,9 +853,14 @@
         "title": "Experimental Features",
         "order": 3,
         "properties": {
-          "fx-extension.enableIncrementalAppBuilding": {
+          "fx-extension.unifyConfigs": {
             "type": "boolean",
-            "description": "Enable incremental app building and unify the local & remote configs. (requires reload of VS Code)",
+            "description": "Unify the local & remote configs. (requires reload of VS Code)",
+            "default": false
+          },
+          "fx-extension.enableInitApp": {
+            "type": "boolean",
+            "description": "Support to initialize a TeamsFx application. (requires reload of VS Code)",
             "default": false
           }
         }

--- a/packages/vscode-extension/src/constants.ts
+++ b/packages/vscode-extension/src/constants.ts
@@ -3,6 +3,7 @@ export enum ConfigurationKey {
   BicepEnvCheckerEnable = "prerequisiteCheck.bicep",
   RootDirectory = "defaultProjectRootDirectory",
   AutomaticNpmInstall = "automaticNpmInstall",
+  EnableIncrementalAppBuilding = "enableIncrementalAppBuilding",
 }
 
 export const AzurePortalUrl = "https://portal.azure.com";

--- a/packages/vscode-extension/src/constants.ts
+++ b/packages/vscode-extension/src/constants.ts
@@ -3,7 +3,8 @@ export enum ConfigurationKey {
   BicepEnvCheckerEnable = "prerequisiteCheck.bicep",
   RootDirectory = "defaultProjectRootDirectory",
   AutomaticNpmInstall = "automaticNpmInstall",
-  EnableIncrementalAppBuilding = "enableIncrementalAppBuilding",
+  UnifyConfigs = "unifyConfigs",
+  EnableInitApp = "enableInitApp",
 }
 
 export const AzurePortalUrl = "https://portal.azure.com";

--- a/packages/vscode-extension/src/utils/commonUtils.ts
+++ b/packages/vscode-extension/src/utils/commonUtils.ts
@@ -212,15 +212,14 @@ export function syncFeatureFlags() {
     ConfigurationKey.RootDirectory
   ).toString();
 
-  process.env["TEAMSFX_INCREMENTAL_APP"] = getConfiguration(
-    ConfigurationKey.EnableIncrementalAppBuilding
-  ).toString();
+  process.env["TEAMSFX_CONFIG_UNIFY"] = getConfiguration(ConfigurationKey.UnifyConfigs).toString();
+
+  process.env["TEAMSFX_INIT_APP"] = getConfiguration(ConfigurationKey.EnableInitApp).toString();
 }
 
 export class FeatureFlags {
   static readonly InsiderPreview = "__TEAMSFX_INSIDER_PREVIEW";
   static readonly TelemetryTest = "TEAMSFX_TELEMETRY_TEST";
-  static readonly EnableIncrementalAppBuilding = "TEAMSFX_INCREMENTAL_APP";
 }
 
 // Determine whether feature flag is enabled based on environment variable setting

--- a/packages/vscode-extension/src/utils/commonUtils.ts
+++ b/packages/vscode-extension/src/utils/commonUtils.ts
@@ -211,11 +211,16 @@ export function syncFeatureFlags() {
   process.env["TEAMSFX_ROOT_DIRECTORY"] = getConfiguration(
     ConfigurationKey.RootDirectory
   ).toString();
+
+  process.env["TEAMSFX_INCREMENTAL_APP"] = getConfiguration(
+    ConfigurationKey.EnableIncrementalAppBuilding
+  ).toString();
 }
 
 export class FeatureFlags {
   static readonly InsiderPreview = "__TEAMSFX_INSIDER_PREVIEW";
   static readonly TelemetryTest = "TEAMSFX_TELEMETRY_TEST";
+  static readonly EnableIncrementalAppBuilding = "TEAMSFX_INCREMENTAL_APP";
 }
 
 // Determine whether feature flag is enabled based on environment variable setting


### PR DESCRIPTION
Add experiential feature flag to enable to init a teamsfx app and unify the local & remote configs.

Preview:

<img src="https://user-images.githubusercontent.com/15644078/156977949-efb58ec0-4bf8-42c8-9a6d-fc5ad2c11855.png" width="400"/>