### PR TITLE
chore: tune fail on err

### DIFF
--- a/packages/fx-core/templates/plugins/resource/cicd/azdo/cd.yml
+++ b/packages/fx-core/templates/plugins/resource/cicd/azdo/cd.yml
@@ -26,9 +26,8 @@ steps:
     TEAMSFX_ENV_NAME: <%env_name%>
   inputs:
     targetType: 'inline'
-    failOnStderr: true
     script: |
-      set -vuxo pipefail
+      set -evuxo pipefail
       
       # Install the local dev dependency of @microsoft/teamsfx-cli. 
       # 'npm ci' is used here to install dependencies and it depends on package-lock.json.

--- a/packages/fx-core/templates/plugins/resource/cicd/azdo/ci.yml
+++ b/packages/fx-core/templates/plugins/resource/cicd/azdo/ci.yml
@@ -18,9 +18,8 @@ steps:
 - task: Bash@3
   inputs:
     targetType: 'inline'
-    failOnStderr: true
     script: |
-      set -vuxo pipefail
+      set -evuxo pipefail
 
       # This is just an example workflow for continuous integration.
       # You should customize it to meet your own requirements.

--- a/packages/fx-core/templates/plugins/resource/cicd/azdo/provision.yml
+++ b/packages/fx-core/templates/plugins/resource/cicd/azdo/provision.yml
@@ -27,9 +27,8 @@ steps:
     TEAMSFX_ENV_NAME: <%env_name%>
   inputs:
     targetType: 'inline'
-    failOnStderr: true
     script: |
-      set -vuxo pipefail
+      set -evuxo pipefail
       
       # Install the local dev dependency of @microsoft/teamsfx-cli. 
       # 'npm ci' is used here to install dependencies and it depends on package-lock.json.

--- a/packages/fx-core/templates/plugins/resource/cicd/azdo/publish.yml
+++ b/packages/fx-core/templates/plugins/resource/cicd/azdo/publish.yml
@@ -24,9 +24,8 @@ steps:
     TEAMSFX_ENV_NAME: <%env_name%>
   inputs:
     targetType: 'inline'
-    failOnStderr: true
     script: |
-      set -vuxo pipefail
+      set -evuxo pipefail
       
       # Install the local dev dependency of @microsoft/teamsfx-cli. 
       # 'npm ci' is used here to install dependencies and it depends on package-lock.json.


### PR DESCRIPTION
failOnStderr is too strict which will cause warning to fail the whole process.
1. remove failOnStderr
2. set -e for the bash to fail as soon as possible