### PR TITLE
feat(m365-func): add m365 func template

### DIFF
--- a/templates/function-base/js/m365/.funcignore
+++ b/templates/function-base/js/m365/.funcignore
@@ -1,0 +1,11 @@
+*.js.map
+*.ts
+.git*
+.vscode
+local.settings.json
+test
+tsconfig.json
+.DS_Store
+.deployment
+node_modules/.bin
+node_modules/azure-functions-core-tools

--- a/templates/function-base/js/m365/.gitignore
+++ b/templates/function-base/js/m365/.gitignore
@@ -1,0 +1,12 @@
+# Dependency directories
+node_modules/
+
+# Azure Functions artifacts
+bin
+obj
+appsettings.json
+local.settings.json
+
+# misc
+.DS_Store
+.deployment

--- a/templates/function-base/js/m365/README.md
+++ b/templates/function-base/js/m365/README.md
@@ -1,0 +1,105 @@
+# Server-side code in Teams applications
+
+Azure Functions are a great way to add server-side behaviors to any Teams application.
+
+## Prerequisites
+
+- [NodeJS](https://nodejs.org/en/)
+- An M365 account. If you do not have M365 account, apply one from [M365 developer program](https://developer.microsoft.com/en-us/microsoft-365/dev-program)
+- [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) or [TeamsFx CLI](https://aka.ms/teamsfx-cli)
+
+## Develop
+
+The Teams Toolkit IDE Extension and TeamsFx CLI provide template code for you to get started with Azure Functions for your Teams application. Microsoft Teams Framework simplifies the task of establishing the user's identity within the Azure Function.
+
+The template handles calls from your Teams "custom tab" (client-side of your app), initializes the TeamsFx SDK to access the current user context, and demonstrates how to obtain a pre-authenticated Microsoft Graph Client. Microsoft Graph is the "data plane" of M365 - you can use it to access content within M365 in your company. With it you can read and write documents, SharePoint collections, Teams channels, and many other entities within M365. Read more about [Microsoft Graph](https://docs.microsoft.com/en-us/graph/overview).
+
+You can add your logic to the single Azure Function created by this template, as well as add more functions as necessary. See [Azure Functions developer guide](https://docs.microsoft.com/en-us/azure/azure-functions/functions-reference) for more information.
+
+### Call the Function
+
+To call your Azure Function, the client sends an HTTP request with an SSO token in the `Authorization` header. The token can be retrieved using the TeamsFx SDK from your app's client (custom tab). Here is an example:
+
+```js
+const { TeamsFx } = require("@microsoft/teamsfx");
+
+var teamsfx = new TeamsFx();
+var accessToken = await teamsfx.getCredential().getToken("");
+// note: empty string argument on the previous line is required for now, this will be fixed in a later release
+var response = await fetch(`${functionEndpoint}/api/${functionName}`, {
+  headers: {
+    Authorization: `Bearer ${accessToken.token}`,
+  },
+});
+```
+
+### Add More Functions
+
+- From Visual Studio Code, open the command palette, select `Teams: Add Resources` and select `Azure Function App`.
+- From TeamsFx CLI: run command `teamsfx resource add azure-function --function-name <your-function-name>` in your project directory.
+
+## Change Node.js runtime version
+
+By default, Teams Toolkit and TeamsFx CLI will provision an Azure function app with function runtime version 3, and node runtime version 12. You can change the node version through Azure Portal.
+
+- Sign in to [Azure Portal](https://azure.microsoft.com/).
+- Find your application's resource group and Azure Function app resource. The resource group name and the Azure function app name are stored in your project configuration file `.fx/env.*.json`. You can find them by searching the key `resourceGroupName` and `functionAppName` in that file.
+- After enter the home page of the Azure function app, you can find a navigation item called `Configuration` under `settings` group.
+- Click `Configuration`, you would see a list of settings. Then click `WEBSITE_NODE_DEFAULT_VERSION` and update the value to `~10`, `~12` or `~14` according to your requirement.
+- After Click `OK` button, don't forget to click `Save` button on the top of the page.
+
+Then following requests sent to the Azure function app will be handled by new node runtime version.
+
+## Debug
+
+- From Visual Studio Code: Start debugging the project by hitting the `F5` key in Visual Studio Code. Alternatively use the `Run and Debug Activity Panel` in Visual Studio Code and click the `Start Debugging` green arrow button.
+- From TeamsFx CLI: Start debugging the project by executing the command `teamsfx preview --local` in your project directory.
+
+## Edit the manifest
+
+You can find the Teams app manifest in `templates/appPackage` folder. The folder contains two manifest files:
+* `manifest.local.template.json`: Manifest file for Teams app running locally.
+* `manifest.remote.template.json`: Manifest file for Teams app running remotely (After deployed to Azure).
+
+Both files contain template arguments with `{...}` statements which will be replaced at build time. You may add any extra properties or permissions you require to this file. See the [schema reference](https://docs.microsoft.com/en-us/microsoftteams/platform/resources/schema/manifest-schema) for more information.
+
+## Deploy to Azure
+
+Deploy your project to Azure by following these steps:
+
+| From Visual Studio Code                                                                                                                                                                                                                                                                                                                                                  | From TeamsFx CLI                                                                                                                                                                                                                   |
+| :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <ul><li>Open Teams Toolkit, and sign into Azure by clicking the `Sign in to Azure` under the `ACCOUNTS` section from sidebar.</li> <li>After you signed in, select a subscription under your account.</li><li>Open the command palette and select: `Teams: Provision in the cloud`.</li><li>Open the command palette and select: `Teams: Deploy to the cloud`.</li></ul> | <ul> <li>Run command `teamsfx account login azure`.</li> <li>Run command `teamsfx account set --subscription <your-subscription-id>`.</li> <li> Run command `teamsfx provision`.</li> <li>Run command `teamsfx deploy`. </li></ul> |
+
+> Note: Provisioning and deployment may incur charges to your Azure Subscription.
+
+## Preview
+
+Once the provisioning and deployment steps are finished, you can preview your app:
+
+- From Visual Studio Code
+
+  1. Open the `Run and Debug Activity Panel`.
+  1. Select `Launch Remote (Edge)` or `Launch Remote (Chrome)` from the launch configuration drop-down.
+  1. Press the Play (green arrow) button to launch your app - now running remotely from Azure.
+
+- From TeamsFx CLI: execute `teamsfx preview --remote` in your project directory to launch your application.
+
+## Validate manifest file
+
+To check that your manifest file is valid:
+
+- From Visual Studio Code: open the command palette and select: `Teams: Validate manifest file`.
+- From TeamsFx CLI: run command `teamsfx validate` in your project directory.
+
+## Package
+
+- From Visual Studio Code: open the command palette and select `Teams: Zip Teams metadata package`.
+- Alternatively, from the command line run `teamsfx package` in the project directory.
+
+## Publish to Teams
+
+Once deployed, you may want to distribute your application to your organization's internal app store in Teams. Your app will be submitted for admin approval.
+
+- From Visual Studio Code: open the command palette and select: `Teams: Publish to Teams`.
+- From TeamsFx CLI: run command `teamsfx publish` in your project directory.

--- a/templates/function-base/js/m365/extensions.csproj
+++ b/templates/function-base/js/m365/extensions.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+	<WarningsAsErrors></WarningsAsErrors>
+	<DefaultItemExcludes>**</DefaultItemExcludes>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.TeamsFx" Version="0.1.*" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="1.1.3" />
+  </ItemGroup>
+</Project>

--- a/templates/function-base/js/m365/host.json
+++ b/templates/function-base/js/m365/host.json
@@ -1,0 +1,11 @@
+{
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      }
+    }
+  }
+}

--- a/templates/function-base/js/m365/local.settings.json.tpl
+++ b/templates/function-base/js/m365/local.settings.json.tpl
@@ -1,0 +1,7 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "",
+    "FUNCTIONS_WORKER_RUNTIME": "node"
+  }
+}

--- a/templates/function-base/js/m365/package.json
+++ b/templates/function-base/js/m365/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "teamsfx-template-api",
+    "version": "1.0.0",
+    "scripts": {
+        "dev:teamsfx": "env-cmd --silent -f .env.teamsfx.local npm run dev",
+        "dev": "func start --javascript --language-worker=\"--inspect=9229\" --port \"7071\" --cors \"*\"",
+        "start": "npx func start"
+    },
+    "dependencies": {
+        "@microsoft/teamsfx": "0.6.0-beta.0",
+        "isomorphic-fetch": "^3.0.0"
+    },
+    "devDependencies": {
+        "env-cmd": "^10.1.0"
+    }
+}

--- a/templates/function-base/js/m365/proxies.json
+++ b/templates/function-base/js/m365/proxies.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "http://json.schemastore.org/proxies",
+  "proxies": {}
+}

