### PR TITLE
chore: add telemetry for spfx

### DIFF
--- a/packages/fx-core/src/plugins/resource/spfx/error.ts
+++ b/packages/fx-core/src/plugins/resource/spfx/error.ts
@@ -113,8 +113,8 @@ export function NpmInstallError(error: Error): SystemError {
   return new SystemError(
     Constants.PLUGIN_NAME,
     "NpmInstallFailed",
-    getDefaultString("plugins.spfx.error.npmInstallFailed"),
-    getLocalizedString("plugins.spfx.error.npmInstallFailed")
+    getDefaultString("plugins.spfx.error.npmInstallFailed", error.message),
+    getLocalizedString("plugins.spfx.error.npmInstallFailed", error.message)
   );
 }
 
@@ -122,8 +122,8 @@ export function DependencyValidateError(dependency: string): SystemError {
   return new SystemError(
     Constants.PLUGIN_NAME,
     "InvalidDependency",
-    getDefaultString("plugins.spfx.error.invalidDependency"),
-    getLocalizedString("plugins.spfx.error.invalidDependency")
+    getDefaultString("plugins.spfx.error.invalidDependency", dependency),
+    getLocalizedString("plugins.spfx.error.invalidDependency", dependency)
   );
 }
 
@@ -131,7 +131,7 @@ export function DependencyInstallError(dependency: string): SystemError {
   return new SystemError(
     Constants.PLUGIN_NAME,
     "DependencyInstallFailed",
-    getDefaultString("plugins.spfx.error.installDependency"),
-    getLocalizedString("plugins.spfx.error.installDependency")
+    getDefaultString("plugins.spfx.error.installDependency", dependency),
+    getLocalizedString("plugins.spfx.error.installDependency", dependency)
   );
 }

--- a/packages/fx-core/src/plugins/resource/spfx/utils/constants.ts
+++ b/packages/fx-core/src/plugins/resource/spfx/utils/constants.ts
@@ -41,6 +41,7 @@ export class TelemetryKey {
   static readonly Success = "success";
   static readonly ErrorType = "error-type";
   static readonly ErrorMessage = "error-message";
+  static readonly ErrorCode = "error-code";
 }
 
 export class TelemetryValue {

--- a/packages/fx-core/src/plugins/resource/spfx/utils/telemetry-helper.ts
+++ b/packages/fx-core/src/plugins/resource/spfx/utils/telemetry-helper.ts
@@ -33,6 +33,7 @@ export class telemetryHelper {
       properties[TelemetryKey.ErrorType] = TelemetryValue.UserError;
     }
     properties[TelemetryKey.ErrorMessage] = e.message;
+    properties[TelemetryKey.ErrorCode] = e.name;
 
     ctx.telemetryReporter?.sendTelemetryEvent(eventName, properties, measurements);
   }

--- a/packages/fx-core/src/plugins/solution/fx-solution/constants.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/constants.ts
@@ -235,6 +235,9 @@ export enum SolutionTelemetryProperty {
   TeamsAppPermission = "teams-app-permission",
   ProgrammingLanguage = "programming-language",
   Env = "env",
+  ErrorCode = "error-code",
+  ErrorMessage = "error-message",
+  HostType = "host-type",
 }
 
 export enum SolutionTelemetrySuccess {

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/scaffolding.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/scaffolding.ts
@@ -46,6 +46,9 @@ export async function scaffoldSourceCode(
   ctx: v2.Context,
   inputs: Inputs
 ): Promise<Result<Void, FxError>> {
+  ctx.telemetryReporter?.sendTelemetryEvent(SolutionTelemetryEvent.CreateStart, {
+    [SolutionTelemetryProperty.Component]: SolutionTelemetryComponentName,
+  });
   if (inputs.projectPath === undefined) {
     return err(
       new SystemError("Solution", SolutionError.InternelError, "projectPath is undefined")
@@ -102,7 +105,7 @@ export async function scaffoldSourceCode(
         [SolutionTelemetryProperty.Capabilities]: (solutionSettings?.capabilities || []).join(";"),
         [SolutionTelemetryProperty.ProgrammingLanguage]:
           ctx.projectSetting?.programmingLanguage ?? "",
-        "host-type": "azure",
+        [SolutionTelemetryProperty.HostType]: "azure",
       });
     } else {
       //For SPFx plugin, execute it alone lastly
@@ -119,7 +122,7 @@ export async function scaffoldSourceCode(
           ),
           [SolutionTelemetryProperty.ProgrammingLanguage]:
             ctx.projectSetting?.programmingLanguage ?? "",
-          "host-type": "spfx",
+          [SolutionTelemetryProperty.HostType]: "spfx",
         });
       }
     }
