### PR TITLE
perf(aad-manifest): partially disable aad manifest json intellisense

### DIFF
--- a/packages/fx-core/src/plugins/solution/fx-solution/debug/scaffolding.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/debug/scaffolding.ts
@@ -115,15 +115,6 @@ export async function _scaffoldLocalDebugSettings(
             EOL: os.EOL,
           }
         );
-
-        await fs.writeJSON(
-          `${inputs.projectPath}/.vscode/settings.json`,
-          Settings.generateSettings(false),
-          {
-            spaces: 4,
-            EOL: os.EOL,
-          }
-        );
       } else {
         const launchConfigurations = isM365
           ? LaunchNext.generateM365Configurations(includeFrontend, includeBackend, includeBot)
@@ -196,7 +187,7 @@ export async function _scaffoldLocalDebugSettings(
 
       await fs.writeJSON(
         `${inputs.projectPath}/.vscode/settings.json`,
-        Settings.generateSettings(includeBackend || includeFuncHostedBot),
+        Settings.generateSettings(includeBackend || includeFuncHostedBot, isSpfx),
         {
           spaces: 4,
           EOL: os.EOL,

--- a/packages/fx-core/src/plugins/solution/fx-solution/debug/util/settings.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/debug/util/settings.ts
@@ -2,13 +2,28 @@
 // Licensed under the MIT license.
 "use strict";
 
-export function generateSettings(includeFunctions: boolean): Record<string, unknown> {
+import { isAadManifestEnabled } from "../../../../../common";
+
+export function generateSettings(
+  includeFunctions: boolean,
+  isSpfx: boolean
+): Record<string, unknown> {
   /**
    * Default settings for extensions
    */
   const settings: Record<string, unknown> = {
     "debug.onTaskErrors": "abort",
   };
+
+  if (!isSpfx && isAadManifestEnabled()) {
+    settings["json.schemas"] = [
+      {
+        fileMatch: ["/aad.*.json"],
+        schema: {},
+      },
+    ];
+  }
+
   if (includeFunctions) {
     // Ensure that Azure Function Extension does not kill the backend process
     settings["azureFunctions.stopFuncTaskPostDebug"] = false;

--- a/packages/fx-core/tests/plugins/solution/debug/solution.debug.scaffolding.test.ts
+++ b/packages/fx-core/tests/plugins/solution/debug/solution.debug.scaffolding.test.ts
@@ -19,7 +19,7 @@ import {
   BotScenario,
 } from "../../../../src/plugins/solution/fx-solution/question";
 import { BotCapabilities, PluginBot } from "../../../../src/plugins/resource/bot/resources/strings";
-import { BotHostTypes } from "../../../../src/common";
+import { BotHostTypes, isAadManifestEnabled } from "../../../../src/common";
 
 const numAADLocalEnvs = 2;
 const numSimpleAuthLocalEnvs = 10;
@@ -108,7 +108,17 @@ describe("solution.debug.scaffolding", () => {
           Object.keys(settings).some((key) => key === "azureFunctions.stopFuncTaskPostDebug")
         );
         chai.assert.equal(settings["azureFunctions.stopFuncTaskPostDebug"], false);
-        chai.assert.equal(Object.keys(settings).length, 4);
+        if (isAadManifestEnabled()) {
+          chai.assert.equal(Object.keys(settings).length, 5);
+          chai.assert.deepEqual(settings["json.schemas"], [
+            {
+              fileMatch: ["/aad.*.json"],
+              schema: {},
+            },
+          ]);
+        } else {
+          chai.assert.equal(Object.keys(settings).length, 4);
+        }
       });
     });
 
@@ -160,7 +170,17 @@ describe("solution.debug.scaffolding", () => {
 
         //assert output settings.json
         const settings = fs.readJSONSync(expectedSettingsFile);
-        chai.assert.equal(Object.keys(settings).length, 1);
+        if (isAadManifestEnabled()) {
+          chai.assert.equal(Object.keys(settings).length, 2);
+          chai.assert.deepEqual(settings["json.schemas"], [
+            {
+              fileMatch: ["/aad.*.json"],
+              schema: {},
+            },
+          ]);
+        } else {
+          chai.assert.equal(Object.keys(settings).length, 1);
+        }
       });
 
       it(`happy path: tab with Simple Auth and without function (${parameter.programmingLanguage})`, async () => {
@@ -194,7 +214,17 @@ describe("solution.debug.scaffolding", () => {
 
         //assert output settings.json
         const settings = fs.readJSONSync(expectedSettingsFile);
-        chai.assert.equal(Object.keys(settings).length, 1);
+        if (isAadManifestEnabled()) {
+          chai.assert.equal(Object.keys(settings).length, 2);
+          chai.assert.deepEqual(settings["json.schemas"], [
+            {
+              fileMatch: ["/aad.*.json"],
+              schema: {},
+            },
+          ]);
+        } else {
+          chai.assert.equal(Object.keys(settings).length, 1);
+        }
       });
 
       it(`happy path: tab without function (${parameter.programmingLanguage}) and AAD`, async () => {
@@ -228,7 +258,17 @@ describe("solution.debug.scaffolding", () => {
 
         //assert output settings.json
         const settings = fs.readJSONSync(expectedSettingsFile);
-        chai.assert.equal(Object.keys(settings).length, 1);
+        if (isAadManifestEnabled()) {
+          chai.assert.equal(Object.keys(settings).length, 2);
+          chai.assert.deepEqual(settings["json.schemas"], [
+            {
+              fileMatch: ["/aad.*.json"],
+              schema: {},
+            },
+          ]);
+        } else {
+          chai.assert.equal(Object.keys(settings).length, 1);
+        }
       });
     });
 
@@ -279,7 +319,17 @@ describe("solution.debug.scaffolding", () => {
 
         //assert output settings.json
         const settings = fs.readJSONSync(expectedSettingsFile);
-        chai.assert.equal(Object.keys(settings).length, 1);
+        if (isAadManifestEnabled()) {
+          chai.assert.equal(Object.keys(settings).length, 2);
+          chai.assert.deepEqual(settings["json.schemas"], [
+            {
+              fileMatch: ["/aad.*.json"],
+              schema: {},
+            },
+          ]);
+        } else {
+          chai.assert.equal(Object.keys(settings).length, 1);
+        }
       });
 
       it(`happy path: app service hosted command and response bot (${parameter.programmingLanguage})`, async () => {
@@ -319,7 +369,17 @@ describe("solution.debug.scaffolding", () => {
 
         //assert output settings.json
         const settings = fs.readJSONSync(expectedSettingsFile);
-        chai.assert.equal(Object.keys(settings).length, 1);
+        if (isAadManifestEnabled()) {
+          chai.assert.equal(Object.keys(settings).length, 2);
+          chai.assert.deepEqual(settings["json.schemas"], [
+            {
+              fileMatch: ["/aad.*.json"],
+              schema: {},
+            },
+          ]);
+        } else {
+          chai.assert.equal(Object.keys(settings).length, 1);
+        }
       });
     });
     const parameters99: TestParameter[] = [
@@ -381,7 +441,17 @@ describe("solution.debug.scaffolding", () => {
           Object.keys(settings).some((key) => key === "azureFunctions.stopFuncTaskPostDebug")
         );
         chai.assert.equal(settings["azureFunctions.stopFuncTaskPostDebug"], false);
-        chai.assert.equal(Object.keys(settings).length, 4);
+        if (isAadManifestEnabled()) {
+          chai.assert.equal(Object.keys(settings).length, 5);
+          chai.assert.deepEqual(settings["json.schemas"], [
+            {
+              fileMatch: ["/aad.*.json"],
+              schema: {},
+            },
+          ]);
+        } else {
+          chai.assert.equal(Object.keys(settings).length, 4);
+        }
       });
     });
 
@@ -438,7 +508,17 @@ describe("solution.debug.scaffolding", () => {
           Object.keys(settings).some((key) => key === "azureFunctions.stopFuncTaskPostDebug")
         );
         chai.assert.equal(settings["azureFunctions.stopFuncTaskPostDebug"], false);
-        chai.assert.equal(Object.keys(settings).length, 4);
+        if (isAadManifestEnabled()) {
+          chai.assert.equal(Object.keys(settings).length, 5);
+          chai.assert.deepEqual(settings["json.schemas"], [
+            {
+              fileMatch: ["/aad.*.json"],
+              schema: {},
+            },
+          ]);
+        } else {
+          chai.assert.equal(Object.keys(settings).length, 4);
+        }
       });
     });
 
@@ -490,7 +570,17 @@ describe("solution.debug.scaffolding", () => {
 
         //assert output settings.json
         const settings = fs.readJSONSync(expectedSettingsFile);
-        chai.assert.equal(Object.keys(settings).length, 1);
+        if (isAadManifestEnabled()) {
+          chai.assert.equal(Object.keys(settings).length, 2);
+          chai.assert.deepEqual(settings["json.schemas"], [
+            {
+              fileMatch: ["/aad.*.json"],
+              schema: {},
+            },
+          ]);
+        } else {
+          chai.assert.equal(Object.keys(settings).length, 1);
+        }
       });
 
       it(`happy path: tab with Simple Auth and without function and bot (${parameter.programmingLanguage})`, async () => {
@@ -524,7 +614,17 @@ describe("solution.debug.scaffolding", () => {
 
         //assert output settings.json
         const settings = fs.readJSONSync(expectedSettingsFile);
-        chai.assert.equal(Object.keys(settings).length, 1);
+        if (isAadManifestEnabled()) {
+          chai.assert.equal(Object.keys(settings).length, 2);
+          chai.assert.deepEqual(settings["json.schemas"], [
+            {
+              fileMatch: ["/aad.*.json"],
+              schema: {},
+            },
+          ]);
+        } else {
+          chai.assert.equal(Object.keys(settings).length, 1);
+        }
       });
 
       it(`happy path: tab without function and bot (${parameter.programmingLanguage}) and AAD`, async () => {
@@ -558,7 +658,17 @@ describe("solution.debug.scaffolding", () => {
 
         //assert output settings.json
         const settings = fs.readJSONSync(expectedSettingsFile);
-        chai.assert.equal(Object.keys(settings).length, 1);
+        if (isAadManifestEnabled()) {
+          chai.assert.equal(Object.keys(settings).length, 2);
+          chai.assert.deepEqual(settings["json.schemas"], [
+            {
+              fileMatch: ["/aad.*.json"],
+              schema: {},
+            },
+          ]);
+        } else {
+          chai.assert.equal(Object.keys(settings).length, 1);
+        }
       });
     });
 
@@ -611,7 +721,17 @@ describe("solution.debug.scaffolding", () => {
 
         //assert output settings.json
         const settings = fs.readJSONSync(expectedSettingsFile);
-        chai.assert.equal(Object.keys(settings).length, 1);
+        if (isAadManifestEnabled()) {
+          chai.assert.equal(Object.keys(settings).length, 2);
+          chai.assert.deepEqual(settings["json.schemas"], [
+            {
+              fileMatch: ["/aad.*.json"],
+              schema: {},
+            },
+          ]);
+        } else {
+          chai.assert.equal(Object.keys(settings).length, 1);
+        }
       });
     });
 
@@ -663,7 +783,17 @@ describe("solution.debug.scaffolding", () => {
 
         //assert output settings.json
         const settings = fs.readJSONSync(expectedSettingsFile);
-        chai.assert.equal(Object.keys(settings).length, 1);
+        if (isAadManifestEnabled()) {
+          chai.assert.equal(Object.keys(settings).length, 2);
+          chai.assert.deepEqual(settings["json.schemas"], [
+            {
+              fileMatch: ["/aad.*.json"],
+              schema: {},
+            },
+          ]);
+        } else {
+          chai.assert.equal(Object.keys(settings).length, 1);
+        }
       });
     });
 


### PR DESCRIPTION
Fix this bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_sprints/taskboard/AuthAndData/Microsoft%20Teams%20Extensibility/CY22-4.2?workitem=14171623

Due to limitation of VSCode, we can only partially disable intellisense using empty JSON schema, see this issue for details: https://github.com/microsoft/vscode/issues/63270

Use empty JSON schema in VSCode settings.json file:
```
{
    "json.schemas": [
        {
            "fileMatch": [
                "/aad.*.json"
            ],
            "schema": {}
        }
    ]
}
```
