### PR TITLE
fix: azure account ui shows for spfx project

### DIFF
--- a/packages/vscode-extension/src/treeview/account/accountTreeViewProvider.ts
+++ b/packages/vscode-extension/src/treeview/account/accountTreeViewProvider.ts
@@ -4,14 +4,11 @@
 import * as vscode from "vscode";
 
 import { TokenProvider } from "@microsoft/teamsfx-api";
-
-import { getAzureSolutionSettings } from "../../handlers";
 import { DynamicNode } from "../dynamicNode";
 import envTreeProviderInstance from "../environmentTreeViewProvider";
 import { AzureAccountNode } from "./azureNode";
 import { M365AccountNode } from "./m365Node";
-import { isSPFxProject } from "../../utils/commonUtils";
-import { ext } from "../../extensionVariables";
+import { isSPFxProject } from "../../globalVariables";
 
 export class AccountTreeViewProvider implements vscode.TreeDataProvider<DynamicNode> {
   private static instance: AccountTreeViewProvider;
@@ -65,7 +62,7 @@ export class AccountTreeViewProvider implements vscode.TreeDataProvider<DynamicN
   }
 
   private async getAccountNodes(): Promise<DynamicNode[]> {
-    if (isSPFxProject(ext.workspaceUri.fsPath)) {
+    if (isSPFxProject) {
       return [this.m365AccountNode];
     } else {
       return [this.m365AccountNode, this.azureAccountNode];

--- a/packages/vscode-extension/src/treeview/account/accountTreeViewProvider.ts
+++ b/packages/vscode-extension/src/treeview/account/accountTreeViewProvider.ts
@@ -10,6 +10,8 @@ import { DynamicNode } from "../dynamicNode";
 import envTreeProviderInstance from "../environmentTreeViewProvider";
 import { AzureAccountNode } from "./azureNode";
 import { M365AccountNode } from "./m365Node";
+import { isSPFxProject } from "../../utils/commonUtils";
+import { ext } from "../../extensionVariables";
 
 export class AccountTreeViewProvider implements vscode.TreeDataProvider<DynamicNode> {
   private static instance: AccountTreeViewProvider;
@@ -63,8 +65,7 @@ export class AccountTreeViewProvider implements vscode.TreeDataProvider<DynamicN
   }
 
   private async getAccountNodes(): Promise<DynamicNode[]> {
-    const solutionSettings = await getAzureSolutionSettings();
-    if (solutionSettings && "SPFx" === solutionSettings.hostType) {
+    if (isSPFxProject(ext.workspaceUri.fsPath)) {
       return [this.m365AccountNode];
     } else {
       return [this.m365AccountNode, this.azureAccountNode];


### PR DESCRIPTION
Root cause:
Sometimes Azure account item can show in spfx project if user start other operations before extension fully activated. This is because two actions executed at the same time and file locked by core. Thus the API call can't get correct result.

Fix:
Check SPFx folder structure in extension level to avoid concurrency issue.

Before:
![image](https://user-images.githubusercontent.com/73154171/170232817-5fc46c45-555b-4bfb-81a5-53e2429be6ad.png)

E2E TEST: NA
