### PR TITLE
fix(vscode): branding typo

### DIFF
--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -24,7 +24,7 @@ Teams apps are a combination of [capabilities](https://aka.ms/teamsfx-capabiliti
 
 ## Getting started
 
-After installing the Teams toolkit, follow the [Get Started](https://aka.ms/teamsfx-build-first-app) instructions in our documentation to smoothly start with.
+After installing the Teams Toolkit, follow the [Get Started](https://aka.ms/teamsfx-build-first-app) instructions in our documentation to smoothly start with.
 
 In the Teams Toolkit for Visual Studio Code, you can easily discover all applicable commands in the sidebar and Command Palette with the keyword "Teams". It also supports [Command Line Interface (CLI)](https://www.npmjs.com/package/@microsoft/teamsfx-cli) to increase efficiency.
 

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -910,7 +910,7 @@
     "walkthroughs": [
       {
         "id": "teamsToolkitQuickStart",
-        "title": "Get started with Teams toolkit",
+        "title": "Get started with Teams Toolkit",
         "description": "Jumpstart your Teams app development experience",
         "steps": [
           {


### PR DESCRIPTION
Related bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/13964752

E2E TEST: N/A