### PR TITLE
fix: template path for aad manifest on .net scenario

### DIFF
--- a/packages/fx-core/src/common/utils.ts
+++ b/packages/fx-core/src/common/utils.ts
@@ -12,7 +12,7 @@ export async function getProjectTemplatesFolderPath(projectPath: string): Promis
       try {
         await fs.rename(path.join(projectPath, "templates"), path.join(projectPath, "Templates"));
       } catch (e) {
-        return path.resolve(projectPath, "templates");
+        return path.resolve(projectPath, "Templates");
       }
     }
     return path.resolve(projectPath, "Templates");

--- a/packages/fx-core/src/core/generateAadManifestTemplate.ts
+++ b/packages/fx-core/src/core/generateAadManifestTemplate.ts
@@ -10,6 +10,7 @@ import {
   RequiredResourceAccess,
 } from "../plugins/resource/aad/interfaces/AADManifest";
 import { AzureSolutionSettings } from "@microsoft/teamsfx-api";
+import { getAppDirectory } from "../common";
 
 interface Permission {
   resource: string;
@@ -24,7 +25,7 @@ export async function generateAadManifestTemplate(
   updateCapabilities = false
 ): Promise<void> {
   const templatesFolder = getTemplatesFolder();
-  const appDir = `${projectFolder}/${Constants.appPackageFolder}`;
+  const appDir = await getAppDirectory(projectFolder);
   const aadManifestTemplate = `${templatesFolder}/${Constants.aadManifestTemplateFolder}/${Constants.aadManifestTemplateName}`;
   await fs.ensureDir(appDir);
 

--- a/packages/fx-core/src/core/middleware/consolidateLocalRemote.ts
+++ b/packages/fx-core/src/core/middleware/consolidateLocalRemote.ts
@@ -29,7 +29,7 @@ import {
   TelemetryProperty,
 } from "../../common/telemetry";
 import { CoreHookContext } from "../types";
-import { TOOLS } from "../globalVars";
+import { globalVars, TOOLS } from "../globalVars";
 import { getLocalizedString } from "../../common/localizeUtils";
 import { getManifestTemplatePath } from "../../plugins/resource/appstudio/manifestTemplate";
 import { getResourceFolder, getTemplatesFolder } from "../../folder";
@@ -157,8 +157,9 @@ export async function needConsolidateLocalRemote(ctx: CoreHookContext): Promise<
     return false;
   }
 
+  const templates = globalVars.isVS ? "Templates" : "templates";
   const consolidateManifestExist = await fs.pathExists(
-    path.join(inputs.projectPath as string, "templates", "appPackage", "manifest.template.json")
+    path.join(inputs.projectPath as string, templates, "appPackage", "manifest.template.json")
   );
   if (!consolidateManifestExist) {
     return true;

--- a/packages/fx-core/src/core/middleware/consolidateLocalRemote.ts
+++ b/packages/fx-core/src/core/middleware/consolidateLocalRemote.ts
@@ -29,23 +29,15 @@ import {
   TelemetryProperty,
 } from "../../common/telemetry";
 import { CoreHookContext } from "../types";
-import { globalVars, TOOLS } from "../globalVars";
+import { TOOLS } from "../globalVars";
 import { getLocalizedString } from "../../common/localizeUtils";
 import { getManifestTemplatePath } from "../../plugins/resource/appstudio/manifestTemplate";
-import { getResourceFolder, getTemplatesFolder } from "../../folder";
+import { getResourceFolder } from "../../folder";
 import { loadProjectSettings } from "./projectSettingsLoader";
 import { addPathToGitignore, needMigrateToArmAndMultiEnv } from "./projectMigrator";
 import * as util from "util";
 import { ManifestTemplate } from "../../plugins/resource/spfx/utils/constants";
-import {
-  generateAadManifest,
-  needMigrateToAadManifest,
-  Permission,
-  permissionsToRequiredResourceAccess,
-} from "./MigrationUtils";
-import { Constants } from "../../plugins/resource/aad/constants";
-import { AADManifest } from "../../plugins/resource/aad/interfaces/AADManifest";
-import { generateAadManifestTemplate } from "../generateAadManifestTemplate";
+import { generateAadManifest, needMigrateToAadManifest } from "./MigrationUtils";
 
 const upgradeButton = "Upgrade";
 const LearnMore = "Learn More";

--- a/packages/fx-core/src/core/middleware/consolidateLocalRemote.ts
+++ b/packages/fx-core/src/core/middleware/consolidateLocalRemote.ts
@@ -12,7 +12,7 @@ import {
   StatesFolderName,
   TeamsAppManifest,
 } from "@microsoft/teamsfx-api";
-import { isSPFxProject, isConfigUnifyEnabled } from "../../common/tools";
+import { isSPFxProject, isConfigUnifyEnabled, getAppDirectory } from "../../common/tools";
 import { environmentManager } from "../environment";
 import { CoreSource, ConsolidateCanceledError } from "../error";
 import { Middleware, NextFunction } from "@feathersjs/hooks/lib";
@@ -157,10 +157,8 @@ export async function needConsolidateLocalRemote(ctx: CoreHookContext): Promise<
     return false;
   }
 
-  const templates = globalVars.isVS ? "Templates" : "templates";
-  const consolidateManifestExist = await fs.pathExists(
-    path.join(inputs.projectPath as string, templates, "appPackage", "manifest.template.json")
-  );
+  const appDir = await getAppDirectory(inputs.projectPath as string);
+  const consolidateManifestExist = await fs.pathExists(path.join(appDir, "manifest.template.json"));
   if (!consolidateManifestExist) {
     return true;
   }

--- a/packages/fx-core/tests/plugins/resource/aad/unit/index.test.ts
+++ b/packages/fx-core/tests/plugins/resource/aad/unit/index.test.ts
@@ -326,6 +326,7 @@ describe("AadAppForTeamsPlugin: CI", () => {
     sinon.stub(fs, "ensureDir").resolves();
     const config = new Map();
     const context = await TestHelper.pluginContext(config, true, false, false);
+    context.root = "./";
 
     sinon.stub(fs, "pathExists").resolves(true);
 
@@ -362,6 +363,7 @@ describe("AadAppForTeamsPlugin: CI", () => {
     sinon.stub(fs, "ensureDir").resolves();
     const config = new Map();
     const context = await TestHelper.pluginContext(config, true, false, false);
+    context.root = "./";
     (context.projectSettings!.solutionSettings as any).capabilities.push("Bot");
     sinon.stub(fs, "pathExists").resolves(true);
 
@@ -393,7 +395,6 @@ describe("AadAppForTeamsPlugin: CI", () => {
       );
     });
     const result = await plugin.scaffold(context);
-
     chai.assert.equal(result.isOk(), true);
   });
 


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_sprints/taskboard/Teams%20Extensibility%20E2E%20Team/Microsoft%20Teams%20Extensibility/CY22-6.2?workitem=14776287

E2E TEST: already covered by packages/cli/tests/e2e/bot/ProvisionAppServiceNotificationBot.dotnet.tests.ts