### PR TITLE
chore: refine templates, align npm ci

### DIFF
--- a/packages/fx-core/src/plugins/resource/cicd/utils/buildScripts.ts
+++ b/packages/fx-core/src/plugins/resource/cicd/utils/buildScripts.ts
@@ -13,15 +13,15 @@ export function generateBuildScript(projectSettings: ProjectSettings): string {
   const hostType = solutionSettings?.["hostType"];
 
   if (capabilities?.includes("Tab")) {
-    if (hostType && hostType === "Azure") parts.push("cd tabs; npm install; npm run build; cd -;");
-    if (hostType && hostType === "SPFx") parts.push("cd SPFx; npm install; npm run build; cd -;");
+    if (hostType && hostType === "Azure") parts.push("cd tabs; npm ci; npm run build; cd -;");
+    if (hostType && hostType === "SPFx") parts.push("cd SPFx; npm ci; npm run build; cd -;");
   }
 
   if (capabilities?.includes("Bot") || capabilities.includes("MessagingExtension")) {
     if (projectSettings.programmingLanguage === "typescript") {
-      parts.push("cd bot; npm install; npm run build; cd -;");
+      parts.push("cd bot; npm ci; npm run build; cd -;");
     } else {
-      parts.push("cd bot; npm install; cd -;");
+      parts.push("cd bot; npm ci; cd -;");
     }
   }
 
@@ -29,7 +29,7 @@ export function generateBuildScript(projectSettings: ProjectSettings): string {
     azureResources?.includes("function") &&
     projectSettings.programmingLanguage === "typescript"
   ) {
-    parts.push("cd api; npm install; npm run build; cd -;");
+    parts.push("cd api; npm ci; npm run build; cd -;");
   }
 
   return parts.join("");

--- a/packages/fx-core/templates/plugins/resource/cicd/azdo/cd.yml
+++ b/packages/fx-core/templates/plugins/resource/cicd/azdo/cd.yml
@@ -26,6 +26,7 @@ steps:
     TEAMSFX_ENV_NAME: <%env_name%>
   inputs:
     targetType: 'inline'
+    failOnStderr: true
     script: |
       set -vuxo pipefail
       

--- a/packages/fx-core/templates/plugins/resource/cicd/azdo/ci.yml
+++ b/packages/fx-core/templates/plugins/resource/cicd/azdo/ci.yml
@@ -18,6 +18,7 @@ steps:
 - task: Bash@3
   inputs:
     targetType: 'inline'
+    failOnStderr: true
     script: |
       set -euxo pipefail
 

--- a/packages/fx-core/templates/plugins/resource/cicd/azdo/ci.yml
+++ b/packages/fx-core/templates/plugins/resource/cicd/azdo/ci.yml
@@ -20,7 +20,7 @@ steps:
     targetType: 'inline'
     failOnStderr: true
     script: |
-      set -euxo pipefail
+      set -vuxo pipefail
 
       # This is just an example workflow for continuous integration.
       # You should customize it to meet your own requirements.

--- a/packages/fx-core/templates/plugins/resource/cicd/azdo/provision.yml
+++ b/packages/fx-core/templates/plugins/resource/cicd/azdo/provision.yml
@@ -1,9 +1,8 @@
 {{=<% %>=}}
 # This is just an example workflow for provision.
 # You should customize it to meet your own requirements.
-trigger:
+trigger: none
 # Manually trigger this workflow, and you should pick the right branch.
-- main
 
 pool:
   vmImage: ubuntu-latest
@@ -28,6 +27,7 @@ steps:
     TEAMSFX_ENV_NAME: <%env_name%>
   inputs:
     targetType: 'inline'
+    failOnStderr: true
     script: |
       set -vuxo pipefail
       

--- a/packages/fx-core/templates/plugins/resource/cicd/azdo/publish.yml
+++ b/packages/fx-core/templates/plugins/resource/cicd/azdo/publish.yml
@@ -1,9 +1,8 @@
 {{=<% %>=}}
 # This is just an example workflow for publishing Teams app.
 # You should customize it to meet your own requirements.
-trigger:
+trigger: none
 # Manually trigger this workflow, and you should pick the right branch.
-- main 
 
 pool:
   vmImage: ubuntu-latest
@@ -25,6 +24,7 @@ steps:
     TEAMSFX_ENV_NAME: <%env_name%>
   inputs:
     targetType: 'inline'
+    failOnStderr: true
     script: |
       set -vuxo pipefail
       


### PR DESCRIPTION
to fix 
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/13883926
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/13883902

1. fix azdo's trigger to `trigger: none`, i.e., the manual trigger.
2. align `npm ci`
3. turn on `failOnStandardErr`