### PR TITLE
chore: use new login for tunneling

### DIFF
--- a/packages/fx-core/src/common/local/microsoftTunnelingManager.ts
+++ b/packages/fx-core/src/common/local/microsoftTunnelingManager.ts
@@ -29,6 +29,8 @@ const TeamsfxTunnelAccessControl: TunnelAccessControl = {
   ],
 };
 
+export const MicrosoftTunnelingAadScope = "46da2f7e-b5ef-422a-88d4-2a7f9de6a0b2/.default";
+
 export interface TunnelInfo {
   tunnelClusterId?: string;
   tunnelId?: string;
@@ -42,7 +44,10 @@ export interface TunnelHostResult {
 export class MicrosoftTunnelingManager {
   private service: MicrosoftTunnelingService;
 
-  constructor(getTunnelingAccessToken: () => Promise<string>, logProvider?: LogProvider) {
+  constructor(
+    getTunnelingAccessToken: () => Promise<Result<string, FxError>>,
+    logProvider?: LogProvider
+  ) {
     this.service = new MicrosoftTunnelingService(getTunnelingAccessToken, logProvider);
   }
 

--- a/packages/vscode-extension/src/debug/microsoftTunnelingTask.ts
+++ b/packages/vscode-extension/src/debug/microsoftTunnelingTask.ts
@@ -77,7 +77,7 @@ export class MicrosoftTunnelingTaskTerminal implements vscode.Pseudoterminal {
     this.manager = new MicrosoftTunnelingManager(
       () =>
         m365Login.getAccessToken({
-          showDialog: true,
+          showDialog: false,
           scopes: [MicrosoftTunnelingAadScope],
         }),
       this.logger

--- a/packages/vscode-extension/src/debug/microsoftTunnelingTask.ts
+++ b/packages/vscode-extension/src/debug/microsoftTunnelingTask.ts
@@ -20,9 +20,10 @@ import {
   getTunnelPorts,
   storeTunnelInfo,
   MicrosoftTunnelingManager,
+  MicrosoftTunnelingAadScope,
 } from "@microsoft/teamsfx-core";
 import * as constants from "./constants";
-import appStudioLogin from "../commonlib/appStudioLogin";
+import m365Login from "../commonlib/m365Login";
 
 const TunnelUpMessage = `The tunnel is up and running.`;
 const TunnelFailMessage = `The tunnel failed to start.`;
@@ -73,14 +74,14 @@ export class MicrosoftTunnelingTaskTerminal implements vscode.Pseudoterminal {
   private async openAsync(): Promise<Result<void, FxError>> {
     // TODO: add telemetry
     // TODO: prevent re-entry (cases when user manually trigger a task)
-    this.manager = new MicrosoftTunnelingManager(async () => {
-      // TODO: switch to new login and pass in Microsoft tunneling scopes
-      const token = await appStudioLogin.getAccessToken();
-      if (!token) {
-        throw new Error("No login");
-      }
-      return token;
-    }, this.logger);
+    this.manager = new MicrosoftTunnelingManager(
+      () =>
+        m365Login.getAccessToken({
+          showDialog: true,
+          scopes: [MicrosoftTunnelingAadScope],
+        }),
+      this.logger
+    );
     const tunnelInfoResult = await loadTunnelInfo(this.projectPath, this.projectSettings.projectId);
     if (tunnelInfoResult.isErr()) {
       return err(tunnelInfoResult.error);


### PR DESCRIPTION
unit test passed locally