### PR TITLE
feat: scaffold bot notification with function template

### DIFF
--- a/packages/fx-core/src/plugins/resource/bot/constants.ts
+++ b/packages/fx-core/src/plugins/resource/bot/constants.ts
@@ -45,6 +45,7 @@ export class TemplateProjectsConstants {
 export enum TemplateProjectsScenarios {
   DEFAULT_SCENARIO_NAME = "default",
   NOTIFICATION_SCENARIO_NAME = "notification",
+  NOTIFICATION_FUNCTION_BASE_SCENARIO_NAME = "notification-function-base",
 }
 
 export class ProgressBarConstants {

--- a/packages/fx-core/src/plugins/resource/bot/languageStrategy.ts
+++ b/packages/fx-core/src/plugins/resource/bot/languageStrategy.ts
@@ -7,7 +7,7 @@ import {
   TemplateProjectsConstants,
   TemplateProjectsScenarios,
 } from "./constants";
-import { Commands } from "./resources/strings";
+import { Commands, HostTypes } from "./resources/strings";
 
 import * as appService from "@azure/arm-appservice";
 import { NameValuePair } from "@azure/arm-appservice/esm/models";
@@ -125,9 +125,14 @@ export class LanguageStrategy {
   private static resolveScenarioFromTeamsBotConfig(
     config: TeamsBotConfig
   ): TemplateProjectsScenarios {
-    // TODO: support more scenarios
-    return config.actRoles.includes(PluginActRoles.Notification)
-      ? TemplateProjectsScenarios.NOTIFICATION_SCENARIO_NAME
-      : TemplateProjectsScenarios.DEFAULT_SCENARIO_NAME;
+    if (config.actRoles.includes(PluginActRoles.Notification)) {
+      if (config.scaffold.hostType === HostTypes.APP_SERVICE) {
+        return TemplateProjectsScenarios.NOTIFICATION_SCENARIO_NAME;
+      } else {
+        return TemplateProjectsScenarios.NOTIFICATION_FUNCTION_BASE_SCENARIO_NAME;
+      }
+    } else {
+      return TemplateProjectsScenarios.DEFAULT_SCENARIO_NAME;
+    }
   }
 }

--- a/packages/fx-core/src/plugins/resource/bot/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/bot/plugin.ts
@@ -95,7 +95,14 @@ export class TeamsBotImpl implements PluginImpl {
 
     if (isBotNotificationEnabled()) {
       // TODO: set host type from input
-      this.config.scaffold.hostType = HostTypes.APP_SERVICE;
+      // Since the UI design is not finalized yet,
+      // for testing purpose we currently use an environment variable to select hostType.
+      // Change the logic after question model is implemented.
+      if (process.env.TEAMSFX_BOT_HOST_TYPE === "function") {
+        this.config.scaffold.hostType = HostTypes.AZURE_FUNCTIONS;
+      } else {
+        this.config.scaffold.hostType = HostTypes.APP_SERVICE;
+      }
     }
 
     // 1. Copy the corresponding template project into target directory.


### PR DESCRIPTION
- add bot notification with azure functions hosting scaffold
- currently UI is not finalized yet, so add an environment variable TEAMSFX_BOT_HOST_TYPE to test different host types. Later this information will be from question model

How to test this:
1. select notification in question model 
2. set TEAMSFX_BOT_HOST_TYPE=function to test function scaffold or set TEAMSFX_BOT_HOST_TYPE=appService to test app service scaffold

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/13762945