### PR TITLE
fix: fix progress bar for func hosted bot

### DIFF
--- a/packages/fx-core/src/plugins/resource/bot/constants.ts
+++ b/packages/fx-core/src/plugins/resource/bot/constants.ts
@@ -71,7 +71,6 @@ export class ProgressBarConstants {
 
   public static readonly SCAFFOLD_STEPS_NUM: number = 2;
 
-  public static readonly SCAFFOLD_FUNCTIONS_NOTIFICATION_TITLE = "Scaffolding notification bot";
   public static readonly SCAFFOLD_FUNCTIONS_NOTIFICATION_STEP_START =
     "Scaffolding notification bot.";
   public static readonly SCAFFOLD_FUNCTIONS_NOTIFICATION_STEP_FETCH_PROJECT_TEMPLATE =

--- a/packages/fx-core/src/plugins/resource/bot/functionsHostedBot/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/bot/functionsHostedBot/plugin.ts
@@ -46,8 +46,9 @@ export class FunctionsHostedBotImpl extends TeamsBotImpl {
 
     Logger.info(Messages.ScaffoldingBot);
 
+    // title must match closeProgressBar in bot/index.ts::scaffold()
     const handler = await ProgressBarFactory.newProgressBar(
-      ProgressBarConstants.SCAFFOLD_FUNCTIONS_NOTIFICATION_TITLE,
+      ProgressBarConstants.SCAFFOLD_TITLE,
       ProgressBarConstants.SCAFFOLD_FUNCTIONS_NOTIFICATION_STEPS_NUM,
       this.ctx
     );


### PR DESCRIPTION
Progress bar title in `scaffold()` must match `index.ts`. Otherwise, the following progress bar will not be closed after success.

![img](https://user-images.githubusercontent.com/9698542/160053769-0e07a2a1-157c-4b30-a55a-04266eeea45b.png)
