### PR TITLE
perf(aad-manifest): only show confirmation when there are Azure resources to deploy

### DIFF
--- a/packages/fx-core/src/common/projectSettingsHelper.ts
+++ b/packages/fx-core/src/common/projectSettingsHelper.ts
@@ -96,6 +96,14 @@ export function hasSPFx(projectSetting: ProjectSettings): boolean {
 export function hasAzureResource(projectSetting: ProjectSettings, excludeAad = false): boolean {
   const solutionSettings = projectSetting.solutionSettings as AzureSolutionSettings | undefined;
   if (!solutionSettings) return false;
+  const azurePlugins = getAzurePlugins(excludeAad);
+  for (const pluginName of solutionSettings.activeResourcePlugins) {
+    if (azurePlugins.includes(pluginName)) return true;
+  }
+  return false;
+}
+
+export function getAzurePlugins(excludeAad = false): string[] {
   const azurePlugins = [
     BuiltInFeaturePluginNames.apim,
     BuiltInFeaturePluginNames.bot,
@@ -109,10 +117,7 @@ export function hasAzureResource(projectSetting: ProjectSettings, excludeAad = f
   if (!excludeAad) {
     azurePlugins.push(BuiltInFeaturePluginNames.aad);
   }
-  for (const pluginName of solutionSettings.activeResourcePlugins) {
-    if (azurePlugins.includes(pluginName)) return true;
-  }
-  return false;
+  return azurePlugins;
 }
 
 export function isExistingTabApp(projectSettings: ProjectSettings): boolean {

--- a/packages/fx-core/src/plugins/resource/aad/constants.ts
+++ b/packages/fx-core/src/plugins/resource/aad/constants.ts
@@ -11,7 +11,6 @@ export class Constants {
   static aadAppPasswordDisplayName = "default";
 
   static INCLUDE_AAD_MANIFEST = "include-aad-manifest";
-  static DEPLOY_AAD = "deploy-aad";
 
   static localDebugPrefix = "local_";
 

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/deploy.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/deploy.ts
@@ -17,7 +17,11 @@ import { isUndefined } from "lodash";
 import Container from "typedi";
 import { PluginDisplayName } from "../../../../common/constants";
 import { getDefaultString, getLocalizedString } from "../../../../common/localizeUtils";
-import { hasAzureResource, isVSProject } from "../../../../common/projectSettingsHelper";
+import {
+  getAzurePlugins,
+  hasAzureResource,
+  isVSProject,
+} from "../../../../common/projectSettingsHelper";
 import { Constants } from "../../../resource/aad/constants";
 import { checkM365Tenant, checkSubscription } from "../commonQuestions";
 import {
@@ -61,7 +65,7 @@ export async function deploy(
   const botTroubleShootMsg = getBotTroubleShootMessage(getAzureSolutionSettings(ctx));
   const provisioned =
     (provisionOutputs[GLOBAL_CONFIG][SOLUTION_PROVISION_SUCCEEDED] as boolean) ||
-    inputs[Constants.DEPLOY_AAD] === "yes";
+    isDeployAADManifestFromVSCode;
 
   if (inAzureProject && !provisioned) {
     return err(
@@ -100,7 +104,7 @@ export async function deploy(
         )
       );
     }
-  } else if (envInfo.envName !== "local" && inputs[Constants.DEPLOY_AAD] !== "yes") {
+  } else if (envInfo.envName !== "local" && !isDeployAADManifestFromVSCode) {
     const checkAzure = await checkSubscription(
       { version: 2, data: envInfo },
       tokenProvider.azureAccountProvider
@@ -139,21 +143,6 @@ export async function deploy(
     }
   }
 
-  if (
-    isAzureProject(getAzureSolutionSettings(ctx)) &&
-    hasAzureResource(ctx.projectSetting, true) &&
-    inputs[Constants.INCLUDE_AAD_MANIFEST] !== "yes"
-  ) {
-    const consent = await askForDeployConsent(
-      ctx,
-      tokenProvider.azureAccountProvider,
-      envInfo as v3.EnvInfoV3
-    );
-    if (consent.isErr()) {
-      return err(consent.error);
-    }
-  }
-
   const plugins = getSelectedPlugins(ctx.projectSetting);
   const thunks: NamedThunk<Json>[] = plugins
     .filter(
@@ -178,6 +167,20 @@ export async function deploy(
           ),
       };
     });
+
+  const azurePlugins = getAzurePlugins(true);
+  const hasAzureResource = thunks.some((thunk) => azurePlugins.includes(thunk.pluginName));
+
+  if (isAzureProject(getAzureSolutionSettings(ctx)) && hasAzureResource) {
+    const consent = await askForDeployConsent(
+      ctx,
+      tokenProvider.azureAccountProvider,
+      envInfo as v3.EnvInfoV3
+    );
+    if (consent.isErr()) {
+      return err(consent.error);
+    }
+  }
 
   if (thunks.length === 0) {
     return err(

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/deploy.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/deploy.ts
@@ -14,14 +14,9 @@ import {
   v3,
 } from "@microsoft/teamsfx-api";
 import { isUndefined } from "lodash";
-import Container from "typedi";
 import { PluginDisplayName } from "../../../../common/constants";
 import { getDefaultString, getLocalizedString } from "../../../../common/localizeUtils";
-import {
-  getAzurePlugins,
-  hasAzureResource,
-  isVSProject,
-} from "../../../../common/projectSettingsHelper";
+import { getAzurePlugins, isVSProject } from "../../../../common/projectSettingsHelper";
 import { Constants } from "../../../resource/aad/constants";
 import { checkM365Tenant, checkSubscription } from "../commonQuestions";
 import {

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/getQuestions.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/getQuestions.ts
@@ -416,7 +416,7 @@ export async function getQuestions(
       }
     }
   } else if (stage === Stage.deploy) {
-    if (inputs[Constants.DEPLOY_AAD] === "yes") {
+    if (inputs.platform === Platform.VSCode && inputs[Constants.INCLUDE_AAD_MANIFEST] === "yes") {
       return ok(node);
     }
 
@@ -457,11 +457,6 @@ export async function getQuestions(
 
     if (plugins.length === 0 && inputs[Constants.INCLUDE_AAD_MANIFEST] !== "yes") {
       return err(new NoCapabilityFoundError(Stage.deploy));
-    }
-
-    // trigger from Deploy AAD App manifest command in VSCode
-    if (inputs.platform === Platform.VSCode && inputs[Constants.INCLUDE_AAD_MANIFEST] === "yes") {
-      return ok(node);
     }
 
     // On VS, users are not expected to select plugins to deploy.

--- a/packages/vscode-extension/src/constants.ts
+++ b/packages/vscode-extension/src/constants.ts
@@ -29,7 +29,6 @@ export enum GlobalKey {
 }
 
 export enum AadManifestDeployConstants {
-  DEPLOY_AAD = "deploy-aad",
   INCLUDE_AAD_MANIFEST = "include-aad-manifest",
 }
 

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -2949,7 +2949,6 @@ export async function deployAadAppManifest(args: any[]): Promise<Result<null, Fx
   ExtTelemetry.sendTelemetryEvent(TelemetryEvent.DeployAadManifestStart);
   const inputs = getSystemInputs();
   inputs[AadManifestDeployConstants.INCLUDE_AAD_MANIFEST] = "yes";
-  inputs[AadManifestDeployConstants.DEPLOY_AAD] = "yes";
 
   if (args && args.length > 1 && args[1] === "CodeLens") {
     const segments = args[0].fsPath.split(".");


### PR DESCRIPTION
Address this bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14677206

Before this PR, there is no confirmation when deploy include aad: 
![image](https://user-images.githubusercontent.com/5545529/172986629-ce0676d4-94f3-4956-86c3-bc5775aaf17b.png)

After this PR, there will be a confirmation message when deploy include aad (The confirmation message will only show when there are Azure resources to deploy):
![image](https://user-images.githubusercontent.com/5545529/172986973-7aef8bb9-80dd-4cf3-a261-2541dee661da.png)



Will add test plan for this