### PR TITLE
chore(vsc): refresh env tree when project settings updated

### DIFF
--- a/packages/vscode-extension/src/envTree.ts
+++ b/packages/vscode-extension/src/envTree.ts
@@ -85,7 +85,10 @@ export async function registerEnvTreeHandler(): Promise<Result<Void, FxError>> {
             contextValue: envInfo,
             icon: envInfo === EnvInfo.ProvisionedRemoteEnv ? "folder-active" : "symbol-folder",
             isCustom: false,
-            expanded: envInfo === EnvInfo.Local || isSpfxProject ? undefined : true,
+            expanded:
+              envInfo === EnvInfo.Local || EnvInfo.LocalForExistingApp || isSpfxProject
+                ? undefined
+                : true,
           },
         ]);
       }

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -50,6 +50,7 @@ import {
   Void,
   VsCodeEnv,
   IProgressHandler,
+  ProjectSettingsFileName,
 } from "@microsoft/teamsfx-api";
 import {
   CollaborationState,
@@ -244,6 +245,10 @@ export async function activate(): Promise<Result<Void, FxError>> {
 
         await refreshEnvTreeOnFileChanged(workspacePath, files);
       });
+
+      workspace.onDidSaveTextDocument(async (event) => {
+        await refreshEnvTreeOnFileContentChanged(workspacePath, event.uri.fsPath);
+      });
     }
   } catch (e) {
     const FxError: FxError = {
@@ -301,6 +306,20 @@ async function refreshEnvTreeOnFileChanged(workspacePath: string, files: readonl
   }
 
   if (needRefresh) {
+    await envTree.registerEnvTreeHandler();
+  }
+}
+
+async function refreshEnvTreeOnFileContentChanged(workspacePath: string, filePath: string) {
+  const projectSettingsPath = path.resolve(
+    workspacePath,
+    `.${ConfigFolderName}`,
+    InputConfigsFolderName,
+    ProjectSettingsFileName
+  );
+
+  // check if file is project config
+  if (path.normalize(filePath) === path.normalize(projectSettingsPath)) {
     await envTree.registerEnvTreeHandler();
   }
 }


### PR DESCRIPTION
refresh env tree and update the `Preview` button to `Local Debug` button when project settings is updated (for example, a component is added to a mini app).


<img src="https://user-images.githubusercontent.com/15644078/159420100-428b4930-47ea-4d58-b7b1-c1e5c0ae6e1a.png" width=400>
<img src="https://user-images.githubusercontent.com/15644078/159402524-4249627e-e6e1-4369-9c08-9133feb76c66.png" width=400>

