### PR TITLE
fix: hide deploy aad manifest command in spfx project

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -171,7 +171,7 @@
       "explorer/context": [
         {
           "command": "fx-extension.deployAadAppManifestFromCtxMenu",
-          "when": "resourceFilename == aad.template.json && fx-extension.isAadManifestEnabled",
+          "when": "resourceFilename == aad.template.json && fx-extension.isAadManifestEnabled && !fx-extension.isSPFx",
           "group": "deploy@0"
         },
         {
@@ -438,12 +438,12 @@
       {
         "command": "fx-extension.deployAadAppManifest",
         "title": "%teamstoolkit.commands.deployAadAppManifest.title%",
-        "enablement": "fx-extension.isAadManifestEnabled"
+        "enablement": "fx-extension.isAadManifestEnabled && !fx-extension.isSPFx"
       },
       {
         "command": "fx-extension.deployAadAppManifestFromCtxMenu",
         "title": "%teamstoolkit.commands.deployAadAppManifestFromCtxMenu.title%",
-        "enablement": "fx-extension.isAadManifestEnabled"
+        "enablement": "fx-extension.isAadManifestEnabled && !fx-extension.isSPFx"
       },
       {
         "command": "fx-extension.signOut",


### PR DESCRIPTION
Address this bug: 
[Bug 14473495](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14473495): Command "Deploy Azure Active Directory app manifest" in spfx project is not hidden

E2E TEST: NA