### PR TITLE
fix: tunnel skip env checker & refactor settings

### DIFF
--- a/packages/fx-core/src/common/local/index.ts
+++ b/packages/fx-core/src/common/local/index.ts
@@ -9,3 +9,4 @@ export * from "./taskDefinition";
 export * from "./constants";
 export * from "./microsoftTunnelingConfig";
 export * from "./microsoftTunnelingManager";
+export * from "./tunnelingSettings";

--- a/packages/fx-core/src/common/local/tunnelingSettings.ts
+++ b/packages/fx-core/src/common/local/tunnelingSettings.ts
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { Inputs } from "@microsoft/teamsfx-api";
+
+/**
+ * This file contains utility functions for core/solution to read tunneling settings and cli/vsc to set tunneling settings.
+ */
+
+export enum TunnelingService {
+  None = "none",
+  Ngrok = "ngrok",
+  MicrosoftTunneling = "microsoftTunneling",
+}
+
+export function getTunnelingEnabled(inputs: Inputs): boolean {
+  return inputs.tunnelingService !== TunnelingService.None;
+}
+
+export function getTunnelingService(inputs: Inputs): TunnelingService {
+  return inputs.tunnelingService in Object.values(TunnelingService)
+    ? inputs.tunnelingService
+    : TunnelingService.Ngrok;
+}
+
+export function setTunnelingService(inputs: Inputs, value: TunnelingService): void {
+  inputs.tunnelingService = value;
+}

--- a/packages/fx-core/src/common/local/tunnelingSettings.ts
+++ b/packages/fx-core/src/common/local/tunnelingSettings.ts
@@ -13,10 +13,6 @@ export enum TunnelingService {
   MicrosoftTunneling = "microsoftTunneling",
 }
 
