### PR TITLE
perf(add sso): open add sso readme when add sso in add function

### DIFF
--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/getQuestions.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/getQuestions.ts
@@ -949,6 +949,7 @@ export async function getQuestionsForAddFeature(
         TabNonSsoItem.id,
         BotNewUIOptionItem.id,
         MessageExtensionItem.id,
+        SingleSignOnOptionItem.id,
       ],
     };
     addFeatureNode.addChild(programmingLanguage);


### PR DESCRIPTION
Fix bug: Readme for add sso will not automatically open when adding sso in add function
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_sprints/taskboard/AuthAndData/Microsoft%20Teams%20Extensibility/CY22-4.2?workitem=14273851