### PR TITLE
chore: update teamsfx sdk in command / notification bot template

### DIFF
--- a/templates/bot/csharp/command-and-response/ProjectName.csproj.tpl
+++ b/templates/bot/csharp/command-and-response/ProjectName.csproj.tpl
@@ -17,7 +17,10 @@
     <PackageReference Include="AdaptiveCards.Templating" Version="1.2.2" />
     <PackageReference Include="Microsoft.Bot.Builder" Version="4.16.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.16.0" />
-    <PackageReference Include="Microsoft.TeamsFx" Version="0.5.0-rc" />
+    <PackageReference Include="Microsoft.TeamsFx" Version="0.5.0-rc">
+      <!-- Exclude TeamsFx wwwroot static files which are for frontend only. -->
+      <ExcludeAssets>contentFiles</ExcludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/templates/bot/csharp/command-and-response/ProjectName.csproj.tpl
+++ b/templates/bot/csharp/command-and-response/ProjectName.csproj.tpl
@@ -17,7 +17,7 @@
     <PackageReference Include="AdaptiveCards.Templating" Version="1.2.2" />
     <PackageReference Include="Microsoft.Bot.Builder" Version="4.16.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.16.0" />
-    <PackageReference Include="Microsoft.TeamsFx" Version="0.4.1-rc" />
+    <PackageReference Include="Microsoft.TeamsFx" Version="0.5.0-rc" />
   </ItemGroup>
 
 </Project>

--- a/templates/bot/csharp/notification-webapi/ProjectName.csproj.tpl
+++ b/templates/bot/csharp/notification-webapi/ProjectName.csproj.tpl
@@ -21,7 +21,10 @@
     <PackageReference Include="AdaptiveCards.Templating" Version="1.2.2" />
     <PackageReference Include="Microsoft.Bot.Builder" Version="4.16.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.16.0" />
-    <PackageReference Include="Microsoft.TeamsFx" Version="0.5.0-rc" />
+    <PackageReference Include="Microsoft.TeamsFx" Version="0.5.0-rc">
+      <!-- Exclude TeamsFx wwwroot static files which are for frontend only. -->
+      <ExcludeAssets>contentFiles</ExcludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Update TeamsFx dotnet SDK to `0.5.0-rc` to use conversation SDK.