### PR TITLE
perf(aad-manifest): allow user to config frontend and bot info

### DIFF
--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -458,6 +458,9 @@ export interface EnvConfig {
         clientSecret?: string;
         objectId?: string;
         accessAsUserScopeId?: string;
+        frontendDomain?: string;
+        botId?: string;
+        botEndpoint?: string;
         [k: string]: unknown;
     };
     azure?: {

--- a/packages/api/src/schemas/envConfig.json
+++ b/packages/api/src/schemas/envConfig.json
@@ -35,17 +35,17 @@
         },
         "frontendDomain": {
           "type": "string",
-          "description": "The frontend domain for redirect Url of existing AAD app for Teams app.",
+          "description": "The frontend domain for redirect URLs of existing AAD app for Teams app.",
           "minLength": 1
         },
         "botId": {
           "type": "string",
-          "description": "The bot id for identifier Uris of existing AAD app for Teams app.",
+          "description": "The bot id for identifier URIs of existing AAD app for Teams app.",
           "minLength": 1
         },
         "botEndpoint": {
           "type": "string",
-          "description": "The bot endpoint for redirect Url of existing AAD app for Teams app.",
+          "description": "The bot endpoint for redirect URLs of existing AAD app for Teams app.",
           "minLength": 1
         }
       },
@@ -53,7 +53,9 @@
         "clientId": ["clientSecret", "objectId", "accessAsUserScopeId"],
         "clientSecret": ["clientId", "objectId", "accessAsUserScopeId"],
         "objectId": ["clientId", "clientSecret", "accessAsUserScopeId"],
