### PR TITLE
fix: fix a bug that cause second local debug to hang

### DIFF
--- a/packages/fx-core/src/common/local/microsoftTunnelingError.ts
+++ b/packages/fx-core/src/common/local/microsoftTunnelingError.ts
@@ -56,13 +56,19 @@ export class MicrosoftTunnelingServiceError extends SystemError {
   }
 }
 
+/**
+ * Unexpected errors like bugs in code or other unexpected errors from the SDK/service.
+ */
 export class MicrosoftTunnelingError extends SystemError {
-  constructor(innerError: Error) {
+  constructor(errorOrMsg: Error | string) {
     super({
       source: CoreSource,
       name: MicrosoftTunnelingError.name,
-      error: innerError,
-      message: "Failed to call Microsoft tunneling service API",
+      error: errorOrMsg instanceof Error ? errorOrMsg : undefined,
+      message:
+        errorOrMsg instanceof Error
+          ? `Microsoft tunneling unknown error: ${errorOrMsg.message}`
+          : errorOrMsg,
     });
   }
 }

--- a/packages/fx-core/src/common/local/microsoftTunnelingManager.ts
+++ b/packages/fx-core/src/common/local/microsoftTunnelingManager.ts
@@ -169,11 +169,22 @@ export class MicrosoftTunnelingManager {
     tunnelInfo?: TunnelInfo
   ): Promise<Result<Tunnel, FxError>> {
     let tunnelInstance: Tunnel;
+
+    // Must set tokenScopes and includePorts so that the returned tunnel.accessTokens and tunnel.ports are not empty.
+    // These two properties are required for tunnelHost.start(tunnel).
+    const tunnelRequestOptions: TunnelRequestOptions = {
+      tokenScopes: [TunnelAccessScopes.Host, TunnelAccessScopes.Connect],
+      includePorts: true,
+    };
+
     if (tunnelInfo?.tunnelClusterId && tunnelInfo?.tunnelId) {
-      const tunnelResult = await this.service.getTunnel({
-        tunnelId: tunnelInfo.tunnelId,
-        clusterId: tunnelInfo.tunnelClusterId,
-      });
+      const tunnelResult = await this.service.getTunnel(
+        {
+          clusterId: tunnelInfo.tunnelClusterId,
+          tunnelId: tunnelInfo.tunnelId,
+        },
+        tunnelRequestOptions
+      );
       if (tunnelResult.isErr()) {
         return err(tunnelResult.error);
       }
@@ -187,10 +198,6 @@ export class MicrosoftTunnelingManager {
       const tunnelRequest: Tunnel = {
         ports: ports.map((port) => ({ portNumber: port, protocol: TunnelProtocol.Http })),
         accessControl: TeamsfxTunnelAccessControl,
-      };
-      const tunnelRequestOptions: TunnelRequestOptions = {
-        tokenScopes: [TunnelAccessScopes.Host, TunnelAccessScopes.Connect],
-        includePorts: true,
       };
       const tunnelResult = await this.service.createTunnel(tunnelRequest, tunnelRequestOptions);
       if (tunnelResult.isErr()) {

--- a/packages/fx-core/tests/common/local/microsoftTunnelingService.test.ts
+++ b/packages/fx-core/tests/common/local/microsoftTunnelingService.test.ts
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import "mocha";
+import * as sinon from "sinon";
+import * as chai from "chai";
+import { ok } from "@microsoft/teamsfx-api";
+import { TunnelAccessScopes } from "@vs/tunnels-contracts";
+import { TunnelRelayTunnelHost } from "@vs/tunnels-connections";
+import { MicrosoftTunnelingService } from "../../../src/common/local/microsoftTunnelingService";
+import { MicrosoftTunnelingError } from "../../../src/common/local/microsoftTunnelingError";
+
+describe("MicrosoftTunnelingService", () => {
+  describe("hostStart()", () => {
+    const sandbox = sinon.createSandbox();
+    beforeEach(() => {});
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it("should not allow host start without access tokens", async () => {
+      // Arrange
+      const service = new MicrosoftTunnelingService(async () => ok("fake token"));
+      sandbox
+        .stub(TunnelRelayTunnelHost.prototype, "start")
+        .callsFake(async (): Promise<void> => {});
+
+      // Act
+      const result = await service.hostStart({
+        tunnelId: "fake id",
+        clusterId: "fake cluster id",
+        ports: [
+          {
+            portNumber: 3978,
+          },
+        ],
+        accessTokens: {},
+      });
+
+      // Assert
+      chai.assert.isTrue(result.isErr());
+      chai.assert.instanceOf(result._unsafeUnwrapErr(), MicrosoftTunnelingError);
+    });
+
+    it("should not allow host start without ports", async () => {
+      // Arrange
+      const service = new MicrosoftTunnelingService(async () => ok("fake token"));
+      sandbox
+        .stub(TunnelRelayTunnelHost.prototype, "start")
+        .callsFake(async (): Promise<void> => {});
+
+      // Act
+      const result = await service.hostStart({
+        tunnelId: "fake id",
+        clusterId: "fake cluster id",
+        ports: [],
+        accessTokens: {
+          [TunnelAccessScopes.Host]: "fake host token",
+          [TunnelAccessScopes.Connect]: "fake connect token",
+        },
+      });
+
+      // Assert
+      chai.assert.isTrue(result.isErr());
+      chai.assert.instanceOf(result._unsafeUnwrapErr(), MicrosoftTunnelingError);
+    });
+  });
+});


### PR DESCRIPTION
Tunneling SDK uses `tunnel.accessTokens["host"/"connect"]` and `tunnel.ports` for `host.start()`.
- For the first time host start, we already passed `tokenScopes` and `includePorts` to `createTunnel` so it works. 
- For the second time host start, I forgot to set these properties for `getTunnel()`. It does not throw error and will cause HTTP timeout when actually sending request through the tunnel

Unit test passed locally. Tested second time local debug locally.