### PR TITLE
chore(m365): add outlook channel prompt in cli preview for bot app

### DIFF
--- a/packages/cli/src/cmds/preview/constants.ts
+++ b/packages/cli/src/cmds/preview/constants.ts
@@ -46,6 +46,7 @@ export const spfxPluginName = "fx-resource-spfx";
 
 export const teamsAppTenantIdConfigKey = "teamsAppTenantId";
 export const remoteTeamsAppIdConfigKey = "teamsAppId";
+export const botIdConfigKey = "botId";
 
 export const frontendStartPattern = /Compiled|Failed/g;
 export const backendStartPattern =
@@ -119,7 +120,8 @@ export const installApp = {
   detection:
     "We detected that you have not yet installed the app in Teams first, please make sure the app is installed.",
   description:
-    "To continue debug your application in Outlook, you need to install the app via Teams first.",
+    "To continue debug your application in Outlook or Office, you need to install the app via Teams manually.",
+  finish: 'Once you have finished the below step, please come back and select "Continue".',
   installInTeams: "Install in Teams",
   installInTeamsDescription: "Pop up Teams Web Client for you to instapp app.",
   continue: "Continue",
@@ -132,5 +134,13 @@ export const installApp = {
       'We detected that you have not yet installed the app in Teams first, please run "teamsfx preview %s --m365-host teams" to install app.',
     manifestChanges:
       'If you changed the manifest file, please run "teamsfx preview %s --m365-host teams" to install app again.',
+  },
+  outlookChannel: {
+    description:
+      "To continue debug your application in Outlook, you need to install the app via Teams and connect your bot to Outlook channel manually.",
+    finish: 'Once you have finished the below 2 steps, please come back and select "Continue".',
+    connectToOutlookChannel: "Connect to Outlook channel",
+    connectToOutlookChannelDescription:
+      'Pop up Bot Framework Portal and click "Save" button to connect your bot to Outlook channel. Please sign in to the portal with your M365 account.',
   },
 };

--- a/packages/cli/src/cmds/preview/preview.ts
+++ b/packages/cli/src/cmds/preview/preview.ts
@@ -421,8 +421,9 @@ export default class Preview extends YargsCommand {
 
     /* === get local teams app id === */
     // re-load local settings
-    let tenantId = undefined,
-      localTeamsAppId = undefined;
+    let tenantId = undefined;
+    let localTeamsAppId = undefined;
+    let localBotId = undefined;
     if (isConfigUnifyEnabled()) {
       configResult = await core.getProjectConfig(inputs);
       if (configResult.isErr()) {
@@ -435,11 +436,15 @@ export default class Preview extends YargsCommand {
       localTeamsAppId = config?.config
         ?.get(constants.appstudioPluginName)
         ?.get(constants.remoteTeamsAppIdConfigKey);
+      localBotId = config?.config
+        ?.get(constants.botPluginName)
+        ?.get(constants.botIdConfigKey) as string;
     } else {
       localSettings = await localEnvManager.getLocalSettings(workspaceFolder); // here does not need crypt data
 
       tenantId = localSettings?.teamsApp?.tenantId as string;
       localTeamsAppId = localSettings?.teamsApp?.teamsAppId as string;
+      localBotId = localSettings?.bot?.botId as string;
     }
 
     if (localTeamsAppId === undefined || localTeamsAppId.length === 0) {
@@ -466,6 +471,7 @@ export default class Preview extends YargsCommand {
         false,
         tenantId,
         localTeamsAppId,
+        localBotId,
         browser,
         browserArguments
       );
@@ -771,6 +777,7 @@ export default class Preview extends YargsCommand {
         false,
         tenantId,
         remoteTeamsAppId,
+        undefined,
         browser,
         browserArguments
       );


### PR DESCRIPTION
Same as the behavior in vsc.
For launch page:
![image](https://user-images.githubusercontent.com/37978464/162125306-726f7bb7-ef9d-4952-8346-317dd082c219.png)

For messaging extension:
![image](https://user-images.githubusercontent.com/37978464/162125205-7795fba8-a1be-49b7-93b5-d5a3ef359764.png)
