### PR TITLE
perf(aad-manifest): automatically create or use existing scope id

### DIFF
--- a/packages/api/src/schemas/envConfig.json
+++ b/packages/api/src/schemas/envConfig.json
@@ -50,9 +50,9 @@
         }
       },
       "dependencies": {
-        "clientId": ["clientSecret", "objectId", "accessAsUserScopeId"],
-        "clientSecret": ["clientId", "objectId", "accessAsUserScopeId"],
-        "objectId": ["clientId", "clientSecret", "accessAsUserScopeId"],
+        "clientId": ["clientSecret", "objectId"],
+        "clientSecret": ["clientId", "objectId"],
+        "objectId": ["clientId", "clientSecret"],
         "accessAsUserScopeId": ["clientId", "clientSecret", "objectId"],
         "botId": ["botEndpoint"],
         "botEndpoint": ["botId"]

--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -617,6 +617,7 @@
   "error.aad.ListCollaboratorError": "Failed to list collaborator.",
   "error.aad.AadManifestLoadError": "Failed to load manifest file from %s, due to %s",
   "error.aad.AadManifestMissingName": "name property is empty or invalid in AAD manifest file",
+  "error.aad.AadManifestMissingScopeIdForTeamsApp": "oauth2Permissions property missing item which value should be access_as_user",
   "error.aad.AadManifestMissingObjectId": "id property is missing or invalid in AAD manifest file, you need to run provision or local debug first",
   "error.aad.AadManifestMissingReplyUrlsWithType": "replyUrlsWithType property is missing or invalid in AAD manifest file, you need to run provision or local debug first",
   "error.aad.AadManifestMissingIdentifierUris": "identifierUris property is missing or invalid in AAD manifest file, you need to run provision or local debug first",

--- a/packages/fx-core/src/plugins/resource/aad/errors.ts
+++ b/packages/fx-core/src/plugins/resource/aad/errors.ts
@@ -261,6 +261,14 @@ export const AadManifestMissingName: AadError = {
   ],
 };
 
