### PR TITLE
fix: disable HTML escape to avoid user-defined config render error

### DIFF
--- a/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/plugin.ts
@@ -199,6 +199,7 @@ export class AppStudioPluginImpl {
         },
       },
     };
+    Mustache.escape = (value) => value;
     const manifestString = Mustache.render(JSON.stringify(manifest), view);
     manifest = JSON.parse(manifestString);
 
@@ -1646,6 +1647,7 @@ export class AppStudioPluginImpl {
         },
       },
     };
+    Mustache.escape = (value) => value;
     manifestString = Mustache.render(manifestString, view);
     const tokens = [
       ...new Set(
@@ -1752,6 +1754,7 @@ export class AppStudioPluginImpl {
         },
       },
     };
+    Mustache.escape = (value) => value;
     manifestString = Mustache.render(manifestString, view);
     return manifestString;
   }


### PR DESCRIPTION
resolve issue: https://github.com/OfficeDev/TeamsFx/issues/5048

![image](https://user-images.githubusercontent.com/71362691/168779004-c1aa5007-fa0c-4e4f-875f-653745b47070.png)