-export function getTunnelingEnabled(inputs: Inputs): boolean {
-  return inputs.tunnelingService !== TunnelingService.None;
-}
-
 export function getTunnelingService(inputs: Inputs): TunnelingService {
   return inputs.tunnelingService in Object.values(TunnelingService)
     ? inputs.tunnelingService

--- a/packages/fx-core/src/common/local/tunnelingSettings.ts
+++ b/packages/fx-core/src/common/local/tunnelingSettings.ts
@@ -14,7 +14,7 @@ export enum TunnelingService {
 }
 
 export function getTunnelingService(inputs: Inputs): TunnelingService {
-  return inputs.tunnelingService in Object.values(TunnelingService)
+  return Object.values(TunnelingService).includes(inputs.tunnelingService)
     ? inputs.tunnelingService
     : TunnelingService.Ngrok;
 }

--- a/packages/fx-core/src/plugins/solution/fx-solution/debug/provisionLocal.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/debug/provisionLocal.ts
@@ -24,10 +24,7 @@ import {
 } from "./error";
 import { getCodespaceName, getCodespaceUrl } from "./util/codespace";
 import { getNgrokHttpUrl, getTunnelingHttpUrl } from "./util/tunneling";
-import {
-  getTunnelingService,
-  getTunnelingEnabled,
-} from "../../../../common/local/tunnelingSettings";
+import { getTunnelingService, TunnelingService } from "../../../../common/local/tunnelingSettings";
 import {
   EnvKeysBackend,
   EnvKeysBot,
@@ -51,7 +48,7 @@ export async function setupLocalDebugSettings(
   const includeBot = ProjectSettingsHelper.includeBot(ctx.projectSetting);
   const includeAAD = ProjectSettingsHelper.includeAAD(ctx.projectSetting);
   const includeSimpleAuth = ProjectSettingsHelper.includeSimpleAuth(ctx.projectSetting);
-  const skipNgrok = inputs.checkerInfo?.skipNgrok as boolean;
+  const tunnelingService = getTunnelingService(inputs);
   const includeFuncHostedBot = ProjectSettingsHelper.includeFuncHostedBot(ctx.projectSetting);
   const botCapabilities = ProjectSettingsHelper.getBotCapabilities(ctx.projectSetting);
 
@@ -62,9 +59,7 @@ export async function setupLocalDebugSettings(
     function: includeBackend ? "true" : "false",
     bot: includeBot ? "true" : "false",
     auth: includeAAD && includeSimpleAuth ? "true" : "false",
-    "skip-ngrok": skipNgrok ? "true" : "false", // only for telemetry backward compatibility
-    "use-tunneling": getTunnelingEnabled(inputs).toString(),
-    "tunneling-service": getTunnelingService(inputs),
+    "tunneling-service": tunnelingService,
     "bot-host-type": includeFuncHostedBot ? BotHostTypes.AzureFunctions : BotHostTypes.AppService,
     "bot-capabilities": JSON.stringify(botCapabilities),
   };
@@ -126,7 +121,7 @@ export async function setupLocalDebugSettings(
           localSettings.bot = {};
         }
 
-        if (!getTunnelingEnabled(inputs)) {
+        if (tunnelingService === TunnelingService.None) {
           const localBotEndpoint = localSettings.bot.botEndpoint as string;
           if (localBotEndpoint === undefined) {
             const error = LocalBotEndpointNotConfigured();
@@ -196,7 +191,7 @@ export async function setupLocalEnvironment(
   const includeBot = ProjectSettingsHelper.includeBot(ctx.projectSetting);
   const includeAAD = ProjectSettingsHelper.includeAAD(ctx.projectSetting);
   const includeSimpleAuth = ProjectSettingsHelper.includeSimpleAuth(ctx.projectSetting);
-  const skipNgrok = inputs.checkerInfo?.skipNgrok as boolean;
+  const tunnelingService = getTunnelingService(inputs);
   const includeFuncHostedBot = ProjectSettingsHelper.includeFuncHostedBot(ctx.projectSetting);
   const botCapabilities = ProjectSettingsHelper.getBotCapabilities(ctx.projectSetting);
 
@@ -207,9 +202,7 @@ export async function setupLocalEnvironment(
     function: includeBackend ? "true" : "false",
     bot: includeBot ? "true" : "false",
     auth: includeAAD && includeSimpleAuth ? "true" : "false",
-    "skip-ngrok": skipNgrok ? "true" : "false", // only for telemetry backward compatibility
-    "tunneling-enabled": getTunnelingEnabled(inputs).toString(),
-    "tunneling-service": getTunnelingService(inputs),
+    "tunneling-service": tunnelingService,
     "bot-host-type": includeFuncHostedBot ? BotHostTypes.AzureFunctions : BotHostTypes.AppService,
     "bot-capabilities": JSON.stringify(botCapabilities),
   };
@@ -271,7 +264,7 @@ export async function setupLocalEnvironment(
           envInfo.state[ResourcePlugins.Bot] = {};
         }
 
-        if (!getTunnelingEnabled(inputs)) {
+        if (tunnelingService === TunnelingService.None) {
           const localBotEndpoint = envInfo.config.bot?.siteEndpoint as string;
           if (localBotEndpoint === undefined) {
             const error = LocalBotEndpointNotConfigured();

--- a/packages/fx-core/src/plugins/solution/fx-solution/debug/util/tunneling.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/debug/util/tunneling.ts
@@ -2,14 +2,17 @@
 // Licensed under the MIT license.
 "use strict";
 
-import { FxError, Result, err, ok } from "@microsoft/teamsfx-api";
+import { FxError, Result, err, ok, Inputs } from "@microsoft/teamsfx-api";
 import axios from "axios";
-import { isMicrosoftTunnelingEnabled } from "../../../../../common/featureFlags";
+import { getTunnelingService, TunnelingService } from "../../../../../common";
 import { getCurrentTunnelPorts } from "../../../../../common/local/microsoftTunnelingManager";
 import { MicrosoftTunnelingNotConnected, NgrokTunnelNotConnected } from "../error";
 
-export async function getTunnelingHttpUrl(port: number): Promise<Result<string, FxError>> {
-  if (isMicrosoftTunnelingEnabled()) {
+export async function getTunnelingHttpUrl(
+  inputs: Inputs,
+  port: number
+): Promise<Result<string, FxError>> {
+  if (getTunnelingService(inputs) === TunnelingService.MicrosoftTunneling) {
     return await getMicrosoftTunnelingHttpUrl(port);
   } else {
     return await getNgrokHttpUrl(port);

--- a/packages/fx-core/src/plugins/solution/fx-solution/debug/util/tunneling.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/debug/util/tunneling.ts
@@ -12,6 +12,7 @@ export async function getTunnelingHttpUrl(
   inputs: Inputs,
   port: number
 ): Promise<Result<string, FxError>> {
+  // Assuming tunneling is enabled
   if (getTunnelingService(inputs) === TunnelingService.MicrosoftTunneling) {
     return await getMicrosoftTunnelingHttpUrl(port);
   } else {

--- a/packages/fx-core/tests/plugins/solution/debug/solution.debug.provisionLocal.test.ts
+++ b/packages/fx-core/tests/plugins/solution/debug/solution.debug.provisionLocal.test.ts
@@ -11,6 +11,7 @@ import {
   configLocalEnvironment,
 } from "../../../../src/plugins/solution/fx-solution/debug/provisionLocal";
 import * as path from "path";
+import { setTunnelingService, TunnelingService } from "../../../../src/common";
 
 chai.use(chaiAsPromised);
 
@@ -117,8 +118,8 @@ describe("solution.debug.provisionLocal", () => {
       const inputs = {
         platform: Platform.VSCode,
         projectPath: path.resolve(__dirname, `./data/${projectSetting.projectId}`),
-        checkerInfo: { skipNgrok: true },
       };
+      setTunnelingService(inputs, TunnelingService.None);
       const v2Context = new MockedV2Context(projectSetting);
       const envInfo = {
         envName: "default",
@@ -157,8 +158,8 @@ describe("solution.debug.provisionLocal", () => {
       const inputs = {
         platform: Platform.VSCode,
         projectPath: path.resolve(__dirname, `./data/${projectSetting.projectId}`),
-        checkerInfo: { skipNgrok: true },
       };
+      setTunnelingService(inputs, TunnelingService.None);
       const v2Context = new MockedV2Context(projectSetting);
       const envInfo = {
         envName: "default",

--- a/packages/vscode-extension/src/debug/depsChecker/vscodeHelper.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/vscodeHelper.ts
@@ -4,7 +4,8 @@
 import { commands, MessageItem, Uri, window, workspace, WorkspaceConfiguration } from "vscode";
 import { hasTeamsfxBackend, hasTeamsfxBot } from "../commonUtils";
 import { vscodeTelemetry } from "./vscodeTelemetry";
-import { DepsCheckerEvent } from "@microsoft/teamsfx-core";
+import { DepsCheckerEvent, TunnelingService } from "@microsoft/teamsfx-core";
+import { getTunnelingServiceFromVSCodeSettings } from "../../utils/commonUtils";
 const configurationPrefix = "fx-extension";
 
 class VSCodeHelper {
@@ -38,7 +39,7 @@ class VSCodeHelper {
   }
 
   public isNgrokCheckerEnabled(): boolean {
-    return this.checkerEnabled("prerequisiteCheck.ngrok");
+    return getTunnelingServiceFromVSCodeSettings() === TunnelingService.Ngrok;
   }
 
   public isTrustDevCertEnabled(): boolean {

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -79,6 +79,7 @@ import {
   isValidProject,
   LocalEnvManager,
   ProjectSettingsHelper,
+  setTunnelingService,
   UserTaskFunctionName,
 } from "@microsoft/teamsfx-core";
 
@@ -145,6 +146,7 @@ import {
   getSubscriptionInfoFromEnv,
   getTeamsAppTelemetryInfoByEnv,
   getTriggerFromProperty,
+  getTunnelingServiceFromVSCodeSettings,
   isExistingTabApp,
   isSPFxProject,
   isTeamsfx,
@@ -1016,6 +1018,7 @@ export async function runCommand(
           skipNgrok: !vscodeHelper.isNgrokCheckerEnabled(),
           trustDevCert: vscodeHelper.isTrustDevCertEnabled(),
         };
+        setTunnelingService(inputs, getTunnelingServiceFromVSCodeSettings());
         result = await core.localDebug(inputs);
         break;
       }

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -1015,7 +1015,6 @@ export async function runCommand(
           inputs.ignoreEnvInfo = true;
         }
         inputs.checkerInfo = {
-          skipNgrok: !vscodeHelper.isNgrokCheckerEnabled(),
           trustDevCert: vscodeHelper.isTrustDevCertEnabled(),
         };
         setTunnelingService(inputs, getTunnelingServiceFromVSCodeSettings());


### PR DESCRIPTION
Fix bugs:
- `prerequisitesCheck.ngrok` is not checked when use Microsoft tunneling.
- ngrok is still installed when using Microsoft tunneling

vscode settings:
-`prerequisitesCheck.ngrok` => whether tunneling is enabled
-`tunneling` => Use MicrosoftTunneling or Ngrok
And then `inputs.tunnelingService` is set to none, microsoftTunneling or ngrok according to above vscode settings.

In core/solution, use `getTunnelingService(inputs)`. In vsc, use `getTunnelingServiceFromVSCodeSettings()`. Env variable is not used anymore.