### PR TITLE
refactor: move function hosted notification code

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -68,6 +68,8 @@
 
 /packages/fx-core/src/plugins/resource/bot @IvanJobs @eriolchan @Yukun-dong @Siglud
 /packages/fx-core/tests/plugins/resource/bot @IvanJobs @eriolchan @Yukun-dong @Siglud
+/packages/fx-core/src/plugins/resource/bot/functionHostedBot @swatDong @XiaofuHuang @a1exwang @kimizhu @IvanJobs @eriolchan @Yukun-dong @Siglud
+/packages/fx-core/tests/plugins/resource/bot/unit/functionHostedBot @swatDong @XiaofuHuang @a1exwang @kimizhu @IvanJobs @eriolchan @Yukun-dong @Siglud
 
 /packages/fx-core/src/plugins/resource/frontend @hund030 @eriolchan @IvanJobs
 /packages/fx-core/tests/plugins/resource/frontend @hund030 @eriolchan @IvanJobs

--- a/packages/fx-core/src/plugins/resource/bot/configs/scaffoldConfig.ts
+++ b/packages/fx-core/src/plugins/resource/bot/configs/scaffoldConfig.ts
@@ -50,4 +50,18 @@ export class ScaffoldConfig {
     utils.checkAndSaveConfig(context, PluginBot.OBJECT_ID, this.objectId);
     utils.checkAndSavePluginSetting(context, PluginBot.HOST_TYPE, this.hostType);
   }
+
+  public static getBotHostType(context: PluginContext): HostType | undefined {
+    // TODO: retrieve host type from context.answers
+    // Since the UI design is not finalized yet,
+    // for testing purpose we currently use an environment variable to select hostType.
+    // Change the logic after question model is implemented.
+    if (process.env.TEAMSFX_BOT_HOST_TYPE) {
+      return process.env.TEAMSFX_BOT_HOST_TYPE === "function"
+        ? HostTypes.AZURE_FUNCTIONS
+        : HostTypes.APP_SERVICE;
+    } else {
+      return undefined;
+    }
+  }
 }

--- a/packages/fx-core/src/plugins/resource/bot/functionsHostedBot/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/bot/functionsHostedBot/plugin.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+import { PluginContext } from "@microsoft/teamsfx-api";
+import { LanguageStrategy } from "../languageStrategy";
+import { Messages } from "../resources/messages";
+import { FxResult, FxBotPluginResultFactory as ResultFactory } from "../result";
+import { ProgressBarConstants, TemplateProjectsConstants } from "../constants";
+
+import { HostTypes } from "../resources/strings";
+import { SomethingMissingError } from "../errors";
+import { ProgressBarFactory } from "../progressBars";
+import { Logger } from "../logger";
+import { TeamsBotImpl } from "../plugin";
+
+export class FunctionsHostedBotImpl extends TeamsBotImpl {
+  public async scaffold(context: PluginContext): Promise<FxResult> {
+    this.ctx = context;
+    throw new Error("not implemented");
+  }
+}

