### PR TITLE
fix: make local debug dev cert properties more clear

### DIFF
--- a/packages/fx-core/src/common/local/localCertificateManager.ts
+++ b/packages/fx-core/src/common/local/localCertificateManager.ts
@@ -43,6 +43,7 @@ export interface LocalCertificate {
   certPath: string;
   keyPath: string;
   isTrusted?: boolean;
+  alreadyTrusted?: boolean;
   error?: FxError;
 }
 
@@ -98,7 +99,9 @@ export class LocalCertificateManager {
         if (certThumbprint && (await this.verifyCertificateInStore(certThumbprint))) {
           // already trusted
           localCert.isTrusted = true;
+          localCert.alreadyTrusted = true;
         } else {
+          localCert.alreadyTrusted = false;
           await this.trustCertificate(
             localCert,
             certThumbprint,

--- a/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
@@ -213,6 +213,7 @@ export enum TelemetryProperty {
   DebugRemote = "remote",
   DebugAppId = "debug-appid",
   DebugProjectComponents = "debug-project-components",
+  DebugDevCertStatus = "debug-dev-cert-status",
   DebugCheckResults = "debug-check-results",
   DebugNpmInstallName = "debug-npm-install-name",
   DebugNpmInstallExitCode = "debug-npm-install-exit-code",
@@ -308,6 +309,13 @@ export enum TelemetrySurveyDataProperty {
   Q4Result = "q4-result",
   Q5Title = "q5-title",
   Q5Result = "q5-result",
+}
+
+export enum TelemetryDebugDevCertStatus {
+  Disabled = "disabled",
+  AlreadyTrusted = "already-trusted",
+  Trusted = "trusted",
+  NotTrusted = "not-trusted",
 }
 
 export const TelemetryComponentType = "extension";


### PR DESCRIPTION
Add property `debug-dev-cert-status` to make cert telemetry more clear

Test (timestamp is in reverse order):
- first event is cancel in first dialog,
- second event is cancel in the second dialog
- third event is disable in vscode settings
- fourth event is confirm trust
- fourth event is second time local debug
![](https://user-images.githubusercontent.com/9698542/174730308-7275aa4f-2778-4652-88ec-ede44c504b3f.png)

E2E TEST: https://github.com/OfficeDev/TeamsFx-UI-Test/blob/76b1d9c8ea6d3d74fb9dbdbeddc28b3afd4259f6/src/ui-test/localdebug/localdebug-bot.test.ts