### PR TITLE
fix: add @types/node hint

### DIFF
--- a/templates/bot/ts/command-and-response/package.json
+++ b/templates/bot/ts/command-and-response/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@types/fs-extra": "^9.0.13",
+    "@types/node": "^14.18.0",
     "@types/node-cron": "^3.0.1",
     "@types/restify": "8.4.2",
     "env-cmd": "^10.1.0",

--- a/templates/bot/ts/notification-function-base/package.json
+++ b/templates/bot/ts/notification-function-base/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@azure/functions": "^1.2.3",
+    "@types/node": "^14.18.0",
     "azurite": "^3.16.0",
     "env-cmd": "^10.1.0",
     "ts-node": "~9.1.1",

--- a/templates/bot/ts/notification-restify/package.json
+++ b/templates/bot/ts/notification-restify/package.json
@@ -24,6 +24,7 @@
     "restify": "^8.5.1"
   },
   "devDependencies": {
+    "@types/node": "^14.18.0",
     "@types/restify": "8.4.2",
     "env-cmd": "^10.1.0",
     "nodemon": "^2.0.7",


### PR DESCRIPTION
Fix https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14171601

There are build failures when using @types/fs-extra 9 and @types/node <= 12.
Force command/notification templates to use @types/node 14 to avoid such errors. (Here uses 14 since our toolkit recommends Node 14)