### PR TITLE
fix: fix dotnet notification func template

### DIFF
--- a/templates/bot/csharp/notification-function-base/ProjectName.csproj.tpl
+++ b/templates/bot/csharp/notification-function-base/ProjectName.csproj.tpl
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include=".notification.localstore.json" />
+    <None Include=".notification.local*.json" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Use `Microsoft.NET.Sdk` since it's a func project.
- Align `Include` section with webapi notification project.

E2E TEST: N/A