### PR TITLE
fix: hide deploy aad manifest command when aad is not enabled

### DIFF
--- a/packages/fx-core/src/common/tools.ts
+++ b/packages/fx-core/src/common/tools.ts
@@ -422,7 +422,7 @@ export function isApiConnectEnabled(): boolean {
 // This method is for deciding whether AAD should be activated.
 // Currently AAD plugin will always be activated when scaffold.
 // This part will be updated when we support adding aad separately.
-export function isAADEnabled(solutionSettings: AzureSolutionSettings): boolean {
+export function isAADEnabled(solutionSettings: AzureSolutionSettings | undefined): boolean {
   if (!solutionSettings) {
     return false;
   }

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -157,7 +157,7 @@
       "explorer/context": [
         {
           "command": "fx-extension.deployAadAppManifestFromCtxMenu",
-          "when": "resourceFilename == aad.template.json && !fx-extension.isSPFx",
+          "when": "resourceFilename == aad.template.json && && fx-extension.isAadManifestEnabled",
           "group": "deploy@0"
         },
         {
@@ -523,7 +523,7 @@
       {
         "command": "fx-extension.deployAadAppManifest",
         "title": "%teamstoolkit.commands.deployAadAppManifest.title%",
-        "enablement": "fx-extension.isTeamsFx && !fx-extension.isSPFx",
+        "enablement": "fx-extension.isTeamsFx && fx-extension.isAadManifestEnabled",
         "category": "Teams"
       },
       {
@@ -594,7 +594,7 @@
       {
         "command": "fx-extension.deployAadAppManifestFromCtxMenu",
         "title": "%teamstoolkit.commands.deployAadAppManifestFromCtxMenu.title%",
-        "enablement": "!fx-extension.isSPFx"
+        "enablement": "fx-extension.isAadManifestEnabled"
       },
       {
         "command": "fx-extension.deployManifestFromCtxMenu",

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -56,6 +56,7 @@ import {
 import { loadLocalizedStrings } from "./utils/localizeUtils";
 import { ExtensionSurvey } from "./utils/survey";
 import { ExtensionUpgrade } from "./utils/upgrade";
+import { isAADEnabled } from "@microsoft/teamsfx-core";
 
 export let VS_CODE_UI: VsCodeUI;
 
@@ -623,6 +624,17 @@ async function initializeContextKey() {
     workspaceUri && (await isM365Project(workspaceUri.fsPath))
   );
 
+  const workspacePath = workspaceUri?.fsPath;
+  if (workspacePath) {
+    const aadTemplateWatcher = vscode.workspace.createFileSystemWatcher("**/aad.template.json");
+
+    aadTemplateWatcher.onDidCreate(async (event) => {
+      await setAadManifestEnabledContext();
+    });
+  }
+
+  await setAadManifestEnabledContext();
+
   await vscode.commands.executeCommand(
     "setContext",
     "fx-extension.canUpgradeToArmAndMultiEnv",
@@ -633,6 +645,14 @@ async function initializeContextKey() {
     "setContext",
     "fx-extension.isConfigUnifyEnabled",
     isConfigUnifyEnabled()
+  );
+}
+
+async function setAadManifestEnabledContext() {
+  vscode.commands.executeCommand(
+    "setContext",
+    "fx-extension.isAadManifestEnabled",
+    isAADEnabled(await handlers.getAzureSolutionSettings())
   );
 }
 

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -16,7 +16,12 @@ import {
   Result,
   TemplateFolderName,
 } from "@microsoft/teamsfx-api";
-import { Correlator, isConfigUnifyEnabled, isValidProject } from "@microsoft/teamsfx-core";
+import {
+  Correlator,
+  isConfigUnifyEnabled,
+  isValidProject,
+  isAADEnabled,
+} from "@microsoft/teamsfx-core";
 
 import {
   AadAppTemplateCodeLensProvider,
@@ -38,7 +43,12 @@ import { registerTeamsfxTaskAndDebugEvents } from "./debug/teamsfxTaskHandler";
 import { TeamsfxTaskProvider } from "./debug/teamsfxTaskProvider";
 import * as exp from "./exp";
 import { TreatmentVariables, TreatmentVariableValue } from "./exp/treatmentVariables";
-import { initializeGlobalVariables, isSPFxProject, workspaceUri } from "./globalVariables";
+import {
+  initializeGlobalVariables,
+  isSPFxProject,
+  isTeamsFxProject,
+  workspaceUri,
+} from "./globalVariables";
 import * as handlers from "./handlers";
 import { ManifestTemplateHoverProvider } from "./hoverProvider";
 import { VsCodeUI } from "./qm/vsc_ui";
@@ -56,7 +66,6 @@ import {
 import { loadLocalizedStrings } from "./utils/localizeUtils";
 import { ExtensionSurvey } from "./utils/survey";
 import { ExtensionUpgrade } from "./utils/upgrade";
-import { isAADEnabled } from "@microsoft/teamsfx-core";
 
 export let VS_CODE_UI: VsCodeUI;
 
@@ -624,8 +633,7 @@ async function initializeContextKey() {
     workspaceUri && (await isM365Project(workspaceUri.fsPath))
   );
 
-  const workspacePath = workspaceUri?.fsPath;
-  if (workspacePath) {
+  if (isTeamsFxProject) {
     const aadTemplateWatcher = vscode.workspace.createFileSystemWatcher("**/aad.template.json");
 
     aadTemplateWatcher.onDidCreate(async (event) => {

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -43,12 +43,7 @@ import { registerTeamsfxTaskAndDebugEvents } from "./debug/teamsfxTaskHandler";
 import { TeamsfxTaskProvider } from "./debug/teamsfxTaskProvider";
 import * as exp from "./exp";
 import { TreatmentVariables, TreatmentVariableValue } from "./exp/treatmentVariables";
-import {
-  initializeGlobalVariables,
-  isSPFxProject,
-  isTeamsFxProject,
-  workspaceUri,
-} from "./globalVariables";
+import { initializeGlobalVariables, isSPFxProject, workspaceUri } from "./globalVariables";
 import * as handlers from "./handlers";
 import { ManifestTemplateHoverProvider } from "./hoverProvider";
 import { VsCodeUI } from "./qm/vsc_ui";
@@ -119,7 +114,7 @@ export async function activate(context: vscode.ExtensionContext) {
   handlers.activate();
 
   // Init VSC context key
-  await initializeContextKey();
+  await initializeContextKey(isTeamsFxProject);
 
   // UI is ready to show & interact
   await vscode.commands.executeCommand("setContext", "fx-extension.isTeamsFx", isTeamsFxProject);
@@ -622,7 +617,7 @@ function registerMenuCommands(context: vscode.ExtensionContext) {
   context.subscriptions.push(specifySubscription);
 }
 
-async function initializeContextKey() {
+async function initializeContextKey(isTeamsFxProject: boolean) {
   await vscode.commands.executeCommand("setContext", "fx-extension.isNotValidNode", !isValidNode());
 
   await vscode.commands.executeCommand("setContext", "fx-extension.isSPFx", isSPFxProject);


### PR DESCRIPTION
Currently, even sso feature is not enabed, the command "deploy aad manifest" still exist in command palette.

E2E TEST: Will add test plan for this