### PR TITLE
fix: refine spfx progress bar

### DIFF
--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -130,7 +130,7 @@
   "plugins.spfx.error.invalidDependency": "Failed to validate package %s",
   "plugins.spfx.error.installDependency": "Failed to install package %s. Learn how to remediate in the [output](command:fx-extension.showOutputChannel).",
   "plugins.spfx.scaffold.dependencyCheck": "Checking dependencies...",
-  "plugins.spfx.scaffold.dependencyInstall": "Installing dependencies ([details](command:fx-extension.showOutputChannel)). This may take more than 5 minutes to finish.",
+  "plugins.spfx.scaffold.dependencyInstall": "Installing dependencies. This may take more than 5 minutes to finish.",
   "plugins.spfx.scaffold.scaffoldProject": "Generate SPFx project using Yeoman CLI",
   "plugins.spfx.scaffold.updateManifest": "Update webpart manifest",
   "plugins.spfx.GetTenantFailedError": "Cannot get tenant %s %s",

--- a/packages/vscode-extension/package.nls.json
+++ b/packages/vscode-extension/package.nls.json
@@ -296,7 +296,6 @@
     "teamstoolkit.progressHandler.prepareTask": " Prepare task.",
     "teamstoolkit.progressHandler.reloadNotice": "%s%s%s (Notice: You can reload the window and retry if task spends too long time.)",
     "teamstoolkit.progressHandler.showOutputLink": "Check [output window](%s) for details.",
-    "teamstoolkit.progressHandler.teamsToolkitComponent": "[Teams Toolkit]",
     "teamstoolkit.qm.emptySelection": "select option is empty",
     "teamstoolkit.qm.multiSelectKeyboard": " (Space key to check/uncheck)",
     "teamstoolkit.qm.ok": "ok (Enter)",

--- a/packages/vscode-extension/src/progressHandler.ts
+++ b/packages/vscode-extension/src/progressHandler.ts
@@ -27,7 +27,7 @@ export class ProgressHandler implements IProgressHandler {
   }
 
   private generateWholeMessage(): string {
-    const head = `${localize("teamstoolkit.progressHandler.teamsToolkitComponent")} ${this.title}`;
+    const head = this.title;
     const body = `: [${this.currentStep}/${this.totalSteps}] ${util.format(
       localize("teamstoolkit.progressHandler.showOutputLink"),
       "command:fx-extension.showOutputChannel"

--- a/packages/vscode-extension/src/qm/vsc_ui.ts
+++ b/packages/vscode-extension/src/qm/vsc_ui.ts
@@ -615,9 +615,7 @@ export class VsCodeUI implements UserInteraction {
           let lastReport = 0;
           const showProgress = config.showProgress === true;
           const total = task.total ? task.total : 1;
-          const head = `${localize("teamstoolkit.progressHandler.teamsToolkitComponent")} ${
-            task.name ? task.name : ""
-          }`;
+          const head = task.name ? task.name : "";
           const report = (task: RunnableTask<T>) => {
             const current = task.current ? task.current : 0;
             const body = showProgress


### PR DESCRIPTION
1> Remove the '[Teams Toolkit]' prefix to avoid truncated output link(Also a feedback from vscode to UX)
2> There's already 'details' link to output window and the one introduced in https://github.com/OfficeDev/TeamsFx/pull/4480 will duplicate the link. So remove the original one

Before:
![image](https://user-images.githubusercontent.com/73154171/163512268-0027c551-db72-4914-88f0-fd93e04504d5.png)
![image](https://user-images.githubusercontent.com/73154171/163512280-37374af6-5ca2-4c2b-af14-bd1c83a6e9e7.png)
![image](https://user-images.githubusercontent.com/73154171/163512447-9b50919e-b8ab-4208-8b7c-cfe69020252d.png)


After:
![image](https://user-images.githubusercontent.com/73154171/163511824-3a1365d3-14b3-4aee-a7b5-6836e114e5c7.png)
![image](https://user-images.githubusercontent.com/73154171/163511836-e1976d54-6bc4-4866-a461-dec8bcb3528a.png)
![image](https://user-images.githubusercontent.com/73154171/163512643-fce93d6c-5b19-4ed1-9bd8-061c82090e3e.png)


ADO:
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14000243
E2E TEST: na