### PR TITLE
chore(template): remove unused npm dependencies in command bot

### DIFF
--- a/templates/bot/js/command-and-response/package.json
+++ b/templates/bot/js/command-and-response/package.json
@@ -17,9 +17,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "@microsoft/adaptivecards-tools": "^0.1.3",
         "@microsoft/teamsfx": "0.7.0-rc.1",
-        "botbuilder": "~4.15.0",
         "restify": "^8.5.1"
     },
     "devDependencies": {

--- a/templates/bot/ts/command-and-response/package.json
+++ b/templates/bot/ts/command-and-response/package.json
@@ -18,23 +18,14 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "@microsoft/adaptivecards-tools": "^0.1.3",
         "@microsoft/teamsfx": "0.7.0-rc.1",
         "botbuilder": "~4.15.0",
-        "botbuilder-azure-blobs": "^4.15.0",
-        "botbuilder-dialogs": "~4.15.0",
-        "fs-extra": "^10.0.0",
-        "isomorphic-fetch": "^3.0.0",
-        "node-cron": "^3.0.0",
         "restify": "^8.5.1"
     },
     "devDependencies": {
-        "@types/fs-extra": "^9.0.13",
-        "@types/node-cron": "^3.0.1",
         "@types/restify": "8.4.2",
         "env-cmd": "^10.1.0",
         "nodemon": "^2.0.7",
-        "shx": "^0.3.3",
         "ts-node": "~9.1.1",
         "typescript": "~3.9.2"
     }


### PR DESCRIPTION
Fix [Bug 14276120](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14276120): Remove unused dependency in scaffolding template