### PR TITLE
chore: add creation-version telemetry property

### DIFF
--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -1305,6 +1305,7 @@ export interface ProjectConfigV3 {
 export interface ProjectSettings {
     // (undocumented)
     appName: string;
+    creationVersion?: string;
     // (undocumented)
     defaultFunctionName?: string;
     // (undocumented)

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -186,9 +186,15 @@ export interface ProjectSettings {
   version?: string;
   /**
    * The package and version of the tool that creates this project. In the format "packageName:version".
-   * Examples:
+   *
+   * Examples in different tools:
+   *  VSC: "ms-teams-vscode-extension:4.1.0"
+   *  CLI: "@microsoft/teamsfx-cli:1.1.0"
+   *  VS: // TODO: should be same format.
+   *
+   * Examples in different cases:
    *  The project is created from scatch/sample using toolkit 1.2.3: "ms-teams-vscode-extension:1.2.3".
-   *  The project is directly cloned using git: The toolkit version when user opens the project for the first time.
+   *  The project is directly cloned using git: The toolkit/CLI version when user opens the project for the first time.
    *  Existing project before this property is added: "unknown".
    *  Shared project between different users. The behavior is the same as projectId.
    */

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -193,7 +193,7 @@ export interface ProjectSettings {
    *  VS: // TODO: should be same format.
    *
    * Examples in different cases:
-   *  The project is created from scatch/sample using toolkit 1.2.3: "ms-teams-vscode-extension:1.2.3".
+   *  The project is created from scratch/sample using toolkit 1.2.3: "ms-teams-vscode-extension:1.2.3".
    *  The project is directly cloned using git: The toolkit/CLI version when user opens the project for the first time.
    *  Existing project before this property is added: "unknown".
    *  Shared project between different users. The behavior is the same as projectId.

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -184,6 +184,15 @@ export interface EnvMeta {
 export interface ProjectSettings {
   appName: string;
   version?: string;
+  /**
+   * The package and version of the tool that creates this project. In the format "packageName:version".
+   * Examples:
+   *  The project is created from scatch/sample using toolkit 1.2.3: "ms-teams-vscode-extension:1.2.3".
+   *  The project is directly cloned using git: The toolkit version when user opens the project for the first time.
+   *  Existing project before this property is added: "unknown".
+   *  Shared project between different users. The behavior is the same as projectId.
+   */
+  creationVersion?: string;
   projectId: string;
   programmingLanguage?: string;
   defaultFunctionName?: string;

--- a/packages/cli/src/commonlib/telemetry.ts
+++ b/packages/cli/src/commonlib/telemetry.ts
@@ -124,7 +124,7 @@ export class CliTelemetryReporter implements TelemetryReporter {
   private async addSharedProperties(properties: { [p: string]: string }): Promise<void> {
     const isFromSample = getIsFromSample(this.rootFolder);
     if (isFromSample !== undefined) {
-      properties[TelemetryProperty.SettingsVersion] = isFromSample;
+      properties[TelemetryProperty.IsFromSample] = isFromSample;
     }
 
     const settingsVersion = getSettingsVersion(this.rootFolder);

--- a/packages/cli/src/telemetry/cliTelemetry.ts
+++ b/packages/cli/src/telemetry/cliTelemetry.ts
@@ -11,7 +11,7 @@ import {
 } from "./cliTelemetryEvents";
 import { FxError, Inputs, UserError } from "@microsoft/teamsfx-api";
 import { getHashedEnv } from "@microsoft/teamsfx-core";
-import { getIsM365, getSettingsVersion, getTeamsAppTelemetryInfoByEnv } from "../utils";
+import { getTeamsAppTelemetryInfoByEnv } from "../utils";
 
 export function makeEnvRelatedProperty(
   projectDir: string,
@@ -69,16 +69,6 @@ export class CliTelemetry {
       properties[TelemetryProperty.Component] = TelemetryComponentType;
     }
 
-    const settingsVersion = getSettingsVersion(CliTelemetry.rootFolder);
-    if (settingsVersion !== undefined) {
-      properties[TelemetryProperty.SettingsVersion] = settingsVersion;
-    }
-
-    const isM365 = getIsM365(CliTelemetry.rootFolder);
-    if (isM365 !== undefined) {
-      properties[TelemetryProperty.IsM365] = isM365;
-    }
-
     CliTelemetry.reporter
       .withRootFolder(CliTelemetry.rootFolder)
       .sendTelemetryEvent(eventName, properties, measurements);
@@ -97,16 +87,6 @@ export class CliTelemetry {
 
     if (TelemetryProperty.Component in properties === false) {
       properties[TelemetryProperty.Component] = TelemetryComponentType;
-    }
-
-    const settingsVersion = getSettingsVersion(CliTelemetry.rootFolder);
-    if (settingsVersion !== undefined) {
-      properties[TelemetryProperty.SettingsVersion] = settingsVersion;
-    }
-
-    const isM365 = getIsM365(CliTelemetry.rootFolder);
-    if (isM365 !== undefined) {
-      properties[TelemetryProperty.IsM365] = isM365;
     }
 
     properties[TelemetryProperty.Success] = TelemetrySuccess.No;
@@ -135,16 +115,6 @@ export class CliTelemetry {
 
     if (TelemetryProperty.Component in properties === false) {
       properties[TelemetryProperty.Component] = TelemetryComponentType;
-    }
-
-    const settingsVersion = getSettingsVersion(CliTelemetry.rootFolder);
-    if (settingsVersion !== undefined) {
-      properties[TelemetryProperty.SettingsVersion] = settingsVersion;
-    }
-
-    const isM365 = getIsM365(CliTelemetry.rootFolder);
-    if (isM365 !== undefined) {
-      properties[TelemetryProperty.IsM365] = isM365;
     }
 
     CliTelemetry.reporter

--- a/packages/cli/src/telemetry/cliTelemetryEvents.ts
+++ b/packages/cli/src/telemetry/cliTelemetryEvents.ts
@@ -118,6 +118,7 @@ export enum TelemetryProperty {
   ListAllCollaborators = "list-all-collaborators",
   FeatureFlags = "feature-flags",
   Env = "env",
+  IsFromSample = "is-from-sample",
   SettingsVersion = "settings-version",
   CreationVersion = "creation-version",
   NewProjectId = "new-project-id",

--- a/packages/cli/src/telemetry/cliTelemetryEvents.ts
+++ b/packages/cli/src/telemetry/cliTelemetryEvents.ts
@@ -119,6 +119,7 @@ export enum TelemetryProperty {
   FeatureFlags = "feature-flags",
   Env = "env",
   SettingsVersion = "settings-version",
+  CreationVersion = "creation-version",
   NewProjectId = "new-project-id",
   IsM365 = "is-m365",
   IsCreatingM365 = "is-creating-m365",

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -403,6 +403,24 @@ export function getSettingsVersion(rootFolder: string | undefined): string | und
 }
 
 // Only used for telemetry
+export function getIsFromSample(rootFolder: string | undefined): string | undefined {
+  if (!rootFolder) {
+    return undefined;
+  }
+  try {
+    if (isWorkspaceSupported(rootFolder)) {
+      const result = readSettingsFileSync(rootFolder);
+      if (result.isOk()) {
+        return result.value.isFromSample;
+      }
+    }
+  } catch (e) {
+    // ignore errors for telemetry
+  }
+  return undefined;
+}
+
+// Only used for telemetry
 export function getIsM365(rootFolder: string | undefined): string | undefined {
   if (!rootFolder) {
     return undefined;
@@ -412,6 +430,24 @@ export function getIsM365(rootFolder: string | undefined): string | undefined {
       const result = readSettingsFileSync(rootFolder);
       if (result.isOk() && result.value.isM365 !== undefined) {
         return `${result.value.isM365}`;
+      }
+    }
+  } catch (e) {
+    // ignore errors for telemetry
+  }
+  return undefined;
+}
+
+// Only used for telemetry
+export function getCreationVersion(rootFolder: string | undefined): string | undefined {
+  if (!rootFolder) {
+    return undefined;
+  }
+  try {
+    if (isWorkspaceSupported(rootFolder)) {
+      const result = readSettingsFileSync(rootFolder);
+      if (result.isOk() && result.value.creationVersion !== undefined) {
+        return `${result.value.creationVersion}`;
       }
     }
   } catch (e) {

--- a/packages/fx-core/src/core/FxCore.ts
+++ b/packages/fx-core/src/core/FxCore.ts
@@ -160,6 +160,7 @@ export class FxCore implements v3.ICore {
   tools: Tools;
   isFromSample?: boolean;
   settingsVersion?: string;
+  creationVersion?: string;
 
   constructor(tools: Tools) {
     this.tools = tools;

--- a/packages/fx-core/src/core/middleware/projectSettingsLoader.ts
+++ b/packages/fx-core/src/core/middleware/projectSettingsLoader.ts
@@ -67,6 +67,7 @@ export const ProjectSettingsLoaderMW: Middleware = async (
     ctx.projectSettings = projectSettings;
     (ctx.self as any).isFromSample = projectSettings.isFromSample === true;
     (ctx.self as any).settingsVersion = projectSettings.version;
+    (ctx.self as any).creationVersion = projectSettings.creationVersion;
     (ctx.self as any).tools.cryptoProvider = new LocalCrypto(projectSettings.projectId);
     ctx.contextV2 = createV2Context(projectSettings);
   }

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -317,6 +317,16 @@ export async function getSettingsVersion(): Promise<string | undefined> {
   return undefined;
 }
 
+export async function getCreationVersion(): Promise<string | undefined> {
+  if (core) {
+    const input = getSystemInputs();
+    input.ignoreEnvInfo = true;
+    await core.getProjectConfig(input);
+    return core.creationVersion;
+  }
+  return undefined;
+}
+
 async function refreshEnvTreeOnFileChanged(workspacePath: string, files: readonly Uri[]) {
   let needRefresh = false;
   for (const file of files) {

--- a/packages/vscode-extension/src/telemetry/extTelemetry.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetry.ts
@@ -26,10 +26,6 @@ export let lastCorrelationId: string | undefined = undefined;
 export namespace ExtTelemetry {
   export let reporter: VSCodeTelemetryReporter;
   export let hasSentTelemetry = false;
-  /* eslint-disable prefer-const */
-  export let isFromSample: boolean | undefined = undefined;
-  export let settingsVersion: string | undefined = undefined;
-  export let isM365: boolean | undefined = undefined;
 
   export function setHasSentTelemetry(eventName: string) {
     if (eventName === "query-expfeature") return;
@@ -37,7 +33,7 @@ export namespace ExtTelemetry {
   }
 
   export function addSharedProperty(name: string, value: string): void {
-    reporter.addSharedProperty(name, value);
+    reporter?.addSharedProperty(name, value);
   }
 
   export class Reporter extends vscode.Disposable {
@@ -97,16 +93,6 @@ export namespace ExtTelemetry {
       properties[TelemetryProperty.IsSpfx] = globalVariables.isSPFxProject.toString();
     }
 
-    if (isFromSample != undefined) {
-      properties![TelemetryProperty.IsFromSample] = isFromSample.toString();
-    }
-    if (isM365 !== undefined) {
-      properties![TelemetryProperty.IsM365] = isM365.toString();
-    }
-    if (settingsVersion !== undefined) {
-      properties![TelemetryProperty.SettingsVersion] = settingsVersion.toString();
-    }
-
     reporter.sendTelemetryEvent(eventName, properties, measurements);
   }
 
@@ -143,16 +129,6 @@ export namespace ExtTelemetry {
       properties[TelemetryProperty.IsSpfx] = globalVariables.isSPFxProject.toString();
     }
 
-    if (isFromSample != undefined) {
-      properties![TelemetryProperty.IsFromSample] = isFromSample.toString();
-    }
-    if (isM365 !== undefined) {
-      properties![TelemetryProperty.IsM365] = isM365.toString();
-    }
-    if (settingsVersion !== undefined) {
-      properties![TelemetryProperty.SettingsVersion] = settingsVersion.toString();
-    }
-
     reporter.sendTelemetryErrorEvent(eventName, properties, measurements, errorProps);
   }
 
@@ -173,16 +149,6 @@ export namespace ExtTelemetry {
 
     if (globalVariables.workspaceUri) {
       properties[TelemetryProperty.IsSpfx] = globalVariables.isSPFxProject.toString();
-    }
-
-    if (isFromSample != undefined) {
-      properties![TelemetryProperty.IsFromSample] = isFromSample.toString();
-    }
-    if (isM365 !== undefined) {
-      properties![TelemetryProperty.IsM365] = isM365.toString();
-    }
-    if (settingsVersion !== undefined) {
-      properties![TelemetryProperty.SettingsVersion] = settingsVersion.toString();
     }
 
     reporter.sendTelemetryException(error, properties, measurements);

--- a/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
@@ -241,6 +241,7 @@ export enum TelemetryProperty {
   IsM365 = "is-m365",
   IsCreatingM365 = "is-creating-m365",
   SettingsVersion = "settings-version",
+  CreationVersion = "creation-version",
   UpdateFailedFiles = "update-failed-files",
   NewProjectId = "new-project-id",
   // Used with TreeViewCommandConcurrentExecution


### PR DESCRIPTION
- add a common property "creation-version" in CLI and VSC
- move these common properties to VSCTelemetryReporter and CliTelemetryReporter respectively. This is to fix the issue that only events sent in vsc/cli contain these properties. (fx-core events do not have them)
- add the [missing "is-from-sample"](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14587942/) to cli



All event between prerequisite-check and debug-start should contain "creation-version":
VSC:
![image](https://user-images.githubusercontent.com/9698542/171318849-1117de0f-8dcd-4c22-aa93-5bcf9a8ea720.png)

CLI:
![image](https://user-images.githubusercontent.com/9698542/171318943-b20c5880-aab5-46ef-9527-e6dcc1e501f8.png)


https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14549235/