### PR TITLE
fix: add capability notification/commandbot manifest

### DIFF
--- a/packages/fx-core/src/plugins/resource/appstudio/v3/index.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/v3/index.ts
@@ -142,7 +142,7 @@ export class AppStudioPluginV3 {
         );
       }
     });
-    const res = await addCapabilities(pluginContext.root, capabilities);
+    const res = await addCapabilities(pluginContext.root, capabilities, inputs);
     if (res.isOk()) {
       TelemetryUtils.sendSuccessEvent(TelemetryEventName.addCapability);
     } else {

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/executeUserTask.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/executeUserTask.ts
@@ -83,6 +83,7 @@ import { getDefaultString, getLocalizedString } from "../../../../common/localiz
 import { getTemplatesFolder } from "../../../../folder";
 import AdmZip from "adm-zip";
 import { unzip } from "../../../../common/template-utils/templatesUtils";
+import { InputsWithProjectPath } from "@microsoft/teamsfx-api/build/v2";
 export async function executeUserTask(
   ctx: v2.Context,
   inputs: Inputs,
@@ -277,7 +278,7 @@ export async function addCapability(
     isMiniApp = true;
   }
   const originalSettings = cloneDeep(solutionSettings);
-  const inputsNew: Inputs = {
+  const inputsNew: InputsWithProjectPath = {
     ...inputs,
     projectPath: inputs.projectPath!,
     existingResources: originalSettings.activeResourcePlugins,
@@ -524,7 +525,7 @@ export async function addCapability(
   }
   // 4. update manifest
   if (capabilitiesToAddManifest.length > 0) {
-    await appStudioPlugin.addCapabilities(ctx, inputsWithProjectPath, capabilitiesToAddManifest);
+    await appStudioPlugin.addCapabilities(ctx, inputsNew, capabilitiesToAddManifest);
   }
   if (capabilitiesAnswer.length > 0) {
     const addNames = capabilitiesAnswer.map((c) => `'${c}'`).join(" and ");

--- a/packages/fx-core/tests/plugins/resource/appstudio/unit/manifestTemplate.test.ts
+++ b/packages/fx-core/tests/plugins/resource/appstudio/unit/manifestTemplate.test.ts
@@ -8,6 +8,7 @@ import fs, { PathLike } from "fs-extra";
 import path from "path";
 import * as uuid from "uuid";
 import { v2, Platform, IStaticTab, IConfigurableTab, IBot } from "@microsoft/teamsfx-api";
+import "reflect-metadata";
 import { Container } from "typedi";
 import { AppStudioPluginV3 } from "./../../../../../src/plugins/resource/appstudio/v3";
 import { LocalCrypto } from "../../../../../src/core/crypto";
@@ -15,6 +16,12 @@ import { getAzureProjectRoot, MockUserInteraction } from "../helper";
 import { MockedLogProvider, MockedTelemetryReporter } from "../../../solution/util";
 import { BuiltInFeaturePluginNames } from "../../../../../src/plugins/solution/fx-solution/v3/constants";
 import { AppStudioError } from "../../../../../src/plugins/resource/appstudio/errors";
+import {
+  AzureSolutionQuestionNames,
+  BotScenario,
+} from "../../../../../src/plugins/solution/fx-solution/question";
+import { QuestionNames } from "../../../../../src/plugins/resource/bot/constants";
+import { AppServiceOptionItem } from "../../../../../src/plugins/resource/bot/question";
 
 describe("Load and Save manifest template", () => {
   const sandbox = sinon.createSandbox();
@@ -136,6 +143,74 @@ describe("Add capability", () => {
       chai.assert.equal(loadedManifestTemplate.value.remote.staticTabs!.length, 2);
 
       chai.assert.equal(loadedManifestTemplate.value.remote.staticTabs![1].entityId, "index1");
+    }
+  });
+
+  it("Add notification bot capability", async () => {
+    sandbox.stub(process, "env").value({
+      BOT_NOTIFICATION_ENABLED: "true",
+    });
+    const fileContent: Map<string, any> = new Map();
+    sandbox.stub(fs, "writeFile").callsFake(async (filePath: number | PathLike, data: any) => {
+      fileContent.set(path.normalize(filePath.toString()), data);
+    });
+
+    sandbox.stub(fs, "readJson").callsFake(async (filePath: string) => {
+      const content = fileContent.get(path.normalize(filePath));
+      if (content) {
+        return JSON.parse(content);
+      } else {
+        return await fs.readJSON(path.normalize(filePath));
+      }
+    });
+
+    const capabilities = [{ name: "Bot" as const }];
+    inputs[AzureSolutionQuestionNames.Scenarios] = [BotScenario.NotificationBot];
+    inputs[QuestionNames.BOT_HOST_TYPE_TRIGGER] = [AppServiceOptionItem.id];
+    const addCapabilityResult = await plugin.addCapabilities(ctx, inputs, capabilities);
+    chai.assert.isTrue(addCapabilityResult.isOk());
+
+    const loadedManifestTemplate = await plugin.loadManifest(ctx, inputs);
+    chai.assert.isTrue(loadedManifestTemplate.isOk());
+
+    if (loadedManifestTemplate.isOk()) {
+      chai.assert.equal(loadedManifestTemplate.value.remote.bots?.length, 1);
+      chai.assert.isUndefined(loadedManifestTemplate.value.remote.bots?.[0].commandLists);
+    }
+  });
+
+  it("Add command and response bot capability", async () => {
+    sandbox.stub(process, "env").value({
+      BOT_NOTIFICATION_ENABLED: "true",
+    });
+    const fileContent: Map<string, any> = new Map();
+    sandbox.stub(fs, "writeFile").callsFake(async (filePath: number | PathLike, data: any) => {
+      fileContent.set(path.normalize(filePath.toString()), data);
+    });
+
+    sandbox.stub(fs, "readJson").callsFake(async (filePath: string) => {
+      const content = fileContent.get(path.normalize(filePath));
+      if (content) {
+        return JSON.parse(content);
+      } else {
+        return await fs.readJSON(path.normalize(filePath));
+      }
+    });
+
+    const capabilities = [{ name: "Bot" as const }];
+    inputs[AzureSolutionQuestionNames.Scenarios] = [BotScenario.CommandAndResponseBot];
+    const addCapabilityResult = await plugin.addCapabilities(ctx, inputs, capabilities);
+    chai.assert.isTrue(addCapabilityResult.isOk());
+
+    const loadedManifestTemplate = await plugin.loadManifest(ctx, inputs);
+    chai.assert.isTrue(loadedManifestTemplate.isOk());
+
+    if (loadedManifestTemplate.isOk()) {
+      chai.assert.equal(loadedManifestTemplate.value.remote.bots?.length, 1);
+      chai.assert.equal(
+        loadedManifestTemplate.value.remote.bots?.[0].commandLists?.[0].commands?.[0].title,
+        "helloWorld"
+      );
     }
   });
 });


### PR DESCRIPTION
- Fix the bug 'manifest is not correct when adding notification/commandresponse capability'

notification:
![img](https://user-images.githubusercontent.com/9698542/162370145-f461aa4d-2c5a-4c53-a924-25a1876db638.png)

command response:
![img](https://user-images.githubusercontent.com/9698542/162370151-2f628a12-9c70-46aa-9f20-e6dab19e4ad2.png)


https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/13942934/