### PR TITLE
feat(m365): add create m365 app command

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -46,6 +46,7 @@
     "onCommand:fx-extension.openDocument",
     "onCommand:fx-extension.cmpAccounts",
     "onCommand:fx-extension.create",
+    "onCommand:fx-extension.create-M365",
     "onCommand:fx-extension.addCapability",
     "onCommand:fx-extension.update",
     "onCommand:fx-extension.openManifest",
@@ -435,6 +436,11 @@
       {
         "command": "fx-extension.create",
         "title": "%teamstoolkit.commands.createProject.title%"
+      },
+      {
+        "command": "fx-extension.create-M365",
+        "title": "%teamstoolkit.commands.createM365Project.title%",
+        "enablement": "fx-extension.isM365AppEnabled"
       },
       {
         "command": "fx-extension.init",

--- a/packages/vscode-extension/package.nls.json
+++ b/packages/vscode-extension/package.nls.json
@@ -45,6 +45,7 @@
     "teamstoolkit.commands.addCloudResource.title": "Teams: Add cloud resources",
     "teamstoolkit.commands.addCICDWorkflows.title": "Teams: Add CI/CD Workflows",
     "teamstoolkit.commands.createEnvironment.title": "Teams: Create new environment",
+    "teamstoolkit.commands.createM365Project.title": "Teams: Create a new M365 app",
     "teamstoolkit.commands.createProject.title": "Teams: Create a new Teams app",
     "teamstoolkit.commands.debug.title": "Select and Start Debuging Teams App",
     "teamstoolkit.commands.deploy.title": "Teams: Deploy to the cloud",

--- a/packages/vscode-extension/package.nls.json
+++ b/packages/vscode-extension/package.nls.json
@@ -45,7 +45,7 @@
     "teamstoolkit.commands.addCloudResource.title": "Teams: Add cloud resources",
     "teamstoolkit.commands.addCICDWorkflows.title": "Teams: Add CI/CD Workflows",
     "teamstoolkit.commands.createEnvironment.title": "Teams: Create new environment",
-    "teamstoolkit.commands.createM365Project.title": "Teams: Create a new M365 app",
+    "teamstoolkit.commands.createM365Project.title": "Teams: Create a new Microsoft 365 app",
     "teamstoolkit.commands.createProject.title": "Teams: Create a new Teams app",
     "teamstoolkit.commands.debug.title": "Select and Start Debuging Teams App",
     "teamstoolkit.commands.deploy.title": "Teams: Deploy to the cloud",

--- a/packages/vscode-extension/src/commonlib/graphLogin.ts
+++ b/packages/vscode-extension/src/commonlib/graphLogin.ts
@@ -25,7 +25,7 @@ import {
 import { localize } from "../utils/localizeUtils";
 
 const accountName = "appStudio";
-const scopes = ["Application.ReadWrite.All"];
+const scopes = ["Application.ReadWrite.All", "TeamsAppInstallation.ReadForUser"];
 
 const cachePlugin = new CryptoCachePlugin(accountName);
 

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -26,6 +26,7 @@ import {
   isValidProject,
   isConfigUnifyEnabled,
   isInitAppEnabled,
+  isM365AppEnabled,
 } from "@microsoft/teamsfx-core";
 import { TreatmentVariableValue, TreatmentVariables } from "./exp/treatmentVariables";
 import {
@@ -86,6 +87,11 @@ export async function activate(context: vscode.ExtensionContext) {
     Correlator.run(handlers.createNewProjectHandler, args)
   );
   context.subscriptions.push(createCmd);
+
+  const createM365Cmd = vscode.commands.registerCommand("fx-extension.create-M365", (...args) =>
+    Correlator.run(handlers.createNewM365ProjectHandler, args)
+  );
+  context.subscriptions.push(createM365Cmd);
 
   const initCmd = vscode.commands.registerCommand("fx-extension.init", (...args) =>
     Correlator.run(handlers.initProjectHandler, args)
@@ -444,6 +450,8 @@ export async function activate(context: vscode.ExtensionContext) {
   );
 
   vscode.commands.executeCommand("setContext", "fx-extension.isInitAppEnabled", isInitAppEnabled());
+
+  vscode.commands.executeCommand("setContext", "fx-extension.isM365AppEnabled", isM365AppEnabled());
 
   vscode.commands.executeCommand(
     "setContext",

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -371,7 +371,10 @@ export async function createNewProjectHandler(args?: any[]): Promise<Result<any,
 }
 
 export async function createNewM365ProjectHandler(args?: any[]): Promise<Result<any, FxError>> {
-  ExtTelemetry.sendTelemetryEvent(TelemetryEvent.CreateProjectStart, getTriggerFromProperty(args));
+  ExtTelemetry.sendTelemetryEvent(TelemetryEvent.CreateProjectStart, {
+    ...getTriggerFromProperty(args),
+    [TelemetryProperty.IsM365]: "true",
+  });
   const inputs = getSystemInputs();
   inputs.isM365 = true;
   const result = await runCommand(Stage.create, inputs);

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -370,6 +370,17 @@ export async function createNewProjectHandler(args?: any[]): Promise<Result<any,
   return result;
 }
 
+export async function createNewM365ProjectHandler(args?: any[]): Promise<Result<any, FxError>> {
+  ExtTelemetry.sendTelemetryEvent(TelemetryEvent.CreateProjectStart, getTriggerFromProperty(args));
+  const inputs = getSystemInputs();
+  inputs.isM365 = true;
+  const result = await runCommand(Stage.create, inputs);
+  if (result.isOk()) {
+    await openFolder(result.value, true, args);
+  }
+  return result;
+}
+
 export async function initProjectHandler(args?: any[]): Promise<Result<any, FxError>> {
   ExtTelemetry.sendTelemetryEvent(TelemetryEvent.InitProjectStart, getTriggerFromProperty(args));
   const result = await runCommand(Stage.init);

--- a/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
@@ -19,6 +19,9 @@ export enum TelemetryEvent {
   CreateProjectStart = "create-project-start",
   CreateProject = "create-project",
 
+  CreateM365ProjectStart = "create-m365-project-start",
+  CreateM365Project = "create-m365-project",
+
   InitProjectStart = "init-project-start",
   InitProject = "init-project",
 

--- a/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
@@ -19,9 +19,6 @@ export enum TelemetryEvent {
   CreateProjectStart = "create-project-start",
   CreateProject = "create-project",
 
-  CreateM365ProjectStart = "create-m365-project-start",
-  CreateM365Project = "create-m365-project",
-
   InitProjectStart = "init-project-start",
   InitProject = "init-project",
 
@@ -206,6 +203,7 @@ export enum TelemetryProperty {
   SourceEnv = "sourceEnv",
   TargetEnv = "targetEnv",
   IsFromSample = "is-from-sample",
+  IsM365 = "is-m365",
   SettingsVersion = "settings-version",
   UpdateFailedFiles = "update-failed-files",
   NewProjectId = "new-project-id",


### PR DESCRIPTION
- add a new command to create a m365 app, this command will be only enabled if m365 feature flag is set
- add create new m365 project handler, set isM365 in inputs to let FxCore know this is to create a m365 project
- add TeamsAppInstallation.ReadForUser to graph scopes

![create-m365-app](https://user-images.githubusercontent.com/37978464/158566884-c7715eed-c10a-4b01-beb2-1f2e98704edb.gif)