### PR TITLE
fix: fix notification sdk and template

### DIFF
--- a/templates/bot/js/notification-restify/src/index.js
+++ b/templates/bot/js/notification-restify/src/index.js
@@ -1,62 +1,68 @@
 const notificationTemplate = require("./adaptiveCards/notification-default.json");
 const { bot, server } = require("./internal/initialize");
 const { AdaptiveCards } = require("@microsoft/adaptivecards-tools");
+const restify = require("restify");
 
 // HTTP trigger to send notification. You need to add authentication / authorization for this API. Refer https://aka.ms/teamsfx-notification for more details.
-server.post("/api/notification", async (req, res) => {
-  for (const target of await bot.notification.installations()) {
-    await target.sendAdaptiveCard(
-      AdaptiveCards.declare(notificationTemplate).render({
-        title: "New Event Occurred!",
-        appName: "Contoso App Notification",
-        description: `This is a sample http-triggered notification to ${target.type}`,
-        notificationUrl: "https://www.adaptivecards.io/",
-      })
-    );
-  }
-
-  /****** To distinguish different target types ******/
-  /** "Channel" means this bot is installed to a Team (default to notify General channel)
-  if (target.type === "Channel") {
-    // Directly notify the Team (to the default General channel)
-    await target.sendAdaptiveCard(...);
-
-    // List all channels in the Team then notify each channel
-    const channels = await target.channels();
-    for (const channel of channels) {
-      await channel.sendAdaptiveCard(...);
+server.post(
+  "/api/notification",
+  restify.plugins.queryParser(),
+  restify.plugins.bodyParser(), // Add more parsers if needed
+  async (req, res) => {
+    for (const target of await bot.notification.installations()) {
+      await target.sendAdaptiveCard(
+        AdaptiveCards.declare(notificationTemplate).render({
+          title: "New Event Occurred!",
+          appName: "Contoso App Notification",
+          description: `This is a sample http-triggered notification to ${target.type}`,
+          notificationUrl: "https://www.adaptivecards.io/",
+        })
+      );
     }
 
-    // List all members in the Team then notify each member
-    const members = await target.members();
-    for (const member of members) {
-      await member.sendAdaptiveCard(...);
+    /****** To distinguish different target types ******/
+    /** "Channel" means this bot is installed to a Team (default to notify General channel)
+    if (target.type === "Channel") {
+      // Directly notify the Team (to the default General channel)
+      await target.sendAdaptiveCard(...);
+
+      // List all channels in the Team then notify each channel
+      const channels = await target.channels();
+      for (const channel of channels) {
+        await channel.sendAdaptiveCard(...);
+      }
+
+      // List all members in the Team then notify each member
+      const members = await target.members();
+      for (const member of members) {
+        await member.sendAdaptiveCard(...);
+      }
     }
-  }
-  **/
+    **/
 
-  /** "Group" means this bot is installed to a Group Chat
-  if (target.type === "Group") {
-    // Directly notify the Group Chat
-    await target.sendAdaptiveCard(...);
+    /** "Group" means this bot is installed to a Group Chat
+    if (target.type === "Group") {
+      // Directly notify the Group Chat
+      await target.sendAdaptiveCard(...);
 
-    // List all members in the Group Chat then notify each member
-    const members = await target.members();
-    for (const member of members) {
-      await member.sendAdaptiveCard(...);
+      // List all members in the Group Chat then notify each member
+      const members = await target.members();
+      for (const member of members) {
+        await member.sendAdaptiveCard(...);
+      }
     }
-  }
-  **/
+    **/
 
-  /** "Person" means this bot is installed as a Personal app
-  if (target.type === "Person") {
-    // Directly notify the individual person
-    await target.sendAdaptiveCard(...);
-  }
-  **/
+    /** "Person" means this bot is installed as a Personal app
+    if (target.type === "Person") {
+      // Directly notify the individual person
+      await target.sendAdaptiveCard(...);
+    }
+    **/
 
-  res.json({});
-});
+    res.json({});
+  }
+);
 
 // Bot Framework message handler.
 server.post("/api/messages", async (req, res) => {

--- a/templates/bot/ts/notification-restify/src/index.ts
+++ b/templates/bot/ts/notification-restify/src/index.ts
@@ -1,63 +1,69 @@
 import { AdaptiveCards } from "@microsoft/adaptivecards-tools";
+import * as restify from "restify";
 import notificationTemplate from "./adaptiveCards/notification-default.json";
 import { bot, server } from "./internal/initialize";
 import { CardData } from "./cardModels";
 
 // HTTP trigger to send notification. You need to add authentication / authorization for this API. Refer https://aka.ms/teamsfx-notification for more details.
-server.post("/api/notification", async (req, res) => {
-  for (const target of await bot.notification.installations()) {
-    await target.sendAdaptiveCard(
-      AdaptiveCards.declare<CardData>(notificationTemplate).render({
-        title: "New Event Occurred!",
-        appName: "Contoso App Notification",
-        description: `This is a sample http-triggered notification to ${target.type}`,
-        notificationUrl: "https://www.adaptivecards.io/",
-      })
-    );
-  }
-
-  /****** To distinguish different target types ******/
-  /** "Channel" means this bot is installed to a Team (default to notify General channel)
-  if (target.type === "Channel") {
-    // Directly notify the Team (to the default General channel)
-    await target.sendAdaptiveCard(...);
-
-    // List all channels in the Team then notify each channel
-    const channels = await target.channels();
-    for (const channel of channels) {
-      await channel.sendAdaptiveCard(...);
+server.post(
+  "/api/notification",
+  restify.plugins.queryParser(),
+  restify.plugins.bodyParser(), // Add more parsers if needed
+  async (req, res) => {
+    for (const target of await bot.notification.installations()) {
+      await target.sendAdaptiveCard(
+        AdaptiveCards.declare<CardData>(notificationTemplate).render({
+          title: "New Event Occurred!",
+          appName: "Contoso App Notification",
+          description: `This is a sample http-triggered notification to ${target.type}`,
+          notificationUrl: "https://www.adaptivecards.io/",
+        })
+      );
     }
 
-    // List all members in the Team then notify each member
-    const members = await target.members();
-    for (const member of members) {
-      await member.sendAdaptiveCard(...);
+    /****** To distinguish different target types ******/
+    /** "Channel" means this bot is installed to a Team (default to notify General channel)
+    if (target.type === "Channel") {
+      // Directly notify the Team (to the default General channel)
+      await target.sendAdaptiveCard(...);
+
+      // List all channels in the Team then notify each channel
+      const channels = await target.channels();
+      for (const channel of channels) {
+        await channel.sendAdaptiveCard(...);
+      }
+
+      // List all members in the Team then notify each member
+      const members = await target.members();
+      for (const member of members) {
+        await member.sendAdaptiveCard(...);
+      }
     }
-  }
-  **/
+    **/
 
-  /** "Group" means this bot is installed to a Group Chat
-  if (target.type === "Group") {
-    // Directly notify the Group Chat
-    await target.sendAdaptiveCard(...);
+    /** "Group" means this bot is installed to a Group Chat
+    if (target.type === "Group") {
+      // Directly notify the Group Chat
+      await target.sendAdaptiveCard(...);
 
-    // List all members in the Group Chat then notify each member
-    const members = await target.members();
-    for (const member of members) {
-      await member.sendAdaptiveCard(...);
+      // List all members in the Group Chat then notify each member
+      const members = await target.members();
+      for (const member of members) {
+        await member.sendAdaptiveCard(...);
+      }
     }
-  }
-  **/
+    **/
 
-  /** "Person" means this bot is installed as a Personal app
-  if (target.type === "Person") {
-    // Directly notify the individual person
-    await target.sendAdaptiveCard(...);
-  }
-  **/
+    /** "Person" means this bot is installed as a Personal app
+    if (target.type === "Person") {
+      // Directly notify the individual person
+      await target.sendAdaptiveCard(...);
+    }
+    **/
 
-  res.json({});
-});
+    res.json({});
+  }
+);
 
 // Bot Framework message handler.
 server.post("/api/messages", async (req, res) => {


### PR DESCRIPTION
Fix:
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14291987/
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14336323/

- Support `BotMessaged` for personal and group chat, as a fix of empty `installations()`
- Support default parsers in `api/notification` request handler

E2E TEST: covered by UI test