+export const AADManifestMissingScopeIdForTeamsApp: AadError = {
+  name: "AadManifestMissingScopeIdForTeamsApp",
+  message: () => [
+    getDefaultString("error.aad.AadManifestMissingScopeIdForTeamsApp"),
+    getLocalizedString("error.aad.AadManifestMissingScopeIdForTeamsApp"),
+  ],
+};
+
 export const AadManifestMissingObjectId: AadError = {
   name: "AadManifestMissingObjectId",
   message: () => [

--- a/packages/fx-core/src/plugins/resource/aad/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/aad/plugin.ts
@@ -287,7 +287,7 @@ export class AadAppForTeamsImpl {
 
   public async postProvision(ctx: PluginContext, isLocalDebug = false): Promise<AadResult> {
     if (isAadManifestEnabled() && isConfigUnifyEnabled()) {
-      return await this.postProvisionUsingManifest(ctx);
+      return await this.postProvisionUsingManifest(ctx, isLocalDebug);
     }
     TelemetryUtils.init(ctx);
     Utils.addLogAndTelemetryWithLocalDebug(
@@ -345,13 +345,16 @@ export class AadAppForTeamsImpl {
     return ResultFactory.Success();
   }
 
-  public async postProvisionUsingManifest(ctx: PluginContext): Promise<AadResult> {
+  public async postProvisionUsingManifest(
+    ctx: PluginContext,
+    isLocalDebug = false
+  ): Promise<AadResult> {
     TelemetryUtils.init(ctx);
     Utils.addLogAndTelemetryWithLocalDebug(
       ctx.logProvider,
       Messages.StartPostProvision,
       Messages.StartPostLocalDebug,
-      false
+      isLocalDebug
     );
 
     const skip = Utils.skipAADProvision(ctx, false);
@@ -368,7 +371,7 @@ export class AadAppForTeamsImpl {
     const manifest = await AadAppManifestManager.loadAadManifest(ctx);
 
     await AadAppClient.updateAadAppUsingManifest(
-      Messages.EndPostProvision.telemetry,
+      isLocalDebug ? Messages.EndPostLocalDebug.telemetry : Messages.EndPostProvision.telemetry,
       manifest,
       skip
     );
@@ -381,7 +384,7 @@ export class AadAppForTeamsImpl {
       ctx.logProvider,
       Messages.EndPostProvision,
       Messages.EndPostLocalDebug,
-      false,
+      isLocalDebug,
       skip ? { [Telemetry.skip]: Telemetry.yes } : {}
     );
 

--- a/packages/fx-core/src/plugins/resource/aad/utils/configs.ts
+++ b/packages/fx-core/src/plugins/resource/aad/utils/configs.ts
@@ -141,19 +141,21 @@ export class Utils {
       ? ConfigUtils.getAadConfig(ctx, ConfigKeys.clientSecret, true)
       : ctx.envInfo.config.auth?.clientSecret;
 
-    if (objectId && clientId && oauth2PermissionScopeId && clientSecret) {
+    if (objectId && clientId && clientSecret) {
       if (!isLocalDebug) {
         ConfigUtils.checkAndSaveConfig(ctx, ConfigKeys.objectId, objectId as string);
         ConfigUtils.checkAndSaveConfig(ctx, ConfigKeys.clientId, clientId as string);
         ConfigUtils.checkAndSaveConfig(ctx, ConfigKeys.clientSecret, clientSecret as string);
-        ConfigUtils.checkAndSaveConfig(
-          ctx,
-          ConfigKeys.oauth2PermissionScopeId,
-          oauth2PermissionScopeId as string
-        );
+        if (oauth2PermissionScopeId) {
+          ConfigUtils.checkAndSaveConfig(
+            ctx,
+            ConfigKeys.oauth2PermissionScopeId,
+            oauth2PermissionScopeId as string
+          );
+        }
       }
       return true;
-    } else if (objectId || clientId || oauth2PermissionScopeId || clientSecret) {
+    } else if (objectId || clientId || clientSecret) {
       throw ResultFactory.UserError(
         GetSkipAppConfigError.name,
         GetSkipAppConfigError.message(Utils.getInputFileName(ctx.envInfo.envName))
@@ -253,9 +255,11 @@ export class ProvisionConfig {
   public oauth2PermissionScopeId?: string;
   private isLocalDebug: boolean;
 
-  constructor(isLocalDebug = false) {
+  constructor(isLocalDebug = false, generateScopeId = true) {
     this.isLocalDebug = isLocalDebug;
-    this.oauth2PermissionScopeId = uuidv4();
+    if (generateScopeId) {
+      this.oauth2PermissionScopeId = uuidv4();
+    }
   }
   public async restoreConfigFromLocalSettings(
     ctx: v2.Context,

--- a/packages/fx-core/tests/plugins/resource/aad/unit/aadAppClient.test.ts
+++ b/packages/fx-core/tests/plugins/resource/aad/unit/aadAppClient.test.ts
@@ -518,15 +518,17 @@ describe("AAD App Client Test", () => {
         "getAadApp",
         objectId,
         secret,
+        oauth2PermissionScopeId,
         new MockGraphTokenProvider()
       );
       chai.assert.equal(getResult.objectId, objectId);
       chai.assert.equal(getResult.clientId, clientId);
     });
 
-    it("throw GetAppConfigError", async () => {
+    it("use existing scope id", async () => {
       const objectId = faker.datatype.uuid();
       const clientId = faker.datatype.uuid();
+      const existingScopeId = faker.datatype.uuid();
       const fileName = "fileName";
       const secret = "secret";
       const displayName = "getAadApp";
@@ -539,20 +541,15 @@ describe("AAD App Client Test", () => {
       });
       sinon.stub(Utils, "getConfigFileName").returns(fileName);
 
-      try {
-        const getResult = await AadAppClient.getAadAppUsingManifest(
-          "getAadApp",
-          objectId,
-          secret,
-          new MockGraphTokenProvider()
-        );
-      } catch (error) {
-        chai.assert.isTrue(error instanceof UserError);
-        chai.assert.equal(
-          error.message,
-          GetAppConfigError.message(ConfigKeys.oauth2PermissionScopeId, fileName)[0]
-        );
-      }
+      const getResult = await AadAppClient.getAadAppUsingManifest(
+        "getAadApp",
+        objectId,
+        secret,
+        existingScopeId,
+        new MockGraphTokenProvider()
+      );
+
+      chai.assert.equal(getResult.oauth2PermissionScopeId, existingScopeId);
     });
 
     it("System Error", async () => {
@@ -578,6 +575,7 @@ describe("AAD App Client Test", () => {
           "getAadApp",
           objectId,
           secret,
+          undefined,
           new MockGraphTokenProvider()
         );
       } catch (error) {
@@ -609,6 +607,7 @@ describe("AAD App Client Test", () => {
           "getAadApp",
           objectId,
           secret,
+          undefined,
           new MockGraphTokenProvider()
         );
       } catch (error) {

--- a/packages/fx-core/tests/plugins/resource/aad/unit/index.test.ts
+++ b/packages/fx-core/tests/plugins/resource/aad/unit/index.test.ts
@@ -171,9 +171,11 @@ describe("AadAppForTeamsPlugin: CI", () => {
     context = await TestHelper.pluginContext(new Map(), true, false, false);
     context.appStudioToken = mockTokenProvider();
     context.graphTokenProvider = mockTokenProviderGraph();
-    sinon
-      .stub<any, any>(AadAppManifestManager, "loadAadManifest")
-      .resolves({ id: "", name: "fake-aad-name", oauth2Permissions: [{}] });
+    sinon.stub<any, any>(AadAppManifestManager, "loadAadManifest").resolves({
+      id: "",
+      name: "fake-aad-name",
+      oauth2Permissions: [{ value: "access_as_user" }],
+    });
     sinon
       .stub<any, any>(AadAppManifestManager, "createAadApp")
       .resolves({ appId: "fake-appId", id: "fake-object-id" });


### PR DESCRIPTION
 For existing aad app scenario, allow user only input "objectId", "clientId" and "clientSecret" without "accessAsUserScopeId"
```json
"auth": {
        "objectId": "58ad2e68-f442-4f6c-9282-xxx",
        "clientId": "c075d7a2-29c8-4d2b-8609-xxx",
        "clientSecret": "xxx",
        "accessAsUserScopeId": "xxx" // now this property is optional
    }
```
Automatically generate `accessAsUserScopeId` will following the sequence below:

1. Try to find it from "auth" config
2. Try to find it from state.xxx.json file
3. Try to find it from remote aad app
4. Generate a new one
