### PR TITLE
chore(sdk): decrease the number of env variables for integration test

### DIFF
--- a/packages/sdk/karma.conf.js
+++ b/packages/sdk/karma.conf.js
@@ -24,15 +24,7 @@ const karmaConfig = {
     "**/*.ts": ["webpack", "sourcemap", "env"],
   },
 
-  envPreprocessor: [
-    "SDK_INTEGRATION_TEST_ACCOUNT_NAME",
-    "SDK_INTEGRATION_TEST_ACCOUNT_PASSWORD",
-    "SDK_INTEGRATION_TEST_M365_AAD_CLIENT_ID",
-    "SDK_INTEGRATION_TEST_M365_AAD_CLIENT_SECRET",
-    "SDK_INTEGRATION_TEST_AAD_TENANT_ID",
-    "SDK_INTEGRATION_TEST_AAD_AUTHORITY_HOST",
-    "SDK_INTEGRATION_TEST_USER_OBJECT_ID",
-  ],
+  envPreprocessor: ["SDK_INTEGRATION_TEST_ACCOUNT", "SDK_INTEGRATION_TEST_AAD"],
 
   webpack: webpackTestConfig,
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -21,7 +21,7 @@
     "test:unit:node": "nyc --no-clean -- mocha 'test/unit/{,!(browser)/**/}*.spec.ts' --file src/index.ts -r config/mocha.env.ts --config config/mocharc.node.js",
     "test:unit": "npm run test:unit:node && npm run test:unit:browser",
     "test:e2e:browser": "karma start --single-run --integration",
-    "test:e2e:node": "nyc --reporter lcovonly -- mocha 'test/e2e/node/*.spec.ts' --file src/index.ts -r config/mocha.env.ts --config config/mocharc.node.js",
+    "test:e2e:node": "nyc --lines 60 --reporter lcovonly -- mocha 'test/e2e/node/*.spec.ts' --file src/index.ts -r config/mocha.env.ts --config config/mocharc.node.js",
     "test:e2e": "npm run test:e2e:node && npm run test:e2e:browser",
     "ui-test": "mocha --no-timeouts -r test/mocha.env.ts -r ts-node/register test/ui/**/*.spec.ts --exit",
     "check-sensitive": "npx eslint --plugin 'no-secrets' --cache --ignore-pattern 'package.json' --ignore-pattern 'package-lock.json'",

--- a/packages/sdk/test/e2e/browser/msGraphAuthProvider.browser.spec.ts
+++ b/packages/sdk/test/e2e/browser/msGraphAuthProvider.browser.spec.ts
@@ -7,10 +7,17 @@ import * as chaiPromises from "chai-as-promised";
 import { MsGraphAuthProvider, TeamsFx, IdentityType } from "../../../src/index.browser";
 import { TeamsUserCredential } from "../../../src/credential/teamsUserCredential.browser";
 import * as sinon from "sinon";
-import { getSSOToken, AADJwtPayLoad, SSOToken, getGraphToken } from "../helper.browser";
+import {
+  getSSOToken,
+  AADJwtPayLoad,
+  SSOToken,
+  getGraphToken,
+  extractIntegrationEnvVariables,
+} from "../helper.browser";
 import jwtDecode from "jwt-decode";
 
 chaiUse(chaiPromises);
