### PR TITLE
chore(vsc): support to init an app when feature flag is enabled

### DIFF
--- a/packages/fx-core/src/core/FxCore.ts
+++ b/packages/fx-core/src/core/FxCore.ts
@@ -1329,10 +1329,7 @@ export class FxCore implements v3.ICore {
     return ok(Void);
   }
 
-  async _init(
-    inputs: v2.InputsWithProjectPath,
-    ctx?: CoreHookContext
-  ): Promise<Result<Void, FxError>> {
+  async _init(inputs: Inputs, ctx?: CoreHookContext): Promise<Result<string, FxError>> {
     if (!ctx) {
       return err(new ObjectIsUndefinedError("ctx for createProject"));
     }
@@ -1367,7 +1364,7 @@ export class FxCore implements v3.ICore {
     const appStudioV3 = Container.get<AppStudioPluginV3>(BuiltInFeaturePluginNames.appStudio);
 
     // init manifest
-    const manifestInitRes = await appStudioV3.init(context, inputs);
+    const manifestInitRes = await appStudioV3.init(context, inputs as v2.InputsWithProjectPath);
     if (manifestInitRes.isErr()) return err(manifestInitRes.error);
 
     if (inputs.existingAppConfig?.isCreatedFromExistingApp) {
@@ -1419,13 +1416,11 @@ export class FxCore implements v3.ICore {
     if (createLocalEnvResult.isErr()) {
       return err(createLocalEnvResult.error);
     }
-    return ok(Void);
+    return ok(inputs.projectPath);
   }
+
   @hooks([ErrorHandlerMW, QuestionModelMW, ContextInjectorMW, ProjectSettingsWriterMW])
-  async init(
-    inputs: v2.InputsWithProjectPath,
-    ctx?: CoreHookContext
-  ): Promise<Result<Void, FxError>> {
+  async init(inputs: Inputs, ctx?: CoreHookContext): Promise<Result<string, FxError>> {
     return this._init(inputs, ctx);
   }
 

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -86,6 +86,10 @@
         "contents": "To start Teams app development experience, create a new Teams app or explore our samples. For more information visit our [Quick Start](command:fx-extension.openWelcome?%5B%22SideBar%22%5D) or [documentation](https://aka.ms/teamsfx-first-app-react).\n[Create a new Teams app](command:fx-extension.create?%5B%22SideBar%22%5D)\n[View samples](command:fx-extension.openSamples?%5B%22SideBar%22%5D)\n\n\n\n\n\nYou can also open an existing Teams app.\n[Open folder](command:vscode.openFolder)"
       },
       {
+        "view": "teamsfx-empty-project-and-init",
+        "contents": "To start Teams app development experience, create a new Teams app or initialize your application with Teams Toolkit.\n[Create a new Teams app](command:fx-extension.create?%5B%22SideBar%22%5D)\n[Initialize an existing application](command:fx-extension.init?%5B%22SideBar%22%5D)\nYou can also explore our samples. For more information visit our [Quick Start](command:fx-extension.openWelcome?%5B%22SideBar%22%5D) or [documentation](https://aka.ms/teamsfx-first-app-react).\n[View samples](command:fx-extension.openSamples?%5B%22SideBar%22%5D)\n\n\n\n\n\nYou can also open an existing Teams app.\n[Open folder](command:vscode.openFolder)"
+      },
+      {
         "view": "teamsfx-empty-project-and-check-upgrade",
         "contents": "To start Teams app development experience, create a new Teams app or explore our samples. For more information visit our [Quick Start](command:fx-extension.openWelcome?%5B%22SideBar%22%5D) or [documentation](https://aka.ms/teamsfx-first-app-react).\n[Create a new Teams app](command:fx-extension.create?%5B%22SideBar%22%5D)\n[View samples](command:fx-extension.openSamples?%5B%22SideBar%22%5D)\n\n\n\n\n\nYou can also open an existing Teams app.\n[Open folder](command:vscode.openFolder)\n\nYou need to upgrade the project to the new configuration files to use the latest features. The upgrade process will not change your custom code and create the backup files in case revert is needed.\nNotice this upgrade is a must-have to continue to use current version Teams Toolkit. If you are not ready to upgrade and want to continue to use the old version Teams Toolkit, please find Teams Toolkit in Extension and install the version <=2.10.0.\n[Upgrade project](command:fx-extension.checkProjectUpgrade)"
       }
@@ -132,7 +136,12 @@
         {
           "id": "teamsfx-empty-project",
           "name": "Teams Toolkit",
-          "when": "fx-extension.sidebarWelcome.default && !fx-extension.canUpgradeToArmAndMultiEnv"
+          "when": "fx-extension.sidebarWelcome.default && !fx-extension.canUpgradeToArmAndMultiEnv && !fx-extension.isInitAppEnabled"
+        },
+        {
+          "id": "teamsfx-empty-project-and-init",
+          "name": "Teams Toolkit",
+          "when": "fx-extension.sidebarWelcome.default && !fx-extension.canUpgradeToArmAndMultiEnv && fx-extension.isInitAppEnabled"
         },
         {
           "id": "teamsfx-empty-project-and-check-upgrade",
@@ -431,6 +440,11 @@
       {
         "command": "fx-extension.create",
         "title": "Teams: Create a new Teams app"
+      },
+      {
+        "command": "fx-extension.init",
+        "title": "Teams: Initialize your application with Teams Toolkit",
+        "enablement": "fx-extension.isInitAppEnabled"
       },
       {
         "command": "fx-extension.update",

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -443,11 +443,7 @@ export async function activate(context: vscode.ExtensionContext) {
     workspacePath && (await isSPFxProject(workspacePath))
   );
 
-  vscode.commands.executeCommand(
-    "setContext",
-    "fx-extension.isInitAppEnabled",
-    workspacePath && isInitAppEnabled()
-  );
+  vscode.commands.executeCommand("setContext", "fx-extension.isInitAppEnabled", isInitAppEnabled());
 
   vscode.commands.executeCommand(
     "setContext",

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -27,6 +27,7 @@ import {
   isMultiEnvEnabled,
   isValidProject,
   isConfigUnifyEnabled,
+  isInitAppEnabled,
 } from "@microsoft/teamsfx-core";
 import { TreatmentVariableValue, TreatmentVariables } from "./exp/treatmentVariables";
 import {
@@ -86,6 +87,11 @@ export async function activate(context: vscode.ExtensionContext) {
     Correlator.run(handlers.createNewProjectHandler, args)
   );
   context.subscriptions.push(createCmd);
+
+  const initCmd = vscode.commands.registerCommand("fx-extension.init", (...args) =>
+    Correlator.run(handlers.initProjectHandler, args)
+  );
+  context.subscriptions.push(initCmd);
 
   context.subscriptions.push(
     vscode.commands.registerCommand("fx-extension.getNewProjectPath", async (...args) => {
@@ -435,6 +441,12 @@ export async function activate(context: vscode.ExtensionContext) {
     "setContext",
     "fx-extension.isSPFx",
     workspacePath && (await isSPFxProject(workspacePath))
+  );
+
+  vscode.commands.executeCommand(
+    "setContext",
+    "fx-extension.isInitAppEnabled",
+    workspacePath && isInitAppEnabled()
   );
 
   vscode.commands.executeCommand(

--- a/packages/vscode-extension/src/resources/Strings.json
+++ b/packages/vscode-extension/src/resources/Strings.json
@@ -25,6 +25,8 @@
       "createProjectTitle": "Create New Project",
       "createProjectTitleNew": "Create a new Teams app",
       "createProjectDescription": "Create a new Teams app from scratch or start from a sample app",
+      "initProjectTitleNew": "Initialize an existing application",
+      "initProjectDescription": "Initialize an existing application",
       "addCapabilitiesTitle": "Add Capabilities",
       "addCapabilitiesTitleNew": "Add capabilities",
       "addCapabilitiesDescription": "Add additional capabilities to your Teams app",

--- a/packages/vscode-extension/src/telemetry/extTelemetry.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetry.ts
@@ -48,6 +48,8 @@ export namespace ExtTelemetry {
     switch (stage) {
       case Stage.create:
         return TelemetryEvent.CreateProject;
+      case Stage.init:
+        return TelemetryEvent.InitProject;
       case Stage.update:
         return TelemetryEvent.AddResource;
       case Stage.provision:

--- a/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
@@ -19,6 +19,9 @@ export enum TelemetryEvent {
   CreateProjectStart = "create-project-start",
   CreateProject = "create-project",
 
+  InitProjectStart = "init-project-start",
+  InitProject = "init-project",
+
   RunIconDebugStart = "run-icon-debug-start",
   RunIconDebug = "run-icon-debug",
 

--- a/packages/vscode-extension/src/treeview/treeViewManager.ts
+++ b/packages/vscode-extension/src/treeview/treeViewManager.ts
@@ -50,6 +50,15 @@ class TreeViewManager {
         { name: "new-folder", custom: false }
       ),
       new TreeViewCommand(
+        StringResources.vsc.commandsTreeViewProvider.initProjectTitleNew,
+        StringResources.vsc.commandsTreeViewProvider.initProjectDescription,
+        "fx-extension.init",
+        vscode.TreeItemCollapsibleState.None,
+        undefined,
+        undefined,
+        { name: "new-folder", custom: false }
+      ),
+      new TreeViewCommand(
         StringResources.vsc.commandsTreeViewProvider.samplesTitleNew,
         StringResources.vsc.commandsTreeViewProvider.samplesDescription,
         "fx-extension.openSamples",


### PR DESCRIPTION
Add support to initialize an existing application when the [feature flag](https://github.com/OfficeDev/TeamsFx/pull/4142) is enabled. 

Please note, this is the draft UX and will be continuously improved according to PM's design.

<img src="https://user-images.githubusercontent.com/15644078/156988788-29a90718-500a-45f2-b8b7-1bc224fcf536.png" width=300>

