### PR TITLE
chore: distinguish dotnet tab and bot local ports

### DIFF
--- a/packages/fx-core/src/plugins/solution/fx-solution/debug/provisionLocal.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/debug/provisionLocal.ts
@@ -159,7 +159,7 @@ export async function setupLocalDebugSettings(
 
       if (includeBot) {
         localSettings.bot ??= {};
-        const ngrokHttpUrl = await getNgrokHttpUrl(2544);
+        const ngrokHttpUrl = await getNgrokHttpUrl(5130);
         if (!ngrokHttpUrl) {
           const error = NgrokTunnelNotConnected();
           TelemetryUtils.sendErrorEvent(TelemetryEventName.setupLocalDebugSettings, error);
@@ -300,7 +300,7 @@ export async function setupLocalEnvironment(
 
       if (includeBot) {
         envInfo.state[ResourcePlugins.Bot] ??= {};
-        const ngrokHttpUrl = await getNgrokHttpUrl(2544);
+        const ngrokHttpUrl = await getNgrokHttpUrl(5130);
         if (!ngrokHttpUrl) {
           const error = NgrokTunnelNotConnected();
           TelemetryUtils.sendErrorEvent(TelemetryEventName.setupLocalDebugSettings, error);

--- a/templates/bot/csharp/command-and-response/GettingStarted.txt
+++ b/templates/bot/csharp/command-and-response/GettingStarted.txt
@@ -5,7 +5,7 @@ Prerequisites
 
 To debug a command-response bot in Visual Studio, you'll need to setup Ngrok(https://ngrok.com/). Ngrok is used to help forward external messages from Azure Bot Framework to your locally running machine.
 
-After installing ngrok, use a Command Prompt to run this command: ngrok http 2544
+After installing ngrok, use a Command Prompt to run this command: ngrok http 5130
 
 
 Quick start
@@ -15,7 +15,7 @@ Before you run or Start Debugging for the first time, follow these steps:
 
 1. If your project only contains a Tab capability, skip to step #3.
 
-2. For projects that contain a Bot or Message Extension capability, first use a Command Prompt to run this command: ngrok http 2544.
+2. For projects that contain a Bot or Message Extension capability, first use a Command Prompt to run this command: ngrok http 5130.
 
 3. Select the Project > Teams Toolkit > Configure Microsoft Teams app menu in Visual Studio. When prompted, sign in using your M365 account.
 

--- a/templates/bot/csharp/command-and-response/Properties/launchSettings.json.tpl
+++ b/templates/bot/csharp/command-and-response/Properties/launchSettings.json.tpl
@@ -5,7 +5,7 @@
       "dotnetRunMessages": "true",
       "launchBrowser": true,
       "launchUrl": "https://teams.microsoft.com/l/app/%TEAMSAPPID%?installAppPackage=true&webjoin=true&appTenantId=%TENANTID%&login_hint=%USERNAME%",
-      "applicationUrl": "http://localhost:2544",
+      "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
@@ -14,7 +14,7 @@
     "{{ProjectName}}": {
       "commandName": "Project",
       "dotnetRunMessages": "true",
-      "applicationUrl": "https://localhost:44302;http://localhost:2544",
+      "applicationUrl": "https://localhost:7130;http://localhost:5130",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },

--- a/templates/bot/csharp/default/GettingStarted.txt
+++ b/templates/bot/csharp/default/GettingStarted.txt
@@ -5,7 +5,7 @@ Prerequisites
 
 To debug a Bot or Message Extension capability in a Teams app, you'll need to setup Ngrok(https://ngrok.com/). Ngrok is used to help forward external messages from Azure Bot Framework to your locally running machine.
 
-After installing ngrok, use a Command Prompt to run this command: ngrok http 2544
+After installing ngrok, use a Command Prompt to run this command: ngrok http 5130
 
 
 Quick start
@@ -13,7 +13,7 @@ Quick start
 
 Before you run or Start Debugging for the first time, follow these steps:
 
-1. For projects that contain a Bot or Message Extension capability, first use a Command Prompt to run this command: ngrok http 2544.
+1. For projects that contain a Bot or Message Extension capability, first use a Command Prompt to run this command: ngrok http 5130.
 
 2. Select the Project > Teams Toolkit > Configure Microsoft Teams app menu in Visual Studio. When prompted, sign in using your M365 account.
 

--- a/templates/bot/csharp/default/Properties/launchSettings.json.tpl
+++ b/templates/bot/csharp/default/Properties/launchSettings.json.tpl
@@ -5,7 +5,7 @@
       "dotnetRunMessages": "true",
       "launchBrowser": true,
       "launchUrl": "https://teams.microsoft.com/l/app/%TEAMSAPPID%?installAppPackage=true&webjoin=true&appTenantId=%TENANTID%&login_hint=%USERNAME%",
-      "applicationUrl": "https://localhost:44302;http://localhost:2544",
+      "applicationUrl": "https://localhost:7130;http://localhost:5130",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
@@ -15,7 +15,7 @@
       "commandName": "Project",
       "dotnetRunMessages": "true",
       "launchBrowser": true,
-      "applicationUrl": "https://localhost:44302;http://localhost:2544",
+      "applicationUrl": "https://localhost:7130;http://localhost:5130",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },

--- a/templates/bot/csharp/notification-webapi/GettingStarted.txt
+++ b/templates/bot/csharp/notification-webapi/GettingStarted.txt
@@ -5,7 +5,7 @@ Prerequisites
 
 To debug a Bot capability in a Teams app, you'll need to setup Ngrok(https://ngrok.com/). Ngrok is used to help forward external messages from Azure Bot Framework to your locally running machine.
 
-After installing ngrok, use a Command Prompt to run this command: ngrok http 2544
+After installing ngrok, use a Command Prompt to run this command: ngrok http 5130
 
 
 Quick start
@@ -13,7 +13,7 @@ Quick start
 
 Before you run or Start Debugging for the first time, follow these steps:
 
-1. This is a Bot project, so first use a Command Prompt to run this command: ngrok http 2544.
+1. This is a Bot project, so first use a Command Prompt to run this command: ngrok http 5130.
 
 2. Select the Project > Teams Toolkit > Configure Microsoft Teams app menu in Visual Studio. When prompted, sign in using your M365 account.
 
@@ -21,7 +21,7 @@ Before you run or Start Debugging for the first time, follow these steps:
 
 4. Once Microsoft Teams is loaded, select the Add button to install your app in Teams.
 
-5. Post HTTP request to http://localhost:2544/api/notification to trigger notification. You can use any HTTP tool: command line, PowerShell, etc.
+5. Post HTTP request to http://localhost:5130/api/notification to trigger notification. You can use any HTTP tool: command line, PowerShell, etc.
 
 
 Deploy your first Teams app on Azure

--- a/templates/bot/csharp/notification-webapi/Properties/launchSettings.json.tpl
+++ b/templates/bot/csharp/notification-webapi/Properties/launchSettings.json.tpl
@@ -5,7 +5,7 @@
       "dotnetRunMessages": "true",
       "launchBrowser": true,
       "launchUrl": "https://teams.microsoft.com/l/app/%TEAMSAPPID%?installAppPackage=true&webjoin=true&appTenantId=%TENANTID%&login_hint=%USERNAME%",
-      "applicationUrl": "http://localhost:2544",
+      "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "$(MSBuildProjectDirectory)"
@@ -15,7 +15,7 @@
     "{{ProjectName}}": {
       "commandName": "Project",
       "dotnetRunMessages": "true",
-      "applicationUrl": "https://localhost:44302;http://localhost:2544",
+      "applicationUrl": "https://localhost:7130;http://localhost:5130",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "$(MSBuildProjectDirectory)"


### PR DESCRIPTION
Distinguish dotnet bot local ports from the tab ones.
Following the [ASP.NET Core Web ports](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/endpoints?view=aspnetcore-6.0) to use 5xxx for http and 7xxx for https.