### PR TITLE
fix(tab): upgrade react-scripts to fix vulnerability

### DIFF
--- a/templates/tab/js/default/package.json
+++ b/templates/tab/js/default/package.json
@@ -16,12 +16,11 @@
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "react-router-dom": "^5.1.2",
-        "react-scripts": "^4.0.3"
+        "react-scripts": "^5.0.1"
     },
     "devDependencies": {
         "cross-env": "^7.0.3",
-        "env-cmd": "^10.1.0",
-        "react-error-overlay": "6.0.9"
+        "env-cmd": "^10.1.0"
     },
     "scripts": {
         "dev:teamsfx": "env-cmd --silent -f .env.teamsfx.local npm run start",

--- a/templates/tab/js/default/package.json
+++ b/templates/tab/js/default/package.json
@@ -24,9 +24,9 @@
     },
     "scripts": {
         "dev:teamsfx": "env-cmd --silent -f .env.teamsfx.local npm run start",
-        "start": "react-scripts start",
+        "start": "cross-env GENERATE_SOURCEMAP=false react-scripts start",
         "install:teamsfx": "npm install",
-        "build": "react-scripts build",
+        "build": "cross-env GENERATE_SOURCEMAP=false react-scripts build",
         "build:teamsfx": "cross-env-shell \"env-cmd -f .env.teamsfx.${TEAMS_FX_ENV} npm run build\"",
         "build:teamsfx:dev": "cross-env TEAMS_FX_ENV=dev npm run build:teamsfx",
         "eject": "react-scripts eject"

--- a/templates/tab/js/m365/package.json
+++ b/templates/tab/js/m365/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@fluentui/react-northstar": "^0.54.0",
+    "@fluentui/react-northstar": "^0.60.1",
     "@microsoft/mgt-element": "2.4.1-next.teamsfx.053a600",
     "@microsoft/mgt-react": "2.4.1-next.teamsfx.053a600",
     "@microsoft/mgt-teamsfx-provider": "2.4.1-next.teamsfx.053a600",
@@ -15,12 +15,11 @@
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "react-router-dom": "^5.1.2",
-    "react-scripts": "^4.0.3"
+    "react-scripts": "^5.0.1"
   },
   "devDependencies": {
     "cross-env": "^7.0.3",
-    "env-cmd": "^10.1.0",
-    "react-error-overlay": "6.0.9"
+    "env-cmd": "^10.1.0"
   },
   "scripts": {
     "dev:teamsfx": "env-cmd --silent -f .env.teamsfx.local npm run start",

--- a/templates/tab/js/non-sso/package.json
+++ b/templates/tab/js/non-sso/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@fluentui/react-northstar": "^0.54.0",
+    "@fluentui/react-northstar": "^0.60.1",
     "@microsoft/teams-js": "^1.9.0",
     "@microsoft/teamsfx": "^0.6.0",
     "axios": "^0.21.1",
@@ -11,12 +11,11 @@
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "react-router-dom": "^5.1.2",
-    "react-scripts": "^4.0.3"
+    "react-scripts": "^5.0.1"
   },
   "devDependencies": {
     "cross-env": "^7.0.3",
-    "env-cmd": "^10.1.0",
-    "react-error-overlay": "6.0.9"
+    "env-cmd": "^10.1.0"
   },
   "scripts": {
     "dev:teamsfx": "env-cmd --silent -f .env.teamsfx.local npm run start",

--- a/templates/tab/ts/default/package.json
+++ b/templates/tab/ts/default/package.json
@@ -16,7 +16,7 @@
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "react-router-dom": "^5.1.2",
-        "react-scripts": "^4.0.3"
+        "react-scripts": "^5.0.1"
     },
     "devDependencies": {
         "@types/node": "^12.0.0",
@@ -25,7 +25,6 @@
         "@types/react-router-dom": "^5.1.7",
         "cross-env": "^7.0.3",
         "env-cmd": "^10.1.0",
-        "react-error-overlay": "6.0.9",
         "typescript": "^4.1.2"
     },
     "scripts": {

--- a/templates/tab/ts/default/package.json
+++ b/templates/tab/ts/default/package.json
@@ -29,9 +29,9 @@
     },
     "scripts": {
         "dev:teamsfx": "env-cmd --silent -f .env.teamsfx.local npm run start",
-        "start": "react-scripts start",
+        "start": "cross-env GENERATE_SOURCEMAP=false react-scripts start",
         "install:teamsfx": "npm install",
-        "build": "react-scripts build",
+        "build": "cross-env GENERATE_SOURCEMAP=false react-scripts build",
         "build:teamsfx": "cross-env-shell \"env-cmd -f .env.teamsfx.${TEAMS_FX_ENV} npm run build\"",
         "build:teamsfx:dev": "cross-env TEAMS_FX_ENV=dev npm run build:teamsfx",
         "eject": "react-scripts eject"

--- a/templates/tab/ts/m365/package.json
+++ b/templates/tab/ts/m365/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "private": true,
     "dependencies": {
-        "@fluentui/react-northstar": "^0.54.0",
+        "@fluentui/react-northstar": "^0.60.1",
         "@microsoft/mgt-element": "2.4.1-next.teamsfx.053a600",
         "@microsoft/mgt-react": "2.4.1-next.teamsfx.053a600",
         "@microsoft/mgt-teamsfx-provider": "2.4.1-next.teamsfx.053a600",
@@ -15,7 +15,7 @@
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "react-router-dom": "^5.1.2",
-        "react-scripts": "^4.0.3"
+        "react-scripts": "^5.0.1"
     },
     "devDependencies": {
         "@types/node": "^12.0.0",
@@ -24,7 +24,6 @@
         "@types/react-router-dom": "^5.1.7",
         "cross-env": "^7.0.3",
         "env-cmd": "^10.1.0",
-        "react-error-overlay": "6.0.9",
         "typescript": "^4.1.2"
     },
     "scripts": {

--- a/templates/tab/ts/non-sso/package.json
+++ b/templates/tab/ts/non-sso/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "private": true,
     "dependencies": {
-        "@fluentui/react-northstar": "^0.54.0",
+        "@fluentui/react-northstar": "^0.60.1",
         "@microsoft/teams-js": "^1.9.0",
         "@microsoft/teamsfx": "^0.6.0",
         "axios": "^0.21.1",
@@ -11,7 +11,7 @@
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "react-router-dom": "^5.1.2",
-        "react-scripts": "^4.0.3"
+        "react-scripts": "^5.0.1"
     },
     "devDependencies": {
         "@types/node": "^12.0.0",
@@ -20,7 +20,6 @@
         "@types/react-router-dom": "^5.1.7",
         "cross-env": "^7.0.3",
         "env-cmd": "^10.1.0",
-        "react-error-overlay": "6.0.9",
         "typescript": "^4.1.2"
     },
     "scripts": {


### PR DESCRIPTION
Upgrades react-scripts to 5.0 to fix:
1. vulnerabilities
![image](https://user-images.githubusercontent.com/26134943/165715403-571b6d6a-892c-465a-9244-b87485a5c48c.png)
1. https://github.com/OfficeDev/TeamsFx/issues/3929


E2E TEST: https://github.com/OfficeDev/TeamsFx/blob/55566067b0a3a1a6838b686e1be492de5603dd8b/packages/cli/tests/e2e/frontend/TestCreateTab.tests.ts#L27