### PR TITLE
fix(bot): add bot capabilities into projectsettings.json

### DIFF
--- a/packages/fx-core/src/plugins/resource/bot/constants.ts
+++ b/packages/fx-core/src/plugins/resource/bot/constants.ts
@@ -205,7 +205,6 @@ export class TelemetryKeys {
   public static readonly AppId = "appid";
   public static readonly HostType = "bot-host-type";
   public static readonly BotCapabilities = "bot-capabilities";
-  public static readonly Language = "bot-language";
 }
 
 export class TelemetryValues {

--- a/packages/fx-core/src/plugins/resource/bot/utils/telemetry-helper.ts
+++ b/packages/fx-core/src/plugins/resource/bot/utils/telemetry-helper.ts
@@ -21,7 +21,6 @@ export class telemetryHelper {
     const capabilities =
       ctx.projectSettings?.pluginSettings?.[PluginBot.PLUGIN_NAME]?.[PluginBot.BOT_CAPABILITIES];
     properties[TelemetryKeys.BotCapabilities] = capabilities ? JSON.stringify(capabilities) : "";
-    properties[TelemetryKeys.Language] = ctx.projectSettings?.programmingLanguage ?? "";
   }
 
   static sendStartEvent(

--- a/packages/fx-core/src/plugins/resource/bot/v2/common.ts
+++ b/packages/fx-core/src/plugins/resource/bot/v2/common.ts
@@ -82,9 +82,7 @@ export function resolveServiceType(ctx: Context): ServiceType {
 export function resolveBotCapabilities(inputs: Inputs): BotCapability[] {
   const botScenarios = inputs?.[AzureSolutionQuestionNames.Scenarios];
   if (Array.isArray(botScenarios)) {
-    return botScenarios
-      .map((scenario) => QuestionBotScenarioToBotCapability.get(scenario))
-      .filter((item): item is BotCapability => item !== undefined);
+    return botScenarios.map((scenario) => QuestionBotScenarioToBotCapability.get(scenario)!);
   } else {
     return [];
   }

--- a/packages/fx-core/src/plugins/resource/bot/v2/common.ts
+++ b/packages/fx-core/src/plugins/resource/bot/v2/common.ts
@@ -11,7 +11,7 @@ import { getLanguage, getServiceType, getTriggerScenarios } from "./mapping";
 import { ServiceType } from "../../../../common/azure-hosting/interfaces";
 import { CoreQuestionNames } from "../../../../core/question";
 import { HostType } from "./enum";
-import { PluginBot } from "../resources/strings";
+import { BotCapability, PluginBot, QuestionBotScenarioToBotCapability } from "../resources/strings";
 import { convertToAlphanumericOnly } from "../../../../common/utils";
 
 export function getTemplateInfos(ctx: Context, inputs: Inputs): CodeTemplateInfo[] {
@@ -77,4 +77,15 @@ export function resolveServiceType(ctx: Context): ServiceType {
       PluginBot.HOST_TYPE
     ] as string) ?? HostType.AppService;
   return getServiceType(rawHostType);
+}
+
+export function resolveBotCapabilities(inputs: Inputs): BotCapability[] {
+  const botScenarios = inputs?.[AzureSolutionQuestionNames.Scenarios];
+  if (Array.isArray(botScenarios)) {
+    return botScenarios
+      .map((scenario) => QuestionBotScenarioToBotCapability.get(scenario))
+      .filter((item): item is BotCapability => item !== undefined);
+  } else {
+    return [];
+  }
 }

--- a/packages/fx-core/src/plugins/resource/bot/v2/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/bot/v2/plugin.ts
@@ -39,7 +39,12 @@ import { Logger } from "../logger";
 import { ProgressBarFactory } from "../progressBars";
 import ignore, { Ignore } from "ignore";
 import { DeployConfigsConstants } from "../../../../common/azure-hosting/hostingConstant";
-import { getTemplateInfos, resolveHostType, resolveServiceType } from "./common";
+import {
+  getTemplateInfos,
+  resolveBotCapabilities,
+  resolveHostType,
+  resolveServiceType,
+} from "./common";
 import { ProgrammingLanguage } from "./enum";
 import { getLanguage, getProjectFileName, getRuntime, moduleMap } from "./mapping";
 
@@ -59,7 +64,9 @@ export class TeamsBotV2Impl {
     const projectPath = checkPrecondition(Messages.WorkingDirIsMissing, inputs.projectPath);
     const workingPath = TeamsBotV2Impl.getWorkingPath(projectPath, lang);
     const hostType = resolveHostType(inputs);
+    const botCapabilities = resolveBotCapabilities(inputs);
     utils.checkAndSavePluginSettingV2(ctx, PluginBot.HOST_TYPE, hostType);
+    utils.checkAndSavePluginSettingV2(ctx, PluginBot.BOT_CAPABILITIES, botCapabilities);
     const templateInfos = getTemplateInfos(ctx, inputs);
 
     await handler?.next(ProgressBarConstants.SCAFFOLD_STEP_FETCH_ZIP);


### PR DESCRIPTION
fix https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14786120.
E2E TEST: N/A
In this PR the projectSettings.json looks like below, the same as 4.0.0.
![image](https://user-images.githubusercontent.com/25220706/174969597-40b5ed13-37b7-4e7e-9069-da01537e5ce7.png)
