### PR TITLE
chore: update call api sample to support strict mode

### DIFF
--- a/packages/fx-core/templates/plugins/resource/apiconnector/sample/js/aad.template
+++ b/packages/fx-core/templates/plugins/resource/apiconnector/sample/js/aad.template
@@ -17,7 +17,7 @@ const teamsFx = new teamsfxSdk.TeamsFx(teamsfxSdk.IdentityType.App, {
 const appCredential = teamsFx.getCredential();
 const authProvider = new teamsfxSdk.BearerTokenAuthProvider(
   // Please replace '<your-api-scope>' with actual api scope value.
-  async () => (await appCredential.getToken("<your-api-scope>"))?.token
+  async () => (await appCredential.getToken("<your-api-scope>")).token
 );
 const {{config.APIName}}Client = teamsfxSdk.createApiClient(
   teamsFx.getConfig("TEAMSFX_API_{{capitalName}}_ENDPOINT"),

--- a/packages/fx-core/templates/plugins/resource/apiconnector/sample/ts/aad.template
+++ b/packages/fx-core/templates/plugins/resource/apiconnector/sample/ts/aad.template
@@ -12,17 +12,17 @@ const teamsFx = new TeamsFx(IdentityType.App);
 const teamsFx = new TeamsFx(IdentityType.App, {
   // You can replace the default authorityHost url with actual value per your requirement.
   authorityHost: "https://login.microsoftonline.com",
-  tenantId: process.env.TEAMSFX_API_{{capitalName}}_TENANT_ID,
-  clientId: process.env.TEAMSFX_API_{{capitalName}}_CLIENT_ID,
+  tenantId: process.env.TEAMSFX_API_{{capitalName}}_TENANT_ID!,
+  clientId: process.env.TEAMSFX_API_{{capitalName}}_CLIENT_ID!,
   // Please add your client secret to .env.teamsfx.local before local debugging.
-  clientSecret: process.env.TEAMSFX_API_{{capitalName}}_CLIENT_SECRET,
+  clientSecret: process.env.TEAMSFX_API_{{capitalName}}_CLIENT_SECRET!,
 });
 {{/if}}
 // Initializes a new axios instance to call {{config.APIName}} API.
 const appCredential = teamsFx.getCredential();
 const authProvider = new BearerTokenAuthProvider(
   // Please replace '<your-api-scope>' with actual api scope value.
-  async () => (await appCredential.getToken("<your-api-scope>"))?.token
+  async () => (await appCredential.getToken("<your-api-scope>"))!.token
 );
 const {{config.APIName}}Client = createApiClient(
   teamsFx.getConfig("TEAMSFX_API_{{capitalName}}_ENDPOINT"),

--- a/packages/fx-core/tests/plugins/resource/apiconnector/expectedFiles/js/aad
+++ b/packages/fx-core/tests/plugins/resource/apiconnector/expectedFiles/js/aad
@@ -6,7 +6,7 @@ const teamsFx = new teamsfxSdk.TeamsFx(teamsfxSdk.IdentityType.App);
 const appCredential = teamsFx.getCredential();
 const authProvider = new teamsfxSdk.BearerTokenAuthProvider(
   // Please replace '<your-api-scope>' with actual api scope value.
-  async () => (await appCredential.getToken("<your-api-scope>"))?.token
+  async () => (await appCredential.getToken("<your-api-scope>")).token
 );
 const fakeClient = teamsfxSdk.createApiClient(
   teamsFx.getConfig("TEAMSFX_API_FAKE_ENDPOINT"),

--- a/packages/fx-core/tests/plugins/resource/apiconnector/expectedFiles/js/aad-existing-app
+++ b/packages/fx-core/tests/plugins/resource/apiconnector/expectedFiles/js/aad-existing-app
@@ -13,7 +13,7 @@ const teamsFx = new teamsfxSdk.TeamsFx(teamsfxSdk.IdentityType.App, {
 const appCredential = teamsFx.getCredential();
 const authProvider = new teamsfxSdk.BearerTokenAuthProvider(
   // Please replace '<your-api-scope>' with actual api scope value.
-  async () => (await appCredential.getToken("<your-api-scope>"))?.token
+  async () => (await appCredential.getToken("<your-api-scope>")).token
 );
 const fakeClient = teamsfxSdk.createApiClient(
   teamsFx.getConfig("TEAMSFX_API_FAKE_ENDPOINT"),

--- a/packages/fx-core/tests/plugins/resource/apiconnector/expectedFiles/ts/aad
+++ b/packages/fx-core/tests/plugins/resource/apiconnector/expectedFiles/ts/aad
@@ -11,7 +11,7 @@ const teamsFx = new TeamsFx(IdentityType.App);
 const appCredential = teamsFx.getCredential();
 const authProvider = new BearerTokenAuthProvider(
   // Please replace '<your-api-scope>' with actual api scope value.
-  async () => (await appCredential.getToken("<your-api-scope>"))?.token
+  async () => (await appCredential.getToken("<your-api-scope>"))!.token
 );
 const fakeClient = createApiClient(
   teamsFx.getConfig("TEAMSFX_API_FAKE_ENDPOINT"),

--- a/packages/fx-core/tests/plugins/resource/apiconnector/expectedFiles/ts/aad-existing-app
+++ b/packages/fx-core/tests/plugins/resource/apiconnector/expectedFiles/ts/aad-existing-app
@@ -9,16 +9,16 @@ import {
 const teamsFx = new TeamsFx(IdentityType.App, {
   // You can replace the default authorityHost url with actual value per your requirement.
   authorityHost: "https://login.microsoftonline.com",
-  tenantId: process.env.TEAMSFX_API_FAKE_TENANT_ID,
-  clientId: process.env.TEAMSFX_API_FAKE_CLIENT_ID,
+  tenantId: process.env.TEAMSFX_API_FAKE_TENANT_ID!,
+  clientId: process.env.TEAMSFX_API_FAKE_CLIENT_ID!,
   // Please add your client secret to .env.teamsfx.local before local debugging.
-  clientSecret: process.env.TEAMSFX_API_FAKE_CLIENT_SECRET,
+  clientSecret: process.env.TEAMSFX_API_FAKE_CLIENT_SECRET!,
 });
 // Initializes a new axios instance to call fake API.
 const appCredential = teamsFx.getCredential();
 const authProvider = new BearerTokenAuthProvider(
   // Please replace '<your-api-scope>' with actual api scope value.
-  async () => (await appCredential.getToken("<your-api-scope>"))?.token
+  async () => (await appCredential.getToken("<your-api-scope>"))!.token
 );
 const fakeClient = createApiClient(
   teamsFx.getConfig("TEAMSFX_API_FAKE_ENDPOINT"),


### PR DESCRIPTION
In ts strict mode, the sample will build failure due to some type check problem.