### PR TITLE
chore: upgrade function template sdk version

### DIFF
--- a/templates/function-base/js/default/package.json
+++ b/templates/function-base/js/default/package.json
@@ -8,7 +8,7 @@
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "dependencies": {
-        "@microsoft/teamsfx": "^0.6.1",
+        "@microsoft/teamsfx": "0.7.0-rc.1",
         "isomorphic-fetch": "^3.0.0"
     },
     "devDependencies": {

--- a/templates/function-base/ts/default/package.json
+++ b/templates/function-base/ts/default/package.json
@@ -14,7 +14,7 @@
     "dependencies": {
         "@azure/functions": "^1.2.2",
         "@microsoft/microsoft-graph-client": "^3.0.0",
-        "@microsoft/teamsfx": "^0.6.1",
+        "@microsoft/teamsfx": "0.7.0-rc.1",
         "isomorphic-fetch": "^3.0.0"
     },
     "devDependencies": {


### PR DESCRIPTION
Add api feature requires latest SDK version.
Since our stable release does not require latest SDK version, merge main to ga changed the SDK version in ga branch. So update function scaffolding template to use latest SDK again.
