### PR TITLE
chore(vsc): cache telemetry event during deactivation

### DIFF
--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -694,7 +694,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 // this method is called when your extension is deactivated
 export async function deactivate() {
-  ExtTelemetry.sendTelemetryEvent(TelemetryEvent.Deactivate);
+  await ExtTelemetry.cacheTelemetryEventAsync(TelemetryEvent.Deactivate);
   await ExtTelemetry.dispose();
   handlers.cmdHdlDisposeTreeView();
   disableRunIcon();

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -254,6 +254,7 @@ export async function activate(): Promise<Result<Void, FxError>> {
     ExtTelemetry.isFromSample = await getIsFromSample();
     ExtTelemetry.settingsVersion = await getSettingsVersion();
     ExtTelemetry.isM365 = await getIsM365();
+    await ExtTelemetry.sendCachedTelemetryEventsAsync();
 
     if (workspacePath) {
       // refresh env tree when env config files added or deleted.

--- a/packages/vscode-extension/src/telemetry/extTelemetry.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetry.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from "vscode";
 import { FxError, Stage, UserError } from "@microsoft/teamsfx-api";
-import { globalStateGet, globalStateUpdate } from "@microsoft/teamsfx-core";
+import { Correlator, globalStateGet, globalStateUpdate } from "@microsoft/teamsfx-core";
 
 import * as extensionPackage from "../../package.json";
 import { VSCodeTelemetryReporter } from "../commonlib/telemetry";
@@ -20,6 +20,7 @@ import {
 } from "./extTelemetryEvents";
 
 const TelemetryCacheKey = "TelemetryEvents";
+let lastCorrelationId: string | undefined = undefined;
 
 export namespace ExtTelemetry {
   export let reporter: VSCodeTelemetryReporter;
@@ -80,6 +81,7 @@ export namespace ExtTelemetry {
     measurements?: { [p: string]: number }
   ): void {
     setHasSentTelemetry(eventName);
+    lastCorrelationId = Correlator.getId();
     if (!properties) {
       properties = {};
     }
@@ -198,6 +200,7 @@ export namespace ExtTelemetry {
     const telemetryEvents = {
       eventName: eventName,
       properties: {
+        [TelemetryProperty.CorrelationId]: lastCorrelationId,
         [TelemetryProperty.ProjectId]: getProjectId(),
         [TelemetryProperty.Timestamp]: new Date().toISOString(),
         ...properties,

--- a/packages/vscode-extension/src/telemetry/extTelemetry.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetry.ts
@@ -2,19 +2,24 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+
 import * as vscode from "vscode";
-import { VSCodeTelemetryReporter } from "../commonlib/telemetry";
-import {
-  TelemetryProperty,
-  TelemetryComponentType,
-  TelemetrySuccess,
-  TelemetryEvent,
-  TelemetryErrorType,
-} from "./extTelemetryEvents";
-import * as extensionPackage from "../../package.json";
 import { FxError, Stage, UserError } from "@microsoft/teamsfx-api";
-import { getIsExistingUser, isSPFxProject } from "../utils/commonUtils";
+import { globalStateGet, globalStateUpdate } from "@microsoft/teamsfx-core";
+
+import * as extensionPackage from "../../package.json";
+import { VSCodeTelemetryReporter } from "../commonlib/telemetry";
 import { ext } from "../extensionVariables";
+import { getIsExistingUser, getProjectId, isSPFxProject } from "../utils/commonUtils";
+import {
+  TelemetryComponentType,
+  TelemetryErrorType,
+  TelemetryEvent,
+  TelemetryProperty,
+  TelemetrySuccess,
+} from "./extTelemetryEvents";
+
+const TelemetryCacheKey = "TelemetryEvents";
 
 export namespace ExtTelemetry {
   export let reporter: VSCodeTelemetryReporter;
@@ -184,6 +189,33 @@ export namespace ExtTelemetry {
     }
 
     reporter.sendTelemetryException(error, properties, measurements);
+  }
+
+  export async function cacheTelemetryEventAsync(
+    eventName: string,
+    properties?: { [p: string]: string }
+  ) {
+    const telemetryEvents = {
+      eventName: eventName,
+      properties: {
+        [TelemetryProperty.ProjectId]: getProjectId(),
+        [TelemetryProperty.Timestamp]: new Date().toISOString(),
+        ...properties,
+      },
+    };
+    const newValue = JSON.stringify(telemetryEvents);
+    await globalStateUpdate(TelemetryCacheKey, newValue);
+  }
+
+  export async function sendCachedTelemetryEventsAsync() {
+    const existingValue = await globalStateGet(TelemetryCacheKey);
+    if (existingValue) {
+      try {
+        const telemetryEvent = JSON.parse(existingValue);
+        reporter.sendTelemetryEvent(telemetryEvent.eventName, telemetryEvent.properties);
+      } catch (e) {}
+      await globalStateUpdate(TelemetryCacheKey, undefined);
+    }
   }
 
   export async function dispose() {

--- a/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
@@ -249,6 +249,8 @@ export enum TelemetryProperty {
   // Used with OpenTutorial
   TutorialName = "tutorial-name",
   DocumentationName = "documentation-name",
+  // Used with Deactivate
+  Timestamp = "timestamp",
 }
 
 export enum TelemetrySuccess {


### PR DESCRIPTION
Telemetry events are not sent in `deactivate()` function. Cache it locally and resend next time.