--- a/packages/fx-core/src/plugins/resource/bot/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/bot/plugin.ts
@@ -70,7 +70,7 @@ import { BOT_ID } from "../appstudio/constants";
 export class TeamsBotImpl implements PluginImpl {
   // Made config public, because expect the upper layer to fill inputs.
   public config: TeamsBotConfig = new TeamsBotConfig();
-  private ctx?: PluginContext;
+  protected ctx?: PluginContext;
 
   private async getAzureAccountCredential(): Promise<TokenCredentialsBase> {
     const serviceClientCredentials =

--- a/packages/fx-core/src/plugins/resource/bot/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/bot/plugin.ts
@@ -94,15 +94,7 @@ export class TeamsBotImpl implements PluginImpl {
     await handler?.start(ProgressBarConstants.SCAFFOLD_STEP_START);
 
     if (isBotNotificationEnabled()) {
-      // TODO: set host type from input
-      // Since the UI design is not finalized yet,
-      // for testing purpose we currently use an environment variable to select hostType.
-      // Change the logic after question model is implemented.
-      if (process.env.TEAMSFX_BOT_HOST_TYPE === "function") {
-        this.config.scaffold.hostType = HostTypes.AZURE_FUNCTIONS;
-      } else {
-        this.config.scaffold.hostType = HostTypes.APP_SERVICE;
-      }
+      this.config.scaffold.hostType = HostTypes.APP_SERVICE;
     }
 
     // 1. Copy the corresponding template project into target directory.

--- a/packages/fx-core/tests/plugins/resource/bot/unit/index.test.ts
+++ b/packages/fx-core/tests/plugins/resource/bot/unit/index.test.ts
@@ -7,7 +7,7 @@ import * as sinon from "sinon";
 const AdmZip = require("adm-zip");
 import * as path from "path";
 
-import { TeamsBot } from "../../../../../src";
+import { BotHostTypes, TeamsBot } from "../../../../../src";
 import { TeamsBotImpl } from "../../../../../src/plugins/resource/bot/plugin";
 
 import * as utils from "../../../../../src/plugins/resource/bot/utils/common";
@@ -16,7 +16,10 @@ import { FxBotPluginResultFactory as ResultFactory } from "../../../../../src/pl
 import * as testUtils from "./utils";
 import { PluginActRoles } from "../../../../../src/plugins/resource/bot/enums/pluginActRoles";
 import * as factory from "../../../../../src/plugins/resource/bot/clientFactory";
-import { CommonStrings } from "../../../../../src/plugins/resource/bot/resources/strings";
+import {
+  CommonStrings,
+  HostTypes,
+} from "../../../../../src/plugins/resource/bot/resources/strings";
 import { AzureOperations } from "../../../../../src/plugins/resource/bot/azureOps";
 import { AADRegistration } from "../../../../../src/plugins/resource/bot/aadRegistration";
 import { BotAuthCredential } from "../../../../../src/plugins/resource/bot/botAuthCredential";
@@ -38,8 +41,58 @@ import {
 } from "../../../solution/util";
 import { randomAppName } from "../../../../core/utils";
 import * as os from "os";
+import { FunctionsHostedBotImpl } from "../../../../../src/plugins/resource/bot/functionsHostedBot/plugin";
+import { ScaffoldConfig } from "../../../../../src/plugins/resource/bot/configs/scaffoldConfig";
+import { DotnetBotImpl } from "../../../../../src/plugins/resource/bot/dotnet/plugin";
 
 describe("Teams Bot Resource Plugin", () => {
+  describe("Test plugin implementation dispatching", () => {
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    let botPlugin: TeamsBot;
+
+    beforeEach(() => {
+      botPlugin = new TeamsBot();
+    });
+
+    it("dispatches to vs", async () => {
+      // Arrange
+      const pluginContext = testUtils.newPluginContext();
+      pluginContext.projectSettings!.programmingLanguage = "csharp";
+
+      // Act
+      const impl = botPlugin.getImpl(pluginContext);
+
+      // Assert
+      chai.assert.isTrue(impl instanceof DotnetBotImpl);
+    });
+
+    it("dispatches to function hosted bot", async () => {
+      // Arrange
+      const pluginContext = testUtils.newPluginContext();
+      sinon.stub(ScaffoldConfig, "getBotHostType").returns(HostTypes.AZURE_FUNCTIONS);
+
+      // Act
+      const impl = botPlugin.getImpl(pluginContext);
+
+      // Assert
+      chai.assert.isTrue(impl instanceof FunctionsHostedBotImpl);
+    });
+
+    it("dispatches to app service hosted bot", async () => {
+      // Arrange
+      const pluginContext = testUtils.newPluginContext();
+
+      // Act
+      const impl = botPlugin.getImpl(pluginContext);
+
+      // Assert
+      chai.assert.isTrue(impl instanceof TeamsBotImpl);
+    });
+  });
+
   describe("Test preScaffold", () => {
     afterEach(() => {
       sinon.restore();


### PR DESCRIPTION
As the offline discussion with @eriolchan team, we will move the function hosted notification code into a inherited class of `TeamsBotImpl`

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/13814055