### PR TITLE
fix: solution resource group check for vs

### DIFF
--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -750,6 +750,8 @@ export interface Inputs extends Json {
     // (undocumented)
     targetResourceGroupName?: string;
     // (undocumented)
+    targetResourceLocationName?: string;
+    // (undocumented)
     vscodeEnv?: VsCodeEnv;
 }
 

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -222,6 +222,7 @@ export interface Inputs extends Json {
   targetEnvName?: string;
   sourceEnvName?: string;
   targetResourceGroupName?: string;
+  targetResourceLocationName?: string; // for vs to create a new resource group
   platform: Platform;
   stage?: Stage;
   vscodeEnv?: VsCodeEnv;

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -306,7 +306,6 @@ export function isWorkspaceSupported(workspace: string): boolean {
 
   const checklist: string[] = [
     p,
-    `${p}/package.json`,
     `${p}/.${ConfigFolderName}`,
     path.join(p, `.${ConfigFolderName}`, InputConfigsFolderName, ProjectSettingsFileName),
   ];


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/13725740
Add a `targetResourceLocationName` property to `Inputs`. Check the platform when checking the resource group.
E2E TEST: 