### PR TITLE
perf(aad-manifest): update scaffold to support bot

### DIFF
--- a/packages/fx-core/src/core/middleware/aadManifestMigration.ts
+++ b/packages/fx-core/src/core/middleware/aadManifestMigration.ts
@@ -201,7 +201,34 @@ async function migrate(ctx: CoreHookContext): Promise<boolean> {
       "appPackage",
       "aad.template.json"
     );
+    const projectSettingsJson = await fs.readJson(projectSettingsPath);
+
+    if (projectSettingsJson.solutionSettings.capabilities.includes("Tab")) {
+      aadManifestJson.replyUrlsWithType.push({
+        url: "{{state.fx-resource-frontend-hosting.endpoint}}/auth-end.html",
+        type: "Web",
+      });
+
+      aadManifestJson.replyUrlsWithType.push({
+        url: "{{state.fx-resource-frontend-hosting.endpoint}}/auth-end.html?clientId={{state.fx-resource-aad-app-for-teams.clientId}}",
+        type: "Spa",
+      });
+
+      aadManifestJson.replyUrlsWithType.push({
+        url: "{{state.fx-resource-frontend-hosting.endpoint}}/blank-auth-end.html",
+        type: "Spa",
+      });
+    }
+
+    if (projectSettingsJson.solutionSettings.capabilities.includes("Bot")) {
+      aadManifestJson.replyUrlsWithType.push({
+        url: "{{state.fx-resource-bot.siteEndpoint}}/auth-end.html",
+        type: "Web",
+      });
+    }
+
     await fs.writeJSON(aadManifestPath, aadManifestJson, { spaces: 4, EOL: os.EOL });
+
     fileList.push(aadManifestPath);
 
     sendTelemetryEvent(Component.core, TelemetryEvent.ProjectAadManifestMigrationAddAADTemplate);
@@ -211,8 +238,6 @@ async function migrate(ctx: CoreHookContext): Promise<boolean> {
       Component.core,
       TelemetryEvent.ProjectAadManifestMigrationAddSSOCapabilityStart
     );
-
-    const projectSettingsJson = await fs.readJson(projectSettingsPath);
 
     if (!projectSettingsJson.solutionSettings.capabilities.includes("SSO")) {
       projectSettingsJson.solutionSettings.capabilities.push("SSO");

--- a/packages/fx-core/templates/plugins/resource/aad/manifest/aad.template.json
+++ b/packages/fx-core/templates/plugins/resource/aad/manifest/aad.template.json
@@ -92,18 +92,5 @@
     "identifierUris": [
         "{{state.fx-resource-aad-app-for-teams.applicationIdUris}}"
     ],
-    "replyUrlsWithType": [
-        {
-            "url": "{{state.fx-resource-frontend-hosting.endpoint}}/auth-end.html",
-            "type": "Web"
-        },
-        {
-            "url": "{{state.fx-resource-frontend-hosting.endpoint}}/auth-end.html?clientId={{state.fx-resource-aad-app-for-teams.clientId}}",
-            "type": "Spa"
-        },
-        {
-            "url": "{{state.fx-resource-frontend-hosting.endpoint}}/blank-auth-end.html",
-            "type": "Spa"
-        }
-    ]
+    "replyUrlsWithType": []
 }

--- a/packages/fx-core/tests/plugins/resource/aad/unit/index.test.ts
+++ b/packages/fx-core/tests/plugins/resource/aad/unit/index.test.ts
@@ -313,14 +313,62 @@ describe("AadAppForTeamsPlugin: CI", () => {
     }
   });
 
