### PR TITLE
fix: appstudio error msg for building package

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -12,6 +12,7 @@ on:
     branches:
       - main
       - dev
+      - hotfix/**/*
     types:
       - assigned
       - opened

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - dev
+      - hotfix/**/*
 
 jobs:
   unit-test:

--- a/packages/fx-core/src/plugins/resource/appstudio/errors.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/errors.ts
@@ -139,24 +139,18 @@ export class AppStudioError {
 
   public static readonly TeamsPackageBuildError = {
     name: "TeamsPackageBuildError",
-    message: (error: any): [string, string] =>
-      error.message
-        ? error.message
-        : [
-            getDefaultString("error.appstudio.buildError"),
-            getLocalizedString("error.appstudio.buildError"),
-          ],
+    message: (error: any): [string, string] => [
+      error.message ?? getDefaultString("error.appstudio.buildError"),
+      error.displayMessage ?? getLocalizedString("error.appstudio.buildError"),
+    ],
   };
 
   public static readonly ScaffoldFailedError = {
     name: "ScaffoldFailed",
-    message: (error: any): [string, string] =>
-      error.message
-        ? error.message
-        : [
-            getDefaultString("error.appstudio.scaffoldFailed"),
-            getLocalizedString("error.appstudio.scaffoldFailed"),
-          ],
+    message: (error: any): [string, string] => [
+      error.message ?? getDefaultString("error.appstudio.scaffoldFailed"),
+      error.displayMessage ?? getLocalizedString("error.appstudio.scaffoldFailed"),
+    ],
   };
 
   public static readonly CheckPermissionFailedError = {


### PR DESCRIPTION
Fixes bug https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/13918768
It is caused by excessive use of `any`, which delays the type error till runtime.
![image](https://user-images.githubusercontent.com/18023393/159867061-d32d06ba-3e36-4868-b3ab-9d285dc7e1d9.png)

Please avoid using `any` when necessary. 

E2E TEST: not needed.