### PR TITLE
perf(aad-manifest): fix m365 sso tab doesn't work issue

### DIFF
--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/utils.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/utils.ts
@@ -268,6 +268,9 @@ export function fillInSolutionSettings(
     hostType = HostTypeOptionSPFx.id;
   } else if (capabilities.includes(M365SsoLaunchPageOptionItem.id)) {
     capabilities = [TabOptionItem.id];
+    if (isAadManifestEnabled()) {
+      capabilities.push(TabSsoItem.id);
+    }
     hostType = HostTypeOptionAzure.id;
   } else if (capabilities.includes(M365SearchAppOptionItem.id)) {
     capabilities = [MessageExtensionItem.id];

--- a/packages/fx-core/tests/plugins/solution/solution.util.test.ts
+++ b/packages/fx-core/tests/plugins/solution/solution.util.test.ts
@@ -64,4 +64,16 @@ describe("util: fillInSolutionSettings() with AAD manifest enabled", async () =>
     expect(solutionSettings?.capabilities?.includes(TabSsoItem.id)).to.be.false;
     expect(solutionSettings?.activeResourcePlugins?.includes(PluginNames.AAD)).to.be.false;
   });
+
+  it("M365 SSO Tab", async () => {
+    const mockInput = {
+      capabilities: ["M365SsoLaunchPage"],
+      platform: Platform.VSCode,
+    };
+
+    const res = fillInSolutionSettings(projectSettings, mockInput);
+    const solutionSettings = projectSettings?.solutionSettings as AzureSolutionSettings;
+    expect(solutionSettings?.capabilities?.includes(TabSsoItem.id)).to.be.true;
+    expect(solutionSettings?.activeResourcePlugins?.includes(PluginNames.AAD)).to.be.true;
+  });
 });


### PR DESCRIPTION
Fix these bugs:

[Bug 14177017](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14177017): No AAD Manifest for MetaOS Apps and SSO is broken

[Bug 14177047](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14177047): SSO should not be added to MetaOS Tab app