### PR TITLE
chore(vsc): add output window link in progress bar

### DIFF
--- a/packages/vscode-extension/package.nls.json
+++ b/packages/vscode-extension/package.nls.json
@@ -263,6 +263,7 @@
     "teamstoolkit.preview.progressTitle": "Preview Teams app",
     "teamstoolkit.progressHandler.prepareTask": " Prepare task.",
     "teamstoolkit.progressHandler.reloadNotice": "%s%s%s (Notice: You can reload the window and retry if task spends too long time.)",
+    "teamstoolkit.progressHandler.showOutputLink": "Check [output window](%s) for details",
     "teamstoolkit.progressHandler.teamsToolkitComponent": "[Teams Toolkit]",
     "teamstoolkit.qm.emptySelection": "select option is empty",
     "teamstoolkit.qm.multiSelectKeyboard": " (Space key to check/uncheck)",

--- a/packages/vscode-extension/package.nls.json
+++ b/packages/vscode-extension/package.nls.json
@@ -263,7 +263,7 @@
     "teamstoolkit.preview.progressTitle": "Preview Teams app",
     "teamstoolkit.progressHandler.prepareTask": " Prepare task.",
     "teamstoolkit.progressHandler.reloadNotice": "%s%s%s (Notice: You can reload the window and retry if task spends too long time.)",
-    "teamstoolkit.progressHandler.showOutputLink": "Check [output window](%s) for details",
+    "teamstoolkit.progressHandler.showOutputLink": "Check [output window](%s) for details.",
     "teamstoolkit.progressHandler.teamsToolkitComponent": "[Teams Toolkit]",
     "teamstoolkit.qm.emptySelection": "select option is empty",
     "teamstoolkit.qm.multiSelectKeyboard": " (Space key to check/uncheck)",

--- a/packages/vscode-extension/src/progressHandler.ts
+++ b/packages/vscode-extension/src/progressHandler.ts
@@ -28,7 +28,10 @@ export class ProgressHandler implements IProgressHandler {
 
   private generateWholeMessage(): string {
     const head = `${localize("teamstoolkit.progressHandler.teamsToolkitComponent")} ${this.title}`;
-    const body = `: [${this.currentStep}/${this.totalSteps}]`;
+    const body = `: [${this.currentStep}/${this.totalSteps}] ${util.format(
+      localize("teamstoolkit.progressHandler.showOutputLink"),
+      "command:fx-extension.showOutputChannel"
+    )}`;
     const tail = this.detail
       ? ` ${this.detail}`
       : localize("teamstoolkit.progressHandler.prepareTask");


### PR DESCRIPTION
Effect Preview:
1. ![image](https://user-images.githubusercontent.com/886116/161181503-600c7246-ff36-4268-8cdf-9275c7e0f694.png)
2. ![image](https://user-images.githubusercontent.com/886116/161181542-1a4fd2ae-bde7-42d3-ba86-297f15fa931d.png)

Related bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/13827715