### PR TITLE
fix: fix getTeamsAppInternalId bug in debug provider

### DIFF
--- a/packages/vscode-extension/src/debug/teamsfxDebugProvider.ts
+++ b/packages/vscode-extension/src/debug/teamsfxDebugProvider.ts
@@ -95,9 +95,11 @@ export class TeamsfxDebugProvider implements vscode.DebugConfigurationProvider {
 
         url = url.replace(localTeamsAppIdPlaceholder, debugConfig.appId);
         url = url.replace(teamsAppIdPlaceholder, debugConfig.appId);
-        const internalId = await getTeamsAppInternalId(debugConfig.appId);
-        if (internalId !== undefined) {
-          url = url.replace(localTeamsAppInternalIdPlaceholder, internalId);
+        if (isLocalM365SideloadingConfiguration) {
+          const internalId = await getTeamsAppInternalId(debugConfig.appId);
+          if (internalId !== undefined) {
+            url = url.replace(localTeamsAppInternalIdPlaceholder, internalId);
+          }
         }
 
         const accountHintPlaceholder = "${account-hint}";


### PR DESCRIPTION
Fix https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/13864517.