### PR TITLE
fix: stop local debug if service failed before browser

### DIFF
--- a/packages/vscode-extension/src/debug/commonUtils.ts
+++ b/packages/vscode-extension/src/debug/commonUtils.ts
@@ -374,14 +374,15 @@ export interface LocalDebugSession {
   id: string;
   startTime?: number;
   properties: { [key: string]: string };
+  failedServices: { name: string; exitCode: number | undefined }[];
 }
 
 export const DebugNoSessionId = "no-session-id";
 // Helper functions for local debug correlation-id, only used for telemetry
 // Use a 2-element tuple to handle concurrent F5
 const localDebugCorrelationIds: [LocalDebugSession, LocalDebugSession] = [
-  { id: DebugNoSessionId, properties: {} },
-  { id: DebugNoSessionId, properties: {} },
+  { id: DebugNoSessionId, properties: {}, failedServices: [] },
+  { id: DebugNoSessionId, properties: {}, failedServices: [] },
 ];
 let current = 0;
 export function startLocalDebugSession(): string {
@@ -390,12 +391,13 @@ export function startLocalDebugSession(): string {
     id: uuid.v4(),
     startTime: performance.now(),
     properties: {},
+    failedServices: [],
   };
   return getLocalDebugSessionId();
 }
 
 export function endLocalDebugSession() {
-  localDebugCorrelationIds[current] = { id: DebugNoSessionId, properties: {} };
+  localDebugCorrelationIds[current] = { id: DebugNoSessionId, properties: {}, failedServices: [] };
   current = (current + 1) % 2;
 }
 

--- a/packages/vscode-extension/src/debug/localTelemetryReporter.ts
+++ b/packages/vscode-extension/src/debug/localTelemetryReporter.ts
@@ -41,7 +41,10 @@ export async function sendDebugAllStartEvent(): Promise<void> {
   localTelemetryReporter.sendTelemetryEvent(TelemetryEvent.DebugAllStart, properties);
 }
 
-export async function sendDebugAllEvent(error?: FxError): Promise<void> {
+export async function sendDebugAllEvent(
+  error?: FxError,
+  additionalProperties?: { [key: string]: string }
+): Promise<void> {
   const session = getLocalDebugSession();
   const now = performance.now();
 
@@ -50,13 +53,13 @@ export async function sendDebugAllEvent(error?: FxError): Promise<void> {
     duration = (now - session.startTime) / 1000;
   }
 
-  const properties = Object.assign(
-    {
-      [TelemetryProperty.CorrelationId]: session.id,
-      [TelemetryProperty.Success]: error === undefined ? TelemetrySuccess.Yes : TelemetrySuccess.No,
-    },
-    session.properties
-  );
+  const properties = {
+    [TelemetryProperty.CorrelationId]: session.id,
+    [TelemetryProperty.Success]: error === undefined ? TelemetrySuccess.Yes : TelemetrySuccess.No,
+    ...session.properties,
+    ...additionalProperties,
+  };
+
   if (error === undefined) {
     localTelemetryReporter.sendTelemetryEvent(TelemetryEvent.DebugAll, properties, {
       [LocalTelemetryReporter.PropertyDuration]: duration,

--- a/packages/vscode-extension/src/error.ts
+++ b/packages/vscode-extension/src/error.ts
@@ -13,6 +13,7 @@ export enum ExtensionErrors {
   UnknownSubscription = "UnknownSubscription",
   PortAlreadyInUse = "PortAlreadyInUse",
   PrerequisitesValidationError = "PrerequisitesValidationError",
+  DebugServiceFailedBeforeStartError = "DebugServiceFailedBeforeStartError",
   OpenExternalFailed = "OpenExternalFailed",
   FolderAlreadyExist = "FolderAlreadyExist",
   InvalidProject = "InvalidProject",

--- a/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
@@ -222,6 +222,7 @@ export enum TelemetryProperty {
   DebugServiceName = "debug-service-name",
   DebugServiceExitCode = "debug-service-exit-code",
   DebugPrereqsDepsType = "debug-prereqs-deps-type",
+  DebugFailedServices = "debug-failed-services",
   Internal = "internal",
   InternalAlias = "internal-alias",
   OSArch = "os-arch",


### PR DESCRIPTION
- If some service fails before browser launching, local debug can stop now. And send 'debug-all' events.

For example, the 'Start Frontend' task fails, the debug session will stop.
[](https://user-images.githubusercontent.com/9698542/173991629-969dd34c-649f-454e-b3be-28496d532b40.png)

![image](https://user-images.githubusercontent.com/9698542/173991984-cc333e9d-b1a7-4068-a033-c9864f5db748.png)

E2E TEST: https://github.com/OfficeDev/TeamsFx-UI-Test/blob/main/src/ui-test/localdebug/localdebug-tab.test.ts