### PR TITLE
chore: send debug-all/debug-all-start

### DIFF
--- a/packages/fx-core/src/common/local/localTelemetryReporter.ts
+++ b/packages/fx-core/src/common/local/localTelemetryReporter.ts
@@ -62,6 +62,19 @@ export class LocalTelemetryReporter {
     return await this.runWithTelemetryGeneric(eventName, action, () => undefined);
   }
 
+  public async runWithTelemetryExceptionProperties<T>(
+    eventName: string,
+    initialProperties: { [key: string]: string },
+    action: (ctx: TelemetryContext) => Promise<T>
+  ): Promise<T> {
+    return await this.runWithTelemetryGeneric(
+      eventName,
+      action,
+      () => undefined,
+      initialProperties
+    );
+  }
+
   /**
    * Ensure "{eventName}-start" and "{eventName}" telemetry events with the following properties/measurements to be sent on start/end/exception.
    *

--- a/packages/vscode-extension/src/debug/localTelemetryReporter.ts
+++ b/packages/vscode-extension/src/debug/localTelemetryReporter.ts
@@ -1,10 +1,69 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { FxError } from "@microsoft/teamsfx-api";
 import { LocalTelemetryReporter } from "@microsoft/teamsfx-core";
+import { performance } from "perf_hooks";
 import { ExtTelemetry } from "../telemetry/extTelemetry";
+import {
+  TelemetryEvent,
+  TelemetryProperty,
+  TelemetrySuccess,
+} from "../telemetry/extTelemetryEvents";
+import { getLocalDebugSession, getProjectComponents } from "./commonUtils";
 
 export const localTelemetryReporter = new LocalTelemetryReporter({
-  sendTelemetryEvent: ExtTelemetry.sendTelemetryEvent,
-  sendTelemetryErrorEvent: ExtTelemetry.sendTelemetryErrorEvent,
+  // Cannot directly refer to a global function because of import dependency cycle in ../telemetry/extTelemetry.ts.
+  sendTelemetryEvent: (
+    eventName: string,
+    properties?: { [p: string]: string },
+    measurements?: { [p: string]: number }
+  ) => ExtTelemetry.sendTelemetryEvent(eventName, properties, measurements),
+
+  sendTelemetryErrorEvent: (
+    eventName: string,
+    error: FxError,
+    properties?: { [p: string]: string },
+    measurements?: { [p: string]: number },
+    errorProps?: string[]
+  ) => ExtTelemetry.sendTelemetryErrorEvent(eventName, error, properties, measurements, errorProps),
 });
+
+export async function sendDebugAllStartEvent(): Promise<void> {
+  const session = getLocalDebugSession();
+  const components = await getProjectComponents();
+  session.properties[TelemetryProperty.DebugProjectComponents] = components + "";
+
+  const properties = Object.assign(
+    { [TelemetryProperty.CorrelationId]: session.id },
+    session.properties
+  );
+  localTelemetryReporter.sendTelemetryEvent(TelemetryEvent.DebugAllStart, properties);
+}
+
+export async function sendDebugAllEvent(error?: FxError): Promise<void> {
+  const session = getLocalDebugSession();
+  const now = performance.now();
+
+  let duration = -1;
+  if (session.startTime !== undefined) {
+    duration = (now - session.startTime) / 1000;
+  }
+
+  const properties = Object.assign(
+    {
+      [TelemetryProperty.CorrelationId]: session.id,
+      [TelemetryProperty.Success]: error === undefined ? TelemetrySuccess.Yes : TelemetrySuccess.No,
+    },
+    session.properties
+  );
+  if (error === undefined) {
+    localTelemetryReporter.sendTelemetryEvent(TelemetryEvent.DebugAll, properties, {
+      [LocalTelemetryReporter.PropertyDuration]: duration,
+    });
+  } else {
+    localTelemetryReporter.sendTelemetryErrorEvent(TelemetryEvent.DebugAll, error, properties, {
+      [LocalTelemetryReporter.PropertyDuration]: duration,
+    });
+  }
+}

--- a/packages/vscode-extension/src/debug/teamsfxDebugProvider.ts
+++ b/packages/vscode-extension/src/debug/teamsfxDebugProvider.ts
@@ -10,6 +10,8 @@ import * as commonUtils from "./commonUtils";
 import { showError } from "../handlers";
 import { terminateAllRunningTeamsfxTasks } from "./teamsfxTaskHandler";
 import { Host, Hub } from "./constants";
+import { localTelemetryReporter, sendDebugAllEvent } from "./localTelemetryReporter";
+import { TelemetryEvent, TelemetryProperty } from "../telemetry/extTelemetryEvents";
 
 export interface TeamsfxDebugConfiguration extends vscode.DebugConfiguration {
   teamsfxIsRemote?: boolean;
@@ -40,98 +42,106 @@ export class TeamsfxDebugProvider implements vscode.DebugConfigurationProvider {
     token?: vscode.CancellationToken
   ): Promise<vscode.DebugConfiguration | undefined> {
     try {
-      if (folder) {
-        if (!(await commonUtils.isFxProject(folder.uri.fsPath))) {
-          return debugConfiguration;
-        }
-
-        // Attach correlation-id to DebugConfiguration so concurrent debug sessions are correctly handled in this stage.
-        // For backend and bot debug sessions, debugConfiguration.url is undefined so we need to set correlation id early.
-        debugConfiguration.teamsfxCorrelationId = commonUtils.getLocalDebugSessionId();
-
-        if (debugConfiguration.url === undefined) {
-          return debugConfiguration;
-        }
-        let url: string = debugConfiguration.url as string;
-
-        const localTeamsAppIdPlaceholder = "${localTeamsAppId}";
-        const isLocalSideloadingConfiguration: boolean = url.includes(localTeamsAppIdPlaceholder);
-        const teamsAppIdPlaceholder = "${teamsAppId}";
-        const isSideloadingConfiguration: boolean = url.includes(teamsAppIdPlaceholder);
-        const localTeamsAppInternalIdPlaceholder = "${localTeamsAppInternalId}";
-        // NOTE: 1. there is no app id in M365 messaging extension launch url
-        //       2. there are no launch remote configurations for M365 app
-        const host = new URL(url).host;
-        const isLocalM365SideloadingConfiguration: boolean =
-          url.includes(localTeamsAppInternalIdPlaceholder) ||
-          host === Host.outlook ||
-          host === Host.office;
-        const isLocalSideloading: boolean =
-          isLocalSideloadingConfiguration || isLocalM365SideloadingConfiguration;
-
-        if (
-          !isLocalSideloadingConfiguration &&
-          !isSideloadingConfiguration &&
-          !isLocalM365SideloadingConfiguration
-        ) {
-          return debugConfiguration;
-        }
-
-        if (debugConfiguration.timeout === undefined) {
-          debugConfiguration.timeout = 20000;
-        }
-
-        let debugConfig = undefined;
-        if (isLocalSideloading && isConfigUnifyEnabled()) {
-          debugConfig = await commonUtils.getDebugConfig(
-            false,
-            environmentManager.getLocalEnvName()
-          );
-        } else {
-          debugConfig = await commonUtils.getDebugConfig(isLocalSideloading);
-        }
-        if (!debugConfig) {
-          // The user cancels env selection.
-          // Returning the value 'undefined' prevents the debug session from starting.
-          return undefined;
-        }
-
-        // Put env and appId in `debugConfiguration` so debug handlers can retrieve it and send telemetry
-        debugConfiguration.teamsfxIsRemote = isSideloadingConfiguration;
-        debugConfiguration.teamsfxEnv = debugConfig.env;
-        debugConfiguration.teamsfxAppId = debugConfig.appId;
-        if (host === Host.teams) {
-          debugConfiguration.teamsfxHub = Hub.teams;
-        } else if (host === Host.outlook) {
-          debugConfiguration.teamsfxHub = Hub.outlook;
-        } else if (host === Host.office) {
-          debugConfiguration.teamsfxHub = Hub.office;
-        }
-
-        url = url.replace(localTeamsAppIdPlaceholder, debugConfig.appId);
-        url = url.replace(teamsAppIdPlaceholder, debugConfig.appId);
-        if (isLocalM365SideloadingConfiguration) {
-          const internalId = await getTeamsAppInternalId(debugConfig.appId);
-          if (internalId !== undefined) {
-            url = url.replace(localTeamsAppInternalIdPlaceholder, internalId);
-          }
-        }
-
-        const accountHintPlaceholder = "${account-hint}";
-        const isaccountHintConfiguration: boolean = url.includes(accountHintPlaceholder);
-        if (isaccountHintConfiguration) {
-          const accountHint = await generateAccountHint(
-            isLocalSideloadingConfiguration || isSideloadingConfiguration
-          );
-          url = url.replace(accountHintPlaceholder, accountHint);
-        }
-
-        debugConfiguration.url = url;
+      if (!folder) {
+        return debugConfiguration;
       }
+      if (!(await commonUtils.isFxProject(folder.uri.fsPath))) {
+        return debugConfiguration;
+      }
+
+      // Attach correlation-id to DebugConfiguration so concurrent debug sessions are correctly handled in this stage.
+      // For backend and bot debug sessions, debugConfiguration.url is undefined so we need to set correlation id early.
+      debugConfiguration.teamsfxCorrelationId = commonUtils.getLocalDebugSessionId();
+
+      if (debugConfiguration.url === undefined) {
+        return debugConfiguration;
+      }
+      let url: string = debugConfiguration.url as string;
+
+      const localTeamsAppIdPlaceholder = "${localTeamsAppId}";
+      const isLocalSideloadingConfiguration: boolean = url.includes(localTeamsAppIdPlaceholder);
+      const teamsAppIdPlaceholder = "${teamsAppId}";
+      const isSideloadingConfiguration: boolean = url.includes(teamsAppIdPlaceholder);
+      const localTeamsAppInternalIdPlaceholder = "${localTeamsAppInternalId}";
+      // NOTE: 1. there is no app id in M365 messaging extension launch url
+      //       2. there are no launch remote configurations for M365 app
+      const host = new URL(url).host;
+      const isLocalM365SideloadingConfiguration: boolean =
+        url.includes(localTeamsAppInternalIdPlaceholder) ||
+        host === Host.outlook ||
+        host === Host.office;
+      const isLocalSideloading: boolean =
+        isLocalSideloadingConfiguration || isLocalM365SideloadingConfiguration;
+
+      if (
+        !isLocalSideloadingConfiguration &&
+        !isSideloadingConfiguration &&
+        !isLocalM365SideloadingConfiguration
+      ) {
+        return debugConfiguration;
+      }
+
+      await localTelemetryReporter.runWithTelemetryExceptionProperties(
+        TelemetryEvent.DebugProviderResolveDebugConfiguration,
+        { [TelemetryProperty.DebugRemote]: (!isSideloadingConfiguration).toString() },
+        async () => {
+          if (debugConfiguration.timeout === undefined) {
+            debugConfiguration.timeout = 20000;
+          }
+
+          let debugConfig = undefined;
+          if (isLocalSideloading && isConfigUnifyEnabled()) {
+            debugConfig = await commonUtils.getDebugConfig(
+              false,
+              environmentManager.getLocalEnvName()
+            );
+          } else {
+            debugConfig = await commonUtils.getDebugConfig(isLocalSideloading);
+          }
+          if (!debugConfig) {
+            // The user cancels env selection.
+            // Returning the value 'undefined' prevents the debug session from starting.
+            return undefined;
+          }
+
+          // Put env and appId in `debugConfiguration` so debug handlers can retrieve it and send telemetry
+          debugConfiguration.teamsfxIsRemote = isSideloadingConfiguration;
+          debugConfiguration.teamsfxEnv = debugConfig.env;
+          debugConfiguration.teamsfxAppId = debugConfig.appId;
+          if (host === Host.teams) {
+            debugConfiguration.teamsfxHub = Hub.teams;
+          } else if (host === Host.outlook) {
+            debugConfiguration.teamsfxHub = Hub.outlook;
+          } else if (host === Host.office) {
+            debugConfiguration.teamsfxHub = Hub.office;
+          }
+
+          url = url.replace(localTeamsAppIdPlaceholder, debugConfig.appId);
+          url = url.replace(teamsAppIdPlaceholder, debugConfig.appId);
+          if (isLocalM365SideloadingConfiguration) {
+            const internalId = await getTeamsAppInternalId(debugConfig.appId);
+            if (internalId !== undefined) {
+              url = url.replace(localTeamsAppInternalIdPlaceholder, internalId);
+            }
+          }
+
+          const accountHintPlaceholder = "${account-hint}";
+          const isaccountHintConfiguration: boolean = url.includes(accountHintPlaceholder);
+          if (isaccountHintConfiguration) {
+            const accountHint = await generateAccountHint(
+              isLocalSideloadingConfiguration || isSideloadingConfiguration
+            );
+            url = url.replace(accountHintPlaceholder, accountHint);
+          }
+
+          debugConfiguration.url = url;
+        }
+      );
     } catch (error: any) {
       showError(error);
       terminateAllRunningTeamsfxTasks();
       await vscode.debug.stopDebugging();
+      await sendDebugAllEvent(error);
       commonUtils.endLocalDebugSession();
     }
     return debugConfiguration;

--- a/packages/vscode-extension/src/debug/teamsfxTaskHandler.ts
+++ b/packages/vscode-extension/src/debug/teamsfxTaskHandler.ts
@@ -25,6 +25,7 @@ import { TreatmentVariableValue } from "../exp/treatmentVariables";
 import { TeamsfxDebugConfiguration } from "./teamsfxDebugProvider";
 import { localize } from "../utils/localizeUtils";
 import { VS_CODE_UI } from "../extension";
+import { sendDebugAllEvent } from "./localTelemetryReporter";
 
 export const allRunningTeamsfxTasks: Map<string, number> = new Map<string, number>();
 export const allRunningDebugSessions: Set<string> = new Set<string>();
@@ -399,6 +400,10 @@ async function onDidStartDebugSessionHandler(event: vscode.DebugSession): Promis
         [TelemetryProperty.DebugAppId]: debugConfig.teamsfxAppId + "",
         [TelemetryProperty.Env]: env,
       });
+      // This is the launch browser local debug session.
+      if (debugConfig.request === "launch" && !debugConfig.teamsfxIsRemote) {
+        await sendDebugAllEvent();
+      }
     }
   }
 }

--- a/packages/vscode-extension/src/debug/teamsfxTaskProvider.ts
+++ b/packages/vscode-extension/src/debug/teamsfxTaskProvider.ts
@@ -14,6 +14,8 @@ import {
   Result,
   v2,
   VsCodeEnv,
+  err,
+  assembleError,
 } from "@microsoft/teamsfx-api";
 import {
   Correlator,
@@ -34,115 +36,122 @@ import {
   TaskDefinition,
 } from "@microsoft/teamsfx-core";
 import { vscodeHelper } from "./depsChecker/vscodeHelper";
-import { localTelemetryReporter, sendDebugAllEvent } from "./localTelemetryReporter";
+import { localTelemetryReporter } from "./localTelemetryReporter";
 import { TelemetryEvent } from "../telemetry/extTelemetryEvents";
 
 export class TeamsfxTaskProvider implements vscode.TaskProvider {
   public static readonly type: string = ProductName;
 
   public provideTasks(token?: vscode.CancellationToken | undefined): Promise<vscode.Task[]> {
-    return Correlator.runWithId(commonUtils.getLocalDebugSessionId(), () =>
-      this._provideTasks(token)
+    return Correlator.runWithId(
+      commonUtils.getLocalDebugSessionId(),
+      async (): Promise<vscode.Task[]> => {
+        const tasks: vscode.Task[] = [];
+        if (commonUtils.getLocalDebugSessionId() === commonUtils.DebugNoSessionId) {
+          await this._provideTasks(tasks, token);
+        } else {
+          // Only send telemetry within a local debug session.
+          await localTelemetryReporter.runWithTelemetry(TelemetryEvent.DebugTaskProvider, () =>
+            this._provideTasks(tasks, token)
+          );
+
+          // Currently do not send end event if task provider failed.
+          // The reason:
+          // If task provider fails (only for ngrok task),
+          // vscode will continue to run "prepare local environment" task (after a long timeout).
+          // "prepare local environment" will fail when checking ngrok.
+          // The "debug-all" event will be sent in "pre-debug-check" command.
+        }
+        return tasks;
+      }
     );
   }
 
   private async _provideTasks(
+    tasks: vscode.Task[],
     token?: vscode.CancellationToken | undefined
-  ): Promise<vscode.Task[]> {
-    const tasks: vscode.Task[] = [];
+  ): Promise<Result<void, FxError>> {
     if (vscode.workspace.workspaceFolders) {
       const workspaceFolder: vscode.WorkspaceFolder = vscode.workspace.workspaceFolders[0];
       const workspacePath: string = workspaceFolder.uri.fsPath;
       if (!(await commonUtils.isFxProject(workspacePath))) {
-        return tasks;
+        return ok(undefined);
       }
 
-      const result = await localTelemetryReporter.runWithTelemetry(
-        TelemetryEvent.DebugTaskProvider,
-        async (): Promise<Result<void, FxError>> => {
-          const localEnvManager = new LocalEnvManager(VsCodeLogInstance, ExtTelemetry.reporter);
-          let projectSettings: ProjectSettings;
-          let localSettings: Json | undefined;
-          let localEnvInfo: v2.EnvInfoV2 | undefined;
-          let localEnv: { [key: string]: string } | undefined;
+      const localEnvManager = new LocalEnvManager(VsCodeLogInstance, ExtTelemetry.reporter);
+      let projectSettings: ProjectSettings;
+      let localSettings: Json | undefined;
+      let localEnvInfo: v2.EnvInfoV2 | undefined;
+      let localEnv: { [key: string]: string } | undefined;
 
-          try {
-            projectSettings = await localEnvManager.getProjectSettings(workspacePath);
-            localSettings = await localEnvManager.getLocalSettings(workspacePath, {
-              projectId: projectSettings.projectId,
-            });
-            if (isConfigUnifyEnabled()) {
-              localEnvInfo = await localEnvManager.getLocalEnvInfo(workspacePath, {
-                projectId: projectSettings.projectId,
-              });
-            }
-            localEnv = await localEnvManager.getLocalDebugEnvs(
-              workspacePath,
-              projectSettings,
-              localSettings,
-              localEnvInfo
-            );
-          } catch (error: any) {
-            showError(error);
-            return error;
-          }
-
-          const programmingLanguage = projectSettings?.programmingLanguage;
-
-          // Always provide the following tasks no matter whether it is defined in tasks.json
-          const frontendRoot = await commonUtils.getProjectRoot(workspacePath, FolderName.Frontend);
-          if (frontendRoot) {
-            tasks.push(await this.createFrontendStartTask(workspaceFolder, localEnv));
-          }
-
-          const backendRoot = await commonUtils.getProjectRoot(workspacePath, FolderName.Function);
-          if (backendRoot) {
-            tasks.push(
-              await this.createBackendStartTask(workspaceFolder, programmingLanguage, localEnv)
-            );
-            if (programmingLanguage === ProgrammingLanguage.typescript) {
-              tasks.push(await this.createBackendWatchTask(workspaceFolder));
-            }
-          }
-
-          const authRoot = commonUtils.getAuthServicePath(localEnv);
-          if (authRoot) {
-            tasks.push(await this.createAuthStartTask(workspaceFolder, authRoot, localEnv));
-          }
-
-          const botRoot = await commonUtils.getProjectRoot(workspacePath, FolderName.Bot);
-          if (botRoot) {
-            const skipNgrok = !vscodeHelper.isNgrokCheckerEnabled();
-            tasks.push(await this.createNgrokStartTask(workspaceFolder, botRoot, skipNgrok));
-            const silent: boolean = frontendRoot !== undefined;
-            tasks.push(
-              await this.createBotStartTask(workspaceFolder, programmingLanguage, localEnv, silent)
-            );
-          }
-
-          const vscodeEnv = detectVsCodeEnv();
-          const isCodeSpaceEnv =
-            vscodeEnv === VsCodeEnv.codespaceBrowser || vscodeEnv === VsCodeEnv.codespaceVsCode;
-          if (isCodeSpaceEnv) {
-            const localTeamsAppId = localSettings?.teamsApp?.teamsAppId as string;
-            const debugConfig = { appId: localTeamsAppId };
-            tasks.push(await this.createOpenTeamsWebClientTask(workspaceFolder, debugConfig));
-          }
-
-          return ok(undefined);
+      try {
+        projectSettings = await localEnvManager.getProjectSettings(workspacePath);
+        localSettings = await localEnvManager.getLocalSettings(workspacePath, {
+          projectId: projectSettings.projectId,
+        });
+        if (isConfigUnifyEnabled()) {
+          localEnvInfo = await localEnvManager.getLocalEnvInfo(workspacePath, {
+            projectId: projectSettings.projectId,
+          });
         }
-      );
+        localEnv = await localEnvManager.getLocalDebugEnvs(
+          workspacePath,
+          projectSettings,
+          localSettings,
+          localEnvInfo
+        );
+      } catch (error: unknown) {
+        const fxError = assembleError(error);
+        showError(fxError);
+        return err(fxError);
+      }
 
-      if (result.isErr()) {
-        // In case user manually run the task
-        if (commonUtils.getLocalDebugSessionId() !== commonUtils.DebugNoSessionId) {
-          await sendDebugAllEvent(result.error);
-          commonUtils.endLocalDebugSession();
+      const programmingLanguage = projectSettings?.programmingLanguage;
+
+      // Always provide the following tasks no matter whether it is defined in tasks.json
+      const frontendRoot = await commonUtils.getProjectRoot(workspacePath, FolderName.Frontend);
+      if (frontendRoot) {
+        tasks.push(await this.createFrontendStartTask(workspaceFolder, localEnv));
+      }
+
+      const backendRoot = await commonUtils.getProjectRoot(workspacePath, FolderName.Function);
+      if (backendRoot) {
+        tasks.push(
+          await this.createBackendStartTask(workspaceFolder, programmingLanguage, localEnv)
+        );
+        if (programmingLanguage === ProgrammingLanguage.typescript) {
+          tasks.push(await this.createBackendWatchTask(workspaceFolder));
         }
       }
+
+      const authRoot = commonUtils.getAuthServicePath(localEnv);
+      if (authRoot) {
+        tasks.push(await this.createAuthStartTask(workspaceFolder, authRoot, localEnv));
+      }
+
+      const botRoot = await commonUtils.getProjectRoot(workspacePath, FolderName.Bot);
+      if (botRoot) {
+        const skipNgrok = !vscodeHelper.isNgrokCheckerEnabled();
+        tasks.push(await this.createNgrokStartTask(workspaceFolder, botRoot, skipNgrok));
+        const silent: boolean = frontendRoot !== undefined;
+        tasks.push(
+          await this.createBotStartTask(workspaceFolder, programmingLanguage, localEnv, silent)
+        );
+      }
+
+      const vscodeEnv = detectVsCodeEnv();
+      const isCodeSpaceEnv =
+        vscodeEnv === VsCodeEnv.codespaceBrowser || vscodeEnv === VsCodeEnv.codespaceVsCode;
+      if (isCodeSpaceEnv) {
+        const localTeamsAppId = localSettings?.teamsApp?.teamsAppId as string;
+        const debugConfig = { appId: localTeamsAppId };
+        tasks.push(await this.createOpenTeamsWebClientTask(workspaceFolder, debugConfig));
+      }
+
+      return ok(undefined);
     }
 
-    return tasks;
+    return ok(undefined);
   }
 
   public async resolveTask(

--- a/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
@@ -117,6 +117,11 @@ export enum TelemetryEvent {
   DebugPrereqsCheckDependencies = "debug-prereqs-check-dependencies",
   DebugPrereqsEnsureDependencies = "debug-prereqs-ensure-dependencies",
   DebugPrereqsInstallPackages = "debug-prereqs-install-packages",
+  DebugPreCheckCoreLocalDebug = "debug-precheck-core-local-debug",
+  DebugTaskProvider = "debug-task-provider",
+  DebugProviderResolveDebugConfiguration = "debug-provider-resolve-debug-configuration",
+  DebugAllStart = "debug-all-start",
+  DebugAll = "debug-all",
 
   AutomaticNpmInstallStart = "automatic-npm-install-start",
   AutomaticNpmInstall = "automatic-npm-install",


### PR DESCRIPTION
- add debug-all/debug-all-start events
- wrap debug provider/task provider/pre-debug check with telemetry events

A success example:
![image](https://user-images.githubusercontent.com/9698542/173792569-a9fa0fda-b656-45ca-9cf7-3272ba645b66.png)

An error example:
![image](https://user-images.githubusercontent.com/9698542/173774993-fe5742b2-f749-4b13-ab53-abe78b1c38b1.png)
In this error case: debug-all will have error code
![image](https://user-images.githubusercontent.com/9698542/173775402-1e517dd5-c9d8-4cd8-8969-c3c100ac60b0.png)
