### PR TITLE
fix: fix missing error code for npm install & env checker

### DIFF
--- a/packages/fx-core/tests/common/local/localTelemetryReporter.test.ts
+++ b/packages/fx-core/tests/common/local/localTelemetryReporter.test.ts
@@ -29,6 +29,7 @@ describe("localTelemetryReporter", () => {
     error?: Error;
     properties?: { [key: string]: string };
     measurements?: { [key: string]: number };
+    errorProps?: string[];
   }[] = [];
 
   const mockToolReporter = {
@@ -36,9 +37,10 @@ describe("localTelemetryReporter", () => {
       eventName: string,
       error: FxError,
       properties?: { [key: string]: string },
-      measurements?: { [key: string]: number }
+      measurements?: { [key: string]: number },
+      errorProps?: string[]
     ): void => {
-      mockedEvents.push({ type: "error", error, eventName, properties, measurements });
+      mockedEvents.push({ type: "error", error, eventName, properties, measurements, errorProps });
     },
 
     sendTelemetryEvent: (
@@ -337,6 +339,7 @@ describe("localTelemetryReporter", () => {
         async (ctx: TelemetryContext) => {
           ctx.properties["ctxProperty"] = "ctxProperty";
           ctx.measurements["ctxMeasurement"] = 42;
+          ctx.errorProps = ["myErrorMessage"];
           return "test result";
         },
         () => undefined,
@@ -358,6 +361,7 @@ describe("localTelemetryReporter", () => {
         initialProperty: "initialProperty",
         ctxProperty: "ctxProperty",
       });
+      chai.assert.deepEqual(mockedEvents[1].errorProps, ["myErrorMessage"]);
       chai.assert.isTrue(Object.keys(mockedEvents[1].measurements || {}).includes("duration"));
       chai.assert.equal(mockedEvents[1].measurements?.["ctxMeasurement"], 42);
     });

--- a/packages/fx-core/tests/common/local/localTelemetryReporter.test.ts
+++ b/packages/fx-core/tests/common/local/localTelemetryReporter.test.ts
@@ -40,7 +40,14 @@ describe("localTelemetryReporter", () => {
       measurements?: { [key: string]: number },
       errorProps?: string[]
     ): void => {
-      mockedEvents.push({ type: "error", error, eventName, properties, measurements, errorProps });
+      mockedEvents.push({
+        type: "error",
+        error,
+        eventName,
+        properties,
+        measurements,
+        errorProps,
+      });
     },
 
     sendTelemetryEvent: (
@@ -339,7 +346,6 @@ describe("localTelemetryReporter", () => {
         async (ctx: TelemetryContext) => {
           ctx.properties["ctxProperty"] = "ctxProperty";
           ctx.measurements["ctxMeasurement"] = 42;
-          ctx.errorProps = ["myErrorMessage"];
           return "test result";
         },
         () => undefined,
@@ -361,7 +367,6 @@ describe("localTelemetryReporter", () => {
         initialProperty: "initialProperty",
         ctxProperty: "ctxProperty",
       });
-      chai.assert.deepEqual(mockedEvents[1].errorProps, ["myErrorMessage"]);
       chai.assert.isTrue(Object.keys(mockedEvents[1].measurements || {}).includes("duration"));
       chai.assert.equal(mockedEvents[1].measurements?.["ctxMeasurement"], 42);
     });
@@ -375,6 +380,7 @@ describe("localTelemetryReporter", () => {
           async (ctx: TelemetryContext) => {
             ctx.properties["ctxProperty"] = "ctxProperty";
             ctx.measurements["ctxMeasurement"] = 42;
+            ctx.errorProps = ["myErrorMessage"];
             throw error;
           },
           () => undefined,
@@ -396,6 +402,7 @@ describe("localTelemetryReporter", () => {
         ctxProperty: "ctxProperty",
         [LocalTelemetryReporter.PropertyDebugLastEventName]: testStartEventName,
       });
+      chai.assert.deepEqual(mockedEvents[1].errorProps, ["myErrorMessage"]);
       chai.assert.isTrue(Object.keys(mockedEvents[1].measurements || {}).includes("duration"));
       chai.assert.equal(mockedEvents[1].measurements?.["ctxMeasurement"], 42);
     });

--- a/packages/vscode-extension/src/error.ts
+++ b/packages/vscode-extension/src/error.ts
@@ -15,6 +15,7 @@ export enum ExtensionErrors {
   PrerequisitesValidationError = "PrerequisitesValidationError",
   PrerequisitesNoM365AccountError = "PrerequisitesNoM365AccountError",
   PrerequisitesSideloadingDisabledError = "PrerequisitesSideloadingDisabledError",
+  PrerequisitesInstallPackagesError = "PrerequisitesPackageInstallError",
   DebugServiceFailedBeforeStartError = "DebugServiceFailedBeforeStartError",
   DebugNpmInstallError = "DebugNpmInstallError",
   OpenExternalFailed = "OpenExternalFailed",

--- a/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
@@ -214,7 +214,7 @@ export enum TelemetryProperty {
   DebugAppId = "debug-appid",
   DebugProjectComponents = "debug-project-components",
   DebugCheckResults = "debug-check-results",
-  DebugErrorCodes = "error-codes",
+  DebugErrorCodes = "debug-error-codes",
   DebugNpmInstallName = "debug-npm-install-name",
   DebugNpmInstallExitCode = "debug-npm-install-exit-code",
   DebugNpmInstallErrorMessage = "debug-npm-install-error-message",

--- a/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
@@ -214,6 +214,7 @@ export enum TelemetryProperty {
   DebugAppId = "debug-appid",
   DebugProjectComponents = "debug-project-components",
   DebugCheckResults = "debug-check-results",
+  DebugErrorCodes = "error-codes",
   DebugNpmInstallName = "debug-npm-install-name",
   DebugNpmInstallExitCode = "debug-npm-install-exit-code",
   DebugNpmInstallErrorMessage = "debug-npm-install-error-message",


### PR DESCRIPTION
Fix local debug telemetry bugs:
- npm install error code was `PrerequisiteValidationError` and contains no useful information
- env checker does not send error-code for telemetry
- `checkResults` should be included in `errorProps` because it includes error message.

test env checker error:
![](https://user-images.githubusercontent.com/9698542/174568326-3195e499-2175-4ad4-aafe-0a9abbe2db30.png)

test npm install error:
![](https://user-images.githubusercontent.com/9698542/174568336-931a60d9-711a-4756-adbe-8f2c36ceac53.png)

E2E TEST: https://github.com/OfficeDev/TeamsFx-UI-Test/blob/76b1d9c8ea6d3d74fb9dbdbeddc28b3afd4259f6/src/ui-test/localdebug/localdebug-bot.test.ts#L11