### PR TITLE
chore: handle BotNotInConversationRoster

### DIFF
--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/NotificationBot.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/NotificationBot.cs
@@ -2,6 +2,8 @@
 {
     using Microsoft.Bot.Builder;
     using Microsoft.Bot.Builder.Teams;
+    using Microsoft.Rest;
+    using System.Net;
 
     /// <summary>
     /// Provide utilities to send notification to varies targets (e.g., member, group, channel).
@@ -77,10 +79,22 @@
                             // try get member to see if the installation is still valid
                             await TeamsInfo.GetPagedMembersAsync(context, 1, null, ct).ConfigureAwait(false);
                         }
-                        catch (Exception)
+                        catch (Exception e)
                         {
-                            // TODO: handle BotNotInConversationRoster
-                            valid = true;
+                            if (e is HttpOperationException httpEx)
+                            {
+                                var response = httpEx.Response;
+                                if (response != null)
+                                {
+                                    var status = response.StatusCode;
+                                    var error = response.Content ?? string.Empty;
+                                    if (status == HttpStatusCode.Forbidden && error.Contains("BotNotInConversationRoster"))
+                                    {
+                                        // bot in uninstalled
+                                        valid = false;
+                                    }
+                                }
+                            }
                         }
                     },
                     cancellationToken

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/NotificationBot.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/NotificationBot.cs
@@ -90,7 +90,7 @@
                                     var error = response.Content ?? string.Empty;
                                     if (status == HttpStatusCode.Forbidden && error.Contains("BotNotInConversationRoster"))
                                     {
-                                        // bot in uninstalled
+                                        // bot is uninstalled
                                         valid = false;
                                     }
                                 }


### PR DESCRIPTION
Finish the `TODO` that handles BotNotInConversationRoster error.