### PR TITLE
chore: send gap duration for local debug

### DIFF
--- a/packages/fx-core/src/common/local/localTelemetryReporter.ts
+++ b/packages/fx-core/src/common/local/localTelemetryReporter.ts
@@ -38,9 +38,14 @@ export class LocalTelemetryReporter {
   private static readonly StartEventSuffix = "-start";
   private readonly reporter: ToolTelemetryReporter;
   private lastEventName: string | undefined;
+  private saveEventTime?: (eventName: string, time: number) => void;
 
-  constructor(reporter: ToolTelemetryReporter) {
+  constructor(
+    reporter: ToolTelemetryReporter,
+    saveEventTime?: (eventName: string, time: number) => void
+  ) {
     this.reporter = reporter;
+    this.saveEventTime = saveEventTime;
   }
 
   /**
@@ -176,6 +181,7 @@ export class LocalTelemetryReporter {
     measurements?: { [key: string]: number }
   ): void {
     this.lastEventName = eventName;
+    this.saveEventTime?.(eventName, performance.now());
     this.reporter.sendTelemetryEvent(eventName, properties, measurements);
   }
 
@@ -193,6 +199,7 @@ export class LocalTelemetryReporter {
       properties[LocalTelemetryReporter.PropertyDebugLastEventName] = this.getLastEventName();
     }
     this.lastEventName = eventName;
+    this.saveEventTime?.(eventName, performance.now());
     this.reporter.sendTelemetryErrorEvent(eventName, error, properties, measurements, errorProps);
   }
 }

--- a/packages/vscode-extension/src/debug/localTelemetryReporter.ts
+++ b/packages/vscode-extension/src/debug/localTelemetryReporter.ts
@@ -12,22 +12,34 @@ import {
 } from "../telemetry/extTelemetryEvents";
 import { getLocalDebugSession, getProjectComponents } from "./commonUtils";
 
-export const localTelemetryReporter = new LocalTelemetryReporter({
-  // Cannot directly refer to a global function because of import dependency cycle in ../telemetry/extTelemetry.ts.
-  sendTelemetryEvent: (
-    eventName: string,
-    properties?: { [p: string]: string },
-    measurements?: { [p: string]: number }
-  ) => ExtTelemetry.sendTelemetryEvent(eventName, properties, measurements),
+function saveEventTime(eventName: string, time: number) {
+  const session = getLocalDebugSession();
+  // Assuming the event is only sent once in one local debug session,
+  // because we only use the "high-level" events like debug-prerequisites, debug-precheck, etc..
+  // And these events are indeed sent once.
+  session.eventTimes[eventName] = time;
+}
 
-  sendTelemetryErrorEvent: (
-    eventName: string,
-    error: FxError,
-    properties?: { [p: string]: string },
-    measurements?: { [p: string]: number },
-    errorProps?: string[]
-  ) => ExtTelemetry.sendTelemetryErrorEvent(eventName, error, properties, measurements, errorProps),
-});
+export const localTelemetryReporter = new LocalTelemetryReporter(
+  {
+    // Cannot directly refer to a global function because of import dependency cycle in ../telemetry/extTelemetry.ts.
+    sendTelemetryEvent: (
+      eventName: string,
+      properties?: { [p: string]: string },
+      measurements?: { [p: string]: number }
+    ) => ExtTelemetry.sendTelemetryEvent(eventName, properties, measurements),
+
+    sendTelemetryErrorEvent: (
+      eventName: string,
+      error: FxError,
+      properties?: { [p: string]: string },
+      measurements?: { [p: string]: number },
+      errorProps?: string[]
+    ) =>
+      ExtTelemetry.sendTelemetryErrorEvent(eventName, error, properties, measurements, errorProps),
+  },
+  saveEventTime
+);
 
 export async function sendDebugAllStartEvent(): Promise<void> {
   const session = getLocalDebugSession();
@@ -50,9 +62,33 @@ export async function sendDebugAllEvent(
   const now = performance.now();
 
   let duration = -1;
-  if (session.startTime !== undefined) {
-    duration = (now - session.startTime) / 1000;
+  const startTime = session.eventTimes[TelemetryEvent.DebugAllStart];
+  if (startTime !== undefined) {
+    duration = (now - startTime) / 1000;
   }
+
+  // Calculate the time between two events
+  // Event must be only once in one debug session.
+  function durationBetween(eventStart: string, eventEnd: string): number {
+    const t0 = session.eventTimes[eventStart];
+    const t1 = session.eventTimes[eventEnd];
+    if (t0 !== undefined && t1 !== undefined) {
+      return t1 - t0;
+    } else {
+      return -1;
+    }
+  }
+
+  // Calculate the "time gap" in a local debug session.
+  // In current local debug implementation, there is some time that vscode is in control and extension has no control.
+  // For example, between "debug-precheck" (task finishes) and "debug-all" (browser starts), vscode is starting the services.
+  // However, we don't know when the services successfully start because we use problem matcher to determine the service start or fail.
+  // And vscode does not provide a callback for that.
+  // Estimating from the current data, this "time gap" can be up to 1 minute, so not neglectable.
+  const precheckGap =
+    durationBetween(TelemetryEvent.DebugPrerequisites, TelemetryEvent.DebugPreCheckStart) / 1000;
+  const precheckTime = session.eventTimes[TelemetryEvent.DebugPreCheck];
+  const servicesGap = precheckTime === undefined ? -1 : (performance.now() - precheckTime) / 1000;
 
   const properties = {
     [TelemetryProperty.CorrelationId]: session.id,
@@ -62,13 +98,20 @@ export async function sendDebugAllEvent(
     ...additionalProperties,
   };
 
+  const measurements = {
+    [LocalTelemetryReporter.PropertyDuration]: duration,
+    [TelemetryProperty.DebugPrecheckGapDuration]: precheckGap,
+    [TelemetryProperty.DebugServicesGapDuration]: servicesGap,
+  };
+
   if (error === undefined) {
-    localTelemetryReporter.sendTelemetryEvent(TelemetryEvent.DebugAll, properties, {
-      [LocalTelemetryReporter.PropertyDuration]: duration,
-    });
+    localTelemetryReporter.sendTelemetryEvent(TelemetryEvent.DebugAll, properties, measurements);
   } else {
-    localTelemetryReporter.sendTelemetryErrorEvent(TelemetryEvent.DebugAll, error, properties, {
-      [LocalTelemetryReporter.PropertyDuration]: duration,
-    });
+    localTelemetryReporter.sendTelemetryErrorEvent(
+      TelemetryEvent.DebugAll,
+      error,
+      properties,
+      measurements
+    );
   }
 }

--- a/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
@@ -226,6 +226,8 @@ export enum TelemetryProperty {
   DebugPrereqsDepsType = "debug-prereqs-deps-type",
   DebugFailedServices = "debug-failed-services",
   DebugPortsInUse = "debug-ports-in-use",
+  DebugPrecheckGapDuration = "debug-precheck-gap-duration",
+  DebugServicesGapDuration = "debug-services-gap-duration",
   Internal = "internal",
   InternalAlias = "internal-alias",
   OSArch = "os-arch",


### PR DESCRIPTION
- calculate the duration that vscode is in control and send in debug-all event
- refactor `LocalDebugSession`


E2E TEST: https://github.com/OfficeDev/TeamsFx-UI-Test/blob/main/src/ui-test/localdebug/localdebug-bot.test.ts