### PR TITLE
fix(vsc): refresh subscription node when it's empty

### DIFF
--- a/packages/vscode-extension/src/treeview/account/subscriptionNode.ts
+++ b/packages/vscode-extension/src/treeview/account/subscriptionNode.ts
@@ -50,10 +50,12 @@ export class SubscriptionNode extends DynamicNode {
   }
 
   public setEmptySubscription() {
+    this.subscription = undefined;
     const validProject = isValidProject(workspaceUri?.fsPath);
     this.contextValue = validProject ? "emptySubscription" : "invalidFxProject";
     this.label = localize("teamstoolkit.accountTree.noSubscriptions");
     this.tooltip = localize("teamstoolkit.accountTree.noSubscriptionsTooltip");
     this.iconPath = warningIcon;
+    this.eventEmitter.fire(this);
   }
 }


### PR DESCRIPTION
Related bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14739456
E2E TEST: N/A