### PR TITLE
chore: improve dotnet notification

### DIFF
--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/NotificationBot.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/NotificationBot.cs
@@ -48,7 +48,7 @@ namespace Microsoft.TeamsFx.Conversation
                 }
                 else
                 {
-                    _storage = new LocalFileStorage(Environment.CurrentDirectory);
+                    _storage = new LocalFileStorage(Path.GetFullPath(Environment.GetEnvironmentVariable("TEAMSFX_NOTIFICATION_LOCALSTORE_DIR") ?? Environment.CurrentDirectory));
                 }
             }
 

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/NotificationOptions.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/NotificationOptions.cs
@@ -22,10 +22,13 @@ namespace Microsoft.TeamsFx.Conversation
         /// </para>
         /// <list type="bullet">
         ///     <item>
-        ///         <description>"{<see cref="Environment.CurrentDirectory"/>}/.notification.localstore.json" if running locally.</description>
+        ///         <description>"{$env:TEAMSFX_NOTIFICATION_LOCALSTORE_DIR}/.notification.localstore.json" if running locally.</description>
         ///     </item>
         ///     <item>
         ///         <description>"{$env:TEMP}/.notification.localstore.json" if {$env:RUNNING_ON_AZURE} is set to "1".</description>
+        ///     </item>
+        ///     <item>
+        ///         <description>"{<see cref="Environment.CurrentDirectory"/>}/.notification.localstore.json" if all above environment variables are not set.</description>
         ///     </item>
         /// </list>
         /// <para>

--- a/templates/bot/csharp/notification-webapi/Controllers/BotController.cs.tpl
+++ b/templates/bot/csharp/notification-webapi/Controllers/BotController.cs.tpl
@@ -3,24 +3,25 @@
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Bot.Builder;
     using Microsoft.Bot.Builder.Integration.AspNet.Core;
+    using Microsoft.TeamsFx.Conversation;
 
     [Route("api/messages")]
     [ApiController]
     public class BotController : ControllerBase
     {
-        private readonly CloudAdapter _adapter;
+        private readonly ConversationBot _conversation;
         private readonly IBot _bot;
 
-        public BotController(CloudAdapter adapter, IBot bot)
+        public BotController(ConversationBot conversation, IBot bot)
         {
-            this._adapter = adapter;
+            this._conversation = conversation;
             this._bot = bot;
         }
 
         [HttpPost]
         public async Task PostAsync(CancellationToken cancellationToken = default)
         {
-            await this._adapter.ProcessAsync(this.Request, this.Response, this._bot, cancellationToken);
+            await (this._conversation.Adapter as CloudAdapter).ProcessAsync(this.Request, this.Response, this._bot, cancellationToken);
         }
     }
 }

--- a/templates/bot/csharp/notification-webapi/Program.cs.tpl
+++ b/templates/bot/csharp/notification-webapi/Program.cs.tpl
@@ -20,12 +20,12 @@ builder.Services.AddSingleton<BotFrameworkAuthentication, ConfigurationBotFramew
 
 // Create the Cloud Adapter with error handling enabled.
 // Note: some classes expect a BotAdapter and some expect a BotFrameworkHttpAdapter, so
-// register the same adapter instance for both types.
+// register the same adapter instance for all types.
 builder.Services.AddSingleton<CloudAdapter, AdapterWithErrorHandler>();
 builder.Services.AddSingleton<IBotFrameworkHttpAdapter>(sp => sp.GetService<CloudAdapter>());
 builder.Services.AddSingleton<BotAdapter>(sp => sp.GetService<CloudAdapter>());
 
-// Create the Conversation with command-response feature enabled.
+// Create the Conversation with notification feature enabled.
 builder.Services.AddSingleton(sp =>
 {
     var options = new ConversationOptions()

--- a/templates/bot/csharp/notification-webapi/Properties/launchSettings.json.tpl
+++ b/templates/bot/csharp/notification-webapi/Properties/launchSettings.json.tpl
@@ -7,7 +7,8 @@
       "launchUrl": "https://teams.microsoft.com/l/app/%TEAMSAPPID%?installAppPackage=true&webjoin=true&appTenantId=%TENANTID%&login_hint=%USERNAME%",
       "applicationUrl": "http://localhost:2544",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "$(MSBuildProjectDirectory)"
       },
       "hotReloadProfile": "aspnetcore"
     },
@@ -16,7 +17,8 @@
       "dotnetRunMessages": "true",
       "applicationUrl": "https://localhost:44302;http://localhost:2544",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "$(MSBuildProjectDirectory)"
       },
       "hotReloadProfile": "aspnetcore"
     }


### PR DESCRIPTION
- Add env `TEAMSFX_NOTIFICATION_LOCALSTORE_DIR` for notification local storage to support Azure Functions. (`Environment.CurrentDirectory` has different behaviors on ASP.NET Core Web API and Azure Functions)
- Make `ConversationBot` part of `BotController` to ensure it's initialized on any activity.
- Fix some typos in template