### PR TITLE
fix: retry exclude 404

### DIFF
--- a/packages/fx-core/src/plugins/resource/bot/appStudio/appStudio.ts
+++ b/packages/fx-core/src/plugins/resource/bot/appStudio/appStudio.ts
@@ -177,7 +177,7 @@ export class AppStudio {
           },
           true
         );
-        if (getBotRegistrationResponse?.status === 201) {
+        if (getBotRegistrationResponse?.status === 200) {
           Logger.info(Messages.BotResourceExist("Appstudio"));
           return;
         }

--- a/packages/fx-core/src/plugins/resource/bot/appStudio/appStudio.ts
+++ b/packages/fx-core/src/plugins/resource/bot/appStudio/appStudio.ts
@@ -162,9 +162,9 @@ export class AppStudio {
     try {
       if (registration.botId) {
         const getBotRegistrationResponse: AxiosResponse<any> | undefined = await RetryHandler.Retry(
-          () => {
+          async () => {
             try {
-              return axiosInstance.get(
+              return await axiosInstance.get(
                 `${AppStudio.baseUrl}/api/botframework/${registration.botId}`
               );
             } catch (e) {
@@ -177,7 +177,7 @@ export class AppStudio {
           },
           true
         );
-        if (getBotRegistrationResponse?.status !== 404) {
+        if (getBotRegistrationResponse?.status === 201) {
           Logger.info(Messages.BotResourceExist("Appstudio"));
           return;
         }

--- a/packages/fx-core/src/plugins/resource/bot/appStudio/appStudio.ts
+++ b/packages/fx-core/src/plugins/resource/bot/appStudio/appStudio.ts
@@ -2,7 +2,7 @@ import { IAADApplication, IAADPassword } from "./interfaces/IAADApplication";
 import { IBotRegistration } from "./interfaces/IBotRegistration";
 import { IAADDefinition } from "./interfaces/IAADDefinition";
 
-import { AxiosInstance, default as axios } from "axios";
+import { AxiosInstance, AxiosResponse, default as axios } from "axios";
 import {
   AADAppCheckingError,
   ConfigUpdatingError,
@@ -161,11 +161,23 @@ export class AppStudio {
     let response = undefined;
     try {
       if (registration.botId) {
-        const getBotRegistrationResponse = await RetryHandler.Retry(
-          () => axiosInstance.get(`${AppStudio.baseUrl}/api/botframework/${registration.botId}`),
+        const getBotRegistrationResponse: AxiosResponse<any> | undefined = await RetryHandler.Retry(
+          () => {
+            try {
+              return axiosInstance.get(
+                `${AppStudio.baseUrl}/api/botframework/${registration.botId}`
+              );
+            } catch (e) {
+              if (e.response?.status === 404) {
+                return e.response;
+              } else {
+                throw e;
+              }
+            }
+          },
           true
         );
-        if (getBotRegistrationResponse && getBotRegistrationResponse.data) {
+        if (getBotRegistrationResponse?.status !== 404) {
           Logger.info(Messages.BotResourceExist("Appstudio"));
           return;
         }

--- a/packages/fx-core/src/plugins/resource/bot/index.ts
+++ b/packages/fx-core/src/plugins/resource/bot/index.ts
@@ -174,7 +174,7 @@ export class TeamsBot implements Plugin {
     const result = await runWithExceptionCatching(
       context,
       () => this.getImpl(context).localDebug(context),
-      false,
+      true,
       LifecycleFuncNames.LOCAL_DEBUG
     );
 
@@ -192,7 +192,7 @@ export class TeamsBot implements Plugin {
     return await runWithExceptionCatching(
       context,
       () => this.getImpl(context).postLocalDebug(context),
-      false,
+      true,
       LifecycleFuncNames.POST_LOCAL_DEBUG
     );
   }

--- a/packages/fx-core/src/plugins/resource/bot/utils/retryHandler.ts
+++ b/packages/fx-core/src/plugins/resource/bot/utils/retryHandler.ts
@@ -3,7 +3,7 @@
 
 import { Retry } from "../constants";
 export class RetryHandler {
-  public static async Retry<T>(fn: () => Promise<T>, ignoreError = false): Promise<T | undefined> {
+  public static async Retry<T>(fn: () => Promise<T> | T, ignoreError = false): Promise<T | undefined> {
     let retries = Retry.RETRY_TIMES;
     while (retries > 0) {
       retries = retries - 1;

--- a/packages/fx-core/src/plugins/resource/bot/utils/retryHandler.ts
+++ b/packages/fx-core/src/plugins/resource/bot/utils/retryHandler.ts
@@ -3,7 +3,10 @@
 
 import { Retry } from "../constants";
 export class RetryHandler {
-  public static async Retry<T>(fn: () => Promise<T> | T, ignoreError = false): Promise<T | undefined> {
+  public static async Retry<T>(
+    fn: () => Promise<T> | T,
+    ignoreError = false
+  ): Promise<T | undefined> {
     let retries = Retry.RETRY_TIMES;
     while (retries > 0) {
       retries = retries - 1;

--- a/packages/fx-core/src/plugins/resource/bot/utils/retryHandler.ts
+++ b/packages/fx-core/src/plugins/resource/bot/utils/retryHandler.ts
@@ -5,12 +5,10 @@ import { Retry } from "../constants";
 export class RetryHandler {
   public static async Retry<T>(fn: () => Promise<T>, ignoreError = false): Promise<T | undefined> {
     let retries = Retry.RETRY_TIMES;
-    let response;
     while (retries > 0) {
       retries = retries - 1;
       try {
-        response = await fn();
-        return response;
+        return await fn();
       } catch (e) {
         if (retries <= 0) {
           if (!ignoreError) throw e;


### PR DESCRIPTION
404 was treated as Exception in Axios, so extract it out as a normal response to represent nonexistence.

https://dev.azure.com/msazure/Microsoft%20Teams%20Extensibility/_workitems/edit/14727888

E2E TEST: None