### PR TITLE
chore(m365): add m365 setting and feature flag

### DIFF
--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -736,6 +736,8 @@ export interface Inputs extends Json {
     // (undocumented)
     ignoreEnvInfo?: boolean;
     // (undocumented)
+    isM365?: boolean;
+    // (undocumented)
     locale?: string;
     // (undocumented)
     platform: Platform;
@@ -1129,6 +1131,8 @@ export interface ProjectSettings {
     defaultFunctionName?: string;
     // (undocumented)
     isFromSample?: boolean;
+    // (undocumented)
+    isM365?: boolean;
     pluginSettings?: Json;
     // (undocumented)
     programmingLanguage?: string;

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -173,6 +173,7 @@ export interface ProjectSettings {
   defaultFunctionName?: string;
   solutionSettings?: SolutionSettings;
   isFromSample?: boolean;
+  isM365?: boolean;
   /**
    * pluginSettings is used for plugin settings irrelevant to environments
    */
@@ -233,6 +234,7 @@ export interface Inputs extends Json {
   existingResources?: string[];
   existingAppConfig?: ExistingAppConfig;
   locale?: string;
+  isM365?: boolean;
 }
 
 // configs for existing app building

--- a/packages/fx-core/src/common/constants.ts
+++ b/packages/fx-core/src/common/constants.ts
@@ -68,6 +68,7 @@ export class FeatureFlagName {
   static readonly DebugTemplate = "TEAMSFX_DEBUG_TEMPLATE";
   static readonly YeomanScaffold = "YEOMAN_SCAFFOLD";
   static readonly BotNotification = "BOT_NOTIFICATION_ENABLED";
+  static readonly M365App = "TEAMSFX_M365_APP";
 }
 
 export class ManifestVariables {

--- a/packages/fx-core/src/common/tools.ts
+++ b/packages/fx-core/src/common/tools.ts
@@ -382,6 +382,10 @@ export function isAadManifestEnabled(): boolean {
   return isFeatureFlagEnabled(FeatureFlagName.AadManifest, false);
 }
 
+export function isM365AppEnabled(): boolean {
+  return isFeatureFlagEnabled(FeatureFlagName.M365App, false);
+}
+
 // This method is for deciding whether AAD should be activated.
 // Currently AAD plugin will always be activated when scaffold.
 // This part will be updated when we support adding aad separately.


### PR DESCRIPTION
- add isM365 in ProjectSettings
- add isM365 in Inputs
- add TEAMSFX_M365_APP feature flag

The setting and feature flag will be used when scaffolding M365 projects.