### PR TITLE
perf(aad-manifest): not remove permissions file when migration

### DIFF
--- a/packages/fx-core/src/core/middleware/aadManifestMigration.ts
+++ b/packages/fx-core/src/core/middleware/aadManifestMigration.ts
@@ -262,10 +262,6 @@ async function migrate(ctx: CoreHookContext): Promise<boolean> {
     const backupPath = path.join(inputs.projectPath as string, backupFolder);
     await fs.ensureDir(path.join(backupPath, ".fx", "configs"));
 
-    await fs.move(permissionFilePath, path.join(backupPath, "permissions.json"), {
-      overwrite: true,
-    });
-    fileList.push(path.join(backupPath, "permissions.json"));
     await fs.writeJSON(
       path.join(backupPath, ".fx", "configs", "projectSettings.json"),
       projectSettings,


### PR DESCRIPTION
Do not remove permissions file when migration to make it compatible with old extension