### PR TITLE
fix(bot): skip deployment after *.ts file is changed

### DIFF
--- a/packages/fx-core/src/plugins/resource/bot/functionsHostedBot/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/bot/functionsHostedBot/plugin.ts
@@ -154,13 +154,8 @@ export class FunctionsHostedBotImpl extends TeamsBotImpl {
       throw new PreconditionError(Messages.SomethingIsMissing(PluginBot.PROGRAMMING_LANGUAGE), []);
     }
 
-    const deployTime: Date = new Date();
     const deployMgr = new FuncHostedDeployMgr(workingDir, this.ctx.envInfo.envName);
-    const needsToRedeploy: boolean = await deployMgr.needsToRedeploy([
-      FolderNames.NODE_MODULES,
-      ...(await deployMgr.getIgnoreRules(FuncHostedBotDeployConfigs.FUNC_IGNORE_FILE)),
-      ...(await deployMgr.getIgnoreRules(FuncHostedBotDeployConfigs.GIT_IGNORE_FILE)),
-    ]);
+    const needsToRedeploy: boolean = await deployMgr.needsToRedeploy();
     if (!needsToRedeploy) {
       Logger.debug(Messages.SkipDeployNoUpdates);
       return ResultFactory.Success();
@@ -178,7 +173,7 @@ export class FunctionsHostedBotImpl extends TeamsBotImpl {
     await LanguageStrategy.localBuild(programmingLanguage, workingDir);
 
     await handler?.next(ProgressBarConstants.DEPLOY_STEP_ZIP_FOLDER);
-
+    const deployTime: Date = new Date();
     const rules = await deployMgr.getIgnoreRules(FuncHostedBotDeployConfigs.FUNC_IGNORE_FILE);
     const zipBuffer = await deployMgr.zipAFolder(rules);
 


### PR DESCRIPTION
Fix the bug during calculate whether need to redeploy.
1. Move the generation of `lastUpdateTime` after `npm build`
2. Do not check the file which is ignored in both `.funcignore` and `.gitignore`.
PS: `*.ts` is ignored in  `.funcignore` bot not in `.gitignore`