### PR TITLE
fix: debug-check-results are redacted sometimes

### DIFF
--- a/packages/vscode-extension/src/debug/commonUtils.ts
+++ b/packages/vscode-extension/src/debug/commonUtils.ts
@@ -374,6 +374,7 @@ export interface LocalDebugSession {
   id: string;
   startTime?: number;
   properties: { [key: string]: string };
+  errorProps: string[];
   failedServices: { name: string; exitCode: number | undefined }[];
 }
 
@@ -381,8 +382,8 @@ export const DebugNoSessionId = "no-session-id";
 // Helper functions for local debug correlation-id, only used for telemetry
 // Use a 2-element tuple to handle concurrent F5
 const localDebugCorrelationIds: [LocalDebugSession, LocalDebugSession] = [
-  { id: DebugNoSessionId, properties: {}, failedServices: [] },
-  { id: DebugNoSessionId, properties: {}, failedServices: [] },
+  { id: DebugNoSessionId, properties: {}, errorProps: [], failedServices: [] },
+  { id: DebugNoSessionId, properties: {}, errorProps: [], failedServices: [] },
 ];
 let current = 0;
 export function startLocalDebugSession(): string {
@@ -391,13 +392,19 @@ export function startLocalDebugSession(): string {
     id: uuid.v4(),
     startTime: performance.now(),
     properties: {},
+    errorProps: [],
     failedServices: [],
   };
   return getLocalDebugSessionId();
 }
 
 export function endLocalDebugSession() {
-  localDebugCorrelationIds[current] = { id: DebugNoSessionId, properties: {}, failedServices: [] };
+  localDebugCorrelationIds[current] = {
+    id: DebugNoSessionId,
+    properties: {},
+    errorProps: [],
+    failedServices: [],
+  };
   current = (current + 1) % 2;
 }
 

