### PR TITLE
chore: adjust settings for dotnet bot templates

### DIFF
--- a/templates/bot/csharp/command-and-response/Properties/launchSettings.json.tpl
+++ b/templates/bot/csharp/command-and-response/Properties/launchSettings.json.tpl
@@ -10,15 +10,17 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
       "hotReloadProfile": "aspnetcore"
-    },
-    "{{ProjectName}}": {
-      "commandName": "Project",
-      "dotnetRunMessages": "true",
-      "applicationUrl": "https://localhost:7130;http://localhost:5130",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "hotReloadProfile": "aspnetcore"
     }
+    //// Uncomment following profile to debug project only (without launching Teams)
+    //,
+    //"{{ProjectName}}": {
+    //  "commandName": "Project",
+    //  "dotnetRunMessages": "true",
+    //  "applicationUrl": "https://localhost:7130;http://localhost:5130",
+    //  "environmentVariables": {
+    //    "ASPNETCORE_ENVIRONMENT": "Development"
+    //  },
+    //  "hotReloadProfile": "aspnetcore"
+    //}
   }
 }

--- a/templates/bot/csharp/default/Properties/launchSettings.json.tpl
+++ b/templates/bot/csharp/default/Properties/launchSettings.json.tpl
@@ -10,16 +10,18 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
       "hotReloadProfile": "aspnetcore"
-    },
-    "{{ProjectName}}": {
-      "commandName": "Project",
-      "dotnetRunMessages": "true",
-      "launchBrowser": true,
-      "applicationUrl": "https://localhost:7130;http://localhost:5130",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "hotReloadProfile": "aspnetcore"
     }
+    //// Uncomment following profile to debug project only (without launching Teams)
+    //,
+    //"{{ProjectName}}": {
+    //  "commandName": "Project",
+    //  "dotnetRunMessages": "true",
+    //  "launchBrowser": true,
+    //  "applicationUrl": "https://localhost:7130;http://localhost:5130",
+    //  "environmentVariables": {
+    //    "ASPNETCORE_ENVIRONMENT": "Development"
+    //  },
+    //  "hotReloadProfile": "aspnetcore"
+    //}
   }
 }

--- a/templates/bot/csharp/notification-function-base/GettingStarted.txt
+++ b/templates/bot/csharp/notification-function-base/GettingStarted.txt
@@ -20,7 +20,7 @@ Notes: your M365 account need to have the sideloading permission to ensure Teams
 
 4. Once Microsoft Teams is loaded, select the "Add" button to install your app in Teams.
 
-5. Post HTTP request to http://localhost:5130/api/notification to trigger notification. You can use any API tool: curl, Postman, etc.
+5. Post HTTP request to http://localhost:5130/api/notification to trigger notification. You can use any API tool: curl (Windows Command Prompt), Postman, etc.
 
 Tips: if you made changes to Teams app manifest file (/templates/appPackage/manifest.template.json), please make sure you run the "Prepare Teams app dependencies" command before you try to locally run the Teams app again.
 

--- a/templates/bot/csharp/notification-function-base/ProjectName.csproj.tpl
+++ b/templates/bot/csharp/notification-function-base/ProjectName.csproj.tpl
@@ -27,7 +27,7 @@
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.16.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.0.1" />
-    <PackageReference Include="Microsoft.TeamsFx" Version="0.5.0-rc">
+    <PackageReference Include="Microsoft.TeamsFx" Version="0.5.0">
       <!-- Exclude TeamsFx wwwroot static files which are for frontend only. -->
       <ExcludeAssets>contentFiles</ExcludeAssets>
     </PackageReference>

--- a/templates/bot/csharp/notification-function-base/Properties/launchSettings.json.tpl
+++ b/templates/bot/csharp/notification-function-base/Properties/launchSettings.json.tpl
@@ -10,15 +10,17 @@
         "ASPNETCORE_ENVIRONMENT": "Development",
         "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "../../.." // Path to project folder $(MSBuildProjectDirectory)
       }
-    },
-    "{{ProjectName}}": {
-      "commandName": "Project",
-      "commandLineArgs": "host start --port 5130 --pause-on-error",
-      "dotnetRunMessages": "true",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "../../.." // Path to project folder $(MSBuildProjectDirectory)
-      }
     }
+    //// Uncomment following profile to debug project only (without launching Teams)
+    //,
+    //"{{ProjectName}}": {
+    //  "commandName": "Project",
+    //  "commandLineArgs": "host start --port 5130 --pause-on-error",
+    //  "dotnetRunMessages": "true",
+    //  "environmentVariables": {
+    //    "ASPNETCORE_ENVIRONMENT": "Development",
+    //    "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "../../.." // Path to project folder $(MSBuildProjectDirectory)
+    //  }
+    //}
   }
 }

--- a/templates/bot/csharp/notification-webapi/GettingStarted.txt
+++ b/templates/bot/csharp/notification-webapi/GettingStarted.txt
@@ -20,7 +20,7 @@ Notes: your M365 account need to have the sideloading permission to ensure Teams
 
 4. Once Microsoft Teams is loaded, select the "Add" button to install your app in Teams.
 
-5. Post HTTP request to http://localhost:5130/api/notification to trigger notification. You can use any API tool: curl, Postman, etc.
+5. Post HTTP request to http://localhost:5130/api/notification to trigger notification. You can use any API tool: curl (Windows Command Prompt), Postman, etc.
 
 Tips: if you made changes to Teams app manifest file (/templates/appPackage/manifest.template.json), please make sure you run the "Prepare Teams app dependencies" command before you try to locally run the Teams app again.
 

--- a/templates/bot/csharp/notification-webapi/Properties/launchSettings.json.tpl
+++ b/templates/bot/csharp/notification-webapi/Properties/launchSettings.json.tpl
@@ -10,15 +10,17 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
       "hotReloadProfile": "aspnetcore"
-    },
-    "{{ProjectName}}": {
-      "commandName": "Project",
-      "dotnetRunMessages": "true",
-      "applicationUrl": "https://localhost:7130;http://localhost:5130",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "hotReloadProfile": "aspnetcore"
     }
+    //// Uncomment following profile to debug project only (without launching Teams)
+    //,
+    //"{{ProjectName}}": {
+    //  "commandName": "Project",
+    //  "dotnetRunMessages": "true",
+    //  "applicationUrl": "https://localhost:7130;http://localhost:5130",
+    //  "environmentVariables": {
+    //    "ASPNETCORE_ENVIRONMENT": "Development"
+    //  },
+    //  "hotReloadProfile": "aspnetcore"
+    //}
   }
 }


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14563789/
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14705024/

- Comment out project-only launch profile to avoid f5 confusing
- Add *Windows Command Prompt* hint for `curl` to avoid host confusing
- Adjust func-hosted sdk version

**NO** Template Breaking Change.