### PR TITLE
fix(sdk): handle Json paring for Android

### DIFF
--- a/packages/sdk/src/credential/teamsUserCredential.browser.ts
+++ b/packages/sdk/src/credential/teamsUserCredential.browser.ts
@@ -119,7 +119,7 @@ export class TeamsUserCredential implements TokenCredential {
 
             let resultJson: any = {};
             try {
-              resultJson = JSON.parse(result);
+              resultJson = typeof result == "string" ? JSON.parse(result) : result;
             } catch (error) {
               // If can not parse result as Json, will throw error.
               const failedToParseResult = "Failed to parse response to Json.";


### PR DESCRIPTION
Fix https://github.com/OfficeDev/TeamsFx/issues/4859

There seems an issue from Teams SDK: https://github.com/OfficeDev/microsoft-teams-library-js/issues/473

Refer to the previous code logic:  https://github.com/OfficeDev/TeamsFx/blob/44ed5ea97551d6abba1c46a891f74bae163e68b2/packages/sdk/src/util/utils.ts#L92, try to handle when `result` is an `object` instead of a `string`.

E2E TEST: N/A