### PR TITLE
fix: fix dotnet notification function app folder

### DIFF
--- a/templates/bot/csharp/notification-trigger-http/NotifyHttpTrigger.cs.tpl
+++ b/templates/bot/csharp/notification-trigger-http/NotifyHttpTrigger.cs.tpl
@@ -12,7 +12,6 @@ namespace {{SafeProjectName}}
 
     public sealed class NotifyHttpTrigger
     {
-        private readonly string _adaptiveCardFilePath = Path.Combine(".", "Resources", "NotificationDefault.json");
         private readonly ConversationBot _conversation;
         private readonly ILogger<NotifyHttpTrigger> _log;
 
@@ -23,12 +22,13 @@ namespace {{SafeProjectName}}
         }
 
         [FunctionName("NotifyHttpTrigger")]
-        public async Task<IActionResult> Run([HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "api/notification")] HttpRequest req)
+        public async Task<IActionResult> Run([HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "api/notification")] HttpRequest req, ExecutionContext context)
         {
             _log.LogInformation("NotifyHttpTrigger is triggered.");
 
             // Read adaptive card template
-            var cardTemplate = await System.IO.File.ReadAllTextAsync(_adaptiveCardFilePath, req.HttpContext.RequestAborted);
+            var adaptiveCardFilePath = Path.Combine(context.FunctionAppDirectory, "Resources", "NotificationDefault.json");
+            var cardTemplate = await System.IO.File.ReadAllTextAsync(adaptiveCardFilePath, req.HttpContext.RequestAborted);
 
             var installations = await _conversation.Notification.GetInstallationsAsync(req.HttpContext.RequestAborted);
             foreach (var installation in installations)

--- a/templates/bot/csharp/notification-trigger-timer/NotifyTimerTrigger.cs.tpl
+++ b/templates/bot/csharp/notification-trigger-timer/NotifyTimerTrigger.cs.tpl
@@ -12,7 +12,6 @@ namespace {{SafeProjectName}}
 
     public sealed class NotifyTimerTrigger
     {
-        private readonly string _adaptiveCardFilePath = Path.Combine(".", "Resources", "NotificationDefault.json");
         private readonly ConversationBot _conversation;
         private readonly ILogger<NotifyTimerTrigger> _log;
 
@@ -23,12 +22,13 @@ namespace {{SafeProjectName}}
         }
 
         [FunctionName("NotifyTimerTrigger")]
-        public async Task Run([TimerTrigger("*/30 * * * * *")]TimerInfo myTimer, CancellationToken cancellationToken)
+        public async Task Run([TimerTrigger("*/30 * * * * *")]TimerInfo myTimer, ExecutionContext context, CancellationToken cancellationToken)
         {
             _log.LogInformation($"NotifyTimerTrigger is triggered at {DateTime.Now}.");
 
             // Read adaptive card template
-            var cardTemplate = await File.ReadAllTextAsync(_adaptiveCardFilePath, cancellationToken);
+            var adaptiveCardFilePath = Path.Combine(context.FunctionAppDirectory, "Resources", "NotificationDefault.json");
+            var cardTemplate = await File.ReadAllTextAsync(adaptiveCardFilePath, cancellationToken);
 
             var installations = await _conversation.Notification.GetInstallationsAsync(cancellationToken);
             foreach (var installation in installations)


### PR DESCRIPTION
Get Function App working folder via `ExecutionContext`, so the same statement works on both local and remote.

E2E TEST: N/A