### PR TITLE
fix(bot): use async deployment api

### DIFF
--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -717,6 +717,8 @@
   "plugins.bot.FailedToUpdateConfigs": "Failed to update configs for %s",
   "plugins.bot.FailedListPublishingCredentials": "Failed to list publishing credentials.",
   "plugins.bot.FailedDeployZipFile": "Failed to deploy zip file.",
+  "plugins.bot.FailedCheckDeployStatus": "Failed to check deployment status.",
+  "plugins.bot.CheckDeployStatusTimeout": "Check deployment status timeout.",
   "plugins.bot.FailedRestartWebApp": "Failed to restart web app.",
   "plugins.bot.FailedUpdateMessageEndpoint": "Failed to update message endpoint with %s",
   "plugins.bot.DownloadFail": "Failed to download from %s",

--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -718,7 +718,7 @@
   "plugins.bot.FailedListPublishingCredentials": "Failed to list publishing credentials.",
   "plugins.bot.FailedDeployZipFile": "Failed to deploy zip file.",
   "plugins.bot.FailedCheckDeployStatus": "Failed to check deployment status.",
-  "plugins.bot.CheckDeployStatusTimeout": "Check deployment status timeout.",
+  "plugins.bot.CheckDeployStatusTimeout": "The deployment status is timeout.",
   "plugins.bot.FailedRestartWebApp": "Failed to restart web app.",
   "plugins.bot.FailedUpdateMessageEndpoint": "Failed to update message endpoint with %s",
   "plugins.bot.DownloadFail": "Failed to download from %s",

--- a/packages/fx-core/src/plugins/resource/bot/azureOps.ts
+++ b/packages/fx-core/src/plugins/resource/bot/azureOps.ts
@@ -10,10 +10,14 @@ import {
   ZipDeployError,
   MessageEndpointUpdatingError,
   RestartWebAppError,
+  DeployStatusError,
+  DeployTimeoutError,
 } from "./errors";
 import { CommonStrings, ConfigNames } from "./resources/strings";
 import * as utils from "./utils/common";
 import { default as axios } from "axios";
