### PR TITLE
chore(vsc): revert extension settings for experimental features

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -862,22 +862,6 @@
             }
           }
         }
-      },
-      {
-        "title": "Experimental Features",
-        "order": 3,
-        "properties": {
-          "fx-extension.unifyConfigs": {
-            "type": "boolean",
-            "description": "Unify the local & remote configs. (requires reload of VS Code)",
-            "default": false
-          },
-          "fx-extension.enableInitApp": {
-            "type": "boolean",
-            "description": "Support to initialize a TeamsFx application. (requires reload of VS Code)",
-            "default": false
-          }
-        }
       }
     ],
     "languages": [

--- a/packages/vscode-extension/src/constants.ts
+++ b/packages/vscode-extension/src/constants.ts
@@ -3,8 +3,6 @@ export enum ConfigurationKey {
   BicepEnvCheckerEnable = "prerequisiteCheck.bicep",
   RootDirectory = "defaultProjectRootDirectory",
   AutomaticNpmInstall = "automaticNpmInstall",
-  UnifyConfigs = "unifyConfigs",
-  EnableInitApp = "enableInitApp",
 }
 
 export const AzurePortalUrl = "https://portal.azure.com";

--- a/packages/vscode-extension/src/utils/commonUtils.ts
+++ b/packages/vscode-extension/src/utils/commonUtils.ts
@@ -211,10 +211,6 @@ export function syncFeatureFlags() {
   process.env["TEAMSFX_ROOT_DIRECTORY"] = getConfiguration(
     ConfigurationKey.RootDirectory
   ).toString();
-
-  process.env["TEAMSFX_CONFIG_UNIFY"] = getConfiguration(ConfigurationKey.UnifyConfigs).toString();
-
-  process.env["TEAMSFX_INIT_APP"] = getConfiguration(ConfigurationKey.EnableInitApp).toString();
 }
 
 export class FeatureFlags {


### PR DESCRIPTION
revert extension settings for experimental features (unify configs & init app), related PR: https://github.com/OfficeDev/TeamsFx/pull/4142

Then, to enable to unify local & remote configs and init app, the environment variables need to be updated manually.

```shell
export TEAMSFX_INIT_APP=true
export TEAMSFX_CONFIG_UNIFY=true
```