### PR TITLE
fix: avoid error log when opening manifest template while provisioning

### DIFF
--- a/packages/fx-core/src/core/middleware/concurrentLocker.ts
+++ b/packages/fx-core/src/core/middleware/concurrentLocker.ts
@@ -94,9 +94,12 @@ export const ConcurrentLockerMW: Middleware = async (ctx: HookContext, next: Nex
     }
   }
   if (!acquired) {
-    TOOLS?.logProvider.error(
-      `[core] failed to acquire lock for task ${taskName} on: ${configFolder}`
-    );
+    const log = `[core] failed to acquire lock for task ${taskName} on: ${configFolder}`;
+    if (inputs.loglevel && inputs.loglevel === "Debug") {
+      TOOLS?.logProvider?.debug(log);
+    } else {
+      TOOLS?.logProvider?.error(log);
+    }
     // failed for 10 times and finally failed
     sendTelemetryErrorEvent(CoreSource, "concurrent-operation", new ConcurrentError(CoreSource), {
       retry: retryNum + "",


### PR DESCRIPTION
Workaround for this bug: 14225849

When executing commands like provisioning, and then open manifest template, it will has some acquire lock errors in output window. But when provisioning done, the real value will show successfully.

So change the log level to avoid this terrifying logs.
Before:
![image](https://user-images.githubusercontent.com/71362691/164959997-55e2e1cd-58d0-4f9c-abb4-6807969e4b13.png)

After:
![image](https://user-images.githubusercontent.com/71362691/164960030-267682b0-166f-4cf5-9743-489a696799b5.png)


