### PR TITLE
fix: disallow adding command / notification to ME

### DIFF
--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/getQuestions.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/getQuestions.ts
@@ -835,7 +835,9 @@ async function getStaticOptionsForAddCapability(
   if (botExceedRes.isErr()) {
     return err(botExceedRes.error);
   }
-  const isBotAddable = !botExceedRes.value;
+
+  const hasMe = settings?.capabilities.includes(MessageExtensionItem.id);
+  const isBotAddable = !botExceedRes.value && !hasMe;
   const meExceedRes = await appStudioPlugin.capabilityExceedLimit(
     ctx,
     inputs as v2.InputsWithProjectPath,


### PR DESCRIPTION
Fix [Bug 14474347](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14474347): Add Feature "Command Bot" to Messaging extension, suggestions command "helloWorld" does not response.

For GA, we should disable adding command/notification feature to a legacy ME project.

E2E Test: N/A (covered by UI test)