### PR TITLE
chore(vsc): hide help tree view by default

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -152,7 +152,8 @@
         {
           "id": "teamsfx-help-and-feedback",
           "name": "Help and feedback",
-          "when": "fx-extension.sidebarWelcome.treeview"
+          "when": "fx-extension.sidebarWelcome.treeview",
+          "visibility": "collapsed"
         },
         {
           "id": "teamsfx-empty-project",


### PR DESCRIPTION
Related bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14431635