### PR TITLE
chore: add bot plugin settings capabilities

### DIFF
--- a/packages/fx-core/src/plugins/resource/bot/configs/teamsBotConfig.ts
+++ b/packages/fx-core/src/plugins/resource/bot/configs/teamsBotConfig.ts
@@ -1,15 +1,19 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { ConfigValue, PluginContext, AzureSolutionSettings } from "@microsoft/teamsfx-api";
+import { ConfigValue, PluginContext, AzureSolutionSettings, Stage } from "@microsoft/teamsfx-api";
 
 import { LocalDebugConfig } from "./localDebugConfig";
 import { ProvisionConfig } from "./provisionConfig";
 import { ScaffoldConfig } from "./scaffoldConfig";
-import { PluginSolution, PluginAAD } from "../resources/strings";
+import {
+  PluginSolution,
+  PluginAAD,
+  QuestionBotScenarioToPluginActRoles,
+} from "../resources/strings";
 import { PluginActRoles } from "../enums/pluginActRoles";
 import { DeployConfig } from "./deployConfig";
 import * as utils from "../utils/common";
-import { AzureSolutionQuestionNames, BotScenario } from "../../../solution/fx-solution/question";
+import { AzureSolutionQuestionNames } from "../../../solution/fx-solution/question";
 
 export class TeamsBotConfig {
   public scaffold: ScaffoldConfig = new ScaffoldConfig();
@@ -49,14 +53,16 @@ export class TeamsBotConfig {
     const capabilities = (context.projectSettings?.solutionSettings as AzureSolutionSettings)
       .capabilities;
 
-    if (capabilities?.includes(PluginActRoles.Bot) && !this.actRoles.includes(PluginActRoles.Bot)) {
-      if (context.answers?.[AzureSolutionQuestionNames.Scenario] === BotScenario.NotificationBot) {
-        this.actRoles.push(PluginActRoles.Notification);
-      } else if (
-        context.answers?.[AzureSolutionQuestionNames.Scenario] === BotScenario.CommandAndResponseBot
-      ) {
-        this.actRoles.push(PluginActRoles.CommandAndResponse);
+    if (capabilities?.includes(PluginActRoles.Bot)) {
+      const scenarios = context.answers?.[AzureSolutionQuestionNames.Scenarios];
+      if (Array.isArray(scenarios)) {
+        const scenarioActRoles = scenarios
+          .map((item) => QuestionBotScenarioToPluginActRoles.get(item))
+          .filter((item): item is PluginActRoles => item !== undefined);
+        // dedup
+        this.actRoles = [...new Set([...this.actRoles, ...scenarioActRoles])];
       } else {
+        // for legacy bot
         this.actRoles.push(PluginActRoles.Bot);
       }
     }

--- a/packages/fx-core/src/plugins/resource/bot/resources/strings.ts
+++ b/packages/fx-core/src/plugins/resource/bot/resources/strings.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 import { getLocalizedString } from "../../../../common/localizeUtils";
+import { BotScenario } from "../../../solution/fx-solution/question";
+import { PluginActRoles } from "../enums/pluginActRoles";
 
 export class CommonStrings {
   public static readonly BOT_WORKING_DIR_NAME = "bot";
@@ -80,6 +82,9 @@ export class PluginBot {
   public static readonly BOT_WEB_APP_RESOURCE_ID = "botWebAppResourceId";
   public static readonly UNPACK_FLAG = "unPackFlag";
   public static readonly HOST_TYPE = "host-type";
+  // Bot capabilities, for example: notification, command-and-response.
+  // Don't mix up with Teams capabilities (tab, bot, etc.)
+  public static readonly BOT_CAPABILITIES = "capabilities";
 }
 
 export class ConfigNames {
@@ -114,6 +119,23 @@ export class ClientNames {
   public static readonly WEB_SITE_MGMT_CLIENT = "webSiteMgmtClient";
   public static readonly BOT_SERVICE_CLIENT = "botServiceClient";
 }
+
+export const BotCapabilities = {
+  NOTIFICATION: "notification",
+  COMMAND_AND_RESPONSE: "command-response",
+} as const;
+
+export type BotCapability = typeof BotCapabilities[keyof typeof BotCapabilities];
+
+export const QuestionBotScenarioToPluginActRoles = new Map<BotScenario, PluginActRoles>([
+  [BotScenario.NotificationBot, PluginActRoles.Notification],
+  [BotScenario.CommandAndResponseBot, PluginActRoles.CommandAndResponse],
+]);
+
+export const QuestionBotScenarioToBotCapability = new Map<BotScenario, BotCapability>([
+  [BotScenario.NotificationBot, BotCapabilities.NOTIFICATION],
+  [BotScenario.CommandAndResponseBot, BotCapabilities.COMMAND_AND_RESPONSE],
+]);
 
 export const HostTypes = {
   APP_SERVICE: "app-service",

--- a/packages/fx-core/src/plugins/solution/fx-solution/question.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/question.ts
@@ -93,7 +93,7 @@ export enum AzureSolutionQuestionNames {
   AskSub = "subscription",
   ProgrammingLanguage = "programming-language",
   Solution = "solution",
-  Scenario = "scenario",
+  Scenarios = "scenarios",
 }
 
 export const HostTypeOptionAzure: OptionItem = {

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/utils.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/utils.ts
@@ -29,7 +29,6 @@ import {
   AzureResourceFunction,
   AzureResourceSQL,
   AzureSolutionQuestionNames,
-  BotNotificationTriggers,
   BotOptionItem,
   BotScenario,
   CommandAndResponseOptionItem,
@@ -239,18 +238,18 @@ export function fillInSolutionSettings(
     capabilities.includes(CommandAndResponseOptionItem.id)
   ) {
     // find and replace "NotificationOptionItem" and "CommandAndResponseOptionItem" to "BotOptionItem", so it does not impact capabilities in projectSettings.json
+    const scenarios: BotScenario[] = [];
     const notificationIndex = capabilities.indexOf(NotificationOptionItem.id);
     if (notificationIndex !== -1) {
       capabilities[notificationIndex] = BotOptionItem.id;
-      answers[AzureSolutionQuestionNames.Scenario] = BotScenario.NotificationBot;
+      scenarios.push(BotScenario.NotificationBot);
     }
-
     const commandAndResponseIndex = capabilities.indexOf(CommandAndResponseOptionItem.id);
     if (commandAndResponseIndex !== -1) {
       capabilities[commandAndResponseIndex] = BotOptionItem.id;
-      answers[AzureSolutionQuestionNames.Scenario] = BotScenario.CommandAndResponseBot;
+      scenarios.push(BotScenario.CommandAndResponseBot);
     }
-
+    answers[AzureSolutionQuestionNames.Scenarios] = scenarios;
     // dedup
     capabilities = [...new Set(capabilities)];
 


### PR DESCRIPTION
- Add 'capabilities' to bot plugin settings to distinguish notification bot, command response bot, etc.
- Refactor 'scenario' to 'scenarios' in ctx.answers (Please note this key was added only for bot. No other plugin is affected)

![image](https://user-images.githubusercontent.com/9698542/159678135-6f52197b-75c4-4917-b9e9-4ae02dc4ecf0.png)

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/13908646