### PR TITLE
fix: manifest template developer field wrong for init app

### DIFF
--- a/packages/fx-core/src/plugins/resource/appstudio/v3/index.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/v3/index.ts
@@ -49,6 +49,7 @@ import { ResourcePermission, TeamsAppAdmin } from "../../../../common/permission
 import isUUID from "validator/lib/isUUID";
 import { AppStudioClient } from "../appStudio";
 import { IUserList } from "../interfaces/IAppDefinition";
+import { isPureExistingApp } from "../../../../common/projectSettingsHelper";
 
 @Service(BuiltInFeaturePluginNames.appStudio)
 export class AppStudioPluginV3 {
@@ -69,7 +70,7 @@ export class AppStudioPluginV3 {
     const res = await init(
       inputs.projectPath,
       ctx.projectSetting.appName,
-      ctx.projectSetting.solutionSettings === undefined
+      isPureExistingApp(ctx.projectSetting)
     );
     if (res.isErr()) return err(res.error);
     const templatesFolder = getTemplatesFolder();

--- a/packages/fx-core/src/plugins/resource/appstudio/v3/index.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/v3/index.ts
@@ -63,14 +63,14 @@ export class AppStudioPluginV3 {
    * @param inputs
    * @returns
    */
-  async init(
-    ctx: v2.Context,
-    inputs: v2.InputsWithProjectPath,
-    existingApp = false
-  ): Promise<Result<any, FxError>> {
+  async init(ctx: v2.Context, inputs: v2.InputsWithProjectPath): Promise<Result<any, FxError>> {
     TelemetryUtils.init(ctx);
     TelemetryUtils.sendStartEvent(TelemetryEventName.init);
-    const res = await init(inputs.projectPath, ctx.projectSetting.appName, existingApp);
+    const res = await init(
+      inputs.projectPath,
+      ctx.projectSetting.appName,
+      ctx.projectSetting.solutionSettings === undefined
+    );
     if (res.isErr()) return err(res.error);
     const templatesFolder = getTemplatesFolder();
     const defaultColorPath = path.join(templatesFolder, COLOR_TEMPLATE);


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/13841713

Root cause:
We use isExistingApp flag to decide whether use config placeholder for developer info in manifest template. But the flag is already removed, so the logic should be updated

Fix:
Check solution settings in ctx: it should be undefined for existing apps.

E2E TEST: bug during development, will add test later