### PR TITLE
perf(aad-manifest): align need provision message for deploying aad

### DIFF
--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -631,7 +631,7 @@
   "error.aad.AadManifestMissingObjectId": "id property is missing or invalid in AAD manifest file, you need to run provision or local debug first",
   "error.aad.AadManifestMissingReplyUrlsWithType": "replyUrlsWithType property is missing or invalid in AAD manifest file, you need to run provision or local debug first",
   "error.aad.AadManifestMissingIdentifierUris": "identifierUris property is missing or invalid in AAD manifest file, you need to run provision or local debug first",
-  "error.aad.AadManifestNotProvisioned": "Failed to generate AAD manifest because the resources have not been provisioned yet. You need to run provision or local debug first.",
+  "error.aad.AadManifestNotProvisioned": "Failed to generate AAD manifest because the resources have not been provisioned yet. You need to run provision or local debug first. Click Get Help to learn more about why you need to provision or local debug.",
   "error.aad.UpdateAadAppError": "Failed to update application in Azure Active Directory: %s",
   "error.aad.AadManifestNotFoundError": "Aad manifest file not found",
   "error.aad.GetDisplayNameError": "Failed to get display name.",

--- a/packages/fx-core/src/plugins/resource/aad/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/aad/plugin.ts
@@ -62,7 +62,7 @@ import * as path from "path";
 import * as fs from "fs-extra";
 import * as os from "os";
 import { ArmTemplateResult } from "../../../common/armInterface";
-import { Bicep, ConstantString } from "../../../common/constants";
+import { Bicep, ConstantString, HelpLinks } from "../../../common/constants";
 import { getTemplatesFolder } from "../../../folder";
 import { AadOwner, ResourcePermission } from "../../../common/permissionInterface";
 import { AppUser } from "../appstudio/interfaces/appUser";
@@ -76,7 +76,7 @@ import {
   TabOptionItem,
 } from "../../solution/fx-solution/question";
 import { format, Formats } from "./utils/format";
-import { SOLUTION_PROVISION_SUCCEEDED } from "../../solution";
+import { PluginNames, REMOTE_AAD_ID, SOLUTION_PROVISION_SUCCEEDED } from "../../solution";
 import { generateAadManifestTemplate } from "../../../core/generateAadManifestTemplate";
 
 export class AadAppForTeamsImpl {
@@ -841,15 +841,22 @@ export class AadAppForTeamsImpl {
   }
 
   public async loadAndBuildManifest(ctx: PluginContext): Promise<AADManifest> {
-    const isProvisionSucceeded =
-      !!(ctx.envInfo.state.get("solution")?.get(SOLUTION_PROVISION_SUCCEEDED) as boolean) ||
-      ctx.answers![Constants.DEPLOY_AAD] === "yes" ||
-      ctx.envInfo.envName === "local";
+    let isProvisionSucceeded;
+    if (ctx.envInfo.envName === "local") {
+      isProvisionSucceeded = !!ctx.envInfo.state.get(PluginNames.AAD)?.get(REMOTE_AAD_ID);
+    } else {
+      isProvisionSucceeded = !!(ctx.envInfo.state
+        .get("solution")
+        ?.get(SOLUTION_PROVISION_SUCCEEDED) as boolean);
+    }
 
     if (!isProvisionSucceeded) {
       throw ResultFactory.UserError(
         AadManifestNotProvisioned.name,
-        AadManifestNotProvisioned.message()
+        AadManifestNotProvisioned.message(),
+        undefined,
+        undefined,
+        HelpLinks.WhyNeedProvision
       );
     }
 

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/deploy.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/deploy.ts
@@ -100,7 +100,7 @@ export async function deploy(
         )
       );
     }
-  } else if (envInfo.envName !== "local") {
+  } else if (envInfo.envName !== "local" && inputs[Constants.DEPLOY_AAD] !== "yes") {
     const checkAzure = await checkSubscription(
       { version: 2, data: envInfo },
       tokenProvider.azureAccountProvider


### PR DESCRIPTION
Currently, preview aad and deploy aad have different message when not provisioned:
![align](https://user-images.githubusercontent.com/5545529/172774031-aa0b2b54-f198-4285-b51f-61952a78bccf.png)

This PR align these two messages:
![aad](https://user-images.githubusercontent.com/5545529/172774082-d5c60cd0-e72c-4296-9326-31a3e15136c1.png)