--- a/templates/function-base/ts/m365/.funcignore
+++ b/templates/function-base/ts/m365/.funcignore
@@ -1,0 +1,11 @@
+*.js.map
+*.ts
+.git*
+.vscode
+local.settings.json
+test
+tsconfig.json
+.DS_Store
+.deployment
+node_modules/.bin
+node_modules/azure-functions-core-tools

--- a/templates/function-base/ts/m365/.gitignore
+++ b/templates/function-base/ts/m365/.gitignore
@@ -1,0 +1,16 @@
+# TypeScript output
+dist
+out
+
+# Dependency directories
+node_modules
+
+# Azure Functions artifacts
+bin
+obj
+appsettings.json
+local.settings.json
+
+# misc
+.DS_Store
+.deployment

--- a/templates/function-base/ts/m365/README.md
+++ b/templates/function-base/ts/m365/README.md
@@ -1,0 +1,105 @@
+# Server-side code in Teams applications
+
+Azure Functions are a great way to add server-side behaviors to any Teams application.
+
+## Prerequisites
+
+- [NodeJS](https://nodejs.org/en/)
+- An M365 account. If you do not have M365 account, apply one from [M365 developer program](https://developer.microsoft.com/en-us/microsoft-365/dev-program)
+- [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) or [TeamsFx CLI](https://aka.ms/teamsfx-cli)
+
+## Develop
+
+The Teams Toolkit IDE Extension and TeamsFx CLI provide template code for you to get started with Azure Functions for your Teams application. Microsoft Teams Framework simplifies the task of establishing the user's identity within the Azure Function.
+
+The template handles calls from your Teams "custom tab" (client-side of your app), initializes the TeamsFx SDK to access the current user context, and demonstrates how to obtain a pre-authenticated Microsoft Graph Client. Microsoft Graph is the "data plane" of M365 - you can use it to access content within M365 in your company. With it you can read and write documents, SharePoint collections, Teams channels, and many other entities within M365. Read more about [Microsoft Graph](https://docs.microsoft.com/en-us/graph/overview).
+
+You can add your logic to the single Azure Function created by this template, as well as add more functions as necessary. See [Azure Functions developer guide](https://docs.microsoft.com/en-us/azure/azure-functions/functions-reference) for more information.
+
+### Call the Function
+
+To call your Azure Function, the client sends an HTTP request with an SSO token in the `Authorization` header. The token can be retrieved using the TeamsFx SDK from your app's client (custom tab). Here is an example:
+
+```ts
+import { TeamsFx } from "@microsoft/teamsfx";
+
+const teamsfx = new TeamsFx();
+const accessToken = await teamsfx.getCredential().getToken("");
+// note: empty string argument on the previous line is required for now, this will be fixed in a later release
+const response = await fetch(`${functionEndpoint}/api/${functionName}`, {
+  headers: {
+    Authorization: `Bearer ${accessToken.token}`,
+  },
+});
+```
+
+### Add More Functions
+
+- From Visual Studio Code, open the command palette, select `Teams: Add Resources` and select `Azure Function App`.
+- From TeamsFx CLI: run command `teamsfx resource add azure-function --function-name <your-function-name>` in your project directory.
+
+## Change Node.js runtime version
+
+By default, Teams Toolkit and TeamsFx CLI will provision an Azure function app with function runtime version 3, and node runtime version 12. You can change the node version through Azure Portal.
+
+- Sign in to [Azure Portal](https://azure.microsoft.com/).
+- Find your application's resource group and Azure Function app resource. The resource group name and the Azure function app name are stored in your project configuration file `.fx/env.*.json`. You can find them by searching the key `resourceGroupName` and `functionAppName` in that file.
+- After enter the home page of the Azure function app, you can find a navigation item called `Configuration` under `settings` group.
+- Click `Configuration`, you would see a list of settings. Then click `WEBSITE_NODE_DEFAULT_VERSION` and update the value to `~10`, `~12` or `~14` according to your requirement.
+- After Click `OK` button, don't forget to click `Save` button on the top of the page.
+
+Then following requests sent to the Azure function app will be handled by new node runtime version.
+
+## Debug
+
+- From Visual Studio Code: Start debugging the project by hitting the `F5` key in Visual Studio Code. Alternatively use the `Run and Debug Activity Panel` in Visual Studio Code and click the `Start Debugging` green arrow button.
+- From TeamsFx CLI: Start debugging the project by executing the command `teamsfx preview --local` in your project directory.
+
+## Edit the manifest
+
+You can find the Teams app manifest in `templates/appPackage` folder. The folder contains two manifest files:
+* `manifest.local.template.json`: Manifest file for Teams app running locally.
+* `manifest.remote.template.json`: Manifest file for Teams app running remotely (After deployed to Azure).
+
+Both files contain template arguments with `{...}` statements which will be replaced at build time. You may add any extra properties or permissions you require to this file. See the [schema reference](https://docs.microsoft.com/en-us/microsoftteams/platform/resources/schema/manifest-schema) for more information.
+
+## Deploy to Azure
+
+Deploy your project to Azure by following these steps:
+
+| From Visual Studio Code                                                                                                                                                                                                                                                                                                                                                  | From TeamsFx CLI                                                                                                                                                                                                                   |
+| :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <ul><li>Open Teams Toolkit, and sign into Azure by clicking the `Sign in to Azure` under the `ACCOUNTS` section from sidebar.</li> <li>After you signed in, select a subscription under your account.</li><li>Open the command palette and select: `Teams: Provision in the cloud`.</li><li>Open the command palette and select: `Teams: Deploy to the cloud`.</li></ul> | <ul> <li>Run command `teamsfx account login azure`.</li> <li>Run command `teamsfx account set --subscription <your-subscription-id>`.</li> <li> Run command `teamsfx provision`.</li> <li>Run command `teamsfx deploy`. </li></ul> |
+
+> Note: Provisioning and deployment may incur charges to your Azure Subscription.
+
+## Preview
+
+Once the provisioning and deployment steps are finished, you can preview your app:
+
+- From Visual Studio Code
+
+  1. Open the `Run and Debug Activity Panel`.
+  1. Select `Launch Remote (Edge)` or `Launch Remote (Chrome)` from the launch configuration drop-down.
+  1. Press the Play (green arrow) button to launch your app - now running remotely from Azure.
+
+- From TeamsFx CLI: execute `teamsfx preview --remote` in your project directory to launch your application.
+
+## Validate manifest file
+
+To check that your manifest file is valid:
+
+- From Visual Studio Code: open the command palette and select: `Teams: Validate manifest file`.
+- From TeamsFx CLI: run command `teamsfx validate` in your project directory.
+
+## Package
+
+- From Visual Studio Code: open the command palette and select `Teams: Zip Teams metadata package`.
+- Alternatively, from the command line run `teamsfx package` in the project directory.
+
+## Publish to Teams
+
+Once deployed, you may want to distribute your application to your organization's internal app store in Teams. Your app will be submitted for admin approval.
+
+- From Visual Studio Code: open the command palette and select: `Teams: Publish to Teams`.
+- From TeamsFx CLI: run command `teamsfx publish` in your project directory.

--- a/templates/function-base/ts/m365/extensions.csproj
+++ b/templates/function-base/ts/m365/extensions.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+	<WarningsAsErrors></WarningsAsErrors>
+	<DefaultItemExcludes>**</DefaultItemExcludes>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.TeamsFx" Version="0.1.*" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="1.1.3" />
+  </ItemGroup>
+</Project>

--- a/templates/function-base/ts/m365/host.json
+++ b/templates/function-base/ts/m365/host.json
@@ -1,0 +1,11 @@
+{
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      }
+    }
+  }
+}

--- a/templates/function-base/ts/m365/local.settings.json.tpl
+++ b/templates/function-base/ts/m365/local.settings.json.tpl
@@ -1,0 +1,7 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "",
+    "FUNCTIONS_WORKER_RUNTIME": "node"
+  }
+}

--- a/templates/function-base/ts/m365/package.json
+++ b/templates/function-base/ts/m365/package.json
@@ -1,0 +1,23 @@
+{
+    "name": "teamsfx-template-api",
+    "version": "1.0.0",
+    "scripts": {
+        "dev:teamsfx": "env-cmd --silent -f .env.teamsfx.local npm run dev",
+        "dev": "func start --typescript --language-worker=\"--inspect=9229\" --port \"7071\" --cors \"*\"",
+        "watch:teamsfx": "tsc --watch",
+        "build": "tsc",
+        "watch": "tsc -w",
+        "prestart": "npm run build",
+        "start": "npx func start"
+    },
+    "dependencies": {
+        "@azure/functions": "^1.2.2",
+        "@microsoft/microsoft-graph-client": "^3.0.0",
+        "@microsoft/teamsfx": "0.6.0-beta.0",
+        "isomorphic-fetch": "^3.0.0"
+    },
+    "devDependencies": {
+        "env-cmd": "^10.1.0",
+        "typescript": "^3.3.3"
+    }
+}

--- a/templates/function-base/ts/m365/proxies.json
+++ b/templates/function-base/ts/m365/proxies.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "http://json.schemastore.org/proxies",
+  "proxies": {}
+}

--- a/templates/function-base/ts/m365/tsconfig.json
+++ b/templates/function-base/ts/m365/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es6",
+    "outDir": "dist",
+    "rootDir": ".",
+    "sourceMap": true,
+    "strict": false
+  }
+}


### PR DESCRIPTION
Add m365 func template: `tempates/function-base/js/m365`, `templates/function-base/ts/m365`. Based on current func template, but update:
1. @microsoft/teamsfx version to 0.6.0-beta.0

The templates will be used in function plugin as a new scenario.