### PR TITLE
fix(e2e): add missing import for bot e2e test

### DIFF
--- a/packages/cli/tests/e2e/bot/ProvisionCommandAndResponseBot.tests.ts
+++ b/packages/cli/tests/e2e/bot/ProvisionCommandAndResponseBot.tests.ts
@@ -5,6 +5,7 @@
  * @author Xiaofu Huang <xiaofhua@microsoft.com>
  */
 
+import { Runtime } from "../../commonlib/constants";
 import { happyPathTest } from "./CommandBotHappyPathCommon";
 
 happyPathTest(Runtime.Node);


### PR DESCRIPTION
E2E TEST: https://github.com/OfficeDev/TeamsFx/blob/187b185cd60cb481f1f4697a92be6355f2a94c53/packages/cli/tests/e2e/bot/ProvisionCommandAndResponseBot.tests.ts#L10