### PR TITLE
fix: add features for legacy bot

### DIFF
--- a/packages/fx-core/src/plugins/resource/bot/configs/teamsBotConfig.ts
+++ b/packages/fx-core/src/plugins/resource/bot/configs/teamsBotConfig.ts
@@ -60,7 +60,7 @@ export class TeamsBotConfig {
 
     if (capabilities?.includes(PluginActRoles.Bot)) {
       const scenarios = context.answers?.[AzureSolutionQuestionNames.Scenarios];
-      if (isBotNotificationEnabled() && Array.isArray(scenarios)) {
+      if (isBotNotificationEnabled() && Array.isArray(scenarios) && scenarios.length > 0) {
         const scenarioActRoles = scenarios
           .map((item) => QuestionBotScenarioToPluginActRoles.get(item))
           .filter((item): item is PluginActRoles => item !== undefined);

--- a/packages/fx-core/tests/plugins/resource/bot/unit/configs/teamsBotConfig.test.ts
+++ b/packages/fx-core/tests/plugins/resource/bot/unit/configs/teamsBotConfig.test.ts
@@ -7,7 +7,10 @@ import { TeamsBotConfig } from "../../../../../../src/plugins/resource/bot/confi
 import * as testUtils from "../utils";
 import { QuestionNames } from "../../../../../../src/plugins/resource/bot/constants";
 import { PluginActRoles } from "../../../../../../src/plugins/resource/bot/enums/pluginActRoles";
-import { BotOptionItem } from "../../../../../../src/plugins/solution/fx-solution/question";
+import {
+  BotOptionItem,
+  AzureSolutionQuestionNames,
+} from "../../../../../../src/plugins/solution/fx-solution/question";
 
 describe("TeamsBotConfig Tests", () => {
   const sandbox = sinon.createSandbox();
@@ -24,6 +27,25 @@ describe("TeamsBotConfig Tests", () => {
     const pluginContext = testUtils.newPluginContext();
     const answers = pluginContext.answers!;
     answers[QuestionNames.CAPABILITIES] = [BotOptionItem.id];
+
+    // Act
+    const config = new TeamsBotConfig();
+    await config.restoreConfigFromContext(pluginContext, true);
+
+    // Assert
+    chai.assert.deepEqual(config.actRoles, [PluginActRoles.Bot]);
+  });
+
+  it("test regression bug for legacy bot with GA features: 'act roles is missing.'", async () => {
+    // For GA, legacy bot is also supported, so also test with feature flags enabled.
+    // legacy bot scaffolding should not make actRoles empty
+
+    // Arrange
+    sinon.stub(process, "env").value({ BOT_NOTIFICATION_ENABLED: "true" });
+    const pluginContext = testUtils.newPluginContext();
+    const answers = pluginContext.answers!;
+    answers[QuestionNames.CAPABILITIES] = [BotOptionItem.id];
+    answers[AzureSolutionQuestionNames.Scenarios] = [];
 
     // Act
     const config = new TeamsBotConfig();


### PR DESCRIPTION
For GA we also support adding features of legacy bot.

![image](https://user-images.githubusercontent.com/9698542/165897994-d6542215-c55d-4b4f-a035-8ca55a029bb6.png)


Fix https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14280060/

E2E TEST: n/a covered by unit test