### PR TITLE
fix(vsc): reorder logic for default option in quickpick

### DIFF
--- a/packages/vscode-extension/src/qm/vsc_ui.ts
+++ b/packages/vscode-extension/src/qm/vsc_ui.ts
@@ -180,18 +180,25 @@ export class VsCodeUI implements UserInteraction {
       return await new Promise<Result<SingleSelectResult, FxError>>(
         async (resolve): Promise<void> => {
           // set items
+          const options = option.options;
           quickPick.items = convertToFxQuickPickItems(option.options);
-          const optionMap = new Map<string, FxQuickPickItem>();
-          for (const item of quickPick.items) {
-            optionMap.set(item.id, item);
-          }
-          /// set default
+          // set default
           if (option.default) {
-            const defaultItem = optionMap.get(option.default);
-            if (defaultItem) {
-              const newitems = quickPick.items.filter((i) => i.id !== option.default);
-              newitems.unshift(defaultItem);
-              quickPick.items = newitems;
+            // let defaultOption: string | OptionItem | undefined;
+            if (options && options.length > 0 && typeof options[0] === "string") {
+              const defaultOption = (options as string[]).find((o) => o == option.default);
+              if (defaultOption) {
+                const newItems = (options as string[]).filter((o) => o != option.default);
+                newItems.unshift(defaultOption);
+                quickPick.items = convertToFxQuickPickItems(newItems);
+              }
+            } else {
+              const defaultOption = (options as OptionItem[]).find((o) => o.id == option.default);
+              if (defaultOption) {
+                const newItems = (options as OptionItem[]).filter((o) => o.id != option.default);
+                newItems.unshift(defaultOption);
+                quickPick.items = convertToFxQuickPickItems(newItems);
+              }
             }
           }
 


### PR DESCRIPTION
Related bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14414796
Fixing effect:
1. choose 'Bot'.
2. go back.
![image](https://user-images.githubusercontent.com/886116/168206486-45b1ccf0-cac2-4144-a1a1-6a2d41bf70d0.png)

E2E TEST: N/A