### PR TITLE
feat(appstudio): scaffold manifest for m365 app

### DIFF
--- a/packages/fx-core/src/plugins/resource/appstudio/constants.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/constants.ts
@@ -512,3 +512,7 @@ export const DEFAULT_DEVELOPER_PRIVACY_URL = "https://www.example.com/privacy";
 
 export const TEAMS_APP_SHORT_NAME_MAX_LENGTH = 30;
 export const STATIC_TABS_MAX_ITEMS = 16;
+
+export const DEVELOPER_PREVIEW_SCHEMA =
+  "https://raw.githubusercontent.com/OfficeDev/microsoft-teams-app-schema/preview/DevPreview/MicrosoftTeams.schema.json";
+export const M365_DEVELOPER_PREVIEW_MANIFEST_VERSION = "m365DevPreview";

--- a/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
@@ -62,6 +62,8 @@ import {
   WEB_APPLICATION_INFO_LOCAL_DEBUG,
   WEB_APPLICATION_INFO_MULTI_ENV,
   TEAMS_APP_MANIFEST_TEMPLATE_LOCAL_DEBUG_V3,
+  DEVELOPER_PREVIEW_SCHEMA,
+  M365_DEVELOPER_PREVIEW_MANIFEST_VERSION,
 } from "./constants";
 import AdmZip from "adm-zip";
 import * as fs from "fs-extra";
@@ -537,13 +539,15 @@ export class AppStudioPluginImpl {
       const hasBot = solutionSettings.capabilities.includes(BotOptionItem.id);
       const hasMessageExtension = solutionSettings.capabilities.includes(MessageExtensionItem.id);
       const hasAad = isAADEnabled(solutionSettings);
+      const isM365 = ctx.projectSettings?.isM365;
       manifest = await createManifest(
         ctx.projectSettings!.appName,
         hasFrontend,
         hasBot,
         hasMessageExtension,
         false,
-        hasAad
+        hasAad,
+        isM365
       );
       if (!isConfigUnifyEnabled()) {
         const localDebugManifest = await createLocalManifest(
@@ -552,7 +556,8 @@ export class AppStudioPluginImpl {
           hasBot,
           hasMessageExtension,
           false,
-          hasAad
+          hasAad,
+          isM365
         );
         await fs.writeFile(
           `${appDir}/${MANIFEST_LOCAL}`,
@@ -1653,7 +1658,8 @@ export async function createLocalManifest(
   hasBot: boolean,
   hasMessageExtension: boolean,
   isSPFx: boolean,
-  hasAad = true
+  hasAad = true,
+  isM365 = false
 ): Promise<TeamsAppManifest> {
   let name = appName;
   const suffix = "-local-debug";
@@ -1677,13 +1683,19 @@ export async function createLocalManifest(
     }
     if (hasFrontend) {
       manifest.staticTabs = STATIC_TABS_TPL_LOCAL_DEBUG;
-      manifest.configurableTabs = CONFIGURABLE_TABS_TPL_LOCAL_DEBUG;
+      if (!isM365) {
+        manifest.configurableTabs = CONFIGURABLE_TABS_TPL_LOCAL_DEBUG;
+      }
     }
     if (hasBot) {
       manifest.bots = BOTS_TPL_LOCAL_DEBUG;
     }
     if (hasMessageExtension) {
       manifest.composeExtensions = COMPOSE_EXTENSIONS_TPL_LOCAL_DEBUG;
+    }
+    if (isM365) {
+      manifest.$schema = DEVELOPER_PREVIEW_SCHEMA;
+      manifest.manifestVersion = M365_DEVELOPER_PREVIEW_MANIFEST_VERSION;
     }
     return manifest;
   }
@@ -1695,7 +1707,8 @@ export async function createManifest(
   hasBot: boolean,
   hasMessageExtension: boolean,
   isSPFx: boolean,
-  hasAad = true
+  hasAad = true,
+  isM365 = false
 ): Promise<TeamsAppManifest | undefined> {
   if (!hasBot && !hasMessageExtension && !hasFrontend && !hasAad) {
     throw new Error(`Invalid capability`);
@@ -1708,13 +1721,19 @@ export async function createManifest(
     }
     if (hasFrontend) {
       manifest.staticTabs = STATIC_TABS_TPL_FOR_MULTI_ENV;
-      manifest.configurableTabs = CONFIGURABLE_TABS_TPL_FOR_MULTI_ENV;
+      if (!isM365) {
+        manifest.configurableTabs = CONFIGURABLE_TABS_TPL_FOR_MULTI_ENV;
+      }
     }
     if (hasBot) {
       manifest.bots = BOTS_TPL_FOR_MULTI_ENV;
     }
     if (hasMessageExtension) {
       manifest.composeExtensions = COMPOSE_EXTENSIONS_TPL_FOR_MULTI_ENV;
+    }
+    if (isM365) {
+      manifest.$schema = DEVELOPER_PREVIEW_SCHEMA;
+      manifest.manifestVersion = M365_DEVELOPER_PREVIEW_MANIFEST_VERSION;
     }
 
     return manifest;


### PR DESCRIPTION
- update $schema and manifestVersion to m365 dev preview
- do not add configurableTabs for m365 frontend app
- add corresponding unit tests