-  it("scaffold", async function () {
+  it("scaffold without bot", async function () {
     sinon.stub<any, any>(tool, "isAadManifestEnabled").returns(true);
     sinon.stub<any, any>(tool, "isConfigUnifyEnabled").returns(true);
     sinon.stub(fs, "ensureDir").resolves();
-    sinon.stub(fs, "copy").resolves();
     const config = new Map();
     const context = await TestHelper.pluginContext(config, true, false, false);
+
+    sinon.stub(fs, "pathExists").resolves(true);
+
+    const fakeManifest = {
+      id: "{{state.fx-resource-aad-app-for-teams.objectId}}",
+      appId: "{{state.fx-resource-aad-app-for-teams.clientId}}",
+      replyUrlsWithType: [
+        {
+          url: "{{state.fx-resource-frontend-hosting.endpoint}}/auth-end.html",
+          type: "Web",
+        },
+      ],
+    };
+    sinon.stub(fs, "readJSON").resolves(fakeManifest);
+    sinon.stub(fs, "writeJSON").callsFake((file, data, options) => {
+      chai.assert.deepEqual(data, fakeManifest);
+    });
     const result = await plugin.scaffold(context);
+    chai.assert.equal(result.isOk(), true);
+  });
+
+  it("scaffold with bot", async function () {
+    sinon.stub<any, any>(tool, "isAadManifestEnabled").returns(true);
+    sinon.stub<any, any>(tool, "isConfigUnifyEnabled").returns(true);
+    sinon.stub(fs, "ensureDir").resolves();
+    const config = new Map();
+    const context = await TestHelper.pluginContext(config, true, false, false);
+    (context.projectSettings!.solutionSettings as any).capabilities.push("Bot");
+    sinon.stub(fs, "pathExists").resolves(true);
+
+    const fakeManifest = {
+      id: "{{state.fx-resource-aad-app-for-teams.objectId}}",
+      appId: "{{state.fx-resource-aad-app-for-teams.clientId}}",
+      replyUrlsWithType: [
+        {
+          url: "{{state.fx-resource-frontend-hosting.endpoint}}/auth-end.html",
+          type: "Web",
+        },
+      ],
+    };
+    sinon.stub(fs, "readJSON").resolves(fakeManifest);
+    sinon.stub(fs, "writeJSON").callsFake((file, data, options) => {
+      chai.assert.equal(
+        data.replyUrlsWithType[1].url,
+        "{{state.fx-resource-bot.siteEndpoint}}/auth-end.html"
+      );
+      chai.assert.equal(data.replyUrlsWithType[1].type, "Web");
+    });
+    const result = await plugin.scaffold(context);
+
     chai.assert.equal(result.isOk(), true);
   });
 

--- a/packages/fx-core/tests/plugins/resource/aad/unit/index.test.ts
+++ b/packages/fx-core/tests/plugins/resource/aad/unit/index.test.ts
@@ -334,7 +334,16 @@ describe("AadAppForTeamsPlugin: CI", () => {
     };
     sinon.stub(fs, "readJSON").resolves(fakeManifest);
     sinon.stub(fs, "writeJSON").callsFake((file, data, options) => {
-      chai.assert.deepEqual(data, fakeManifest);
+      chai.assert.equal(data.replyUrlsWithType.length, 3);
+      chai.assert.deepEqual(fakeManifest.replyUrlsWithType[0], data.replyUrlsWithType[0]);
+      chai.assert.equal(
+        data.replyUrlsWithType[1].url,
+        "{{state.fx-resource-frontend-hosting.endpoint}}/auth-end.html?clientId={{state.fx-resource-aad-app-for-teams.clientId}}"
+      );
+      chai.assert.equal(
+        data.replyUrlsWithType[2].url,
+        "{{state.fx-resource-frontend-hosting.endpoint}}/blank-auth-end.html"
+      );
     });
     const result = await plugin.scaffold(context);
     chai.assert.equal(result.isOk(), true);
@@ -361,11 +370,20 @@ describe("AadAppForTeamsPlugin: CI", () => {
     };
     sinon.stub(fs, "readJSON").resolves(fakeManifest);
     sinon.stub(fs, "writeJSON").callsFake((file, data, options) => {
+      chai.assert.equal(data.replyUrlsWithType.length, 4);
+      chai.assert.deepEqual(fakeManifest.replyUrlsWithType[0], data.replyUrlsWithType[0]);
       chai.assert.equal(
         data.replyUrlsWithType[1].url,
+        "{{state.fx-resource-frontend-hosting.endpoint}}/auth-end.html?clientId={{state.fx-resource-aad-app-for-teams.clientId}}"
+      );
+      chai.assert.equal(
+        data.replyUrlsWithType[2].url,
+        "{{state.fx-resource-frontend-hosting.endpoint}}/blank-auth-end.html"
+      );
+      chai.assert.equal(
+        data.replyUrlsWithType[3].url,
         "{{state.fx-resource-bot.siteEndpoint}}/auth-end.html"
       );
-      chai.assert.equal(data.replyUrlsWithType[1].type, "Web");
     });
     const result = await plugin.scaffold(context);
 


### PR DESCRIPTION
When scaffold, based on capability whether contain "Bot" or "Tab" to add redirect URL in aad.template.json file