+extractIntegrationEnvVariables();
 const env = (window as any).__env__;
 
 describe("MsGraphAuthProvider Tests - Browser", () => {

--- a/packages/sdk/test/e2e/browser/msGraphClientProvider.browser.spec.ts
+++ b/packages/sdk/test/e2e/browser/msGraphClientProvider.browser.spec.ts
@@ -5,11 +5,17 @@ import { assert, expect, use as chaiUse } from "chai";
 import * as chaiPromises from "chai-as-promised";
 import { createMicrosoftGraphClient, TeamsFx, IdentityType } from "../../../src/index.browser";
 import { TeamsUserCredential } from "../../../src/credential/teamsUserCredential.browser";
-import { getGraphToken, getSSOToken, SSOToken } from "../helper.browser";
+import {
+  extractIntegrationEnvVariables,
+  getGraphToken,
+  getSSOToken,
+  SSOToken,
+} from "../helper.browser";
 import * as sinon from "sinon";
 import { AccessToken } from "@azure/core-auth";
 
 chaiUse(chaiPromises);
+extractIntegrationEnvVariables();
 const env = (window as any).__env__;
 
 describe("MsGraphClientProvider Tests - Browser", () => {

--- a/packages/sdk/test/e2e/browser/teamsUserCredential.browser.spec.ts
+++ b/packages/sdk/test/e2e/browser/teamsUserCredential.browser.spec.ts
@@ -40,7 +40,7 @@ describe("TeamsUserCredential Tests - Browser", () => {
       clientId: env.SDK_INTEGRATION_TEST_M365_AAD_CLIENT_ID,
     });
     const info = await credential.getUserInfo();
-    assert.strictEqual(info.preferredUserName, env.SDK_INTEGRATION_TEST_ACCOUNT_NAME);
+    assert.strictEqual(info.preferredUserName, env.SDK_INTEGRATION_TEST_ACCOUNT.split(";")[0]);
     assert.strictEqual(info.displayName, "Integration Test");
     assert.strictEqual(info.objectId, TEST_USER_OBJECT_ID);
   });

--- a/packages/sdk/test/e2e/helper.browser.ts
+++ b/packages/sdk/test/e2e/helper.browser.ts
@@ -5,6 +5,29 @@ import { JwtPayload } from "jwt-decode";
 
 const env = (window as any).__env__;
 
+export function extractIntegrationEnvVariables() {
+  if (!env.SDK_INTEGRATION_TEST_ACCOUNT) {
+    throw new Error("Please set env SDK_INTEGRATION_TEST_ACCOUNT");
+  }
+  const accountData = env.SDK_INTEGRATION_TEST_ACCOUNT.split(";");
+  if (accountData.length === 2) {
+    env.SDK_INTEGRATION_TEST_ACCOUNT_NAME = accountData[0];
+    env.SDK_INTEGRATION_TEST_ACCOUNT_PASSWORD = accountData[1];
+  }
+  if (!env.SDK_INTEGRATION_TEST_AAD) {
+    throw new Error("Please set env SDK_INTEGRATION_TEST_AAD");
+  }
+  const aadData = env.SDK_INTEGRATION_TEST_AAD.split(";");
+  if (aadData.length === 6) {
+    env.SDK_INTEGRATION_TEST_AAD_AUTHORITY_HOST = aadData[0];
+    env.SDK_INTEGRATION_TEST_AAD_TENANT_ID = aadData[1];
+    env.SDK_INTEGRATION_TEST_USER_OBJECT_ID = aadData[2];
+    env.SDK_INTEGRATION_TEST_M365_AAD_CLIENT_ID = aadData[3];
+    env.SDK_INTEGRATION_TEST_M365_AAD_CLIENT_SECRET = aadData[4];
+    env.SDK_INTEGRATION_TEST_M365_AAD_CERTIFICATE_CONTENT = aadData[5];
+  }
+}
+
 /**
  * Get SSO Token from a specific AAD app client id.
  */

--- a/packages/sdk/test/e2e/helper.ts
+++ b/packages/sdk/test/e2e/helper.ts
@@ -7,6 +7,40 @@ import * as dotenv from "dotenv";
 import { AuthenticationConfiguration } from "../../src";
 const urljoin = require("url-join");
 
+export function extractIntegrationEnvVariables() {
+  dotenv.config();
+  if (!process.env.SDK_INTEGRATION_TEST_ACCOUNT) {
+    throw new Error("Please set env SDK_INTEGRATION_TEST_ACCOUNT");
+  }
+  const accountData = process.env.SDK_INTEGRATION_TEST_ACCOUNT.split(";");
+  if (accountData.length === 2) {
+    process.env.SDK_INTEGRATION_TEST_ACCOUNT_NAME = accountData[0];
+    process.env.SDK_INTEGRATION_TEST_ACCOUNT_PASSWORD = accountData[1];
+  }
+  if (!process.env.SDK_INTEGRATION_TEST_SQL) {
+    throw new Error("Please set env SDK_INTEGRATION_TEST_SQL");
+  }
+  const sqlData = process.env.SDK_INTEGRATION_TEST_SQL.split(";");
+  if (sqlData.length === 4) {
+    process.env.SDK_INTEGRATION_SQL_ENDPOINT = sqlData[0];
+    process.env.SDK_INTEGRATION_SQL_DATABASE_NAME = sqlData[1];
+    process.env.SDK_INTEGRATION_SQL_USER_NAME = sqlData[2];
+    process.env.SDK_INTEGRATION_SQL_PASSWORD = sqlData[3];
+  }
+  if (!process.env.SDK_INTEGRATION_TEST_AAD) {
+    throw new Error("Please set env SDK_INTEGRATION_TEST_AAD");
+  }
+  const aadData = process.env.SDK_INTEGRATION_TEST_AAD.split(";");
+  if (aadData.length === 6) {
+    process.env.SDK_INTEGRATION_TEST_AAD_AUTHORITY_HOST = aadData[0];
+    process.env.SDK_INTEGRATION_TEST_AAD_TENANT_ID = aadData[1];
+    process.env.SDK_INTEGRATION_TEST_USER_OBJECT_ID = aadData[2];
+    process.env.SDK_INTEGRATION_TEST_M365_AAD_CLIENT_ID = aadData[3];
+    process.env.SDK_INTEGRATION_TEST_M365_AAD_CLIENT_SECRET = aadData[4];
+    process.env.SDK_INTEGRATION_TEST_M365_AAD_CERTIFICATE_CONTENT = aadData[5];
+  }
+}
+
 /**
  * Get Access Token from a specific AAD app client id.
  * @param clientId - remote or local AAD App id.
@@ -84,7 +118,6 @@ export async function getSsoTokenFromTeams(): Promise<string> {
  * Once invoke MockEnvironmentVariables, mock the variables in it with another value, it will take effect immediately.
  */
 export function MockEnvironmentVariable(): () => void {
-  dotenv.config();
   return mockedEnv({
     M365_CLIENT_ID: process.env.SDK_INTEGRATION_TEST_M365_AAD_CLIENT_ID,
     M365_CLIENT_SECRET: process.env.SDK_INTEGRATION_TEST_M365_AAD_CLIENT_SECRET,
@@ -101,7 +134,6 @@ export function MockEnvironmentVariable(): () => void {
 }
 
 export function MockAuthenticationConfiguration(): AuthenticationConfiguration {
-  dotenv.config();
   return {
     clientId: process.env.SDK_INTEGRATION_TEST_M365_AAD_CLIENT_ID,
     clientSecret: process.env.SDK_INTEGRATION_TEST_M365_AAD_CLIENT_SECRET,

--- a/packages/sdk/test/e2e/node/appCredential.spec.ts
+++ b/packages/sdk/test/e2e/node/appCredential.spec.ts
@@ -10,9 +10,12 @@ import {
   MockAuthenticationConfiguration,
   AADJwtPayLoad,
   convertCertificateContent,
+  extractIntegrationEnvVariables,
 } from "../helper";
 
 chaiUse(chaiPromises);
+extractIntegrationEnvVariables();
+
 describe("AppCredential Tests - Node", () => {
   const fake_client_secret = "fake_client_secret";
   const defaultGraphScope = ["https://graph.microsoft.com/.default"];

--- a/packages/sdk/test/e2e/node/msGraphAuthProvider.spec.ts
+++ b/packages/sdk/test/e2e/node/msGraphAuthProvider.spec.ts
@@ -9,10 +9,12 @@ import {
   MockEnvironmentVariable,
   RestoreEnvironmentVariable,
   AADJwtPayLoad,
+  extractIntegrationEnvVariables,
 } from "../helper";
 import jwtDecode from "jwt-decode";
 
 chaiUse(chaiPromises);
+extractIntegrationEnvVariables();
 let restore: () => void;
 
 describe("MsGraphAuthProvider Tests - Node", () => {

--- a/packages/sdk/test/e2e/node/msGraphClientProvider.spec.ts
+++ b/packages/sdk/test/e2e/node/msGraphClientProvider.spec.ts
@@ -6,12 +6,14 @@ import "isomorphic-fetch";
 import * as chaiPromises from "chai-as-promised";
 import { createMicrosoftGraphClient, TeamsFx, IdentityType } from "../../../src";
 import {
+  extractIntegrationEnvVariables,
   getSsoTokenFromTeams,
   MockEnvironmentVariable,
   RestoreEnvironmentVariable,
 } from "../helper";
 
 chaiUse(chaiPromises);
+extractIntegrationEnvVariables();
 let restore: () => void;
 
 describe("createMicrosoftGraphClient Tests - Node", () => {

--- a/packages/sdk/test/e2e/node/onBehalfOfUserCredential.spec.ts
+++ b/packages/sdk/test/e2e/node/onBehalfOfUserCredential.spec.ts
@@ -15,6 +15,7 @@ import { SSOTokenV2Info } from "../../../src/models/ssoTokenInfo";
 import { parseJwt } from "../../../src/util/utils";
 import {
   convertCertificateContent,
+  extractIntegrationEnvVariables,
   getSsoTokenFromTeams,
   MockAuthenticationConfiguration,
   MockEnvironmentVariable,
@@ -22,6 +23,7 @@ import {
 } from "../helper";
 
 chaiUse(chaiPromises);
+extractIntegrationEnvVariables();
 let restore: () => void;
 
 let ssoToken: string;

--- a/packages/sdk/test/e2e/node/sqlConnector.spec.ts
+++ b/packages/sdk/test/e2e/node/sqlConnector.spec.ts
@@ -7,9 +7,14 @@ import * as msRestNodeAuth from "@azure/ms-rest-nodeauth";
 import * as chaiPromises from "chai-as-promised";
 import { Connection, Request } from "tedious";
 import { getTediousConnectionConfig, TeamsFx } from "../../../src";
-import { MockEnvironmentVariable, RestoreEnvironmentVariable } from "../helper";
+import {
+  extractIntegrationEnvVariables,
+  MockEnvironmentVariable,
+  RestoreEnvironmentVariable,
+} from "../helper";
 
 chaiUse(chaiPromises);
+extractIntegrationEnvVariables();
 let restore: () => void;
 
 describe("DefaultTediousConnection Tests - Node", () => {

--- a/packages/sdk/test/e2e/node/teamsBotSsoPrompt.spec.ts
+++ b/packages/sdk/test/e2e/node/teamsBotSsoPrompt.spec.ts
@@ -26,6 +26,7 @@ import {
 import { assert, use as chaiUse } from "chai";
 import * as chaiPromises from "chai-as-promised";
 import {
+  extractIntegrationEnvVariables,
   getSsoTokenFromTeams,
   MockEnvironmentVariable,
   RestoreEnvironmentVariable,
@@ -35,6 +36,7 @@ import * as sinon from "sinon";
 import { TeamsInfo } from "botbuilder";
 
 chaiUse(chaiPromises);
+extractIntegrationEnvVariables();
 let restore: () => void;
 
 describe("TeamsBotSsoPrompt Tests - Node", () => {


### PR DESCRIPTION
Using 3 environment variables in e2e test:
- SDK_INTEGRATION_TEST_SQL
- SDK_INTEGRATION_TEST_ACCOUNT
- SDK_INTEGRATION_TEST_AAD