### PR TITLE
chore: improve cli preview telemetry

### DIFF
--- a/packages/cli/src/cmds/preview/errors.ts
+++ b/packages/cli/src/cmds/preview/errors.ts
@@ -114,10 +114,25 @@ export function DependencyCheckerFailed(): SystemError {
   );
 }
 
-export function PrerequisitesValidationError(error: string | Error, helpLink?: string): UserError {
+export function PrerequisitesValidationNodejsError(
+  error: string | Error,
+  helpLink?: string
+): UserError {
   return new UserError({
     source: constants.cliSource,
-    name: "PrerequisitesValidationError",
+    name: "PrerequisitesValidationNodejsError",
+    helpLink,
+    message: error instanceof Error ? error.message : (error as string),
+  });
+}
+
+export function PrerequisitesValidationM365AccountError(
+  error: string | Error,
+  helpLink?: string
+): UserError {
+  return new UserError({
+    source: constants.cliSource,
+    name: "PrerequisitesValidationM365AccountError",
     helpLink,
     message: error instanceof Error ? error.message : (error as string),
   });

--- a/packages/cli/src/cmds/preview/launch.ts
+++ b/packages/cli/src/cmds/preview/launch.ts
@@ -8,18 +8,14 @@ import * as path from "path";
 import { OpeningBrowserFailed } from "./errors";
 import CLIUIInstance from "../../userInteraction";
 import * as constants from "./constants";
-import cliTelemetry from "../../telemetry/cliTelemetry";
 import cliLogger from "../../commonlib/log";
 import * as commonUtils from "./commonUtils";
-import {
-  TelemetryEvent,
-  TelemetryProperty,
-  TelemetrySuccess,
-} from "../../telemetry/cliTelemetryEvents";
-import { Colors, LogLevel } from "@microsoft/teamsfx-api";
+import { TelemetryEvent } from "../../telemetry/cliTelemetryEvents";
+import { Colors, LogLevel, ok, err } from "@microsoft/teamsfx-api";
 import { getColorizedString, sleep } from "../../utils";
 import { ConfigFolderName } from "@microsoft/teamsfx-api";
 import { TempFolderManager } from "./tempFolderManager";
+import { localTelemetryReporter } from "./localTelemetryReporter";
 
 export async function openHubWebClient(
   includeFrontend: boolean,
@@ -30,65 +26,56 @@ export async function openHubWebClient(
   browserArguments: string[] = [],
   telemetryProperties?: { [key: string]: string } | undefined
 ): Promise<void> {
-  if (telemetryProperties) {
-    cliTelemetry.sendTelemetryEvent(TelemetryEvent.PreviewSideloadingStart, telemetryProperties);
-  }
-  let sideloadingUrl = "";
-  if (hub === constants.Hub.teams) {
-    sideloadingUrl = constants.LaunchUrl.teams;
-  } else if (hub === constants.Hub.outlook) {
-    sideloadingUrl = includeFrontend
-      ? constants.LaunchUrl.outlookTab
-      : constants.LaunchUrl.outlookBot;
-  } else if (hub === constants.Hub.office) {
-    sideloadingUrl = constants.LaunchUrl.officeTab;
-  }
-  sideloadingUrl = sideloadingUrl.replace(constants.teamsAppIdPlaceholder, appId);
-  sideloadingUrl = sideloadingUrl.replace(constants.teamsAppInternalIdPlaceholder, appId);
-  const accountHint = await commonUtils.generateAccountHint(
-    tenantIdFromConfig,
-    hub === constants.Hub.teams
-  );
-  sideloadingUrl = sideloadingUrl.replace(constants.accountHintPlaceholder, accountHint);
-
-  const message = [
-    {
-      content: `preview url: `,
-      color: Colors.WHITE,
-    },
-    {
-      content: sideloadingUrl,
-      color: Colors.BRIGHT_CYAN,
-    },
-  ];
-  cliLogger.necessaryLog(LogLevel.Info, getColorizedString(message));
-
-  const previewBar = CLIUIInstance.createProgressBar(constants.previewTitle, 1);
-  await previewBar.start(constants.previewStartMessage);
-  await previewBar.next(constants.previewStartMessage);
-  try {
-    await commonUtils.openBrowser(browser, sideloadingUrl, browserArguments);
-  } catch {
-    const error = OpeningBrowserFailed(browser);
-    if (telemetryProperties) {
-      cliTelemetry.sendTelemetryErrorEvent(
-        TelemetryEvent.PreviewSideloading,
-        error,
-        telemetryProperties
+  await localTelemetryReporter.runWithTelemetryProperties(
+    TelemetryEvent.PreviewSideloading,
+    telemetryProperties || {},
+    async () => {
+      let sideloadingUrl = "";
+      if (hub === constants.Hub.teams) {
+        sideloadingUrl = constants.LaunchUrl.teams;
+      } else if (hub === constants.Hub.outlook) {
+        sideloadingUrl = includeFrontend
+          ? constants.LaunchUrl.outlookTab
+          : constants.LaunchUrl.outlookBot;
+      } else if (hub === constants.Hub.office) {
+        sideloadingUrl = constants.LaunchUrl.officeTab;
+      }
+      sideloadingUrl = sideloadingUrl.replace(constants.teamsAppIdPlaceholder, appId);
+      sideloadingUrl = sideloadingUrl.replace(constants.teamsAppInternalIdPlaceholder, appId);
+      const accountHint = await commonUtils.generateAccountHint(
+        tenantIdFromConfig,
+        hub === constants.Hub.teams
       );
-    }
-    cliLogger.necessaryLog(LogLevel.Warning, constants.openBrowserHintMessage);
-    await previewBar.end(false);
-    return;
-  }
-  await previewBar.end(true);
+      sideloadingUrl = sideloadingUrl.replace(constants.accountHintPlaceholder, accountHint);
 
-  if (telemetryProperties) {
-    cliTelemetry.sendTelemetryEvent(TelemetryEvent.PreviewSideloading, {
-      ...telemetryProperties,
-      [TelemetryProperty.Success]: TelemetrySuccess.Yes,
-    });
-  }
+      const message = [
+        {
+          content: `preview url: `,
+          color: Colors.WHITE,
+        },
+        {
+          content: sideloadingUrl,
+          color: Colors.BRIGHT_CYAN,
+        },
+      ];
+      cliLogger.necessaryLog(LogLevel.Info, getColorizedString(message));
+
+      const previewBar = CLIUIInstance.createProgressBar(constants.previewTitle, 1);
+      await previewBar.start(constants.previewStartMessage);
+      await previewBar.next(constants.previewStartMessage);
+      try {
+        await commonUtils.openBrowser(browser, sideloadingUrl, browserArguments);
+      } catch {
+        const error = OpeningBrowserFailed(browser);
+        cliLogger.necessaryLog(LogLevel.Warning, constants.openBrowserHintMessage);
+        await previewBar.end(false);
+        return err(error);
+      }
+      await previewBar.end(true);
+
+      return ok(undefined);
+    }
+  );
 }
 
 export async function openUrlWithNewProfile(url: string): Promise<boolean> {

--- a/packages/cli/src/cmds/preview/localTelemetryReporter.ts
+++ b/packages/cli/src/cmds/preview/localTelemetryReporter.ts
@@ -1,10 +1,23 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { FxError } from "@microsoft/teamsfx-api";
 import { LocalTelemetryReporter } from "@microsoft/teamsfx-core";
 import cliTelemetry from "../../telemetry/cliTelemetry";
 
+// Cannot directly refer to a global function which will cause unit test mock to fail
 export const localTelemetryReporter = new LocalTelemetryReporter({
-  sendTelemetryEvent: cliTelemetry.sendTelemetryEvent,
-  sendTelemetryErrorEvent: cliTelemetry.sendTelemetryErrorEvent,
+  sendTelemetryEvent: (
+    eventName: string,
+    properties?: { [p: string]: string },
+    measurements?: { [p: string]: number }
+  ) => cliTelemetry.sendTelemetryEvent(eventName, properties, measurements),
+
+  sendTelemetryErrorEvent: (
+    eventName: string,
+    error: FxError,
+    properties?: { [key: string]: string },
+    measurements?: { [key: string]: number },
+    errorProps?: string[]
+  ) => cliTelemetry.sendTelemetryErrorEvent(eventName, error, properties, measurements, errorProps),
 });

--- a/packages/cli/src/cmds/preview/preview.ts
+++ b/packages/cli/src/cmds/preview/preview.ts
@@ -905,29 +905,6 @@ export default class Preview extends YargsCommand {
     return ok(null);
   }
 
-  separateErrorProperties(
-    result: Result<unknown, FxError>
-  ): [{ [key: string]: unknown }, { [key: string]: unknown }] {
-    const error = result?.isErr() ? result.error : undefined;
-    return [
-      {
-        success: error === undefined ? TelemetrySuccess.Yes : TelemetrySuccess.No,
-        errorCode: error?.name,
-        errorType:
-          error === undefined
-            ? undefined
-            : error instanceof UserError
-            ? "user"
-            : error instanceof SystemError
-            ? "system"
-            : "unknown",
-      },
-      {
-        errorMessage: error?.message,
-        errorStack: error?.stack,
-      },
-    ];
-  }
   private prepareDevEnv(
     core: FxCore,
     inputs: Inputs,

--- a/packages/cli/src/cmds/preview/task.ts
+++ b/packages/cli/src/cmds/preview/task.ts
@@ -26,7 +26,7 @@ export interface TaskResult {
 }
 
 export class Task {
-  private taskTitle: string;
+  public readonly taskTitle: string;
   private background: boolean;
   private command: string;
   private args?: string[];

--- a/packages/cli/src/cmds/preview/task.ts
+++ b/packages/cli/src/cmds/preview/task.ts
@@ -26,7 +26,7 @@ export interface TaskResult {
 }
 
 export class Task {
-  public readonly taskTitle: string;
+  private taskTitle: string;
   private background: boolean;
   private command: string;
   private args?: string[];

--- a/packages/cli/src/telemetry/cliTelemetryEvents.ts
+++ b/packages/cli/src/telemetry/cliTelemetryEvents.ts
@@ -49,7 +49,6 @@ export enum TelemetryEvent {
   PublishStart = "publish-start",
   Publish = "publish",
 
-  PreviewStart = "preview-start",
   Preview = "preview",
   PreviewNpmInstallStart = "preview-npm-install-start",
   PreviewNpmInstall = "preview-npm-install",
@@ -57,10 +56,17 @@ export enum TelemetryEvent {
   PreviewGulpCertStart = "preview-gulp-cert-start",
   PreviewServiceStart = "preview-service-start",
   PreviewService = "preview-service",
-  PreviewSideloadingStart = "preview-sideloading-start",
-  PreviewSideloading = "preview-sideloading",
   PreviewSPFxOpenBrowserStart = "preview-spfx-open-browser-start",
   PreviewSPFxOpenBrowser = "preview-spfx-open-browser",
+  PreviewPrerequisites = "preview-prerequisites",
+  PreviewPrereqsCheckNode = "preview-prereqs-check-node",
+  PreviewPrereqsCheckM365Account = "preview-prereqs-check-m365-account",
+  PreviewPrereqsCheckCert = "preview-prereqs-check-cert",
+  PreviewPrereqsCheckDependencies = "preview-prereqs-check-dependencies",
+  PreviewPrereqsCheckPorts = "preview-prereqs-check-ports",
+  PreviewPrepareDevEnv = "preview-prepare-dev-env",
+  PreviewStartServices = "preview-start-services",
+  PreviewSideloading = "preview-sideloading",
 
   AutomaticNpmInstallStart = "automatic-npm-install-start",
   AutomaticNpmInstall = "automatic-npm-install",
@@ -92,6 +98,7 @@ export enum TelemetryProperty {
   UserId = "hashed-userid",
   AccountType = "account-type",
   Success = "success",
+  Duration = "duration",
   ErrorType = "error-type",
   ErrorCode = "error-code",
   ErrorMessage = "error-message",
@@ -113,8 +120,11 @@ export enum TelemetryProperty {
   PreviewServiceName = "preview-service-name",
   PreviewOSArch = "preview-os-arch",
   PreviewOSRelease = "preview-os-release",
-  PreviewPrerequisitesCheckTime = "preview-prerequisites-check-time",
   PreviewProjectComponents = "preview-project-components",
+  PreviewCheckResults = "preview-check-results",
+  PreviewPortsInUse = "preview-ports-in-use",
+  PreviewDevCertStatus = "preview-dev-cert-status",
+  PreviewLastEventName = "preview-last-event-name",
   ListAllCollaborators = "list-all-collaborators",
   FeatureFlags = "feature-flags",
   Env = "env",
@@ -138,6 +148,13 @@ export enum TelemetryErrorType {
 export enum TelemetryAccountType {
   Azure = "azure",
   M365 = "m365",
+}
+
+export enum TelemetryPreviewDevCertStatus {
+  Disabled = "disabled",
+  AlreadyTrusted = "already-trusted",
+  Trusted = "trusted",
+  NotTrusted = "not-trusted",
 }
 
 export const TelemetryComponentType = "cli";

--- a/packages/cli/src/telemetry/cliTelemetryEvents.ts
+++ b/packages/cli/src/telemetry/cliTelemetryEvents.ts
@@ -56,6 +56,8 @@ export enum TelemetryEvent {
   PreviewGulpCertStart = "preview-gulp-cert-start",
   PreviewServiceStart = "preview-service-start",
   PreviewService = "preview-service",
+  PreviewSideloading = "preview-sideloading",
+  PreviewSideloadingStart = "preview-sideloading-start",
   PreviewSPFxOpenBrowserStart = "preview-spfx-open-browser-start",
   PreviewSPFxOpenBrowser = "preview-spfx-open-browser",
   PreviewPrerequisites = "preview-prerequisites",
@@ -66,7 +68,6 @@ export enum TelemetryEvent {
   PreviewPrereqsCheckPorts = "preview-prereqs-check-ports",
   PreviewPrepareDevEnv = "preview-prepare-dev-env",
   PreviewStartServices = "preview-start-services",
-  PreviewSideloading = "preview-sideloading",
 
   AutomaticNpmInstallStart = "automatic-npm-install-start",
   AutomaticNpmInstall = "automatic-npm-install",


### PR DESCRIPTION
- unify handling of start/end events for preview stages (use localTelemetryReporter so `duration` is automatically added)
- align telemetry with vsc
    - separate PrerequisiteValidationError for account check and node check
    - `preview` event will contain `preview-last-event-name` and `preview-check-results`
    - add `preview-dev-cert-status` for cert event
    - remove `PreviewPrerequisitesCheckTime` because every end events contains `duration` now
 
Test:
![image](https://user-images.githubusercontent.com/9698542/175264807-2e7e2b22-b8d0-4de6-be75-d50342b0cb6b.png)

"teamsfx-cli/preview" event
![image](https://user-images.githubusercontent.com/9698542/175265284-e8e1771b-1ab9-4c09-9a90-5cb79416a8ab.png)
