### PR TITLE
chore(cd): remove mo

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -126,7 +126,6 @@ jobs:
 
       - name: generate templates
         run: |
-          curl -sSL https://git.io/get-mo -o mo && chmod +x mo && sudo mv mo /usr/local/bin/
           .github/scripts/template-zip-autogen.sh ${{ runner.temp }}/teamsfx_templates
 
       - name: update tag


### PR DESCRIPTION
`mo` has been removed from `template-zip-autogen.sh`. https://github.com/OfficeDev/TeamsFx/pull/4025