### PR TITLE
perf(solution, fe): add non sso Tab item in create project

### DIFF
--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -347,6 +347,8 @@
   "core.TabSPFxOption.detail": "Teams-aware webpages with SPFx framework embedded in Microsoft Teams",
   "core.Sso.description": "Single Sign On",
   "core.Sso.detail": "Enable Single Sign On in your Teams app",
+  "core.TabNonSso.description": "UI-based app without SSO",
+  "core.TabNonSso.detail": "Teams-aware webpages embedded in Microsoft Teams without Single Sign On",
   "core.createCapabilityQuestion.title": "Select capabilities",
   "core.createCapabilityQuestion.placeholder": "Select at least 1 capability",
   "core.createCapabilityQuestion.validation1": "Teams Toolkit offers only the Tab capability in a Teams app with Visual Studio Code and SharePoint Framework. The Bot and Messaging extension capabilities are not available",

--- a/packages/fx-core/src/core/FxCore.ts
+++ b/packages/fx-core/src/core/FxCore.ts
@@ -49,6 +49,7 @@ import { TelemetryReporterInstance } from "../common/telemetry";
 import {
   createV2Context,
   getRootDirectory,
+  isAadManifestEnabled,
   isConfigUnifyEnabled,
   mapToJson,
   undefinedName,
@@ -59,6 +60,7 @@ import {
   BotOptionItem,
   MessageExtensionItem,
   NotificationOptionItem,
+  SsoItem,
   TabOptionItem,
   TabSPFxItem,
 } from "../plugins/solution/fx-solution/question";
@@ -356,7 +358,10 @@ export class FxCore implements v3.ICore {
       if (!inputs.existingAppConfig?.isCreatedFromExistingApp) {
         // addFeature
         const features: string[] = [];
-        if (!capabilities.includes(TabSPFxItem.id)) {
+        if (!isAadManifestEnabled() && !capabilities.includes(TabSPFxItem.id)) {
+          features.push(BuiltInFeaturePluginNames.aad);
+        }
+        if (isAadManifestEnabled() && capabilities.includes(SsoItem.id)) {
           features.push(BuiltInFeaturePluginNames.aad);
         }
         if (inputs.platform === Platform.VS) {

--- a/packages/fx-core/src/core/question.ts
+++ b/packages/fx-core/src/core/question.ts
@@ -18,7 +18,12 @@ import * as fs from "fs-extra";
 import * as os from "os";
 import { environmentManager } from "./environment";
 import { sampleProvider } from "../common/samples";
-import { getRootDirectory, isBotNotificationEnabled, isM365AppEnabled } from "../common/tools";
+import {
+  getRootDirectory,
+  isAadManifestEnabled,
+  isBotNotificationEnabled,
+  isM365AppEnabled,
+} from "../common/tools";
 import { getLocalizedString } from "../common/localizeUtils";
 import {
   BotOptionItem,
@@ -29,6 +34,7 @@ import {
   M365LaunchPageOptionItem,
   M365MessagingExtensionOptionItem,
   CommandAndResponseOptionItem,
+  TabNonSsoItem,
 } from "../plugins/solution/fx-solution/question";
 
 export enum CoreQuestionNames {
@@ -202,6 +208,7 @@ export function createCapabilityQuestion(): MultiSelectQuestion {
       ...[TabOptionItem, BotOptionItem],
       ...(isBotNotificationEnabled() ? [NotificationOptionItem, CommandAndResponseOptionItem] : []),
       ...[MessageExtensionItem, TabSPFxItem],
+      ...(isAadManifestEnabled() ? [TabNonSsoItem] : []),
     ],
     default: [TabOptionItem.id],
     placeholder: getLocalizedString("core.createCapabilityQuestion.placeholder"),
@@ -277,6 +284,16 @@ export function createCapabilityQuestion(): MultiSelectQuestion {
           previousSelectedIds,
           currentSelectedIds
         );
+      }
+
+      if (isAadManifestEnabled()) {
+        if (currentSelectedIds.has(TabNonSsoItem.id) && currentSelectedIds.has(TabOptionItem.id)) {
+          if (previousSelectedIds.has(TabNonSsoItem.id)) {
+            currentSelectedIds.delete(TabNonSsoItem.id);
+          } else {
+            currentSelectedIds.delete(TabOptionItem.id);
+          }
+        }
       }
 
       return currentSelectedIds;

--- a/packages/fx-core/src/plugins/resource/frontend/resources/templateInfo.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/resources/templateInfo.ts
@@ -8,6 +8,7 @@ import { InvalidTabLanguageError } from "./errors";
 import { getTemplatesFolder } from "../../../../folder";
 import { templatesVersion } from "../../../../common/template-utils/templates";
 import { isAadManifestEnabled } from "../../../../common";
+import { SsoItem } from "../../../solution/fx-solution/question";
 
 export type TemplateVariable = { [key: string]: string };
 
@@ -50,9 +51,12 @@ export class TemplateInfo {
       showFunction: isFunctionPlugin.toString(),
     };
 
+    const capabilities = (ctx.projectSettings?.solutionSettings as AzureSolutionSettings)
+      ?.capabilities;
+
     this.scenario = ctx.projectSettings?.isM365
       ? Scenario.M365
-      : isAadManifestEnabled()
+      : isAadManifestEnabled() && !capabilities.includes(SsoItem.id)
       ? Scenario.NonSso
       : Scenario.Default;
 

--- a/packages/fx-core/src/plugins/solution/fx-solution/question.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/question.ts
@@ -64,7 +64,15 @@ export const SsoItem: OptionItem = {
   label: "SSO",
   cliName: "sso",
   description: getLocalizedString("core.Sso.description"),
-  detail: getLocalizedString("core.TabSPFxOption.detail"),
+  detail: getLocalizedString("core.Sso.detail"),
+};
+
+export const TabNonSsoItem: OptionItem = {
+  id: "TabNonSso",
+  label: "Tab(Non-SSO)",
+  cliName: "tab-non-sso",
+  description: getLocalizedString("core.TabNonSso.description"),
+  detail: getLocalizedString("core.TabNonSso.detail"),
 };
 
 export const M365LaunchPageOptionItem: OptionItem = {

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/getQuestions.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/getQuestions.ts
@@ -35,6 +35,7 @@ import {
   getUserEmailQuestion,
   MessageExtensionItem,
   NotificationOptionItem,
+  TabNonSsoItem,
   TabOptionItem,
   TabSPFxItem,
 } from "../question";
@@ -53,6 +54,7 @@ import { NoCapabilityFoundError } from "../../../../core";
 import { isVSProject } from "../../../../common/projectSettingsHelper";
 import { ProgrammingLanguageQuestion } from "../../../../core/question";
 import { getLocalizedString } from "../../../../common/localizeUtils";
+import { isAadManifestEnabled } from "../../../../common";
 
 export async function getQuestionsForScaffolding(
   ctx: v2.Context,
@@ -75,6 +77,7 @@ export async function getQuestionsForScaffolding(
         NotificationOptionItem.id,
         CommandAndResponseOptionItem.id,
         MessageExtensionItem.id,
+        ...(isAadManifestEnabled() ? [TabNonSsoItem.id] : []),
       ],
     };
     if (!inputs.isM365) {
@@ -122,7 +125,10 @@ export async function getQuestionsForScaffolding(
           return "Invalid inputs";
         }
         const cap = inputs[AzureSolutionQuestionNames.Capabilities] as string[];
-        if (cap.includes(TabOptionItem.id)) {
+        if (
+          cap.includes(TabOptionItem.id) ||
+          (isAadManifestEnabled() && cap.includes(TabNonSsoItem.id))
+        ) {
           return undefined;
         }
         return "Tab is not selected";

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/utils.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/utils.ts
@@ -17,7 +17,7 @@ import {
   ProjectSettings,
 } from "@microsoft/teamsfx-api";
 import { LocalSettingsTeamsAppKeys } from "../../../../common/localSettingsConstants";
-import { isAADEnabled, isConfigUnifyEnabled } from "../../../../common/tools";
+import { isAADEnabled, isAadManifestEnabled, isConfigUnifyEnabled } from "../../../../common/tools";
 import {
   GLOBAL_CONFIG,
   SolutionError,
@@ -37,6 +37,8 @@ import {
   HostTypeOptionSPFx,
   MessageExtensionItem,
   NotificationOptionItem,
+  SsoItem,
+  TabNonSsoItem,
   TabOptionItem,
   TabSPFxItem,
 } from "../question";
@@ -224,6 +226,15 @@ export function fillInSolutionSettings(
 ): Result<Void, FxError> {
   const solutionSettings = (projectSettings.solutionSettings as AzureSolutionSettings) || {};
   let capabilities = (answers[AzureSolutionQuestionNames.Capabilities] as string[]) || [];
+  if (isAadManifestEnabled()) {
+    if (capabilities.includes(TabOptionItem.id)) {
+      capabilities.push(SsoItem.id);
+    } else if (capabilities.includes(TabNonSsoItem.id)) {
+      const index = capabilities.indexOf(TabNonSsoItem.id);
+      capabilities.splice(index);
+      capabilities.push(TabOptionItem.id);
+    }
+  }
   if (!capabilities || capabilities.length === 0) {
     return err(
       returnSystemError(

--- a/packages/fx-core/tests/plugins/solution/solution.util.test.ts
+++ b/packages/fx-core/tests/plugins/solution/solution.util.test.ts
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+import { AzureSolutionSettings, Platform, ProjectSettings } from "@microsoft/teamsfx-api";
+import chai from "chai";
+import { it } from "mocha";
+import * as sinon from "sinon";
+import * as uuid from "uuid";
+import { SsoItem } from "../../../src/plugins/solution/fx-solution/question";
+import { fillInSolutionSettings } from "../../../src/plugins/solution/fx-solution/v2/utils";
+import { PluginNames } from "../../../src";
+import mockedEnv from "mocked-env";
+const tool = require("../../../src/common/tools");
+const expect = chai.expect;
+
+describe("util: fillInSolutionSettings() with AAD manifest enabled", async () => {
+  const mocker = sinon.createSandbox();
+  let projectSettings: ProjectSettings;
+  let mockedEnvRestore: () => void;
+
+  beforeEach(async () => {
+    mockedEnvRestore = mockedEnv({
+      TEAMSFX_AAD_MANIFEST: "true",
+    });
+
+    projectSettings = {
+      appName: "my app",
+      projectId: uuid.v4(),
+      solutionSettings: {
+        name: "test",
+        version: "1.0",
+      },
+    };
+
+    // mocker.stub(tool, "isAadManifestEnabled").returns(true);
+  });
+
+  afterEach(async () => {
+    mockedEnvRestore();
+    mocker.restore();
+  });
+
+  it("Tab with SSO", async () => {
+    const mockInput = {
+      capabilities: ["Tab"],
+      platform: Platform.VSCode,
+    };
+
+    const res = fillInSolutionSettings(projectSettings, mockInput);
+
+    const solutionSettings = projectSettings?.solutionSettings as AzureSolutionSettings;
+    expect(solutionSettings?.capabilities?.includes(SsoItem.id)).to.be.true;
+    expect(solutionSettings?.activeResourcePlugins?.includes(PluginNames.AAD)).to.be.true;
+  });
+
+  it("Tab without SSO", async () => {
+    const mockInput = {
+      capabilities: ["TabNonSso"],
+      platform: Platform.VSCode,
+    };
+
+    const res = fillInSolutionSettings(projectSettings, mockInput);
+
+    const solutionSettings = projectSettings?.solutionSettings as AzureSolutionSettings;
+    expect(solutionSettings?.capabilities?.includes(SsoItem.id)).to.be.false;
+    expect(solutionSettings?.activeResourcePlugins?.includes(PluginNames.AAD)).to.be.false;
+  });
+});


### PR DESCRIPTION
1. Add non SSO Tab in selection.
![image](https://user-images.githubusercontent.com/63089166/159850489-f5dc6c4a-0c1f-4b2e-ab84-b9a6ac2d8a84.png)

2. Use default tab template when Tab is selected.