### PR TITLE
chore: improve npm install telemetry

### DIFF
--- a/packages/vscode-extension/src/debug/localTelemetryReporter.ts
+++ b/packages/vscode-extension/src/debug/localTelemetryReporter.ts
@@ -7,6 +7,7 @@ import { performance } from "perf_hooks";
 import { ExtTelemetry } from "../telemetry/extTelemetry";
 import {
   TelemetryEvent,
+  TelemetryMeasurements,
   TelemetryProperty,
   TelemetrySuccess,
 } from "../telemetry/extTelemetryEvents";
@@ -100,8 +101,8 @@ export async function sendDebugAllEvent(
 
   const measurements = {
     [LocalTelemetryReporter.PropertyDuration]: duration,
-    [TelemetryProperty.DebugPrecheckGapDuration]: precheckGap,
-    [TelemetryProperty.DebugServicesGapDuration]: servicesGap,
+    [TelemetryMeasurements.DebugPrecheckGapDuration]: precheckGap,
+    [TelemetryMeasurements.DebugServicesGapDuration]: servicesGap,
   };
 
   if (error === undefined) {

--- a/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
@@ -115,6 +115,7 @@ export enum TelemetryEvent {
   DebugPrereqsCheckPorts = "debug-prereqs-check-ports",
   DebugPrereqsCheckCert = "debug-prereqs-check-cert",
   DebugPrereqsCheckDependencies = "debug-prereqs-check-dependencies",
+  DebugPrereqsCheckNpmInstall = "debug-prereqs-check-npm-install",
   DebugPrereqsInstallPackages = "debug-prereqs-install-packages",
   DebugPreCheckCoreLocalDebug = "debug-precheck-core-local-debug",
   DebugTaskProvider = "debug-task-provider",
@@ -217,6 +218,7 @@ export enum TelemetryProperty {
   DebugCheckResultsSafe = "debug-check-results-safe",
   DebugErrorCodes = "debug-error-codes",
   DebugNpmInstallName = "debug-npm-install-name",
+  DebugNpmInstallAlreadyInstalled = "debug-npm-install-already-installed",
   DebugNpmInstallExitCode = "debug-npm-install-exit-code",
   DebugNpmInstallErrorMessage = "debug-npm-install-error-message",
   DebugNpmInstallNodeVersion = "debug-npm-install-node-version",
@@ -226,8 +228,6 @@ export enum TelemetryProperty {
   DebugPrereqsDepsType = "debug-prereqs-deps-type",
   DebugFailedServices = "debug-failed-services",
   DebugPortsInUse = "debug-ports-in-use",
-  DebugPrecheckGapDuration = "debug-precheck-gap-duration",
-  DebugServicesGapDuration = "debug-services-gap-duration",
   Internal = "internal",
   InternalAlias = "internal-alias",
   OSArch = "os-arch",
@@ -257,6 +257,12 @@ export enum TelemetryProperty {
   DocumentationName = "documentation-name",
   // Used with Deactivate
   Timestamp = "timestamp",
+}
+
+export enum TelemetryMeasurements {
+  Duration = "duration",
+  DebugPrecheckGapDuration = "debug-precheck-gap-duration",
+  DebugServicesGapDuration = "debug-services-gap-duration",
 }
 
 export enum TelemetrySuccess {


### PR DESCRIPTION
- add `debug-prereqs-check-npm-install` to track whether npm install is already installed
- add `duration` to `debug-npm-install`

First time:
![image](https://user-images.githubusercontent.com/9698542/176143166-b996a6ad-a72d-4888-b3b3-a643e8c38c22.png)
Second time:
![image](https://user-images.githubusercontent.com/9698542/176143519-f38b0ac4-794b-4db2-9f75-76bb1bd4e0f5.png)


E2E TEST: https://github.com/OfficeDev/TeamsFx-UI-Test/blob/main/src/ui-test/localdebug/localdebug-bot.test.ts