### PR TITLE
chore: use latest sdk in function template

### DIFF
--- a/templates/function-base/js/default/package.json
+++ b/templates/function-base/js/default/package.json
@@ -8,7 +8,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@microsoft/teamsfx": "^0.6.1",
+    "@microsoft/teamsfx": "0.6.2-alpha.0",
     "isomorphic-fetch": "^3.0.0"
   },
   "devDependencies": {

--- a/templates/function-base/ts/default/package.json
+++ b/templates/function-base/ts/default/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@azure/functions": "^1.2.2",
     "@microsoft/microsoft-graph-client": "^3.0.0",
-    "@microsoft/teamsfx": "^0.6.1",
+    "@microsoft/teamsfx": "0.6.2-alpha.0",
     "isomorphic-fetch": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The connection existing api feature requires latest SDK. This PR enables auto version sync for function template.