### PR TITLE
fix: assume preview features enabled

### DIFF
--- a/packages/cli/tests/e2e/multienv/TestRemoteHappyPath.tests.ts
+++ b/packages/cli/tests/e2e/multienv/TestRemoteHappyPath.tests.ts
@@ -198,11 +198,8 @@ describe("Multi Env Happy Path for Azure", function () {
           chai.expect(result.stderr).to.be.empty;
         }
 
-        const updateManifestCmd =
-          processEnv["TEAMSFX_DEPLOY_MANIFEST"] === "true"
-            ? `teamsfx deploy manifest --env ${env} --include-app-manifest yes`
-            : `teamsfx manifest update --env ${env}`;
         // update manifest
+        const updateManifestCmd = `teamsfx deploy manifest --env ${env} --include-app-manifest yes`;
         result = await execAsyncWithRetry(updateManifestCmd, {
           cwd: projectPath,
           env: processEnv,


### PR DESCRIPTION
Fix E2E Test for  tests/e2e/multienv/TestRemoteHappyPath.tests.ts.

Preview features are enabled by default in this branch and the previous flag check is incorrect and removed.

Triggered action: https://github.com/OfficeDev/TeamsFx/actions/runs/2298092538