+import { waitSeconds } from "../../../common";
+import { DeployStatus } from "./constants";
 
 export class AzureOperations {
   public static async UpdateBotChannelRegistration(
@@ -132,7 +136,7 @@ export class AzureOperations {
     zipDeployEndpoint: string,
     zipBuffer: Buffer,
     config: any
-  ): Promise<void> {
+  ): Promise<string> {
     let res = undefined;
     try {
       res = await axios.post(zipDeployEndpoint, zipBuffer, config);
@@ -140,9 +144,34 @@ export class AzureOperations {
       throw new ZipDeployError(e);
     }
 
-    if (!res || !utils.isHttpCodeOkOrCreated(res?.status)) {
+    if (!res || !utils.isHttpCodeAccepted(res?.status)) {
       throw new ZipDeployError();
     }
+
+    return res.headers.location;
+  }
+
+  public static async CheckDeployStatus(location: string, config: any): Promise<void> {
+    let res = undefined;
+    for (let i = 0; i < DeployStatus.RETRY_TIMES; ++i) {
+      try {
+        res = await axios.get(location, config);
+      } catch (e) {
+        throw new DeployStatusError(e);
+      }
+
+      if (res) {
+        if (utils.isHttpCodeAccepted(res?.status)) {
+          await waitSeconds(DeployStatus.BACKOFF_TIME_S);
+        } else if (utils.isHttpCodeOkOrCreated(res?.status)) {
+          return;
+        } else {
+          throw new DeployStatusError();
+        }
+      }
+    }
+
+    throw new DeployTimeoutError();
   }
 
   public static async RestartWebApp(

--- a/packages/fx-core/src/plugins/resource/bot/constants.ts
+++ b/packages/fx-core/src/plugins/resource/bot/constants.ts
@@ -146,6 +146,11 @@ export class Retry {
   public static readonly BACKOFF_TIME_MS = 5000;
 }
 
+export class DeployStatus {
+  public static readonly RETRY_TIMES = 60;
+  public static readonly BACKOFF_TIME_S = 10;
+}
+
 export class ErrorNames {
   // System Exceptions
   public static readonly PRECONDITION_ERROR = "PreconditionError";
@@ -154,6 +159,8 @@ export class ErrorNames {
   public static readonly CONFIG_VALIDATION_ERROR = "ConfigValidationError";
   public static readonly LIST_PUBLISHING_CREDENTIALS_ERROR = "ListPublishingCredentialsError";
   public static readonly ZIP_DEPLOY_ERROR = "ZipDeployError";
+  public static readonly DEPLOY_STATUS_ERROR = "DeployStatusError";
+  public static readonly DEPLOY_TIMEOUT_ERROR = "DeployTimeoutError";
   public static readonly RESTART_WEBAPP_ERROR = "RestartWebappError";
   public static readonly MSG_ENDPOINT_UPDATING_ERROR = "MessageEndpointUpdatingError";
   public static readonly COMMAND_EXECUTION_ERROR = "CommandExecutionError";

--- a/packages/fx-core/src/plugins/resource/bot/errors.ts
+++ b/packages/fx-core/src/plugins/resource/bot/errors.ts
@@ -260,7 +260,27 @@ export class ZipDeployError extends PluginError {
   }
 }
 
-// TODO: merge and update message
+export class DeployStatusError extends PluginError {
+  constructor(innerError?: InnerError) {
+    super(
+      ErrorType.USER,
+      ErrorNames.DEPLOY_STATUS_ERROR,
+      Messages.FailToCheckDeployStatus,
+      [Messages.CheckOutputLogAndTryToFix, Messages.RetryTheCurrentStep],
+      innerError
+    );
+  }
+}
+
+export class DeployTimeoutError extends PluginError {
+  constructor() {
+    super(ErrorType.USER, ErrorNames.DEPLOY_TIMEOUT_ERROR, Messages.CheckDeployStatusTimeout, [
+      Messages.CheckOutputLogAndTryToFix,
+      Messages.RetryTheCurrentStep,
+    ]);
+  }
+}
+
 export class RestartWebAppError extends PluginError {
   constructor(innerError?: InnerError) {
     super(

--- a/packages/fx-core/src/plugins/resource/bot/functionsHostedBot/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/bot/functionsHostedBot/plugin.ts
@@ -205,7 +205,8 @@ export class FunctionsHostedBotImpl extends TeamsBotImpl {
 
     const zipDeployEndpoint: string = getZipDeployEndpoint(this.config.provision.siteName!);
     await handler?.next(ProgressBarConstants.DEPLOY_STEP_ZIP_DEPLOY);
-    await AzureOperations.ZipDeployPackage(zipDeployEndpoint, zipBuffer, config);
+    const statusUrl = await AzureOperations.ZipDeployPackage(zipDeployEndpoint, zipBuffer, config);
+    await AzureOperations.CheckDeployStatus(statusUrl, config);
 
     await AzureOperations.RestartWebApp(
       webSiteMgmtClient,

--- a/packages/fx-core/src/plugins/resource/bot/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/bot/plugin.ts
@@ -59,6 +59,7 @@ import { generateBicepFromFile, isConfigUnifyEnabled } from "../../../common/too
 import { isBotNotificationEnabled } from "../../../common/featureFlags";
 import { PluginImpl } from "./interface";
 import { BOT_ID } from "../appstudio/constants";
+import { CommonConstants } from "./functionsHostedBot/constants";
 
 export class TeamsBotImpl implements PluginImpl {
   // Made config public, because expect the upper layer to fill inputs.
@@ -341,7 +342,8 @@ export class TeamsBotImpl implements PluginImpl {
 
     const zipDeployEndpoint: string = getZipDeployEndpoint(this.config.provision.siteName!);
     await handler?.next(ProgressBarConstants.DEPLOY_STEP_ZIP_DEPLOY);
-    await AzureOperations.ZipDeployPackage(zipDeployEndpoint, zipBuffer, config);
+    const statusUrl = await AzureOperations.ZipDeployPackage(zipDeployEndpoint, zipBuffer, config);
+    await AzureOperations.CheckDeployStatus(statusUrl, config);
 
     await deployMgr.updateLastDeployTime(deployTimeCandidate);
 

--- a/packages/fx-core/src/plugins/resource/bot/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/bot/plugin.ts
@@ -59,7 +59,6 @@ import { generateBicepFromFile, isConfigUnifyEnabled } from "../../../common/too
 import { isBotNotificationEnabled } from "../../../common/featureFlags";
 import { PluginImpl } from "./interface";
 import { BOT_ID } from "../appstudio/constants";
-import { CommonConstants } from "./functionsHostedBot/constants";
 
 export class TeamsBotImpl implements PluginImpl {
   // Made config public, because expect the upper layer to fill inputs.

--- a/packages/fx-core/src/plugins/resource/bot/resources/messages.ts
+++ b/packages/fx-core/src/plugins/resource/bot/resources/messages.ts
@@ -45,6 +45,16 @@ export class Messages {
     getDefaultString("plugins.bot.FailedDeployZipFile"),
     getLocalizedString("plugins.bot.FailedDeployZipFile"),
   ];
+  public static readonly FailToCheckDeployStatus: [string, string] = [
+    getDefaultString("plugins.bot.FailedCheckDeployStatus"),
+    getLocalizedString("plugins.bot.FailedCheckDeployStatus"),
+  ];
+
+  public static readonly CheckDeployStatusTimeout: [string, string] = [
+    getDefaultString("plugins.bot.CheckDeployStatusTimeout"),
+    getLocalizedString("plugins.bot.CheckDeployStatusTimeout"),
+  ];
+
   public static readonly FailToRestartWebApp: [string, string] = [
     getDefaultString("plugins.bot.FailedRestartWebApp"),
     getLocalizedString("plugins.bot.FailedRestartWebApp"),

--- a/packages/fx-core/src/plugins/resource/bot/utils/common.ts
+++ b/packages/fx-core/src/plugins/resource/bot/utils/common.ts
@@ -128,7 +128,7 @@ export function isHttpCodeOkOrCreated(code: number): boolean {
 }
 
 export function isHttpCodeAccepted(code: number): boolean {
-  return [202].includes(code);
+  return code === 202;
 }
 
 export function convertToLangKey(programmingLanguage: ProgrammingLanguage): string {

--- a/packages/fx-core/src/plugins/resource/bot/utils/common.ts
+++ b/packages/fx-core/src/plugins/resource/bot/utils/common.ts
@@ -127,6 +127,10 @@ export function isHttpCodeOkOrCreated(code: number): boolean {
   return [200, 201].includes(code);
 }
 
+export function isHttpCodeAccepted(code: number): boolean {
+  return [202].includes(code);
+}
+
 export function convertToLangKey(programmingLanguage: ProgrammingLanguage): string {
   switch (programmingLanguage) {
     case ProgrammingLanguage.JavaScript: {

--- a/packages/fx-core/src/plugins/resource/bot/utils/zipDeploy.ts
+++ b/packages/fx-core/src/plugins/resource/bot/utils/zipDeploy.ts
@@ -2,5 +2,5 @@
 // Licensed under the MIT license.
 
 export function getZipDeployEndpoint(siteName: string): string {
-  return `https://${siteName}.scm.azurewebsites.net/api/zipdeploy`;
+  return `https://${siteName}.scm.azurewebsites.net/api/zipdeploy?isAsync=true`;
 }

--- a/packages/fx-core/src/plugins/resource/bot/v3/index.ts
+++ b/packages/fx-core/src/plugins/resource/bot/v3/index.ts
@@ -523,7 +523,8 @@ export class NodeJSBotPluginV3 implements v3.PluginV3 {
 
     const zipDeployEndpoint: string = getZipDeployEndpoint(botConfig.siteName);
     await handler?.next(ProgressBarConstants.DEPLOY_STEP_ZIP_DEPLOY);
-    await AzureOperations.ZipDeployPackage(zipDeployEndpoint, zipBuffer, config);
+    const statusUrl = await AzureOperations.ZipDeployPackage(zipDeployEndpoint, zipBuffer, config);
+    await AzureOperations.CheckDeployStatus(statusUrl, config);
 
     await deployMgr.updateLastDeployTime(deployTimeCandidate);
 

--- a/packages/fx-core/tests/plugins/resource/bot/unit/index.test.ts
+++ b/packages/fx-core/tests/plugins/resource/bot/unit/index.test.ts
@@ -481,7 +481,8 @@ describe("Teams Bot Resource Plugin", () => {
         publishingUserName: "test-username",
         publishingPassword: "test-password",
       });
-      sinon.stub(AzureOperations, "ZipDeployPackage").resolves();
+      sinon.stub(AzureOperations, "ZipDeployPackage").resolves("");
+      sinon.stub(AzureOperations, "CheckDeployStatus").resolves();
     });
 
     afterEach(async () => {
@@ -531,7 +532,8 @@ describe("Teams Bot Resource Plugin", () => {
         publishingPassword: "test-password",
       });
       sinon.stub(AzureOperations, "RestartWebApp").resolves();
-      sinon.stub(AzureOperations, "ZipDeployPackage").resolves();
+      sinon.stub(AzureOperations, "ZipDeployPackage").resolves("");
+      sinon.stub(AzureOperations, "CheckDeployStatus").resolves();
     });
 
     afterEach(async () => {
@@ -566,7 +568,8 @@ describe("Teams Bot Resource Plugin", () => {
         publishingUserName: "test-username",
         publishingPassword: "test-password",
       });
-      sinon.stub(AzureOperations, "ZipDeployPackage").resolves();
+      sinon.stub(AzureOperations, "ZipDeployPackage").resolves("");
+      sinon.stub(AzureOperations, "CheckDeployStatus").resolves();
       sinon.stub(fs, "pathExists").resolves(true);
     });
 

--- a/packages/fx-core/tests/plugins/resource/bot/unit/utils/zipDeploy.test.ts
+++ b/packages/fx-core/tests/plugins/resource/bot/unit/utils/zipDeploy.test.ts
@@ -16,7 +16,7 @@ describe("Test zipDeploy", () => {
 
       // Assert
       chai.assert.isTrue(
-        deployEndpoint === `https://${siteName}.scm.azurewebsites.net/api/zipdeploy`
+        deployEndpoint === `https://${siteName}.scm.azurewebsites.net/api/zipdeploy?isAsync=true`
       );
     });
   });


### PR DESCRIPTION
A limit of app service is that the deploy API will response 500 (Request Timed Out) after approx 230s. Now the first-time deployment may spend about 8 mins. Our solution is to use the [async zip deployment API]((https://github.com/projectkudu/kudu/wiki/Deploying-from-a-zip-file-or-url)) to check the deployment status.

Detail: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14103329/
