### PR TITLE
fix(vsc): register azure account signin as internal command

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -439,11 +439,6 @@
         "category": "Teams"
       },
       {
-        "command": "fx-extension.cmpAccounts",
-        "title": "%teamstoolkit.commands.accounts.title%",
-        "category": "Teams"
-      },
-      {
         "command": "fx-extension.getNewProjectPath",
         "title": "Teams - Get Path",
         "enablement": "never"
@@ -512,6 +507,12 @@
         "title": "%teamstoolkit.commands.upgradeProject.title%",
         "enablement": "fx-extension.initialized",
         "category": "Teams"
+      },
+      {
+        "command": "fx-extension.cmpAccounts",
+        "title": "%teamstoolkit.commands.accounts.title%",
+        "category": "Teams",
+        "enablement": "fx-extension.initialized"
       },
       {
         "command": "fx-extension.deploy",

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -275,6 +275,11 @@ function registerInternalCommands(context: vscode.ExtensionContext) {
     () => Correlator.runWithId(startLocalDebugSession(), handlers.validateSpfxDependenciesHandler)
   );
   context.subscriptions.push(validateSpfxDependenciesCmd);
+
+  const signinAzure = vscode.commands.registerCommand("fx-extension.signinAzure", (...args) =>
+    Correlator.run(handlers.signinAzureCallback, args)
+  );
+  context.subscriptions.push(signinAzure);
 }
 
 function registerTreeViewCommandsInDevelopment(context: vscode.ExtensionContext) {
@@ -436,11 +441,6 @@ function registerTeamsFxCommands(context: vscode.ExtensionContext) {
     (...args) => Correlator.run(handlers.checkSideloadingCallback, args)
   );
   context.subscriptions.push(checkSideloading);
-
-  const signinAzure = vscode.commands.registerCommand("fx-extension.signinAzure", (...args) =>
-    Correlator.run(handlers.signinAzureCallback, args)
-  );
-  context.subscriptions.push(signinAzure);
 }
 
 /**


### PR DESCRIPTION
Non-teamsfx project can also manage accounts.

Related bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14714911

E2E TEST: N/A