### PR TITLE
chore(react): disable sourcemap generation

### DIFF
--- a/packages/sdk-react/tsconfig.json
+++ b/packages/sdk-react/tsconfig.json
@@ -7,7 +7,7 @@
     "declaration": true /* Generates corresponding '.d.ts' file. */,
     "strict": true /* Enable all strict type-checking options. */,
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
-    "sourceMap": true,
+    "sourceMap": false,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "lib": ["es6", "dom.iterable", "dom"],


### PR DESCRIPTION
Fixing the source map error in tab app templates caused by @microsoft/teamsfx-react after upgrading to CRA5.
According to https://github.com/facebook/create-react-app/discussions/11767, the `sourcemap` config is disabled.