### PR TITLE
chore(bot): add SCM_ZIPDEPLOY_DONOT_PRESERVE_FILETIME into func hosted bot app settings

### DIFF
--- a/packages/fx-core/templates/plugins/resource/bot/bicep/funcHostedBotProvision.template.bicep
+++ b/packages/fx-core/templates/plugins/resource/bot/bicep/funcHostedBotProvision.template.bicep
@@ -91,6 +91,10 @@ resource functionApp 'Microsoft.Web/sites@2021-02-01' = {
           name: 'RUNNING_ON_AZURE'
           value: '1'
         }
+        {
+          name: 'SCM_ZIPDEPLOY_DONOT_PRESERVE_FILETIME'
+          value: '1' // Zipdeploy files will always be updated. Detail: https://aka.ms/teamsfx-zipdeploy-donot-preserve-filetime
+        }
       ]
     }
   }

--- a/packages/fx-core/tests/plugins/resource/bot/unit/expectedBicepFiles/botProvisionOfFuncHosted.result.bicep
+++ b/packages/fx-core/tests/plugins/resource/bot/unit/expectedBicepFiles/botProvisionOfFuncHosted.result.bicep
@@ -91,6 +91,10 @@ resource functionApp 'Microsoft.Web/sites@2021-02-01' = {
           name: 'RUNNING_ON_AZURE'
           value: '1'
         }
+        {
+          name: 'SCM_ZIPDEPLOY_DONOT_PRESERVE_FILETIME'
+          value: '1' // Zipdeploy files will always be updated. Detail: https://aka.ms/teamsfx-zipdeploy-donot-preserve-filetime
+        }
       ]
     }
   }


### PR DESCRIPTION
Zip deploy does not update node module files for NPM 5.6 and later
See https://github.com/projectkudu/kudu/issues/2917 and https://github.com/npm/npm/issues/20439. This affects the default zipdeploy behavior where it is optimized to only copy files that are changed. To workaround the issue, do set appSettings SCM_ZIPDEPLOY_DONOT_PRESERVE_FILETIME=1. Zipdeploy files will always be updated and, as a result, overwriting the existing ones regardless of change.