### PR TITLE
fix(vsc): missing extension name in error events

### DIFF
--- a/packages/vscode-extension/package-lock.json
+++ b/packages/vscode-extension/package-lock.json
@@ -2652,9 +2652,9 @@
       "dev": true
     },
     "@vscode/extension-telemetry": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.5.1.tgz",
-      "integrity": "sha512-cvFq8drxdLRF8KN72WcV4lTEa9GqDiRwy9EbnYuoSCD9Jdk8zHFF49MmACC1qs4R9Ko/C1uMOmeLJmVi8EA0rQ=="
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.4.8.tgz",
+      "integrity": "sha512-5xtf8k7vQJ+EOqhAcEaGwbnj9t/qLjIJQePmq7eBKEZzt8vpnOg0ZJIJx6VnQFAwO3lfsf3M+X3NT+IpKRymZw=="
     },
     "@vscode/webview-ui-toolkit": {
       "version": "0.9.3",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -1178,7 +1178,7 @@
     "@microsoft/teamsfx-api": "^0.19.0-rc.0",
     "@microsoft/teamsfx-core": "^1.9.0-rc.1",
     "@npmcli/package-json": "^1.0.1",
-    "@vscode/extension-telemetry": "^0.5.1",
+    "@vscode/extension-telemetry": "^0.4.8",
     "@vscode/webview-ui-toolkit": "^0.9.3",
     "ajv": "^8.5.0",
     "async-mutex": "^0.3.1",


### PR DESCRIPTION
Related bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14482778

E2E TEST: N/A