### PR TITLE
fix: remove BotMessaged from notification sdk

### DIFF
--- a/packages/sdk/src/conversation/middleware.ts
+++ b/packages/sdk/src/conversation/middleware.ts
@@ -44,13 +44,6 @@ export class NotificationMiddleware implements Middleware {
         await this.conversationReferenceStore.set(reference);
         break;
       }
-      case ActivityType.CurrentBotMessaged: {
-        const reference = TurnContext.getConversationReference(context.activity);
-        if (!(await this.conversationReferenceStore.check(reference))) {
-          await this.conversationReferenceStore.set(reference);
-        }
-        break;
-      }
       case ActivityType.CurrentBotUninstalled:
       case ActivityType.TeamDeleted: {
         const reference = TurnContext.getConversationReference(context.activity);
@@ -73,8 +66,6 @@ export class NotificationMiddleware implements Middleware {
       } else {
         return ActivityType.CurrentBotUninstalled;
       }
-    } else if (activityType === "message") {
-      return ActivityType.CurrentBotMessaged;
     } else if (activityType === "conversationUpdate") {
       const eventType = activity.channelData?.eventType as string;
       if (eventType === "teamDeleted") {

--- a/packages/sdk/test/unit/node/conversation/middleware.spec.ts
+++ b/packages/sdk/test/unit/node/conversation/middleware.spec.ts
@@ -167,7 +167,7 @@ describe("Notification Middleware Tests - Node", () => {
     assert.deepStrictEqual(testStorage.items, {});
   });
 
-  it("onTurn should correctly handle bot messaged (new)", async () => {
+  it("onTurn should ignore bot messaged (new)", async () => {
     const testContext = {
       activity: {
         type: "message",
@@ -182,18 +182,10 @@ describe("Notification Middleware Tests - Node", () => {
       },
     };
     await middleware.onTurn(testContext as any, async () => {});
-    assert.deepStrictEqual(testStorage.items, {
-      _a_1: {
-        channelId: "1",
-        conversation: {
-          id: "1",
-          tenantId: "a",
-        },
-      },
-    });
+    assert.deepStrictEqual(testStorage.items, {});
   });
 
-  it("onTurn should correctly handle bot messaged (exist)", async () => {
+  it("onTurn should ignore bot messaged (exist)", async () => {
     testStorage.items = {
       _a_1: {
         channelId: "1",


### PR DESCRIPTION
To fix https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14102628/
The bot could be mentioned anywhere with different conversation ids, so cannot be persisted.

E2E TEST: N/A, covered by unit test