### PR TITLE
perf(add sso): call addSso when add func

### DIFF
--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/executeUserTask.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/executeUserTask.ts
@@ -466,6 +466,14 @@ export async function addCapability(
       if (toAddTab && !alreadyHasTabSso) {
         newCapabilitySet.add(TabSsoItem.id);
         pluginNamesToScaffold.add(ResourcePluginsV2.AadPlugin);
+
+        // Add webapplicationInfo in teams app manifest
+        const appStudioPlugin = Container.get<AppStudioPluginV3>(
+          BuiltInFeaturePluginNames.appStudio
+        );
+        await appStudioPlugin.addCapabilities(ctx, inputs as v2.InputsWithProjectPath, [
+          { name: "WebApplicationInfo" },
+        ]);
       }
     }
 

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/executeUserTask.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/executeUserTask.ts
@@ -679,16 +679,7 @@ export async function addResource(
     // Since APIM also have dependency on Function, will only add depenedency here.
     if (!isAADEnabled(solutionSettings)) {
       if (isAadManifestEnabled()) {
-        const aadPlugin = Container.get<v2.ResourcePlugin>(ResourcePluginsV2.AadPlugin);
-        pluginsToScaffold.push(aadPlugin);
-        pluginsToDoArm.push(aadPlugin);
-
-        if (solutionSettings.capabilities.includes(TabOptionItem.id)) {
-          solutionSettings.capabilities.push(TabSsoItem.id);
-        }
-        if (solutionSettings.capabilities.includes(BotOptionItem.id)) {
-          solutionSettings.capabilities.push(BotSsoItem.id);
-        }
+        await addSso(ctx, inputs, localSettings);
       } else {
         solutionSettings.activeResourcePlugins?.push(PluginNames.AAD);
       }


### PR DESCRIPTION
Update:
Call addSso when adding function in sso not enabled projects. Thus we will have code sample added and also telemetry for add sso.
Fix bug:
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_sprints/taskboard/AuthAndData/Microsoft%20Teams%20Extensibility/CY22-4.2?workitem=14273584
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_sprints/taskboard/AuthAndData/Microsoft%20Teams%20Extensibility/CY22-4.2?workitem=14273586