### PR TITLE
chore: use createApiClient in M365 tab template

### DIFF
--- a/templates/tab/js/m365/src/components/sample/AzureFunctions.jsx
+++ b/templates/tab/js/m365/src/components/sample/AzureFunctions.jsx
@@ -1,21 +1,20 @@
 import React from "react";
 import { Button, Loader } from "@fluentui/react-northstar";
 import { useData } from "./lib/useData";
-import * as axios from "axios";
-import { TeamsFx } from "@microsoft/teamsfx";
+import { BearerTokenAuthProvider, createApiClient, TeamsFx } from "@microsoft/teamsfx";
 
 var functionName = process.env.REACT_APP_FUNC_NAME || "myFunc";
 
 async function callFunction() {
   try {
     const teamsfx = new TeamsFx();
-    const accessToken = await teamsfx.getCredential().getToken("");
-    const endpoint = teamsfx.getConfig("apiEndpoint");
-    const response = await axios.default.get(endpoint + "/api/" + functionName, {
-      headers: {
-        authorization: "Bearer " + accessToken.token,
-      },
-    });
+    const credential = teamsfx.getCredential();
+    const apiBaseUrl = teamsfx.getConfig("apiEndpoint") + "/api/";
+    // createApiClient(...) creates an Axios instance which uses BearerTokenAuthProvider to inject token to request header
+    const apiClient = createApiClient(
+      apiBaseUrl,
+      new BearerTokenAuthProvider(async () => (await credential.getToken("")).token));
+    const response = await apiClient.get(functionName);
     return response.data;
   } catch (err) {
     let funcErrorMsg = "";

--- a/templates/tab/ts/m365/src/components/sample/AzureFunctions.tsx
+++ b/templates/tab/ts/m365/src/components/sample/AzureFunctions.tsx
@@ -2,20 +2,20 @@ import React from "react";
 import { Button, Loader } from "@fluentui/react-northstar";
 import { useData } from "./lib/useData";
 import * as axios from "axios";
-import { TeamsFx } from "@microsoft/teamsfx";
+import { BearerTokenAuthProvider, createApiClient, TeamsFx } from "@microsoft/teamsfx";
 
 var functionName = process.env.REACT_APP_FUNC_NAME || "myFunc";
 
 async function callFunction() {
   try {
     const teamsfx = new TeamsFx();
-    const accessToken = await teamsfx.getCredential().getToken("");
-    const endpoint = teamsfx.getConfig("apiEndpoint");
-    const response = await axios.default.get(endpoint + "/api/" + functionName, {
-      headers: {
-        authorization: "Bearer " + accessToken?.token || "",
-      },
-    });
+    const credential = teamsfx.getCredential();
+    const apiBaseUrl = teamsfx.getConfig("apiEndpoint") + "/api/";
+    // createApiClient(...) creates an Axios instance which uses BearerTokenAuthProvider to inject token to request header
+    const apiClient = createApiClient(
+      apiBaseUrl,
+      new BearerTokenAuthProvider(async () => (await credential.getToken(""))!.token));
+    const response = await apiClient.get(functionName);
     return response.data;
   } catch (err: unknown) {
     if (axios.default.isAxiosError(err)) {


### PR DESCRIPTION
Use API client with BearerTokenAuthProvider to call functions, so users do not need to manually get token and set to header for every request.