### PR TITLE
fix(vsc): remove Azure signing in status on UI

### DIFF
--- a/packages/vscode-extension/src/treeview/account/accountTreeViewProvider.ts
+++ b/packages/vscode-extension/src/treeview/account/accountTreeViewProvider.ts
@@ -110,7 +110,8 @@ async function azureAccountStatusChangeHandler(
       envTreeProviderInstance.refreshRemoteEnvWarning();
     }
   } else if (status === "SigningIn") {
-    instance.azureAccountNode.setSigningIn();
+    // "Azure Account" extension only sends SigningIn signal without SignededOut in 0.10.x, so remove this status change until it's fixed.
+    // instance.azureAccountNode.setSigningIn();
   } else if (status === "SignedOut") {
     instance.azureAccountNode.setSignedOut();
     envTreeProviderInstance.refreshRemoteEnvWarning();


### PR DESCRIPTION
Azure account only shows "signed out" and "signed in" on UI to prevent forever signing in status.
Will restore until "Azure Account" extension has fixed this issue.

Related bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14474430

E2E TEST: N/A