### PR TITLE
chore: revert sdk change from main branch

### DIFF
--- a/packages/fx-core/templates/plugins/resource/apiconnector/package.json
+++ b/packages/fx-core/templates/plugins/resource/apiconnector/package.json
@@ -1,5 +1,5 @@
 {
     "dependencies": {
-        "@microsoft/teamsfx": "^0.7.0"
+        "@microsoft/teamsfx": "0.7.0-rc.1"
     }
 }


### PR DESCRIPTION
api connector plugin should use latest SDK version in next release