### PR TITLE
fix: prereqs check account error code

### DIFF
--- a/packages/vscode-extension/src/error.ts
+++ b/packages/vscode-extension/src/error.ts
@@ -13,6 +13,8 @@ export enum ExtensionErrors {
   UnknownSubscription = "UnknownSubscription",
   PortAlreadyInUse = "PortAlreadyInUse",
   PrerequisitesValidationError = "PrerequisitesValidationError",
+  PrerequisitesNoM365AccountError = "PrerequisitesNoM365AccountError",
+  PrerequisitesSideloadingDisabledError = "PrerequisitesSideloadingDisabledError",
   DebugServiceFailedBeforeStartError = "DebugServiceFailedBeforeStartError",
   DebugNpmInstallError = "DebugNpmInstallError",
   OpenExternalFailed = "OpenExternalFailed",


### PR DESCRIPTION
Fix bugs
- All prereqs check account errors (like UserCancel) are sent as `PrerequsiteValidationError`. This PR makes these different errors distinguishable from telemetry.
- UserCancel was previously wrapped as SystemError `No M365 account login`. But it is not system error

test:
<img width="708" alt="image" src="https://user-images.githubusercontent.com/9698542/174524998-5475cbb4-a0d4-481f-bf01-b91157641e59.png">


E2E TEST: https://github.com/OfficeDev/TeamsFx-UI-Test/blob/main/src/ui-test/localdebug/localdebug-bot.test.ts