### PR TITLE
fix: remove Node v10 from versions supported by SPFx

### DIFF
--- a/packages/fx-core/src/common/deps-checker/internal/nodeChecker.ts
+++ b/packages/fx-core/src/common/deps-checker/internal/nodeChecker.ts
@@ -162,7 +162,7 @@ export class SPFxNodeChecker extends NodeChecker {
   }
 
   protected async getSupportedVersions(): Promise<string[]> {
-    return ["10", "12", "14"];
+    return ["12", "14"];
   }
 }
 


### PR DESCRIPTION
Fix [bug](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14234230)

E2E TEST: N/A