### PR TITLE
fix(adaptivecards-tools): change @type/react from devDependency to dependency

### DIFF
--- a/packages/adaptivecards-tools-sdk/package.json
+++ b/packages/adaptivecards-tools-sdk/package.json
@@ -25,7 +25,6 @@
     "@rollup/plugin-node-resolve": "^8.0.0",
     "@rollup/plugin-replace": "^2.2.0",
     "@types/markdown-it": "^12.2.1",
-    "@types/react": "^17.0.14",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^4.13.0",
     "eslint": "^8.1.0",
@@ -46,7 +45,8 @@
     "adaptivecards-templating": "^2.1.0",
     "json-schema-to-typescript": "^10.1.4",
     "markdown-it": "^12.2.0",
-    "react": "^17.0.2"
+    "react": "^17.0.2",
+    "@types/react": "^17.0.14"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Some of the declaration files in adaptivecards-tools has error. This can be fixed by changing @type/react from devDependency to dependency.

![1650456173(1)](https://user-images.githubusercontent.com/25220706/164226247-92df58c7-60fd-4df8-a0a9-28d592a46fb6.jpg)

