### PR TITLE
fix(vsc+core+cli): tutorial entry and feature flags

### DIFF
--- a/packages/cli/src/cmds/add.ts
+++ b/packages/cli/src/cmds/add.ts
@@ -35,7 +35,7 @@ import {
   isBotNotificationEnabled,
   isAadManifestEnabled,
   isApiConnectEnabled,
-  isGAPreviewEnabled,
+  isPreviewFeaturesEnabled,
 } from "@microsoft/teamsfx-core";
 
 export class AddCICD extends YargsCommand {
@@ -219,7 +219,7 @@ export default class Add extends YargsCommand {
   public readonly description = "Adds features to your Teams application.";
 
   public readonly subCommands: YargsCommand[] = [
-    ...(isGAPreviewEnabled()
+    ...(isPreviewFeaturesEnabled()
       ? [
           // Category 1: Add Teams Capability
           ...(isBotNotificationEnabled()

--- a/packages/cli/src/cmds/index.ts
+++ b/packages/cli/src/cmds/index.ts
@@ -5,7 +5,7 @@
 
 import { Argv } from "yargs";
 
-import { isGAPreviewEnabled } from "@microsoft/teamsfx-core";
+import { isPreviewFeaturesEnabled } from "@microsoft/teamsfx-core";
 
 import { YargsCommand } from "../yargsCommand";
 import Account from "./account";
@@ -30,7 +30,7 @@ export const commands: YargsCommand[] = [
   new Account(),
   new New(),
   new Add(),
-  ...(isGAPreviewEnabled() ? [] : [new Capability(), new Resource()]),
+  ...(isPreviewFeaturesEnabled() ? [] : [new Capability(), new Resource()]),
   new Provision(),
   new Deploy(),
   new Package(),

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,8 +7,8 @@ import "./console/screen";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 
-import { initializeGAFeatureFlags } from "@microsoft/teamsfx-core";
-initializeGAFeatureFlags();
+import { initializePreviewFeatureFlags } from "@microsoft/teamsfx-core";
+initializePreviewFeatureFlags();
 
 import { registerCommands } from "./cmds";
 import * as constants from "./constants";

--- a/packages/cli/tests/commonlib/cliHelper.ts
+++ b/packages/cli/tests/commonlib/cliHelper.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { isGAPreviewEnabled } from "@microsoft/teamsfx-core";
+import { isPreviewFeaturesEnabled } from "@microsoft/teamsfx-core";
 
 import { execAsync, execAsyncWithRetry } from "../e2e/commonUtils";
 import { Capability, Resource, ResourceToDeploy } from "./constants";
@@ -210,7 +210,7 @@ export class CliHelper {
   }
 
   static async addCapabilityToProject(projectPath: string, capabilityToAdd: Capability) {
-    const command = isGAPreviewEnabled()
+    const command = isPreviewFeaturesEnabled()
       ? `teamsfx add ${capabilityToAdd}`
       : `teamsfx capability add ${capabilityToAdd}`;
     const timeout = 100000;
@@ -240,7 +240,7 @@ export class CliHelper {
     options = "",
     processEnv?: NodeJS.ProcessEnv
   ) {
-    const command = isGAPreviewEnabled()
+    const command = isPreviewFeaturesEnabled()
       ? `teamsfx add ${resourceToAdd} ${options}`
       : `teamsfx resource add ${resourceToAdd} ${options}`;
     const timeout = 100000;

--- a/packages/cli/tests/e2e/command/argumentCheck.tests.ts
+++ b/packages/cli/tests/e2e/command/argumentCheck.tests.ts
@@ -5,7 +5,7 @@
  * @author Zhiyu You <zhiyou@microsoft.com>
  */
 
-import { isGAPreviewEnabled } from "@microsoft/teamsfx-core";
+import { isPreviewFeaturesEnabled } from "@microsoft/teamsfx-core";
 import { expect } from "chai";
 
 import { execAsync } from "../commonUtils";
@@ -13,7 +13,7 @@ import { execAsync } from "../commonUtils";
 describe("teamsfx command argument check", function () {
   it(`teamsfx add me`, async function () {
     try {
-      const command = isGAPreviewEnabled() ? `teamsfx add me` : `teamsfx capability add me`;
+      const command = isPreviewFeaturesEnabled() ? `teamsfx add me` : `teamsfx capability add me`;
       await execAsync(command, {
         env: process.env,
         timeout: 0,

--- a/packages/cli/tests/e2e/command/helpInfo.tests.ts
+++ b/packages/cli/tests/e2e/command/helpInfo.tests.ts
@@ -5,7 +5,7 @@
  * @author Zhiyu You <zhiyou@microsoft.com>
  */
 
-import { isGAPreviewEnabled } from "@microsoft/teamsfx-core";
+import { isPreviewFeaturesEnabled } from "@microsoft/teamsfx-core";
 import { expect } from "chai";
 
 import { execAsync } from "../commonUtils";
@@ -20,7 +20,7 @@ describe("teamsfx command help", function () {
   });
 
   it(`teamsfx add azure-apim -h`, async function () {
-    const command = isGAPreviewEnabled()
+    const command = isPreviewFeaturesEnabled()
       ? `teamsfx add azure-apim -h`
       : `teamsfx resource add azure-apim -h`;
     const result = await execAsync(command, {

--- a/packages/fx-core/src/common/constants.ts
+++ b/packages/fx-core/src/common/constants.ts
@@ -76,7 +76,7 @@ export class FeatureFlagName {
   static readonly GeneratorCheckerEnable = "TEAMSFX_GENERATOR_ENV_CHECKER_ENABLE";
   static readonly ApiConnect = "TEAMSFX_API_CONNECT_ENABLE";
   static readonly DeployManifest = "TEAMSFX_DEPLOY_MANIFEST";
-  static readonly GAPreview = "TEAMSFX_GA_PREVIEW";
+  static readonly Preview = "TEAMSFX_PREVIEW";
 }
 
 export class ManifestVariables {

--- a/packages/fx-core/src/common/featureFlags.ts
+++ b/packages/fx-core/src/common/featureFlags.ts
@@ -14,10 +14,10 @@ export function isFeatureFlagEnabled(featureFlagName: string, defaultValue = fal
 }
 
 /**
- * Update feature flags related to GA.
+ * Update all preview feature flags.
  */
-export function initializeGAFeatureFlags(): void {
-  if (isFeatureFlagEnabled(FeatureFlagName.GAPreview, false)) {
+export function initializePreviewFeatureFlags(): void {
+  if (isFeatureFlagEnabled(FeatureFlagName.Preview, false)) {
     process.env[FeatureFlagName.BotNotification] = "true";
     process.env[FeatureFlagName.M365App] = "true";
     process.env[FeatureFlagName.ExistingTabApp] = "true";
@@ -32,6 +32,6 @@ export function isBotNotificationEnabled(): boolean {
   return isFeatureFlagEnabled(FeatureFlagName.BotNotification, false);
 }
 
-export function isGAPreviewEnabled(): boolean {
-  return isFeatureFlagEnabled(FeatureFlagName.GAPreview, false);
+export function isPreviewFeaturesEnabled(): boolean {
+  return isFeatureFlagEnabled(FeatureFlagName.Preview, false);
 }

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/getQuestions.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/getQuestions.ts
@@ -61,7 +61,10 @@ import { canAddCapability, canAddResource } from "./executeUserTask";
 import { NoCapabilityFoundError } from "../../../../core/error";
 import { isVSProject } from "../../../../common/projectSettingsHelper";
 import { isAadManifestEnabled, isDeployManifestEnabled } from "../../../../common/tools";
-import { isBotNotificationEnabled, isGAPreviewEnabled } from "../../../../common/featureFlags";
+import {
+  isBotNotificationEnabled,
+  isPreviewFeaturesEnabled,
+} from "../../../../common/featureFlags";
 import {
   ProgrammingLanguageQuestion,
   onChangeSelectionForCapabilities,
@@ -128,7 +131,7 @@ export async function getQuestionsForScaffolding(
   const tabRes = await getTabScaffoldQuestionsV2(
     ctx,
     inputs,
-    !isGAPreviewEnabled() && CLIPlatforms.includes(inputs.platform) // only CLI and CLI_HELP support azure-resources question
+    !isPreviewFeaturesEnabled() && CLIPlatforms.includes(inputs.platform) // only CLI and CLI_HELP support azure-resources question
   );
   if (tabRes.isErr()) return tabRes;
   if (tabRes.value) {

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -480,7 +480,7 @@
       {
         "command": "fx-extension.addFeature",
         "title": "%teamstoolkit.commands.addFeature.title%",
-        "enablement": "!fx-extension.isSPFx && !fx-extension.isM365 && fx-entension.gaPreviewEnabled"
+        "enablement": "!fx-extension.isSPFx && !fx-extension.isM365 && fx-entension.previewFeaturesEnabled"
       },
       {
         "command": "fx-extension.openManifest",
@@ -944,25 +944,10 @@
         "title": "Experimental Features",
         "order": 3,
         "properties": {
-          "fx-extension.enableGAPreviewFeatures": {
+          "fx-extension.enablePreviewFeatures": {
             "order": 0,
             "type": "boolean",
-            "description": "Enable GA related features including notification bot, M365 app, existing app etc. (requires reload of VS Code)",
-            "default": false
-          },
-          "fx-extension.enableNotification / CommandAndResponseBot": {
-            "type": "boolean",
-            "description": "Enable notification bot and command and response bot. (requires reload of VS Code)",
-            "default": false
-          },
-          "fx-extension.enableM365App": {
-            "type": "boolean",
-            "title": "Enable Microsoft 365 App",
-            "description": "Enable to create a new Microsoft 365 app. (requires reload of VS Code)"
-          },
-          "fx-extension.enableExistingApp": {
-            "type": "boolean",
-            "description": "Enable to create a new app for existing web pages. (requires reload of VS Code)",
+            "description": "Enable a set of experimental features, including creating notification bot and command bot, extending apps across Microsoft 365, add sso and call an API. (Requires reload of VS Code)",
             "default": false
           }
         }

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -480,7 +480,7 @@
       {
         "command": "fx-extension.addFeature",
         "title": "%teamstoolkit.commands.addFeature.title%",
-        "enablement": "!fx-extension.isSPFx && !fx-extension.isM365 && fx-entension.previewFeaturesEnabled"
+        "enablement": "!fx-extension.isSPFx && fx-entension.previewFeaturesEnabled"
       },
       {
         "command": "fx-extension.openManifest",

--- a/packages/vscode-extension/package.nls.json
+++ b/packages/vscode-extension/package.nls.json
@@ -183,6 +183,7 @@
     "teamstoolkit.commandsTreeViewProvider.validateManifestTitle": "Validate App Manifest File",
     "teamstoolkit.commandsTreeViewProvider.validateManifestTitleNew": "Validate manifest file",
     "teamstoolkit.common.cancel": "Cancel",
+    "teamstoolkit.common.commingSoon": "Tutorials are in active development and will come soon in future release, please stay tuned.",
     "teamstoolkit.common.confirm": "Confirm",
     "teamstoolkit.common.readMore": "Read more",
     "teamstoolkit.common.signin": "Sign in",

--- a/packages/vscode-extension/src/constants.ts
+++ b/packages/vscode-extension/src/constants.ts
@@ -3,12 +3,9 @@ export enum ConfigurationKey {
   BicepEnvCheckerEnable = "prerequisiteCheck.bicep",
   RootDirectory = "defaultProjectRootDirectory",
   AutomaticNpmInstall = "automaticNpmInstall",
-  EnableExistingApp = "enableExistingApp",
-  BotNotificationCommandAndResponseEnabled = "enableNotification / CommandAndResponseBot",
   YoEnvCheckerEnable = "SPFxPrerequisiteCheck.yo",
   generatorEnvCheckerEnable = "SPFxPrerequisiteCheck.sharepointYeomanGenerator",
-  enableM365App = "enableM365App",
-  EnableGAPreviewFeatures = "enableGAPreviewFeatures",
+  EnablePreviewFeatures = "enablePreviewFeatures",
 }
 
 export const AzurePortalUrl = "https://portal.azure.com";

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -455,8 +455,8 @@ export async function activate(context: vscode.ExtensionContext) {
 
   vscode.commands.executeCommand(
     "setContext",
-    "fx-entension.gaPreviewEnabled",
-    isFeatureFlagEnabled(FeatureFlags.GeneralAvailablityPreview, false)
+    "fx-entension.previewFeaturesEnabled",
+    isFeatureFlagEnabled(FeatureFlags.Preview, false)
   );
 
   // Setup CodeLens provider for userdata file

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -103,6 +103,8 @@ import {
   isTriggerFromWalkThrough,
   getTriggerFromProperty,
   isExistingTabApp,
+  isFeatureFlagEnabled,
+  FeatureFlags,
 } from "./utils/commonUtils";
 import * as fs from "fs-extra";
 import { VSCodeDepsChecker } from "./debug/depsChecker/vscodeChecker";
@@ -3035,6 +3037,10 @@ export async function deployAadAppManifest(args: any[]): Promise<Result<null, Fx
 
 export async function selectTutorialsHandler(args?: any[]): Promise<Result<unknown, FxError>> {
   ExtTelemetry.sendTelemetryEvent(TelemetryEvent.ViewGuidedTutorials, getTriggerFromProperty(args));
+  if (!isFeatureFlagEnabled(FeatureFlags.Preview)) {
+    VS_CODE_UI.showMessage("info", localize("teamstoolkit.common.commingSoon"), false);
+    return ok(null);
+  }
   const config: SingleSelectConfig = {
     name: "tutorialName",
     title: "Tutorials",

--- a/packages/vscode-extension/src/treeview/treeViewManager.ts
+++ b/packages/vscode-extension/src/treeview/treeViewManager.ts
@@ -151,7 +151,7 @@ class TreeViewManager {
     );
 
     if (isNonSPFx) {
-      if (isFeatureFlagEnabled(FeatureFlags.GeneralAvailablityPreview)) {
+      if (isFeatureFlagEnabled(FeatureFlags.Preview)) {
         developmentCommand.push(
           new TreeViewCommand(
             localize("teamstoolkit.commandsTreeViewProvider.addFeatureTitle"),
@@ -272,7 +272,7 @@ class TreeViewManager {
       ),
     ];
 
-    if (!isFeatureFlagEnabled(FeatureFlags.GeneralAvailablityPreview)) {
+    if (!isFeatureFlagEnabled(FeatureFlags.Preview)) {
       deployCommand.push(
         new TreeViewCommand(
           localize("teamstoolkit.commandsTreeViewProvider.addCICDWorkflowsTitle"),
@@ -332,31 +332,39 @@ class TreeViewManager {
         { name: "lightningBolt_16", custom: true },
         TreeCategory.GettingStarted
       ),
-      new TreeViewCommand(
-        localize("teamstoolkit.commandsTreeViewProvider.tutorialTitle"),
-        localize("teamstoolkit.commandsTreeViewProvider.tutorialDescription"),
-        "fx-extension.selectTutorials",
-        undefined,
-        { name: "tutorial", custom: true },
-        TreeCategory.GettingStarted
-      ),
-      new TreeViewCommand(
-        localize("teamstoolkit.commandsTreeViewProvider.documentationTitle"),
-        localize("teamstoolkit.commandsTreeViewProvider.documentationDescription"),
-        "fx-extension.openDocument",
-        undefined,
-        { name: "book", custom: false },
-        TreeCategory.GettingStarted
-      ),
-      new TreeViewCommand(
-        localize("teamstoolkit.commandsTreeViewProvider.reportIssuesTitleNew"),
-        localize("teamstoolkit.commandsTreeViewProvider.reportIssuesDescription"),
-        "fx-extension.openReportIssues",
-        undefined,
-        { name: "github", custom: false },
-        TreeCategory.Feedback
-      ),
     ];
+    if (isFeatureFlagEnabled(FeatureFlags.Preview)) {
+      helpCommand.push(
+        new TreeViewCommand(
+          localize("teamstoolkit.commandsTreeViewProvider.tutorialTitle"),
+          localize("teamstoolkit.commandsTreeViewProvider.tutorialDescription"),
+          "fx-extension.selectTutorials",
+          undefined,
+          { name: "tutorial", custom: true },
+          TreeCategory.GettingStarted
+        )
+      );
+    }
+    helpCommand.push(
+      ...[
+        new TreeViewCommand(
+          localize("teamstoolkit.commandsTreeViewProvider.documentationTitle"),
+          localize("teamstoolkit.commandsTreeViewProvider.documentationDescription"),
+          "fx-extension.openDocument",
+          undefined,
+          { name: "book", custom: false },
+          TreeCategory.GettingStarted
+        ),
+        new TreeViewCommand(
+          localize("teamstoolkit.commandsTreeViewProvider.reportIssuesTitleNew"),
+          localize("teamstoolkit.commandsTreeViewProvider.reportIssuesDescription"),
+          "fx-extension.openReportIssues",
+          undefined,
+          { name: "github", custom: false },
+          TreeCategory.Feedback
+        ),
+      ]
+    );
     const helpProvider = new CommandsTreeViewProvider(helpCommand);
     disposables.push(
       vscode.window.registerTreeDataProvider("teamsfx-help-and-feedback", helpProvider)

--- a/packages/vscode-extension/src/utils/commonUtils.ts
+++ b/packages/vscode-extension/src/utils/commonUtils.ts
@@ -19,7 +19,7 @@ import {
 } from "@microsoft/teamsfx-api";
 import {
   environmentManager,
-  initializeGAFeatureFlags,
+  initializePreviewFeatureFlags,
   isValidProject,
   PluginNames,
 } from "@microsoft/teamsfx-core";
@@ -257,18 +257,11 @@ export function syncFeatureFlags() {
     ConfigurationKey.generatorEnvCheckerEnable
   ).toString();
 
-  process.env["BOT_NOTIFICATION_ENABLED"] = getConfiguration(
-    ConfigurationKey.BotNotificationCommandAndResponseEnabled
+  process.env["TEAMSFX_PREVIEW"] = getConfiguration(
+    ConfigurationKey.EnablePreviewFeatures
   ).toString();
 
-  process.env["TEAMSFX_M365_APP"] = getConfiguration(ConfigurationKey.enableM365App).toString();
-  process.env["TEAMSFX_INIT_APP"] = getConfiguration(ConfigurationKey.EnableExistingApp).toString();
-
-  process.env["TEAMSFX_GA_PREVIEW"] = getConfiguration(
-    ConfigurationKey.EnableGAPreviewFeatures
-  ).toString();
-
-  initializeGAFeatureFlags();
+  initializePreviewFeatureFlags();
 }
 
 export class FeatureFlags {
@@ -276,7 +269,7 @@ export class FeatureFlags {
   static readonly TelemetryTest = "TEAMSFX_TELEMETRY_TEST";
   static readonly YoCheckerEnable = "TEAMSFX_YO_ENV_CHECKER_ENABLE";
   static readonly GeneratorCheckerEnable = "TEAMSFX_GENERATOR_ENV_CHECKER_ENABLE";
-  static readonly GeneralAvailablityPreview = "TEAMSFX_GA_PREVIEW";
+  static readonly Preview = "TEAMSFX_PREVIEW";
 }
 
 // Determine whether feature flag is enabled based on environment variable setting


### PR DESCRIPTION
1. Clean VS Code configuration and wording.
2. Move tutorial command under feature flag control.

Related AzDO bug: 14176509, 14176540