### PR TITLE
fix: project name restriction

### DIFF
--- a/packages/cli/tests/e2e/apim/CanDeployToCustomizedRg.tests.ts
+++ b/packages/cli/tests/e2e/apim/CanDeployToCustomizedRg.tests.ts
@@ -19,6 +19,7 @@ import {
   createResourceGroup,
   deleteResourceGroupByName,
   getConfigFileName,
+  convertToAlphanumericOnly,
 } from "../commonUtils";
 import { environmentManager } from "@microsoft/teamsfx-core";
 import { CliHelper } from "../../commonlib/cliHelper";
@@ -33,6 +34,7 @@ describe("Deploy to customized resource group", function () {
   const appName = getUniqueAppName();
   const projectPath = path.resolve(testFolder, appName);
   const env = environmentManager.getDefaultEnvName();
+  const apiPrefix = convertToAlphanumericOnly(appName);
 
   after(async () => {
     await cleanUp(appName, projectPath, true, false, false);
@@ -69,14 +71,14 @@ describe("Deploy to customized resource group", function () {
     await CliHelper.deployProject(
       ResourceToDeploy.Apim,
       projectPath,
-      ` --open-api-document openapi/openapi.json --api-prefix ${appName} --api-version v1`,
+      ` --open-api-document openapi/openapi.json --api-prefix ${apiPrefix} --api-version v1`,
       process.env,
       3,
       `teamsfx deploy apim --open-api-document openapi/openapi.json --api-version v1`
     );
 
     const deployContext = await fs.readJSON(getConfigFileName(appName));
-    await ApimValidator.validateDeploy(deployContext, projectPath, appName, "v1");
+    await ApimValidator.validateDeploy(deployContext, projectPath, apiPrefix, "v1");
 
     await deleteResourceGroupByName(customizedRgName);
   });

--- a/packages/cli/tests/e2e/apim/TestCreateNewApim.tests.ts
+++ b/packages/cli/tests/e2e/apim/TestCreateNewApim.tests.ts
@@ -16,6 +16,7 @@ import {
   cleanUp,
   loadContext,
   setSimpleAuthSkuNameToB1Bicep,
+  convertToAlphanumericOnly,
 } from "../commonUtils";
 import AzureLogin from "../../../src/commonlib/azureLogin";
 import M365Login from "../../../src/commonlib/m365Login";
@@ -33,6 +34,8 @@ describe("Create a new API Management Service", function () {
   const subscriptionId = getSubscriptionId();
   const projectPath = path.resolve(testFolder, appName);
   const env = environmentManager.getDefaultEnvName();
+  const apiPrefix = convertToAlphanumericOnly(appName);
+
   it(
     `Import API into a new API Management Service`,
     { testPlanCaseId: 10107958 },
@@ -61,14 +64,14 @@ describe("Create a new API Management Service", function () {
       await CliHelper.deployProject(
         ResourceToDeploy.Apim,
         projectPath,
-        ` --open-api-document openapi/openapi.json --api-prefix ${appName} --api-version v1`,
+        ` --open-api-document openapi/openapi.json --api-prefix ${apiPrefix} --api-version v1`,
         testProcessEnv,
         3,
         `teamsfx deploy apim --open-api-document openapi/openapi.json --api-version v1`
       );
 
       const deployContext = await fs.readJSON(getConfigFileName(appName));
-      await ApimValidator.validateDeploy(deployContext, projectPath, appName, "v1");
+      await ApimValidator.validateDeploy(deployContext, projectPath, apiPrefix, "v1");
     }
   );
 

--- a/packages/cli/tests/e2e/apim/TestImportApiIntoApim.tests.ts
+++ b/packages/cli/tests/e2e/apim/TestImportApiIntoApim.tests.ts
@@ -15,6 +15,7 @@ import {
   getConfigFileName,
   cleanUp,
   setSimpleAuthSkuNameToB1Bicep,
+  convertToAlphanumericOnly,
 } from "../commonUtils";
 import AzureLogin from "../../../src/commonlib/azureLogin";
 import M365Login from "../../../src/commonlib/m365Login";
@@ -32,6 +33,7 @@ describe("Import API into API Management", function () {
   const appName = getUniqueAppName();
   const subscriptionId = getSubscriptionId();
   const projectPath = path.resolve(testFolder, appName);
+  const apiPrefix = convertToAlphanumericOnly(appName);
   before(async () => {
     // new a project
     await CliHelper.createProjectWithCapability(
@@ -49,7 +51,7 @@ describe("Import API into API Management", function () {
     await CliHelper.deployProject(
       ResourceToDeploy.Apim,
       projectPath,
-      ` --open-api-document openapi/openapi.json --api-prefix ${appName} --api-version v1`,
+      ` --open-api-document openapi/openapi.json --api-prefix ${apiPrefix} --api-version v1`,
       testProcessEnv,
       3,
       `teamsfx deploy apim --open-api-document openapi/openapi.json --api-version v1`
@@ -69,7 +71,7 @@ describe("Import API into API Management", function () {
       );
 
       const deployContext = await fs.readJSON(getConfigFileName(appName));
-      await ApimValidator.validateDeploy(deployContext, projectPath, appName, "v2");
+      await ApimValidator.validateDeploy(deployContext, projectPath, apiPrefix, "v2");
     }
   );
 
@@ -86,7 +88,7 @@ describe("Import API into API Management", function () {
       );
 
       const deployContext = await fs.readJSON(getConfigFileName(appName));
-      await ApimValidator.validateDeploy(deployContext, projectPath, appName, "v1");
+      await ApimValidator.validateDeploy(deployContext, projectPath, apiPrefix, "v1");
     }
   );
 

--- a/packages/cli/tests/e2e/commonUtils.ts
+++ b/packages/cli/tests/e2e/commonUtils.ts
@@ -94,6 +94,10 @@ export function getUniqueAppName() {
   return getAppNamePrefix() + Date.now().toString() + uuidv4().slice(0, 2);
 }
 
+export function convertToAlphanumericOnly(appName: string): string {
+  return appName.replace(/[^\da-zA-Z]/g, "");
+}
+
 export function getSubscriptionId() {
   return cfg.AZURE_SUBSCRIPTION_ID || "";
 }

--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -476,7 +476,7 @@
   "error.apiConnector.pkgFileNotExistError": "In %s project, there is no package.json exist",
   "error.apiConnector.componentNotExistError": "Component %s not exist, please add first",
   "error.apiConnector.envVarExistError": "Please provide a different API name to avoid conflicts with existing env variables %s in .env.teamsfx.local",
-  "core.QuestionAppName.validation.pattern": "Application name must start with a letter and can only contain letters and digits.",
+  "core.QuestionAppName.validation.pattern": "Application name must start with letters and contain at least two letters or digits. It can not contain some special characters.",
   "core.QuestionAppName.validation.maxlength": "Application name is longer than the maximum length of 30.",
   "core.QuestionAppName.validation.pathExist": "Path exists: %s. Select a different application name.",
   "core.ProgrammingLanguageQuestion.title": "Programming Language",

--- a/packages/fx-core/src/common/utils.ts
+++ b/packages/fx-core/src/common/utils.ts
@@ -15,3 +15,7 @@ export async function getProjectTemplatesFolderPath(projectPath: string): Promis
   }
   return path.resolve(projectPath, "templates");
 }
+
+export function convertToAlphanumericOnly(appName: string): string {
+  return appName.replace(/[^\da-zA-Z]/g, "");
+}

--- a/packages/fx-core/src/component/workflow.ts
+++ b/packages/fx-core/src/component/workflow.ts
@@ -36,6 +36,7 @@ import {
   serviceEffectPlanString,
 } from "./utils";
 import { getDefaultString, getLocalizedString } from "../common/localizeUtils";
+import { convertToAlphanumericOnly } from "../common/utils";
 
 export async function getAction(
   name: string,
@@ -450,7 +451,11 @@ export async function executeFunctionAction(
         if (bicep) {
           const bicepPlans = persistBicepPlans(inputs.projectPath, bicep);
           bicepPlans.forEach((p) => effects.push(p));
-          await persistBicep(inputs.projectPath, context.projectSetting.appName, bicep);
+          await persistBicep(
+            inputs.projectPath,
+            convertToAlphanumericOnly(context.projectSetting.appName),
+            bicep
+          );
         }
       } else {
         effects.push(effect);

--- a/packages/fx-core/src/core/FxCore.ts
+++ b/packages/fx-core/src/core/FxCore.ts
@@ -245,7 +245,7 @@ export class FxCore implements v3.ICore {
       }
 
       const projectSettings: ProjectSettings = {
-        appName: appName,
+        appName,
         projectId: inputs.projectId ? inputs.projectId : uuid.v4(),
         version: getProjectSettingsVersion(),
         isFromSample: false,

--- a/packages/fx-core/src/core/question.ts
+++ b/packages/fx-core/src/core/question.ts
@@ -59,9 +59,11 @@ export enum CoreQuestionNames {
   NewResourceGroupLocation = "newResourceGroupLocation",
   NewTargetEnvName = "newTargetEnvName",
   ExistingTabEndpoint = "existing-tab-endpoint",
+  SafeProjectName = "safeProjectName",
 }
 
-export const ProjectNamePattern = "^[a-zA-Z][\\da-zA-Z]+$";
+export const ProjectNamePattern =
+  '^(?=(.*[\\da-zA-Z]){2})[a-zA-Z][^"<>:\\?/*|\u0000-\u001F]*[^"\\s.<>:\\?/*|\u0000-\u001F]$';
 
 export function createAppNameQuestion(validateProjectPathExistence = true): TextInputQuestion {
   const question: TextInputQuestion = {

--- a/packages/fx-core/src/plugins/resource/aad/utils/configs.ts
+++ b/packages/fx-core/src/plugins/resource/aad/utils/configs.ts
@@ -40,6 +40,7 @@ import { BuiltInFeaturePluginNames } from "../../../solution/fx-solution/v3/cons
 import { ResultFactory } from "../results";
 import { getPermissionRequest } from "../permissions";
 import { GraphScopes, isAadManifestEnabled } from "../../../../common";
+import { convertToAlphanumericOnly } from "../../../../common/utils";
 
 export class Utils {
   public static addLogAndTelemetryWithLocalDebug(
@@ -267,15 +268,7 @@ export class ProvisionConfig {
     inputs: v2.InputsWithProjectPath,
     localSettings: v2.LocalSettings
   ): Promise<Result<any, FxError>> {
-    const displayName: string = ctx.projectSetting.appName;
-    if (displayName) {
-      this.displayName = displayName.substr(0, Constants.aadAppMaxLength) as string;
-    } else {
-      throw ResultFactory.SystemError(
-        GetConfigError.name,
-        GetConfigError.message(Errors.GetDisplayNameError[0])
-      );
-    }
+    this.setDisplayName(ctx.projectSetting.appName);
     const permissionRes = await getPermissionRequest(inputs.projectPath);
     if (permissionRes.isErr()) {
       return err(permissionRes.error);
@@ -296,15 +289,7 @@ export class ProvisionConfig {
     inputs: v2.InputsWithProjectPath,
     envInfo: v3.EnvInfoV3
   ): Promise<Result<any, FxError>> {
-    const displayName: string = ctx.projectSetting.appName;
-    if (displayName) {
-      this.displayName = displayName.substr(0, Constants.aadAppMaxLength) as string;
-    } else {
-      throw ResultFactory.SystemError(
-        GetConfigError.name,
-        GetConfigError.message(Errors.GetDisplayNameError[0])
-      );
-    }
+    this.setDisplayName(ctx.projectSetting.appName);
     const permissionRes = await getPermissionRequest(inputs.projectPath);
     if (permissionRes.isErr()) {
       return err(permissionRes.error);
@@ -322,15 +307,7 @@ export class ProvisionConfig {
     return ok(undefined);
   }
   public async restoreConfigFromContext(ctx: PluginContext): Promise<void> {
-    const displayName: string = ctx.projectSettings!.appName;
-    if (displayName) {
-      this.displayName = displayName.substr(0, Constants.aadAppMaxLength) as string;
-    } else {
-      throw ResultFactory.SystemError(
-        GetConfigError.name,
-        GetConfigError.message(Errors.GetDisplayNameError[0])
-      );
-    }
+    this.setDisplayName(ctx.projectSettings!.appName);
 
     if (!isAadManifestEnabled()) {
       this.permissionRequest = await ConfigUtils.getPermissionRequest(ctx);
@@ -416,6 +393,18 @@ export class ProvisionConfig {
   }
   private static getOauthAuthority(tenantId: string): string {
     return `${Constants.oauthAuthorityPrefix}/${tenantId}`;
+  }
+
+  private setDisplayName(appName: string): void {
+    const displayName: string = convertToAlphanumericOnly(appName);
+    if (displayName) {
+      this.displayName = displayName.substr(0, Constants.aadAppMaxLength) as string;
+    } else {
+      throw ResultFactory.SystemError(
+        GetConfigError.name,
+        GetConfigError.message(Errors.GetDisplayNameError[0])
+      );
+    }
   }
 }
 

--- a/packages/fx-core/src/plugins/resource/apim/index.ts
+++ b/packages/fx-core/src/plugins/resource/apim/index.ts
@@ -45,7 +45,7 @@ import { ResourcePlugins } from "../../solution/fx-solution/ResourcePluginContai
 import "./v2";
 import "./v3";
 import { ArmTemplateResult } from "../../../common/armInterface";
-import { CliQuestionManager, VscQuestionManager } from "./managers/questionManager";
+import { convertToAlphanumericOnly } from "../../../common/utils";
 
 @Service(ResourcePlugins.ApimPlugin)
 export class ApimPlugin implements Plugin {
@@ -186,8 +186,9 @@ async function _scaffold(ctx: PluginContext, progressBar: ProgressBar): Promise<
     ctx.logProvider
   );
   const appName = AssertNotEmpty("projectSettings.appName", ctx?.projectSettings?.appName);
+  const convertedAppName = convertToAlphanumericOnly(appName);
   await progressBar.next(ProgressStep.Scaffold, ProgressMessages[ProgressStep.Scaffold].Scaffold);
-  await scaffoldManager.scaffold(appName, ctx.root);
+  await scaffoldManager.scaffold(convertedAppName, ctx.root);
 }
 
 async function _provision(ctx: PluginContext, progressBar: ProgressBar): Promise<void> {
@@ -206,7 +207,6 @@ async function _provision(ctx: PluginContext, progressBar: ProgressBar): Promise
   );
 
   const appName = AssertNotEmpty("projectSettings.appName", ctx?.projectSettings?.appName);
-
   await progressBar.next(
     ProgressStep.Provision,
     ProgressMessages[ProgressStep.Provision].CreateApim

--- a/packages/fx-core/src/plugins/resource/apim/v3/index.ts
+++ b/packages/fx-core/src/plugins/resource/apim/v3/index.ts
@@ -39,6 +39,8 @@ import { AssertNotEmpty } from "../error";
 import { Factory } from "../factory";
 import { ProgressBar } from "../utils/progressBar";
 import fs from "fs-extra";
+import { convertToAlphanumericOnly } from "../../../../common/utils";
+
 @Service(BuiltInFeaturePluginNames.apim)
 export class ApimPluginV3 implements v3.PluginV3 {
   name = BuiltInFeaturePluginNames.apim;
@@ -77,7 +79,7 @@ export class ApimPluginV3 implements v3.PluginV3 {
       ctx.telemetryReporter,
       ctx.logProvider
     );
-    const appName = ctx.projectSetting.appName;
+    const appName = convertToAlphanumericOnly(ctx.projectSetting.appName);
     if (answer.validate) {
       await answer.validate(PluginLifeCycle.Scaffold, apimConfig, inputs.projectPath);
     }
@@ -204,7 +206,6 @@ export class ApimPluginV3 implements v3.PluginV3 {
     );
 
     const appName = AssertNotEmpty("projectSettings.appName", ctx.projectSetting.appName);
-
     await this.progressBar.next(
       ProgressStep.Provision,
       ProgressMessages[ProgressStep.Provision].CreateApim

--- a/packages/fx-core/src/plugins/resource/bot/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/bot/plugin.ts
@@ -58,6 +58,7 @@ import { BOT_ID } from "../appstudio/constants";
 import { AzureOperations } from "../../../common/azure-hosting/azureOps";
 import { AzureUploadConfig } from "../../../common/azure-hosting/interfaces";
 import { HostType } from "./v2/enum";
+import { convertToAlphanumericOnly } from "../../../common/utils";
 
 export class TeamsBotImpl implements PluginImpl {
   // Made config public, because expect the upper layer to fill inputs.
@@ -412,7 +413,11 @@ export class TeamsBotImpl implements PluginImpl {
       botId: isConfigUnifyEnabled()
         ? this.ctx?.envInfo.state.get(ResourcePlugins.Bot).get(BOT_ID)
         : this.config.localDebug.localBotId,
-      name: this.ctx!.projectSettings?.appName + PluginLocalDebug.LOCAL_DEBUG_SUFFIX,
+      name:
+        (!this.ctx!.projectSettings?.appName
+          ? ""
+          : convertToAlphanumericOnly(this.ctx!.projectSettings?.appName)) +
+        PluginLocalDebug.LOCAL_DEBUG_SUFFIX,
       description: "",
       iconUrl: "",
       messagingEndpoint: endpoint,
@@ -479,7 +484,11 @@ export class TeamsBotImpl implements PluginImpl {
     // 2. Register bot by app studio.
     const botReg: IBotRegistration = {
       botId: botAuthCreds.clientId,
-      name: this.ctx!.projectSettings?.appName + PluginLocalDebug.LOCAL_DEBUG_SUFFIX,
+      name:
+        (!this.ctx?.projectSettings?.appName
+          ? ""
+          : convertToAlphanumericOnly(this.ctx.projectSettings?.appName)) +
+        PluginLocalDebug.LOCAL_DEBUG_SUFFIX,
       description: "",
       iconUrl: "",
       messagingEndpoint: "",

--- a/packages/fx-core/src/plugins/resource/bot/v2/common.ts
+++ b/packages/fx-core/src/plugins/resource/bot/v2/common.ts
@@ -9,19 +9,23 @@ import { AppServiceOptionItem, FunctionsOptionItems } from "../question";
 import { CodeTemplateInfo } from "./interface/codeTemplateInfo";
 import { getLanguage, getServiceType, getTriggerScenarios } from "./mapping";
 import { ServiceType } from "../../../../common/azure-hosting/interfaces";
+import { CoreQuestionNames } from "../../../../core/question";
 import { HostType } from "./enum";
 import { PluginBot } from "../resources/strings";
+import { convertToAlphanumericOnly } from "../../../../common/utils";
 
 export function getTemplateInfos(ctx: Context, inputs: Inputs): CodeTemplateInfo[] {
   const lang = getLanguage(ctx.projectSetting.programmingLanguage);
   const scenarios = Array.from(decideTemplateScenarios(ctx, inputs));
   const projectName = ctx.projectSetting.appName;
+  const safeProjectName =
+    inputs[CoreQuestionNames.SafeProjectName] ?? convertToAlphanumericOnly(projectName);
   return scenarios.map((scenario) => {
     return {
       group: TemplateProjectsConstants.GROUP_NAME_BOT,
       language: lang,
       scenario: scenario,
-      variables: { ProjectName: projectName },
+      variables: { ProjectName: projectName, SafeProjectName: safeProjectName },
     };
   });
 }

--- a/packages/fx-core/src/plugins/resource/bot/v3/index.ts
+++ b/packages/fx-core/src/plugins/resource/bot/v3/index.ts
@@ -80,6 +80,7 @@ import {
 import { ensureSolutionSettings } from "../../../solution/fx-solution/utils/solutionSettingsHelper";
 import { AzureOperations } from "../../../../common/azure-hosting/azureOps";
 import { AzureUploadConfig } from "../../../../common/azure-hosting/interfaces";
+import { convertToAlphanumericOnly } from "../../../../common/utils";
 
 @Service(BuiltInFeaturePluginNames.bot)
 export class NodeJSBotPluginV3 implements v3.PluginV3 {
@@ -329,7 +330,9 @@ export class NodeJSBotPluginV3 implements v3.PluginV3 {
       // 2. Register bot by app studio.
       const botReg: IBotRegistration = {
         botId: botConfig.botId,
-        name: ctx.projectSetting.appName + PluginLocalDebug.LOCAL_DEBUG_SUFFIX,
+        name:
+          convertToAlphanumericOnly(ctx.projectSetting.appName) +
+          PluginLocalDebug.LOCAL_DEBUG_SUFFIX,
         description: "",
         iconUrl: "",
         messagingEndpoint: "",
@@ -433,7 +436,7 @@ export class NodeJSBotPluginV3 implements v3.PluginV3 {
       const botConfig = envInfo.state[this.name] as v3.AzureBot;
       CheckThrowSomethingMissing(ConfigNames.LOCAL_ENDPOINT, botConfig.siteEndpoint);
       await this.updateMessageEndpointOnAppStudio(
-        ctx.projectSetting.appName,
+        convertToAlphanumericOnly(ctx.projectSetting.appName),
         tokenProvider,
         botConfig.botId,
         `${botConfig.siteEndpoint}${CommonStrings.MESSAGE_ENDPOINT_SUFFIX}`

--- a/packages/fx-core/src/plugins/resource/cicd/providers/provider.ts
+++ b/packages/fx-core/src/plugins/resource/cicd/providers/provider.ts
@@ -11,6 +11,7 @@ import Mustache from "mustache";
 import { getTemplatesFolder } from "../../../../folder";
 import { Context } from "@microsoft/teamsfx-api/build/v2";
 import { generateBuildScript } from "../utils/buildScripts";
+import { convertToAlphanumericOnly } from "../../../../common/utils";
 
 export class CICDProvider {
   public scaffoldTo = "";
@@ -82,7 +83,7 @@ export class CICDProvider {
       hosting_type_contains_azure: hostType === "Azure",
       cloud_resources_contains_sql:
         context.projectSetting.solutionSettings?.["azureResources"].includes("sql") ?? false,
-      api_prefix: context.projectSetting.appName,
+      api_prefix: convertToAlphanumericOnly(context.projectSetting.appName),
       cloud_resources_contains_apim:
         context.projectSetting.solutionSettings?.["azureResources"].includes("apim") ?? false,
     };

--- a/packages/fx-core/src/plugins/resource/frontend/dotnet/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/frontend/dotnet/plugin.ts
@@ -51,6 +51,8 @@ import { ProgressHelper } from "../utils/progress-helper";
 import { WebappDeployProgress as DeployProgress } from "./resources/steps";
 import { BotOptionItem, TabOptionItem } from "../../../solution/fx-solution/question";
 import { PluginNames } from "../../../solution/fx-solution/constants";
+import { CoreQuestionNames } from "../../../../core/question";
+import { convertToAlphanumericOnly } from "../../../../common/utils";
 
 type Site = WebSiteManagementModels.Site;
 type TeamsFxResult = Result<any, FxError>;
@@ -111,11 +113,17 @@ export class DotnetPluginImpl implements PluginImpl {
     if (!ctx.projectSettings) {
       throw new NoProjectSettingError();
     }
+
     const projectName = ctx.projectSettings!.appName;
-    await scaffoldFromZipPackage(ctx.root, new TemplateInfo({ ProjectName: projectName }));
+    const safeProjectName =
+      ctx.answers?.[CoreQuestionNames.SafeProjectName] ?? convertToAlphanumericOnly(projectName);
+    await scaffoldFromZipPackage(
+      ctx.root,
+      new TemplateInfo({ ProjectName: projectName, SafeProjectName: safeProjectName })
+    );
     ctx.projectSettings.pluginSettings = {
       ...ctx.projectSettings?.pluginSettings,
-      projectFilePath: path.join(ctx.root, PathInfo.projectFilename(ctx.projectSettings.appName)),
+      projectFilePath: path.join(ctx.root, PathInfo.projectFilename(projectName)),
     };
 
     Logger.info(Messages.EndScaffold);

--- a/packages/fx-core/src/plugins/resource/function/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/function/plugin.ts
@@ -295,7 +295,7 @@ export class FunctionPluginImpl {
       DefaultValues.functionTriggerType,
       functionName,
       {
-        appName: ctx.projectSettings!.appName,
+        appName: ctx.projectSettings!.appName, // not used. ignore
         functionName: functionName,
       }
     );

--- a/packages/fx-core/src/plugins/resource/function/v3/index.ts
+++ b/packages/fx-core/src/plugins/resource/function/v3/index.ts
@@ -29,6 +29,7 @@ import {
   getSiteNameFromResourceId,
   getSubscriptionIdFromResourceId,
 } from "../../../../common/tools";
+import { convertToAlphanumericOnly } from "../../../../common/utils";
 import { CommonErrorHandlerMW } from "../../../../core/middleware/CommonErrorHandlerMW";
 import { getTemplatesFolder } from "../../../../folder";
 import { AzureResourceFunction } from "../../../solution/fx-solution/question";
@@ -232,7 +233,7 @@ export class FunctionPluginV3 implements v3.PluginV3 {
       DefaultValues.functionTriggerType,
       functionName,
       {
-        appName: ctx.projectSetting.appName,
+        appName: convertToAlphanumericOnly(ctx.projectSetting.appName),
         functionName: functionName,
       }
     );

--- a/packages/fx-core/src/plugins/resource/simpleauth/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/simpleauth/plugin.ts
@@ -239,7 +239,7 @@ export class SimpleAuthPluginImpl {
       Constants.SolutionPlugin.configKeys.location
     ) as string;
 
-    const webAppName = Utils.generateResourceName(ctx.projectSettings!.appName, resourceNameSuffix);
+    const webAppName = Utils.generateResourceName(ctx.projectSettings!.appName, resourceNameSuffix); // appName will be normalized in generateResourceName(), so we don't do any conversion here.
     const appServicePlanName = webAppName;
 
     this.webAppClient = new WebAppClient(

--- a/packages/fx-core/src/plugins/resource/spfx/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/spfx/plugin.ts
@@ -107,7 +107,7 @@ export class SPFxPluginImpl {
 
       await progressHandler?.next(ScaffoldProgressMessage.ScaffoldProject);
       const framework = ctx.answers![SPFXQuestionNames.framework_type] as string;
-      const solutionName = ctx.projectSettings?.appName as string;
+      const solutionName = ctx.projectSettings?.appName as string; // I did not change this.
       if (ctx.answers?.platform === Platform.VSCode) {
         (ctx.logProvider as any).outputChannel.show();
       }

--- a/packages/fx-core/src/plugins/resource/spfx/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/spfx/plugin.ts
@@ -107,7 +107,7 @@ export class SPFxPluginImpl {
 
       await progressHandler?.next(ScaffoldProgressMessage.ScaffoldProject);
       const framework = ctx.answers![SPFXQuestionNames.framework_type] as string;
-      const solutionName = ctx.projectSettings?.appName as string; // I did not change this.
+      const solutionName = ctx.projectSettings?.appName as string;
       if (ctx.answers?.platform === Platform.VSCode) {
         (ctx.logProvider as any).outputChannel.show();
       }

--- a/packages/fx-core/src/plugins/solution/fx-solution/arm.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/arm.ts
@@ -57,7 +57,7 @@ import { ProgressHelper } from "./utils/progressHelper";
 import { getPluginContext, sendErrorTelemetryThenReturnError } from "./utils/util";
 import { NamedArmResourcePluginAdaptor } from "./v2/adaptor";
 import { getDefaultString, getLocalizedString } from "../../../common/localizeUtils";
-import { getProjectTemplatesFolderPath } from "../../../common/utils";
+import { convertToAlphanumericOnly, getProjectTemplatesFolderPath } from "../../../common/utils";
 
 const bicepOrchestrationFileName = "main.bicep";
 const bicepOrchestrationProvisionMainFileName = "mainProvision.bicep";
@@ -868,7 +868,10 @@ async function doGenerateArmTemplate(
   ctx: SolutionContext,
   selectedPlugins: NamedArmResourcePlugin[]
 ): Promise<Result<any, FxError>> {
-  const baseName = generateResourceBaseName(ctx.projectSettings!.appName, ctx.envInfo!.envName);
+  const baseName = generateResourceBaseName(
+    convertToAlphanumericOnly(ctx.projectSettings!.appName),
+    ctx.envInfo!.envName
+  );
   const plugins = getActivatedV2ResourcePlugins(ctx.projectSettings!).map(
     (p) => new NamedArmResourcePluginAdaptor(p)
   ); // This function ensures return result won't be empty
@@ -951,7 +954,10 @@ async function doGenerateBicep(
   addedPlugins: string[],
   existingPlugins: string[]
 ): Promise<Result<any, FxError>> {
-  const baseName = generateResourceBaseName(ctx.projectSetting.appName, "");
+  const baseName = generateResourceBaseName(
+    convertToAlphanumericOnly(ctx.projectSetting.appName),
+    ""
+  );
   const allPlugins = addedPlugins.concat(existingPlugins);
   const bicepOrchestrationTemplate = new BicepOrchestrationContent(allPlugins, baseName);
   const moduleProvisionFiles = new Map<string, string>();

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/deploy.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/deploy.ts
@@ -208,9 +208,10 @@ export async function deploy(
   const result = await executeConcurrently(thunks, ctx.logProvider);
 
   if (result.kind === "success") {
+    const appName = ctx.projectSetting.appName;
     if (inAzureProject) {
       let msg =
-        getLocalizedString("core.deploy.successNotice", ctx.projectSetting.appName) +
+        getLocalizedString("core.deploy.successNotice", appName) +
         botTroubleShootMsg.textForLogging;
 
       if (isDeployAADManifestFromVSCode) {
@@ -222,7 +223,7 @@ export async function deploy(
         ctx.userInteraction
           .showMessage(
             "info",
-            `${getLocalizedString("core.deploy.successNotice", ctx.projectSetting.appName)} ${
+            `${getLocalizedString("core.deploy.successNotice", appName)} ${
               botTroubleShootMsg.textForMsgBox
             }`,
             false,

--- a/packages/fx-core/src/plugins/solution/fx-solution/v3/provision.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v3/provision.ts
@@ -34,6 +34,7 @@ import {
   TelemetryProperty,
 } from "../../../../common/telemetry";
 import { AppStudioScopes, getHashedEnv, getResourceGroupInPortal } from "../../../../common/tools";
+import { convertToAlphanumericOnly } from "../../../../common/utils";
 import { AppStudioPluginV3 } from "../../../resource/appstudio/v3";
 import arm from "../arm";
 import { ResourceGroupInfo } from "../commonQuestions";
@@ -390,7 +391,7 @@ export async function fillInAzureConfigs(
   const resourceGroupNameFromEnvConfig = envInfo.config.azure?.resourceGroupName;
   const resourceGroupNameFromState = envInfo.state.solution.resourceGroupName;
   const resourceGroupLocationFromState = envInfo.state.solution.location;
-  const appName = ctx.projectSetting.appName;
+  const appName = convertToAlphanumericOnly(ctx.projectSetting.appName);
   const defaultResourceGroupName = `${snakeCase(appName)}${"-" + envInfo.envName}-rg`;
   let resourceGroupInfo: ResourceGroupInfo;
   const telemetryProperties: { [key: string]: string } = {};

--- a/packages/fx-core/tests/common/utils.test.ts
+++ b/packages/fx-core/tests/common/utils.test.ts
@@ -1,0 +1,21 @@
+import "mocha";
+import chai from "chai";
+import { convertToAlphanumericOnly } from "../../src/common/utils";
+
+describe("convert to valid AppName in ProjectSetting", () => {
+  it("convert app name", () => {
+    const appName = "app.123";
+    const expected = "app123";
+    const projectSettingsName = convertToAlphanumericOnly(appName);
+
+    chai.assert.equal(projectSettingsName, expected);
+  });
+
+  it("convert app name", () => {
+    const appName = "app.1@@2！3";
+    const expected = "app123";
+    const projectSettingsName = convertToAlphanumericOnly(appName);
+
+    chai.assert.equal(projectSettingsName, expected);
+  });
+});

--- a/packages/fx-core/tests/core/question.test.ts
+++ b/packages/fx-core/tests/core/question.test.ts
@@ -191,8 +191,78 @@ describe("App name question", async () => {
     chai.assert.equal(result, getLocalizedString("core.QuestionAppName.validation.maxlength"));
   });
 
-  it("app name with wrong pattern", async () => {
+  it("app name with only letters", async () => {
+    const input = "app";
+    const result = await validFunc(input);
+
+    chai.assert.isUndefined(result);
+  });
+
+  it("app name starting with digit", async () => {
     const input = "123app";
+    const result = await validFunc(input);
+
+    chai.assert.equal(result, getLocalizedString("core.QuestionAppName.validation.pattern"));
+  });
+
+  it("app name count of alphanumerics less than 2", async () => {
+    const input = "a..(";
+    const result = await validFunc(input);
+
+    chai.assert.equal(result, getLocalizedString("core.QuestionAppName.validation.pattern"));
+  });
+
+  it("app name containing dot", async () => {
+    const input = "app.123";
+    const result = await validFunc(input);
+
+    chai.assert.isUndefined(result);
+  });
+
+  it("app name containing hyphen", async () => {
+    const input = "app-123";
+    const result = await validFunc(input);
+
+    chai.assert.isUndefined(result);
+  });
+
+  it("app name containing multiple special characters", async () => {
+    const input = "a..(1";
+    const result = await validFunc(input);
+
+    chai.assert.isUndefined(result);
+  });
+
+  it("app name containing space", async () => {
+    const input = "app 123";
+    const result = await validFunc(input);
+
+    chai.assert.isUndefined(result);
+  });
+
+  it("app name containing dot at the end - wrong pattern", async () => {
+    const input = "app.app.";
+    const result = await validFunc(input);
+
+    chai.assert.equal(result, getLocalizedString("core.QuestionAppName.validation.pattern"));
+  });
+
+  it("app name containing space at the end - wrong pattern", async () => {
+    const input = "app123 ";
+    const result = await validFunc(input);
+
+    chai.assert.equal(result, getLocalizedString("core.QuestionAppName.validation.pattern"));
+  });
+
+  it("app name containing invalid control code", async () => {
+    const input = "a\u0001a";
+    const result = await validFunc(input);
+
+    chai.assert.equal(result, getLocalizedString("core.QuestionAppName.validation.pattern"));
+  });
+
+  it("app name containing invalid character", async () => {
+    const input = "app<>123";
     const result = await validFunc(input);
 
     chai.assert.equal(result, getLocalizedString("core.QuestionAppName.validation.pattern"));

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -813,11 +813,16 @@ export async function showOutputChannel(args?: any[]): Promise<Result<any, FxErr
 }
 
 export async function openFolderHandler(args?: any[]): Promise<Result<any, FxError>> {
+  const scheme = "file://";
   ExtTelemetry.sendTelemetryEvent(TelemetryEvent.OpenFolder, {
     [TelemetryProperty.TriggerFrom]: TelemetryTriggerFrom.Notification,
   });
   if (args && args.length > 0 && args[0]) {
-    const uri = Uri.parse(args[0]);
+    let path = args[0] as string;
+    if (path.startsWith(scheme)) {
+      path = path.substring(scheme.length);
+    }
+    const uri = Uri.file(path);
     openFolderInExplorer(uri.fsPath);
   }
   return ok(null);

--- a/templates/bot/csharp/command-and-response/AdapterWithErrorHandler.cs.tpl
+++ b/templates/bot/csharp/command-and-response/AdapterWithErrorHandler.cs.tpl
@@ -1,4 +1,4 @@
-﻿namespace {{ProjectName}}
+﻿namespace {{SafeProjectName}}
 {
     using Microsoft.Bot.Builder.Integration.AspNet.Core;
     using Microsoft.Bot.Builder.TraceExtensions;

--- a/templates/bot/csharp/command-and-response/Commands/HelloWorldCommandHandler.cs.tpl
+++ b/templates/bot/csharp/command-and-response/Commands/HelloWorldCommandHandler.cs.tpl
@@ -1,6 +1,6 @@
-﻿namespace {{ProjectName}}.Commands
+﻿namespace {{SafeProjectName}}.Commands
 {
-    using {{ProjectName}}.Models;
+    using {{SafeProjectName}}.Models;
     using AdaptiveCards.Templating;
     using Microsoft.Bot.Builder;
     using Microsoft.Bot.Schema;

--- a/templates/bot/csharp/command-and-response/Controllers/BotController.cs.tpl
+++ b/templates/bot/csharp/command-and-response/Controllers/BotController.cs.tpl
@@ -1,4 +1,4 @@
-﻿namespace {{ProjectName}}.Controllers
+﻿namespace {{SafeProjectName}}.Controllers
 {
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Bot.Builder;

--- a/templates/bot/csharp/command-and-response/Models/HelloWorldModel.cs.tpl
+++ b/templates/bot/csharp/command-and-response/Models/HelloWorldModel.cs.tpl
@@ -1,4 +1,4 @@
-﻿namespace {{ProjectName}}.Models
+﻿namespace {{SafeProjectName}}.Models
 {
     public class HelloWorldModel
     {

--- a/templates/bot/csharp/command-and-response/Program.cs.tpl
+++ b/templates/bot/csharp/command-and-response/Program.cs.tpl
@@ -1,5 +1,5 @@
-using {{ProjectName}};
-using {{ProjectName}}.Commands;
+using {{SafeProjectName}};
+using {{SafeProjectName}}.Commands;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.TeamsFx.Conversation;

--- a/templates/bot/csharp/command-and-response/TeamsBot.cs.tpl
+++ b/templates/bot/csharp/command-and-response/TeamsBot.cs.tpl
@@ -1,4 +1,4 @@
-﻿namespace {{ProjectName}}
+﻿namespace {{SafeProjectName}}
 {
     using Microsoft.Bot.Builder;
     using System.Threading;

--- a/templates/bot/csharp/default/AdapterWithErrorHandler.cs.tpl
+++ b/templates/bot/csharp/default/AdapterWithErrorHandler.cs.tpl
@@ -2,7 +2,7 @@
 using Microsoft.Bot.Builder.TraceExtensions;
 using Microsoft.Bot.Connector.Authentication;
 
-namespace {{ProjectName}};
+namespace {{SafeProjectName}};
 
 public class AdapterWithErrorHandler : CloudAdapter
 {

--- a/templates/bot/csharp/default/Bot/TeamsMessageExtension.cs.tpl
+++ b/templates/bot/csharp/default/Bot/TeamsMessageExtension.cs.tpl
@@ -5,7 +5,7 @@ using Microsoft.Bot.Schema.Teams;
 
 using Newtonsoft.Json.Linq;
 
-namespace {{ProjectName}}.Bot;
+namespace {{SafeProjectName}}.Bot;
 
 public class TeamsMessageExtension : TeamsActivityHandler
 {

--- a/templates/bot/csharp/default/Controllers/BotController.cs.tpl
+++ b/templates/bot/csharp/default/Controllers/BotController.cs.tpl
@@ -2,7 +2,7 @@
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 
-namespace {{ProjectName}}.Controllers;
+namespace {{SafeProjectName}}.Controllers;
 
 // This ASP Controller is created to handle a request. Dependency Injection will provide the Adapter and IBot
 // implementation at runtime. Multiple different IBot implementations running at different endpoints can be

--- a/templates/bot/csharp/default/Program.cs.tpl
+++ b/templates/bot/csharp/default/Program.cs.tpl
@@ -1,5 +1,5 @@
-using {{ProjectName}};
-using {{ProjectName}}.Bot;
+using {{SafeProjectName}};
+using {{SafeProjectName}}.Bot;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 

--- a/templates/bot/csharp/notification-function-base/AdapterWithErrorHandler.cs.tpl
+++ b/templates/bot/csharp/notification-function-base/AdapterWithErrorHandler.cs.tpl
@@ -1,4 +1,4 @@
-namespace {{ProjectName}}
+namespace {{SafeProjectName}}
 {
     using Microsoft.Bot.Builder.Integration.AspNet.Core;
     using Microsoft.Bot.Builder.TraceExtensions;

--- a/templates/bot/csharp/notification-function-base/MessageHandler.cs.tpl
+++ b/templates/bot/csharp/notification-function-base/MessageHandler.cs.tpl
@@ -1,4 +1,4 @@
-namespace {{ProjectName}}
+namespace {{SafeProjectName}}
 {
     using Microsoft.Azure.WebJobs;
     using Microsoft.Azure.WebJobs.Extensions.Http;

--- a/templates/bot/csharp/notification-function-base/Models/NotificationDefaultModel.cs.tpl
+++ b/templates/bot/csharp/notification-function-base/Models/NotificationDefaultModel.cs.tpl
@@ -1,4 +1,4 @@
-namespace {{ProjectName}}.Models
+namespace {{SafeProjectName}}.Models
 {
     public class NotificationDefaultModel
     {

--- a/templates/bot/csharp/notification-function-base/Startup.cs.tpl
+++ b/templates/bot/csharp/notification-function-base/Startup.cs.tpl
@@ -6,9 +6,9 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.TeamsFx.Conversation;
 
-[assembly: FunctionsStartup(typeof({{ProjectName}}.Startup))]
+[assembly: FunctionsStartup(typeof({{SafeProjectName}}.Startup))]
 
-namespace {{ProjectName}}
+namespace {{SafeProjectName}}
 {
     public class Startup : FunctionsStartup
     {

--- a/templates/bot/csharp/notification-function-base/TeamsBot.cs.tpl
+++ b/templates/bot/csharp/notification-function-base/TeamsBot.cs.tpl
@@ -1,4 +1,4 @@
-namespace {{ProjectName}}
+namespace {{SafeProjectName}}
 {
     using Microsoft.Bot.Builder;
 

--- a/templates/bot/csharp/notification-function-base/host.json.tpl
+++ b/templates/bot/csharp/notification-function-base/host.json.tpl
@@ -8,7 +8,7 @@
       }
     },
     "logLevel": {
-      "{{ProjectName}}": "Information"
+      "{{SafeProjectName}}": "Information"
     }
   },
   "extensions": {

--- a/templates/bot/csharp/notification-trigger-http/NotifyHttpTrigger.cs.tpl
+++ b/templates/bot/csharp/notification-trigger-http/NotifyHttpTrigger.cs.tpl
@@ -1,6 +1,6 @@
-namespace {{ProjectName}}
+namespace {{SafeProjectName}}
 {
-    using {{ProjectName}}.Models;
+    using {{SafeProjectName}}.Models;
     using AdaptiveCards.Templating;
     using Microsoft.Azure.WebJobs;
     using Microsoft.Azure.WebJobs.Extensions.Http;

--- a/templates/bot/csharp/notification-trigger-timer/NotifyTimerTrigger.cs.tpl
+++ b/templates/bot/csharp/notification-trigger-timer/NotifyTimerTrigger.cs.tpl
@@ -1,6 +1,6 @@
-namespace {{ProjectName}}
+namespace {{SafeProjectName}}
 {
-    using {{ProjectName}}.Models;
+    using {{SafeProjectName}}.Models;
     using AdaptiveCards.Templating;
     using Microsoft.Azure.WebJobs;
     using Microsoft.Azure.WebJobs.Extensions.Http;

--- a/templates/bot/csharp/notification-webapi/AdapterWithErrorHandler.cs.tpl
+++ b/templates/bot/csharp/notification-webapi/AdapterWithErrorHandler.cs.tpl
@@ -1,4 +1,4 @@
-﻿namespace {{ProjectName}}
+﻿namespace {{SafeProjectName}}
 {
     using Microsoft.Bot.Builder.Integration.AspNet.Core;
     using Microsoft.Bot.Builder.TraceExtensions;

--- a/templates/bot/csharp/notification-webapi/Controllers/BotController.cs.tpl
+++ b/templates/bot/csharp/notification-webapi/Controllers/BotController.cs.tpl
@@ -1,4 +1,4 @@
-﻿namespace {{ProjectName}}.Controllers
+﻿namespace {{SafeProjectName}}.Controllers
 {
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Bot.Builder;

--- a/templates/bot/csharp/notification-webapi/Controllers/NotificationController.cs.tpl
+++ b/templates/bot/csharp/notification-webapi/Controllers/NotificationController.cs.tpl
@@ -1,6 +1,6 @@
-﻿namespace {{ProjectName}}.Controllers
+﻿namespace {{SafeProjectName}}.Controllers
 {
-    using {{ProjectName}}.Models;
+    using {{SafeProjectName}}.Models;
     using AdaptiveCards.Templating;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.TeamsFx.Conversation;

--- a/templates/bot/csharp/notification-webapi/Models/NotificationDefaultModel.cs.tpl
+++ b/templates/bot/csharp/notification-webapi/Models/NotificationDefaultModel.cs.tpl
@@ -1,4 +1,4 @@
-namespace {{ProjectName}}.Models
+namespace {{SafeProjectName}}.Models
 {
     public class NotificationDefaultModel
     {

--- a/templates/bot/csharp/notification-webapi/Program.cs.tpl
+++ b/templates/bot/csharp/notification-webapi/Program.cs.tpl
@@ -1,4 +1,4 @@
-using {{ProjectName}};
+using {{SafeProjectName}};
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Connector.Authentication;

--- a/templates/bot/csharp/notification-webapi/TeamsBot.cs.tpl
+++ b/templates/bot/csharp/notification-webapi/TeamsBot.cs.tpl
@@ -1,4 +1,4 @@
-namespace {{ProjectName}}
+namespace {{SafeProjectName}}
 {
     using Microsoft.Bot.Builder;
 

--- a/templates/tab/csharp/default/Interop/InteropModuleBase.cs.tpl
+++ b/templates/tab/csharp/default/Interop/InteropModuleBase.cs.tpl
@@ -1,6 +1,6 @@
 ﻿using Microsoft.JSInterop;
 
-namespace {{ProjectName}}.Interop;
+namespace {{SafeProjectName}}.Interop;
 
 public abstract class InteropModuleBase
 {

--- a/templates/tab/csharp/default/Interop/TeamsSDK/EnumDescriptionConverter.cs.tpl
+++ b/templates/tab/csharp/default/Interop/TeamsSDK/EnumDescriptionConverter.cs.tpl
@@ -3,7 +3,7 @@ using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace {{ProjectName}}.Interop.TeamsSDK;
+namespace {{SafeProjectName}}.Interop.TeamsSDK;
 
 internal class EnumDescriptionConverter<T> : JsonConverter<T> where T : struct, Enum
 {

--- a/templates/tab/csharp/default/Interop/TeamsSDK/MicrosoftTeams.cs.tpl
+++ b/templates/tab/csharp/default/Interop/TeamsSDK/MicrosoftTeams.cs.tpl
@@ -1,6 +1,6 @@
 ﻿using Microsoft.JSInterop;
 
-namespace {{ProjectName}}.Interop.TeamsSDK;
+namespace {{SafeProjectName}}.Interop.TeamsSDK;
 
 public class MicrosoftTeams : InteropModuleBase
 {

--- a/templates/tab/csharp/default/Interop/TeamsSDK/TeamsContext.cs.tpl
+++ b/templates/tab/csharp/default/Interop/TeamsSDK/TeamsContext.cs.tpl
@@ -1,7 +1,7 @@
 ﻿using System.ComponentModel;
 using System.Text.Json.Serialization;
 
-namespace {{ProjectName}}.Interop.TeamsSDK;
+namespace {{SafeProjectName}}.Interop.TeamsSDK;
 
 public class TeamsContext
 {

--- a/templates/tab/csharp/default/Interop/TeamsSDK/TeamsInstanceSettings.cs.tpl
+++ b/templates/tab/csharp/default/Interop/TeamsSDK/TeamsInstanceSettings.cs.tpl
@@ -1,4 +1,4 @@
-﻿namespace {{ProjectName}}.Interop.TeamsSDK;
+﻿namespace {{SafeProjectName}}.Interop.TeamsSDK;
 
 public class TeamsInstanceSettings
 {

--- a/templates/tab/csharp/default/Pages/Error.cshtml.cs.tpl
+++ b/templates/tab/csharp/default/Pages/Error.cshtml.cs.tpl
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Logging;
 
-namespace {{ProjectName}}.Pages;
+namespace {{SafeProjectName}}.Pages;
 
 [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
 [IgnoreAntiforgeryToken]

--- a/templates/tab/csharp/default/Pages/Error.cshtml.tpl
+++ b/templates/tab/csharp/default/Pages/Error.cshtml.tpl
@@ -1,5 +1,5 @@
 @page
-@model {{ProjectName}}.Pages.ErrorModel
+@model {{SafeProjectName}}.Pages.ErrorModel
 
 <!DOCTYPE html>
 <html>

--- a/templates/tab/csharp/default/Pages/Tab.razor.tpl
+++ b/templates/tab/csharp/default/Pages/Tab.razor.tpl
@@ -1,6 +1,6 @@
 ﻿@page "/"
 @page "/tab"
-@using {{ProjectName}}.Components;
+@using {{SafeProjectName}}.Components;
 
 <div>
     <Welcome />

--- a/templates/tab/csharp/default/Pages/_Host.cshtml.tpl
+++ b/templates/tab/csharp/default/Pages/_Host.cshtml.tpl
@@ -1,5 +1,5 @@
 @page "/"
-@namespace {{ProjectName}}.Pages
+@namespace {{SafeProjectName}}.Pages
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @{
     Layout = null;

--- a/templates/tab/csharp/default/Program.cs.tpl
+++ b/templates/tab/csharp/default/Program.cs.tpl
@@ -1,4 +1,4 @@
-using {{ProjectName}}.Interop.TeamsSDK;
+using {{SafeProjectName}}.Interop.TeamsSDK;
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/templates/tab/csharp/default/_Imports.razor.tpl
+++ b/templates/tab/csharp/default/_Imports.razor.tpl
@@ -6,9 +6,9 @@
 @using Microsoft.AspNetCore.Components.Web
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @using Microsoft.JSInterop
-@using {{ProjectName}}
-@using {{ProjectName}}.Shared
-@using {{ProjectName}}.Interop.TeamsSDK;
-@using {{ProjectName}}.Components
+@using {{SafeProjectName}}
+@using {{SafeProjectName}}.Shared
+@using {{SafeProjectName}}.Interop.TeamsSDK;
+@using {{SafeProjectName}}.Components
 @using Microsoft.Fast.Components.FluentUI;
 @using Microsoft.TeamsFx


### PR DESCRIPTION
- Change the restriction of app name. It will allow almost all characters except "<>:\\?/*|\u0000-\u001F and cannot end with dot or space. And it has to start with a letter, and contain at least two alphanumeric characters, and the length should be less than 30. (Same as what we have today).
- AppName in projectSettings will be the original app name that may include special characters
- Remove non-alphanumeric characters in appName in plugins when provisioning resources.
- Update templates for C# projects to use safeProjectName for namespaces and projectName for file name. Related PR: https://devdiv.visualstudio.com/InternalTools/_git/VSProject/pullrequest/404491
- E2E test:
    - https://github.com/OfficeDev/TeamsFx/actions/runs/2506449140 original one
    - https://github.com/OfficeDev/TeamsFx/actions/runs/2507343488 projectName with dot

E2E TEST: na