### PR TITLE
fix: add timeout to port detect

### DIFF
--- a/packages/fx-core/src/common/local/portChecker.ts
+++ b/packages/fx-core/src/common/local/portChecker.ts
@@ -30,7 +30,12 @@ const botServicePorts = [3978];
 async function detectPortListening(port: number, logger?: LogProvider): Promise<boolean> {
   try {
     sendTelemetryEvent(Component.core, TelemetryEvent.DetectPortStart, { port: port.toString() });
-    const portChosen = await detectPort(port);
+    const race = Promise.race([
+      detectPort(port),
+      // in case `detectPort` hangs, set 10 seconds timeout
+      new Promise<number>((resolve) => setTimeout(() => resolve(port), 10 * 1000)),
+    ]);
+    const portChosen = await race;
     sendTelemetryEvent(Component.core, TelemetryEvent.DetectPort, {
       portChosen: portChosen.toString(),
       port: port.toString(),

--- a/packages/fx-core/tests/common/local/portChecker.test.ts
+++ b/packages/fx-core/tests/common/local/portChecker.test.ts
@@ -47,6 +47,36 @@ describe("portChecker", () => {
       chai.assert.equal(ports.length, 0);
     });
 
+    it("detect-port timeout", async () => {
+      const portChecker = proxyquire("../../../src/common/local/portChecker", {
+        "detect-port": async (port: number) =>
+          new Promise((resolve) => {
+            setTimeout(() => resolve(port + 1), 60 * 1000);
+          }),
+      });
+      const clock = sinon.useFakeTimers();
+
+      const portsPromise = portChecker.getPortsInUse(
+        projectPath,
+        {
+          appName: "unit-test0",
+          projectId: "11111111-1111-1111-1111-111111111111",
+          programmingLanguage: "javascript",
+          solutionSettings: {
+            name: "fx-solution-azure",
+            hostType: "Azure",
+            capabilities: ["Bot"],
+          },
+        },
+        true
+      );
+      clock.tick(30 * 1000);
+      const ports = await portsPromise;
+
+      chai.assert.isDefined(ports);
+      chai.assert.equal(ports.length, 0);
+    });
+
     it("53000 in use", async () => {
       const portChecker = proxyquire("../../../src/common/local/portChecker", {
         "detect-port": async (port: number) => (port === 53000 ? 53001 : port),


### PR DESCRIPTION
Fix https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14124366
In case `detect-port` hangs, add 10 seconds timeout to skip port check.

E2E TEST: N/A, covered by unit test