### PR TITLE
chore: use createApiClient to call function API

### DIFF
--- a/templates/tab/js/default/src/components/sample/AzureFunctions.jsx
+++ b/templates/tab/js/default/src/components/sample/AzureFunctions.jsx
@@ -1,7 +1,7 @@
 import { useContext } from "react";
 import { Button, Loader } from "@fluentui/react-northstar";
 import { useData } from "@microsoft/teamsfx-react";
-import * as axios from "axios";
+import { BearerTokenAuthProvider, createApiClient } from "@microsoft/teamsfx"
 import { TeamsFxContext } from "../Context";
 
 const functionName = process.env.REACT_APP_FUNC_NAME || "myFunc";
@@ -11,13 +11,12 @@ async function callFunction(teamsfx) {
     throw new Error("TeamsFx SDK is not initialized.");
   }
   try {
-    const accessToken = await teamsfx.getCredential().getToken("");
-    const endpoint = teamsfx.getConfig("apiEndpoint");
-    const response = await axios.default.get(endpoint + "/api/" + functionName, {
-      headers: {
-        authorization: "Bearer " + accessToken.token,
-      },
-    });
+    const credential = teamsfx.getCredential();
+    const apiBaseUrl = teamsfx.getConfig("apiEndpoint") + "/api/";
+    const apiClient = createApiClient(
+      apiBaseUrl,
+      new BearerTokenAuthProvider(async () => (await credential.getToken("")).token));
+    const response = await apiClient.get(functionName);
     return response.data;
   } catch (err) {
     let funcErrorMsg = "";

--- a/templates/tab/js/default/src/components/sample/AzureFunctions.jsx
+++ b/templates/tab/js/default/src/components/sample/AzureFunctions.jsx
@@ -13,6 +13,7 @@ async function callFunction(teamsfx) {
   try {
     const credential = teamsfx.getCredential();
     const apiBaseUrl = teamsfx.getConfig("apiEndpoint") + "/api/";
+    // createApiClient(...) creates an Axios instance which uses BearerTokenAuthProvider to inject token to request header
     const apiClient = createApiClient(
       apiBaseUrl,
       new BearerTokenAuthProvider(async () => (await credential.getToken("")).token));

--- a/templates/tab/ts/default/src/components/sample/AzureFunctions.tsx
+++ b/templates/tab/ts/default/src/components/sample/AzureFunctions.tsx
@@ -2,7 +2,7 @@ import { useContext } from "react";
 import { Button, Loader } from "@fluentui/react-northstar";
 import { useData } from "@microsoft/teamsfx-react";
 import * as axios from "axios";
-import { TeamsFx } from "@microsoft/teamsfx";
+import { BearerTokenAuthProvider, createApiClient, TeamsFx } from "@microsoft/teamsfx";
 import { TeamsFxContext } from "../Context";
 
 const functionName = process.env.REACT_APP_FUNC_NAME || "myFunc";
@@ -12,13 +12,12 @@ async function callFunction(teamsfx?: TeamsFx) {
     throw new Error("TeamsFx SDK is not initialized.");
   }
   try {
-    const accessToken = await teamsfx.getCredential().getToken("");
-    const endpoint = teamsfx.getConfig("apiEndpoint");
-    const response = await axios.default.get(endpoint + "/api/" + functionName, {
-      headers: {
-        authorization: "Bearer " + accessToken?.token || "",
-      },
-    });
+    const credential = teamsfx.getCredential();
+    const apiBaseUrl = teamsfx.getConfig("apiEndpoint") + "/api/";
+    const apiClient = createApiClient(
+      apiBaseUrl,
+      new BearerTokenAuthProvider(async () => (await credential.getToken(""))!.token));
+    const response = await apiClient.get(functionName);
     return response.data;
   } catch (err: unknown) {
     if (axios.default.isAxiosError(err)) {

--- a/templates/tab/ts/default/src/components/sample/AzureFunctions.tsx
+++ b/templates/tab/ts/default/src/components/sample/AzureFunctions.tsx
@@ -14,6 +14,7 @@ async function callFunction(teamsfx?: TeamsFx) {
   try {
     const credential = teamsfx.getCredential();
     const apiBaseUrl = teamsfx.getConfig("apiEndpoint") + "/api/";
+    // createApiClient(...) creates an Axios instance which uses BearerTokenAuthProvider to inject token to request header
     const apiClient = createApiClient(
       apiBaseUrl,
       new BearerTokenAuthProvider(async () => (await credential.getToken(""))!.token));


### PR DESCRIPTION
Use API client with BearerTokenAuthProvider to call functions, so users do not need to manually get token and set to header for every request.