### PR TITLE
chore: change server packing name

### DIFF
--- a/packages/server/buildExe.js
+++ b/packages/server/buildExe.js
@@ -36,15 +36,7 @@ const [nodeRange, platform, arch] = target.split("-");
     const built = path.join(dirname, filename.replace("fetched", "built"));
     await fs.rename(fetched, built);
 
-    await pkg.exec([
-      "./lib/index.js",
-      "-t",
-      target,
-      "-o",
-      "./lib/server",
-      "-c",
-      "pkg.json",
-      "--build",
-    ]);
+    const output = path.join("lib", `server-${arch}-${version}.exe`);
+    await pkg.exec(["./lib/index.js", "-t", target, "-o", output, "-c", "pkg.json", "--build"]);
   }
 })();


### PR DESCRIPTION
Naming rule: server-${arch}-${version}.exe. This is to distinguish the different version/arch of the server.