### PR TITLE
chore(m365): scaffold m365 tab template

### DIFF
--- a/packages/fx-core/src/plugins/resource/frontend/resources/templateInfo.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/resources/templateInfo.ts
@@ -21,6 +21,7 @@ export class Scenario {
   static readonly Default = "default";
   static readonly WithFunction = "with-function";
   static readonly NonSso = "non-sso";
+  static readonly M365 = "m365";
 }
 
 export class TemplateInfo {
@@ -49,7 +50,11 @@ export class TemplateInfo {
       showFunction: isFunctionPlugin.toString(),
     };
 
-    this.scenario = isAadManifestEnabled() ? Scenario.NonSso : Scenario.Default;
+    this.scenario = ctx.projectSettings?.isM365
+      ? Scenario.M365
+      : isAadManifestEnabled()
+      ? Scenario.NonSso
+      : Scenario.Default;
 
     this.localTemplateBaseName = [this.group, this.language, this.scenario].join(".");
     this.localTemplatePath = path.join(

--- a/templates/tab/js/m365/package.json
+++ b/templates/tab/js/m365/package.json
@@ -4,9 +4,9 @@
     "private": true,
     "dependencies": {
         "@fluentui/react-northstar": "^0.54.0",
-        "@microsoft/mgt-element": "2.4.1-next.teamsfx.3511fba",
-        "@microsoft/mgt-react": "2.4.1-next.teamsfx.3511fba",
-        "@microsoft/mgt-teamsfx-provider": "2.4.1-next.teamsfx.3511fba",
+        "@microsoft/mgt-element": "2.4.1-next.teamsfx.053a600",
+        "@microsoft/mgt-react": "2.4.1-next.teamsfx.053a600",
+        "@microsoft/mgt-teamsfx-provider": "2.4.1-next.teamsfx.053a600",
         "@microsoft/microsoft-graph-client": "^3.0.1",
         "@microsoft/teams-js": "2.0.0-beta.2",
         "@microsoft/teamsfx": "0.6.0-beta.0",

--- a/templates/tab/js/m365/src/components/sample/Welcome.jsx
+++ b/templates/tab/js/m365/src/components/sample/Welcome.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { Image, Menu } from "@fluentui/react-northstar";
+import * as microsoftTeams from "@microsoft/teams-js";
 import "./Welcome.css";
 import { EditCode } from "./EditCode";
 import { AzureFunctions } from "./AzureFunctions";
@@ -44,11 +45,19 @@ export function Welcome(props) {
     return isInTeams ? await teamsfx.getUserInfo() : undefined;
   })?.data;
   const userName = userProfile ? userProfile.displayName : "";
+  const hubName = useData(async () => {
+    await microsoftTeams.app.initialize();
+    const context = await microsoftTeams.app.getContext();
+    return context.app.host.name;
+  })?.data;
   return (
     <div className="welcome page">
       <div className="narrow page-padding">
         <Image src="hello.png" />
         <h1 className="center">Congratulations{userName ? ", " + userName : ""}!</h1>
+        {hubName && (
+          <p className="center">Your app is running in {hubName}</p>
+        )}
         <p className="center">Your app is running in your {friendlyEnvironmentName}</p>
         <Menu defaultActiveIndex={0} items={items} underlined secondary />
         <div className="sections">

--- a/templates/tab/ts/m365/package.json
+++ b/templates/tab/ts/m365/package.json
@@ -4,9 +4,9 @@
     "private": true,
     "dependencies": {
         "@fluentui/react-northstar": "^0.54.0",
-        "@microsoft/mgt-element": "2.4.1-next.teamsfx.3511fba",
-        "@microsoft/mgt-react": "2.4.1-next.teamsfx.3511fba",
-        "@microsoft/mgt-teamsfx-provider": "2.4.1-next.teamsfx.3511fba",
+        "@microsoft/mgt-element": "2.4.1-next.teamsfx.053a600",
+        "@microsoft/mgt-react": "2.4.1-next.teamsfx.053a600",
+        "@microsoft/mgt-teamsfx-provider": "2.4.1-next.teamsfx.053a600",
         "@microsoft/microsoft-graph-client": "^3.0.1",
         "@microsoft/teams-js": "2.0.0-beta.2",
         "@microsoft/teamsfx": "0.6.0-beta.0",

--- a/templates/tab/ts/m365/src/components/sample/Welcome.tsx
+++ b/templates/tab/ts/m365/src/components/sample/Welcome.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Image, Menu } from "@fluentui/react-northstar";
+import * as microsoftTeams from "@microsoft/teams-js";
 import "./Welcome.css";
 import { EditCode } from "./EditCode";
 import { AzureFunctions } from "./AzureFunctions";
@@ -44,11 +45,19 @@ export function Welcome(props: { showFunction?: boolean; environment?: string })
     return isInTeams ? await teamsfx.getUserInfo() : undefined;
   })?.data;
   const userName = userProfile ? userProfile.displayName : "";
+  const hubName = useData(async () => {
+    await microsoftTeams.app.initialize();
+    const context = await microsoftTeams.app.getContext();
+    return context.app.host.name;
+  })?.data;
   return (
     <div className="welcome page">
       <div className="narrow page-padding">
         <Image src="hello.png" />
         <h1 className="center">Congratulations{userName ? ", " + userName : ""}!</h1>
+        {hubName && (
+          <p className="center">Your app is running in {hubName}</p>
+        )}
         <p className="center">Your app is running in your {friendlyEnvironmentName}</p>
         <Menu defaultActiveIndex={0} items={items} underlined secondary />
         <div className="sections">


### PR DESCRIPTION
Frontend plugin:
- scaffold m365 tab template if isM365 is true

M365 template:
- use teams-js v2 to get hub name
- show hub name in template welcome page
- update @microsoft/mgt-element version to 2.4.1-next.teamsfx.053a600
- update @microsoft/mgt-react version to 2.4.1-next.teamsfx.053a600
- update @microsoft/mgt-teamsfx-provider version to 2.4.1-next.teamsfx.053a600

![image](https://user-images.githubusercontent.com/37978464/158560740-139dfb92-76e6-4187-8468-89a9be2be3f9.png)
