### PR TITLE
chore(template): remove vs specific gitignore items for command/notification bot

### DIFF
--- a/templates/bot/csharp/command-and-response/.gitignore
+++ b/templates/bot/csharp/command-and-response/.gitignore
@@ -1,3 +1,6 @@
+# User-specific files
+*.user
+
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/

--- a/templates/bot/csharp/command-and-response/.gitignore
+++ b/templates/bot/csharp/command-and-response/.gitignore
@@ -1,9 +1,3 @@
-# User-specific files
-*.suo
-*.user
-*.userosscache
-*.userprefs
-
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/
@@ -16,15 +10,3 @@ bld/
 [Oo]bj/
 [Ll]og/
 
-# Visual Studio cache/options directory
-.vs/
-# Uncomment if you have tasks that create the project's static files in wwwroot
-# wwwroot/
-
-# MSTest test Results
-[Tt]est[Rr]esult*/
-[Bb]uild[Ll]og.*
-
-# NUNIT
-*.VisualState.xml
-TestResult.xml

--- a/templates/bot/csharp/notification-webapi/.gitignore
+++ b/templates/bot/csharp/notification-webapi/.gitignore
@@ -1,3 +1,6 @@
+# User-specific files
+*.user
+
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/

--- a/templates/bot/csharp/notification-webapi/.gitignore
+++ b/templates/bot/csharp/notification-webapi/.gitignore
@@ -1,9 +1,3 @@
-# User-specific files
-*.suo
-*.user
-*.userosscache
-*.userprefs
-
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/
@@ -15,19 +9,6 @@ bld/
 [Bb]in/
 [Oo]bj/
 [Ll]og/
-
-# Visual Studio cache/options directory
-.vs/
-# Uncomment if you have tasks that create the project's static files in wwwroot
-# wwwroot/
-
-# MSTest test Results
-[Tt]est[Rr]esult*/
-[Bb]uild[Ll]og.*
-
-# NUNIT
-*.VisualState.xml
-TestResult.xml
 
 # Notification local store
 .notification.localstore.json


### PR DESCRIPTION
Fix [Bug 14583886](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14583886): [VS] Should git ignore .vs folder in bot app.

Per discussion in the meeting, we will not ignore vs related items in our generated `.gitignore`.