-        "accessAsUserScopeId": ["clientId", "clientSecret", "objectId"]
+        "accessAsUserScopeId": ["clientId", "clientSecret", "objectId"],
+        "botId": ["botEndpoint"],
+        "botEndpoint": ["botId"]
       }
     },
     "azure": {

--- a/packages/api/src/schemas/envConfig.json
+++ b/packages/api/src/schemas/envConfig.json
@@ -32,6 +32,21 @@
           "type": "string",
           "description": "The access_as_user scope id of existing AAD app for Teams app.",
           "minLength": 1
+        },
+        "frontendDomain": {
+          "type": "string",
+          "description": "The frontend domain for redirect Url of existing AAD app for Teams app.",
+          "minLength": 1
+        },
+        "botId": {
+          "type": "string",
+          "description": "The bot id for identifierUris of existing AAD app for Teams app.",
+          "minLength": 1
+        },
+        "botEndpoint": {
+          "type": "string",
+          "description": "The bot endpoint for redirect Url of existing AAD app for Teams app.",
+          "minLength": 1
         }
       },
       "dependencies": {

--- a/packages/api/src/schemas/envConfig.json
+++ b/packages/api/src/schemas/envConfig.json
@@ -40,7 +40,7 @@
         },
         "botId": {
           "type": "string",
-          "description": "The bot id for identifierUris of existing AAD app for Teams app.",
+          "description": "The bot id for identifier Uris of existing AAD app for Teams app.",
           "minLength": 1
         },
         "botEndpoint": {

--- a/packages/api/src/schemas/envConfig.ts
+++ b/packages/api/src/schemas/envConfig.ts
@@ -31,7 +31,6 @@ export interface EnvConfig {
      * The access_as_user scope id of existing AAD app for Teams app.
      */
     accessAsUserScopeId?: string;
-    [k: string]: unknown;
     /**
      * The frontend domain for redirect Url of existing AAD app for Teams app.
      */
@@ -44,6 +43,7 @@ export interface EnvConfig {
      * The bot endpoint for redirect Url of existing AAD app for Teams app.
      */
     botEndpoint?: string;
+    [k: string]: unknown;
   };
   /**
    * The Azure resource related configuration.

--- a/packages/api/src/schemas/envConfig.ts
+++ b/packages/api/src/schemas/envConfig.ts
@@ -32,15 +32,15 @@ export interface EnvConfig {
      */
     accessAsUserScopeId?: string;
     /**
-     * The frontend domain for redirect Url of existing AAD app for Teams app.
+     * The frontend domain for redirect URLs of existing AAD app for Teams app.
      */
     frontendDomain?: string;
     /**
-     * The bot id for identifier Uris of existing AAD app for Teams app.
+     * The bot id for identifier URIs of existing AAD app for Teams app.
      */
     botId?: string;
     /**
-     * The bot endpoint for redirect Url of existing AAD app for Teams app.
+     * The bot endpoint for redirect URLs of existing AAD app for Teams app.
      */
     botEndpoint?: string;
     [k: string]: unknown;

--- a/packages/api/src/schemas/envConfig.ts
+++ b/packages/api/src/schemas/envConfig.ts
@@ -32,6 +32,18 @@ export interface EnvConfig {
      */
     accessAsUserScopeId?: string;
     [k: string]: unknown;
+    /**
+     * The frontend domain for redirect Url of existing AAD app for Teams app.
+     */
+    frontendDomain?: string;
+    /**
+     * The bot id for identifier Uris of existing AAD app for Teams app.
+     */
+    botId?: string;
+    /**
+     * The bot endpoint for redirect Url of existing AAD app for Teams app.
+     */
+    botEndpoint?: string;
   };
   /**
    * The Azure resource related configuration.

--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -545,6 +545,7 @@
   "error.aad.UpdateAppIdUriError": "Failed to update Application ID URI in Azure Active Directory. %s",
   "error.aad.UpdatePermissionError": "Failed to update application permission in Azure Active Directory.",
   "error.aad.AppIdUriInvalidError": "Invalid Application ID URI. Provision your application before continuing.",
+  "error.aad.CannotGenerateIdentifierUris": "Cannot generate identifierUris because no botId or frontend domain found, you need to specified at least one of them in config file",
   "error.aad.InvalidSelectedPlugins": "Invalid selected plugins. %s",
   "error.aad.ParsePermissionError": "Failed to parse permission request.",
   "error.aad.UnhandledError": "Unhandled Error. ",

--- a/packages/fx-core/src/core/middleware/aadManifestMigration.ts
+++ b/packages/fx-core/src/core/middleware/aadManifestMigration.ts
@@ -205,24 +205,24 @@ async function migrate(ctx: CoreHookContext): Promise<boolean> {
 
     if (projectSettingsJson.solutionSettings.capabilities.includes("Tab")) {
       aadManifestJson.replyUrlsWithType.push({
-        url: "{{state.fx-resource-frontend-hosting.endpoint}}/auth-end.html",
+        url: "{{state.fx-resource-aad-app-for-teams.frontendEndpoint}}/auth-end.html",
         type: "Web",
       });
 
       aadManifestJson.replyUrlsWithType.push({
-        url: "{{state.fx-resource-frontend-hosting.endpoint}}/auth-end.html?clientId={{state.fx-resource-aad-app-for-teams.clientId}}",
+        url: "{{state.fx-resource-aad-app-for-teams.frontendEndpoint}}/auth-end.html?clientId={{state.fx-resource-aad-app-for-teams.clientId}}",
         type: "Spa",
       });
 
       aadManifestJson.replyUrlsWithType.push({
-        url: "{{state.fx-resource-frontend-hosting.endpoint}}/blank-auth-end.html",
+        url: "{{state.fx-resource-aad-app-for-teams.frontendEndpoint}}/blank-auth-end.html",
         type: "Spa",
       });
     }
 
     if (projectSettingsJson.solutionSettings.capabilities.includes("Bot")) {
       aadManifestJson.replyUrlsWithType.push({
-        url: "{{state.fx-resource-bot.siteEndpoint}}/auth-end.html",
+        url: "{{state.fx-resource-aad-app-for-teams.botEndpoint}}/auth-end.html",
         type: "Web",
       });
     }

--- a/packages/fx-core/src/plugins/resource/aad/constants.ts
+++ b/packages/fx-core/src/plugins/resource/aad/constants.ts
@@ -98,6 +98,9 @@ export class ConfigKeys {
   static clientSecret = "clientSecret";
   static objectId = "objectId";
   static oauth2PermissionScopeId = "oauth2PermissionScopeId";
+  static frontendEndpoint = "frontendEndpoint";
+  static botId = "botId";
+  static botEndpoint = "botEndpoint";
   static teamsMobileDesktopAppId = "teamsMobileDesktopAppId";
   static teamsWebAppId = "teamsWebAppId";
   static domain = "domain";

--- a/packages/fx-core/src/plugins/resource/aad/errors.ts
+++ b/packages/fx-core/src/plugins/resource/aad/errors.ts
@@ -124,6 +124,14 @@ export const AppIdUriInvalidError: AadError = {
   ],
 };
 
+export const CannotGenerateIdentifierUrisError: AadError = {
+  name: "CannotGenerateIdentifierUris",
+  message: () => [
+    getDefaultString("error.aad.CannotGenerateIdentifierUris"),
+    getLocalizedString("error.aad.CannotGenerateIdentifierUris"),
+  ],
+};
+
 export const InvalidSelectedPluginsError: AadError = {
   name: "InvalidSelectedPlugins",
   message: (message) => [

--- a/packages/fx-core/src/plugins/resource/aad/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/aad/plugin.ts
@@ -68,6 +68,7 @@ import { isAadManifestEnabled, isConfigUnifyEnabled } from "../../../common/tool
 import { getPermissionMap } from "./permissions";
 import { AadAppManifestManager } from "./aadAppManifestManager";
 import { AADManifest, ReplyUrlsWithType } from "./interfaces/AADManifest";
+import { format, Formats } from "./utils/format";
 
 export class AadAppForTeamsImpl {
   public async provision(ctx: PluginContext, isLocalDebug = false): Promise<AadResult> {
@@ -233,9 +234,15 @@ export class AadAppForTeamsImpl {
     const config: SetApplicationInContextConfig = new SetApplicationInContextConfig(isLocalDebug);
     config.restoreConfigFromContext(ctx);
 
-    const userSetFrontendDomain = ctx.envInfo.config.auth?.frontendDomain as string;
-    const userSetBotId = ctx.envInfo.config.auth?.botId as string;
-    const userSetBotEndpoint = ctx.envInfo.config.auth?.botEndpoint as string;
+    const userSetFrontendDomain = format(
+      ctx.envInfo.config.auth?.frontendDomain as string,
+      Formats.Domain
+    );
+    const userSetBotId = format(ctx.envInfo.config.auth?.botId as string, Formats.UUID);
+    const userSetBotEndpoint = format(
+      ctx.envInfo.config.auth?.botEndpoint as string,
+      Formats.Endpoint
+    );
 
     if (!config.frontendDomain && !config.botId) {
       const azureSolutionSettings = ctx.projectSettings?.solutionSettings as AzureSolutionSettings;

--- a/packages/fx-core/src/plugins/resource/aad/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/aad/plugin.ts
@@ -35,6 +35,7 @@ import {
   AadManifestMissingReplyUrlsWithType,
   AadManifestMissingIdentifierUris,
   AadManifestMissingName,
+  CannotGenerateIdentifierUrisError,
 } from "./errors";
 import { Envs } from "./interfaces/models";
 import { DialogUtils } from "./utils/dialog";
@@ -232,17 +233,37 @@ export class AadAppForTeamsImpl {
     const config: SetApplicationInContextConfig = new SetApplicationInContextConfig(isLocalDebug);
     config.restoreConfigFromContext(ctx);
 
+    const userSetFrontendDomain = ctx.envInfo.config.auth?.frontendDomain as string;
+    const userSetBotId = ctx.envInfo.config.auth?.botId as string;
+    const userSetBotEndpoint = ctx.envInfo.config.auth?.botEndpoint as string;
+
     if (!config.frontendDomain && !config.botId) {
-      throw ResultFactory.UserError(AppIdUriInvalidError.name, AppIdUriInvalidError.message());
+      const azureSolutionSettings = ctx.projectSettings?.solutionSettings as AzureSolutionSettings;
+      if (
+        azureSolutionSettings?.capabilities.includes("Tab") ||
+        azureSolutionSettings?.capabilities.includes("Bot")
+      ) {
+        throw ResultFactory.UserError(AppIdUriInvalidError.name, AppIdUriInvalidError.message());
+      }
     }
 
-    let applicationIdUri = "api://";
-    applicationIdUri += config.frontendDomain ? `${config.frontendDomain}/` : "";
-    applicationIdUri += config.botId ? "botid-" + config.botId : config.clientId;
-    config.applicationIdUri = applicationIdUri;
+    config.frontendDomain = userSetFrontendDomain ?? config.frontendDomain;
+    config.botId = userSetBotId ?? config.botId;
+    config.botEndpoint = userSetBotEndpoint ?? config.botEndpoint;
 
-    ctx.logProvider?.info(Messages.getLog(Messages.SetAppIdUriSuccess));
-    config.saveConfigIntoContext(ctx);
+    if (config.frontendDomain || config.botId) {
+      let applicationIdUri = "api://";
+      applicationIdUri += config.frontendDomain ? `${config.frontendDomain}/` : "";
+      applicationIdUri += config.botId ? "botid-" + config.botId : config.clientId;
+      config.applicationIdUri = applicationIdUri;
+      ctx.logProvider?.info(Messages.getLog(Messages.SetAppIdUriSuccess));
+    } else {
+      throw ResultFactory.UserError(
+        CannotGenerateIdentifierUrisError.name,
+        CannotGenerateIdentifierUrisError.message()
+      );
+    }
+    config.saveConfigIntoContext(ctx, config.frontendDomain, config.botId, config.botEndpoint);
     return ResultFactory.Success();
   }
 
@@ -754,7 +775,8 @@ export class AadAppForTeamsImpl {
       }
 
       if (azureSolutionSettings.capabilities.includes("Tab")) {
-        const tabRedirectUrl1 = "{{state.fx-resource-frontend-hosting.endpoint}}/auth-end.html";
+        const tabRedirectUrl1 =
+          "{{state.fx-resource-aad-app-for-teams.frontendEndpoint}}/auth-end.html";
 
         if (!this.isRedirectUrlExist(aadJson.replyUrlsWithType, tabRedirectUrl1, "Web")) {
           aadJson.replyUrlsWithType.push({
@@ -764,7 +786,7 @@ export class AadAppForTeamsImpl {
         }
 
         const tabRedirectUrl2 =
-          "{{state.fx-resource-frontend-hosting.endpoint}}/auth-end.html?clientId={{state.fx-resource-aad-app-for-teams.clientId}}";
+          "{{state.fx-resource-aad-app-for-teams.frontendEndpoint}}/auth-end.html?clientId={{state.fx-resource-aad-app-for-teams.clientId}}";
 
         if (!this.isRedirectUrlExist(aadJson.replyUrlsWithType, tabRedirectUrl2, "Spa")) {
           aadJson.replyUrlsWithType.push({
@@ -774,7 +796,7 @@ export class AadAppForTeamsImpl {
         }
 
         const tabRedirectUrl3 =
-          "{{state.fx-resource-frontend-hosting.endpoint}}/blank-auth-end.html";
+          "{{state.fx-resource-aad-app-for-teams.frontendEndpoint}}/blank-auth-end.html";
 
         if (!this.isRedirectUrlExist(aadJson.replyUrlsWithType, tabRedirectUrl3, "Spa")) {
           aadJson.replyUrlsWithType.push({
@@ -785,7 +807,7 @@ export class AadAppForTeamsImpl {
       }
 
       if (azureSolutionSettings.capabilities.includes("Bot")) {
-        const botRedirectUrl = "{{state.fx-resource-bot.siteEndpoint}}/auth-end.html";
+        const botRedirectUrl = "{{state.fx-resource-aad-app-for-teams.botEndpoint}}/auth-end.html";
 
         if (!this.isRedirectUrlExist(aadJson.replyUrlsWithType, botRedirectUrl, "Web")) {
           aadJson.replyUrlsWithType.push({

--- a/packages/fx-core/src/plugins/resource/aad/utils/configs.ts
+++ b/packages/fx-core/src/plugins/resource/aad/utils/configs.ts
@@ -417,6 +417,7 @@ export class ProvisionConfig {
 export class SetApplicationInContextConfig {
   public frontendDomain?: string;
   public botId?: string;
+  public botEndpoint?: string;
   public clientId?: string;
   public applicationIdUri?: string;
   private isLocalDebug: boolean;
@@ -450,6 +451,15 @@ export class SetApplicationInContextConfig {
       : ctx.envInfo.state.get(Plugins.teamsBot)?.get(ConfigKeysOfOtherPlugin.teamsBotId);
     if (botId) {
       this.botId = format(botId as string, Formats.UUID);
+    }
+
+    if (isAadManifestEnabled()) {
+      const botEndpoint: ConfigValue = ctx.envInfo.state
+        .get(Plugins.teamsBot)
+        ?.get(ConfigKeysOfOtherPlugin.teamsBotEndpoint);
+      if (botEndpoint) {
+        this.botEndpoint = format(frontendDomain as string, Formats.Domain);
+      }
     }
 
     const clientId: ConfigValue = ConfigUtils.getAadConfig(
@@ -511,13 +521,24 @@ export class SetApplicationInContextConfig {
       );
     }
   }
-  public saveConfigIntoContext(ctx: PluginContext): void {
+  public saveConfigIntoContext(
+    ctx: PluginContext,
+    frontendDomain: string | undefined,
+    botId: string | undefined,
+    botEndpoint: string | undefined
+  ): void {
     ConfigUtils.checkAndSaveConfig(
       ctx,
       ConfigKeys.applicationIdUri,
       this.applicationIdUri,
       this.isLocalDebug
     );
+
+    if (isAadManifestEnabled()) {
+      ConfigUtils.checkAndSaveConfig(ctx, ConfigKeys.botId, botId);
+      ConfigUtils.checkAndSaveConfig(ctx, ConfigKeys.botEndpoint, botEndpoint);
+      ConfigUtils.checkAndSaveConfig(ctx, ConfigKeys.frontendEndpoint, `https://${frontendDomain}`);
+    }
   }
 }
 

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/getQuestions.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/getQuestions.ts
@@ -290,7 +290,7 @@ export async function getQuestions(
       plugins = getAllV2ResourcePlugins();
     }
     plugins = plugins.filter((plugin) => !!plugin.deploy && plugin.displayName !== "AAD");
-    if (plugins.length === 0) {
+    if (plugins.length === 0 && inputs.skipAadDeploy !== "no") {
       return err(new NoCapabilityFoundError(Stage.deploy));
     }
 

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/provision.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/provision.ts
@@ -18,6 +18,7 @@ import {
   extractSolutionInputs,
   getAzureSolutionSettings,
   getSelectedPlugins,
+  hasAzureResourcesToProvision,
   isAzureProject,
 } from "./utils";
 import {
@@ -184,7 +185,11 @@ export async function provisionResource(
   solutionInputs.remoteTeamsAppId = teamsAppId;
 
   // call deployArmTemplates
-  if (isAzureProject(azureSolutionSettings) && !inputs.isForUT) {
+  if (
+    isAzureProject(azureSolutionSettings) &&
+    !inputs.isForUT &&
+    hasAzureResourcesToProvision(azureSolutionSettings)
+  ) {
     const contextAdaptor = new ProvisionContextAdapter([ctx, inputs, envInfo, tokenProvider]);
     const armDeploymentResult = await deployArmTemplates(contextAdaptor);
     if (armDeploymentResult.isErr()) {

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/provision.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/provision.ts
@@ -18,7 +18,6 @@ import {
   extractSolutionInputs,
   getAzureSolutionSettings,
   getSelectedPlugins,
-  hasAzureResourcesToProvision,
   isAzureProject,
 } from "./utils";
 import {
@@ -41,7 +40,11 @@ import { BuiltInFeaturePluginNames } from "../v3/constants";
 import { askForProvisionConsent, fillInAzureConfigs, getM365TenantId } from "../v3/provision";
 import { resourceGroupHelper } from "../utils/ResourceGroupHelper";
 import { solutionGlobalVars } from "../v3/solutionGlobalVars";
-import { hasAAD, isPureExistingApp } from "../../../../common/projectSettingsHelper";
+import {
+  hasAAD,
+  hasAzureResource,
+  isPureExistingApp,
+} from "../../../../common/projectSettingsHelper";
 import { getLocalizedString } from "../../../../common/localizeUtils";
 
 export async function provisionResource(
@@ -188,7 +191,7 @@ export async function provisionResource(
   if (
     isAzureProject(azureSolutionSettings) &&
     !inputs.isForUT &&
-    hasAzureResourcesToProvision(azureSolutionSettings)
+    hasAzureResource(ctx.projectSetting)
   ) {
     const contextAdaptor = new ProvisionContextAdapter([ctx, inputs, envInfo, tokenProvider]);
     const armDeploymentResult = await deployArmTemplates(contextAdaptor);

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/utils.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/utils.ts
@@ -59,23 +59,6 @@ export function isAzureProject(azureSettings: AzureSolutionSettings | undefined)
   return azureSettings !== undefined && HostTypeOptionAzure.id === azureSettings.hostType;
 }
 
-export function hasAzureResourcesToProvision(
-  azureSettings: AzureSolutionSettings | undefined
-): boolean {
-  if (
-    isAzureProject(azureSettings) &&
-    (azureSettings?.activeResourcePlugins.includes(PluginNames.FE) ||
-      azureSettings?.activeResourcePlugins.includes(PluginNames.BOT) ||
-      azureSettings?.activeResourcePlugins.includes(PluginNames.MSID) ||
-      azureSettings?.activeResourcePlugins.includes(PluginNames.FUNC) ||
-      azureSettings?.activeResourcePlugins.includes(PluginNames.APIM))
-  ) {
-    return true;
-  }
-
-  return false;
-}
-
 export function combineRecords<T>(records: { name: string; result: T }[]): Record<string, T> {
   const ret: Record<v2.PluginName, T> = {};
   for (const record of records) {

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/utils.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/utils.ts
@@ -23,6 +23,7 @@ import {
   SolutionError,
   SOLUTION_PROVISION_SUCCEEDED,
   SolutionSource,
+  PluginNames,
 } from "../constants";
 import {
   AzureResourceApim,
@@ -56,6 +57,23 @@ export function getAzureSolutionSettings(ctx: v2.Context): AzureSolutionSettings
 
 export function isAzureProject(azureSettings: AzureSolutionSettings | undefined): boolean {
   return azureSettings !== undefined && HostTypeOptionAzure.id === azureSettings.hostType;
+}
+
+export function hasAzureResourcesToProvision(
+  azureSettings: AzureSolutionSettings | undefined
+): boolean {
+  if (
+    isAzureProject(azureSettings) &&
+    (azureSettings?.activeResourcePlugins.includes(PluginNames.FE) ||
+      azureSettings?.activeResourcePlugins.includes(PluginNames.BOT) ||
+      azureSettings?.activeResourcePlugins.includes(PluginNames.MSID) ||
+      azureSettings?.activeResourcePlugins.includes(PluginNames.FUNC) ||
+      azureSettings?.activeResourcePlugins.includes(PluginNames.APIM))
+  ) {
+    return true;
+  }
+
+  return false;
 }
 
 export function combineRecords<T>(records: { name: string; result: T }[]): Record<string, T> {

--- a/packages/fx-core/tests/plugins/resource/aad/unit/index.test.ts
+++ b/packages/fx-core/tests/plugins/resource/aad/unit/index.test.ts
@@ -190,6 +190,30 @@ describe("AadAppForTeamsPlugin: CI", () => {
     chai.assert.isTrue(postProvision.isOk());
   });
 
+  it("setApplicationInContext: using manifest", async function () {
+    sinon.stub<any, any>(tool, "isAadManifestEnabled").returns(true);
+    sinon.stub<any, any>(tool, "isConfigUnifyEnabled").returns(true);
+    context = await TestHelper.pluginContext(new Map(), true, true, false);
+    context.appStudioToken = mockTokenProvider();
+    context.graphTokenProvider = mockTokenProviderGraph();
+    mockProvisionResult(context);
+    const setAppId = plugin.setApplicationInContext(context);
+    chai.assert.isTrue(setAppId.isOk());
+    chai.assert.equal(
+      context.envInfo.state.get("fx-resource-aad-app-for-teams").frontendEndpoint,
+      context.envInfo.state.get("fx-resource-frontend-hosting").endpoint
+    );
+    chai.assert.equal(
+      context.envInfo.state.get("fx-resource-aad-app-for-teams").botId,
+      context.envInfo.state.get("fx-resource-bot").botId
+    );
+
+    chai.assert.equal(
+      context.envInfo.state.get("fx-resource-aad-app-for-teams").botEndpoint,
+      context.envInfo.state.get("fx-resource-bot").siteEndpoint
+    );
+  });
+
   it("local debug: tab and bot", async function () {
     context = await TestHelper.pluginContext(new Map(), true, true, true);
     context.appStudioToken = mockTokenProvider();
@@ -327,7 +351,7 @@ describe("AadAppForTeamsPlugin: CI", () => {
       appId: "{{state.fx-resource-aad-app-for-teams.clientId}}",
       replyUrlsWithType: [
         {
-          url: "{{state.fx-resource-frontend-hosting.endpoint}}/auth-end.html",
+          url: "{{state.fx-resource-aad-app-for-teams.frontendEndpoint}}/auth-end.html",
           type: "Web",
         },
       ],
@@ -338,11 +362,11 @@ describe("AadAppForTeamsPlugin: CI", () => {
       chai.assert.deepEqual(fakeManifest.replyUrlsWithType[0], data.replyUrlsWithType[0]);
       chai.assert.equal(
         data.replyUrlsWithType[1].url,
-        "{{state.fx-resource-frontend-hosting.endpoint}}/auth-end.html?clientId={{state.fx-resource-aad-app-for-teams.clientId}}"
+        "{{state.fx-resource-aad-app-for-teams.frontendEndpoint}}/auth-end.html?clientId={{state.fx-resource-aad-app-for-teams.clientId}}"
       );
       chai.assert.equal(
         data.replyUrlsWithType[2].url,
-        "{{state.fx-resource-frontend-hosting.endpoint}}/blank-auth-end.html"
+        "{{state.fx-resource-aad-app-for-teams.frontendEndpoint}}/blank-auth-end.html"
       );
     });
     const result = await plugin.scaffold(context);
@@ -363,7 +387,7 @@ describe("AadAppForTeamsPlugin: CI", () => {
       appId: "{{state.fx-resource-aad-app-for-teams.clientId}}",
       replyUrlsWithType: [
         {
-          url: "{{state.fx-resource-frontend-hosting.endpoint}}/auth-end.html",
+          url: "{{state.fx-resource-aad-app-for-teams.frontendEndpoint}}/auth-end.html",
           type: "Web",
         },
       ],
@@ -374,15 +398,15 @@ describe("AadAppForTeamsPlugin: CI", () => {
       chai.assert.deepEqual(fakeManifest.replyUrlsWithType[0], data.replyUrlsWithType[0]);
       chai.assert.equal(
         data.replyUrlsWithType[1].url,
-        "{{state.fx-resource-frontend-hosting.endpoint}}/auth-end.html?clientId={{state.fx-resource-aad-app-for-teams.clientId}}"
+        "{{state.fx-resource-aad-app-for-teams.frontendEndpoint}}/auth-end.html?clientId={{state.fx-resource-aad-app-for-teams.clientId}}"
       );
       chai.assert.equal(
         data.replyUrlsWithType[2].url,
-        "{{state.fx-resource-frontend-hosting.endpoint}}/blank-auth-end.html"
+        "{{state.fx-resource-aad-app-for-teams.frontendEndpoint}}/blank-auth-end.html"
       );
       chai.assert.equal(
         data.replyUrlsWithType[3].url,
-        "{{state.fx-resource-bot.siteEndpoint}}/auth-end.html"
+        "{{state.fx-resource-aad-app-for-teams.botEndpoint}}/auth-end.html"
       );
     });
     const result = await plugin.scaffold(context);

--- a/packages/fx-core/tests/plugins/solution/solution.provision.test.ts
+++ b/packages/fx-core/tests/plugins/solution/solution.provision.test.ts
@@ -1152,5 +1152,49 @@ describe("API v2 implementation", () => {
       );
       expect(result.isOk()).equals(true);
     });
+
+    it("should not call arm deployment when there is no Azure resource to provision", async () => {
+      const projectSettings: ProjectSettings = {
+        appName: "my app",
+        projectId: uuid.v4(),
+        solutionSettings: {
+          hostType: HostTypeOptionAzure.id,
+          name: "azure",
+          version: "1.0",
+          activeResourcePlugins: [appStudioPluginV2.name, aadPluginV2.name],
+        },
+      };
+      const mockedCtx = new MockedV2Context(projectSettings);
+      mockedCtx.userInteraction = new MockUserInteraction();
+      const mockedInputs: Inputs = {
+        platform: Platform.VSCode,
+        projectPath: "./",
+        isForUT: true,
+      };
+      const mockedTokenProvider: TokenProvider = {
+        azureAccountProvider: new MockedAzureTokenProvider(),
+        appStudioToken: new MockedAppStudioTokenProvider(),
+        graphTokenProvider: new MockedGraphTokenProvider(),
+        sharepointTokenProvider: new MockedSharepointProvider(),
+      };
+      const mockedEnvInfo: v2.EnvInfoV2 = {
+        envName: "default",
+        config: { manifest: { appName: { short: "test-app" } } },
+        state: {},
+      };
+      mockProvisionV2ThatAlwaysSucceed(appStudioPluginV2);
+      mockProvisionV2ThatAlwaysSucceed(aadPluginV2);
+
+      const solution = new TeamsAppSolutionV2();
+      const armSpy = sinon.spy(arm, "deployArmTemplates");
+      const result = await solution.provisionResources(
+        mockedCtx,
+        mockedInputs,
+        mockedEnvInfo,
+        mockedTokenProvider
+      );
+      chai.assert.equal(armSpy.callCount, 0);
+      expect(result.isOk()).equals(true);
+    });
   });
 });


### PR DESCRIPTION
1. Allow user to config frontend and bot info for existing app, user config has the highest priority:

```
{
    "$schema": "https://aka.ms/teamsfx-env-config-schema",
    "description": "You can customize the TeamsFx config for different environments. Visit https://aka.ms/teamsfx-env-config to learn more about this.",
    "manifest": {
        "appName": {
            "short": "test-local-debug",
            "full": "Full name for test-local-debug"
        }
    },
    "auth": {
        "frontendDomain": "example.com",
        "botId": "xxxx",
        "botEndpoint": "https://example.com"
    }
}
```

2. Skip arm deployment if there is no Azure resource need to provision
3. Update config json schema