### PR TITLE
chore: incorrect type constraints in adaptive card builder api

### DIFF
--- a/docs/sdk/teamsfx.messagebuilder.attachadaptivecard.md
+++ b/docs/sdk/teamsfx.messagebuilder.attachadaptivecard.md
@@ -12,7 +12,7 @@ Build a bot message activity attached with adaptive card.
 <b>Signature:</b>
 
 ```typescript
-static attachAdaptiveCard<TData extends Record<string, unknown>>(cardTemplate: unknown, data: TData): Partial<Activity>;
+static attachAdaptiveCard<TData extends object>(cardTemplate: unknown, data: TData): Partial<Activity>;
 ```
 
 ## Parameters

--- a/packages/sdk/review/teamsfx.api.md
+++ b/packages/sdk/review/teamsfx.api.md
@@ -229,7 +229,7 @@ export class Member implements NotificationTarget {
 // @public
 export class MessageBuilder {
     // @beta
-    static attachAdaptiveCard<TData extends Record<string, unknown>>(cardTemplate: unknown, data: TData): Partial<Activity_2>;
+    static attachAdaptiveCard<TData extends object>(cardTemplate: unknown, data: TData): Partial<Activity_2>;
     // @beta
     static attachAdaptiveCardWithoutData(card: unknown): Partial<Activity_2>;
     // @beta

--- a/packages/sdk/src/conversation/messageBuilder.ts
+++ b/packages/sdk/src/conversation/messageBuilder.ts
@@ -56,7 +56,7 @@ export class MessageBuilder {
    *
    * @beta
    */
-  public static attachAdaptiveCard<TData extends Record<string, unknown>>(
+  public static attachAdaptiveCard<TData extends object>(
     cardTemplate: unknown,
     data: TData
   ): Partial<Activity> {


### PR DESCRIPTION
Fix incorrect type constraints in adaptive card builder api, otherwise it will break current notification/command bot template that use `CardModel`.