### PR TITLE
docs: add auth notice for notification bot

### DIFF
--- a/templates/bot/js/notification-function-base/README.md
+++ b/templates/bot/js/notification-function-base/README.md
@@ -65,6 +65,16 @@ You can find the Teams app manifest in `templates/appPackage/manifest.template.j
 
 The file contains template arguments with `{...}` statements which will be replaced at build time. You may add any extra properties or permissions you require to this file. See the [schema reference](https://docs.microsoft.com/microsoftteams/platform/resources/schema/manifest-schema) for more information.
 
+## Go production
+
+If you choose http trigger, the scaffolded notification API does not have authentication / authorization enabled. We suggest you add authentication / authorization for this API before using it for production purpose. Here're some common ways to add authentication / authorization for an API:
+
+1. Use an API Key. Azure Functions already provides [function access keys](https://docs.microsoft.com/en-us/azure/azure-functions/security-concepts?tabs=v4#function-access-keys), which may be helpful to you.
+
+2. Use an access token issued by [Azure Active Directory](https://docs.microsoft.com/en-us/azure/active-directory/authentication/)
+
+There would be more authentication / authorization solutions for an API. You can choose the one that satisfies your requirement best.
+
 ## Deployment
 
 Teams Toolkit can help provision cloud resource for your app, refer [Use Teams Toolkit to provision cloud resources](https://docs.microsoft.com/microsoftteams/platform/toolkit/provision) for more information.

--- a/templates/bot/js/notification-function-base/README.md
+++ b/templates/bot/js/notification-function-base/README.md
@@ -65,7 +65,7 @@ You can find the Teams app manifest in `templates/appPackage/manifest.template.j
 
 The file contains template arguments with `{...}` statements which will be replaced at build time. You may add any extra properties or permissions you require to this file. See the [schema reference](https://docs.microsoft.com/microsoftteams/platform/resources/schema/manifest-schema) for more information.
 
-## Go production
+## Add authentication for your notification API
 
 If you choose http trigger, the scaffolded notification API does not have authentication / authorization enabled. We suggest you add authentication / authorization for this API before using it for production purpose. Here're some common ways to add authentication / authorization for an API:
 

--- a/templates/bot/js/notification-restify/README.md
+++ b/templates/bot/js/notification-restify/README.md
@@ -60,7 +60,7 @@ You can find the Teams app manifest in `templates/appPackage/manifest.template.j
 
 The file contains template arguments with `{...}` statements which will be replaced at build time. You may add any extra properties or permissions you require to this file. See the [schema reference](https://docs.microsoft.com/microsoftteams/platform/resources/schema/manifest-schema) for more information.
 
-## Go production
+## Add authentication for your notification API
 
 The scaffolded notification API does not have authentication / authorization enabled. We suggest you add authentication / authorization for this API before using it for production purpose. Here're some common ways to add authentication / authorization for an API:
 

--- a/templates/bot/js/notification-restify/README.md
+++ b/templates/bot/js/notification-restify/README.md
@@ -60,6 +60,16 @@ You can find the Teams app manifest in `templates/appPackage/manifest.template.j
 
 The file contains template arguments with `{...}` statements which will be replaced at build time. You may add any extra properties or permissions you require to this file. See the [schema reference](https://docs.microsoft.com/microsoftteams/platform/resources/schema/manifest-schema) for more information.
 
+## Go production
+
+The scaffolded notification API does not have authentication / authorization enabled. We suggest you add authentication / authorization for this API before using it for production purpose. Here're some common ways to add authentication / authorization for an API:
+
+1. Use an API Key
+
+2. Use an access token issued by [Azure Active Directory](https://docs.microsoft.com/en-us/azure/active-directory/authentication/)
+
+There would be more authentication / authorization solutions for an API. You can choose the one that satisfies your requirement best.
+
 ## Deployment
 
 Teams Toolkit can help provision cloud resource for your app, refer [Use Teams Toolkit to provision cloud resources](https://docs.microsoft.com/microsoftteams/platform/toolkit/provision) for more information.

--- a/templates/bot/js/notification-restify/src/index.js
+++ b/templates/bot/js/notification-restify/src/index.js
@@ -2,7 +2,7 @@ const notificationTemplate = require("./adaptiveCards/notification-default.json"
 const { bot, server } = require("./internal/initialize");
 const { AdaptiveCards } = require("@microsoft/adaptivecards-tools");
 
-// HTTP trigger to send notification.
+// HTTP trigger to send notification. You need to add authentication / authorization for this API. Refer https://aka.ms/teamsfx-notification for more details.
 server.post("/api/notification", async (req, res) => {
   for (const target of await bot.notification.installations()) {
     await target.sendAdaptiveCard(

--- a/templates/bot/js/notification-trigger-http/src/httpTrigger.js
+++ b/templates/bot/js/notification-trigger-http/src/httpTrigger.js
@@ -2,7 +2,7 @@ const notificationTemplate = require("./adaptiveCards/notification-default.json"
 const { AdaptiveCards } = require("@microsoft/adaptivecards-tools");
 const { bot } = require("./internal/initialize");
 
-// HTTP trigger to send notification.
+// HTTP trigger to send notification. You need to add authentication / authorization for this API. Refer https://aka.ms/teamsfx-notification for more details.
 module.exports = async function (context, req) {
   for (const target of await bot.notification.installations()) {
     await target.sendAdaptiveCard(

--- a/templates/bot/ts/notification-function-base/README.md
+++ b/templates/bot/ts/notification-function-base/README.md
@@ -65,6 +65,16 @@ You can find the Teams app manifest in `templates/appPackage/manifest.template.j
 
 The file contains template arguments with `{...}` statements which will be replaced at build time. You may add any extra properties or permissions you require to this file. See the [schema reference](https://docs.microsoft.com/microsoftteams/platform/resources/schema/manifest-schema) for more information.
 
+## Go production
+
+If you choose http trigger, the scaffolded notification API does not have authentication / authorization enabled. We suggest you add authentication / authorization for this API before using it for production purpose. Here're some common ways to add authentication / authorization for an API:
+
+1. Use an API Key. Azure Functions already provides [function access keys](https://docs.microsoft.com/en-us/azure/azure-functions/security-concepts?tabs=v4#function-access-keys), which may be helpful to you.
+
+2. Use an access token issued by [Azure Active Directory](https://docs.microsoft.com/en-us/azure/active-directory/authentication/)
+
+There would be more authentication / authorization solutions for an API. You can choose the one that satisfies your requirement best.
+
 ## Deployment
 
 Teams Toolkit can help provision cloud resource for your app, refer [Use Teams Toolkit to provision cloud resources](https://docs.microsoft.com/microsoftteams/platform/toolkit/provision) for more information.

--- a/templates/bot/ts/notification-function-base/README.md
+++ b/templates/bot/ts/notification-function-base/README.md
@@ -65,7 +65,7 @@ You can find the Teams app manifest in `templates/appPackage/manifest.template.j
 
 The file contains template arguments with `{...}` statements which will be replaced at build time. You may add any extra properties or permissions you require to this file. See the [schema reference](https://docs.microsoft.com/microsoftteams/platform/resources/schema/manifest-schema) for more information.
 
-## Go production
+## Add authentication for your notification API
 
 If you choose http trigger, the scaffolded notification API does not have authentication / authorization enabled. We suggest you add authentication / authorization for this API before using it for production purpose. Here're some common ways to add authentication / authorization for an API:
 

--- a/templates/bot/ts/notification-restify/README.md
+++ b/templates/bot/ts/notification-restify/README.md
@@ -60,7 +60,7 @@ You can find the Teams app manifest in `templates/appPackage/manifest.template.j
 
 The file contains template arguments with `{...}` statements which will be replaced at build time. You may add any extra properties or permissions you require to this file. See the [schema reference](https://docs.microsoft.com/microsoftteams/platform/resources/schema/manifest-schema) for more information.
 
-## Go production
+## Add authentication for your notification API
 
 The scaffolded notification API does not have authentication / authorization enabled. We suggest you add authentication / authorization for this API before using it for production purpose. Here're some common ways to add authentication / authorization for an API:
 

--- a/templates/bot/ts/notification-restify/README.md
+++ b/templates/bot/ts/notification-restify/README.md
@@ -60,6 +60,16 @@ You can find the Teams app manifest in `templates/appPackage/manifest.template.j
 
 The file contains template arguments with `{...}` statements which will be replaced at build time. You may add any extra properties or permissions you require to this file. See the [schema reference](https://docs.microsoft.com/microsoftteams/platform/resources/schema/manifest-schema) for more information.
 
+## Go production
+
+The scaffolded notification API does not have authentication / authorization enabled. We suggest you add authentication / authorization for this API before using it for production purpose. Here're some common ways to add authentication / authorization for an API:
+
+1. Use an API Key
+
+2. Use an access token issued by [Azure Active Directory](https://docs.microsoft.com/en-us/azure/active-directory/authentication/)
+
+There would be more authentication / authorization solutions for an API. You can choose the one that satisfies your requirement best.
+
 ## Deployment
 
 Teams Toolkit can help provision cloud resource for your app, refer [Use Teams Toolkit to provision cloud resources](https://docs.microsoft.com/microsoftteams/platform/toolkit/provision) for more information.

--- a/templates/bot/ts/notification-restify/src/index.ts
+++ b/templates/bot/ts/notification-restify/src/index.ts
@@ -3,7 +3,7 @@ import notificationTemplate from "./adaptiveCards/notification-default.json";
 import { bot, server } from "./internal/initialize";
 import { CardData } from "./cardModels";
 
-// HTTP trigger to send notification.
+// HTTP trigger to send notification. You need to add authentication / authorization for this API. Refer https://aka.ms/teamsfx-notification for more details.
 server.post("/api/notification", async (req, res) => {
   for (const target of await bot.notification.installations()) {
     await target.sendAdaptiveCard(

--- a/templates/bot/ts/notification-trigger-http/src/httpTrigger.ts
+++ b/templates/bot/ts/notification-trigger-http/src/httpTrigger.ts
@@ -4,7 +4,7 @@ import notificationTemplate from "./adaptiveCards/notification-default.json";
 import { CardData } from "./cardModels";
 import { bot } from "./internal/initialize";
 
-// HTTP trigger to send notification.
+// HTTP trigger to send notification. You need to add authentication / authorization for this API. Refer https://aka.ms/teamsfx-notification for more details.
 const httpTrigger: AzureFunction = async function (
   context: Context,
   req: HttpRequest


### PR DESCRIPTION
The scaffolded http trigger does not have auth, we need tell users they should add auth for the http trigger before using it for production purpose.