### PR TITLE
fix(bot): set deploy timeout to 20 min

### DIFF
--- a/packages/fx-core/src/plugins/resource/bot/azureOps.ts
+++ b/packages/fx-core/src/plugins/resource/bot/azureOps.ts
@@ -20,6 +20,8 @@ import { waitSeconds } from "../../../common";
 import { DeployStatus } from "./constants";
 
 export class AzureOperations {
+  private static readonly axiosInstance = axios.create();
+
   public static async UpdateBotChannelRegistration(
     botClient: AzureBotService,
     resourceGroup: string,
@@ -137,10 +139,9 @@ export class AzureOperations {
     zipBuffer: Buffer,
     config: any
   ): Promise<string> {
-    const axiosInstance = axios.create();
     let res = undefined;
     try {
-      res = await axiosInstance.post(zipDeployEndpoint, zipBuffer, config);
+      res = await AzureOperations.axiosInstance.post(zipDeployEndpoint, zipBuffer, config);
     } catch (e) {
       throw new ZipDeployError(e);
     }
@@ -153,11 +154,10 @@ export class AzureOperations {
   }
 
   public static async CheckDeployStatus(location: string, config: any): Promise<void> {
-    const axiosInstance = axios.create();
     let res = undefined;
     for (let i = 0; i < DeployStatus.RETRY_TIMES; ++i) {
       try {
-        res = await axiosInstance.get(location, config);
+        res = await AzureOperations.axiosInstance.get(location, config);
       } catch (e) {
         throw new DeployStatusError(e);
       }

--- a/packages/fx-core/src/plugins/resource/bot/azureOps.ts
+++ b/packages/fx-core/src/plugins/resource/bot/azureOps.ts
@@ -137,9 +137,10 @@ export class AzureOperations {
     zipBuffer: Buffer,
     config: any
   ): Promise<string> {
+    const axiosInstance = axios.create();
     let res = undefined;
     try {
-      res = await axios.post(zipDeployEndpoint, zipBuffer, config);
+      res = await axiosInstance.post(zipDeployEndpoint, zipBuffer, config);
     } catch (e) {
       throw new ZipDeployError(e);
     }
@@ -152,10 +153,11 @@ export class AzureOperations {
   }
 
   public static async CheckDeployStatus(location: string, config: any): Promise<void> {
+    const axiosInstance = axios.create();
     let res = undefined;
     for (let i = 0; i < DeployStatus.RETRY_TIMES; ++i) {
       try {
-        res = await axios.get(location, config);
+        res = await axiosInstance.get(location, config);
       } catch (e) {
         throw new DeployStatusError(e);
       }

--- a/packages/fx-core/src/plugins/resource/bot/constants.ts
+++ b/packages/fx-core/src/plugins/resource/bot/constants.ts
@@ -147,7 +147,7 @@ export class Retry {
 }
 
 export class DeployStatus {
-  public static readonly RETRY_TIMES = 60;
+  public static readonly RETRY_TIMES = 120; // Timeout: 20 min
   public static readonly BACKOFF_TIME_S = 10;
 }
 


### PR DESCRIPTION
fix the comments in PR: https://github.com/OfficeDev/TeamsFx/pull/4720
If `always on` is enabled, the deployment will never be timeout. 
If `always on` is closed, the deployment will be timeout after 20 min. https://github.com/projectkudu/kudu/wiki/Investigating-issues#deployment-process-got-terminated-due-to-idle-timeout