### PR TITLE
chore: update

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,5 @@
   "bin": {
     "teamsfx": "./packages/cli/cli.js"
   },
-  "dependencies": {},
-  "lint-staged": {
-    "*": [
-      "npx eslint --plugin 'no-secrets' --cache --ignore-pattern 'package-lock.json' --ignore-pattern 'package.json'"
-    ]
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
since the root package.json run lint:staged needs no-secrets plugins.
so delete this secret-checker.