### PR TITLE
fix: remove bot commands for notification bot

### DIFF
--- a/packages/fx-core/src/plugins/resource/appstudio/constants.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/constants.ts
@@ -364,6 +364,15 @@ export const BOTS_TPL_FOR_MULTI_ENV: IBot[] = [
   },
 ];
 
+export const BOTS_TPL_FOR_NOTIFICATION: IBot[] = [
+  {
+    botId: "{{state.fx-resource-bot.botId}}",
+    scopes: ["personal", "team", "groupchat"],
+    supportsFiles: false,
+    isNotificationOnly: false,
+  },
+];
+
 export const BOTS_TPL_FOR_COMMAND_AND_RESPONSE: IBot[] = [
   {
     botId: "{{state.fx-resource-bot.botId}}",

--- a/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
@@ -68,6 +68,7 @@ import {
   DEVELOPER_PREVIEW_SCHEMA,
   M365_DEVELOPER_PREVIEW_MANIFEST_VERSION,
   BOTS_TPL_FOR_COMMAND_AND_RESPONSE,
+  BOTS_TPL_FOR_NOTIFICATION,
 } from "./constants";
 import AdmZip from "adm-zip";
 import * as fs from "fs-extra";
@@ -581,6 +582,8 @@ export class AppStudioPluginImpl {
       const scenarios = ctx.answers?.[AzureSolutionQuestionNames.Scenarios];
       const hasCommandAndResponseBot =
         scenarios?.includes && scenarios.includes(BotScenario.CommandAndResponseBot);
+      const hasNotificationBot =
+        scenarios?.includes && scenarios.includes(BotScenario.NotificationBot);
       const hasMessageExtension = solutionSettings.capabilities.includes(MessageExtensionItem.id);
       const hasAad = isAADEnabled(solutionSettings);
       const isM365 = ctx.projectSettings?.isM365;
@@ -588,6 +591,7 @@ export class AppStudioPluginImpl {
         ctx.projectSettings!.appName,
         hasFrontend,
         hasBot,
+        hasNotificationBot,
         hasCommandAndResponseBot,
         hasMessageExtension,
         false,
@@ -1794,6 +1798,7 @@ export async function createManifest(
   appName: string,
   hasFrontend: boolean,
   hasBot: boolean,
+  hasNotificationBot: boolean,
   hasCommandAndResponseBot: boolean,
   hasMessageExtension: boolean,
   isSPFx: boolean,
@@ -1818,6 +1823,8 @@ export async function createManifest(
     if (hasBot) {
       if (hasCommandAndResponseBot) {
         manifest.bots = BOTS_TPL_FOR_COMMAND_AND_RESPONSE;
+      } else if (hasNotificationBot) {
+        manifest.bots = BOTS_TPL_FOR_NOTIFICATION;
       } else {
         manifest.bots = BOTS_TPL_FOR_MULTI_ENV;
       }

--- a/packages/fx-core/tests/plugins/resource/appstudio/unit/scaffold.test.ts
+++ b/packages/fx-core/tests/plugins/resource/appstudio/unit/scaffold.test.ts
@@ -23,6 +23,7 @@ import {
 import {
   BOTS_TPL_FOR_COMMAND_AND_RESPONSE,
   BOTS_TPL_FOR_MULTI_ENV,
+  BOTS_TPL_FOR_NOTIFICATION,
   COMPOSE_EXTENSIONS_TPL_FOR_MULTI_ENV,
   CONFIGURABLE_TABS_TPL_FOR_MULTI_ENV,
   DEVELOPER_PREVIEW_SCHEMA,
@@ -273,6 +274,56 @@ describe("Scaffold", () => {
       .expect(manifest.bots, "Bots should be empty, because only msgext is chosen")
       .to.deep.equal([]);
     chai.expect(manifest.composeExtensions).to.deep.equal(COMPOSE_EXTENSIONS_TPL_FOR_MULTI_ENV);
+
+    chai.expect(
+      fileContent.has(
+        path.normalize(`${ctx.root}/templates/${AppPackageFolderName}/resources/color.png`)
+      )
+    ).to.be.true;
+    chai.expect(
+      fileContent.has(
+        path.normalize(`${ctx.root}/templates/${AppPackageFolderName}/resources/outline.png`)
+      )
+    ).to.be.true;
+  });
+
+  it("should generate manifest for notification bot", async () => {
+    sandbox.stub(process, "env").value({
+      TEAMSFX_CONFIG_UNIFY: "true",
+      BOT_NOTIFICATION_ENABLED: "true",
+    });
+    fileContent.clear();
+
+    ctx.projectSettings = {
+      appName: "my app",
+      projectId: uuid.v4(),
+      solutionSettings: {
+        name: "azure",
+        version: "1.0",
+        capabilities: ["Bot"],
+      },
+    };
+    if (ctx.answers) {
+      ctx.answers[AzureSolutionQuestionNames.Scenarios] = [BotScenario.NotificationBot];
+    }
+
+    const result = await plugin.scaffold(ctx);
+    chai.expect(result.isOk()).equals(true);
+    const manifest: TeamsAppManifest = JSON.parse(
+      fileContent.get(path.normalize(getManifestConsolidatePath(ctx.root)))
+    );
+    chai
+      .expect(manifest.staticTabs, "staticTabs should be empty, because only bot is chosen")
+      .to.deep.equal([]);
+    chai
+      .expect(
+        manifest.configurableTabs,
+        "configurableTabs should be empty, because only bot is chosen"
+      )
+      .to.deep.equal([]);
+    chai
+      .expect(manifest.bots, "Bots should be a notification bot, without commands")
+      .to.deep.equal(BOTS_TPL_FOR_NOTIFICATION);
 
     chai.expect(
       fileContent.has(


### PR DESCRIPTION
From dogfooding feedback, there is no command provided by the notification bot, so it makes no senses to put them in the manifest.