### PR TITLE
chore: update notification sdk version

### DIFF
--- a/templates/bot/ts/notification-function-base/package.json
+++ b/templates/bot/ts/notification-function-base/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@microsoft/adaptivecards-tools": "^0.1.3",
-    "@microsoft/teamsfx": "0.6.0-notification.0",
+    "@microsoft/teamsfx": "0.6.0-test-notification.0",
     "botbuilder": "~4.15.0",
     "botbuilder-azure-blobs": "^4.15.0",
     "botbuilder-dialogs": "~4.15.0",


### PR DESCRIPTION
Include "test" in the semver prerelease part to prevent auto upgrading. 