### PR TITLE
chore: dotnet bot uses latest dotnet sdk

### DIFF
--- a/templates/bot/csharp/command-and-response/ProjectName.csproj.tpl
+++ b/templates/bot/csharp/command-and-response/ProjectName.csproj.tpl
@@ -19,7 +19,7 @@
     <PackageReference Include="AdaptiveCards.Templating" Version="1.2.2" />
     <PackageReference Include="Microsoft.Bot.Builder" Version="4.16.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.16.0" />
-    <PackageReference Include="Microsoft.TeamsFx" Version="0.5.0">
+    <PackageReference Include="Microsoft.TeamsFx" Version="1.0.0">
       <!-- Exclude TeamsFx wwwroot static files which are for frontend only. -->
       <ExcludeAssets>contentFiles</ExcludeAssets>
     </PackageReference>

--- a/templates/bot/csharp/notification-function-base/ProjectName.csproj.tpl
+++ b/templates/bot/csharp/notification-function-base/ProjectName.csproj.tpl
@@ -27,7 +27,7 @@
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.16.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.0.1" />
-    <PackageReference Include="Microsoft.TeamsFx" Version="0.5.0">
+    <PackageReference Include="Microsoft.TeamsFx" Version="1.0.0">
       <!-- Exclude TeamsFx wwwroot static files which are for frontend only. -->
       <ExcludeAssets>contentFiles</ExcludeAssets>
     </PackageReference>

--- a/templates/bot/csharp/notification-webapi/ProjectName.csproj.tpl
+++ b/templates/bot/csharp/notification-webapi/ProjectName.csproj.tpl
@@ -23,7 +23,7 @@
     <PackageReference Include="AdaptiveCards.Templating" Version="1.2.2" />
     <PackageReference Include="Microsoft.Bot.Builder" Version="4.16.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.16.0" />
-    <PackageReference Include="Microsoft.TeamsFx" Version="0.5.0">
+    <PackageReference Include="Microsoft.TeamsFx" Version="1.0.0">
       <!-- Exclude TeamsFx wwwroot static files which are for frontend only. -->
       <ExcludeAssets>contentFiles</ExcludeAssets>
     </PackageReference>


### PR DESCRIPTION
Workitem: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14786691
Upgrade dotnet bot templates to use [Microsoft.TeamsFx 1.0.0](https://www.nuget.org/packages/Microsoft.TeamsFx/1.0.0) 