### PR TITLE
chore(cicd): throw error while adding cicd to minimal app

### DIFF
--- a/packages/fx-core/src/core/error.ts
+++ b/packages/fx-core/src/core/error.ts
@@ -275,7 +275,7 @@ export class OperationNotPermittedError extends UserError {
 }
 
 export class NoCapabilityFoundError extends UserError {
-  constructor(operation: Stage) {
+  constructor(operation: string) {
     super(
       new.target.name,
       getLocalizedString("core.deploy.noCapabilityFound", operation),

--- a/packages/fx-core/src/plugins/resource/cicd/index.ts
+++ b/packages/fx-core/src/plugins/resource/cicd/index.ts
@@ -37,6 +37,8 @@ import { Logger } from "./logger";
 import { environmentManager } from "../../../core/environment";
 import { telemetryHelper } from "./utils/telemetry-helper";
 import { getLocalizedString } from "../../../common/localizeUtils";
+import { isPureExistingApp } from "../../../common";
+import { NoCapabilityFoundError } from "../../../core/error";
 
 @Service(ResourcePluginsV2.CICDPlugin)
 export class CICDPluginV2 implements ResourcePlugin {
@@ -65,6 +67,11 @@ export class CICDPluginV2 implements ResourcePlugin {
     envInfo: DeepReadonly<v2.EnvInfoV2>,
     tokenProvider: TokenProvider
   ): Promise<FxResult> {
+    // add CI CD workflows for minimal app is not supported.
+    if (ctx.projectSetting && isPureExistingApp(ctx.projectSetting)) {
+      throw new NoCapabilityFoundError("add CI CD workflows");
+    }
+
     const cicdWorkflowQuestions = new QTreeNode({
       type: "group",
     });


### PR DESCRIPTION
For minimal app, there's no need to add CI/CD workflows for minimal app as it doesn't contain app source code.
<img src="https://user-images.githubusercontent.com/15644078/159636836-8aa4f296-51db-4b7d-bc4a-ea3cd6f8ca32.png" width=500>