### PR TITLE
fix(localdebug): add back cascadeTerminateToConfigurations

### DIFF
--- a/packages/fx-core/src/plugins/solution/fx-solution/debug/util/launch.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/debug/util/launch.ts
@@ -24,11 +24,15 @@ export function generateConfigurations(
   ];
 
   if (includeFrontend) {
-    launchConfigurations.push(startAndAttachToFrontend(LaunchBrowser.edge, "Edge"));
-    launchConfigurations.push(startAndAttachToFrontend(LaunchBrowser.chrome, "Chrome"));
+    launchConfigurations.push(
+      startAndAttachToFrontend(LaunchBrowser.edge, "Edge", includeBackend, includeBot)
+    );
+    launchConfigurations.push(
+      startAndAttachToFrontend(LaunchBrowser.chrome, "Chrome", includeBackend, includeBot)
+    );
   } else if (includeBot) {
-    launchConfigurations.push(launchBot(LaunchBrowser.edge, "Edge"));
-    launchConfigurations.push(launchBot(LaunchBrowser.chrome, "Chrome"));
+    launchConfigurations.push(launchBot(LaunchBrowser.edge, "Edge", includeBackend));
+    launchConfigurations.push(launchBot(LaunchBrowser.chrome, "Chrome", includeBackend));
   }
 
   if (includeBot) {
@@ -249,14 +253,24 @@ function launchRemote(
 
 function startAndAttachToFrontend(
   browserType: string,
-  browserName: string
+  browserName: string,
+  includeBackend: boolean,
+  includeBot: boolean
 ): Record<string, unknown> {
+  const cascadeTerminateToConfigurations = [];
+  if (includeBackend) {
+    cascadeTerminateToConfigurations.push("Attach to Backend");
+  }
+  if (includeBot) {
+    cascadeTerminateToConfigurations.push("Attach to Bot");
+  }
   return {
     name: `Start and Attach to Frontend (${browserName})`,
     type: browserType,
     request: "launch",
     url: "https://teams.microsoft.com/l/app/${localTeamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
     preLaunchTask: "Start Frontend",
+    cascadeTerminateToConfigurations,
     presentation: {
       group: "all",
       hidden: true,
@@ -264,12 +278,21 @@ function startAndAttachToFrontend(
   };
 }
 
-function launchBot(browserType: string, browserName: string): Record<string, unknown> {
+function launchBot(
+  browserType: string,
+  browserName: string,
+  includeBackend: boolean
+): Record<string, unknown> {
+  const cascadeTerminateToConfigurations = ["Attach to Bot"];
+  if (includeBackend) {
+    cascadeTerminateToConfigurations.push("Attach to Backend");
+  }
   return {
     name: `Launch Bot (${browserName})`,
     type: browserType,
     request: "launch",
     url: "https://teams.microsoft.com/l/app/${localTeamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
+    cascadeTerminateToConfigurations,
     presentation: {
       group: "all",
       hidden: true,


### PR DESCRIPTION
- if no cascadeTerminateToConfigurations, closing browser will not stop `Attach to Backend` and `Attach to Bot` even though stopAll in compound is true

Fix a regression bug https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/13929895.

E2E TEST: N/A