### PR TITLE
chore(vsc): add tree registration for non-teamsfx project

### DIFF
--- a/packages/vscode-extension/src/treeview/treeViewManager.ts
+++ b/packages/vscode-extension/src/treeview/treeViewManager.ts
@@ -73,7 +73,8 @@ class TreeViewManager {
     if (isValidProject(workspacePath)) {
       return this.registerTreeViewsForTeamsFxProject(workspacePath);
     } else {
-      // No need to register TreeView because walkthrough is enabled.
+      // TODO: remove this logic because walkthrough is enabled.
+      return this.registerTreeViewsForNonTeamsFxProject();
     }
     return [];
   }
@@ -167,6 +168,15 @@ class TreeViewManager {
     this.registerDevelopment(developmentCommands, disposables);
     this.registerDeployment(disposables);
     this.registerHelper(disposables);
+
+    return disposables;
+  }
+
+  private async registerTreeViewsForNonTeamsFxProject() {
+    const disposables: vscode.Disposable[] = [];
+
+    this.registerAccount(disposables);
+    this.registerEnvironment(disposables);
 
     return disposables;
   }


### PR DESCRIPTION
Register tree views since environment tree depends on TreeViewProvider in non-teamsfx project and causes exception otherwise.