### PR TITLE
fix: error message is omitted

### DIFF
--- a/packages/fx-core/src/plugins/resource/frontend/resources/errors.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/resources/errors.ts
@@ -75,14 +75,14 @@ export class FrontendPluginError extends Error {
   getMessage(): string {
     return getLocalizedString(
       "plugins.baseErrorMessage",
-      this.message[0],
+      this.messages[0],
       this.suggestions.join(" ")
     );
   }
   getDefaultMessage(): string {
     return getDefaultString(
       "plugins.baseErrorMessage",
-      this.message[1],
+      this.messages[1],
       this.suggestions.join(" ")
     );
   }

--- a/packages/fx-core/src/plugins/resource/function/resources/errors.ts
+++ b/packages/fx-core/src/plugins/resource/function/resources/errors.ts
@@ -64,14 +64,14 @@ export class FunctionPluginError extends Error {
   getMessage(): string {
     return getLocalizedString(
       "plugins.baseErrorMessage",
-      this.message[1],
+      this.messages[1],
       this.suggestions.join(" ")
     );
   }
   getDefaultMessage(): string {
     return getDefaultString(
       "plugins.baseErrorMessage",
-      this.message[0],
+      this.messages[0],
       this.suggestions.join(" ")
     );
   }


### PR DESCRIPTION
E2E TEST: https://github.com/OfficeDev/TeamsFx/blob/3506843d440df397868ecde66760343708337a37/packages/cli/tests/e2e/frontend/TestCreateTab.tests.ts#L86

Frontend plugin or function plugin throw error without error message:
```
a Suggestions: Run 'npm run build' in the folder: 'tabs'. Check log for more information.
```
should be
```
Failed to build Tab app. Suggestions: Run 'npm run build' in the folder: 'tabs'. Check log for more information.
```