### PR TITLE
feat: addCapability for notification/command response bot

### DIFF
--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -353,6 +353,7 @@
   "core.Sso.detail": "Enable Single Sign On in your Teams app",
   "core.TabNonSso.description": "UI-based app without SSO",
   "core.TabNonSso.detail": "Teams-aware webpages embedded in Microsoft Teams without Single Sign On",
+  "core.addCapabilityQuestion.notificationCommandAndResponseConflict": "Notification and Command and Response capabilities are in conflict",
   "core.createCapabilityQuestion.title": "Select capabilities",
   "core.createCapabilityQuestion.placeholder": "Select at least 1 capability",
   "core.createCapabilityQuestion.validation1": "Teams Toolkit offers only the Tab capability in a Teams app with Visual Studio Code and SharePoint Framework. The Bot and Messaging extension capabilities are not available",

--- a/packages/fx-core/src/core/FxCore.ts
+++ b/packages/fx-core/src/core/FxCore.ts
@@ -58,6 +58,7 @@ import { getLocalAppName } from "../plugins/resource/appstudio/utils/utils";
 import { AppStudioPluginV3 } from "../plugins/resource/appstudio/v3";
 import {
   BotOptionItem,
+  CommandAndResponseOptionItem,
   MessageExtensionItem,
   NotificationOptionItem,
   SsoItem,
@@ -375,7 +376,8 @@ export class FxCore implements v3.ICore {
           if (
             capabilities.includes(BotOptionItem.id) ||
             capabilities.includes(MessageExtensionItem.id) ||
-            capabilities.includes(NotificationOptionItem.id)
+            capabilities.includes(NotificationOptionItem.id) ||
+            capabilities.includes(CommandAndResponseOptionItem.id)
           ) {
             features.push(BuiltInFeaturePluginNames.bot);
           }

--- a/packages/fx-core/src/plugins/resource/bot/configs/scaffoldConfig.ts
+++ b/packages/fx-core/src/plugins/resource/bot/configs/scaffoldConfig.ts
@@ -90,8 +90,7 @@ export class ScaffoldConfig {
     if (context.answers === undefined) {
       return undefined;
     }
-    const fromInputs = isScaffold;
-    if (fromInputs) {
+    if (isScaffold) {
       return context.answers
         ? this.getHostTypeFromHostTypeTriggerQuestion(context.answers)
         : undefined;

--- a/packages/fx-core/src/plugins/resource/bot/configs/scaffoldConfig.ts
+++ b/packages/fx-core/src/plugins/resource/bot/configs/scaffoldConfig.ts
@@ -78,12 +78,16 @@ export class ScaffoldConfig {
 
   /**
    * Get bot host type from plugin context.
-   * For stages like scaffolding, the host type is from user inputs of question model (i.e. context.answers).
+   * For stages like scaffolding (including create new and add capability),
+   *    the host type is from user inputs of question model (i.e. context.answers).
    * For later stages, the host type is persisted in projectSettings.json.
+   * @param isScaffold true for the `scaffold` lifecycle, false otherwise.
    */
-  public static getBotHostType(context: PluginContext): HostType | undefined {
-    // TODO: support other stages (maybe addCapability)
-    const fromInputs = context.answers?.stage === Stage.create;
+  public static getBotHostType(context: PluginContext, isScaffold: boolean): HostType | undefined {
+    if (context.answers === undefined) {
+      return undefined;
+    }
+    const fromInputs = isScaffold;
     if (fromInputs) {
       return context.answers
         ? this.getHostTypeFromHostTypeTriggerQuestion(context.answers)

--- a/packages/fx-core/src/plugins/resource/bot/configs/scaffoldConfig.ts
+++ b/packages/fx-core/src/plugins/resource/bot/configs/scaffoldConfig.ts
@@ -87,9 +87,6 @@ export class ScaffoldConfig {
    * @param isScaffold true for the `scaffold` lifecycle, false otherwise.
    */
   public static getBotHostType(context: PluginContext, isScaffold: boolean): HostType | undefined {
-    if (context.answers === undefined) {
-      return undefined;
-    }
     if (isScaffold) {
       return context.answers
         ? this.getHostTypeFromHostTypeTriggerQuestion(context.answers)

--- a/packages/fx-core/src/plugins/resource/bot/configs/scaffoldConfig.ts
+++ b/packages/fx-core/src/plugins/resource/bot/configs/scaffoldConfig.ts
@@ -36,7 +36,10 @@ export class ScaffoldConfig {
     return false;
   }
 
-  public async restoreConfigFromContext(context: PluginContext): Promise<void> {
+  public async restoreConfigFromContext(
+    context: PluginContext,
+    isScaffold: boolean
+  ): Promise<void> {
     this.workingDir = path.join(context.root, CommonStrings.BOT_WORKING_DIR_NAME);
     this.botId = context.config.get(PluginBot.BOT_ID) as string;
     this.botPassword = context.config.get(PluginBot.BOT_PASSWORD) as string;
@@ -52,7 +55,7 @@ export class ScaffoldConfig {
       this.programmingLanguage = rawProgrammingLanguage;
     }
 
-    this.botCapabilities = ScaffoldConfig.getBotCapabilities(context);
+    this.botCapabilities = ScaffoldConfig.getBotCapabilities(context, isScaffold);
 
     this.hostType = ScaffoldConfig.getHostTypeFromProjectSettings(context);
 
@@ -117,10 +120,9 @@ export class ScaffoldConfig {
     return utils.convertToConstValues(rawHostType, HostTypes);
   }
 
-  private static getBotCapabilities(context: PluginContext): BotCapability[] {
-    if (context.answers?.stage === Stage.create) {
+  private static getBotCapabilities(context: PluginContext, isScaffold: boolean): BotCapability[] {
+    if (isScaffold) {
       // For scaffolding and addCapability, the bot capabilities are from user input (context.answers)
-      // TODO: support addCapability
       const scenarios = context.answers?.[AzureSolutionQuestionNames.Scenarios];
       if (Array.isArray(scenarios)) {
         return scenarios

--- a/packages/fx-core/src/plugins/resource/bot/configs/teamsBotConfig.ts
+++ b/packages/fx-core/src/plugins/resource/bot/configs/teamsBotConfig.ts
@@ -28,8 +28,8 @@ export class TeamsBotConfig {
   public actRoles: PluginActRoles[] = [];
   public resourceNameSuffix = "";
 
-  public async restoreConfigFromContext(context: PluginContext): Promise<void> {
-    await this.scaffold.restoreConfigFromContext(context);
+  public async restoreConfigFromContext(context: PluginContext, isScaffold = false): Promise<void> {
+    await this.scaffold.restoreConfigFromContext(context, isScaffold);
     await this.provision.restoreConfigFromContext(context);
     await this.localDebug.restoreConfigFromContext(context);
     await this.deploy.restoreConfigFromContext(context);

--- a/packages/fx-core/src/plugins/resource/bot/functionsHostedBot/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/bot/functionsHostedBot/plugin.ts
@@ -41,7 +41,7 @@ export class FunctionsHostedBotImpl extends TeamsBotImpl {
   public async scaffold(context: PluginContext): Promise<FxResult> {
     this.ctx = context;
 
-    await this.config.restoreConfigFromContext(context);
+    await this.config.restoreConfigFromContext(context, true);
     this.config.scaffold.hostType = HostTypes.AZURE_FUNCTIONS;
 
     Logger.info(Messages.ScaffoldingBot);

--- a/packages/fx-core/src/plugins/resource/bot/index.ts
+++ b/packages/fx-core/src/plugins/resource/bot/index.ts
@@ -39,7 +39,7 @@ import { PluginImpl } from "./interface";
 import { isVSProject, BotHostTypes, isBotNotificationEnabled } from "../../../common";
 import { FunctionsHostedBotImpl } from "./functionsHostedBot/plugin";
 import { ScaffoldConfig } from "./configs/scaffoldConfig";
-import { createHostTypeTriggerQuestion } from "./question";
+import { createHostTypeTriggerQuestion, showNotificationCondition } from "./question";
 import { getLocalizedString } from "../../../common/localizeUtils";
 
 @Service(ResourcePlugins.BotPlugin)
@@ -54,10 +54,13 @@ export class TeamsBot implements Plugin {
   public dotnetBotImpl: DotnetBotImpl = new DotnetBotImpl();
   public functionsBotImpl: FunctionsHostedBotImpl = new FunctionsHostedBotImpl();
 
-  public getImpl(context: PluginContext): PluginImpl {
+  /**
+   * @param isScaffold true for `scaffold` lifecycle, false otherwise.
+   */
+  public getImpl(context: PluginContext, isScaffold = false): PluginImpl {
     if (isVSProject(context.projectSettings)) {
       return this.dotnetBotImpl;
-    } else if (this.isFunctionsHostedBot(context)) {
+    } else if (this.isFunctionsHostedBot(context, isScaffold)) {
       return this.functionsBotImpl;
     } else {
       return this.teamsBotImpl;
@@ -69,7 +72,7 @@ export class TeamsBot implements Plugin {
 
     const result = await TeamsBot.runWithExceptionCatching(
       context,
-      () => this.getImpl(context).scaffold(context),
+      () => this.getImpl(context, true).scaffold(context),
       true,
       LifecycleFuncNames.SCAFFOLD
     );
@@ -208,6 +211,7 @@ export class TeamsBot implements Plugin {
               type: "group",
             });
             res.addChild(new QTreeNode(createHostTypeTriggerQuestion()));
+            res.condition = showNotificationCondition;
             return ok(res);
           } else {
             return ok(undefined);
@@ -235,6 +239,7 @@ export class TeamsBot implements Plugin {
             type: "group",
           });
           res.addChild(new QTreeNode(createHostTypeTriggerQuestion()));
+          res.condition = showNotificationCondition;
           return ok(res);
         } else {
           return ok(undefined);
@@ -321,8 +326,8 @@ export class TeamsBot implements Plugin {
     }
   }
 
-  private isFunctionsHostedBot(context: PluginContext): boolean {
-    return ScaffoldConfig.getBotHostType(context) === BotHostTypes.AzureFunctions;
+  private isFunctionsHostedBot(context: PluginContext, isScaffold: boolean): boolean {
+    return ScaffoldConfig.getBotHostType(context, isScaffold) === BotHostTypes.AzureFunctions;
   }
 }
 

--- a/packages/fx-core/src/plugins/resource/bot/index.ts
+++ b/packages/fx-core/src/plugins/resource/bot/index.ts
@@ -60,7 +60,7 @@ export class TeamsBot implements Plugin {
   public getImpl(context: PluginContext, isScaffold = false): PluginImpl {
     if (isVSProject(context.projectSettings)) {
       return this.dotnetBotImpl;
-    } else if (this.isFunctionsHostedBot(context, isScaffold)) {
+    } else if (TeamsBot.isFunctionsHostedBot(context, isScaffold)) {
       return this.functionsBotImpl;
     } else {
       return this.teamsBotImpl;
@@ -326,7 +326,7 @@ export class TeamsBot implements Plugin {
     }
   }
 
-  private isFunctionsHostedBot(context: PluginContext, isScaffold: boolean): boolean {
+  private static isFunctionsHostedBot(context: PluginContext, isScaffold: boolean): boolean {
     return ScaffoldConfig.getBotHostType(context, isScaffold) === BotHostTypes.AzureFunctions;
   }
 }

--- a/packages/fx-core/src/plugins/resource/bot/index.ts
+++ b/packages/fx-core/src/plugins/resource/bot/index.ts
@@ -39,7 +39,7 @@ import { PluginImpl } from "./interface";
 import { isVSProject, BotHostTypes, isBotNotificationEnabled } from "../../../common";
 import { FunctionsHostedBotImpl } from "./functionsHostedBot/plugin";
 import { ScaffoldConfig } from "./configs/scaffoldConfig";
-import { createHostTypeTriggerQuestion, showNotificationCondition } from "./question";
+import { createHostTypeTriggerQuestion, showNotificationTriggerCondition } from "./question";
 import { getLocalizedString } from "../../../common/localizeUtils";
 
 @Service(ResourcePlugins.BotPlugin)
@@ -211,7 +211,7 @@ export class TeamsBot implements Plugin {
               type: "group",
             });
             res.addChild(new QTreeNode(createHostTypeTriggerQuestion()));
-            res.condition = showNotificationCondition;
+            res.condition = showNotificationTriggerCondition;
             return ok(res);
           } else {
             return ok(undefined);
@@ -239,7 +239,7 @@ export class TeamsBot implements Plugin {
             type: "group",
           });
           res.addChild(new QTreeNode(createHostTypeTriggerQuestion()));
-          res.condition = showNotificationCondition;
+          res.condition = showNotificationTriggerCondition;
           return ok(res);
         } else {
           return ok(undefined);

--- a/packages/fx-core/src/plugins/resource/bot/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/bot/plugin.ts
@@ -79,7 +79,7 @@ export class TeamsBotImpl implements PluginImpl {
 
   public async scaffold(context: PluginContext): Promise<FxResult> {
     this.ctx = context;
-    await this.config.restoreConfigFromContext(context);
+    await this.config.restoreConfigFromContext(context, true);
     Logger.info(Messages.ScaffoldingBot);
 
     const handler = await ProgressBarFactory.newProgressBar(

--- a/packages/fx-core/src/plugins/resource/bot/question.ts
+++ b/packages/fx-core/src/plugins/resource/bot/question.ts
@@ -1,7 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { MultiSelectQuestion, OptionItem } from "@microsoft/teamsfx-api";
+import { Inputs, MultiSelectQuestion, OptionItem } from "@microsoft/teamsfx-api";
 import { getLocalizedString } from "../../../common/localizeUtils";
+import {
+  AzureSolutionQuestionNames,
+  NotificationOptionItem,
+} from "../../solution/fx-solution/question";
 import { QuestionNames } from "./constants";
 import {
   HostType,
@@ -81,6 +85,21 @@ export function createHostTypeTriggerQuestion(): MultiSelectQuestion {
     },
   };
 }
+
+// Question model condition to determine whether to show "Select triggers" question after "Select capabilities".
+// Return undefined for true, a string for false. The string itself it not used.
+export const showNotificationCondition = {
+  validFunc: (input: unknown, inputs?: Inputs): string | undefined => {
+    if (!inputs) {
+      return "Invalid inputs";
+    }
+    const cap = inputs[AzureSolutionQuestionNames.Capabilities];
+    if (Array.isArray(cap) && cap.includes(NotificationOptionItem.id)) {
+      return undefined;
+    }
+    return "Notification is not selected";
+  },
+};
 
 type HostTypeTriggerOptionItemWithoutText = Omit<
   HostTypeTriggerOptionItem,

--- a/packages/fx-core/src/plugins/resource/bot/question.ts
+++ b/packages/fx-core/src/plugins/resource/bot/question.ts
@@ -88,7 +88,7 @@ export function createHostTypeTriggerQuestion(): MultiSelectQuestion {
 
 // Question model condition to determine whether to show "Select triggers" question after "Select capabilities".
 // Return undefined for true, a string for false. The string itself it not used.
-export const showNotificationCondition = {
+export const showNotificationTriggerCondition = {
   validFunc: (input: unknown, inputs?: Inputs): string | undefined => {
     if (!inputs) {
       return "Invalid inputs";

--- a/packages/fx-core/src/plugins/solution/fx-solution/question.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/question.ts
@@ -208,6 +208,8 @@ export function addCapabilityQuestion(
   if (!alreadyHaveBot) {
     options.push(BotOptionItem);
     options.push(MessageExtensionItem);
+    options.push(NotificationOptionItem);
+    options.push(CommandAndResponseOptionItem);
   }
   return {
     name: AzureSolutionQuestionNames.Capabilities,

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/executeUserTask.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/executeUserTask.ts
@@ -287,7 +287,7 @@ export async function addCapability(
   }
   const commandAndResponseIndex = capabilitiesAnswer.indexOf(CommandAndResponseOptionItem.id);
   if (commandAndResponseIndex !== -1) {
-    capabilitiesAnswer[commandAndResponseIndex] = NotificationOptionItem.id;
+    capabilitiesAnswer[commandAndResponseIndex] = BotOptionItem.id;
     scenarios.push(BotScenario.CommandAndResponseBot);
   }
   inputsNew[AzureSolutionQuestionNames.Scenarios] = scenarios;

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/getQuestions.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/getQuestions.ts
@@ -19,7 +19,7 @@ import {
 } from "@microsoft/teamsfx-api";
 import Container from "typedi";
 import { HelpLinks } from "../../../../common/constants";
-import { SolutionError, SolutionSource } from "../constants";
+import { PluginNames, SolutionError, SolutionSource } from "../constants";
 import {
   AskSubscriptionQuestion,
   AzureResourceApim,
@@ -52,9 +52,10 @@ import { AppStudioPluginV3 } from "../../../resource/appstudio/v3";
 import { canAddCapability, canAddResource } from "./executeUserTask";
 import { NoCapabilityFoundError } from "../../../../core";
 import { isVSProject } from "../../../../common/projectSettingsHelper";
-import { ProgrammingLanguageQuestion } from "../../../../core/question";
+import { handleSelectionConflict, ProgrammingLanguageQuestion } from "../../../../core/question";
 import { getLocalizedString } from "../../../../common/localizeUtils";
 import { isAadManifestEnabled } from "../../../../common";
+import { isBotNotificationEnabled } from "../../../../common";
 
 export async function getQuestionsForScaffolding(
   ctx: v2.Context,
@@ -155,7 +156,8 @@ export async function getQuestionsForScaffolding(
           if (
             cap.includes(BotOptionItem.id) ||
             cap.includes(MessageExtensionItem.id) ||
-            cap.includes(NotificationOptionItem.id)
+            cap.includes(NotificationOptionItem.id) ||
+            cap.includes(CommandAndResponseOptionItem.id)
           ) {
             return undefined;
           }
@@ -367,7 +369,7 @@ export async function getQuestionsForUserTask(
   const namespace = func.namespace;
   const array = namespace.split("/");
   if (func.method === "addCapability") {
-    return await getQuestionsForAddCapability(ctx, inputs);
+    return await getQuestionsForAddCapability(ctx, inputs, func, envInfo, tokenProvider);
   }
   if (func.method === "addResource") {
     return await getQuestionsForAddResource(ctx, inputs, func, envInfo, tokenProvider);
@@ -385,7 +387,10 @@ export async function getQuestionsForUserTask(
 
 export async function getQuestionsForAddCapability(
   ctx: v2.Context,
-  inputs: Inputs
+  inputs: Inputs,
+  func: Func,
+  envInfo: v2.DeepReadonly<v2.EnvInfoV2>,
+  tokenProvider: TokenProvider
 ): Promise<Result<QTreeNode | undefined, FxError>> {
   const settings = ctx.projectSetting.solutionSettings as AzureSolutionSettings | undefined;
   const addCapQuestion: MultiSelectQuestion = {
@@ -394,11 +399,45 @@ export async function getQuestionsForAddCapability(
     type: "multiSelect",
     staticOptions: [],
     default: [],
+    validation: {
+      validFunc: async (input: string[]): Promise<string | undefined> => {
+        if (
+          input.includes(NotificationOptionItem.id) &&
+          input.includes(CommandAndResponseOptionItem.id)
+        ) {
+          return getLocalizedString(
+            "core.addCapabilityQuestion.notificationCommandAndResponseConflict"
+          );
+        }
+
+        // undefined for success
+        return undefined;
+      },
+    },
+    onDidChangeSelection: async function (
+      currentSelectedIds: Set<string>,
+      previousSelectedIds: Set<string>
+    ): Promise<Set<string>> {
+      return handleSelectionConflict(
+        [
+          new Set([BotOptionItem.id, MessageExtensionItem.id]),
+          new Set([NotificationOptionItem.id]),
+          new Set([CommandAndResponseOptionItem.id]),
+        ],
+        previousSelectedIds,
+        currentSelectedIds
+      );
+    },
   };
   const isDynamicQuestion = DynamicPlatforms.includes(inputs.platform);
   if (!isDynamicQuestion) {
     // For CLI_HELP
-    addCapQuestion.staticOptions = [TabOptionItem, BotOptionItem, MessageExtensionItem];
+    addCapQuestion.staticOptions = [
+      TabOptionItem,
+      BotOptionItem,
+      ...(isBotNotificationEnabled() ? [NotificationOptionItem, CommandAndResponseOptionItem] : []),
+      MessageExtensionItem,
+    ];
     return ok(new QTreeNode(addCapQuestion));
   }
   const canProceed = canAddCapability(settings, ctx.telemetryReporter);
@@ -443,10 +482,41 @@ export async function getQuestionsForAddCapability(
   }
   const options = [];
   if (isTabAddable) options.push(TabOptionItem);
-  if (isBotAddable) options.push(BotOptionItem);
+  if (isBotAddable) {
+    options.push(BotOptionItem);
+    if (isBotNotificationEnabled()) {
+      options.push(NotificationOptionItem);
+      options.push(CommandAndResponseOptionItem);
+    }
+  }
   if (isMEAddable) options.push(MessageExtensionItem);
   addCapQuestion.staticOptions = options;
   const addCapNode = new QTreeNode(addCapQuestion);
+
+  if (isBotNotificationEnabled()) {
+    // Hardcoded to call bot plugin to get notification trigger questions.
+    // Originally, v2 solution will not call getQuestionForUserTask of plugins on addCapability.
+    // V3 will not need this hardcoding.
+    const pluginMap = getAllV2ResourcePluginMap();
+    const plugin = pluginMap.get(PluginNames.BOT);
+    if (plugin && plugin.getQuestionsForUserTask) {
+      const result = await plugin.getQuestionsForUserTask(
+        ctx,
+        inputs,
+        func,
+        envInfo,
+        tokenProvider
+      );
+      if (result.isErr()) {
+        return result;
+      }
+      const botQuestionNode = result.value;
+      if (botQuestionNode) {
+        addCapNode.addChild(botQuestionNode);
+      }
+    }
+  }
+
   if (!ctx.projectSetting.programmingLanguage) {
     // Language
     const programmingLanguage = new QTreeNode(ProgrammingLanguageQuestion);

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/getQuestions.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/getQuestions.ts
@@ -385,6 +385,33 @@ export async function getQuestionsForUserTask(
   return ok(undefined);
 }
 
+async function validateAddCapability(input: string[]): Promise<string | undefined> {
+  if (
+    input.includes(NotificationOptionItem.id) &&
+    input.includes(CommandAndResponseOptionItem.id)
+  ) {
+    return getLocalizedString("core.addCapabilityQuestion.notificationCommandAndResponseConflict");
+  }
+
+  // undefined for success
+  return undefined;
+}
+
+async function onDidChangeSelectionForAddCapability(
+  currentSelectedIds: Set<string>,
+  previousSelectedIds: Set<string>
+): Promise<Set<string>> {
+  return handleSelectionConflict(
+    [
+      new Set([BotOptionItem.id, MessageExtensionItem.id]),
+      new Set([NotificationOptionItem.id]),
+      new Set([CommandAndResponseOptionItem.id]),
+    ],
+    previousSelectedIds,
+    currentSelectedIds
+  );
+}
+
 export async function getQuestionsForAddCapability(
   ctx: v2.Context,
   inputs: Inputs,
@@ -400,34 +427,9 @@ export async function getQuestionsForAddCapability(
     staticOptions: [],
     default: [],
     validation: {
-      validFunc: async (input: string[]): Promise<string | undefined> => {
-        if (
-          input.includes(NotificationOptionItem.id) &&
-          input.includes(CommandAndResponseOptionItem.id)
-        ) {
-          return getLocalizedString(
-            "core.addCapabilityQuestion.notificationCommandAndResponseConflict"
-          );
-        }
-
-        // undefined for success
-        return undefined;
-      },
+      validFunc: validateAddCapability,
     },
-    onDidChangeSelection: async function (
-      currentSelectedIds: Set<string>,
-      previousSelectedIds: Set<string>
-    ): Promise<Set<string>> {
-      return handleSelectionConflict(
-        [
-          new Set([BotOptionItem.id, MessageExtensionItem.id]),
-          new Set([NotificationOptionItem.id]),
-          new Set([CommandAndResponseOptionItem.id]),
-        ],
-        previousSelectedIds,
-        currentSelectedIds
-      );
-    },
+    onDidChangeSelection: onDidChangeSelectionForAddCapability,
   };
   const isDynamicQuestion = DynamicPlatforms.includes(inputs.platform);
   if (!isDynamicQuestion) {

--- a/packages/fx-core/src/plugins/solution/fx-solution/v3/userTask.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v3/userTask.ts
@@ -51,7 +51,7 @@ export async function getQuestionsForUserTask(
   tokenProvider: TokenProvider
 ): Promise<Result<QTreeNode | undefined, FxError>> {
   if (func.method === "addCapability") {
-    return await getQuestionsForAddCapability(ctx, inputs);
+    return await getQuestionsForAddCapability(ctx, inputs, func, envInfo, tokenProvider);
   }
   if (func.method === "addResource") {
     return await getQuestionsForAddResource(ctx, inputs);

--- a/packages/fx-core/tests/plugins/resource/bot/unit/configs/scaffoldConfig.test.ts
+++ b/packages/fx-core/tests/plugins/resource/bot/unit/configs/scaffoldConfig.test.ts
@@ -121,12 +121,11 @@ describe("triggers Tests", () => {
       const pluginContext = testUtils.newPluginContext();
       const answers = pluginContext.answers!;
 
-      answers.stage = Stage.create;
       answers[QuestionNames.BOT_HOST_TYPE_TRIGGER] = answer;
       const scaffoldConfig = new ScaffoldConfig();
 
       // Act
-      scaffoldConfig.restoreConfigFromContext(pluginContext);
+      scaffoldConfig.restoreConfigFromContext(pluginContext, true);
 
       // Assert
       const result = [...scaffoldConfig.triggers].sort();
@@ -138,35 +137,35 @@ describe("triggers Tests", () => {
 });
 
 describe("Plugin Settings: 'capabilities'", () => {
-  // stage, pluginSettings, answer["scenarios"], expected, message
-  const cases: [Stage, Json, BotScenario[], BotCapability[], string][] = [
-    [Stage.create, {}, [], [], "Scaffold legacy bot"],
+  // isScaffold, pluginSettings, answer["scenarios"], expected, message
+  const cases: [boolean, Json, BotScenario[], BotCapability[], string][] = [
+    [true, {}, [], [], "Scaffold legacy bot"],
     [
-      Stage.create,
+      true,
       {},
       [BotScenario.NotificationBot],
       [BotCapabilities.NOTIFICATION],
       "Scaffold notification bot",
     ],
     [
-      Stage.create,
+      true,
       {},
       [BotScenario.CommandAndResponseBot],
       [BotCapabilities.COMMAND_AND_RESPONSE],
       "Scaffold command and response bot",
     ],
     [
-      Stage.create,
+      true,
       {},
       [BotScenario.NotificationBot, BotScenario.CommandAndResponseBot],
       [BotCapabilities.NOTIFICATION, BotCapabilities.COMMAND_AND_RESPONSE],
       // Currently not supported end to end but tested for generality
       "Scaffold multiple capabilities",
     ],
-    [Stage.provision, {}, [], [], "Provision legacy bot"],
-    [Stage.provision, {}, [BotScenario.NotificationBot], [], "Provision legacy bot 2"],
+    [false, {}, [], [], "Provision legacy bot"],
+    [false, {}, [BotScenario.NotificationBot], [], "Provision legacy bot 2"],
     [
-      Stage.provision,
+      false,
       {
         [ResourcePlugins.Bot]: {
           [PluginBot.BOT_CAPABILITIES]: [BotCapabilities.NOTIFICATION],
@@ -178,7 +177,7 @@ describe("Plugin Settings: 'capabilities'", () => {
       "Provision notification bot",
     ],
     [
-      Stage.provision,
+      false,
       {
         [ResourcePlugins.Bot]: {
           [PluginBot.BOT_CAPABILITIES]: [
@@ -192,20 +191,19 @@ describe("Plugin Settings: 'capabilities'", () => {
       "Provision multiple capabilities",
     ],
   ];
-  for (const [stage, pluginSettings, scenarios, expectedList, message] of cases) {
+  for (const [isScaffold, pluginSettings, scenarios, expectedList, message] of cases) {
     it(`Case '${message}'`, async () => {
       // Arrange
       const pluginContext = testUtils.newPluginContext();
       const answers = pluginContext.answers!;
       const projectSettings = pluginContext.projectSettings!;
 
-      answers.stage = stage;
       answers[AzureSolutionQuestionNames.Scenarios] = scenarios;
       projectSettings.pluginSettings = pluginSettings;
       const scaffoldConfig = new ScaffoldConfig();
 
       // Act
-      scaffoldConfig.restoreConfigFromContext(pluginContext);
+      scaffoldConfig.restoreConfigFromContext(pluginContext, isScaffold);
 
       // Assert
       const result = [...(scaffoldConfig.botCapabilities || [])].sort();

--- a/packages/fx-core/tests/plugins/resource/bot/unit/configs/scaffoldConfig.test.ts
+++ b/packages/fx-core/tests/plugins/resource/bot/unit/configs/scaffoldConfig.test.ts
@@ -35,11 +35,10 @@ describe("getBotHostType Tests", () => {
     // Arrange
     const pluginContext = testUtils.newPluginContext();
     const answers = pluginContext.answers!;
-    answers.stage = Stage.create;
     answers[QuestionNames.BOT_HOST_TYPE_TRIGGER] = [FunctionsHttpTriggerOptionItem.id];
 
     // Act
-    const hostType = ScaffoldConfig.getBotHostType(pluginContext);
+    const hostType = ScaffoldConfig.getBotHostType(pluginContext, true);
 
     // Assert
     chai.assert.equal(hostType, HostTypes.AZURE_FUNCTIONS);
@@ -50,7 +49,6 @@ describe("getBotHostType Tests", () => {
     const pluginContext = testUtils.newPluginContext();
     const answers = pluginContext.answers!;
     const projectSettings = pluginContext.projectSettings!;
-    answers.stage = Stage.provision;
     projectSettings.pluginSettings = {
       [PluginBot.PLUGIN_NAME]: {
         [PluginBot.HOST_TYPE]: BotHostTypes.AzureFunctions,
@@ -59,7 +57,7 @@ describe("getBotHostType Tests", () => {
     answers[QuestionNames.BOT_HOST_TYPE_TRIGGER] = [AppServiceOptionItem.id];
 
     // Act
-    const hostType = ScaffoldConfig.getBotHostType(pluginContext);
+    const hostType = ScaffoldConfig.getBotHostType(pluginContext, false);
 
     // Assert
     chai.assert.equal(hostType, HostTypes.AZURE_FUNCTIONS);
@@ -69,11 +67,10 @@ describe("getBotHostType Tests", () => {
     // Arrange
     const pluginContext = testUtils.newPluginContext();
     const answers = pluginContext.answers!;
-    answers.stage = Stage.create;
     answers[QuestionNames.BOT_HOST_TYPE_TRIGGER] = [AppServiceOptionItem.id];
 
     // Act
-    const hostType = ScaffoldConfig.getBotHostType(pluginContext);
+    const hostType = ScaffoldConfig.getBotHostType(pluginContext, true);
 
     // Assert
     chai.assert.equal(hostType, HostTypes.APP_SERVICE);
@@ -84,7 +81,6 @@ describe("getBotHostType Tests", () => {
     const pluginContext = testUtils.newPluginContext();
     const answers = pluginContext.answers!;
     const projectSettings = pluginContext.projectSettings!;
-    answers.stage = Stage.provision;
     projectSettings.pluginSettings = {
       [PluginBot.PLUGIN_NAME]: {
         [PluginBot.HOST_TYPE]: BotHostTypes.AppService,
@@ -93,7 +89,7 @@ describe("getBotHostType Tests", () => {
     answers[QuestionNames.BOT_HOST_TYPE_TRIGGER] = [FunctionsHttpTriggerOptionItem.id];
 
     // Act
-    const hostType = ScaffoldConfig.getBotHostType(pluginContext);
+    const hostType = ScaffoldConfig.getBotHostType(pluginContext, false);
 
     // Assert
     chai.assert.equal(hostType, HostTypes.APP_SERVICE);

--- a/packages/fx-core/tests/plugins/resource/bot/unit/question.test.ts
+++ b/packages/fx-core/tests/plugins/resource/bot/unit/question.test.ts
@@ -4,13 +4,19 @@ import "mocha";
 import * as chai from "chai";
 import * as sinon from "sinon";
 
-import { FuncValidation } from "@microsoft/teamsfx-api";
+import { FuncValidation, Inputs, Platform } from "@microsoft/teamsfx-api";
 import {
   AppServiceOptionItem,
   createHostTypeTriggerQuestion,
   FunctionsHttpTriggerOptionItem,
   FunctionsTimerTriggerOptionItem,
+  showNotificationCondition,
 } from "../../../../../src/plugins/resource/bot/question";
+import {
+  AzureSolutionQuestionNames,
+  CommandAndResponseOptionItem,
+  NotificationOptionItem,
+} from "../../../../../src/plugins/solution/fx-solution/question";
 
 describe("Test question", () => {
   describe("HostTypeTrigger question", () => {
@@ -121,6 +127,33 @@ describe("Test question", () => {
           );
         }
       }
+    });
+  });
+
+  describe("Test showNotificationCondition", () => {
+    it("Should not ask trigger questions for legacy bot", async () => {
+      // Arrange
+      const inputs: Inputs = { platform: Platform.VSCode };
+      // Act
+      inputs[AzureSolutionQuestionNames.Capabilities] = undefined;
+      // Assert
+      chai.assert.isTrue(showNotificationCondition.validFunc(undefined, inputs) !== undefined);
+    });
+    it("Should ask trigger questions for notification bot", async () => {
+      // Arrange
+      const inputs: Inputs = { platform: Platform.VSCode };
+      // Act
+      inputs[AzureSolutionQuestionNames.Capabilities] = [NotificationOptionItem.id];
+      // Assert
+      chai.assert.isUndefined(showNotificationCondition.validFunc(undefined, inputs));
+    });
+    it("Should not ask trigger questions for command and response bot", async () => {
+      // Arrange
+      const inputs: Inputs = { platform: Platform.VSCode };
+      // Act
+      inputs[AzureSolutionQuestionNames.Capabilities] = [CommandAndResponseOptionItem.id];
+      // Assert
+      chai.assert.isTrue(showNotificationCondition.validFunc(undefined, inputs) !== undefined);
     });
   });
 });

--- a/packages/fx-core/tests/plugins/resource/bot/unit/question.test.ts
+++ b/packages/fx-core/tests/plugins/resource/bot/unit/question.test.ts
@@ -10,7 +10,7 @@ import {
   createHostTypeTriggerQuestion,
   FunctionsHttpTriggerOptionItem,
   FunctionsTimerTriggerOptionItem,
-  showNotificationCondition,
+  showNotificationTriggerCondition,
 } from "../../../../../src/plugins/resource/bot/question";
 import {
   AzureSolutionQuestionNames,
@@ -137,7 +137,9 @@ describe("Test question", () => {
       // Act
       inputs[AzureSolutionQuestionNames.Capabilities] = undefined;
       // Assert
-      chai.assert.isTrue(showNotificationCondition.validFunc(undefined, inputs) !== undefined);
+      chai.assert.isTrue(
+        showNotificationTriggerCondition.validFunc(undefined, inputs) !== undefined
+      );
     });
     it("Should ask trigger questions for notification bot", async () => {
       // Arrange
@@ -145,7 +147,7 @@ describe("Test question", () => {
       // Act
       inputs[AzureSolutionQuestionNames.Capabilities] = [NotificationOptionItem.id];
       // Assert
-      chai.assert.isUndefined(showNotificationCondition.validFunc(undefined, inputs));
+      chai.assert.isUndefined(showNotificationTriggerCondition.validFunc(undefined, inputs));
     });
     it("Should not ask trigger questions for command and response bot", async () => {
       // Arrange
@@ -153,7 +155,9 @@ describe("Test question", () => {
       // Act
       inputs[AzureSolutionQuestionNames.Capabilities] = [CommandAndResponseOptionItem.id];
       // Assert
-      chai.assert.isTrue(showNotificationCondition.validFunc(undefined, inputs) !== undefined);
+      chai.assert.isTrue(
+        showNotificationTriggerCondition.validFunc(undefined, inputs) !== undefined
+      );
     });
   });
 });


### PR DESCRIPTION
- call `getQuestionsForUserTask` when addCapability for bot plugin. (offline discussed with @jayzhang to hardcode bot plugin for v2 now, v3 will not need this)
- support notification/command response bot for addCapability

![image](https://user-images.githubusercontent.com/9698542/159881759-c87fb500-85c6-4efc-86b4-574d77493a9e.png)


https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/13883632
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/13863654
