### PR TITLE
feat(SDK)!: load all env in TeamsFx

### DIFF
--- a/packages/sdk/src/core/teamsfx.ts
+++ b/packages/sdk/src/core/teamsfx.ts
@@ -11,6 +11,23 @@ import { ErrorWithCode, ErrorCode, ErrorMessage } from "../core/errors";
 import { internalLogger } from "../util/logger";
 import { TeamsFxConfiguration } from "../models/teamsfxConfiguration";
 
+// Following keys are used by SDK internally
+const ReservedKey: Set<string> = new Set<string>([
+  "authorityHost",
+  "tenantId",
+  "clientId",
+  "clientSecret",
+  "initiateLoginEndpoint",
+  "applicationIdUri",
+  "apiEndpoint",
+  "apiName",
+  "sqlServerEndpoint",
+  "sqlUsername",
+  "sqlPassword",
+  "sqlDatabaseName",
+  "sqlIdentityId",
+]);
+
 /**
  * A class providing credential and configuration.
  * @beta
@@ -208,10 +225,12 @@ export class TeamsFx implements TeamsFxConfiguration {
     this.configuration.set("sqlIdentityId", env.IDENTITY_ID);
 
     Object.keys(env).forEach((key: string) => {
-      const value = env[key];
-      if (key.startsWith("TEAMSFX_") && value) {
-        this.configuration.set(key.substring(8), value);
+      if (ReservedKey.has(key)) {
+        internalLogger.warn(
+          `The name of environment variable ${key} is preserved. Will not load it as configuration.`
+        );
       }
+      this.configuration.set(key, env[key]);
     });
   }
 }

--- a/packages/sdk/test/unit/node/teamsFx.spec.ts
+++ b/packages/sdk/test/unit/node/teamsFx.spec.ts
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { assert, expect, use as chaiUse } from "chai";
+import mockedEnv from "mocked-env";
+import { TeamsFx } from "../../../src";
+
+describe("TeamsFx Tests - Node", () => {
+  let restore: () => void;
+
+  afterEach(() => {
+    restore();
+  });
+
+  it("should load all environment variables", () => {
+    restore = mockedEnv({
+      TEST_ENV: "test value",
+    });
+
+    const teamsFx = new TeamsFx();
+
+    assert.equal(teamsFx.getConfig("TEST_ENV"), "test value");
+  });
+
+  it("should not override reserved key", () => {
+    restore = mockedEnv({
+      clientId: "test value",
+    });
+
+    const teamsFx = new TeamsFx(undefined, {
+      clientId: "predefined value",
+    });
+
+    assert.equal(teamsFx.getConfig("clientId"), "predefined value");
+  });
+});


### PR DESCRIPTION
New feature: `TeamsFx` will load all environment variables now

BREAKING CHANGE: `TeamsFx` will not remove `TEAMSFX_` prefix in loaded environment variables. To read environment variable `TEAMSFX_MY_ENV`, you need to use `TeamsFx.getConfig('TEAMSFX_MY_ENV')` instead of `TeamsFx.getConfig('MY_ENV')`. This makes configuration set and read more consistent.