### PR TITLE
fix(vsc): account command registration

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -41,6 +41,7 @@
   ],
   "activationEvents": [
     "onStartupFinished",
+    "onCommand:fx-extension.cmpAccounts",
     "onCommand:fx-extension.create",
     "onCommand:fx-extension.getNewProjectPath",
     "onCommand:fx-extension.openDeploymentTreeview",
@@ -50,7 +51,6 @@
     "onCommand:fx-extension.openWelcome",
     "onCommand:fx-extension.selectAndDebug",
     "onCommand:fx-extension.selectTutorials",
-    "onCommand:fx-extension.signinM365",
     "onCommand:fx-extension.validate-getStarted-prerequisites",
     "onCommand:workbench.action.tasks.runTask",
     "workspaceContains:**/.fx/*",
@@ -439,6 +439,11 @@
         "category": "Teams"
       },
       {
+        "command": "fx-extension.cmpAccounts",
+        "title": "%teamstoolkit.commands.accounts.title%",
+        "category": "Teams"
+      },
+      {
         "command": "fx-extension.getNewProjectPath",
         "title": "Teams - Get Path",
         "enablement": "never"
@@ -505,12 +510,6 @@
       {
         "command": "fx-extension.checkProjectUpgrade",
         "title": "%teamstoolkit.commands.upgradeProject.title%",
-        "enablement": "fx-extension.initialized",
-        "category": "Teams"
-      },
-      {
-        "command": "fx-extension.cmpAccounts",
-        "title": "%teamstoolkit.commands.accounts.title%",
         "enablement": "fx-extension.initialized",
         "category": "Teams"
       },
@@ -985,7 +984,7 @@
           {
             "id": "teamsToolkitCreateFreeAccount",
             "title": "Create a M365 testing tenant for free",
-            "description": "Create a free M365 testing tenant to install and preview your Teams apps in Teams.\n If you already have an M365 organizational account, [sign in to M365](command:fx-extension.signinM365?%5B%22WalkThrough%22%5D) and validate [sideloading](https://docs.microsoft.com/en-us/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading) is enabled.\n[Create a M365 testing tenant](https://developer.microsoft.com/en-us/microsoft-365/dev-program)",
+            "description": "Create a free M365 testing tenant to install and preview your Teams apps in Teams.\n If you already have an M365 organizational account, [sign in to M365](command:fx-extension.cmpAccounts?%5B%22WalkThrough%22%5D) and validate [sideloading](https://docs.microsoft.com/en-us/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading) is enabled.\n[Create a M365 testing tenant](https://developer.microsoft.com/en-us/microsoft-365/dev-program)",
             "media": {
               "markdown": "media/itp/itp.md"
             }

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -146,6 +146,12 @@ function registerActivateCommands(context: vscode.ExtensionContext) {
   );
   context.subscriptions.push(checkUpgradeCmd);
 
+  // user can manage account in non-teamsfx project
+  const cmpAccountsCmd = vscode.commands.registerCommand("fx-extension.cmpAccounts", () =>
+    Correlator.run(handlers.cmpAccountsHandler)
+  );
+  context.subscriptions.push(cmpAccountsCmd);
+
   // Create a new Teams app
   registerInCommandController(
     context,
@@ -197,11 +203,6 @@ function registerActivateCommands(context: vscode.ExtensionContext) {
     "fx-extension.selectTutorials",
     handlers.selectTutorialsHandler
   );
-
-  const signinM365 = vscode.commands.registerCommand("fx-extension.signinM365", (...args) =>
-    Correlator.run(handlers.signinM365Callback, args)
-  );
-  context.subscriptions.push(signinM365);
 
   // Prerequisites check
   const validateGetStartedPrerequisitesCmd = vscode.commands.registerCommand(
@@ -351,11 +352,6 @@ function registerTeamsFxCommands(context: vscode.ExtensionContext) {
       Correlator.run(handlers.createNewEnvironment, [TelemetryTriggerFrom.ViewTitleNavigation])
   );
   context.subscriptions.push(createNewEnvironment);
-
-  const cmpAccountsCmd = vscode.commands.registerCommand("fx-extension.cmpAccounts", () =>
-    Correlator.run(handlers.cmpAccountsHandler)
-  );
-  context.subscriptions.push(cmpAccountsCmd);
 
   const deployAadAppManifest = vscode.commands.registerCommand(
     "fx-extension.deployAadAppManifest",
@@ -609,6 +605,11 @@ function registerMenuCommands(context: vscode.ExtensionContext) {
     Correlator.run(handlers.selectAndDebugHandler, args)
   );
   context.subscriptions.push(runIconCmd);
+
+  const signinM365 = vscode.commands.registerCommand("fx-extension.signinM365", (...args) =>
+    Correlator.run(handlers.signinM365Callback, args)
+  );
+  context.subscriptions.push(signinM365);
 
   const specifySubscription = vscode.commands.registerCommand(
     "fx-extension.specifySubscription",


### PR DESCRIPTION
Make "Teams: Account" activation event and register it first.

Related bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14653357

E2E TEST: N/A