### PR TITLE
feat(cli): support add capability for notification/command response bot

### DIFF
--- a/packages/cli/src/cmds/capability.ts
+++ b/packages/cli/src/cmds/capability.ts
@@ -7,7 +7,7 @@ import * as path from "path";
 import { Argv } from "yargs";
 
 import { err, FxError, ok, Platform, Result } from "@microsoft/teamsfx-api";
-import { ProjectSettingsHelper } from "@microsoft/teamsfx-core";
+import { isBotNotificationEnabled, ProjectSettingsHelper } from "@microsoft/teamsfx-core";
 
 import activate from "../activate";
 import { getSystemInputs } from "../utils";
@@ -226,6 +226,88 @@ export class CapabilityAddMessageExtension extends YargsCommand {
   }
 }
 
+function createCapabilityCommand(commandHead: string, description: string, yargsHelp: string) {
+  return class extends YargsCommand {
+    public readonly commandHead = commandHead;
+    public readonly command = `${this.commandHead}`;
+    public readonly description = description;
+
+    public builder(yargs: Argv): Argv<any> {
+      this.params = HelpParamGenerator.getYargsParamForHelp(yargsHelp);
+      return yargs.options(this.params);
+    }
+
+    public override modifyArguments(args: { [argName: string]: any }) {
+      CLIUIInstance.updatePresetAnswer("capabilities", args["capabilities"]);
+      delete args["capabilities"];
+      return args;
+    }
+
+    public async runCommand(args: { [argName: string]: string }): Promise<Result<null, FxError>> {
+      const rootFolder = path.resolve(args.folder || "./");
+      CliTelemetry.withRootFolder(rootFolder).sendTelemetryEvent(TelemetryEvent.AddCapStart);
+
+      const result = await activate(rootFolder);
+      if (result.isErr()) {
+        CliTelemetry.sendTelemetryErrorEvent(TelemetryEvent.AddCap, result.error, {
+          [TelemetryProperty.Capabilities]: this.commandHead,
+        });
+        return err(result.error);
+      }
+
+      const func = {
+        namespace: "fx-solution-azure",
+        method: "addCapability",
+      };
+
+      const core = result.value;
+      const configResult = await core.getProjectConfig({
+        projectPath: rootFolder,
+        platform: Platform.CLI,
+        ignoreEnvInfo: true,
+      });
+      if (configResult.isErr()) {
+        CliTelemetry.sendTelemetryErrorEvent(TelemetryEvent.AddCap, configResult.error, {
+          [TelemetryProperty.Capabilities]: this.commandHead,
+        });
+        return err(configResult.error);
+      }
+      const includeBot = ProjectSettingsHelper.includeBot(configResult.value?.settings);
+      {
+        const inputs = getSystemInputs(rootFolder);
+        inputs.ignoreEnvInfo = true;
+        const result = await core.executeUserTask(func, inputs);
+        if (result.isErr()) {
+          CliTelemetry.sendTelemetryErrorEvent(TelemetryEvent.AddCap, result.error, {
+            [TelemetryProperty.Capabilities]: this.commandHead,
+          });
+          return err(result.error);
+        }
+      }
+
+      await automaticNpmInstallHandler(rootFolder, true, true, includeBot);
+
+      CliTelemetry.sendTelemetryEvent(TelemetryEvent.AddCap, {
+        [TelemetryProperty.Success]: TelemetrySuccess.Yes,
+        [TelemetryProperty.Capabilities]: this.commandHead,
+      });
+      return ok(null);
+    }
+  };
+}
+
+export const CapabilityAddNotification = createCapabilityCommand(
+  "notification",
+  "Add notification.",
+  "addCapability-Notification"
+);
+
+export const CapabilityAddCommandAndResponse = createCapabilityCommand(
+  "command-and-response",
+  "Add command and response.",
+  "addCapability-CommandAndResponse"
+);
+
 export class CapabilityAdd extends YargsCommand {
   public readonly commandHead = `add`;
   public readonly command = `${this.commandHead} [capability]`;
@@ -233,7 +315,9 @@ export class CapabilityAdd extends YargsCommand {
 
   public readonly subCommands: YargsCommand[] = [
     new CapabilityAddTab(),
-    new CapabilityAddBot(),
+    ...(isBotNotificationEnabled()
+      ? [new CapabilityAddCommandAndResponse(), new CapabilityAddNotification()]
+      : [new CapabilityAddBot()]),
     new CapabilityAddMessageExtension(),
   ];
 

--- a/packages/cli/src/cmds/capability.ts
+++ b/packages/cli/src/cmds/capability.ts
@@ -292,14 +292,14 @@ export class CapabilityAddMessageExtension extends YargsCommand {
   }
 }
 
-class CapabilityAddNotification extends CapabilityAddBase {
+export class CapabilityAddNotification extends CapabilityAddBase {
   public readonly commandHead = "notification";
   public readonly command = `${this.commandHead}`;
   public readonly description = "Add notification.";
   public readonly yargsHelp = "addCapability-Notification";
 }
 
-class CapabilityAddCommandAndResponse extends CapabilityAddBase {
+export class CapabilityAddCommandAndResponse extends CapabilityAddBase {
   public readonly commandHead = "command-and-response";
   public readonly command = `${this.commandHead}`;
   public readonly description = "Add command and response.";

--- a/packages/cli/tests/unit/cmds/capability.tests.ts
+++ b/packages/cli/tests/unit/cmds/capability.tests.ts
@@ -12,6 +12,8 @@ import Capability, {
   CapabilityAddTab,
   CapabilityAddBot,
   CapabilityAddMessageExtension,
+  CapabilityAddNotification,
+  CapabilityAddCommandAndResponse,
 } from "../../../src/cmds/capability";
 import CliTelemetry from "../../../src/telemetry/cliTelemetry";
 import HelpParamGenerator from "../../../src/helpParamGenerator";
@@ -190,6 +192,70 @@ describe("Capability Command Tests", function () {
 
   it("Capability Add Messging-Extension Command Running Check with Error", async () => {
     const cmd = new CapabilityAddMessageExtension();
+    const args = {
+      [constants.RootFolderNode.data.name as string]: "fake",
+    };
+    try {
+      await cmd.handler(args);
+      throw new Error("Should throw an error.");
+    } catch (e) {
+      expect(telemetryEvents).deep.equals([TelemetryEvent.AddCapStart, TelemetryEvent.AddCap]);
+      expect(telemetryEventStatus).equals(TelemetrySuccess.No);
+      expect(e).instanceOf(UserError);
+      expect(e.name).equals("NotSupportedProjectType");
+    }
+  });
+
+  it("Capability Add Notification Command Running Check", async () => {
+    sandbox.stub(process, "env").value({
+      BOT_NOTIFICATION_ENABLED: "true",
+    });
+    const cmd = new CapabilityAddNotification();
+    const args = {
+      [constants.RootFolderNode.data.name as string]: "real",
+    };
+    await cmd.handler(args);
+    expect(telemetryEvents).deep.equals([TelemetryEvent.AddCapStart, TelemetryEvent.AddCap]);
+    expect(telemetryEventStatus).equals(TelemetrySuccess.Yes);
+  });
+
+  it("Capability Add Notification Command Running Check with Error", async () => {
+    sandbox.stub(process, "env").value({
+      BOT_NOTIFICATION_ENABLED: "true",
+    });
+    const cmd = new CapabilityAddNotification();
+    const args = {
+      [constants.RootFolderNode.data.name as string]: "fake",
+    };
+    try {
+      await cmd.handler(args);
+      throw new Error("Should throw an error.");
+    } catch (e) {
+      expect(telemetryEvents).deep.equals([TelemetryEvent.AddCapStart, TelemetryEvent.AddCap]);
+      expect(telemetryEventStatus).equals(TelemetrySuccess.No);
+      expect(e).instanceOf(UserError);
+      expect(e.name).equals("NotSupportedProjectType");
+    }
+  });
+
+  it("Capability Add Command-And-Response Command Running Check", async () => {
+    sandbox.stub(process, "env").value({
+      BOT_NOTIFICATION_ENABLED: "true",
+    });
+    const cmd = new CapabilityAddCommandAndResponse();
+    const args = {
+      [constants.RootFolderNode.data.name as string]: "real",
+    };
+    await cmd.handler(args);
+    expect(telemetryEvents).deep.equals([TelemetryEvent.AddCapStart, TelemetryEvent.AddCap]);
+    expect(telemetryEventStatus).equals(TelemetrySuccess.Yes);
+  });
+
+  it("Capability Add Command-And-Response Command Running Check with Error", async () => {
+    sandbox.stub(process, "env").value({
+      BOT_NOTIFICATION_ENABLED: "true",
+    });
+    const cmd = new CapabilityAddCommandAndResponse();
     const args = {
       [constants.RootFolderNode.data.name as string]: "fake",
     };

--- a/packages/cli/tests/unit/cmds/capability.tests.ts
+++ b/packages/cli/tests/unit/cmds/capability.tests.ts
@@ -36,7 +36,7 @@ describe("Capability Command Tests", function () {
   let telemetryEvents: string[] = [];
   let telemetryEventStatus: string | undefined = undefined;
 
-  before(() => {
+  beforeEach(() => {
     sandbox.stub(HelpParamGenerator, "getYargsParamForHelp").returns({});
     sandbox
       .stub<any, any>(yargs, "command")
@@ -93,17 +93,15 @@ describe("Capability Command Tests", function () {
     sandbox.stub(ProjectSettingsHelper, "includeBot").returns(false);
     sandbox.stub(npmInstallHandler, "automaticNpmInstallHandler").callsFake(async () => {});
     sandbox.stub(LogProvider, "necessaryLog").returns();
-  });
 
-  after(() => {
-    sandbox.restore();
-  });
-
-  beforeEach(() => {
     registeredCommands = [];
     options = [];
     telemetryEvents = [];
     telemetryEventStatus = undefined;
+  });
+
+  afterEach(() => {
+    sandbox.restore();
   });
 
   it("Builder Check", () => {

--- a/packages/fx-core/src/plugins/resource/bot/question.ts
+++ b/packages/fx-core/src/plugins/resource/bot/question.ts
@@ -100,6 +100,8 @@ export const showNotificationTriggerCondition = {
     }
     return "Notification is not selected";
   },
+  // Workaround for CLI: it requires containsAny to be set, or it will crash.
+  containsAny: [NotificationOptionItem.id],
 };
 
 type HostTypeTriggerOptionItemWithoutText = Omit<

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/getQuestions.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/getQuestions.ts
@@ -432,7 +432,31 @@ export async function getQuestionsForAddCapability(
       MessageExtensionItem,
       ...(isAadManifestEnabled() ? [TabNonSsoItem] : []),
     ];
-    return ok(new QTreeNode(addCapQuestion));
+    const addCapNode = new QTreeNode(addCapQuestion);
+    if (isBotNotificationEnabled()) {
+      // Hardcoded to call bot plugin to get notification trigger questions.
+      // Originally, v2 solution will not call getQuestionForUserTask of plugins on addCapability.
+      // V3 will not need this hardcoding.
+      const pluginMap = getAllV2ResourcePluginMap();
+      const plugin = pluginMap.get(PluginNames.BOT);
+      if (plugin && plugin.getQuestionsForUserTask) {
+        const result = await plugin.getQuestionsForUserTask(
+          ctx,
+          inputs,
+          func,
+          envInfo,
+          tokenProvider
+        );
+        if (result.isErr()) {
+          return result;
+        }
+        const botQuestionNode = result.value;
+        if (botQuestionNode) {
+          addCapNode.addChild(botQuestionNode);
+        }
+      }
+    }
+    return ok(addCapNode);
   }
   const canProceed = canAddCapability(settings, ctx.telemetryReporter);
   if (canProceed.isErr()) {


### PR DESCRIPTION
- Add CLI support for add capability notification/command response bot
![image](https://user-images.githubusercontent.com/9698542/162189429-628e18fe-27b5-4698-9d49-6f621ce88dbb.png)

![image](https://user-images.githubusercontent.com/9698542/162189269-2298210f-9265-4027-90d9-360f86b1493a.png)

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/13883760/