### PR TITLE
chore(vsc): add command handlers

### DIFF
--- a/packages/vscode-extension/src/treeview/treeViewManager.ts
+++ b/packages/vscode-extension/src/treeview/treeViewManager.ts
@@ -76,7 +76,6 @@ class TreeViewManager {
       // TODO: remove this logic because walkthrough is enabled.
       return this.registerTreeViewsForNonTeamsFxProject();
     }
-    return [];
   }
 
   public getTreeView(viewName: string) {
@@ -177,6 +176,10 @@ class TreeViewManager {
 
     this.registerAccount(disposables);
     this.registerEnvironment(disposables);
+    const developmentCommands = this.getDevelopmentCommands(false, false);
+    this.registerDevelopment(developmentCommands, disposables);
+    this.registerDeployment(disposables);
+    this.registerHelper(disposables);
 
     return disposables;
   }


### PR DESCRIPTION
Since tree view commands are handled in TreeViewManager, they should be registered in non-teamsfx project too.
Will fix this logic in later PR.

E2E TEST: manual tested.