### PR TITLE
fix: command and response should not ask for trigger

### DIFF
--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/getQuestions.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/getQuestions.ts
@@ -154,11 +154,11 @@ export async function getQuestionsForScaffolding(
             return "Invalid inputs";
           }
           const cap = inputs[AzureSolutionQuestionNames.Capabilities] as string[];
+          // TODO(aochengwang): add a parent question node to prevent overwriting bot question.condition
           if (
             cap.includes(BotOptionItem.id) ||
             cap.includes(MessageExtensionItem.id) ||
-            cap.includes(NotificationOptionItem.id) ||
-            cap.includes(CommandAndResponseOptionItem.id)
+            cap.includes(NotificationOptionItem.id)
           ) {
             return undefined;
           }


### PR DESCRIPTION
This is a quick fix for command and response bot to not ask for triggers. Later change to add a new tree node to prevent overwriting plugin's `node.condition` in solution.