### PR TITLE
test: fix e2e test case for dotnet

### DIFF
--- a/packages/cli/tests/e2e/frontend/CanScaffoldDotNetProject.tests.ts
+++ b/packages/cli/tests/e2e/frontend/CanScaffoldDotNetProject.tests.ts
@@ -39,7 +39,7 @@ describe(".NET projects", function () {
       });
       it(`should create a .NET project`, async () => {
         await CliHelper.createDotNetProject(appName, testFolder, Capability.Tab);
-        const programCsPath = path.join(testFolder, appName, "Program.cs");
+        const programCsPath = path.join(testFolder, appName, "App.razor");
         chai.assert.isTrue(await fs.pathExists(programCsPath));
       });
     }


### PR DESCRIPTION
The default template for dotnet projects doesn't have Program.cs now.  Change the assertion to fix the case.