### PR TITLE
fix: adjust sample gallery layout and remove proactive sample

### DIFF
--- a/packages/fx-core/src/common/samples-config.json
+++ b/packages/fx-core/src/common/samples-config.json
@@ -138,20 +138,6 @@
             "suggested": false
         },
         {
-            "id": "bot-proactive-messaging-teamsfx",
-            "title": "Proactive Messaging",
-            "shortDescription": "Demonstrates how to send proactive messages to users.",
-            "fullDescription": "This is a sample which shows how to save user's conversation reference information to send proactive reminder message using Bots.",
-            "tags": [
-                "Bot" , "JS"
-            ],
-            "time": "5min to run",
-            "configuration": "Ready for local debug",
-            "suggested": false,
-            "url": "https://github.com/OfficeDev/Microsoft-Teams-Samples/tree/main/samples/",
-            "packageLink": "https://github.com/OfficeDev/Microsoft-Teams-Samples/archive/refs/heads/main.zip"
-        },
-        {
             "id": "adaptive-card-notification",
             "title": "Adaptive Card Notification",
             "shortDescription": "Demonstrates how to send adaptive card notification to users.",

--- a/packages/vscode-extension/src/controls/SampleGallery.scss
+++ b/packages/vscode-extension/src/controls/SampleGallery.scss
@@ -221,7 +221,7 @@
 
 @media only screen and (max-width: 1024px) {
   .sample-gallery{
-    .box1, .box4, .box7, .box10, .box13, .box14, .box17 {
+    .box1, .box4, .box7, .box10, .box13, .box16 {
       grid-column: 1/5;
     }
     .box2, .box5, .box8, .box11, .box14, .box17 {
@@ -236,10 +236,10 @@
 
 @media only screen and (max-width: 813px){
   .sample-gallery{
-    .box1, .box3, .box5, .box7, .box9, .box11, .box13, .box15 {
+    .box1, .box3, .box5, .box7, .box9, .box11, .box13, .box15, .box17 {
       grid-column: 1/7;
     }
-    .box2, .box4,.box6,.box8, .box10,.box12, .box14 {
+    .box2, .box4,.box6,.box8, .box10,.box12, .box14, .box16 {
       grid-column: 7/13;
     }
   }
@@ -255,7 +255,7 @@
   .sample-gallery {
     min-width: 320px;
 
-  .box1, .box2, .box3, .box4, .box5, .box6, .box7, .box8, .box9, .box10, .box11, .box12, .box13, .box14, .box15 {
+  .box1, .box2, .box3, .box4, .box5, .box6, .box7, .box8, .box9, .box10, .box11, .box12, .box13, .box14, .box15, .box16, .box17 {
       grid-column: 1/13;
     }
   }


### PR DESCRIPTION
1. fix sample gallery layout for 'incoming webhook notification' and 'graph connector app'
2. remove proactive message app which is reverted unexpectedly when merging to ga
Note: the resources of 'Adaptive card notification' and 'incoming webhook notification' will be added by sample owner later
After:
![image](https://user-images.githubusercontent.com/73154171/167236468-636b8428-9502-4ad1-b753-6532e2844d88.png)
ADO:
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14344432

E2E TEST: NA