### PR TITLE
fix: app name does not show when local debug

### DIFF
--- a/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
@@ -181,6 +181,7 @@ export class AppStudioPluginImpl {
     }
 
     const view = {
+      config: ctx.envInfo.config,
       localSettings: {
         teamsApp: {
           teamsAppId: localTeamsAppID,


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/73154171/157612931-14360497-1844-43d8-9466-74516769f23d.png)

After:
![image](https://user-images.githubusercontent.com/73154171/157612398-44215f92-4784-417b-9192-483e406cc5f6.png)

E2E TEST: only for extension