### PR TITLE
chore(vsc): enable preview feature by default

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -1003,18 +1003,6 @@
             }
           }
         }
-      },
-      {
-        "title": "Experimental Features",
-        "order": 3,
-        "properties": {
-          "fx-extension.enablePreviewFeatures": {
-            "order": 0,
-            "type": "boolean",
-            "description": "Enable a set of experimental features, including creating notification bot and command bot, extending apps across Microsoft 365, add sso and call an API. (Requires reload of VS Code)",
-            "default": false
-          }
-        }
       }
     ],
     "languages": [

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -22,6 +22,7 @@ import {
   isConfigUnifyEnabled,
   isDeployManifestEnabled,
   isExistingTabAppEnabled,
+  isPreviewFeaturesEnabled,
 } from "@microsoft/teamsfx-core";
 
 import {
@@ -52,8 +53,6 @@ import { TelemetryTriggerFrom } from "./telemetry/extTelemetryEvents";
 import {
   canUpgradeToArmAndMultiEnv,
   delay,
-  FeatureFlags,
-  isFeatureFlagEnabled,
   isM365Project,
   isSPFxProject,
   isSupportAutoOpenAPI,
@@ -475,7 +474,7 @@ export async function activate(context: vscode.ExtensionContext) {
   vscode.commands.executeCommand(
     "setContext",
     "fx-entension.previewFeaturesEnabled",
-    isFeatureFlagEnabled(FeatureFlags.Preview, false)
+    isPreviewFeaturesEnabled()
   );
 
   // Setup CodeLens provider for userdata file

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -65,6 +65,7 @@ import {
   globalStateUpdate,
   InvalidProjectError,
   isConfigUnifyEnabled,
+  isPreviewFeaturesEnabled,
   isUserCancelError,
   isValidProject,
   LocalEnvManager,
@@ -104,8 +105,6 @@ import {
   isTriggerFromWalkThrough,
   getTriggerFromProperty,
   isExistingTabApp,
-  isFeatureFlagEnabled,
-  FeatureFlags,
 } from "./utils/commonUtils";
 import * as fs from "fs-extra";
 import { VSCodeDepsChecker } from "./debug/depsChecker/vscodeChecker";
@@ -3068,7 +3067,7 @@ export async function deployAadAppManifest(args: any[]): Promise<Result<null, Fx
 
 export async function selectTutorialsHandler(args?: any[]): Promise<Result<unknown, FxError>> {
   ExtTelemetry.sendTelemetryEvent(TelemetryEvent.ViewGuidedTutorials, getTriggerFromProperty(args));
-  if (!isFeatureFlagEnabled(FeatureFlags.Preview)) {
+  if (!isPreviewFeaturesEnabled()) {
     VS_CODE_UI.showMessage("info", localize("teamstoolkit.common.commingSoon"), false);
     return ok(null);
   }

--- a/packages/vscode-extension/src/treeview/treeViewManager.ts
+++ b/packages/vscode-extension/src/treeview/treeViewManager.ts
@@ -5,10 +5,10 @@
 import * as vscode from "vscode";
 
 import { TreeCategory } from "@microsoft/teamsfx-api";
-import { isValidProject } from "@microsoft/teamsfx-core";
+import { isPreviewFeaturesEnabled, isValidProject } from "@microsoft/teamsfx-core";
 
 import { AdaptiveCardCodeLensProvider } from "../codeLensProvider";
-import { FeatureFlags, isFeatureFlagEnabled, isSPFxProject } from "../utils/commonUtils";
+import { isSPFxProject } from "../utils/commonUtils";
 import { localize } from "../utils/localizeUtils";
 import { CommandsTreeViewProvider } from "./commandsTreeViewProvider";
 import { CommandStatus, TreeViewCommand } from "./treeViewCommand";
@@ -151,7 +151,7 @@ class TreeViewManager {
     );
 
     if (isNonSPFx) {
-      if (isFeatureFlagEnabled(FeatureFlags.Preview)) {
+      if (isPreviewFeaturesEnabled()) {
         developmentCommand.push(
           new TreeViewCommand(
             localize("teamstoolkit.commandsTreeViewProvider.addFeatureTitle"),
@@ -272,7 +272,7 @@ class TreeViewManager {
       ),
     ];
 
-    if (!isFeatureFlagEnabled(FeatureFlags.Preview)) {
+    if (!isPreviewFeaturesEnabled()) {
       deployCommand.push(
         new TreeViewCommand(
           localize("teamstoolkit.commandsTreeViewProvider.addCICDWorkflowsTitle"),
@@ -333,7 +333,7 @@ class TreeViewManager {
         TreeCategory.GettingStarted
       ),
     ];
-    if (isFeatureFlagEnabled(FeatureFlags.Preview)) {
+    if (isPreviewFeaturesEnabled()) {
       helpCommand.push(
         new TreeViewCommand(
           localize("teamstoolkit.commandsTreeViewProvider.tutorialTitle"),

--- a/packages/vscode-extension/src/utils/commonUtils.ts
+++ b/packages/vscode-extension/src/utils/commonUtils.ts
@@ -258,9 +258,8 @@ export function syncFeatureFlags() {
     ConfigurationKey.generatorEnvCheckerEnable
   ).toString();
 
-  process.env["TEAMSFX_PREVIEW"] = getConfiguration(
-    ConfigurationKey.EnablePreviewFeatures
-  ).toString();
+  // TODO: enable preview feature flag in fx-core after E2E tests are fixed.
+  process.env[FeatureFlags.Preview] = "true";
 
   initializePreviewFeatureFlags();
 }


### PR DESCRIPTION
Enable in VS Code and will update `isPreviewFeaturesEnabled()` in fx-core after E2E tests are all fixed.