### PR TITLE
fix(cli): hide option for existing tab endpoint

### DIFF
--- a/packages/cli/tests/e2e/existingapp/TestCreateExistingTab.tests.ts
+++ b/packages/cli/tests/e2e/existingapp/TestCreateExistingTab.tests.ts
@@ -22,6 +22,7 @@ describe("Create existing tab app", function () {
 
   before(() => {
     mockedEnvRestore = mockedEnv({
+      TEAMSFX_PREVIEW: "true",
       TEAMSFX_INIT_APP: "true",
     });
   });

--- a/packages/fx-core/src/core/middleware/questionModel.ts
+++ b/packages/fx-core/src/core/middleware/questionModel.ts
@@ -22,7 +22,7 @@ import {
   v3,
 } from "@microsoft/teamsfx-api";
 import { Container } from "typedi";
-import { createV2Context, deepCopy } from "../../common/tools";
+import { createV2Context, deepCopy, isExistingTabAppEnabled } from "../../common/tools";
 import { newProjectSettings } from "../../common/projectSettingsHelper";
 import { SPFxPluginV3 } from "../../plugins/resource/spfx/v3";
 import { ExistingTabOptionItem, TabSPFxItem } from "../../plugins/solution/fx-solution/question";
@@ -438,17 +438,13 @@ export async function getQuestionsForCreateProjectV2(
   capNode.addChild(programmingLanguage);
 
   // existing tab endpoint
-  const existingTabEndpoint = new QTreeNode(ExistingTabEndpointQuestion);
-  if (isPreviewFeaturesEnabled()) {
+  if (isExistingTabAppEnabled()) {
+    const existingTabEndpoint = new QTreeNode(ExistingTabEndpointQuestion);
     existingTabEndpoint.condition = {
       equals: ExistingTabOptionItem.id,
     };
-  } else {
-    existingTabEndpoint.condition = {
-      contains: ExistingTabOptionItem.id,
-    };
+    capNode.addChild(existingTabEndpoint);
   }
-  capNode.addChild(existingTabEndpoint);
 
   createNew.addChild(new QTreeNode(QuestionRootFolder));
   createNew.addChild(new QTreeNode(createAppNameQuestion()));


### PR DESCRIPTION
Before:
<img src="https://user-images.githubusercontent.com/15644078/168502683-0baef48e-901d-4b70-82a9-0bf681157fed.png" width=60% />

After:
<img src="https://user-images.githubusercontent.com/15644078/168505319-bb8af371-dece-4a47-be9f-e1e5c9339782.png" width=60% />

E2E Result: https://github.com/OfficeDev/TeamsFx/actions/runs/2329233226

E2E TEST: https://github.com/OfficeDev/TeamsFx/blob/01d6a9fb35d8418a3cec89a96949325bcbbea968/packages/cli/tests/e2e/existingapp/TestCreateExistingTab.tests.ts#L17