### PR TITLE
fix(existing-tab): load active plugins

### DIFF
--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/provisionLocal.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/provisionLocal.ts
@@ -70,11 +70,16 @@ export async function provisionLocalResource(
   if (m365TenantMatches.isErr()) {
     return new v2.FxFailure(m365TenantMatches.error);
   }
-  const pureExistingApp = isExistingTabApp(ctx.projectSetting);
-  // for minimized teamsfx project, there is only one plugin (app studio)
-  const plugins = pureExistingApp
-    ? [Container.get<v2.ResourcePlugin>(ResourcePluginsV2.AppStudioPlugin)]
-    : getSelectedPlugins(ctx.projectSetting);
+
+  const plugins = getSelectedPlugins(ctx.projectSetting);
+  if (isExistingTabApp(ctx.projectSetting)) {
+    // for existing tab app, enable app studio plugin when solution settings is empty.
+    const appStudioPlugin = Container.get<v2.ResourcePlugin>(ResourcePluginsV2.AppStudioPlugin);
+    if (!plugins.find((p) => p.name === appStudioPlugin.name)) {
+      plugins.push(appStudioPlugin);
+    }
+  }
+
   const provisionLocalResourceThunks = plugins
     .filter((plugin) => !isUndefined(plugin.provisionLocalResource))
     .map((plugin) => {


### PR DESCRIPTION
After added SSO to an embed existing app, the plugin `fx-resource-aad-app-for-teams` also needs to be loaded to provision AAD app for local environment.

The projectSettings.json will be like:
```
{
    "appName": "myapp",
    "projectId": "9519ed3e-357c-44ff-8b0c-7da651f9f07b",
    "version": "2.1.0",
    "solutionSettings": {
        "name": "fx-solution-azure",
        "version": "1.0.0",
        "hostType": "Azure",
        "capabilities": [
            "TabSSO"
        ],
        "azureResources": [],
        "activeResourcePlugins": [
            "fx-resource-aad-app-for-teams"
        ]
    }
}
```

E2E TEST: https://github.com/OfficeDev/TeamsFx/blob/01d6a9fb35d8418a3cec89a96949325bcbbea968/packages/cli/tests/e2e/existingapp/TestCreateExistingTab.tests.ts#L17