### PR TITLE
refactor(vsc): reorganize activate()

### DIFF
--- a/packages/vscode-extension/src/commonlib/azureLogin.ts
+++ b/packages/vscode-extension/src/commonlib/azureLogin.ts
@@ -575,7 +575,7 @@ export class AzureAccountManager extends login implements AzureAccountProvider {
   async getSubscriptionInfoPath(): Promise<string | undefined> {
     if (globalVariables.workspaceUri) {
       const workspacePath: string = globalVariables.workspaceUri.fsPath;
-      if (!(await commonUtils.isFxProject(workspacePath))) {
+      if (!globalVariables.isTeamsFxProject) {
         return undefined;
       }
       const configRoot = await commonUtils.getProjectRoot(workspacePath, `.${ConfigFolderName}`);

--- a/packages/vscode-extension/src/debug/commonUtils.ts
+++ b/packages/vscode-extension/src/debug/commonUtils.ts
@@ -84,33 +84,32 @@ export async function isFxProject(folderPath: string): Promise<boolean> {
 }
 
 export async function hasTeamsfxBackend(): Promise<boolean> {
-  if (!vscode.workspace.workspaceFolders) {
+  if (!globalVariables.workspaceUri) {
     return false;
   }
 
-  const workspaceFolder: vscode.WorkspaceFolder = vscode.workspace.workspaceFolders[0];
-  const workspacePath: string = workspaceFolder.uri.fsPath;
-  if (!(await isFxProject(workspacePath))) {
+  if (!globalVariables.isTeamsFxProject) {
     return false;
   }
 
-  const backendRoot = await getProjectRoot(workspacePath, FolderName.Function);
+  const backendRoot = await getProjectRoot(
+    globalVariables.workspaceUri.fsPath,
+    FolderName.Function
+  );
 
   return backendRoot !== undefined;
 }
 
 export async function hasTeamsfxBot(): Promise<boolean> {
-  if (!vscode.workspace.workspaceFolders) {
+  if (!globalVariables.workspaceUri) {
     return false;
   }
 
-  const workspaceFolder: vscode.WorkspaceFolder = vscode.workspace.workspaceFolders[0];
-  const workspacePath: string = workspaceFolder.uri.fsPath;
-  if (!(await isFxProject(workspacePath))) {
+  if (!globalVariables.isTeamsFxProject) {
     return false;
   }
 
-  const botRoot = await getProjectRoot(workspacePath, FolderName.Bot);
+  const botRoot = await getProjectRoot(globalVariables.workspaceUri.fsPath, FolderName.Bot);
 
   return botRoot !== undefined;
 }

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -46,7 +46,7 @@ import { registerTeamsfxTaskAndDebugEvents } from "./debug/teamsfxTaskHandler";
 import { TeamsfxTaskProvider } from "./debug/teamsfxTaskProvider";
 import * as exp from "./exp";
 import { TreatmentVariables, TreatmentVariableValue } from "./exp/treatmentVariables";
-import { initializeExtensionVariables, isSPFxProject } from "./globalVariables";
+import { initializeExtensionVariables, isSPFxProject, workspaceUri } from "./globalVariables";
 import * as handlers from "./handlers";
 import { ManifestTemplateHoverProvider } from "./hoverProvider";
 import { VsCodeUI } from "./qm/vsc_ui";
@@ -464,19 +464,18 @@ export async function activate(context: vscode.ExtensionContext) {
   );
   context.subscriptions.push(specifySubscription);
 
-  const workspacePath = handlers.getWorkspacePath();
   vscode.commands.executeCommand("setContext", "fx-extension.isSPFx", isSPFxProject);
 
   vscode.commands.executeCommand(
     "setContext",
     "fx-extension.isM365",
-    workspacePath && (await isM365Project(workspacePath))
+    workspaceUri && (await isM365Project(workspaceUri.fsPath))
   );
 
   vscode.commands.executeCommand(
     "setContext",
     "fx-extension.canUpgradeToArmAndMultiEnv",
-    await canUpgradeToArmAndMultiEnv(workspacePath)
+    await canUpgradeToArmAndMultiEnv(workspaceUri?.fsPath)
   );
 
   vscode.commands.executeCommand(

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -46,7 +46,7 @@ import { registerTeamsfxTaskAndDebugEvents } from "./debug/teamsfxTaskHandler";
 import { TeamsfxTaskProvider } from "./debug/teamsfxTaskProvider";
 import * as exp from "./exp";
 import { TreatmentVariables, TreatmentVariableValue } from "./exp/treatmentVariables";
-import { initializeExtensionVariables, isSPFxProject, workspaceUri } from "./globalVariables";
+import { initializeGlobalVariables, isSPFxProject, workspaceUri } from "./globalVariables";
 import * as handlers from "./handlers";
 import { ManifestTemplateHoverProvider } from "./hoverProvider";
 import { VsCodeUI } from "./qm/vsc_ui";
@@ -72,14 +72,50 @@ export async function activate(context: vscode.ExtensionContext) {
   // load the feature flags.
   syncFeatureFlags();
 
-  // Init VSC context key
-  initializeContextKey();
-
   VS_CODE_UI = new VsCodeUI(context);
-  // Init context
-  initializeExtensionVariables(context);
-
   context.subscriptions.push(new ExtTelemetry.Reporter(context));
+  // Init context
+  initializeGlobalVariables(context);
+
+  registerTreeViewCommandsInDevelopment(context);
+  registerTreeViewCommandsInDeployment(context);
+  registerTreeViewCommandsInHelper(context);
+
+  registerCommands(context);
+
+  registerCodelensAndHoverProviders(context);
+
+  registerDebugConfigProviders(context);
+
+  // Register task and debug event handlers, as well as sending telemetries
+  registerTeamsfxTaskAndDebugEvents();
+
+  registerRunIcon();
+
+  // Register teamsfx task provider
+  const taskProvider: TeamsfxTaskProvider = new TeamsfxTaskProvider();
+  context.subscriptions.push(
+    vscode.tasks.registerTaskProvider(TeamsfxTaskProvider.type, taskProvider)
+  );
+
+  context.subscriptions.push(
+    vscode.workspace.onWillSaveTextDocument(handlers.saveTextDocumentHandler)
+  );
+
+  // Call activate function of toolkit core.
+  handlers.activate();
+
+  // Init VSC context key
+  await initializeContextKey();
+  await handlers.cmdHdlLoadTreeView(context);
+
+  ExtTelemetry.isFromSample = await handlers.getIsFromSample();
+  ExtTelemetry.settingsVersion = await handlers.getSettingsVersion();
+  ExtTelemetry.isM365 = await handlers.getIsM365();
+  await ExtTelemetry.sendCachedTelemetryEventsAsync();
+
+  await handlers.autoOpenProjectHandler();
+  await handlers.postUpgrade();
 
   // activate upgrade
   const upgrade = new ExtensionUpgrade(context);
@@ -93,11 +129,197 @@ export async function activate(context: vscode.ExtensionContext) {
       TreatmentVariables.EmbeddedSurvey,
       true
     )) as boolean | undefined;
+  if (!TreatmentVariableValue.isEmbeddedSurvey) {
+    const survey = ExtensionSurvey.getInstance();
+    survey.activate();
+  }
 
-  registerTreeViewCommandsInDevelopment(context);
-  registerTreeViewCommandsInDeployment(context);
-  registerTreeViewCommandsInHelper(context);
+  openWelcomePageAfterExtensionInstallation();
 
+  showDebugChangesNotification();
+
+  loadLocalizedStrings();
+}
+
+// this method is called when your extension is deactivated
+export async function deactivate() {
+  await ExtTelemetry.cacheTelemetryEventAsync(TelemetryEvent.Deactivate);
+  await ExtTelemetry.dispose();
+  handlers.cmdHdlDisposeTreeView();
+  disableRunIcon();
+}
+
+async function initializeContextKey() {
+  if (isValidNode()) {
+    vscode.commands.executeCommand("setContext", "fx-extension.isNotValidNode", false);
+  } else {
+    vscode.commands.executeCommand("setContext", "fx-extension.isNotValidNode", true);
+  }
+  vscode.commands.executeCommand("setContext", "fx-extension.customizedTreeview", false);
+
+  vscode.commands.executeCommand("setContext", "fx-extension.isSPFx", isSPFxProject);
+
+  vscode.commands.executeCommand(
+    "setContext",
+    "fx-extension.isM365",
+    workspaceUri && (await isM365Project(workspaceUri.fsPath))
+  );
+
+  vscode.commands.executeCommand(
+    "setContext",
+    "fx-extension.canUpgradeToArmAndMultiEnv",
+    await canUpgradeToArmAndMultiEnv(workspaceUri?.fsPath)
+  );
+
+  vscode.commands.executeCommand(
+    "setContext",
+    "fx-extension.isAadManifestEnabled",
+    isAadManifestEnabled()
+  );
+
+  vscode.commands.executeCommand(
+    "setContext",
+    "fx-extension.isDeployManifestEnabled",
+    isDeployManifestEnabled()
+  );
+
+  vscode.commands.executeCommand(
+    "setContext",
+    "fx-extension.isConfigUnifyEnabled",
+    isConfigUnifyEnabled()
+  );
+
+  vscode.commands.executeCommand(
+    "setContext",
+    "fx-extension.isApiConnectEnabled",
+    isApiConnectEnabled()
+  );
+
+  vscode.commands.executeCommand(
+    "setContext",
+    "fx-entension.previewFeaturesEnabled",
+    isPreviewFeaturesEnabled()
+  );
+}
+
+function registerTreeViewCommandsInDevelopment(context: vscode.ExtensionContext) {
+  // Create a new Teams app
+  registerInCommandController(
+    context,
+    "fx-extension.create",
+    handlers.createNewProjectHandler,
+    "createProject"
+  );
+
+  // Initialize an existing application
+  registerInCommandController(
+    context,
+    "fx-extension.init",
+    handlers.initProjectHandler,
+    "initProject"
+  );
+
+  // View samples
+  registerInCommandController(context, "fx-extension.openSamples", handlers.openSamplesHandler);
+
+  // Add features
+  registerInCommandController(
+    context,
+    "fx-extension.addFeature",
+    handlers.addFeatureHandler,
+    "addFeature"
+  );
+
+  // Add capabilities
+  registerInCommandController(
+    context,
+    "fx-extension.addCapability",
+    handlers.addCapabilityHandler,
+    "addCapabilities"
+  );
+
+  // Add cloud resources
+  registerInCommandController(
+    context,
+    "fx-extension.update",
+    handlers.addResourceHandler,
+    "addResources"
+  );
+
+  // Edit manifest file
+  registerInCommandController(
+    context,
+    "fx-extension.openManifest",
+    handlers.openManifestHandler,
+    "manifestEditor"
+  );
+
+  // Open adaptive card
+  registerInCommandController(
+    context,
+    "fx-extension.OpenAdaptiveCardExt",
+    handlers.openAdaptiveCardExt
+  );
+}
+
+function registerTreeViewCommandsInDeployment(context: vscode.ExtensionContext) {
+  // Provision in the cloud
+  registerInCommandController(
+    context,
+    "fx-extension.provision",
+    handlers.provisionHandler,
+    "provision"
+  );
+
+  // Zip Teams metadata package
+  registerInCommandController(
+    context,
+    "fx-extension.build",
+    handlers.buildPackageHandler,
+    "buildPackage"
+  );
+
+  // Deploy to the cloud
+  registerInCommandController(context, "fx-extension.deploy", handlers.deployHandler, "deploy");
+
+  // Publish to Teams
+  registerInCommandController(context, "fx-extension.publish", handlers.publishHandler, "publish");
+
+  // Add CI/CD Workflows
+  registerInCommandController(
+    context,
+    "fx-extension.addCICDWorkflows",
+    handlers.addCICDWorkflowsHandler,
+    "addCICDWorkflows"
+  );
+
+  // Developer Portal for Teams
+  registerInCommandController(
+    context,
+    "fx-extension.openAppManagement",
+    handlers.openAppManagement
+  );
+}
+
+function registerTreeViewCommandsInHelper(context: vscode.ExtensionContext) {
+  // Quick start
+  registerInCommandController(context, "fx-extension.openWelcome", handlers.openWelcomeHandler);
+
+  // Tutorials
+  registerInCommandController(
+    context,
+    "fx-extension.selectTutorials",
+    handlers.selectTutorialsHandler
+  );
+
+  // Documentation
+  registerInCommandController(context, "fx-extension.openDocument", handlers.openDocumentHandler);
+
+  // Report issues on GitHub
+  registerInCommandController(context, "fx-extension.openReportIssues", handlers.openReportIssues);
+}
+
+function registerCommands(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand("fx-extension.getNewProjectPath", async (...args) => {
       if (!isSupportAutoOpenAPI()) {
@@ -189,12 +411,6 @@ export async function activate(context: vscode.ExtensionContext) {
     () => Correlator.runWithId(getLocalDebugSessionId(), handlers.backendExtensionsInstallHandler)
   );
   context.subscriptions.push(backendExtensionsInstallCmd);
-
-  // 1.10 Register teamsfx task provider
-  const taskProvider: TeamsfxTaskProvider = new TeamsfxTaskProvider();
-  context.subscriptions.push(
-    vscode.tasks.registerTaskProvider(TeamsfxTaskProvider.type, taskProvider)
-  );
 
   const checkUpgradeCmd = vscode.commands.registerCommand(
     "fx-extension.checkProjectUpgrade",
@@ -310,7 +526,7 @@ export async function activate(context: vscode.ExtensionContext) {
     "fx-extension.openPreviewAadFile",
     (...args) => Correlator.run(handlers.openPreviewAadFile, args)
   );
-  context.subscriptions.push(manifestTemplateCodeLensCmd);
+  context.subscriptions.push(aadManifestTemplateCodeLensCmd);
 
   const openConfigStateCmd = vscode.commands.registerCommand(
     "fx-extension.openConfigState",
@@ -464,50 +680,26 @@ export async function activate(context: vscode.ExtensionContext) {
   );
   context.subscriptions.push(specifySubscription);
 
-  vscode.commands.executeCommand("setContext", "fx-extension.isSPFx", isSPFxProject);
-
-  vscode.commands.executeCommand(
-    "setContext",
-    "fx-extension.isM365",
-    workspaceUri && (await isM365Project(workspaceUri.fsPath))
+  // Register local debug run icon
+  const runIconCmd = vscode.commands.registerCommand("fx-extension.selectAndDebug", (...args) =>
+    Correlator.run(handlers.selectAndDebugHandler, args)
   );
+  context.subscriptions.push(runIconCmd);
 
-  vscode.commands.executeCommand(
-    "setContext",
-    "fx-extension.canUpgradeToArmAndMultiEnv",
-    await canUpgradeToArmAndMultiEnv(workspaceUri?.fsPath)
+  const migrateTeamsTabAppCmd = vscode.commands.registerCommand(
+    "fx-extension.migrateTeamsTabApp",
+    () => Correlator.run(handlers.migrateTeamsTabAppHandler)
   );
+  context.subscriptions.push(migrateTeamsTabAppCmd);
 
-  vscode.commands.executeCommand(
-    "setContext",
-    "fx-extension.isAadManifestEnabled",
-    isAadManifestEnabled()
+  const migrateTeamsManifestCmd = vscode.commands.registerCommand(
+    "fx-extension.migrateTeamsManifest",
+    () => Correlator.run(handlers.migrateTeamsManifestHandler)
   );
+  context.subscriptions.push(migrateTeamsManifestCmd);
+}
 
-  vscode.commands.executeCommand(
-    "setContext",
-    "fx-extension.isDeployManifestEnabled",
-    isDeployManifestEnabled()
-  );
-
-  vscode.commands.executeCommand(
-    "setContext",
-    "fx-extension.isConfigUnifyEnabled",
-    isConfigUnifyEnabled()
-  );
-
-  vscode.commands.executeCommand(
-    "setContext",
-    "fx-extension.isApiConnectEnabled",
-    isApiConnectEnabled()
-  );
-
-  vscode.commands.executeCommand(
-    "setContext",
-    "fx-entension.previewFeaturesEnabled",
-    isPreviewFeaturesEnabled()
-  );
-
+function registerCodelensAndHoverProviders(context: vscode.ExtensionContext) {
   // Setup CodeLens provider for userdata file
   const codelensProvider = new CryptoCodeLensProvider();
   const userDataSelector = {
@@ -555,12 +747,6 @@ export async function activate(context: vscode.ExtensionContext) {
     language: "json",
     scheme: "file",
     pattern: `**/${TemplateFolderName}/${AppPackageFolderName}/aad.template.json`,
-  };
-
-  const aadManifestPreviewSelector = {
-    language: "json",
-    scheme: "file",
-    pattern: `**/${BuildFolderName}/${AppPackageFolderName}/aad.*.json`,
   };
 
   const permissionsJsonFileCodeLensProvider = new PermissionsJsonFileCodeLensProvider();
@@ -614,6 +800,11 @@ export async function activate(context: vscode.ExtensionContext) {
   );
 
   // Register hover provider
+  const aadManifestPreviewSelector = {
+    language: "json",
+    scheme: "file",
+    pattern: `**/${BuildFolderName}/${AppPackageFolderName}/aad.*.json`,
+  };
   const manifestTemplateHoverProvider = new ManifestTemplateHoverProvider();
   context.subscriptions.push(
     vscode.languages.registerHoverProvider(manifestTemplateSelector, manifestTemplateHoverProvider)
@@ -629,8 +820,9 @@ export async function activate(context: vscode.ExtensionContext) {
       aadAppTemplateCodeLensProvider
     )
   );
+}
 
-  // Register debug configuration provider
+function registerDebugConfigProviders(context: vscode.ExtensionContext) {
   const debugProvider: TeamsfxDebugProvider = new TeamsfxDebugProvider();
   context.subscriptions.push(
     vscode.debug.registerDebugConfigurationProvider("pwa-chrome", debugProvider)
@@ -644,182 +836,6 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.debug.registerDebugConfigurationProvider("msedge", debugProvider)
   );
-
-  // Register task and debug event handlers, as well as sending telemetries
-  registerTeamsfxTaskAndDebugEvents();
-
-  await handlers.cmdHdlLoadTreeView(context);
-
-  // Register local debug run icon
-  const runIconCmd = vscode.commands.registerCommand("fx-extension.selectAndDebug", (...args) =>
-    Correlator.run(handlers.selectAndDebugHandler, args)
-  );
-  context.subscriptions.push(runIconCmd);
-  registerRunIcon();
-
-  context.subscriptions.push(
-    vscode.workspace.onWillSaveTextDocument(handlers.saveTextDocumentHandler)
-  );
-
-  const migrateTeamsTabAppCmd = vscode.commands.registerCommand(
-    "fx-extension.migrateTeamsTabApp",
-    () => Correlator.run(handlers.migrateTeamsTabAppHandler)
-  );
-  context.subscriptions.push(migrateTeamsTabAppCmd);
-
-  const migrateTeamsManifestCmd = vscode.commands.registerCommand(
-    "fx-extension.migrateTeamsManifest",
-    () => Correlator.run(handlers.migrateTeamsManifestHandler)
-  );
-  context.subscriptions.push(migrateTeamsManifestCmd);
-
-  // 2. Call activate function of toolkit core.
-  await handlers.activate();
-
-  if (!TreatmentVariableValue.isEmbeddedSurvey) {
-    const survey = ExtensionSurvey.getInstance();
-    survey.activate();
-  }
-
-  openWelcomePageAfterExtensionInstallation();
-
-  showDebugChangesNotification();
-
-  loadLocalizedStrings();
-}
-
-// this method is called when your extension is deactivated
-export async function deactivate() {
-  await ExtTelemetry.cacheTelemetryEventAsync(TelemetryEvent.Deactivate);
-  await ExtTelemetry.dispose();
-  handlers.cmdHdlDisposeTreeView();
-  disableRunIcon();
-}
-
-function initializeContextKey() {
-  if (isValidNode()) {
-    vscode.commands.executeCommand("setContext", "fx-extension.isNotValidNode", false);
-  } else {
-    vscode.commands.executeCommand("setContext", "fx-extension.isNotValidNode", true);
-  }
-  vscode.commands.executeCommand("setContext", "fx-extension.customizedTreeview", false);
-}
-
-function registerTreeViewCommandsInDevelopment(context: vscode.ExtensionContext) {
-  // Create a new Teams app
-  registerInCommandController(
-    context,
-    "fx-extension.create",
-    handlers.createNewProjectHandler,
-    "createProject"
-  );
-
-  // Initialize an existing application
-  registerInCommandController(
-    context,
-    "fx-extension.init",
-    handlers.initProjectHandler,
-    "initProject"
-  );
-
-  // View samples
-  registerInCommandController(context, "fx-extension.openSamples", handlers.openSamplesHandler);
-
-  // Add features
-  registerInCommandController(
-    context,
-    "fx-extension.addFeature",
-    handlers.addFeatureHandler,
-    "addFeature"
-  );
-
-  // Add capabilities
-  registerInCommandController(
-    context,
-    "fx-extension.addCapability",
-    handlers.addCapabilityHandler,
-    "addCapabilities"
-  );
-
-  // Add cloud resources
-  registerInCommandController(
-    context,
-    "fx-extension.update",
-    handlers.addResourceHandler,
-    "addResources"
-  );
-
-  // Edit manifest file
-  registerInCommandController(
-    context,
-    "fx-extension.openManifest",
-    handlers.openManifestHandler,
-    "manifestEditor"
-  );
-
-  // Open adaptive card
-  registerInCommandController(
-    context,
-    "fx-extension.OpenAdaptiveCardExt",
-    handlers.openAdaptiveCardExt
-  );
-}
-
-function registerTreeViewCommandsInDeployment(context: vscode.ExtensionContext) {
-  // Provision in the cloud
-  registerInCommandController(
-    context,
-    "fx-extension.provision",
-    handlers.provisionHandler,
-    "provision"
-  );
-
-  // Zip Teams metadata package
-  registerInCommandController(
-    context,
-    "fx-extension.build",
-    handlers.buildPackageHandler,
-    "buildPackage"
-  );
-
-  // Deploy to the cloud
-  registerInCommandController(context, "fx-extension.deploy", handlers.deployHandler, "deploy");
-
-  // Publish to Teams
-  registerInCommandController(context, "fx-extension.publish", handlers.publishHandler, "publish");
-
-  // Add CI/CD Workflows
-  registerInCommandController(
-    context,
-    "fx-extension.addCICDWorkflows",
-    handlers.addCICDWorkflowsHandler,
-    "addCICDWorkflows"
-  );
-
-  // Developer Portal for Teams
-  registerInCommandController(
-    context,
-    "fx-extension.openAppManagement",
-    handlers.openAppManagement
-  );
-}
-
-function registerTreeViewCommandsInHelper(context: vscode.ExtensionContext) {
-  // Quick start
-  registerInCommandController(context, "fx-extension.openWelcome", handlers.openWelcomeHandler);
-
-  // Tutorials
-  registerInCommandController(
-    context,
-    "fx-extension.selectTutorials",
-    handlers.selectTutorialsHandler
-  );
-
-  // Documentation
-  registerInCommandController(context, "fx-extension.openDocument", handlers.openDocumentHandler);
-
-  // Report issues on GitHub
-  registerInCommandController(context, "fx-extension.openReportIssues", handlers.openReportIssues);
 }
 
 function registerInCommandController(

--- a/packages/vscode-extension/src/globalVariables.ts
+++ b/packages/vscode-extension/src/globalVariables.ts
@@ -1,27 +1,31 @@
-/* eslint-disable @typescript-eslint/no-namespace */
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-"use strict";
-
-import * as vscode from "vscode";
 import * as fs from "fs";
+import * as path from "path";
+import * as vscode from "vscode";
+
+import { ConfigFolderName } from "@microsoft/teamsfx-api";
+
+import { UserState } from "./constants";
 
 /**
  * Common variables used throughout the extension. They must be initialized in the activate() method of extension.ts
  */
 export let context: vscode.ExtensionContext;
 export let workspaceUri: vscode.Uri | undefined;
+export let isTeamsFxProject = false;
 export let isSPFxProject = false;
+export let isExistingUser = "no";
 
 export function initializeExtensionVariables(ctx: vscode.ExtensionContext): void {
   context = ctx;
+  isExistingUser = context.globalState.get<string>(UserState.IsExisting) || "no";
   if (vscode.workspace && vscode.workspace.workspaceFolders) {
     if (vscode.workspace.workspaceFolders.length > 0) {
       workspaceUri = vscode.workspace.workspaceFolders[0].uri;
     }
   }
-  if (fs.existsSync(`${workspaceUri?.fsPath}/SPFx`)) {
-    isSPFxProject = true;
-  }
+  isTeamsFxProject = fs.existsSync(path.join(workspaceUri?.fsPath ?? "./", `.${ConfigFolderName}`));
+  isSPFxProject = fs.existsSync(path.join(workspaceUri?.fsPath ?? "./", "SPFx"));
 }

--- a/packages/vscode-extension/src/globalVariables.ts
+++ b/packages/vscode-extension/src/globalVariables.ts
@@ -18,7 +18,7 @@ export let isTeamsFxProject = false;
 export let isSPFxProject = false;
 export let isExistingUser = "no";
 
-export function initializeExtensionVariables(ctx: vscode.ExtensionContext): void {
+export function initializeGlobalVariables(ctx: vscode.ExtensionContext): void {
   context = ctx;
   isExistingUser = context.globalState.get<string>(UserState.IsExisting) || "no";
   if (vscode.workspace && vscode.workspace.workspaceFolders) {

--- a/packages/vscode-extension/src/telemetry/extTelemetry.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetry.ts
@@ -10,7 +10,7 @@ import { Correlator, globalStateGet, globalStateUpdate } from "@microsoft/teamsf
 import * as extensionPackage from "../../package.json";
 import { VSCodeTelemetryReporter } from "../commonlib/telemetry";
 import * as globalVariables from "../globalVariables";
-import { getIsExistingUser, getProjectId } from "../utils/commonUtils";
+import { getProjectId } from "../utils/commonUtils";
 import {
   TelemetryComponentType,
   TelemetryErrorType,
@@ -90,8 +90,7 @@ export namespace ExtTelemetry {
       properties[TelemetryProperty.Component] = TelemetryComponentType;
     }
 
-    const isExistingUser = getIsExistingUser();
-    properties[TelemetryProperty.IsExistingUser] = isExistingUser ? isExistingUser : "";
+    properties[TelemetryProperty.IsExistingUser] = globalVariables.isExistingUser;
 
     if (globalVariables.workspaceUri) {
       properties[TelemetryProperty.IsSpfx] = globalVariables.isSPFxProject.toString();
@@ -125,8 +124,7 @@ export namespace ExtTelemetry {
       properties[TelemetryProperty.Component] = TelemetryComponentType;
     }
 
-    const isExistingUser = getIsExistingUser();
-    properties[TelemetryProperty.IsExistingUser] = isExistingUser ? isExistingUser : "";
+    properties[TelemetryProperty.IsExistingUser] = globalVariables.isExistingUser;
 
     properties[TelemetryProperty.Success] = TelemetrySuccess.No;
     if (error instanceof UserError) {
@@ -170,8 +168,7 @@ export namespace ExtTelemetry {
       properties[TelemetryProperty.Component] = TelemetryComponentType;
     }
 
-    const isExistingUser = getIsExistingUser();
-    properties[TelemetryProperty.IsExistingUser] = isExistingUser ? isExistingUser : "";
+    properties[TelemetryProperty.IsExistingUser] = globalVariables.isExistingUser;
 
     if (globalVariables.workspaceUri) {
       properties[TelemetryProperty.IsSpfx] = globalVariables.isSPFxProject.toString();

--- a/packages/vscode-extension/src/treeview/account/subscriptionNode.ts
+++ b/packages/vscode-extension/src/treeview/account/subscriptionNode.ts
@@ -8,7 +8,7 @@ import { SubscriptionInfo } from "@microsoft/teamsfx-api";
 import { isValidProject } from "@microsoft/teamsfx-core";
 
 import AzureAccountManager from "../../commonlib/azureLogin";
-import { getWorkspacePath } from "../../handlers";
+import { workspaceUri } from "../../globalVariables";
 import { localize } from "../../utils/localizeUtils";
 import { DynamicNode } from "../dynamicNode";
 import { infoIcon, keyIcon, warningIcon } from "./common";
@@ -52,7 +52,7 @@ export class SubscriptionNode extends DynamicNode {
   }
 
   public setEmptySubscription() {
-    const validProject = isValidProject(getWorkspacePath());
+    const validProject = isValidProject(workspaceUri?.fsPath);
     this.contextValue = validProject ? "emptySubscription" : "invalidFxProject";
     this.label = localize("teamstoolkit.accountTree.noSubscriptions");
     this.tooltip = localize("teamstoolkit.accountTree.noSubscriptionsTooltip");

--- a/packages/vscode-extension/src/treeview/environmentTreeViewProvider.ts
+++ b/packages/vscode-extension/src/treeview/environmentTreeViewProvider.ts
@@ -4,7 +4,7 @@
 import { Mutex } from "async-mutex";
 import * as vscode from "vscode";
 
-import { err, FxError, LocalEnvironmentName, ok, Result, Void } from "@microsoft/teamsfx-api";
+import { FxError, LocalEnvironmentName, ok, Result, Void } from "@microsoft/teamsfx-api";
 import { environmentManager, isValidProject } from "@microsoft/teamsfx-core";
 
 import * as globalVariables from "../globalVariables";
@@ -18,6 +18,7 @@ export class EnvironmentTreeViewProvider implements vscode.TreeDataProvider<Dyna
   readonly onDidChangeTreeData: vscode.Event<DynamicNode | undefined | void> =
     this._onDidChangeTreeData.event;
 
+  private needRefresh = true;
   private environments: DynamicNode[] = [];
   private mutex = new Mutex();
 
@@ -34,16 +35,11 @@ export class EnvironmentTreeViewProvider implements vscode.TreeDataProvider<Dyna
     if (!globalVariables.workspaceUri || !isValidProject(globalVariables.workspaceUri.fsPath)) {
       return ok(Void);
     }
-    const workspacePath: string = globalVariables.workspaceUri.fsPath;
     return await this.mutex.runExclusive(async () => {
-      const envNamesResult = await environmentManager.listRemoteEnvConfigs(workspacePath);
-      if (envNamesResult.isErr()) {
-        return err(envNamesResult.error);
+      if (!this.needRefresh) {
+        this.needRefresh = true;
+        this._onDidChangeTreeData.fire();
       }
-
-      const envNames = [LocalEnvironmentName].concat(envNamesResult.value);
-      this.environments = envNames.map((env) => new EnvironmentNode(env));
-      this._onDidChangeTreeData.fire();
       return ok(Void);
     });
   }
@@ -67,9 +63,30 @@ export class EnvironmentTreeViewProvider implements vscode.TreeDataProvider<Dyna
 
   public getChildren(element?: DynamicNode): Thenable<DynamicNode[] | undefined | null> {
     if (!element) {
-      return Promise.resolve(this.environments);
+      return this.getEnvironments();
     }
     return element.getChildren();
+  }
+
+  private async getEnvironments(): Promise<DynamicNode[] | undefined | null> {
+    if (!globalVariables.workspaceUri) {
+      return null;
+    }
+    const workspacePath: string = globalVariables.workspaceUri.fsPath;
+    return await this.mutex.runExclusive(async () => {
+      if (this.needRefresh) {
+        const envNamesResult = await environmentManager.listRemoteEnvConfigs(workspacePath);
+        if (envNamesResult.isErr()) {
+          this.needRefresh = false;
+          return null;
+        }
+
+        const envNames = [LocalEnvironmentName].concat(envNamesResult.value);
+        this.environments = envNames.map((env) => new EnvironmentNode(env));
+        this.needRefresh = false;
+      }
+      return this.environments;
+    });
   }
 }
 

--- a/packages/vscode-extension/src/utils/commonUtils.ts
+++ b/packages/vscode-extension/src/utils/commonUtils.ts
@@ -243,16 +243,6 @@ export function anonymizeFilePaths(stack?: string): string {
   return updatedStack;
 }
 
-export async function isTeamsfx(): Promise<boolean> {
-  if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
-    const workspaceFolder = vscode.workspace.workspaceFolders[0];
-
-    return await commonUtils.isFxProject(workspaceFolder.uri.fsPath);
-  }
-
-  return false;
-}
-
 export function getConfiguration(key: string): boolean {
   const configuration: vscode.WorkspaceConfiguration =
     vscode.workspace.getConfiguration(CONFIGURATION_PREFIX);
@@ -307,10 +297,6 @@ export function getAllFeatureFlags(): string[] | undefined {
     });
 
   return result;
-}
-
-export function getIsExistingUser(): string | undefined {
-  return globalVariables.context.globalState.get<string>(UserState.IsExisting);
 }
 
 export async function getSubscriptionInfoFromEnv(
@@ -397,18 +383,13 @@ export async function getProvisionSucceedFromEnv(env: string): Promise<boolean |
 }
 
 async function getProvisionResultJson(env: string): Promise<Json | undefined> {
-  if (vscode.workspace.workspaceFolders) {
-    const workspaceFolder: vscode.WorkspaceFolder = vscode.workspace.workspaceFolders[0];
-
-    const workspacePath: string = workspaceFolder.uri.fsPath;
-
-    if (!(await commonUtils.isFxProject(workspacePath))) {
+  if (globalVariables.workspaceUri) {
+    if (!globalVariables.isTeamsFxProject) {
       return undefined;
     }
 
     const configRoot = await commonUtils.getProjectRoot(
-      workspaceFolder.uri.fsPath,
-
+      globalVariables.workspaceUri.fsPath,
       `.${ConfigFolderName}`
     );
 

--- a/packages/vscode-extension/test/unit/extension/commonUtils.test.ts
+++ b/packages/vscode-extension/test/unit/extension/commonUtils.test.ts
@@ -138,11 +138,6 @@ suite("CommonUtils", () => {
       const { name, removeCallback } = tmp.dirSync({ unsafeCleanup: true });
       cleanupCallback = removeCallback;
       workspacePath = name;
-
-      // if (!("workspaceUri" in globalVariables)) {
-      //   // ensure the property exist to prevent sinon "Cannot stub non-existent property" error
-      //   (globalVariables.workspaceUri as any) = undefined;
-      // }
       sandbox.stub(globalVariables, "workspaceUri").value(Uri.file(workspacePath));
     });
 

--- a/packages/vscode-extension/test/unit/extension/commonUtils.test.ts
+++ b/packages/vscode-extension/test/unit/extension/commonUtils.test.ts
@@ -139,10 +139,10 @@ suite("CommonUtils", () => {
       cleanupCallback = removeCallback;
       workspacePath = name;
 
-      if (!("workspaceUri" in globalVariables)) {
-        // ensure the property exist to prevent sinon "Cannot stub non-existent property" error
-        (globalVariables.workspaceUri as any) = undefined;
-      }
+      // if (!("workspaceUri" in globalVariables)) {
+      //   // ensure the property exist to prevent sinon "Cannot stub non-existent property" error
+      //   (globalVariables.workspaceUri as any) = undefined;
+      // }
       sandbox.stub(globalVariables, "workspaceUri").value(Uri.file(workspacePath));
     });
 

--- a/packages/vscode-extension/test/unit/extension/extTelemetry.test.ts
+++ b/packages/vscode-extension/test/unit/extension/extTelemetry.test.ts
@@ -4,7 +4,6 @@ import { Stage, UserError } from "@microsoft/teamsfx-api";
 import { ExtTelemetry } from "../../../src/telemetry/extTelemetry";
 import { TelemetryEvent } from "../../../src/telemetry/extTelemetryEvents";
 import sinon = require("sinon");
-import * as commonUtils from "../../../src/utils/commonUtils";
 import * as fs from "fs-extra";
 import * as globalVariables from "../../../src/globalVariables";
 import { Uri } from "vscode";
@@ -137,7 +136,7 @@ suite("ExtTelemetry", () => {
           stringProp: "some string",
           component: "extension",
           success: "no",
-          "is-existing-user": "",
+          "is-existing-user": "no",
           "is-spfx": "false",
           "error-type": "user",
           "error-message": `${error.message}${error.stack ? "\nstack:\n" + error.stack : ""}`,
@@ -153,7 +152,7 @@ suite("ExtTelemetry", () => {
           stringProp: "some string",
           component: "extension",
           success: "no",
-          "is-existing-user": "",
+          "is-existing-user": "no",
           "is-spfx": "false",
           "error-type": "user",
           "error-message": `${error.displayMessage}${
@@ -179,7 +178,7 @@ suite("ExtTelemetry", () => {
         {
           stringProp: "some string",
           component: "extension",
-          "is-existing-user": "",
+          "is-existing-user": "no",
           "is-spfx": "false",
         },
         { numericMeasure: 123 }

--- a/packages/vscode-extension/test/unit/extension/extTelemetry.test.ts
+++ b/packages/vscode-extension/test/unit/extension/extTelemetry.test.ts
@@ -87,10 +87,10 @@ suite("ExtTelemetry", () => {
     const sandbox = sinon.createSandbox();
     suiteSetup(() => {
       chai.util.addProperty(ExtTelemetry, "reporter", () => reporterSpy);
-      sandbox.stub(commonUtils, "getIsExistingUser").returns(undefined);
       sandbox.stub(fs, "pathExistsSync").returns(false);
       sandbox.stub(globalVariables, "workspaceUri").value(Uri.file("test"));
       sandbox.stub(globalVariables, "isSPFxProject").value(false);
+      sandbox.stub(globalVariables, "isExistingUser").value("no");
     });
 
     suiteTeardown(() => {
@@ -109,7 +109,7 @@ suite("ExtTelemetry", () => {
         {
           stringProp: "some string",
           component: "extension",
-          "is-existing-user": "",
+          "is-existing-user": "no",
           "is-spfx": "false",
         },
         { numericMeasure: 123 }

--- a/packages/vscode-extension/test/unit/extension/globalVariables.test.ts
+++ b/packages/vscode-extension/test/unit/extension/globalVariables.test.ts
@@ -12,7 +12,7 @@ suite("Global Variables", () => {
         return false;
       });
 
-      globalVariables.initializeExtensionVariables({} as ExtensionContext);
+      globalVariables.initializeGlobalVariables({} as ExtensionContext);
 
       chai.expect(globalVariables.isSPFxProject).equals(false);
 
@@ -24,7 +24,7 @@ suite("Global Variables", () => {
         return true;
       });
 
-      globalVariables.initializeExtensionVariables({} as ExtensionContext);
+      globalVariables.initializeGlobalVariables({} as ExtensionContext);
 
       chai.expect(globalVariables.isSPFxProject).equals(true);
 

--- a/packages/vscode-extension/test/unit/extension/globalVariables.test.ts
+++ b/packages/vscode-extension/test/unit/extension/globalVariables.test.ts
@@ -12,7 +12,11 @@ suite("Global Variables", () => {
         return false;
       });
 
-      globalVariables.initializeGlobalVariables({} as ExtensionContext);
+      globalVariables.initializeGlobalVariables({
+        globalState: {
+          get: () => undefined,
+        },
+      } as unknown as ExtensionContext);
 
       chai.expect(globalVariables.isSPFxProject).equals(false);
 
@@ -24,7 +28,11 @@ suite("Global Variables", () => {
         return true;
       });
 
-      globalVariables.initializeGlobalVariables({} as ExtensionContext);
+      globalVariables.initializeGlobalVariables({
+        globalState: {
+          get: () => undefined,
+        },
+      } as unknown as ExtensionContext);
 
       chai.expect(globalVariables.isSPFxProject).equals(true);
 

--- a/packages/vscode-extension/test/unit/extension/handlers.test.ts
+++ b/packages/vscode-extension/test/unit/extension/handlers.test.ts
@@ -25,6 +25,7 @@ import * as commonUtils from "../../../src/utils/commonUtils";
 import * as extension from "../../../src/extension";
 import TreeViewManagerInstance from "../../../src/treeview/treeViewManager";
 import { CollaborationState, CoreHookContext } from "@microsoft/teamsfx-core";
+import * as globalState from "@microsoft/teamsfx-core/build/common/globalState";
 import * as globalVariables from "../../../src/globalVariables";
 import { Uri } from "vscode";
 import envTreeProviderInstance from "../../../src/treeview/environmentTreeViewProvider";
@@ -83,6 +84,7 @@ suite("handlers", () => {
       const disposeFunc = sinon.stub(ExtTelemetry, "dispose");
       const createProject = sinon.spy(handlers.core, "createProject");
       const executeCommandFunc = sinon.stub(vscode.commands, "executeCommand");
+      const globalStateUpdateStub = sinon.stub(globalState, "globalStateUpdate");
 
       await handlers.createNewProjectHandler();
 
@@ -98,7 +100,7 @@ suite("handlers", () => {
       clock.tick(3000);
       chai.assert.isTrue(executeCommandFunc.calledOnceWith("vscode.openFolder"));
       sinon.restore();
-      clock.restore;
+      clock.restore();
     });
 
     test("provisionHandler()", async () => {

--- a/packages/vscode-extension/test/unit/extension/handlers.test.ts
+++ b/packages/vscode-extension/test/unit/extension/handlers.test.ts
@@ -33,10 +33,6 @@ import * as extTelemetryEvents from "../../../src/telemetry/extTelemetryEvents";
 import * as uuid from "uuid";
 
 suite("handlers", () => {
-  test("getWorkspacePath()", () => {
-    chai.expect(handlers.getWorkspacePath()).equals(undefined);
-  });
-
   suite("activate()", function () {
     const sandbox = sinon.createSandbox();
     let setStatusChangeMap: any;
@@ -146,7 +142,6 @@ suite("handlers", () => {
       sinon.stub(handlers, "core").value(new MockCore());
       sinon.stub(ExtTelemetry, "sendTelemetryEvent");
       sinon.stub(ExtTelemetry, "sendTelemetryErrorEvent");
-      sinon.stub(handlers, "getWorkspacePath").resolves(undefined);
       const showMessage = sinon.spy(vscode.window, "showErrorMessage");
 
       await handlers.buildPackageHandler();


### PR DESCRIPTION
1. Move variables into `globalVariables.ts`.
2. Group & reorder registrations in `extension.ts:activate()`.
3. Turn `handler.ts:activate()` into synchronized function.
4. Refactor env tree to remove the data operation `reloadEnvironments()` during activation.

E2E TEST: N/A