### PR TITLE
chore(env): no need to save userdata file when no secrets

### DIFF
--- a/packages/fx-core/src/core/environment.ts
+++ b/packages/fx-core/src/core/environment.ts
@@ -172,8 +172,13 @@ class EnvironmentManager {
     this.encrypt(secrets, cryptoProvider);
 
     try {
-      await fs.writeFile(envFiles.envState, JSON.stringify(data, null, 4));
-      await fs.writeFile(envFiles.userDataFile, serializeDict(secrets));
+      if (!this.isEmptyRecord(data)) {
+        await fs.writeFile(envFiles.envState, JSON.stringify(data, null, 4));
+      }
+
+      if (!this.isEmptyRecord(secrets)) {
+        await fs.writeFile(envFiles.userDataFile, serializeDict(secrets));
+      }
     } catch (error) {
       return err(WriteFileError(error));
     }
@@ -410,6 +415,10 @@ class EnvironmentManager {
     }
 
     return ok(secrets);
+  }
+
+  private isEmptyRecord(data: Record<any, any>): boolean {
+    return Object.keys(data).length === 0;
   }
 
   public getDefaultEnvName() {

--- a/packages/fx-core/tests/core/environment.test.ts
+++ b/packages/fx-core/tests/core/environment.test.ts
@@ -450,9 +450,8 @@ describe("APIs of Environment Manager", () => {
         projectPath
       );
 
-      const expectedEnvStateContent = JSON.stringify(envStateDataWithoutCredential, null, 4);
       assert.deepEqual(JSON.parse(fileMap.get(envFiles.envState)), envStateDataWithoutCredential);
-      assert.equal(fileMap.get(envFiles.userDataFile), "");
+      assert.isUndefined(fileMap.get(envFiles.userDataFile));
     });
 
     it("no userdata: write environment state with target env", async () => {
@@ -464,12 +463,8 @@ describe("APIs of Environment Manager", () => {
       );
       const envFiles = environmentManager.getEnvStateFilesPath(targetEnvName, projectPath);
 
-      const expectedEnvStateContent = JSON.stringify(envStateDataWithoutCredential, null, 4);
-      assert.equal(
-        formatContent(fileMap.get(envFiles.envState)),
-        formatContent(expectedEnvStateContent)
-      );
-      assert.equal(fileMap.get(envFiles.userDataFile), "");
+      assert.deepEqual(JSON.parse(fileMap.get(envFiles.envState)), envStateDataWithoutCredential);
+      assert.isUndefined(fileMap.get(envFiles.userDataFile));
     });
 
     it("with userdata: write environment state without target env", async () => {


### PR DESCRIPTION
if there's no secret, then no need to save *.userdata file under .fx/configs/