### PR TITLE
chore: rename messaging extension to message extension

### DIFF
--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -18,9 +18,9 @@ Teams apps are a combination of [capabilities](https://aka.ms/teamsfx-capabiliti
 
 <a href=https://docs.microsoft.com/en-us/microsoftteams/platform/bots/what-are-bots>Bots</a> allow users to interact with your web service through text, interactive cards, and task modules.
 
-### Messaging Extension
+### Message Extension
 
-<a href=https://docs.microsoft.com/en-us/microsoftteams/platform/messaging-extensions/what-are-messaging-extensions>Messaging extensions</a> allow users to interact with your web service through buttons and forms in the Microsoft Teams client.
+<a href=https://docs.microsoft.com/en-us/microsoftteams/platform/messaging-extensions/what-are-messaging-extensions>Message extensions</a> allow users to interact with your web service through buttons and forms in the Microsoft Teams client.
 
 ## Getting started
 

--- a/templates/bot/js/default/README.md
+++ b/templates/bot/js/default/README.md
@@ -1,12 +1,12 @@
-# How to use this Bots and Messaging Extensions HelloWorld app
+# How to use this Bots and Message Extensions HelloWorld app
 
 A bot, chatbot, or conversational bot is an app that responds to simple commands sent in chat and replies in meaningful ways. Examples of bots in everyday use include: bots that notify about build failures, bots that provide information about the weather or bus schedules, or provide travel information. A bot interaction can be a quick question and answer, or it can be a complex conversation. Being a cloud application, a bot can provide valuable and secure access to cloud services and corporate resources.
 
-A Messaging Extension allows users to interact with your web service while composing messages in the Microsoft Teams client. Users can invoke your web service to assist message composition, from the message compose box, or from the search bar.
+A Message Extension allows users to interact with your web service while composing messages in the Microsoft Teams client. Users can invoke your web service to assist message composition, from the message compose box, or from the search bar.
 
-Messaging Extensions are implemented on top of the Bot support architecture within Teams.
+Message Extensions are implemented on top of the Bot support architecture within Teams.
 
-This is a simple hello world application with both Bot and Messaging extension capabilities.
+This is a simple hello world application with both Bot and Message extension capabilities.
 
 ## Prerequisites
 
@@ -68,7 +68,7 @@ Once deployed, you may want to distribute your application to your organization'
 - From Visual Studio Code: open the Teams Toolkit and click `Publish to Teams` or open the command palette and select: `Teams: Publish to Teams`.
 - From TeamsFx CLI: run command `teamsfx publish` in your project directory.
 
-## Play with Messaging Extension
+## Play with Message Extension
 
 This template provides some sample functionality:
 
@@ -88,15 +88,15 @@ This template provides some sample functionality:
 
 To trigger these functions, there are multiple entry points:
 
-- `@mention` Your messaging extension, from the `search box area`.
+- `@mention` Your message extension, from the `search box area`.
 
   ![AtBotFromSearch](./images/AtBotFromSearch.png)
 
-- `@mention` your messaging extension from the `compose message area`.
+- `@mention` your message extension from the `compose message area`.
 
   ![AtBotFromMessage](./images/AtBotInMessage.png)
 
-- Click the `...` under compose message area, find your messaging extension.
+- Click the `...` under compose message area, find your message extension.
 
   ![ComposeArea](./images/ThreeDot.png)
 
@@ -112,7 +112,7 @@ To trigger these functions, there are multiple entry points:
 - [Bot Framework Documentation](https://docs.botframework.com/)
 - [Azure Bot Service Introduction](https://docs.microsoft.com/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0)
 
-### Messaging Extension
+### Message Extension
 
 - [Search Command](https://docs.microsoft.com/en-us/microsoftteams/platform/messaging-extensions/how-to/search-commands/define-search-command)
 - [Action Command](https://docs.microsoft.com/en-us/microsoftteams/platform/messaging-extensions/how-to/action-commands/define-action-command)

--- a/templates/bot/js/default/teamsBot.js
+++ b/templates/bot/js/default/teamsBot.js
@@ -1,6 +1,6 @@
 const axios = require("axios");
 const querystring = require("querystring");
-const { TeamsActivityHandler, CardFactory, TurnContext} = require("botbuilder");
+const { TeamsActivityHandler, CardFactory, TurnContext } = require("botbuilder");
 const rawWelcomeCard = require("./adaptiveCards/welcome.json");
 const rawLearnCard = require("./adaptiveCards/learn.json");
 const cardTools = require("@microsoft/adaptivecards-tools");
@@ -15,9 +15,7 @@ class TeamsBot extends TeamsActivityHandler {
     this.onMessage(async (context, next) => {
       console.log("Running with Message Activity.");
       let txt = context.activity.text;
-      const removedMentionText = TurnContext.removeRecipientMention(
-        context.activity
-      );
+      const removedMentionText = TurnContext.removeRecipientMention(context.activity);
       if (removedMentionText) {
         // Remove the line break
         txt = removedMentionText.toLowerCase().replace(/\n|\r/g, "").trim();
@@ -78,7 +76,7 @@ class TeamsBot extends TeamsActivityHandler {
     }
   }
 
-  // Messaging extension Code
+  // Message extension Code
   // Action.
   handleTeamsMessagingExtensionSubmitAction(context, action) {
     switch (action.commandId) {
@@ -181,7 +179,7 @@ function shareMessageCommand(context, action) {
     userName = action.messagePayload.from.user.displayName;
   }
 
-  // This Messaging Extension example allows the user to check a box to include an image with the
+  // This Message Extension example allows the user to check a box to include an image with the
   // shared message.  This demonstrates sending custom parameters along with the message payload.
   let images = [];
   const includeImage = action.data.includeImage;

--- a/templates/bot/js/m365/README.md
+++ b/templates/bot/js/m365/README.md
@@ -1,10 +1,10 @@
-# How to use this M365 Messaging Extensions Search app
+# How to use this M365 Message Extensions Search app
 
-A Messaging Extension allows users to interact with your web service while composing messages in the Microsoft Teams and Outlook client. Users can invoke your web service to assist message composition, from the message compose box, or from the search bar.
+A Message Extension allows users to interact with your web service while composing messages in the Microsoft Teams and Outlook client. Users can invoke your web service to assist message composition, from the message compose box, or from the search bar.
 
-Messaging Extensions are implemented on top of the Bot support architecture within Teams.
+Message Extensions are implemented on top of the Bot support architecture within Teams.
 
-This is a simple search application with Messaging extension capabilities.
+This is a simple search application with Message extension capabilities.
 
 ![Search App Demo](./images/SearchAppDemo.gif)
 
@@ -78,7 +78,7 @@ Once deployed, you may want to distribute your application to your organization'
 - From Visual Studio Code: open the Teams Toolkit and click `Publish to Teams` or open the command palette and select: `Teams: Publish to Teams`.
 - From TeamsFx CLI: run command `teamsfx publish` in your project directory.
 
-## Play with Messaging Extension
+## Play with Message Extension
 
 This template provides the sample functionality:
 
@@ -86,20 +86,20 @@ This template provides the sample functionality:
 
 To trigger the function in Teams, there are multiple entry points:
 
-- `@mention` Your messaging extension, from the `search box area`.
+- `@mention` Your message extension, from the `search box area`.
 
   ![AtBotFromSearch](./images/AtBotFromSearch.png)
 
-- `@mention` your messaging extension from the `compose message area`.
+- `@mention` your message extension from the `compose message area`.
 
   ![AtBotFromMessage](./images/AtBotInMessage.png)
 
-- Click the `...` under compose message area, find your messaging extension.
+- Click the `...` under compose message area, find your message extension.
 
   ![ComposeArea](./images/ThreeDot.png)
 
 To trigger these functions in Outlook:
-- Click the "More apps" icon under compose email area, find your messaging extension.
+- Click the "More apps" icon under compose email area, find your message extension.
 
   ![InOutlook](./images/InOutlook.png)
 
@@ -111,6 +111,6 @@ To trigger these functions in Outlook:
 - [Bot Framework Documentation](https://docs.botframework.com/)
 - [Azure Bot Service Introduction](https://docs.microsoft.com/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0)
 
-### Messaging Extension
+### Message Extension
 
 - [Search Command](https://docs.microsoft.com/en-us/microsoftteams/platform/messaging-extensions/how-to/search-commands/define-search-command)

--- a/templates/bot/js/m365/teamsBot.js
+++ b/templates/bot/js/m365/teamsBot.js
@@ -7,7 +7,7 @@ class TeamsBot extends TeamsActivityHandler {
     super();
   }
 
-  // Messaging extension Code
+  // Message extension Code
   // Search.
   async handleTeamsMessagingExtensionQuery(context, query) {
     const searchQuery = query.parameters[0].value;

--- a/templates/bot/ts/default/README.md
+++ b/templates/bot/ts/default/README.md
@@ -1,12 +1,12 @@
-# How to use this Bots and Messaging Extensions HelloWorld app
+# How to use this Bots and Message Extensions HelloWorld app
 
 A bot, chatbot, or conversational bot is an app that responds to simple commands sent in chat and replies in meaningful ways. Examples of bots in everyday use include: bots that notify about build failures, bots that provide information about the weather or bus schedules, or provide travel information. A bot interaction can be a quick question and answer, or it can be a complex conversation. Being a cloud application, a bot can provide valuable and secure access to cloud services and corporate resources.
 
-A Messaging Extension allows users to interact with your web service while composing messages in the Microsoft Teams client. Users can invoke your web service to assist message composition, from the message compose box, or from the search bar.
+A Message Extension allows users to interact with your web service while composing messages in the Microsoft Teams client. Users can invoke your web service to assist message composition, from the message compose box, or from the search bar.
 
-Messaging Extensions are implemented on top of the Bot support architecture within Teams.
+Message Extensions are implemented on top of the Bot support architecture within Teams.
 
-This is a simple hello world application with both Bot and Messaging extension capabilities.
+This is a simple hello world application with both Bot and Message extension capabilities.
 
 ## Prerequisites
 
@@ -88,15 +88,15 @@ This template provides some sample functionality:
 
 To trigger these functions, there are multiple entry points:
 
-- `@mention` Your messaging extension, from the `search box area`.
+- `@mention` Your message extension, from the `search box area`.
 
   ![AtBotFromSearch](./images/AtBotFromSearch.png)
 
-- `@mention` your messaging extension from the `compose message area`.
+- `@mention` your message extension from the `compose message area`.
 
   ![AtBotFromMessage](./images/AtBotInMessage.png)
 
-- Click the `...` under compose message area, find your messaging extension.
+- Click the `...` under compose message area, find your message extension.
 
   ![ComposeArea](./images/ThreeDot.png)
 
@@ -112,7 +112,7 @@ To trigger these functions, there are multiple entry points:
 - [Bot Framework Documentation](https://docs.botframework.com/)
 - [Azure Bot Service Introduction](https://docs.microsoft.com/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0)
 
-### Messaging Extension
+### Message Extension
 
 - [Search Command](https://docs.microsoft.com/en-us/microsoftteams/platform/messaging-extensions/how-to/search-commands/define-search-command)
 - [Action Command](https://docs.microsoft.com/en-us/microsoftteams/platform/messaging-extensions/how-to/action-commands/define-action-command)

--- a/templates/bot/ts/default/teamsBot.ts
+++ b/templates/bot/ts/default/teamsBot.ts
@@ -1,12 +1,18 @@
 import { default as axios } from "axios";
 import * as querystring from "querystring";
-import { TeamsActivityHandler, CardFactory, TurnContext, AdaptiveCardInvokeValue, AdaptiveCardInvokeResponse} from "botbuilder";
-import rawWelcomeCard from "./adaptiveCards/welcome.json"
-import rawLearnCard from "./adaptiveCards/learn.json"
+import {
+  TeamsActivityHandler,
+  CardFactory,
+  TurnContext,
+  AdaptiveCardInvokeValue,
+  AdaptiveCardInvokeResponse,
+} from "botbuilder";
+import rawWelcomeCard from "./adaptiveCards/welcome.json";
+import rawLearnCard from "./adaptiveCards/learn.json";
 import { AdaptiveCards } from "@microsoft/adaptivecards-tools";
 
 export interface DataInterface {
-  likeCount: number
+  likeCount: number;
 }
 
 export class TeamsBot extends TeamsActivityHandler {
@@ -22,9 +28,7 @@ export class TeamsBot extends TeamsActivityHandler {
       console.log("Running with Message Activity.");
 
       let txt = context.activity.text;
-      const removedMentionText = TurnContext.removeRecipientMention(
-        context.activity
-      );
+      const removedMentionText = TurnContext.removeRecipientMention(context.activity);
       if (removedMentionText) {
         // Remove the line break
         txt = removedMentionText.toLowerCase().replace(/\n|\r/g, "").trim();
@@ -87,7 +91,7 @@ export class TeamsBot extends TeamsActivityHandler {
     }
   }
 
-  // Messaging extension Code
+  // Message extension Code
   // Action.
   public async handleTeamsMessagingExtensionSubmitAction(
     context: TurnContext,
@@ -196,7 +200,7 @@ async function shareMessageCommand(context: TurnContext, action: any): Promise<a
     userName = action.messagePayload.from.user.displayName;
   }
 
-  // This Messaging Extension example allows the user to check a box to include an image with the
+  // This Message Extension example allows the user to check a box to include an image with the
   // shared message.  This demonstrates sending custom parameters along with the message payload.
   let images = [];
   const includeImage = action.data.includeImage;

--- a/templates/bot/ts/m365/README.md
+++ b/templates/bot/ts/m365/README.md
@@ -1,10 +1,10 @@
-# How to use this M365 Messaging Extensions Search app
+# How to use this M365 Message Extensions Search app
 
-A Messaging Extension allows users to interact with your web service while composing messages in the Microsoft Teams and Outlook client. Users can invoke your web service to assist message composition, from the message compose box, or from the search bar.
+A Message Extension allows users to interact with your web service while composing messages in the Microsoft Teams and Outlook client. Users can invoke your web service to assist message composition, from the message compose box, or from the search bar.
 
-Messaging Extensions are implemented on top of the Bot support architecture within Teams.
+Message Extensions are implemented on top of the Bot support architecture within Teams.
 
-This is a simple search application with Messaging extension capabilities.
+This is a simple search application with Message extension capabilities.
 
 ![Search App Demo](./images/SearchAppDemo.gif)
 
@@ -78,7 +78,7 @@ Once deployed, you may want to distribute your application to your organization'
 - From Visual Studio Code: open the Teams Toolkit and click `Publish to Teams` or open the command palette and select: `Teams: Publish to Teams`.
 - From TeamsFx CLI: run command `teamsfx publish` in your project directory.
 
-## Play with Messaging Extension
+## Play with Message Extension
 
 This template provides the sample functionality:
 
@@ -86,20 +86,20 @@ This template provides the sample functionality:
 
 To trigger the function in Teams, there are multiple entry points:
 
-- `@mention` Your messaging extension, from the `search box area`.
+- `@mention` Your message extension, from the `search box area`.
 
   ![AtBotFromSearch](./images/AtBotFromSearch.png)
 
-- `@mention` your messaging extension from the `compose message area`.
+- `@mention` your message extension from the `compose message area`.
 
   ![AtBotFromMessage](./images/AtBotInMessage.png)
 
-- Click the `...` under compose message area, find your messaging extension.
+- Click the `...` under compose message area, find your message extension.
 
   ![ComposeArea](./images/ThreeDot.png)
 
 To trigger these functions in Outlook:
-- Click the "More apps" icon under compose email area, find your messaging extension.
+- Click the "More apps" icon under compose email area, find your message extension.
 
   ![InOutlook](./images/InOutlook.png)
 
@@ -111,6 +111,6 @@ To trigger these functions in Outlook:
 - [Bot Framework Documentation](https://docs.botframework.com/)
 - [Azure Bot Service Introduction](https://docs.microsoft.com/azure/bot-service/bot-service-overview-introduction?view=azure-bot-service-4.0)
 
-### Messaging Extension
+### Message Extension
 
 - [Search Command](https://docs.microsoft.com/en-us/microsoftteams/platform/messaging-extensions/how-to/search-commands/define-search-command)

--- a/templates/bot/ts/m365/teamsBot.ts
+++ b/templates/bot/ts/m365/teamsBot.ts
@@ -11,7 +11,7 @@ export class TeamsBot extends TeamsActivityHandler {
     super();
   }
 
-  // Messaging extension Code
+  // Message extension Code
   // Search.
   public async handleTeamsMessagingExtensionQuery(context: TurnContext, query: any): Promise<any> {
     const searchQuery = query.parameters[0].value;


### PR DESCRIPTION
Update naming for scaffold template from bot plugin
Error message is already handled by Localization Team

Still need to sync with Teams team about the interface which contains the naming 'messaging extension'
Like 'handleTeamsMessagingExtensionQuery'