### PR TITLE
feat: add hover for manifest template

### DIFF
--- a/packages/vscode-extension/src/codeLensProvider.ts
+++ b/packages/vscode-extension/src/codeLensProvider.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 import * as vscode from "vscode";
 import { localSettingsJsonName } from "./debug/constants";
+import { manifestConfigDataRegex, manifestStateDataRegex } from "./constants";
 import * as fs from "fs-extra";
 import * as parser from "jsonc-parser";
 import { Mutex } from "async-mutex";
@@ -113,8 +114,6 @@ export class AdaptiveCardCodeLensProvider implements vscode.CodeLensProvider {
 
 export class ManifestTemplateCodeLensProvider implements vscode.CodeLensProvider {
   private schemaRegex = /\$schema/;
-  private manifestConfigDataRegex = /{{config.manifest[\.a-zA-Z]+}}/g;
-  private manifestStateDataRegex = /{{state\.[a-zA-Z-_]+\.\w+}}/g;
 
   private projectConfigs: ProjectConfigV3 | undefined = undefined;
   private mutex = new Mutex();
@@ -206,22 +205,22 @@ export class ManifestTemplateCodeLensProvider implements vscode.CodeLensProvider
     if (isConfigUnifyEnabled()) {
       if (document.fileName.endsWith("manifest.template.json")) {
         // code lens will be resolved later
-        const configCodelenses = this.calculateCodeLens(document, this.manifestConfigDataRegex);
+        const configCodelenses = this.calculateCodeLens(document, manifestConfigDataRegex);
         codeLenses.push(...configCodelenses);
 
-        const stateCodelenses = this.calculateCodeLens(document, this.manifestStateDataRegex);
+        const stateCodelenses = this.calculateCodeLens(document, manifestStateDataRegex);
         codeLenses.push(...stateCodelenses);
       }
     } else {
       if (document.fileName.endsWith("manifest.remote.template.json")) {
-        const configCodelenses = this.calculateCodeLens(document, this.manifestConfigDataRegex, {
+        const configCodelenses = this.calculateCodeLens(document, manifestConfigDataRegex, {
           title: "✏️Edit the config file",
           command: "fx-extension.openConfigState",
           arguments: [{ type: "config" }],
         });
         codeLenses.push(...configCodelenses);
 
-        const stateCodelenses = this.calculateCodeLens(document, this.manifestStateDataRegex, {
+        const stateCodelenses = this.calculateCodeLens(document, manifestStateDataRegex, {
           title: "👀View the state file",
           command: "fx-extension.openConfigState",
           arguments: [{ type: "state" }],

--- a/packages/vscode-extension/src/constants.ts
+++ b/packages/vscode-extension/src/constants.ts
@@ -32,3 +32,6 @@ export enum GlobalKey {
   ShowLocalDebugMessage = "ShowLocalDebugMessage",
   ShowLocalPreviewMessage = "ShowLocalPreviewMessage",
 }
+
+export const manifestConfigDataRegex = /{{config.manifest[\.a-zA-Z]+}}/g;
+export const manifestStateDataRegex = /{{state\.[a-zA-Z-_]+\.\w+}}/g;

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -22,6 +22,7 @@ import {
   CryptoCodeLensProvider,
   ManifestTemplateCodeLensProvider,
 } from "./codeLensProvider";
+import { ManifestTemplateHoverProvider } from "./hoverProvider";
 import {
   Correlator,
   isConfigUnifyEnabled,
@@ -491,6 +492,12 @@ export async function activate(context: vscode.ExtensionContext) {
       aadAppTemplateSelector,
       aadAppTemplateCodeLensProvider
     )
+  );
+
+  // Register hover provider
+  const manifestTemplateHoverProvider = new ManifestTemplateHoverProvider();
+  context.subscriptions.push(
+    vscode.languages.registerHoverProvider(manifestTemplateSelecctor, manifestTemplateHoverProvider)
   );
 
   // Register debug configuration provider

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -443,7 +443,7 @@ export async function activate(context: vscode.ExtensionContext) {
   };
 
   const manifestTemplateCodeLensProvider = new ManifestTemplateCodeLensProvider();
-  const manifestTemplateSelecctor = {
+  const manifestTemplateSelector = {
     language: "json",
     scheme: "file",
     pattern: isConfigUnifyEnabled()
@@ -477,7 +477,7 @@ export async function activate(context: vscode.ExtensionContext) {
   );
   context.subscriptions.push(
     vscode.languages.registerCodeLensProvider(
-      manifestTemplateSelecctor,
+      manifestTemplateSelector,
       manifestTemplateCodeLensProvider
     )
   );
@@ -497,7 +497,7 @@ export async function activate(context: vscode.ExtensionContext) {
   // Register hover provider
   const manifestTemplateHoverProvider = new ManifestTemplateHoverProvider();
   context.subscriptions.push(
-    vscode.languages.registerHoverProvider(manifestTemplateSelecctor, manifestTemplateHoverProvider)
+    vscode.languages.registerHoverProvider(manifestTemplateSelector, manifestTemplateHoverProvider)
   );
 
   // Register debug configuration provider

--- a/packages/vscode-extension/src/hoverProvider.ts
+++ b/packages/vscode-extension/src/hoverProvider.ts
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as vscode from "vscode";
+import { getPropertyByPath } from "@microsoft/teamsfx-core";
+import { manifestConfigDataRegex, manifestStateDataRegex } from "./constants";
+import { core, getSystemInputs } from "./handlers";
+
+export class ManifestTemplateHoverProvider implements vscode.HoverProvider {
+  public async provideHover(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    token: vscode.CancellationToken
+  ): Promise<vscode.Hover | undefined> {
+    const line = document.lineAt(position.line);
+
+    let regex;
+    let matches = manifestStateDataRegex.exec(line.text);
+    if (matches !== null) {
+      regex = manifestStateDataRegex;
+    } else {
+      matches = manifestConfigDataRegex.exec(line.text);
+      if (matches !== null) {
+        regex = manifestConfigDataRegex;
+      }
+    }
+
+    if (matches !== null && regex !== undefined) {
+      const key = matches[0].replace(/{/g, "").replace(/}/g, "");
+      const indexOf = line.text.indexOf(matches[0]);
+      const position = new vscode.Position(line.lineNumber, indexOf);
+      const range = document.getWordRangeAtPosition(
+        new vscode.Position(position.line, indexOf),
+        new RegExp(regex)
+      );
+      const message = await this.generateHoverMessage(key);
+      const hover = new vscode.Hover(message, range);
+      return hover;
+    }
+
+    return undefined;
+  }
+
+  private async generateHoverMessage(key: string): Promise<vscode.MarkdownString> {
+    const inputs = getSystemInputs();
+    const getConfigRes = await core.getProjectConfigV3(inputs);
+    if (getConfigRes.isErr()) throw getConfigRes.error;
+    const projectConfigs = getConfigRes.value;
+
+    let message = "";
+    if (projectConfigs && projectConfigs.envInfos) {
+      for (const envName in projectConfigs.envInfos) {
+        const envInfo = projectConfigs.envInfos[envName];
+        const value = getPropertyByPath(envInfo, key);
+        message += `**${envName}**: ${value} \n\n`;
+      }
+      if (key.startsWith("state")) {
+        const args = [{ type: "state" }];
+        const commandUri = vscode.Uri.parse(
+          `command:fx-extension.openConfigState?${encodeURIComponent(JSON.stringify(args))}`
+        );
+        message += `[👀View the state file](${commandUri})`;
+      } else {
+        const args = [{ type: "config" }];
+        const commandUri = vscode.Uri.parse(
+          `command:fx-extension.openConfigState?${encodeURIComponent(JSON.stringify(args))}`
+        );
+        message += `[✏️Edit the config file](${commandUri})`;
+      }
+    }
+    const markdown = new vscode.MarkdownString(message);
+    markdown.isTrusted = true;
+    return markdown;
+  }
+}


### PR DESCRIPTION
When user hover over the placeholder, it will show values from all environments, with the button to open state/config file.
![image](https://user-images.githubusercontent.com/71362691/162869155-884452d1-d50f-4d55-837d-71a43d9c01d9.png)
