### PR TITLE
chore: use latest version of axios

### DIFF
--- a/packages/sdk/package-lock.json
+++ b/packages/sdk/package-lock.json
@@ -2915,11 +2915,29 @@
       "integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY="
     },
     "axios": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
       "requires": {
-        "follow-redirects": "^1.14.4"
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      },
+      "dependencies": {
+        "follow-redirects": {
+          "version": "1.14.9",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+          "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
+        },
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "axios-mock-adapter": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -51,7 +51,7 @@
     "@azure/msal-node": "~1.1.0",
     "@microsoft/adaptivecards-tools": "^0.1.6",
     "@microsoft/microsoft-graph-client": "^3.0.1",
-    "axios": "^0.24.0",
+    "axios": "^0.27.2",
     "botbuilder": ">=4.15.0 <5.0.0",
     "botbuilder-dialogs": ">=4.15.0 <5.0.0",
     "botframework-schema": ">=4.15.0 <5.0.0",


### PR DESCRIPTION
Use latest axios release which has some impactful breaking change (especially on error handling) and security fixes. The release note can be found here: https://github.com/axios/axios/releases

Using latest release will avoid introducing such breaking change in the future.