### PR TITLE
chore: add telemetry to detect cicd platforms

### DIFF
--- a/packages/cli/src/cmds/config.ts
+++ b/packages/cli/src/cmds/config.ts
@@ -35,7 +35,6 @@ const GlobalOptions = new Set([
   CliConfigOptions.EnvCheckerValidateNode as string,
   CliConfigOptions.EnvCheckerValidateNgrok as string,
   CliConfigOptions.TrustDevCert as string,
-  CliConfigOptions.RunFrom as string,
   CliConfigOptions.Interactive as string,
   // CliConfigOptions.AutomaticNpmInstall as string,
 ]);

--- a/packages/cli/src/commonlib/common/cicdPlatformDetector.ts
+++ b/packages/cli/src/commonlib/common/cicdPlatformDetector.ts
@@ -9,15 +9,15 @@ export function tryDetectCICDPlatform(): CliConfigRunFrom {
   if (process.env.GITHUB_ACTIONS === "true") {
     // https://docs.github.com/cn/actions/learn-github-actions/environment-variables#default-environment-variables
     return CliConfigRunFrom.GitHub;
+  } else if (process.env.JENKINS_URL && process.env.BUILD_URL) {
+    // https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#using-environment-variables
+    // Same logic compared with AzDo.
+    return CliConfigRunFrom.Jenkins;
   } else if (process.env.BUILD_SOURCEBRANCHNAME && process.env.AGENT_BUILDDIRECTORY) {
     // https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml
     // Not found any pre-defined env var to indicate cli is running in Azure DevOps pipelines.
     // Just using two pre-defined env vars here so there should be very low possibility that they coexisted when not in AzDo.
     return CliConfigRunFrom.AzDo;
-  } else if (process.env.JENKINS_URL && process.env.BUILD_URL) {
-    // https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#using-environment-variables
-    // Same logic compared with AzDo.
-    return CliConfigRunFrom.Jenkins;
   } else {
     return CliConfigRunFrom.Other;
   }

--- a/packages/cli/src/commonlib/common/cicdPlatformDetector.ts
+++ b/packages/cli/src/commonlib/common/cicdPlatformDetector.ts
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+"use strict";
+
+import { CliConfigRunFrom } from "../../userSetttings";
+
+export function tryDetectCICDPlatform(): CliConfigRunFrom {
+  if (process.env.GITHUB_ACTIONS === "true") {
+    // https://docs.github.com/cn/actions/learn-github-actions/environment-variables#default-environment-variables
+    return CliConfigRunFrom.GitHub;
+  } else if (process.env.BUILD_SOURCEBRANCHNAME && process.env.AGENT_BUILDDIRECTORY) {
+    // https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml
+    // Not found any pre-defined env var to indicate cli is running in Azure DevOps pipelines.
+    // Just using two pre-defined env vars here so there should be very low possibility that they coexisted when not in AzDo.
+    return CliConfigRunFrom.AzDo;
+  } else if (process.env.JENKINS_URL && process.env.BUILD_URL) {
+    // https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#using-environment-variables
+    // Same logic compared with AzDo.
+    return CliConfigRunFrom.Jenkins;
+  } else {
+    return CliConfigRunFrom.Other;
+  }
+}

--- a/packages/cli/src/commonlib/telemetry.ts
+++ b/packages/cli/src/commonlib/telemetry.ts
@@ -8,6 +8,7 @@ import { Correlator } from "@microsoft/teamsfx-core";
 import { TelemetryProperty } from "../telemetry/cliTelemetryEvents";
 import { getAllFeatureFlags, getProjectId } from "../utils";
 import { CliConfigOptions, CliConfigRunFrom, UserSettings } from "../userSetttings";
+import { tryDetectCICDPlatform } from "./common/cicdPlatformSenser";
 
 /**
  *  CLI telemetry reporter used by fx-core.
@@ -48,9 +49,7 @@ export class CliTelemetryReporter implements TelemetryReporter {
     properties[TelemetryProperty.ProjectId] = projectId ? projectId : "";
     properties[TelemetryProperty.CorrelationId] = Correlator.getId();
 
-    const result = UserSettings.getRunFromSetting();
-    const runFrom = result.isOk() ? result.value : CliConfigRunFrom.Other;
-    properties[CliConfigOptions.RunFrom] = runFrom;
+    properties[CliConfigOptions.RunFrom] = tryDetectCICDPlatform();
 
     const featureFlags = getAllFeatureFlags();
     properties[TelemetryProperty.FeatureFlags] = featureFlags ? featureFlags.join(";") : "";
@@ -71,9 +70,7 @@ export class CliTelemetryReporter implements TelemetryReporter {
     properties[TelemetryProperty.ProjectId] = projectId ? projectId : "";
     properties[TelemetryProperty.CorrelationId] = Correlator.getId();
 
-    const result = UserSettings.getRunFromSetting();
-    const runFrom = result.isOk() ? result.value : CliConfigRunFrom.Other;
-    properties[CliConfigOptions.RunFrom] = runFrom;
+    properties[CliConfigOptions.RunFrom] = tryDetectCICDPlatform();
 
     const featureFlags = getAllFeatureFlags();
     properties[TelemetryProperty.FeatureFlags] = featureFlags ? featureFlags.join(";") : "";
@@ -94,9 +91,7 @@ export class CliTelemetryReporter implements TelemetryReporter {
     properties[TelemetryProperty.ProjectId] = projectId ? projectId : "";
     properties[TelemetryProperty.CorrelationId] = Correlator.getId();
 
-    const result = UserSettings.getRunFromSetting();
-    const runFrom = result.isOk() ? result.value : CliConfigRunFrom.Other;
-    properties[CliConfigOptions.RunFrom] = runFrom;
+    properties[CliConfigOptions.RunFrom] = tryDetectCICDPlatform();
 
     const featureFlags = getAllFeatureFlags();
     properties[TelemetryProperty.FeatureFlags] = featureFlags ? featureFlags.join(";") : "";

--- a/packages/cli/src/commonlib/telemetry.ts
+++ b/packages/cli/src/commonlib/telemetry.ts
@@ -7,8 +7,8 @@ import { TelemetryReporter } from "@microsoft/teamsfx-api";
 import { Correlator } from "@microsoft/teamsfx-core";
 import { TelemetryProperty } from "../telemetry/cliTelemetryEvents";
 import { getAllFeatureFlags, getProjectId } from "../utils";
-import { CliConfigOptions, CliConfigRunFrom, UserSettings } from "../userSetttings";
-import { tryDetectCICDPlatform } from "./common/cicdPlatformSenser";
+import { CliConfigOptions } from "../userSetttings";
+import { tryDetectCICDPlatform } from "./common/cicdPlatformDetector";
 
 /**
  *  CLI telemetry reporter used by fx-core.

--- a/packages/cli/src/userSetttings.ts
+++ b/packages/cli/src/userSetttings.ts
@@ -36,8 +36,9 @@ export enum CliConfigEnvChecker {
 }
 
 export enum CliConfigRunFrom {
-  GitHubAction = "GitHubAction",
-  AzDoTask = "AzDoTask",
+  GitHub = "GitHub",
+  AzDo = "AzDo",
+  Jenkins = "Jenkins",
   Other = "Other",
 }
 
@@ -107,20 +108,6 @@ export class UserSettings {
     }
 
     return ok(true);
-  }
-
-  public static getRunFromSetting(): Result<CliConfigRunFrom, FxError> {
-    const result = this.getConfigSync();
-    if (result.isErr()) {
-      return err(result.error);
-    }
-
-    const config = result.value[CliConfigOptions.RunFrom];
-    if (!config || !Object.values(CliConfigRunFrom).includes(config)) {
-      return ok(CliConfigRunFrom.Other);
-    }
-
-    return ok(config);
   }
 
   public static getInteractiveSetting(): Result<boolean, FxError> {

--- a/packages/cli/tests/unit/telemetry/detectCICDPlatform.tests.ts
+++ b/packages/cli/tests/unit/telemetry/detectCICDPlatform.tests.ts
@@ -26,6 +26,15 @@ function restoreAndDeleteEnv(key: string) {
 }
 
 describe("Detect CI/CD Platforms", () => {
+  before(() => {
+    // As the UT is to be executed under GitHub, reset the predefined var.
+    backupAndSetEnv("GITHUB_ACTIONS", "false");
+  });
+
+  after(() => {
+    restoreAndDeleteEnv("GITHUB_ACTIONS");
+  });
+
   describe("Detect CI/CD Platforms", () => {
     it("No CI/CD Platform Detected", () => {
       // Arrange

--- a/packages/cli/tests/unit/telemetry/detectCICDPlatform.tests.ts
+++ b/packages/cli/tests/unit/telemetry/detectCICDPlatform.tests.ts
@@ -2,10 +2,9 @@
 // Licensed under the MIT license.
 
 import sinon from "sinon";
-import { describe } from "yargs";
 import { tryDetectCICDPlatform } from "../../../src/commonlib/common/cicdPlatformDetector";
 import { CliConfigRunFrom } from "../../../src/userSetttings";
-
+import "mocha";
 import { expect } from "../utils";
 
 describe("Detect CI/CD Platforms", () => {

--- a/packages/cli/tests/unit/telemetry/detectCICDPlatform.tests.ts
+++ b/packages/cli/tests/unit/telemetry/detectCICDPlatform.tests.ts
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import sinon from "sinon";
+import { describe } from "yargs";
+import { tryDetectCICDPlatform } from "../../../src/commonlib/common/cicdPlatformDetector";
+import { CliConfigRunFrom } from "../../../src/userSetttings";
+
+import { expect } from "../utils";
+
+describe("Detect CI/CD Platforms", () => {
+  describe("Detect CI/CD Platforms", () => {
+    const sandbox = sinon.createSandbox();
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it("No CI/CD Platform Detected", () => {
+      // Arrange
+      // Act
+      const plat = tryDetectCICDPlatform();
+      // Assert
+      expect(plat).to.be.equals(CliConfigRunFrom.Other);
+    });
+
+    it("GitHub Detected", () => {
+      // Arrange
+      sandbox.stub(process.env, "GITHUB_ACTIONS").value("true");
+      // Act
+      const plat = tryDetectCICDPlatform();
+      // Assert
+      expect(plat).to.be.equals(CliConfigRunFrom.GitHub);
+    });
+
+    it("Azure DevOps Detected", () => {
+      // Arrange
+      sandbox.stub(process.env, "BUILD_SOURCEBRANCHNAME").value("anything");
+      sandbox.stub(process.env, "AGENT_BUILDDIRECTORY").value("anything");
+      // Act
+      const plat = tryDetectCICDPlatform();
+      // Assert
+      expect(plat).to.be.equals(CliConfigRunFrom.AzDo);
+    });
+
+    it("Jenkins Detected", () => {
+      // Arrange
+      sandbox.stub(process.env, "JENKINS_URL").value("anything");
+      sandbox.stub(process.env, "BUILD_URL").value("anything");
+      // Act
+      const plat = tryDetectCICDPlatform();
+      // Assert
+      expect(plat).to.be.equals(CliConfigRunFrom.Jenkins);
+    });
+  });
+});


### PR DESCRIPTION
https://dev.azure.com/msazure/Microsoft%20Teams%20Extensibility/_workitems/edit/14611067

Detect which CI/CD platform Teams Toolkit CLI runs in by predefined env var in each platform.