### PR TITLE
feat(cli): add teamsfx validate back

### DIFF
--- a/packages/cli/src/cmds/index.ts
+++ b/packages/cli/src/cmds/index.ts
@@ -20,6 +20,7 @@ import Manifest from "./manifest";
 import { isRemoteCollaborationEnabled } from "../utils";
 import Permission from "./permission";
 import Env from "./env";
+import { ManifestValidate } from "./validate";
 
 export const commands: YargsCommand[] = [
   new Account(),
@@ -30,6 +31,7 @@ export const commands: YargsCommand[] = [
   new Deploy(),
   new Package(),
   new Manifest(),
+  new ManifestValidate(),
   new Publish(),
   new Config(),
   new Preview(),

--- a/packages/cli/src/cmds/manifest.ts
+++ b/packages/cli/src/cmds/manifest.ts
@@ -23,7 +23,7 @@ export default class Manifest extends YargsCommand {
   public readonly description =
     "Manage Teams app manifest. The supported actions are 'validate' and 'update'.";
 
-  public readonly subCommands: YargsCommand[] = [new ManifestValidate(), new ManifestUpdate()];
+  public readonly subCommands: YargsCommand[] = [new ManifestUpdate()];
 
   public builder(yargs: Argv): Argv<any> {
     yargs.options("action", {
@@ -38,58 +38,6 @@ export default class Manifest extends YargsCommand {
   }
 
   public async runCommand(args: { [argName: string]: string }): Promise<Result<null, FxError>> {
-    return ok(null);
-  }
-}
-
-class ManifestValidate extends YargsCommand {
-  public readonly commandHead = `validate`;
-  public readonly command = this.commandHead;
-  public readonly description = "Validate the Teams app manifest.";
-
-  public builder(yargs: Argv): Argv<any> {
-    this.params = HelpParamGenerator.getYargsParamForHelp("validate");
-    return yargs.version(false).options(this.params);
-  }
-
-  public async runCommand(args: {
-    [argName: string]: string | string[];
-  }): Promise<Result<null, FxError>> {
-    const rootFolder = path.resolve((args.folder as string) || "./");
-    CliTelemetry.withRootFolder(rootFolder).sendTelemetryEvent(
-      TelemetryEvent.ValidateManifestStart
-    );
-
-    const result = await activate(rootFolder);
-    if (result.isErr()) {
-      CliTelemetry.sendTelemetryErrorEvent(TelemetryEvent.ValidateManifest, result.error);
-      return err(result.error);
-    }
-    const core = result.value;
-    let inputs: Inputs;
-    {
-      const func: Func = {
-        namespace: "fx-solution-azure",
-        method: "validateManifest",
-      };
-
-      inputs = getSystemInputs(rootFolder, args.env as any);
-      const result = await core.executeUserTask!(func, inputs);
-      if (result.isErr()) {
-        CliTelemetry.sendTelemetryErrorEvent(
-          TelemetryEvent.ValidateManifest,
-          result.error,
-          makeEnvRelatedProperty(rootFolder, inputs)
-        );
-
-        return err(result.error);
-      }
-    }
-
-    CliTelemetry.sendTelemetryEvent(TelemetryEvent.ValidateManifest, {
-      [TelemetryProperty.Success]: TelemetrySuccess.Yes,
-      ...makeEnvRelatedProperty(rootFolder, inputs),
-    });
     return ok(null);
   }
 }

--- a/packages/cli/src/cmds/validate.ts
+++ b/packages/cli/src/cmds/validate.ts
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+"use strict";
+
+import { Argv } from "yargs";
+import * as path from "path";
+import { FxError, err, ok, Result, Func, Inputs } from "@microsoft/teamsfx-api";
+import activate from "../activate";
+import { YargsCommand } from "../yargsCommand";
+import { getSystemInputs } from "../utils";
+import CliTelemetry, { makeEnvRelatedProperty } from "../telemetry/cliTelemetry";
+import {
+  TelemetryEvent,
+  TelemetryProperty,
+  TelemetrySuccess,
+} from "../telemetry/cliTelemetryEvents";
+import HelpParamGenerator from "../helpParamGenerator";
+
+export class ManifestValidate extends YargsCommand {
+  public readonly commandHead = `validate`;
+  public readonly command = this.commandHead;
+  public readonly description = "Validate the Teams app manifest.";
+
+  public builder(yargs: Argv): Argv<any> {
+    this.params = HelpParamGenerator.getYargsParamForHelp("validate");
+    return yargs.version(false).options(this.params);
+  }
+
+  public async runCommand(args: {
+    [argName: string]: string | string[];
+  }): Promise<Result<null, FxError>> {
+    const rootFolder = path.resolve((args.folder as string) || "./");
+    CliTelemetry.withRootFolder(rootFolder).sendTelemetryEvent(
+      TelemetryEvent.ValidateManifestStart
+    );
+
+    const result = await activate(rootFolder);
+    if (result.isErr()) {
+      CliTelemetry.sendTelemetryErrorEvent(TelemetryEvent.ValidateManifest, result.error);
+      return err(result.error);
+    }
+    const core = result.value;
+    let inputs: Inputs;
+    {
+      const func: Func = {
+        namespace: "fx-solution-azure",
+        method: "validateManifest",
+      };
+
+      inputs = getSystemInputs(rootFolder, args.env as any);
+      const result = await core.executeUserTask!(func, inputs);
+      if (result.isErr()) {
+        CliTelemetry.sendTelemetryErrorEvent(
+          TelemetryEvent.ValidateManifest,
+          result.error,
+          makeEnvRelatedProperty(rootFolder, inputs)
+        );
+
+        return err(result.error);
+      }
+    }
+
+    CliTelemetry.sendTelemetryEvent(TelemetryEvent.ValidateManifest, {
+      [TelemetryProperty.Success]: TelemetrySuccess.Yes,
+      ...makeEnvRelatedProperty(rootFolder, inputs),
+    });
+    return ok(null);
+  }
+}

--- a/packages/cli/tests/e2e/bot/ProvisionResourceProjectWithNewBot.tests.ts
+++ b/packages/cli/tests/e2e/bot/ProvisionResourceProjectWithNewBot.tests.ts
@@ -96,7 +96,7 @@ describe("Provision", function () {
     }
 
     // test (validate)
-    await execAsyncWithRetry(`teamsfx manifest validate`, {
+    await execAsyncWithRetry(`teamsfx validate`, {
       cwd: projectPath,
       env: process.env,
       timeout: 0,

--- a/packages/cli/tests/e2e/function/TestAddFunction.tests.ts
+++ b/packages/cli/tests/e2e/function/TestAddFunction.tests.ts
@@ -84,7 +84,7 @@ describe("Test Add Function", function () {
     await functionValidator.validateDeploy();
 
     // validate
-    await execAsyncWithRetry(`teamsfx manifest validate`, {
+    await execAsyncWithRetry(`teamsfx validate`, {
       cwd: projectPath,
       env: process.env,
       timeout: 0,

--- a/packages/cli/tests/e2e/multienv/TestRemoteHappyPath.tests.ts
+++ b/packages/cli/tests/e2e/multienv/TestRemoteHappyPath.tests.ts
@@ -151,7 +151,7 @@ describe("Multi Env Happy Path for Azure", function () {
       }
 
       // validate manifest
-      result = await execAsyncWithRetry(`teamsfx manifest validate --env ${env}`, {
+      result = await execAsyncWithRetry(`teamsfx validate --env ${env}`, {
         cwd: projectPath,
         env: processEnv,
         timeout: 0,

--- a/packages/cli/tests/e2e/multienv/TestRemoteHappyPathSPFx.tests.ts
+++ b/packages/cli/tests/e2e/multienv/TestRemoteHappyPathSPFx.tests.ts
@@ -122,7 +122,7 @@ describe("Multi Env Happy Path for SPFx", function () {
     }
 
     // validate manifest
-    result = await execAsyncWithRetry(`teamsfx manifest validate --env ${env}`, {
+    result = await execAsyncWithRetry(`teamsfx validate --env ${env}`, {
       cwd: projectPath,
       env: processEnv,
       timeout: 0,

--- a/packages/cli/tests/e2e/spfx/CreateSPFxProject.tests.ts
+++ b/packages/cli/tests/e2e/spfx/CreateSPFxProject.tests.ts
@@ -65,7 +65,7 @@ describe("Start a new project", function () {
     expect(result.stderr).to.eq("");
 
     // validation succeed without provision
-    command = "teamsfx manifest validate";
+    command = "teamsfx validate";
     result = await execAsync(command, {
       cwd: path.join(testFolder, appName),
       env: process.env,

--- a/packages/cli/tests/unit/cmds/index.tests.ts
+++ b/packages/cli/tests/unit/cmds/index.tests.ts
@@ -39,6 +39,7 @@ describe("Register Commands Tests", function () {
     expect(registeredCommands).includes("deploy");
     expect(registeredCommands).includes("package");
     expect(registeredCommands).includes("manifest");
+    expect(registeredCommands).includes("validate");
     expect(registeredCommands).includes("publish");
     expect(registeredCommands).includes("config");
     expect(registeredCommands).includes("preview");


### PR DESCRIPTION
Change `teamsfx manifest validate` to `teamsfx validate`
Related task https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_sprints/taskboard/Teams%20Extensibility%20E2E%20Team/Microsoft%20Teams%20Extensibility/CY22-3.1?workitem=13294507

E2E TEST: multiple cases are changed in the PR