### PR TITLE
docs: Trim the volume of instructions to get started

### DIFF
--- a/templates/bot/csharp/command-and-response/GettingStarted.txt
+++ b/templates/bot/csharp/command-and-response/GettingStarted.txt
@@ -1,65 +1,24 @@
-Welcome to the Teams Toolkit! Here are some tips to get started to play with Teams Toolkit.
+Welcome to Teams Toolkit!
 
-Prerequisites
-----------
+Quick Start
+-------------------------
+1. Download and install ngrok (https://ngrok.com/)
+2. Open a command prompt and run ngrok http 5130
+3. Right-click your project and select Teams Toolkit > Prepare Teams app dependencies
+4. If prompted, sign in with an M365 account for the Teams organization you want 
+to install the app to
+5. Press F5, or select the Debug > Start Debugging menu in Visual Studio
+6. In the launched browser, select the Add button to load the app in Teams
+7. In the chat bar, type and send "helloworld" to your app to trigger a response
 
-To run / debug a command bot, you'll need to setup Ngrok(https://ngrok.com/) first. Ngrok is used to forward external messages from Azure Bot Framework to your local machine.
-
-Quick start
-----------
-
-To run and debug Teams project on your local machine:
-
-1. Use a Command Prompt to run this command: ngrok http 5130.
-
-2. In Visual Studio Solution Explorer, right click on your project file and select "Teams Toolkit" -> "Prepare Teams app dependencies". You will be asked to login to your M365 account. This command will prepare local debug dependencies and register a Teams app in the tenant which your account belongs to.
-
-Notes: your M365 account need to have the sideloading permission to ensure Teams app can be uploaded to your tenant, otherwise you will end up with failure to see your Teams app running in Teams client. Learn more about sideloading permission by visiting https://aka.ms/teamsfx-sideloading-option.
-
-3. Go to the "Debug" menu > click on "Start Debugging" or directly press F5. Visual Studio will launch the Teams app inside Microsoft Teams client in a browser. Learn more by visiting https://aka.ms/teamsfx-vs-debug.
-
-Tips: you can use hotreload function of VS during debug. Learn more by visiting https://aka.ms/teamsfx-vs-hotreload.
-
-4. Once Microsoft Teams is loaded, select the "Add" button to install your app in Teams.
-
-5. Send a "helloworld" command in your Teams chat with the command bot, and you will receive an adaptive card message from your app.
-
-Tips: if you made changes to Teams app manifest file (Templates/appPackage/manifest.template.json), please right click on your project and select "Teams Toolkit" -> "Prepare Teams app dependencies" command before you try to locally run the Teams app again.
-
-Deploy your Teams app on Azure
-------------------------------------
-
-To run your Teams app on Azure:
-
-1. Right click on your project and select "Teams Toolkit" -> "Provision in the cloud..." to create resources in Azure for your app. You can select a proper subscription and resource group which you would like to use for your Teams app. Please be noted that this might cause charges to your Azure account. Learn more by visiting https://aka.ms/teamsfx-vs-provision.
-
-2. Right click on your project and select "Teams Toolkit" -> "Deploy to the cloud...", this step will deploy your code to the Azure resources created in previous step. It is common to deploy multiple times to the same set of Azure resources, so there is no need to run "Provision in the cloud..." every time before run "Deploy to the cloud...". Both the commands will take several minutes to complete, please wait until it finished. Learn more by visiting https://aka.ms/teamsfx-vs-deploy.
-
-3. Right click on your project and select "Teams Toolkit" -> "Preview in Teams" to launch your app in a browser. 
-
-4. Once Microsoft Teams is loaded, select the "Add" button to install your app in Teams. You will see your app running remotely from Azure.
-
-Notes: there is an alternative way to find all the commands mentioned above, go to the "Project" menu in Visual Studio, select "Teams Toolkit" and you will find all the commands there.
-
-Tips: if you made changes to Teams app manifest file (Templates/appPackage/manifest.template.json), please right click on your project and select "Teams Toolkit" -> "Update manifest in Teams Developer Portal" command before you try to run the Teams app remotely from Azure again.
+Learn more
+-------------------------
+New to Teams app development or Teams Toolkit? Learn more about 
+Teams app manifests, deploying to the cloud, and more in the documentation 
+at https://aka.ms/teams-toolkit-vs-docs
 
 Report an issue
----------------
-
-If you encountered any problem while you are building Teams app using Teams Toolkit, you can create an issue in our GitHub repository: https://github.com/OfficeDev/TeamsFx/issues
-
-
-Q&A
----------------
-
-1. How do I log out or switch my M365 account in Teams Toolkit?
-   Right click on your project, select "Teams Toolkit" -> "Prepare Teams app dependencies". You can switch your M365 account in the pop up window.
-
-2. How do I request more permissions and scopes in a Graph call?
-   If you have selected Personal Tab capability and you want to change the scope in a Graph call, you can first change the parameter _scope in Components/Graph.razor. Then go to Azure Portal -> Azure Active Directory -> App Registrations, find the AAD application Toolkit created for you (default name is the same as the project name), under Manage, select API Permissions. Select Add a permission > Microsoft Graph > Delegated permissions, then add the permissions you want.
-
-3. Why is my bot not working in Teams?
-   Please check if the ngrok is running correctly in your local environment. ngrok will expire every 2 hours and you need to restart it unless you log in with a paid subscription. After the restart, the endpoint will change and you need to run the command "Prepare Teams app dependencies" to update the new endpoint.
-
-4. Why does the command "Prepare Teams app dependencies" shows that ngrok is not running correctly?
-   We only support the ngrok is running with default settings. Please make sure the ngrok web interface is http://127.0.0.1:4040.
+-------------------------
+Select Visual Studio > Help > Send Feedback > Report a Problem. 
+Or, you can create an issue directly in our GitHub repository: 
+https://github.com/OfficeDev/TeamsFx/issues

--- a/templates/bot/csharp/default/Bot/TeamsMessageExtension.cs.tpl
+++ b/templates/bot/csharp/default/Bot/TeamsMessageExtension.cs.tpl
@@ -59,7 +59,7 @@ public class TeamsMessageExtension : TeamsActivityHandler
         // The user has chosen to share a message by choosing the 'Share Message' context menu command.
         var heroCard = new HeroCard
         {
-            Title = $"{action.MessagePayload.From?.User?.DisplayName} orignally sent this message:",
+            Title = $"{action.MessagePayload.From?.User?.DisplayName} originally sent this message:",
             Text = action.MessagePayload.Body.Content,
         };
 

--- a/templates/bot/csharp/default/GettingStarted.txt
+++ b/templates/bot/csharp/default/GettingStarted.txt
@@ -1,59 +1,20 @@
-Welcome to the Teams Toolkit! Here are some tips to get started to play with Teams Toolkit.
+Welcome to Teams Toolkit!
+Quick Start
+-------------------------
+1. Right-click your project and select Teams Toolkit > Prepare Teams app dependencies
+2. If prompted, sign in with an M365 account for the Teams organization you want 
+to install the app to
+3. Press F5, or select the Debug > Start Debugging menu in Visual Studio
+4. In the launched browser, select the Add button to load the app in Teams
 
-Prerequisites
-----------
-
-To run / debug a Bot or Message Extension app, you'll need to setup Ngrok(https://ngrok.com/) first. Ngrok is used to forward external messages from Azure Bot Framework to your local machine.
-
-Quick start
-----------
-
-To run and debug Teams project on your local machine:
-
-1. Use a Command Prompt to run this command: ngrok http 5130.
-
-2. In Visual Studio Solution Explorer, right click on your project file and select "Teams Toolkit" -> "Prepare Teams app dependencies". You will be asked to login to your M365 account. This command will prepare local debug dependencies and register a Teams app in the tenant which your account belongs to.
-
-Notes: your M365 account need to have the sideloading permission to ensure Teams app can be uploaded to your tenant, otherwise you will end up with failure to see your Teams app running in Teams client. Learn more about sideloading permission by visiting https://aka.ms/teamsfx-sideloading-option. 
-
-3. Go to the "Debug" menu > click on "Start Debugging" or directly press F5. Visual Studio will launch the Teams app inside Microsoft Teams client in a browser. Learn more by visiting https://aka.ms/teamsfx-vs-debug.
-
-Tips: you can use hotreload function of VS during debug. Learn more by visiting https://aka.ms/teamsfx-vs-hotreload.
-
-4. Once Microsoft Teams is loaded, select the "Add" button to install your app in Teams.
-
-Tips: if you made changes to Teams app manifest file (Templates/appPackage/manifest.template.json), please right click on your project and select "Teams Toolkit" -> "Prepare Teams app dependencies" command before you try to locally run the Teams app again.
-
-Deploy your Teams app on Azure
-------------------------------------
-
-To run your Teams app on Azure:
-
-1. Right click on your project and select "Teams Toolkit" -> "Provision in the cloud..." to create resources in Azure for your app. You can select a proper subscription and resource group which you would like to use for your Teams app. Please be noted that this might cause charges to your Azure account. Learn more by visiting https://aka.ms/teamsfx-vs-provision.
-
-2. Right click on your project and select "Teams Toolkit" -> "Deploy to the cloud...", this step will deploy your code to the Azure resources created in previous step. It is common to deploy multiple times to the same set of Azure resources, so there is no need to run "Provision in the cloud..." every time before run "Deploy to the cloud...". Both the commands will take several minutes to complete, please wait until it finished. Learn more by visiting https://aka.ms/teamsfx-vs-deploy.
-
-3. Right click on your project and select "Teams Toolkit" -> "Preview in Teams" to launch your app in a browser. 
-
-4. Once Microsoft Teams is loaded, select the "Add" button to install your app in Teams. You will see your app running remotely from Azure.
-
-Notes: there is an alternative way to find all the commands mentioned above, go to the "Project" menu in Visual Studio, select "Teams Toolkit" and you will find all the commands there.
-
-Tips: if you made changes to Teams app manifest file (Templates/appPackage/manifest.template.json), please right click on your project and select "Teams Toolkit" -> "Update manifest in Teams Developer Portal" command before you try to run the Teams app remotely from Azure again.
+Learn more
+-------------------------
+New to Teams app development or Teams Toolkit? Learn more about 
+Teams app manifests, deploying to the cloud, and more in the documentation 
+at https://aka.ms/teams-toolkit-vs-docs
 
 Report an issue
----------------
-
-If you encountered any problem while you are building Teams app using Teams Toolkit, you can create an issue in our GitHub repository: https://github.com/OfficeDev/TeamsFx/issues
-
-Q&A
----------------
-
-1. How do I log out or switch my M365 account in Teams Toolkit?
-   Right click on your project, select "Teams Toolkit" -> "Prepare Teams app dependencies". You can switch your M365 account in the pop up window.
-
-2. Why is my bot not working in Teams?
-   Please check if the ngrok is running correctly in your local environment. ngrok will expire every 2 hours and you need to restart it unless you log in with a paid subscription. After the restart, the endpoint will change and you need to run the command "Prepare Teams app dependencies" to update the new endpoint.
-
-3. Why does the command "Prepare Teams app dependencies" shows that ngrok is not running correctly?
-   We only support the ngrok is running with default settings. Please make sure the ngrok web interface is http://127.0.0.1:4040.
+-------------------------
+Select Visual Studio > Help > Send Feedback > Report a Problem. 
+Or, you can create an issue directly in our GitHub repository: 
+https://github.com/OfficeDev/TeamsFx/issues

--- a/templates/bot/csharp/default/GettingStarted.txt
+++ b/templates/bot/csharp/default/GettingStarted.txt
@@ -1,11 +1,15 @@
 Welcome to Teams Toolkit!
+
 Quick Start
 -------------------------
-1. Right-click your project and select Teams Toolkit > Prepare Teams app dependencies
-2. If prompted, sign in with an M365 account for the Teams organization you want 
+1. Download and install ngrok (https://ngrok.com/)
+2. Open a command prompt and run ngrok http 5130
+3. Right-click your project and select Teams Toolkit > Prepare Teams app dependencies
+4. If prompted, sign in with an M365 account for the Teams organization you want 
 to install the app to
-3. Press F5, or select the Debug > Start Debugging menu in Visual Studio
-4. In the launched browser, select the Add button to load the app in Teams
+5. Press F5, or select the Debug > Start Debugging menu in Visual Studio
+6. In the launched browser, select the Add button to load the app in Teams
+7. You can play with this app to create an adaptive card, share a message, search for an nuget package or unfurl links from ".botframwork.com" domain.
 
 Learn more
 -------------------------

--- a/templates/bot/csharp/notification-function-base/GettingStarted.txt
+++ b/templates/bot/csharp/notification-function-base/GettingStarted.txt
@@ -1,62 +1,26 @@
-Welcome to the Teams Toolkit! Here are some tips to get started to play with Teams Toolkit.
+Welcome to Teams Toolkit!
 
-Prerequisites
-----------
+Quick Start
+-------------------------
+1. Download and install ngrok (https://ngrok.com/)
+2. Open a command prompt and run ngrok http 5130
+3. Right-click your project and select Teams Toolkit > Prepare Teams app dependencies
+4. If prompted, sign in with an M365 account for the Teams organization you want 
+to install the app to
+5. Press F5, or select the Debug > Start Debugging menu in Visual Studio
+6. In the launched browser, select the Add button to load the app in Teams
+7. Open Powershell and post an HTTP request to trigger the notification:
 
-To run / debug a notification bot, you'll need to setup Ngrok(https://ngrok.com/) first. Ngrok is used to forward external messages from Azure Bot Framework to your local machine.
+   Invoke-WebRequest -Uri "http://localhost:5130/api/notification" -Method Post
 
-Quick start
-----------
-
-To run and debug Teams project on your local machine:
-
-1. Use a Command Prompt to run this command: ngrok http 5130.
-
-2. In Visual Studio Solution Explorer, right click on your project file and select "Teams Toolkit" -> "Prepare Teams app dependencies". You will be asked to login to your M365 account. This command will prepare local debug dependencies and register a Teams app in the tenant which your account belongs to.
-
-Notes: your M365 account need to have the sideloading permission to ensure Teams app can be uploaded to your tenant, otherwise you will end up with failure to see your Teams app running in Teams client. Learn more about sideloading permission by visiting https://aka.ms/teamsfx-sideloading-option.
-
-3. Go to the "Debug" menu > click on "Start Debugging" or directly press F5. Visual Studio will launch the Teams app inside Microsoft Teams client in a browser. Learn more by visiting https://aka.ms/teamsfx-vs-debug.
-
-Tips: you can use hotreload function of VS during debug. Learn more by visiting https://aka.ms/teamsfx-vs-hotreload.
-
-4. Once Microsoft Teams is loaded, select the "Add" button to install your app in Teams.
-
-5. Post HTTP request to http://localhost:5130/api/notification to trigger notification. You can use any API tool: curl (Windows Command Prompt), Postman, etc.
-
-Tips: if you made changes to Teams app manifest file (Templates/appPackage/manifest.template.json), please right click on your project and select "Teams Toolkit" -> "Prepare Teams app dependencies" command before you try to locally run the Teams app again.
-
-Deploy your Teams app on Azure
-------------------------------------
-
-To run your Teams app on Azure:
-
-1. Right click on your project and select "Teams Toolkit" -> "Provision in the cloud..." to create resources in Azure for your app. You can select a proper subscription and resource group which you would like to use for your Teams app. Please be noted that this might cause charges to your Azure account. Learn more by visiting https://aka.ms/teamsfx-vs-provision.
-
-2. Right click on your project and select "Teams Toolkit" -> "Deploy to the cloud...", this step will deploy your code to the Azure resources created in previous step. It is common to deploy multiple times to the same set of Azure resources, so there is no need to run "Provision in the cloud..." every time before run "Deploy to the cloud...". Both the commands will take several minutes to complete, please wait until it finished. Learn more by visiting https://aka.ms/teamsfx-vs-deploy.
-
-3. Right click on your project and select "Teams Toolkit" -> "Preview in Teams" to launch your app in a browser. 
-
-4. Once Microsoft Teams is loaded, select the "Add" button to install your app in Teams. You will see your app running remotely from Azure.
-
-Notes: there is an alternative way to find all the commands mentioned above, go to the "Project" menu in Visual Studio, select "Teams Toolkit" and you will find all the commands there.
-
-Tips: if you made changes to Teams app manifest file (Templates/appPackage/manifest.template.json), please right click on your project and select "Teams Toolkit" -> "Update manifest in Teams Developer Portal" command before you try to run the Teams app remotely from Azure again.
+Learn more
+-------------------------
+New to Teams app development or Teams Toolkit? Learn more about 
+Teams app manifests, deploying to the cloud, and more in the documentation 
+at https://aka.ms/teams-toolkit-vs-docs
 
 Report an issue
----------------
-
-If you encountered any problem while you are building Teams app using Teams Toolkit, you can create an issue in our GitHub repository: https://github.com/OfficeDev/TeamsFx/issues
-
-
-Q&A
----------------
-
-1. How do I log out or switch my M365 account in Teams Toolkit?
-   Right click on your project, select "Teams Toolkit" -> "Prepare Teams app dependencies". You can switch your M365 account in the pop up window.
-
-2. Why is my bot not working in Teams?
-   Please check if the ngrok is running correctly in your local environment. ngrok will expire every 2 hours and you need to restart it unless you log in with a paid subscription. After the restart, the endpoint will change and you need to run the command "Prepare Teams app dependencies" to update the new endpoint.
-
-3. Why does the command "Prepare Teams app dependencies" shows that ngrok is not running correctly?
-   We only support the ngrok is running with default settings. Please make sure the ngrok web interface is http://127.0.0.1:4040.
+-------------------------
+Select Visual Studio > Help > Send Feedback > Report a Problem. 
+Or, you can create an issue directly in our GitHub repository: 
+https://github.com/OfficeDev/TeamsFx/issues

--- a/templates/bot/csharp/notification-webapi/GettingStarted.txt
+++ b/templates/bot/csharp/notification-webapi/GettingStarted.txt
@@ -1,62 +1,26 @@
-Welcome to the Teams Toolkit! Here are some tips to get started to play with Teams Toolkit.
+Welcome to Teams Toolkit!
 
-Prerequisites
-----------
+Quick Start
+-------------------------
+1. Download and install ngrok (https://ngrok.com/)
+2. Open a command prompt and run ngrok http 5130
+3. Right-click your project and select Teams Toolkit > Prepare Teams app dependencies
+4. If prompted, sign in with an M365 account for the Teams organization you want 
+to install the app to
+5. Press F5, or select the Debug > Start Debugging menu in Visual Studio
+6. In the launched browser, select the Add button to load the app in Teams
+7. Open Powershell and post an HTTP request to trigger the notification:
 
-To run / debug a notification bot, you'll need to setup Ngrok(https://ngrok.com/) first. Ngrok is used to forward external messages from Azure Bot Framework to your local machine.
+   Invoke-WebRequest -Uri "http://localhost:5130/api/notification" -Method Post
 
-Quick start
-----------
-
-To run and debug Teams project on your local machine:
-
-1. Use a Command Prompt to run this command: ngrok http 5130.
-
-2. In Visual Studio Solution Explorer, right click on your project file and select "Teams Toolkit" -> "Prepare Teams app dependencies". You will be asked to login to your M365 account. This command will prepare local debug dependencies and register a Teams app in the tenant which your account belongs to.
-
-Notes: your M365 account need to have the sideloading permission to ensure Teams app can be uploaded to your tenant, otherwise you will end up with failure to see your Teams app running in Teams client. Learn more about sideloading permission by visiting https://aka.ms/teamsfx-sideloading-option. 
-
-3. Go to the "Debug" menu > click on "Start Debugging" or directly press F5. Visual Studio will launch the Teams app inside Microsoft Teams client in a browser. Learn more by visiting https://aka.ms/teamsfx-vs-debug.
-
-Tips: you can use hotreload function of VS during debug. Learn more by visiting https://aka.ms/teamsfx-vs-hotreload.
-
-4. Once Microsoft Teams is loaded, select the "Add" button to install your app in Teams.
-
-5. Post HTTP request to http://localhost:5130/api/notification to trigger notification. You can use any API tool: curl (Windows Command Prompt), Postman, etc.
-
-Tips: if you made changes to Teams app manifest file (Templates/appPackage/manifest.template.json), please right click on your project and select "Teams Toolkit" -> "Prepare Teams app dependencies" command before you try to locally run the Teams app again.
-
-Deploy your Teams app on Azure
-------------------------------------
-
-To run your Teams app on Azure:
-
-1. Right click on your project and select "Teams Toolkit" -> "Provision in the cloud..." to create resources in Azure for your app. You can select a proper subscription and resource group which you would like to use for your Teams app. Please be noted that this might cause charges to your Azure account. Learn more by visiting https://aka.ms/teamsfx-vs-provision.
-
-2. Right click on your project and select "Teams Toolkit" -> "Deploy to the cloud...", this step will deploy your code to the Azure resources created in previous step. It is common to deploy multiple times to the same set of Azure resources, so there is no need to run "Provision in the cloud..." every time before run "Deploy to the cloud...". Both the commands will take several minutes to complete, please wait until it finished. Learn more by visiting https://aka.ms/teamsfx-vs-deploy.
-
-3. Right click on your project and select "Teams Toolkit" -> "Preview in Teams" to launch your app in a browser. 
-
-4. Once Microsoft Teams is loaded, select the "Add" button to install your app in Teams. You will see your app running remotely from Azure.
-
-Notes: there is an alternative way to find all the commands mentioned above, go to the "Project" menu in Visual Studio, select "Teams Toolkit" and you will find all the commands there.
-
-Tips: if you made changes to Teams app manifest file (Templates/appPackage/manifest.template.json), please right click on your project and select "Teams Toolkit" -> "Update manifest in Teams Developer Portal" command before you try to run the Teams app remotely from Azure again.
+Learn more
+-------------------------
+New to Teams app development or Teams Toolkit? Learn more about 
+Teams app manifests, deploying to the cloud, and more in the documentation 
+at https://aka.ms/teams-toolkit-vs-docs
 
 Report an issue
----------------
-
-If you encountered any problem while you are building Teams app using Teams Toolkit, you can create an issue in our GitHub repository: https://github.com/OfficeDev/TeamsFx/issues
-
-
-Q&A
----------------
-
-1. How do I log out or switch my M365 account in Teams Toolkit?
-   Right click on your project, select "Teams Toolkit" -> "Prepare Teams app dependencies". You can switch your M365 account in the pop up window.
-
-2. Why is my bot not working in Teams?
-   Please check if the ngrok is running correctly in your local environment. ngrok will expire every 2 hours and you need to restart it unless you log in with a paid subscription. After the restart, the endpoint will change and you need to run the command "Prepare Teams app dependencies" to update the new endpoint.
-
-3. Why does the command "Prepare Teams app dependencies" shows that ngrok is not running correctly?
-   We only support the ngrok is running with default settings. Please make sure the ngrok web interface is http://127.0.0.1:4040.
+-------------------------
+Select Visual Studio > Help > Send Feedback > Report a Problem. 
+Or, you can create an issue directly in our GitHub repository: 
+https://github.com/OfficeDev/TeamsFx/issues

--- a/templates/tab/csharp/default/GettingStarted.txt
+++ b/templates/tab/csharp/default/GettingStarted.txt
@@ -1,61 +1,21 @@
-Welcome to the Teams Toolkit! Here are some tips to get started to play with Teams Toolkit.
+Welcome to Teams Toolkit!
 
-Quick start
-----------
+Quick Start
+-------------------------
+1. Right-click your project and select Teams Toolkit > Prepare Teams app dependencies
+2. If prompted, sign in with an M365 account for the Teams organization you want 
+to install the app to
+3. Press F5, or select the Debug > Start Debugging menu in Visual Studio
+4. In the launched browser, select the Add button to load the app in Teams
 
-To run and debug Teams project on your local machine:
-
-1. In Visual Studio Solution Explorer, right click on your project file and select "Teams Toolkit" -> "Prepare Teams app dependencies". You will be asked to login to your M365 account. This command will prepare local debug dependencies and register a Teams app in the tenant which your account belongs to.
-
-Notes: your M365 account need to have the sideloading permission to ensure Teams app can be uploaded to your tenant, otherwise you will end up with failure to see your Teams app running in Teams client. Learn more about sideloading permission by visiting https://aka.ms/teamsfx-sideloading-option
-
-2. Go to the "Debug" menu > click on "Start Debugging" or directly press F5. Visual Studio will launch the Teams app inside Microsoft Teams client in a browser. Learn more by visiting https://aka.ms/teamsfx-vs-debug.
-
-Tips: you can use hotreload function of VS during debug. Learn more by visiting https://aka.ms/teamsfx-vs-hotreload.
-
-3. Once Microsoft Teams is loaded, select the "Add" button to install your app in Teams.
-
-Tips: 
-1. if you want to launch the Teams app as a web app instead of running in Teams client, first remove the 'launchUrl' in \Properties\launchSettings.json, then right click on the solution, in Properties > Configuration Properties > Configuration, uncheck the 'Deploy' process and select 'OK'.
-
-2. If you made changes to Teams app manifest file (Templates/appPackage/manifest.template.json), please right click on your project and select "Teams Toolkit" -> "Prepare Teams app dependencies" command before you try to locally run the Teams app again.
-
-Building your Tab app
-----------------------
-
-Fluent UI is a front-end framework designed to build experiences that fit seamlessly into a broad range of Microsoft products. To make it simpler for you to build applications for Microsoft Teams, this template showcases Fluent UI Blazor components that are part of the Microsoft.Fast.Components.FluentUI package. Learn more about these components here: https://github.com/microsoft/fast-blazor.
-
-If you want to know more about SDK usage, please check the GitHub page: https://github.com/OfficeDev/TeamsFx/tree/dev/packages/dotnet-sdk.
-
-
-Deploy your Teams app on Azure
-------------------------------------
-
-To run your Teams app on Azure:
-
-1. Right click on your project and select "Teams Toolkit" -> "Provision in the cloud..." to create resources in Azure for your app. You can select a proper subscription and resource group which you would like to use for your Teams app. Please be noted that this might cause charges to your Azure account. Learn more by visiting https://aka.ms/teamsfx-vs-provision.
-
-2. Right click on your project and select "Teams Toolkit" -> "Deploy to the cloud...", this step will deploy your code to the Azure resources created in previous step. It is common to deploy multiple times to the same set of Azure resources, so there is no need to run "Provision in the cloud..." every time before run "Deploy to the cloud...". Both the commands will take several minutes to complete, please wait until it finished. Learn more by visiting https://aka.ms/teamsfx-vs-deploy.
-
-3. Right click on your project and select "Teams Toolkit" -> "Preview in Teams" to launch your app in a browser. 
-
-4. Once Microsoft Teams is loaded, select the "Add" button to install your app in Teams. You will see your app running remotely from Azure.
-
-Notes: there is an alternative way to find all the commands mentioned above, go to the "Project" menu in Visual Studio, select "Teams Toolkit" and you will find all the commands there.
-
-Tips: if you made changes to Teams app manifest file (Templates/appPackage/manifest.template.json), please right click on your project and select "Teams Toolkit" -> "Update manifest in Teams Developer Portal" command before you try to run the Teams app remotely from Azure again.
+Learn more
+-------------------------
+New to Teams app development or Teams Toolkit? Learn more about 
+Teams app manifests, deploying to the cloud, and more in the documentation 
+at https://aka.ms/teams-toolkit-vs-docs
 
 Report an issue
----------------
-
-If you encountered any problem while you are building Teams app using Teams Toolkit, you can create an issue in our GitHub repository: https://github.com/OfficeDev/TeamsFx/issues
-
-
-Q&A
----------------
-
-1. How do I log out or switch my M365 account in Teams Toolkit?
-   Right click on your project, select "Teams Toolkit" -> "Prepare Teams app dependencies". You can switch your M365 account in the pop up window.
-
-2. How do I request more permissions and scopes in a Graph call?
-   If you have selected Personal Tab capability and you want to change the scope in a Graph call, you can first change the parameter _scope in Components/Graph.razor. Then go to Azure Portal -> Azure Active Directory -> App Registrations, find the AAD application which Toolkit created for you (default name is the same name as the project name), under Manage, select API Permissions. Select Add a permission > Microsoft Graph > Delegated permissions, then add the permissions you want.
+-------------------------
+Select Visual Studio > Help > Send Feedback > Report a Problem. 
+Or, you can create an issue directly in our GitHub repository: 
+https://github.com/OfficeDev/TeamsFx/issues


### PR DESCRIPTION
Make the getting started doc simpler. 

The helpful content in this document will be moved to documentation where we can provide visuals, better formatting, code samples, and other helpful links. 
