### PR TITLE
fix(bot): set default host type for backward compatibility

### DIFF
--- a/packages/fx-core/src/plugins/resource/bot/v2/common.ts
+++ b/packages/fx-core/src/plugins/resource/bot/v2/common.ts
@@ -70,8 +70,9 @@ export function resolveHostType(inputs: Inputs): HostType {
 }
 
 export function resolveServiceType(ctx: Context): ServiceType {
-  const rawHostType = ctx.projectSetting?.pluginSettings?.[PluginBot.PLUGIN_NAME]?.[
-    PluginBot.HOST_TYPE
-  ] as string;
+  const rawHostType =
+    (ctx.projectSetting?.pluginSettings?.[PluginBot.PLUGIN_NAME]?.[
+      PluginBot.HOST_TYPE
+    ] as string) ?? HostTypes.APP_SERVICE;
   return getServiceType(rawHostType);
 }


### PR DESCRIPTION
Project created by Teams Toolkit older than v3.7 cannot be deployed by latest Teams Toolkit

E2E TEST: https://github.com/OfficeDev/TeamsFx/blob/54c1d932c536a8a63b00584e56196f5eb168dbfd/packages/cli/tests/e2e/bot/CanDeployToCustomizedRg.tests.ts#L37