### PR TITLE
chore(core): add null check for method isAADEnabled

### DIFF
--- a/packages/fx-core/src/common/tools.ts
+++ b/packages/fx-core/src/common/tools.ts
@@ -386,6 +386,10 @@ export function isAadManifestEnabled(): boolean {
 // Currently AAD plugin will always be activated when scaffold.
 // This part will be updated when we support adding aad separately.
 export function isAADEnabled(solutionSettings: AzureSolutionSettings): boolean {
+  if (!solutionSettings) {
+    return false;
+  }
+
   if (isAadManifestEnabled()) {
     return (
       solutionSettings.hostType === HostTypeOptionAzure.id &&


### PR DESCRIPTION
Due to the usage of https://github.com/OfficeDev/TeamsFx/blob/dev/packages/fx-core/src/common/local/projectSettingsHelper.ts#L51, the `projectSettings?.solutionSettings as AzureSolutionSettings` might be undefined and throw exception while calling `isAADEnabled.`