### PR TITLE
perf(aad-manifest): update aad manifest migration middleware

### DIFF
--- a/packages/fx-core/resource/aad-manifest-change-logs.md
+++ b/packages/fx-core/resource/aad-manifest-change-logs.md
@@ -1,0 +1,27 @@
+# Congratulations! You have successfully upgraded your Teams App project structure.
+
+We have updated the configuration files so that your project is compatible with the latest Teams Toolkit features, including add a AAD manifest template file.
+
+> Import Notes: If you collaborate on this project with your co-workers, and his teams toolkit extension version <= 3.7.0, please ensure your team members update the Teams Toolkit extension to the latest version after committing the changes with this upgrade.
+
+## Why upgrade
+Teams Toolkit continues to improve your Teams application development experience. We are upgrading the Teams app project structure so that you can:
+
+1. Use AAD manifest template to customize your AAD app.
+1. Allow to add single sign-on (SSO) feature for Bot (hosting on Azure App Service), Messaging Extension, Static Launch Page, and Embed existing web App
+
+## Know about the changes we made
+After the project upgrade, there are following changes we made:
+1. Update `.fx\configs\projectSettings.json` capabilities to include TabSSO and/or BotSSO based on original project capabilities.
+1. AAD manifest template file will be added to `templates\appPackage\aad.template.json`
+1. The required resource access information in `permissions.json` file will be merged into `aad.template.json` file
+
+## Know about how to restore your project
+If anything went wrong after the upgrade process, you could restore your old project configuration files by:
+* Copy the .backup/.fx folder to your project root path.
+* Delete `templates\appPackage\aad.template.json` file if needed
+
+
+
+
+

--- a/packages/fx-core/resource/aad-manifest-change-logs.md
+++ b/packages/fx-core/resource/aad-manifest-change-logs.md
@@ -14,7 +14,7 @@ Teams Toolkit continues to improve your Teams application development experience
 After the project upgrade, there are following changes we made:
 1. Update `.fx\configs\projectSettings.json` capabilities to include TabSSO and/or BotSSO based on original project capabilities.
 1. AAD manifest template file will be added to `templates\appPackage\aad.template.json`
-1. The required resource access information in `permissions.json` file will be merged into `aad.template.json` file and `permissions.json file` will be deprecated, please customize `requiredResourceAccess` property in `aad.template.json` file.
+1. The required resource access information in `permissions.json` file will be merged into `aad.template.json` file and `permissions.json` file will be deprecated, please customize `requiredResourceAccess` property in `aad.template.json` file.
 
 ## Know about how to restore your project
 If anything went wrong after the upgrade process, you could restore your old project configuration files by:

--- a/packages/fx-core/resource/aad-manifest-change-logs.md
+++ b/packages/fx-core/resource/aad-manifest-change-logs.md
@@ -14,7 +14,7 @@ Teams Toolkit continues to improve your Teams application development experience
 After the project upgrade, there are following changes we made:
 1. Update `.fx\configs\projectSettings.json` capabilities to include TabSSO and/or BotSSO based on original project capabilities.
 1. AAD manifest template file will be added to `templates\appPackage\aad.template.json`
-1. The required resource access information in `permissions.json` file will be merged into `aad.template.json` file and `permission.json file` will be deprecated, please customize `requiredResourceAccess` property in `aad.template.json` file.
+1. The required resource access information in `permissions.json` file will be merged into `aad.template.json` file and `permissions.json file` will be deprecated, please customize `requiredResourceAccess` property in `aad.template.json` file.
 
 ## Know about how to restore your project
 If anything went wrong after the upgrade process, you could restore your old project configuration files by:

--- a/packages/fx-core/resource/aad-manifest-change-logs.md
+++ b/packages/fx-core/resource/aad-manifest-change-logs.md
@@ -14,8 +14,7 @@ Teams Toolkit continues to improve your Teams application development experience
 After the project upgrade, there are following changes we made:
 1. Update `.fx\configs\projectSettings.json` capabilities to include TabSSO and/or BotSSO based on original project capabilities.
 1. AAD manifest template file will be added to `templates\appPackage\aad.template.json`
-1. The required resource access information in `permissions.json` file will be merged into `aad.template.json` file.
-1. `permissions.json` file will not be used any more, you can update permissions using `requiredResourceAccess` property in `aad.template.json` file. You can safely delete `permissions.json` file if you and your co-workers do not use Teams Toolkit extension version <= 3.7.0.
+1. The required resource access information in `permissions.json` file will be merged into `aad.template.json` file and `permission.json file` will be deprecated, please customize `requiredResourceAccess` property in `aad.template.json` file.
 
 ## Know about how to restore your project
 If anything went wrong after the upgrade process, you could restore your old project configuration files by:

--- a/packages/fx-core/resource/aad-manifest-change-logs.md
+++ b/packages/fx-core/resource/aad-manifest-change-logs.md
@@ -14,7 +14,8 @@ Teams Toolkit continues to improve your Teams application development experience
 After the project upgrade, there are following changes we made:
 1. Update `.fx\configs\projectSettings.json` capabilities to include TabSSO and/or BotSSO based on original project capabilities.
 1. AAD manifest template file will be added to `templates\appPackage\aad.template.json`
-1. The required resource access information in `permissions.json` file will be merged into `aad.template.json` file
+1. The required resource access information in `permissions.json` file will be merged into `aad.template.json` file.
+1. `permissions.json` file will not be used any more, you can update permissions using `requiredResourceAccess` property in `aad.template.json` file. You can safely delete `permissions.json` file if you and your co-workers do not use Teams Toolkit extension version <= 3.7.0.
 
 ## Know about how to restore your project
 If anything went wrong after the upgrade process, you could restore your old project configuration files by:


### PR DESCRIPTION
1. Do not show modal dialog when open old project
2. Generate aad-manifest-change-logs.md file after migration success
3. Add learn more button