### PR TITLE
fix: spfx scaffold failed due to yo not recognized

### DIFF
--- a/packages/fx-core/src/plugins/resource/spfx/depsChecker/generatorChecker.ts
+++ b/packages/fx-core/src/plugins/resource/spfx/depsChecker/generatorChecker.ts
@@ -168,7 +168,8 @@ export class GeneratorChecker implements DependencyChecker {
         `${name}@${supportedVersion}`,
         "--prefix",
         `${this.getDefaultInstallPath()}`,
-        "--no-audit"
+        "--no-audit",
+        "--global-style"
       );
 
       await fs.ensureFile(this.getSentinelPath());

--- a/packages/fx-core/src/plugins/resource/spfx/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/spfx/plugin.ts
@@ -406,7 +406,7 @@ export class SPFxPluginImpl {
         (error as any).message.includes("'yo' is not recognized as an internal or external command")
       ) {
         ctx.logProvider?.error(
-          "NPM v6.x is recommended for spfx scaffolding and later development. You can use correct version and try again."
+          "NPM v6.x with Node.js v12.13.0+ (Erbium) or Node.js v14.15.0+ (Fermium) is recommended for spfx scaffolding and later development. You can use correct version and try again."
         );
       }
       await progressHandler?.end(false);

--- a/packages/fx-core/src/plugins/resource/spfx/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/spfx/plugin.ts
@@ -111,7 +111,7 @@ export class SPFxPluginImpl {
 
         const yoEnv: NodeJS.ProcessEnv = process.env;
         yoEnv.PATH = isYoCheckerEnabled()
-          ? `${yoChecker.getBinFolder()}${path.delimiter}${process.env.PATH ?? ""}`
+          ? `${await yoChecker.getBinFolder()}${path.delimiter}${process.env.PATH ?? ""}`
           : process.env.PATH;
         await cpUtils.executeCommand(
           ctx.root,

--- a/packages/fx-core/src/plugins/resource/spfx/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/spfx/plugin.ts
@@ -401,6 +401,14 @@ export class SPFxPluginImpl {
           `Teams Toolkit recommends using ${yoInfo.displayName} ${genInfo.displayName}`
         );
       }
+      if (
+        (error as any).message &&
+        (error as any).message.includes("'yo' is not recognized as an internal or external command")
+      ) {
+        ctx.logProvider?.error(
+          "NPM v6.x is recommended for spfx scaffolding and later development. You can use correct version and try again."
+        );
+      }
       await progressHandler?.end(false);
       return err(ScaffoldError(error));
     }


### PR DESCRIPTION
ADO:
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14000279

1> Get bin folder according to npm version since npm v7 has different behavior with npm v6
2> Show instruction to tell user suggested versions for npm and node.(Maybe add help link to tell user how to troubleshooting later in dev branch)

![image](https://user-images.githubusercontent.com/73154171/161875483-400176df-8fc2-4cec-affd-f330a73ddfaf.png)


E2E TEST: will add later