### PR TITLE
chore: pack d.ts into adaptivecards-tools

### DIFF
--- a/packages/adaptivecards-tools-sdk/rollup.config.js
+++ b/packages/adaptivecards-tools-sdk/rollup.config.js
@@ -31,7 +31,9 @@ export default {
     }),
     nodeResolve(),
     cjs(),
-    typescript(),
+    typescript({
+      useTsconfigDeclarationDir: true,
+    }),
     json(),
   ],
 };


### PR DESCRIPTION
It is defined in `package.json` that all d.ts files under `types` folder will be packed, however there are no `types` folder generated after build.

This PR modify `rollup.config.js` to generate d.ts files into `types` folder when build.