--- a/packages/vscode-extension/src/debug/prerequisitesHandler.ts
+++ b/packages/vscode-extension/src/debug/prerequisitesHandler.ts
@@ -190,7 +190,9 @@ function convertCheckResultsForTelemetry(checkResults: CheckResult[]): [string, 
       source: checkResult.error?.source,
       errorCode: checkResult.error?.name,
       errorType:
-        checkResult.error instanceof UserError
+        checkResult.error === undefined
+          ? undefined
+          : checkResult.error instanceof UserError
           ? "user"
           : checkResult.error instanceof SystemError
           ? "system"

--- a/packages/vscode-extension/src/debug/prerequisitesHandler.ts
+++ b/packages/vscode-extension/src/debug/prerequisitesHandler.ts
@@ -209,10 +209,10 @@ function addCheckResultsForTelemetry(
   errorProps: string[]
 ): void {
   const [resultRaw, resultSafe] = convertCheckResultsForTelemetry(checkResults);
-  properties[TelemetryProperty.DebugCheckResults] = resultSafe;
-  properties[TelemetryProperty.DebugCheckResultsRaw] = resultRaw;
+  properties[TelemetryProperty.DebugCheckResultsSafe] = resultSafe;
+  properties[TelemetryProperty.DebugCheckResults] = resultRaw;
   // only the raw event contains error message
-  errorProps.push(TelemetryProperty.DebugCheckResultsRaw);
+  errorProps.push(TelemetryProperty.DebugCheckResults);
 }
 
 async function checkPort(

--- a/packages/vscode-extension/src/debug/prerequisitesHandler.ts
+++ b/packages/vscode-extension/src/debug/prerequisitesHandler.ts
@@ -164,8 +164,7 @@ async function runWithCheckResultsTelemetry(
       } else {
         // multiple errors in one event
         ctx.properties[TelemetryProperty.DebugErrorCodes] = JSON.stringify(errorCodes);
-        ctx.properties[TelemetryProperty.DebugCheckResults] = JSON.stringify(results);
-        ctx.errorProps.push(TelemetryProperty.DebugCheckResults);
+        addCheckResultsForTelemetry(results, ctx.properties, ctx.errorProps);
         return new UserError({
           source: ExtensionSource,
           name: errorName,
@@ -173,6 +172,45 @@ async function runWithCheckResultsTelemetry(
       }
     }
   );
+}
+
+// Mainly addresses two issues:
+// 1. Some error messages contain special characters which will cause the whole debug-check-results to be redacted.
+// 2. CheckResult[] is hard to parse in kusto query (an array of objects).
+//
+// `debug-check-results` contains only known content and we know it will not be redacted.
+// `debug-check-results-raw` might contain arbitrary string and be redacted.
+function convertCheckResultsForTelemetry(checkResults: CheckResult[]): [string, string] {
+  const resultRaw: { [checker: string]: unknown } = {};
+  const resultSafe: { [checker: string]: { [key: string]: string | undefined } } = {};
+  for (const checkResult of checkResults) {
+    resultRaw[checkResult.checker] = checkResult;
+    resultSafe[checkResult.checker] = {
+      result: checkResult.result,
+      source: checkResult.error?.source,
+      errorCode: checkResult.error?.name,
+      errorType:
+        checkResult.error instanceof UserError
+          ? "user"
+          : checkResult.error instanceof SystemError
+          ? "system"
+          : "unknown",
+    };
+  }
+
+  return [JSON.stringify(resultRaw), JSON.stringify(resultSafe)];
+}
+
+function addCheckResultsForTelemetry(
+  checkResults: CheckResult[],
+  properties: { [key: string]: string },
+  errorProps: string[]
+): void {
+  const [resultRaw, resultSafe] = convertCheckResultsForTelemetry(checkResults);
+  properties[TelemetryProperty.DebugCheckResults] = resultSafe;
+  properties[TelemetryProperty.DebugCheckResultsRaw] = resultRaw;
+  // only the raw event contains error message
+  errorProps.push(TelemetryProperty.DebugCheckResultsRaw);
 }
 
 async function checkPort(
@@ -430,8 +468,10 @@ async function _checkAndInstall(ctx: TelemetryContext): Promise<Result<void, FxE
     const fxError = assembleError(error);
     showError(fxError);
     await progressHelper?.stop(false);
-    ctx.properties[TelemetryProperty.DebugCheckResults] = JSON.stringify(checkResults);
-    ctx.errorProps.push(TelemetryProperty.DebugCheckResults);
+    // also add checkResult to the debug-all event
+    const session = commonUtils.getLocalDebugSession();
+    addCheckResultsForTelemetry(checkResults, session.properties, session.errorProps);
+    addCheckResultsForTelemetry(checkResults, ctx.properties, ctx.errorProps);
     return err(fxError);
   }
   return ok(undefined);

--- a/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
@@ -215,6 +215,7 @@ export enum TelemetryProperty {
   DebugProjectComponents = "debug-project-components",
   DebugDevCertStatus = "debug-dev-cert-status",
   DebugCheckResults = "debug-check-results",
+  DebugCheckResultsRaw = "debug-check-results-raw",
   DebugErrorCodes = "debug-error-codes",
   DebugNpmInstallName = "debug-npm-install-name",
   DebugNpmInstallExitCode = "debug-npm-install-exit-code",

--- a/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
@@ -215,7 +215,7 @@ export enum TelemetryProperty {
   DebugProjectComponents = "debug-project-components",
   DebugDevCertStatus = "debug-dev-cert-status",
   DebugCheckResults = "debug-check-results",
-  DebugCheckResultsRaw = "debug-check-results-raw",
+  DebugCheckResultsSafe = "debug-check-results-safe",
   DebugErrorCodes = "debug-error-codes",
   DebugNpmInstallName = "debug-npm-install-name",
   DebugNpmInstallExitCode = "debug-npm-install-exit-code",


### PR DESCRIPTION
- fix: `debug-check-results` are redacted sometimes
- add `debug-check-results` to `debug-all` event


Previous:
![](https://user-images.githubusercontent.com/9698542/174767469-0ae21b36-0325-4937-a7aa-f4e1d9843b98.png)

Now:
![image](https://user-images.githubusercontent.com/9698542/174767447-9b87f98a-0732-4771-9ae0-fc2b66cc93f8.png)

E2E TEST: https://github.com/OfficeDev/TeamsFx-UI-Test/blob/76b1d9c8ea6d3d74fb9dbdbeddc28b3afd4259f6/src/ui-test/localdebug/localdebug-bot.test.ts