### PR TITLE
refactor(template): move all fallback zip to a common folder

### DIFF
--- a/packages/fx-core/.gitignore
+++ b/packages/fx-core/.gitignore
@@ -6,8 +6,5 @@ coverage
 .env
 .prettierrc.json
 .fx
-templates/plugins/resource/bot/**/*.zip
-templates/plugins/resource/frontend/**/*.zip
-templates/plugins/resource/function/**/*.zip
-templates/plugins/resource/dotnet/**/*.zip
+templates/**/*.zip
 tests/**/TeamsSPFxApp.zip

--- a/packages/fx-core/scripts/download-templates-zip.js
+++ b/packages/fx-core/scripts/download-templates-zip.js
@@ -22,18 +22,12 @@ async function step(desc, fn) {
   }
 }
 
-async function getTemplateNames(tag) {
+async function getTemplateMetadata(tag) {
   const url = `${config.templateReleaseURL}/${tag}`;
-  const templateMetadata = await step(`Download release metadata from ${url}`, async () => {
+  return await step(`Download release metadata from ${url}`, async () => {
     const res = await axios.get(url);
     return res.data.assets;
   });
-
-  let templateNames = [];
-  for (let template of templateMetadata) {
-    templateNames.push(template.name);
-  }
-  return templateNames;
 }
 
 async function downloadTemplates(version) {
@@ -43,8 +37,9 @@ async function downloadTemplates(version) {
   const folder = path.join(__dirname, "..", "templates", "fallback");
   await fs.ensureDir(folder);
 
-  const templateNames = await getTemplateNames(tag);
-  for (let filename of templateNames) {
+  const templates = await getTemplateMetadata(tag);
+  for (let template of templates) {
+    const filename = template.name;
     step(`Download ${config.templateDownloadBaseURL}/${tag}/${filename}`, async () => {
       const res = await axios.get(`${config.templateDownloadBaseURL}/${tag}/${filename}`, {
         responseType: "arraybuffer",

--- a/packages/fx-core/src/common/template-utils/templatesActions.ts
+++ b/packages/fx-core/src/common/template-utils/templatesActions.ts
@@ -27,7 +27,7 @@ export interface ScaffoldContext {
   timeoutInMs?: number;
 
   // Used by fallback zip.
-  templatesFolderName?: string;
+  templatesFolderPath?: string;
 
   // Used by rendering template file.
   fileNameReplaceFn?: (name: string, data: Buffer) => string;
@@ -58,7 +58,7 @@ export enum ScaffoldActionName {
 }
 
 // * This action is only for debug purpose
-export const fetchTemplateZipFromSourceCode: ScaffoldAction = {
+export const fetchTemplateZipFromSourceCodeAction: ScaffoldAction = {
   name: ScaffoldActionName.FetchTemplateZipFromSourceCode,
   run: async (context: ScaffoldContext) => {
     const isDebugMode = () => {
@@ -168,19 +168,12 @@ export const fetchTemplateZipFromLocalAction: ScaffoldAction = {
       throw new Error(missKeyErrorInfo("scenario"));
     }
 
-    if (!context.templatesFolderName) {
-      throw new Error(missKeyErrorInfo("templatesFolderName"));
+    if (!context.templatesFolderPath) {
+      context.templatesFolderPath = path.join(getTemplatesFolder(), "fallback");
     }
 
     const fileName: string = [context.group, context.lang, context.scenario, "zip"].join(".");
-
-    const zipPath: string = path.join(
-      getTemplatesFolder(),
-      "plugins",
-      "resource",
-      context.templatesFolderName,
-      fileName
-    );
+    const zipPath: string = path.join(context.templatesFolderPath, fileName);
 
     const data: Buffer = await fs.readFile(zipPath);
     context.zip = new AdmZip(data);
@@ -203,7 +196,7 @@ export const unzipAction: ScaffoldAction = {
 };
 
 export const defaultActionSeq: ScaffoldAction[] = [
-  fetchTemplateZipFromSourceCode,
+  fetchTemplateZipFromSourceCodeAction,
   fetchTemplatesUrlWithTagAction,
   fetchTemplatesZipFromUrlAction,
   fetchTemplateZipFromLocalAction,
@@ -214,14 +207,14 @@ export function genTemplateRenderReplaceFn(variable: { [key: string]: string }) 
   return (name: string, data: Buffer) => renderTemplateContent(name, data, variable);
 }
 
-export function removeTemplateExtReplaceFn(name: string, data: Buffer) {
+export function removeTemplateExtReplaceFn(name: string, data: Buffer): string {
   return name.replace(/\.tpl/, "");
 }
 
 export async function scaffoldFromTemplates(
   context: ScaffoldContext,
   actions: ScaffoldAction[] = defaultActionSeq
-) {
+): Promise<void> {
   for (const action of actions) {
     try {
       await context.onActionStart?.(action, context);

--- a/packages/fx-core/src/common/templates-config.json
+++ b/packages/fx-core/src/common/templates-config.json
@@ -2,5 +2,6 @@
     "version": "^0.4.0",
     "tagPrefix": "templates@",
     "tagListURL": "https://github.com/OfficeDev/TeamsFx/releases/download/template-tag-list/template-tags.txt",
-    "templateDownloadBaseURL": "https://github.com/OfficeDev/TeamsFx/releases/download"
+    "templateDownloadBaseURL": "https://github.com/OfficeDev/TeamsFx/releases/download",
+    "templateReleaseURL": "https://api.github.com/repos/OfficeDev/TeamsFx/releases/tags"
 }

--- a/packages/fx-core/src/plugins/resource/bot/constants.ts
+++ b/packages/fx-core/src/plugins/resource/bot/constants.ts
@@ -40,7 +40,6 @@ export class ScaffoldPlaceholders {
 
 export class TemplateProjectsConstants {
   public static readonly GROUP_NAME_BOT: string = "bot";
-  public static readonly TEMPLATE_FOLDER_NAME: string = "bot";
   public static readonly GROUP_NAME_MSGEXT: string = "msgext";
   public static readonly GROUP_NAME_BOT_MSGEXT: string = "bot-msgext";
   public static readonly VERSION_RANGE: string = "0.0.*";

--- a/packages/fx-core/src/plugins/resource/bot/languageStrategy.ts
+++ b/packages/fx-core/src/plugins/resource/bot/languageStrategy.ts
@@ -26,7 +26,6 @@ import {
 import { TeamsBotConfig } from "./configs/teamsBotConfig";
 import { PluginActRoles } from "./enums/pluginActRoles";
 import * as path from "path";
-import * as fs from "fs-extra";
 
 export class LanguageStrategy {
   public static async scaffoldProject(
@@ -69,7 +68,6 @@ export class LanguageStrategy {
         group: group_name,
         lang: utils.convertToLangKey(config.scaffold.programmingLanguage!),
         scenario: scenario,
-        templatesFolderName: TemplateProjectsConstants.TEMPLATE_FOLDER_NAME,
         dst: dst,
         onActionEnd: async (action: ScaffoldAction, context: ScaffoldContext) => {
           if (action.name === ScaffoldActionName.FetchTemplatesUrlWithTag) {

--- a/packages/fx-core/src/plugins/resource/bot/v3/index.ts
+++ b/packages/fx-core/src/plugins/resource/bot/v3/index.ts
@@ -127,7 +127,6 @@ export class NodeJSBotPluginV3 implements v3.PluginV3 {
       group: group_name,
       lang: lang,
       scenario: TemplateProjectsScenarios.DEFAULT_SCENARIO_NAME,
-      templatesFolderName: TemplateProjectsConstants.TEMPLATE_FOLDER_NAME,
       dst: workingDir,
       onActionEnd: async (action: ScaffoldAction, context: ScaffoldContext) => {
         if (action.name === ScaffoldActionName.FetchTemplatesUrlWithTag) {

--- a/packages/fx-core/src/plugins/resource/frontend/constants.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/constants.ts
@@ -43,7 +43,6 @@ export class Commands {
 export class FrontendPathInfo {
   static WorkingDir = "tabs";
   static TemplateRelativeDir = path.join("plugins", "resource", "frontend");
-  static TemplateFolderName = "frontend";
   static BicepTemplateRelativeDir = path.join(FrontendPathInfo.TemplateRelativeDir, "bicep");
   static TemplateFileExt = ".tpl";
   static TemplatePackageExt = ".zip";

--- a/packages/fx-core/src/plugins/resource/frontend/dotnet/constants.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/dotnet/constants.ts
@@ -41,7 +41,6 @@ export class DotnetPathInfo {
 
   static readonly bicepTemplateFolder = (templateFolder: string) =>
     path.join(templateFolder, "plugins", "resource", "webapp", "bicep");
-  static readonly TemplateFolderName = "dotnet";
   static readonly projectFilename = (projectName: string): string => `${projectName}.csproj`;
 
   static readonly indexPath = ""; // Index path is '/', relative path is empty.

--- a/packages/fx-core/src/plugins/resource/frontend/dotnet/ops/scaffold.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/dotnet/ops/scaffold.ts
@@ -27,7 +27,6 @@ export async function scaffoldFromZipPackage(
     group: templateInfo.group,
     lang: templateInfo.language,
     scenario: templateInfo.scenario,
-    templatesFolderName: PathInfo.TemplateFolderName,
     dst: componentPath,
     fileNameReplaceFn: genTemplateNameRenderReplaceFn(templateInfo.variables.BlazorAppServer),
     fileDataReplaceFn: genTemplateRenderReplaceFn(templateInfo.variables),

--- a/packages/fx-core/src/plugins/resource/frontend/ops/scaffold.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/ops/scaffold.ts
@@ -29,7 +29,6 @@ export class FrontendScaffold {
       group: templateInfo.group,
       lang: templateInfo.language,
       scenario: templateInfo.scenario,
-      templatesFolderName: PathInfo.TemplateFolderName,
       dst: componentPath,
       fileNameReplaceFn: removeTemplateExtReplaceFn,
       fileDataReplaceFn: genTemplateRenderReplaceFn(templateInfo.variables),

--- a/packages/fx-core/src/plugins/resource/frontend/v3/index.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/v3/index.ts
@@ -89,7 +89,6 @@ export class NodeJSTabFrontendPlugin implements v3.PluginV3 {
       group: TemplateInfo.TemplateGroupName,
       lang: language,
       scenario: Scenario.Default,
-      templatesFolderName: FrontendPathInfo.TemplateFolderName,
       dst: componentPath,
       fileNameReplaceFn: removeTemplateExtReplaceFn,
       fileDataReplaceFn: genTemplateRenderReplaceFn(variables),

--- a/packages/fx-core/src/plugins/resource/function/constants.ts
+++ b/packages/fx-core/src/plugins/resource/function/constants.ts
@@ -37,7 +37,6 @@ export class FunctionPluginPathInfo {
   public static readonly solutionFolderName: string = "api";
   public static readonly templateZipExt: string = ".zip";
   public static readonly templateZipNameSep: string = ".";
-  public static readonly templateFolderName: string = "function";
   public static readonly functionExtensionsFolderName: string = "bin";
   public static readonly functionExtensionsFileName: string = "extensions.csproj";
   public static readonly funcDeploymentFolderName: string = ".deployment";

--- a/packages/fx-core/src/plugins/resource/function/ops/scaffold.ts
+++ b/packages/fx-core/src/plugins/resource/function/ops/scaffold.ts
@@ -70,7 +70,6 @@ export class FunctionScaffold {
       group: group,
       lang: this.convertTemplateLanguage(language),
       scenario: scenario,
-      templatesFolderName: PathInfo.templateFolderName,
       dst: componentPath,
       fileNameReplaceFn: _nameReplaceFn,
       fileDataReplaceFn: genTemplateRenderReplaceFn(variables),

--- a/packages/fx-core/tests/plugins/resource/bot/unit/index.test.ts
+++ b/packages/fx-core/tests/plugins/resource/bot/unit/index.test.ts
@@ -7,7 +7,7 @@ import * as sinon from "sinon";
 const AdmZip = require("adm-zip");
 import * as path from "path";
 
-import { BotHostTypes, PluginNames, TeamsBot } from "../../../../../src";
+import { PluginNames, TeamsBot } from "../../../../../src";
 import { TeamsBotImpl } from "../../../../../src/plugins/resource/bot/plugin";
 
 import * as utils from "../../../../../src/plugins/resource/bot/utils/common";
@@ -52,7 +52,6 @@ import * as os from "os";
 import { FunctionsHostedBotImpl } from "../../../../../src/plugins/resource/bot/functionsHostedBot/plugin";
 import { ScaffoldConfig } from "../../../../../src/plugins/resource/bot/configs/scaffoldConfig";
 import { DotnetBotImpl } from "../../../../../src/plugins/resource/bot/dotnet/plugin";
-import { TeamsFxAzureSolution } from "../../../../../src/plugins/solution/fx-solution/v3/solution";
 
 describe("Teams Bot Resource Plugin", () => {
   describe("Test plugin implementation dispatching", () => {

--- a/packages/fx-core/tests/plugins/resource/bot/unit/languageStrategy.test.ts
+++ b/packages/fx-core/tests/plugins/resource/bot/unit/languageStrategy.test.ts
@@ -38,7 +38,7 @@ describe("Language Strategy", () => {
       actRoles: [PluginActRoles.Bot],
     } as TeamsBotConfig;
     before(() => {
-      const commonPath = path.join(getTemplatesFolder(), "plugins", "resource", "bot");
+      const commonPath = path.join(getTemplatesFolder(), "fallback");
       const botJsPath = path.join(
         commonPath,
         `${TemplateProjectsConstants.GROUP_NAME_BOT}.${utils.convertToLangKey(

--- a/packages/fx-core/tests/plugins/resource/frontend/unit/index.test.ts
+++ b/packages/fx-core/tests/plugins/resource/frontend/unit/index.test.ts
@@ -55,15 +55,8 @@ describe("FrontendPlugin", () => {
 
     before(() => {
       const config: any = {};
-      config[
-        path.join(
-          getTemplatesFolder(),
-          "plugins",
-          "resource",
-          FrontendPathInfo.TemplateFolderName,
-          "tab.js.default.zip"
-        )
-      ] = new AdmZip().toBuffer();
+      config[path.join(getTemplatesFolder(), "fallback", "tab.js.default.zip")] =
+        new AdmZip().toBuffer();
       mock(config);
     });
 

--- a/packages/fx-core/tests/plugins/resource/function/unit/scaffold.test.ts
+++ b/packages/fx-core/tests/plugins/resource/function/unit/scaffold.test.ts
@@ -29,24 +29,10 @@ describe(FunctionPluginInfo.pluginName, () => {
 
     before(() => {
       const config: any = {};
-      config[
-        path.join(
-          getTemplatesFolder(),
-          "plugins",
-          "resource",
-          "function",
-          "function-base.js.default.zip"
-        )
-      ] = new AdmZip().toBuffer();
-      config[
-        path.join(
-          getTemplatesFolder(),
-          "plugins",
-          "resource",
-          "function",
-          "function-triggers.js.HTTPTrigger.zip"
-        )
-      ] = new AdmZip().toBuffer();
+      config[path.join(getTemplatesFolder(), "fallback", "function-base.js.default.zip")] =
+        new AdmZip().toBuffer();
+      config[path.join(getTemplatesFolder(), "fallback", "function-triggers.js.HTTPTrigger.zip")] =
+        new AdmZip().toBuffer();
       mock(config);
     });
 
@@ -72,7 +58,7 @@ describe(FunctionPluginInfo.pluginName, () => {
       context.answers[QuestionKey.functionName] = "httpTrigger";
       const zip = new AdmZip();
       zip.addFile("test.js.tpl", Buffer.from("{{appName}} {{functionName}}"));
-      sinon.stub(fetch, "fetchTemplateUrl").resolves("fackurl");
+      sinon.stub(fetch, "fetchTemplateUrl").resolves("fakeUrl");
       sinon.stub(fetch, "fetchZipFromUrl").resolves(zip);
 
       const plugin: FunctionPlugin = new FunctionPlugin();
@@ -87,11 +73,11 @@ describe(FunctionPluginInfo.pluginName, () => {
 
     it("Test scaffold with additional function", async () => {
       // Arrange
-      context.answers = context.answers = { platform: Platform.VSCode };
+      context.answers = { platform: Platform.VSCode };
       context.answers[QuestionKey.functionName] = "httpTrigger";
       const zip = new AdmZip();
       zip.addFile("test.js.tpl", Buffer.from("{{appName}} {{functionName}}"));
-      sinon.stub(fetch, "fetchTemplateUrl").resolves(undefined);
+      sinon.stub(fetch, "fetchTemplateUrl").resolves("fakeUrl");
       sinon.stub(fetch, "fetchZipFromUrl").resolves(zip);
 
       const plugin: FunctionPlugin = new FunctionPlugin();
@@ -106,7 +92,7 @@ describe(FunctionPluginInfo.pluginName, () => {
 
     it("Test scaffold with fallback in JS", async () => {
       // Arrange
-      context.answers = context.answers = { platform: Platform.VSCode };
+      context.answers = { platform: Platform.VSCode };
       context.answers[QuestionKey.functionName] = "httpTrigger";
       sinon.stub(fetch, "fetchTemplateUrl").rejects(new Error());
       const plugin: FunctionPlugin = new FunctionPlugin();


### PR DESCRIPTION
1. Move all fallback zip to a common folder.
2. download-template-zip.js download all assets from github release by tag name.

By doing so, we do not need to update download-template-zip.js when there is new template added.

E2E TEST: all passed https://github.com/OfficeDev/TeamsFx/actions/runs/1990669349