### PR TITLE
fix: fix legacy bot add capability

### DIFF
--- a/packages/fx-core/src/plugins/resource/bot/configs/teamsBotConfig.ts
+++ b/packages/fx-core/src/plugins/resource/bot/configs/teamsBotConfig.ts
@@ -14,6 +14,7 @@ import { PluginActRoles } from "../enums/pluginActRoles";
 import { DeployConfig } from "./deployConfig";
 import * as utils from "../utils/common";
 import { AzureSolutionQuestionNames } from "../../../solution/fx-solution/question";
+import { isBotNotificationEnabled } from "../../../../common";
 
 export class TeamsBotConfig {
   public scaffold: ScaffoldConfig = new ScaffoldConfig();
@@ -55,7 +56,7 @@ export class TeamsBotConfig {
 
     if (capabilities?.includes(PluginActRoles.Bot)) {
       const scenarios = context.answers?.[AzureSolutionQuestionNames.Scenarios];
-      if (Array.isArray(scenarios)) {
+      if (isBotNotificationEnabled() && Array.isArray(scenarios)) {
         const scenarioActRoles = scenarios
           .map((item) => QuestionBotScenarioToPluginActRoles.get(item))
           .filter((item): item is PluginActRoles => item !== undefined);

--- a/packages/fx-core/tests/plugins/resource/bot/unit/configs/teamsBotConfig.test.ts
+++ b/packages/fx-core/tests/plugins/resource/bot/unit/configs/teamsBotConfig.test.ts
@@ -9,7 +9,7 @@ import { QuestionNames } from "../../../../../../src/plugins/resource/bot/consta
 import { PluginActRoles } from "../../../../../../src/plugins/resource/bot/enums/pluginActRoles";
 import { BotOptionItem } from "../../../../../../src/plugins/solution/fx-solution/question";
 
-describe("getBotHostType Tests", () => {
+describe("TeamsBotConfig Tests", () => {
   const sandbox = sinon.createSandbox();
   afterEach(() => {
     sandbox.restore();

--- a/packages/fx-core/tests/plugins/resource/bot/unit/configs/teamsBotConfig.test.ts
+++ b/packages/fx-core/tests/plugins/resource/bot/unit/configs/teamsBotConfig.test.ts
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+import "mocha";
+import * as chai from "chai";
+import * as sinon from "sinon";
+import { TeamsBotConfig } from "../../../../../../src/plugins/resource/bot/configs/teamsBotConfig";
+import * as testUtils from "../utils";
+import { QuestionNames } from "../../../../../../src/plugins/resource/bot/constants";
+import { PluginActRoles } from "../../../../../../src/plugins/resource/bot/enums/pluginActRoles";
+import { BotOptionItem } from "../../../../../../src/plugins/solution/fx-solution/question";
+
+describe("getBotHostType Tests", () => {
+  const sandbox = sinon.createSandbox();
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("test regression bug for legacy bot: 'act roles is missing.'", async () => {
+    // TODO: remove case after removing isBotNotificationEnabled()
+    // legacy bot scaffolding should not make actRoles empty
+
+    // Arrange
+    sinon.stub(process, "env").value({ BOT_NOTIFICATION_ENABLED: "false" });
+    const pluginContext = testUtils.newPluginContext();
+    const answers = pluginContext.answers!;
+    answers[QuestionNames.CAPABILITIES] = [BotOptionItem.id];
+
+    // Act
+    const config = new TeamsBotConfig();
+    await config.restoreConfigFromContext(pluginContext, true);
+
+    // Assert
+    chai.assert.deepEqual(config.actRoles, [PluginActRoles.Bot]);
+  });
+});


### PR DESCRIPTION
- bug: with BOT_NOTIFICATION_ENABLED=false, add capability of legacy bot will throw error: `[Bot Plugin] act roles is missing.`
- This is due to a missing feature flag check. Fixed and regression test attached.
Tested add capability with `BOT_NOTIFICATION_ENABLED=false`
![image](https://user-images.githubusercontent.com/9698542/160569753-fdd0ead4-2b88-4851-aee1-098a968741a0.png)
