### PR TITLE
fix(vsc): env view shows if no project opened

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -103,7 +103,8 @@
         },
         {
           "id": "teamsfx-environment",
-          "name": "Environment"
+          "name": "Environment",
+          "when": "fx-extension.sidebarWelcome.treeview"
         },
         {
           "id": "teamsfx-development",


### PR DESCRIPTION
fix bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/13862400/
E2E TEST: UI related.