### PR TITLE
chore(cicd): set ci_enabled for azure projects

### DIFF
--- a/packages/fx-core/templates/plugins/resource/cicd/azdo/cd.yml
+++ b/packages/fx-core/templates/plugins/resource/cicd/azdo/cd.yml
@@ -21,8 +21,9 @@ steps:
     M365_ACCOUNT_NAME: $(M365_ACCOUNT_NAME)
     M365_ACCOUNT_PASSWORD: $(M365_ACCOUNT_PASSWORD)
     M365_TENANT_ID: $(M365_TENANT_ID)
-    CI_ENABLED: 'true'
 <%/hosting_type_contains_spfx%>
+    # To enable M365 account login by environment variables and non-interactive mode.
+    CI_ENABLED: 'true'
     TEAMSFX_ENV_NAME: <%env_name%>
   inputs:
     targetType: 'inline'

--- a/packages/fx-core/templates/plugins/resource/cicd/jenkins/Jenkinsfile.cd
+++ b/packages/fx-core/templates/plugins/resource/cicd/jenkins/Jenkinsfile.cd
@@ -15,10 +15,9 @@ pipeline {
         M365_ACCOUNT_NAME = credentials('M365_ACCOUNT_NAME')
         M365_ACCOUNT_PASSWORD = credentials('M365_ACCOUNT_PASSWORD')
         M365_TENANT_ID = credentials('M365_TENANT_ID')
-        // To enable M365 account login by non-interactive mode. 
-        CI_ENABLED = 'true'
 <%/hosting_type_contains_spfx%>
-
+        // To enable M365 account login by environment variables and non-interactive mode. 
+        CI_ENABLED = 'true'
         // To specify the env name for multi-env feature.
         TEAMSFX_ENV_NAME = '<%env_name%>'
     }


### PR DESCRIPTION
Bug: https://dev.azure.com/msazure/Microsoft%20Teams%20Extensibility/_workitems/edit/14236128

Use CI_ENABLED=true to cover:
1. M365 login by env vars.
2. Make CLI non-interactive.