### PR TITLE
fix(m365): add registerChangeSettingsHandler mapping

### DIFF
--- a/packages/vscode-extension/src/migration/migrationTool/ts/mappings.json
+++ b/packages/vscode-extension/src/migration/migrationTool/ts/mappings.json
@@ -114,6 +114,10 @@
       "target": "microsoftTeams.pages.config.registerChangeConfigHandler"
     },
     {
+      "source": "microsoftTeams.registerChangeSettingsHandler",
+      "target": "microsoftTeams.pages.config.registerChangeConfigHandler"
+    },
+    {
       "source": "microsoftTeams.enterFullscreen",
       "target": "microsoftTeams.pages.fullTrust.enterFullscreen"
     },


### PR DESCRIPTION
teams-js 1.x has changed the `registerChangeSettingsHandler` to `registerEnterSettingsHandler` and rollback.
Add mapping from `registerChangeSettingsHandler` to `microsoftTeams.pages.config.registerChangeConfigHandler`