### PR TITLE
chore: use default string when string is not localized

### DIFF
--- a/packages/fx-core/src/common/localizeUtils.ts
+++ b/packages/fx-core/src/common/localizeUtils.ts
@@ -32,6 +32,10 @@ export function getLocalizedString(key: string, ...params: any[]): string {
   if (value && params && params.length > 0) {
     value = util.format(value, ...params);
   }
+
+  if (!value) {
+    return getDefaultString(key, ...params);
+  }
   return value || "";
 }
 


### PR DESCRIPTION
This is to avoid empty UI before strings are localized as reported in this GitHub issue: https://github.com/OfficeDev/TeamsFx/issues/5352