### PR TITLE
fix: missing commands and descriptions of teamsfx add

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -2401,8 +2401,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "resolved": "",
           "dev": true
         },
         "is-fullwidth-code-point": {
@@ -5152,8 +5151,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "resolved": "",
           "dev": true
         },
         "is-fullwidth-code-point": {
@@ -6027,8 +6025,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "resolved": "",
           "dev": true
         },
         "camelcase": {

--- a/packages/cli/src/cmds/add.ts
+++ b/packages/cli/src/cmds/add.ts
@@ -29,6 +29,7 @@ import {
   CapabilityAddCommandAndResponse,
   CapabilityAddMessageExtension,
   CapabilityAddNotification,
+  CapabilityAddSSOTab,
   CapabilityAddTab,
 } from "./capability";
 import {
@@ -41,7 +42,7 @@ import {
 export class AddCICD extends YargsCommand {
   public readonly commandHead = `cicd`;
   public readonly command = this.commandHead;
-  public readonly description = "Add CI/CD Workflows for GitHub, Azure DevOps or Jenkins.";
+  public readonly description = "Add CI/CD Workflows for GitHub, Azure DevOps or Jenkins";
 
   public builder(yargs: Argv): Argv<any> {
     this.params = HelpParamGenerator.getYargsParamForHelp("addCICDWorkflows");
@@ -146,7 +147,7 @@ export class AddExistingApiSubCommand extends AddExistingApiAuthBase {
 export class AddExistingApiMainCommand extends AddExistingApiAuthBase {
   public readonly commandHead = `api-connection`;
   public readonly command = `${this.commandHead} [auth-type]`;
-  public readonly description = "Add connection to an API";
+  public readonly description = "Connect to an API with authentication support using TeamsFx SDK";
 
   public readonly subCommands: YargsCommand[] = [
     new AddExistingApiSubCommand("basic"),
@@ -167,10 +168,12 @@ export class AddExistingApiMainCommand extends AddExistingApiAuthBase {
     });
   }
 }
+
 export class AddSso extends YargsCommand {
   public readonly commandHead = `sso`;
   public readonly command = this.commandHead;
-  public readonly description = "Add Single Sign On for your project.";
+  public readonly description =
+    "Develop a Single Sign-On feature for Teams Launch pages and Bot capability";
 
   public builder(yargs: Argv): Argv<any> {
     this.params = HelpParamGenerator.getYargsParamForHelp("addSso");
@@ -223,23 +226,25 @@ export default class Add extends YargsCommand {
       ? [
           // Category 1: Add Teams Capability
           ...(isBotNotificationEnabled()
-            ? [new CapabilityAddCommandAndResponse(), new CapabilityAddNotification()]
-            : [new CapabilityAddBot()]),
-          new CapabilityAddMessageExtension(),
+            ? [new CapabilityAddNotification(), new CapabilityAddCommandAndResponse()]
+            : []),
+          new CapabilityAddSSOTab(),
           new CapabilityAddTab(),
+          new CapabilityAddBot(),
+          new CapabilityAddMessageExtension(),
 
           // Category 2: Add Cloud Resources
           new ResourceAddFunction(),
-          new ResourceAddSql(),
           new ResourceAddApim(),
+          new ResourceAddSql(),
           new ResourceAddKeyVault(),
         ]
       : []),
 
     // Category 3: Standalone features
-    new AddCICD(),
-    ...(isApiConnectEnabled() ? [new AddExistingApiMainCommand()] : []),
     ...(isAadManifestEnabled() ? [new AddSso()] : []),
+    ...(isApiConnectEnabled() ? [new AddExistingApiMainCommand()] : []),
+    new AddCICD(),
   ];
 
   public builder(yargs: Argv): Argv<any> {

--- a/packages/cli/src/cmds/capability.ts
+++ b/packages/cli/src/cmds/capability.ts
@@ -10,6 +10,7 @@ import { err, FxError, ok, Platform, ProjectSettings, Result } from "@microsoft/
 import {
   AzureSolutionQuestionNames as Names,
   isBotNotificationEnabled,
+  isPreviewFeaturesEnabled,
   ProjectSettingsHelper,
 } from "@microsoft/teamsfx-core";
 
@@ -105,8 +106,12 @@ abstract class CapabilityAddBase extends YargsCommand {
 export class CapabilityAddTab extends CapabilityAddBase {
   public readonly commandHead = `tab`;
   public readonly command = `${this.commandHead}`;
-  public readonly description = "Hello world webpages embedded in Microsoft Teams";
-  public readonly yargsHelp = "addCapability-TabNonSso";
+  public readonly description = isPreviewFeaturesEnabled()
+    ? "Hello world webpages embedded in Microsoft Teams"
+    : "Teams identity aware webpages embedded in Microsoft Teams";
+  public readonly yargsHelp = isPreviewFeaturesEnabled()
+    ? "addCapability-TabNonSso"
+    : "addCapability-Tab";
 
   public override getNpmInstallExcludeCaps(settings: ProjectSettings | undefined) {
     return {

--- a/packages/cli/src/cmds/capability.ts
+++ b/packages/cli/src/cmds/capability.ts
@@ -105,7 +105,22 @@ abstract class CapabilityAddBase extends YargsCommand {
 export class CapabilityAddTab extends CapabilityAddBase {
   public readonly commandHead = `tab`;
   public readonly command = `${this.commandHead}`;
-  public readonly description = "Add a tab.";
+  public readonly description = "Hello world webpages embedded in Microsoft Teams";
+  public readonly yargsHelp = "addCapability-TabNonSso";
+
+  public override getNpmInstallExcludeCaps(settings: ProjectSettings | undefined) {
+    return {
+      excludeFrontend: ProjectSettingsHelper.includeFrontend(settings),
+      excludeBackend: true,
+      excludeBot: true,
+    };
+  }
+}
+
+export class CapabilityAddSSOTab extends CapabilityAddBase {
+  public readonly commandHead = `sso-tab`;
+  public readonly command = `${this.commandHead}`;
+  public readonly description = "Teams identity aware webpages embedded in Microsoft Teams";
   public readonly yargsHelp = "addCapability-Tab";
 
   public override getNpmInstallExcludeCaps(settings: ProjectSettings | undefined) {
@@ -130,28 +145,29 @@ abstract class CapabilityAddBotBase extends CapabilityAddBase {
 export class CapabilityAddBot extends CapabilityAddBotBase {
   public readonly commandHead = `bot`;
   public readonly command = `${this.commandHead}`;
-  public readonly description = "Add a bot.";
+  public readonly description = "Hello world chatbot to run simple and repetitive tasks by user";
   public readonly yargsHelp = "addCapability-Bot";
 }
 
 export class CapabilityAddMessageExtension extends CapabilityAddBotBase {
   public readonly commandHead = `message-extension`;
   public readonly command = `${this.commandHead}`;
-  public readonly description = "Add Message Extensions.";
+  public readonly description =
+    "Hello world message extension allowing interactions via buttons and forms";
   public readonly yargsHelp = "addCapability-MessagingExtension";
 }
 
 export class CapabilityAddNotification extends CapabilityAddBotBase {
   public readonly commandHead = "notification";
   public readonly command = `${this.commandHead}`;
-  public readonly description = "Add notification.";
+  public readonly description = "Send notification to Microsoft Teams via various triggers";
   public readonly yargsHelp = "addCapability-Notification";
 }
 
 export class CapabilityAddCommandAndResponse extends CapabilityAddBotBase {
   public readonly commandHead = "command-and-response";
   public readonly command = `${this.commandHead}`;
-  public readonly description = "Add command and response.";
+  public readonly description = "Respond to simple commands in Microsoft Teams chat";
   public readonly yargsHelp = "addCapability-CommandAndResponse";
 }
 

--- a/packages/cli/src/cmds/resource.ts
+++ b/packages/cli/src/cmds/resource.ts
@@ -96,7 +96,8 @@ export class ResourceAdd extends YargsCommand {
 export class ResourceAddSql extends YargsCommand {
   public readonly commandHead = `azure-sql`;
   public readonly command = `${this.commandHead}`;
-  public readonly description = "Add a new SQL database.";
+  public readonly description =
+    "An always-up-to-date relational database service built for the cloud";
 
   public builder(yargs: Argv): Argv<any> {
     this.params = HelpParamGenerator.getYargsParamForHelp("addResource-sql");
@@ -153,7 +154,8 @@ export class ResourceAddSql extends YargsCommand {
 export class ResourceAddApim extends YargsCommand {
   public readonly commandHead = `azure-apim`;
   public readonly command = `${this.commandHead}`;
-  public readonly description = "Add a new API Managment service instance.";
+  public readonly description =
+    "A hybrid, multicloud management platform for APIs across all environments";
 
   public builder(yargs: Argv): Argv<any> {
     this.params = HelpParamGenerator.getYargsParamForHelp("addResource-apim");
@@ -228,7 +230,8 @@ export class ResourceAddApim extends YargsCommand {
 export class ResourceAddFunction extends YargsCommand {
   public readonly commandHead = `azure-function`;
   public readonly command = `${this.commandHead}`;
-  public readonly description = "Add a new function app.";
+  public readonly description =
+    "A serverless, event-driven compute solution that allows you to write less code";
 
   public builder(yargs: Argv): Argv<any> {
     this.params = HelpParamGenerator.getYargsParamForHelp("addResource-function");
@@ -298,7 +301,7 @@ export class ResourceAddFunction extends YargsCommand {
 export class ResourceAddKeyVault extends YargsCommand {
   public readonly commandHead = `azure-keyvault`;
   public readonly command = `${this.commandHead}`;
-  public readonly description = "Add a new Azure Key Vault service.";
+  public readonly description = "A cloud service for securely storing and accessing secrets";
 
   public builder(yargs: Argv): Argv<any> {
     this.params = HelpParamGenerator.getYargsParamForHelp("addResource-keyvault");

--- a/packages/cli/src/userInteraction.ts
+++ b/packages/cli/src/userInteraction.ts
@@ -287,6 +287,12 @@ export class CLIUserInteraction implements UserInteraction {
   }
 
   private toChoices<T>(option: StaticOptions, defaultValue?: T): [ChoiceOptions[], T | undefined] {
+    const labelClean = (label: string) => {
+      return label
+        .replace("$(browser)", "")
+        .replace("$(hubot)", "")
+        .replace("$(comment-discussion)", "");
+    };
     if (typeof option[0] === "string") {
       const choices = (option as string[]).map((op) => {
         return {
@@ -302,7 +308,7 @@ export class CLIUserInteraction implements UserInteraction {
         return {
           name: op.id,
           extra: {
-            title: op.label,
+            title: labelClean(op.label),
             description: op.description,
             detail: op.detail,
           },

--- a/packages/cli/tests/commonlib/constants.ts
+++ b/packages/cli/tests/commonlib/constants.ts
@@ -33,6 +33,7 @@ export const fileEncoding = "UTF8";
 
 export enum Capability {
   Tab = "tab",
+  SSOTab = "sso-tab",
   Bot = "bot",
   MessageExtension = "message-extension",
   M365SsoLaunchPage = "sso-launch-page",

--- a/packages/cli/tests/e2e/bot/BotAddTab.tests.ts
+++ b/packages/cli/tests/e2e/bot/BotAddTab.tests.ts
@@ -16,7 +16,7 @@ import {
   setBotSkuNameToB1Bicep,
   setSimpleAuthSkuNameToB1Bicep,
 } from "../commonUtils";
-import { environmentManager } from "@microsoft/teamsfx-core";
+import { environmentManager, isPreviewFeaturesEnabled } from "@microsoft/teamsfx-core";
 import { CliHelper } from "../../commonlib/cliHelper";
 import { Capability } from "../../commonlib/constants";
 import { BotValidator } from "../../commonlib";
@@ -34,7 +34,11 @@ describe("Configuration successfully changed when with different plugins", funct
 
   it(`bot + tab`, async function () {
     await CliHelper.createProjectWithCapability(appName, testFolder, Capability.Bot);
-    await CliHelper.addCapabilityToProject(projectPath, Capability.Tab);
+    if (isPreviewFeaturesEnabled()) {
+      await CliHelper.addCapabilityToProject(projectPath, Capability.SSOTab);
+    } else {
+      await CliHelper.addCapabilityToProject(projectPath, Capability.Tab);
+    }
 
     // Provision
     await setSimpleAuthSkuNameToB1Bicep(projectPath, env);

--- a/packages/cli/tests/e2e/manifest/addCapability.tests.ts
+++ b/packages/cli/tests/e2e/manifest/addCapability.tests.ts
@@ -14,6 +14,7 @@ import * as fs from "fs-extra";
 import { TeamsAppManifest } from "@microsoft/teamsfx-api";
 import { it } from "../../commonlib/it";
 import * as chai from "chai";
+import { isPreviewFeaturesEnabled } from "@microsoft/teamsfx-core";
 
 describe("Add capabilities", function () {
   const testFolder = getTestFolder();
@@ -32,7 +33,11 @@ describe("Add capabilities", function () {
   it("tab project can add tab capability with correct manifest template", async function () {
     await CliHelper.createProjectWithCapability(appName, testFolder, Capability.Tab);
 
-    await CliHelper.addCapabilityToProject(projectPath, Capability.Tab);
+    if (isPreviewFeaturesEnabled()) {
+      await CliHelper.addCapabilityToProject(projectPath, Capability.SSOTab);
+    } else {
+      await CliHelper.addCapabilityToProject(projectPath, Capability.Tab);
+    }
 
     const manifest: TeamsAppManifest = await fs.readJSON(
       `${projectPath}/templates/appPackage/manifest.template.json`

--- a/packages/cli/tests/e2e/solution/AddCapabilities_BotAddTab.tests.ts
+++ b/packages/cli/tests/e2e/solution/AddCapabilities_BotAddTab.tests.ts
@@ -6,7 +6,7 @@
  */
 
 import path from "path";
-import { environmentManager } from "@microsoft/teamsfx-core";
+import { environmentManager, isPreviewFeaturesEnabled } from "@microsoft/teamsfx-core";
 import {
   getSubscriptionId,
   getTestFolder,
@@ -36,7 +36,11 @@ describe("Add capabilities", function () {
     await CliHelper.createProjectWithCapability(appName, testFolder, Capability.Bot);
 
     // Act
-    await CliHelper.addCapabilityToProject(projectPath, Capability.Tab);
+    if (isPreviewFeaturesEnabled()) {
+      await CliHelper.addCapabilityToProject(projectPath, Capability.SSOTab);
+    } else {
+      await CliHelper.addCapabilityToProject(projectPath, Capability.Tab);
+    }
 
     await setSimpleAuthSkuNameToB1Bicep(projectPath, env);
     await setBotSkuNameToB1Bicep(projectPath, env);

--- a/packages/cli/tests/e2e/solution/AddCapabilities_MEAddTab.tests.ts
+++ b/packages/cli/tests/e2e/solution/AddCapabilities_MEAddTab.tests.ts
@@ -6,7 +6,7 @@
  */
 
 import path from "path";
-import { environmentManager } from "@microsoft/teamsfx-core";
+import { environmentManager, isPreviewFeaturesEnabled } from "@microsoft/teamsfx-core";
 import {
   getSubscriptionId,
   getTestFolder,
@@ -36,7 +36,11 @@ describe("Add capabilities", function () {
     await CliHelper.createProjectWithCapability(appName, testFolder, Capability.MessageExtension);
 
     // Act
-    await CliHelper.addCapabilityToProject(projectPath, Capability.Tab);
+    if (isPreviewFeaturesEnabled()) {
+      await CliHelper.addCapabilityToProject(projectPath, Capability.SSOTab);
+    } else {
+      await CliHelper.addCapabilityToProject(projectPath, Capability.Tab);
+    }
 
     await setSimpleAuthSkuNameToB1Bicep(projectPath, env);
     await setBotSkuNameToB1Bicep(projectPath, env);

--- a/packages/cli/tests/unit/cmds/addApiConnection.tests.ts
+++ b/packages/cli/tests/unit/cmds/addApiConnection.tests.ts
@@ -5,7 +5,7 @@ import sinon from "sinon";
 import yargs, { Options } from "yargs";
 
 import { FxError, Inputs, ok, Func } from "@microsoft/teamsfx-api";
-import { FxCore } from "@microsoft/teamsfx-core";
+import { FxCore, isPreviewFeaturesEnabled } from "@microsoft/teamsfx-core";
 import HelpParamGenerator from "../../../src/helpParamGenerator";
 import { TelemetryEvent } from "../../../src/telemetry/cliTelemetryEvents";
 import CliTelemetry from "../../../src/telemetry/cliTelemetry";
@@ -67,16 +67,37 @@ describe("Add api-connector Command Tests", () => {
   it("Builder Check", () => {
     const cmd = new Add();
     yargs.command(cmd.command, cmd.description, cmd.builder.bind(cmd), cmd.handler.bind(cmd));
-    expect(registeredCommands).deep.equals([
-      "add <feature>",
-      "cicd",
-      "api-connection [auth-type]",
-      "basic",
-      "aad",
-      "apikey",
-      "cert",
-      "custom",
-    ]);
+    expect(registeredCommands).deep.equals(
+      isPreviewFeaturesEnabled()
+        ? [
+            "add <feature>",
+            "sso-tab",
+            "tab",
+            "bot",
+            "message-extension",
+            "azure-function",
+            "azure-apim",
+            "azure-sql",
+            "azure-keyvault",
+            "api-connection [auth-type]",
+            "basic",
+            "aad",
+            "apikey",
+            "cert",
+            "custom",
+            "cicd",
+          ]
+        : [
+            "add <feature>",
+            "api-connection [auth-type]",
+            "basic",
+            "aad",
+            "apikey",
+            "cert",
+            "custom",
+            "cicd",
+          ]
+    );
   });
 
   it("Add api-connection Command Running Check", async () => {

--- a/packages/cli/tests/unit/cmds/addCICD.tests.ts
+++ b/packages/cli/tests/unit/cmds/addCICD.tests.ts
@@ -5,7 +5,7 @@ import sinon from "sinon";
 import yargs, { Options } from "yargs";
 
 import { FxError, Inputs, LogLevel, ok, Func } from "@microsoft/teamsfx-api";
-import { FxCore } from "@microsoft/teamsfx-core";
+import { FxCore, isPreviewFeaturesEnabled } from "@microsoft/teamsfx-core";
 
 import Add from "../../../src/cmds/add";
 import CliTelemetry from "../../../src/telemetry/cliTelemetry";
@@ -68,7 +68,22 @@ describe("Add CICD Command Tests", function () {
   it("Builder Check", () => {
     const cmd = new Add();
     yargs.command(cmd.command, cmd.description, cmd.builder.bind(cmd), cmd.handler.bind(cmd));
-    expect(registeredCommands).deep.equals(["add <feature>", "cicd"]);
+    expect(registeredCommands).deep.equals(
+      isPreviewFeaturesEnabled()
+        ? [
+            "add <feature>",
+            "sso-tab",
+            "tab",
+            "bot",
+            "message-extension",
+            "azure-function",
+            "azure-apim",
+            "azure-sql",
+            "azure-keyvault",
+            "cicd",
+          ]
+        : ["add <feature>", "cicd"]
+    );
   });
 
   it("Add CICD Command Running Check", async () => {

--- a/packages/cli/tests/unit/cmds/addSso.tests.ts
+++ b/packages/cli/tests/unit/cmds/addSso.tests.ts
@@ -12,7 +12,7 @@ import CliTelemetry from "../../../src/telemetry/cliTelemetry";
 import { expect } from "../utils";
 import Add from "../../../src/cmds/add";
 import mockedEnv from "mocked-env";
-import { FxCore } from "@microsoft/teamsfx-core";
+import { FxCore, isPreviewFeaturesEnabled } from "@microsoft/teamsfx-core";
 import { TelemetryEvent } from "../../../src/telemetry/cliTelemetryEvents";
 
 describe("Add Command Tests", function () {
@@ -79,7 +79,23 @@ describe("Add Command Tests", function () {
   it("Builder Check", () => {
     const cmd = new Add();
     yargs.command(cmd.command, cmd.description, cmd.builder.bind(cmd), cmd.handler.bind(cmd));
-    expect(registeredCommands).deep.equals(["add <feature>", "cicd", "sso"]);
+    expect(registeredCommands).deep.equals(
+      isPreviewFeaturesEnabled()
+        ? [
+            "add <feature>",
+            "sso-tab",
+            "tab",
+            "bot",
+            "message-extension",
+            "azure-function",
+            "azure-apim",
+            "azure-sql",
+            "azure-keyvault",
+            "sso",
+            "cicd",
+          ]
+        : ["add <feature>", "sso", "cicd"]
+    );
   });
 
   it("Add SSO", async () => {

--- a/packages/cli/tests/unit/cmds/index.tests.ts
+++ b/packages/cli/tests/unit/cmds/index.tests.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { isPreviewFeaturesEnabled } from "@microsoft/teamsfx-core";
 import sinon from "sinon";
 import yargs from "yargs";
 
@@ -33,8 +34,10 @@ describe("Register Commands Tests", function () {
     registerCommands(yargs);
     expect(registeredCommands).includes("account");
     expect(registeredCommands).includes("new");
-    expect(registeredCommands).includes("capability");
-    expect(registeredCommands).includes("resource");
+    if (!isPreviewFeaturesEnabled()) {
+      expect(registeredCommands).includes("capability");
+      expect(registeredCommands).includes("resource");
+    }
     expect(registeredCommands).includes("provision");
     expect(registeredCommands).includes("deploy");
     expect(registeredCommands).includes("package");


### PR DESCRIPTION
1. Change the descriptions of `teamsfx add -h`.
2. Add `teamsfx add sso-tab` if the preview feature flag opens.
3. Remove the meaningless prefix of capabilities when running `teamsfx new`.
![image](https://user-images.githubusercontent.com/15262146/167524680-a6a6cf54-bf2f-4b58-98f4-192b4c2f6476.png)
![image](https://user-images.githubusercontent.com/15262146/167524719-f1e657f5-e370-4136-a434-9d7e9fc8299c.png)
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14378128
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14378135
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14378149
E2E TEST: https://github.com/OfficeDev/TeamsFx/actions/runs/2297896401 the failures are not caused by this PR.