### PR TITLE
chore(cli): rename messaging extension to message extension

### DIFF
--- a/packages/cli/src/cmds/capability.ts
+++ b/packages/cli/src/cmds/capability.ts
@@ -135,9 +135,9 @@ export class CapabilityAddBot extends CapabilityAddBotBase {
 }
 
 export class CapabilityAddMessageExtension extends CapabilityAddBotBase {
-  public readonly commandHead = `messaging-extension`;
+  public readonly commandHead = `message-extension`;
   public readonly command = `${this.commandHead}`;
-  public readonly description = "Add Messaging Extensions.";
+  public readonly description = "Add Message Extensions.";
   public readonly yargsHelp = "addCapability-MessagingExtension";
 }
 

--- a/packages/cli/src/cmds/preview/errors.ts
+++ b/packages/cli/src/cmds/preview/errors.ts
@@ -151,6 +151,6 @@ export function OnlyLaunchPageSupportedInOffice(): UserError {
   return new UserError(
     constants.cliSource,
     "OnlyLaunchPageSupportedByOffice",
-    "Only launch page is supported in Office. Messaging extension is not supported in Office."
+    "Only launch page is supported in Office. Message extension is not supported in Office."
   );
 }

--- a/packages/cli/tests/commonlib/constants.ts
+++ b/packages/cli/tests/commonlib/constants.ts
@@ -34,7 +34,7 @@ export const fileEncoding = "UTF8";
 export enum Capability {
   Tab = "tab",
   Bot = "bot",
-  MessagingExtension = "messaging-extension",
+  MessageExtension = "message-extension",
   M365SsoLaunchPage = "sso-launch-page",
   M365SearchApp = "search-app",
   ExistingTab = "existing-tab",

--- a/packages/cli/tests/e2e/m365/CreateMessagingExtension.tests.ts
+++ b/packages/cli/tests/e2e/m365/CreateMessagingExtension.tests.ts
@@ -14,7 +14,7 @@ import { M365Validator } from "../../commonlib/m365Validator";
 import { BotValidator } from "../../commonlib";
 import { Capability } from "../../commonlib/constants";
 
-describe("Create M365 Messaging Extension", function () {
+describe("Create M365 Message Extension", function () {
   const testFolder = getTestFolder();
   const appName = getUniqueAppName();
   const projectPath = path.resolve(testFolder, appName);

--- a/packages/cli/tests/e2e/solution/AddCapabilities_MEAddTab.tests.ts
+++ b/packages/cli/tests/e2e/solution/AddCapabilities_MEAddTab.tests.ts
@@ -31,9 +31,9 @@ describe("Add capabilities", function () {
     await cleanUp(appName, projectPath, true, true, false);
   });
 
-  it("messaging extension project can add tab capability and provision", async () => {
+  it("message extension project can add tab capability and provision", async () => {
     // Arrange
-    await CliHelper.createProjectWithCapability(appName, testFolder, Capability.MessagingExtension);
+    await CliHelper.createProjectWithCapability(appName, testFolder, Capability.MessageExtension);
 
     // Act
     await CliHelper.addCapabilityToProject(projectPath, Capability.Tab);

--- a/packages/cli/tests/e2e/solution/AddCapabilities_TabAddME.tests.ts
+++ b/packages/cli/tests/e2e/solution/AddCapabilities_TabAddME.tests.ts
@@ -31,12 +31,12 @@ describe("Add capabilities", function () {
     await cleanUp(appName, projectPath, true, true, false);
   });
 
-  it("tab project can add messaging extension capability and provision", async () => {
+  it("tab project can add message extension capability and provision", async () => {
     // Arrange
     await CliHelper.createProjectWithCapability(appName, testFolder, Capability.Tab);
 
     // Act
-    await CliHelper.addCapabilityToProject(projectPath, Capability.MessagingExtension);
+    await CliHelper.addCapabilityToProject(projectPath, Capability.MessageExtension);
 
     await setSimpleAuthSkuNameToB1Bicep(projectPath, env);
     await setBotSkuNameToB1Bicep(projectPath, env);

--- a/packages/cli/tests/unit/cmds/capability.tests.ts
+++ b/packages/cli/tests/unit/cmds/capability.tests.ts
@@ -112,7 +112,7 @@ describe("Capability Command Tests", function () {
       "add [capability]",
       "tab",
       "bot",
-      "messaging-extension",
+      "message-extension",
     ]);
   });
 

--- a/packages/fx-core/src/plugins/solution/fx-solution/question.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/question.ts
@@ -74,7 +74,7 @@ export const ExistingTabOptionItem: OptionItem = {
 export const MessageExtensionItem: OptionItem = {
   id: "MessagingExtension",
   label: getLocalizedString("core.MessageExtensionOption.label"),
-  cliName: "messaging-extension",
+  cliName: "message-extension",
   description: getLocalizedString("core.MessageExtensionOption.description"),
   detail: getLocalizedString("core.MessageExtensionOption.detail"),
 };
@@ -82,7 +82,7 @@ export const MessageExtensionItem: OptionItem = {
 export const MessageExtensionNewUIItem: OptionItem = {
   id: "MessagingExtension",
   label: `$(comment-discussion) ${getLocalizedString("core.MessageExtensionOption.labelNew")}`,
-  cliName: "messaging-extension",
+  cliName: "message-extension",
   detail: getLocalizedString("core.MessageExtensionOption.detail"),
   groupName: getLocalizedString("core.options.separator.basic"),
 };


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15262146/165488908-f1a8bd0f-813e-46b2-ba3e-df99a3920326.png)
Bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14264635
E2E TEST: https://github.com/OfficeDev/TeamsFx/runs/6204077904?check_suite_focus=true