### PR TITLE
chore: update unify cancel error

### DIFF
--- a/packages/fx-core/src/core/error.ts
+++ b/packages/fx-core/src/core/error.ts
@@ -325,10 +325,11 @@ export function UpgradeCanceledError(): UserError {
 
 export function ConsolidateCanceledError(): UserError {
   return new UserError(
+    CoreSource,
     // @see tools.isUserCancelError()
     "UserCancel",
-    getLocalizedString("error.ConsolidateCanceledError"),
-    CoreSource
+    getDefaultString("error.ConsolidateCanceledError"),
+    getLocalizedString("error.ConsolidateCanceledError")
   );
 }
 


### PR DESCRIPTION
1. Move unify config cancel error message to normal place.

![image](https://user-images.githubusercontent.com/13211513/168516862-254e0a58-316b-4800-967e-22c09daa1a42.png)