@@ -130,6 +133,13 @@ export async function scaffoldSourceCode(
     );
     return ok(Void);
   } else {
+    ctx.telemetryReporter?.sendTelemetryErrorEvent(SolutionTelemetryEvent.Create, {
+      [SolutionTelemetryProperty.Component]: SolutionTelemetryComponentName,
+      [SolutionTelemetryProperty.Success]: SolutionTelemetrySuccess.No,
+      [SolutionTelemetryProperty.ErrorCode]: result.error.name,
+      [SolutionTelemetryProperty.ErrorMessage]: result.error.message,
+      [SolutionTelemetryProperty.HostType]: isAzureProject(solutionSettings) ? "azure" : "spfx",
+    });
     return err(result.error);
   }
 }

--- a/packages/vscode-extension/src/envTree.ts
+++ b/packages/vscode-extension/src/envTree.ts
@@ -74,7 +74,7 @@ export async function registerEnvTreeHandler(): Promise<Result<Void, FxError>> {
       for (const item of envNames) {
         showEnvList.push(item);
         const envInfo = await getCurrentEnvInfo(workspacePath, item);
-        const isSpfxProject = await isSPFxProject(ext.workspaceUri.fsPath);
+        const isSpfxProject = isSPFxProject(ext.workspaceUri.fsPath);
 
         environmentTreeProvider.add([
           {
@@ -265,7 +265,7 @@ async function checkAccountForEnvironment(env: string): Promise<accountStatus | 
   }
 
   // Check Azure account status
-  const isSpfxProject = await isSPFxProject(ext.workspaceUri.fsPath);
+  const isSpfxProject = isSPFxProject(ext.workspaceUri.fsPath);
   if (!isSpfxProject) {
     if (AzureAccountManager.getAccountInfo() !== undefined) {
       const subscriptionInfo = await getSubscriptionInfoFromEnv(env);

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -380,7 +380,7 @@ export async function activate(context: vscode.ExtensionContext) {
   vscode.commands.executeCommand(
     "setContext",
     "fx-extension.isSPFx",
-    workspacePath && (await isSPFxProject(workspacePath))
+    workspacePath && isSPFxProject(workspacePath)
   );
 
   vscode.commands.executeCommand("setContext", "fx-extension.isInitAppEnabled", isInitAppEnabled());

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -1419,7 +1419,7 @@ export async function openReadMeHandler(args: any[]) {
     const workspaceFolder = workspace.workspaceFolders[0];
     const workspacePath: string = workspaceFolder.uri.fsPath;
     let targetFolder: string | undefined;
-    if (await isSPFxProject(workspacePath)) {
+    if (isSPFxProject(workspacePath)) {
       targetFolder = `${workspacePath}/SPFx`;
     } else if (await getIsFromSample()) {
       openSampleReadmeHandler(args);
@@ -1832,7 +1832,7 @@ export async function grantPermission(env: string): Promise<Result<any, FxError>
 
       let warningMsg = localize("teamstoolkit.handlers.grantPermissionWarning");
       let helpUrl = AzureAssignRoleHelpUrl;
-      if (await isSPFxProject(ext.workspaceUri.fsPath)) {
+      if (isSPFxProject(ext.workspaceUri.fsPath)) {
         warningMsg = localize("teamstoolkit.handlers.grantPermissionWarningSpfx");
         helpUrl = SpfxManageSiteAdminUrl;
       }

--- a/packages/vscode-extension/src/telemetry/extTelemetry.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetry.ts
@@ -13,7 +13,8 @@ import {
 } from "./extTelemetryEvents";
 import * as extensionPackage from "../../package.json";
 import { FxError, Stage, UserError } from "@microsoft/teamsfx-api";
-import { getIsExistingUser } from "../utils/commonUtils";
+import { getIsExistingUser, isSPFxProject } from "../utils/commonUtils";
+import { ext } from "../extensionVariables";
 
 export namespace ExtTelemetry {
   export let reporter: VSCodeTelemetryReporter;
@@ -84,6 +85,9 @@ export namespace ExtTelemetry {
     const isExistingUser = getIsExistingUser();
     properties[TelemetryProperty.IsExistingUser] = isExistingUser ? isExistingUser : "";
 
+    const isSPFx = isSPFxProject(ext.workspaceUri.fsPath);
+    properties[TelemetryProperty.IsSpfx] = isSPFx.toString();
+
     if (isFromSample != undefined) {
       properties![TelemetryProperty.IsFromSample] = isFromSample.toString();
     }
@@ -124,6 +128,9 @@ export namespace ExtTelemetry {
       error.stack ? "\nstack:\n" + error.stack : ""
     }`;
 
+    const isSPFx = isSPFxProject(ext.workspaceUri.fsPath);
+    properties[TelemetryProperty.IsSpfx] = isSPFx.toString();
+
     if (isFromSample != undefined) {
       properties![TelemetryProperty.IsFromSample] = isFromSample.toString();
     }
@@ -149,6 +156,9 @@ export namespace ExtTelemetry {
 
     const isExistingUser = getIsExistingUser();
     properties[TelemetryProperty.IsExistingUser] = isExistingUser ? isExistingUser : "";
+
+    const isSPFx = isSPFxProject(ext.workspaceUri.fsPath);
+    properties[TelemetryProperty.IsSpfx] = isSPFx.toString();
 
     if (isFromSample != undefined) {
       properties![TelemetryProperty.IsFromSample] = isFromSample.toString();

--- a/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
@@ -215,6 +215,7 @@ export enum TelemetryProperty {
   SourceEnv = "sourceEnv",
   TargetEnv = "targetEnv",
   IsFromSample = "is-from-sample",
+  IsSpfx = "is-spfx",
   IsM365 = "is-m365",
   SettingsVersion = "settings-version",
   UpdateFailedFiles = "update-failed-files",

--- a/packages/vscode-extension/src/treeview/treeViewManager.ts
+++ b/packages/vscode-extension/src/treeview/treeViewManager.ts
@@ -161,7 +161,7 @@ class TreeViewManager {
     this.registerAccount(disposables);
     this.registerEnvironment(disposables);
 
-    const isNonSPFx = (workspacePath && !(await isSPFxProject(workspacePath))) as boolean;
+    const isNonSPFx = (workspacePath && !isSPFxProject(workspacePath)) as boolean;
     const hasAdaptiveCard = await AdaptiveCardCodeLensProvider.detectedAdaptiveCards();
     const developmentCommands = this.getDevelopmentCommands(isNonSPFx, hasAdaptiveCard);
     this.registerDevelopment(developmentCommands, disposables);

--- a/packages/vscode-extension/src/utils/commonUtils.ts
+++ b/packages/vscode-extension/src/utils/commonUtils.ts
@@ -115,8 +115,8 @@ export function getProjectId(): string | undefined {
   }
 }
 
-export async function isSPFxProject(workspacePath: string): Promise<boolean> {
-  if (await fs.pathExists(`${workspacePath}/SPFx`)) {
+export function isSPFxProject(workspacePath: string): boolean {
+  if (fs.pathExistsSync(`${workspacePath}/SPFx`)) {
     return true;
   }
 
@@ -230,6 +230,8 @@ export function syncFeatureFlags() {
 export class FeatureFlags {
   static readonly InsiderPreview = "__TEAMSFX_INSIDER_PREVIEW";
   static readonly TelemetryTest = "TEAMSFX_TELEMETRY_TEST";
+  static readonly YoCheckerEnable = "TEAMSFX_YO_ENV_CHECKER_ENABLE";
+  static readonly GeneratorCheckerEnable = "TEAMSFX_GENERATOR_ENV_CHECKER_ENABLE";
 }
 
 // Determine whether feature flag is enabled based on environment variable setting

--- a/packages/vscode-extension/test/unit/extension/commonUtils.test.ts
+++ b/packages/vscode-extension/test/unit/extension/commonUtils.test.ts
@@ -76,7 +76,7 @@ suite("CommonUtils", () => {
         return false;
       });
 
-      chai.expect(await commonUtils.isSPFxProject("./invalidPath")).equals(false);
+      chai.expect(commonUtils.isSPFxProject("./invalidPath")).equals(false);
 
       sinon.restore();
     });
@@ -92,7 +92,7 @@ suite("CommonUtils", () => {
         return false;
       });
 
-      chai.expect(await commonUtils.isSPFxProject(testPath)).equals(true);
+      chai.expect(commonUtils.isSPFxProject(testPath)).equals(true);
 
       sinon.restore();
     });


### PR DESCRIPTION
1. Add isSPFx property to all lifecycle in extension
2. Improve 'create' telemetry event in solution so for create project we can query how many spfx projects created
3. Attach spfx dependency checker to events
4. Send error code in spfx plugin so we can query how many users get dependency installation failed error
5. Fix error due to wrong conflict resolve for main merge back to dev