### PR TITLE
perf: update msg

### DIFF
--- a/packages/fx-core/src/plugins/resource/apiconnector/errors.ts
+++ b/packages/fx-core/src/plugins/resource/apiconnector/errors.ts
@@ -62,7 +62,7 @@ export class ErrorMessage {
   };
 
   public static readonly NoValidCompoentExistError = {
-    name: "NoValidCompoentExistError",
+    name: "NoBotOrFunctionExistError",
     message: (): ApiConnectionMsg =>
       ErrorMessage.getMessages(`error.apiConnector.${ErrorMessage.NoValidCompoentExistError.name}`),
   };

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -716,8 +716,6 @@ export async function connectExistingApiHandler(args?: any[]): Promise<Result<nu
 
   const res = await runUserTask(func, TelemetryEvent.ConnectExistingApi, true);
   if (!res.isOk()) {
-    showError(res.error);
-    ExtTelemetry.sendTelemetryErrorEvent(TelemetryEvent.ConnectExistingApi, res.error);
     return err(res.error);
   }
 


### PR DESCRIPTION
https://dev.azure.com/msazure/Microsoft%20Teams%20Extensibility/_workitems/edit/14171495

fx-core already sendTelemetryEvent once, and showErrorMsg, no need to do again on extension handler