### PR TITLE
fix(existing-app): hide embed existing app from UI and Tutorial

### DIFF
--- a/packages/fx-core/src/common/featureFlags.ts
+++ b/packages/fx-core/src/common/featureFlags.ts
@@ -20,7 +20,6 @@ export function initializePreviewFeatureFlags(): void {
   if (isFeatureFlagEnabled(FeatureFlagName.Preview, false)) {
     process.env[FeatureFlagName.BotNotification] = "true";
     process.env[FeatureFlagName.M365App] = "true";
-    process.env[FeatureFlagName.ExistingTabApp] = "true";
     process.env[FeatureFlagName.ConfigUnify] = "true";
     process.env[FeatureFlagName.AadManifest] = "true";
     process.env[FeatureFlagName.ApiConnect] = "true";

--- a/packages/fx-core/src/core/question.ts
+++ b/packages/fx-core/src/core/question.ts
@@ -281,7 +281,6 @@ export function createCapabilityQuestionPreview(): SingleSelectQuestion {
   const staticOptions: StaticOptions = [
     NotificationOptionItem,
     CommandAndResponseOptionItem,
-    ExistingTabOptionItem,
     TabNewUIOptionItem,
     TabSPFxNewUIItem,
     TabNonSsoItem,
@@ -290,6 +289,11 @@ export function createCapabilityQuestionPreview(): SingleSelectQuestion {
     M365SsoLaunchPageOptionItem,
     M365SearchAppOptionItem,
   ];
+
+  if (isExistingTabAppEnabled()) {
+    staticOptions.splice(2, 0, ExistingTabOptionItem);
+  }
+
   return {
     name: CoreQuestionNames.Capabilities,
     title: getLocalizedString("core.createCapabilityQuestion.titleNew"),

--- a/packages/fx-core/tests/core/question.test.ts
+++ b/packages/fx-core/tests/core/question.test.ts
@@ -168,7 +168,6 @@ describe("Capability Questions", () => {
       chai.assert.deepEqual(question.staticOptions, [
         NotificationOptionItem,
         CommandAndResponseOptionItem,
-        ExistingTabOptionItem,
         TabNewUIOptionItem,
         TabSPFxNewUIItem,
         TabNonSsoItem,

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -73,6 +73,7 @@ import {
   globalStateUpdate,
   InvalidProjectError,
   isConfigUnifyEnabled,
+  isExistingTabAppEnabled,
   isPreviewFeaturesEnabled,
   isUserCancelError,
   isValidProject,
@@ -3055,12 +3056,6 @@ export async function selectTutorialsHandler(args?: any[]): Promise<Result<unkno
     title: "Tutorials",
     options: [
       {
-        id: "embedWebPages",
-        label: `${localize("teamstoolkit.tutorials.embedWebPages.label")}`,
-        detail: localize("teamstoolkit.tutorials.embedWebPages.detail"),
-        data: "https://aka.ms/teamsfx-embed-existing-web",
-      },
-      {
         id: "sendNotification",
         label: `${localize("teamstoolkit.tutorials.sendNotification.label")}`,
         detail: localize("teamstoolkit.tutorials.sendNotification.detail"),
@@ -3087,6 +3082,16 @@ export async function selectTutorialsHandler(args?: any[]): Promise<Result<unkno
     ],
     returnObject: true,
   };
+
+  if (isExistingTabAppEnabled()) {
+    config.options.splice(0, 0, {
+      id: "embedWebPages",
+      label: `${localize("teamstoolkit.tutorials.embedWebPages.label")}`,
+      detail: localize("teamstoolkit.tutorials.embedWebPages.detail"),
+      data: "https://aka.ms/teamsfx-embed-existing-web",
+    });
+  }
+
   const selectedTutorial = await VS_CODE_UI.selectOption(config);
   if (selectedTutorial.isErr()) {
     return err(selectedTutorial.error);


### PR DESCRIPTION
Due to the latest decision from PM side, "embed existing app" will be hide from UI and Tutorial.

work item: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14355354/
E2E TEST: https://github.com/OfficeDev/TeamsFx/blob/01d6a9fb35d8418a3cec89a96949325bcbbea968/packages/cli/tests/e2e/existingapp/TestCreateExistingTab.tests.ts#L17