### PR TITLE
fix(tab): remove extra bracket

### DIFF
--- a/templates/tab/js/non-sso/src/components/App.jsx
+++ b/templates/tab/js/non-sso/src/components/App.jsx
@@ -21,14 +21,12 @@ export default function App() {
         <Route exact path="/">
           <Redirect to="/tab" />
         </Route>
-        (
-          <>
-            <Route exact path="/privacy" component={Privacy} />
-            <Route exact path="/termsofuse" component={TermsOfUse} />
-            <Route exact path="/tab" component={Tab} />
-            <Route exact path="/config" component={TabConfig} />
-          </>
-        )
+        <>
+          <Route exact path="/privacy" component={Privacy} />
+          <Route exact path="/termsofuse" component={TermsOfUse} />
+          <Route exact path="/tab" component={Tab} />
+          <Route exact path="/config" component={TabConfig} />
+        </>
       </Router>
     </Provider>
   );

--- a/templates/tab/ts/non-sso/src/components/App.tsx
+++ b/templates/tab/ts/non-sso/src/components/App.tsx
@@ -21,14 +21,12 @@ export default function App() {
         <Route exact path="/">
           <Redirect to="/tab" />
         </Route>
-        (
-          <>
-            <Route exact path="/privacy" component={Privacy} />
-            <Route exact path="/termsofuse" component={TermsOfUse} />
-            <Route exact path="/tab" component={Tab} />
-            <Route exact path="/config" component={TabConfig} />
-          </>
-        )
+        <>
+          <Route exact path="/privacy" component={Privacy} />
+          <Route exact path="/termsofuse" component={TermsOfUse} />
+          <Route exact path="/tab" component={Tab} />
+          <Route exact path="/config" component={TabConfig} />
+        </>
       </Router>
     </Provider>
   );


### PR DESCRIPTION
Fix the bug [14290637](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14290637/). useless bracket in tab config description after add app to a chat or a team.

E2E TEST: https://github.com/OfficeDev/TeamsFx/blob/6ea4ac9e4d603118b47ccc8e6bae8638c6a23ea2/packages/cli/tests/e2e/frontend/TestCreateTab.tests.ts#L38