### PR TITLE
chore: improve wordings for CLI

### DIFF
--- a/packages/fx-core/src/plugins/resource/bot/index.ts
+++ b/packages/fx-core/src/plugins/resource/bot/index.ts
@@ -6,6 +6,7 @@ import {
   Func,
   FxError,
   ok,
+  Platform,
   Plugin,
   PluginContext,
   QTreeNode,
@@ -210,7 +211,7 @@ export class TeamsBot implements Plugin {
             const res = new QTreeNode({
               type: "group",
             });
-            res.addChild(new QTreeNode(createHostTypeTriggerQuestion()));
+            res.addChild(new QTreeNode(createHostTypeTriggerQuestion(context.answers?.platform)));
             res.condition = showNotificationTriggerCondition;
             return ok(res);
           } else {
@@ -238,7 +239,7 @@ export class TeamsBot implements Plugin {
           const res = new QTreeNode({
             type: "group",
           });
-          res.addChild(new QTreeNode(createHostTypeTriggerQuestion()));
+          res.addChild(new QTreeNode(createHostTypeTriggerQuestion(context.answers?.platform)));
           res.condition = showNotificationTriggerCondition;
           return ok(res);
         } else {

--- a/packages/fx-core/src/plugins/resource/bot/question.ts
+++ b/packages/fx-core/src/plugins/resource/bot/question.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { Inputs, MultiSelectQuestion, OptionItem } from "@microsoft/teamsfx-api";
+import { Inputs, MultiSelectQuestion, OptionItem, Platform } from "@microsoft/teamsfx-api";
 import { getLocalizedString } from "../../../common/localizeUtils";
 import {
   AzureSolutionQuestionNames,
@@ -14,7 +14,7 @@ import {
   NotificationTriggers,
 } from "./resources/strings";
 
-export interface HostTypeTriggerOptionItem extends OptionItem {
+interface HostTypeTriggerOptionItem extends OptionItem {
   hostType: HostType;
   trigger?: NotificationTrigger;
 }
@@ -47,13 +47,27 @@ export const HostTypeTriggerOptions: HostTypeTriggerOptionItem[] = [
 // The restrictions of this question:
 //   - appService and function are mutually exclusive
 //   - users must select at least one trigger.
-export function createHostTypeTriggerQuestion(): MultiSelectQuestion {
+export function createHostTypeTriggerQuestion(platform?: Platform): MultiSelectQuestion {
   const prefix = "plugins.bot.questionHostTypeTrigger";
+
+  let staticOptions: HostTypeTriggerOptionItem[];
+  if (platform === Platform.CLI) {
+    // The UI in CLI is different. It does not have description. So we need to merge that into label.
+    staticOptions = HostTypeTriggerOptions.map((option) => {
+      // do not change the original option
+      const cliOption = Object.assign({}, option);
+      cliOption.label = `${option.label} (${option.description})`;
+      return cliOption;
+    });
+  } else {
+    staticOptions = HostTypeTriggerOptions;
+  }
+
   return {
     name: QuestionNames.BOT_HOST_TYPE_TRIGGER,
     title: getLocalizedString(`${prefix}.title`),
     type: "multiSelect",
-    staticOptions: HostTypeTriggerOptions,
+    staticOptions: staticOptions,
     default: [AppServiceOptionItem.id],
     placeholder: getLocalizedString(`${prefix}.placeholder`),
     validation: {

--- a/packages/fx-core/tests/plugins/resource/bot/unit/question.test.ts
+++ b/packages/fx-core/tests/plugins/resource/bot/unit/question.test.ts
@@ -41,7 +41,7 @@ describe("Test question", () => {
           "should accept all functions triggers",
         ],
       ];
-      const question = createHostTypeTriggerQuestion();
+      const question = createHostTypeTriggerQuestion(Platform.VSCode);
       const validFunc = (question.validation as FuncValidation<string[]>).validFunc;
 
       for (const c of cases) {
@@ -92,7 +92,7 @@ describe("Test question", () => {
           "should do nothing on un-selecting",
         ],
       ];
-      const question = createHostTypeTriggerQuestion();
+      const question = createHostTypeTriggerQuestion(Platform.VSCode);
       chai.assert.notStrictEqual(question.onDidChangeSelection, undefined);
       const onDidChangeSelection = question.onDidChangeSelection!;
 
@@ -116,7 +116,7 @@ describe("Test question", () => {
   describe("Workaround CLI default value issue, remove me after CLI is fixed", () => {
     it("cliName and ID must be the same", () => {
       // Arrange
-      const question = createHostTypeTriggerQuestion();
+      const question = createHostTypeTriggerQuestion(Platform.VSCode);
       for (const option of question.staticOptions) {
         if (typeof option !== "string") {
           // Assert
@@ -125,6 +125,19 @@ describe("Test question", () => {
             option.cliName,
             "option.id and option.cliName must be the same to workaround CLI default value issue"
           );
+        }
+      }
+    });
+  });
+
+  describe("Workaround CLI label display issue", () => {
+    it("merges description into label", () => {
+      const question = createHostTypeTriggerQuestion(Platform.CLI);
+      for (const option of question.staticOptions) {
+        chai.assert.isNotString(option);
+        if (typeof option !== "string") {
+          chai.assert.isOk(option.description);
+          chai.assert.include(option.label, option.description!);
         }
       }
     });


### PR DESCRIPTION
Display notification host type in `option.label` in CLI because CLI does not have `option.description`.
<img width="1033" alt="image" src="https://user-images.githubusercontent.com/9698542/163548556-564d58f0-85d4-4a77-836c-cb15613ffbdf.png">
