### PR TITLE
chore(cli): add init command

### DIFF
--- a/packages/cli/src/cmds/index.ts
+++ b/packages/cli/src/cmds/index.ts
@@ -21,6 +21,8 @@ import { isRemoteCollaborationEnabled } from "../utils";
 import Permission from "./permission";
 import Env from "./env";
 import { ManifestValidate } from "./validate";
+import Init from "./init";
+import { isInitAppEnabled } from "@microsoft/teamsfx-core";
 
 export const commands: YargsCommand[] = [
   new Account(),
@@ -37,6 +39,11 @@ export const commands: YargsCommand[] = [
   new Preview(),
   new Env(),
 ];
+
+if (isInitAppEnabled()) {
+  // add Init command after the New command.
+  commands.splice(2, 0, new Init());
+}
 
 /**
  * Registers cli and partner commands with yargs.

--- a/packages/cli/src/cmds/init.ts
+++ b/packages/cli/src/cmds/init.ts
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+"use strict";
+
+import { Argv } from "yargs";
+import { FxError, Result } from "@microsoft/teamsfx-api";
+import { YargsCommand } from "../yargsCommand";
+
+export default class Init extends YargsCommand {
+  public readonly commandHead = `init`;
+  public readonly command = `${this.commandHead}`;
+  public readonly description = "Initialize an existing application.";
+
+  public builder(yargs: Argv): Argv<any> {
+    throw new Error("Method not implemented.");
+  }
+
+  public async runCommand(args: {
+    [argName: string]: string | string[];
+  }): Promise<Result<null, FxError>> {
+    throw new Error("Method not implemented.");
+  }
+}


### PR DESCRIPTION
Add `init` command if feature flag `TEAMSFX_INIT_APP` is enabled.

work item: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/13725446/
<img src="https://user-images.githubusercontent.com/15644078/157586050-cb40d001-4040-4604-9d64-5b2a7ae9ad5c.png" width=600>
