### PR TITLE
fix(vsc): upgrade lowest vscode engine version

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "engines": {
-    "vscode": "^1.58.0"
+    "vscode": "^1.64.0"
   },
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
Fix CD error that "@types/vscode ^1.64.0 greater than engines.vscode ^1.58.0."

E2E TEST: N/A