### PR TITLE
docs(readme): Update SSO README for Tab and Bot

### DIFF
--- a/packages/fx-core/templates/plugins/resource/aad/auth/tab/README.md
+++ b/packages/fx-core/templates/plugins/resource/aad/auth/tab/README.md
@@ -1,6 +1,6 @@
 # Enable single sign-on for tab applications
 
-Microsoft Teams provides a mechanism by which an application can obtain the signed-in Teams user token to access Microsoft Graph (and other APIs). Teams Toolkit faciliates this interaction by abstracting some of the Azure Active Directory flows and integrations behind some simple, high level APIs. This enalbes you to add single sign-on (SSO) features easily to your Teams application.
+Microsoft Teams provides a mechanism by which an application can obtain the signed-in Teams user token to access Microsoft Graph (and other APIs). Teams Toolkit facilitates this interaction by abstracting some of the Azure Active Directory flows and integrations behind some simple, high level APIs. This enables you to add single sign-on (SSO) features easily to your Teams application.
 
 # Changes to your project
 
@@ -10,15 +10,15 @@ After you successfully added SSO into your project, Teams Toolkit will create an
 
 | Action | File | Description |
 | - | - | - |
-| Create| `aad.template.json` under `template\appPackage` | The Azure Active Directory application manifest that is used to register the application with AAD. |
-| Modify | `manifest.template.json` under `template\appPackage` | An `webApplicationInfo` object will be added into your Teams app manifest template. This field is required by Teams when enabling SSO. |
-| Create | `auth/tabs` | Reference code, redirect pages and a `README.md` file. These files are provided for reference. See below for more information. |
+| Create| `aad.template.json` under `templates/appPackage` | The Azure Active Directory application manifest that is used to register the application with AAD. |
+| Modify | `manifest.template.json` under `templates/appPackage` | An `webApplicationInfo` object will be added into your Teams app manifest template. This field is required by Teams when enabling SSO. |
+| Create | `auth/tab` | Reference code, redirect pages and a `README.md` file. These files are provided for reference. See below for more information. |
 
 # Update your code to add SSO
 
 As described above, the Teams Toolkit generated some configuration to set up your application for SSO, but you need to update your application business logic to take advantage of the SSO feature as appropriate.
 
-1. Copy `auth-start.html` and `auth-end.htm` in `auth/public` folder to `tabs/public/`.
+1. Copy `auth-start.html` and `auth-end.html` in `auth/public` folder to `tabs/public/`.
 These two HTML files are used for auth redirects.
 
 1. Copy `sso` folder under `auth/tab` to `tabs/src/sso/`.
@@ -28,11 +28,11 @@ These two HTML files are used for auth redirects.
     `GetUserProfile`: This file implements a function that calls Microsoft Graph API to get user info.
 
 1. Execute the following commands under `tabs/`: `npm install @microsoft/teamsfx-react`
-1. Add the following lines to `tabs/src/components/sample/Welcome.tsx` to import `InitTeamsFx`:
+1. Add the following lines to `tabs/src/components/sample/Welcome.*` to import `InitTeamsFx`:
     ```
     import { InitTeamsFx } from "../../sso/InitTeamsFx";
     ```
-1. Replace the following line: `<AddSSO />` with `<InitTeamsFx />` to replace the `AddSso` component with `InitTeamsFx` component.
+1. Replace the following line: `<AddSSO />` with `<InitTeamsFx />` to replace the `AddSSO` component with `InitTeamsFx` component.
 
 # Debug your application
 
@@ -46,4 +46,6 @@ To learn more about Teams Toolkit local debug functionalities, refer to this [do
 
 The AAD [manifest](https://docs.microsoft.com/azure/active-directory/develop/reference-app-manifest) allows you to customize various aspects of your application registration. You can update the manifest as needed.
 
-Follow this [document](https://aka.ms/teamsfx-aad-manifest#customize-aad-manifest-template) if you need to include additional API permissions to access your desired APIs.
+Follow this [document](https://aka.ms/teamsfx-aad-manifest#how-to-customize-the-aad-manifest-template) if you need to include additional API permissions to access your desired APIs.
+
+Follow this [document](https://aka.ms/teamsfx-aad-manifest#How-to-view-the-AAD-app-on-the-Azure-portal) to view your AAD application in Azure Portal.


### PR DESCRIPTION
- [x] Fix typos in tab and bot README, see bug [14417771](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14417771/)
- [x] Fix inconsistent use of slash and backslash, see [14418255](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14418255)
- [x] Fix instruction highlight / format, see [14418264](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14418264) 
- [x] Referencing view AAD app documentation.
- [x] Include steps for how to add second command after executing add sso for bot.  