### PR TITLE
chore: remove redundant is-remote from "debug-all"

### DIFF
--- a/packages/vscode-extension/src/debug/localTelemetryReporter.ts
+++ b/packages/vscode-extension/src/debug/localTelemetryReporter.ts
@@ -55,7 +55,6 @@ export async function sendDebugAllStartEvent(): Promise<void> {
 }
 
 export async function sendDebugAllEvent(
-  isRemote?: boolean,
   error?: FxError,
   additionalProperties?: { [key: string]: string }
 ): Promise<void> {
@@ -93,7 +92,6 @@ export async function sendDebugAllEvent(
 
   const properties = {
     [TelemetryProperty.CorrelationId]: session.id,
-    [TelemetryProperty.DebugRemote]: `${isRemote}`, // undefined, true or false
     [TelemetryProperty.Success]: error === undefined ? TelemetrySuccess.Yes : TelemetrySuccess.No,
     ...session.properties,
     ...additionalProperties,

--- a/packages/vscode-extension/src/debug/teamsfxDebugProvider.ts
+++ b/packages/vscode-extension/src/debug/teamsfxDebugProvider.ts
@@ -143,7 +143,10 @@ export class TeamsfxDebugProvider implements vscode.DebugConfigurationProvider {
       showError(error);
       terminateAllRunningTeamsfxTasks();
       await vscode.debug.stopDebugging();
-      await sendDebugAllEvent(telemetryIsRemote, error);
+      // not for undefined
+      if (telemetryIsRemote === false) {
+        await sendDebugAllEvent(error);
+      }
       commonUtils.endLocalDebugSession();
     }
     return debugConfiguration;

--- a/packages/vscode-extension/src/debug/teamsfxTaskHandler.ts
+++ b/packages/vscode-extension/src/debug/teamsfxTaskHandler.ts
@@ -456,7 +456,6 @@ async function onDidStartDebugSessionHandler(event: vscode.DebugSession): Promis
           terminateAllRunningTeamsfxTasks();
           await vscode.debug.stopDebugging();
           sendDebugAllEvent(
-            debugConfig.teamsfxIsRemote,
             new UserError({
               source: ExtensionSource,
               name: ExtensionErrors.DebugServiceFailedBeforeStartError,
@@ -471,7 +470,7 @@ async function onDidStartDebugSessionHandler(event: vscode.DebugSession): Promis
           return;
         }
 
-        await sendDebugAllEvent(debugConfig.teamsfxIsRemote);
+        await sendDebugAllEvent();
       }
     }
   }

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -1216,7 +1216,7 @@ export async function validateLocalPrerequisitesHandler(): Promise<string | unde
   const result = await localPrerequisites.checkAndInstall();
   if (result.isErr()) {
     // Only local debug use validate-local-prerequisites command
-    await sendDebugAllEvent(false, result.error);
+    await sendDebugAllEvent(result.error);
     commonUtils.endLocalDebugSession();
     // return non-zero value to let task "exit ${command:xxx}" to exit
     return "1";
@@ -1374,7 +1374,7 @@ export async function preDebugCheckHandler(): Promise<string | undefined> {
     terminateAllRunningTeamsfxTasks();
     await debug.stopDebugging();
     // only local debug uses pre-debug-check command
-    await sendDebugAllEvent(false, result.error);
+    await sendDebugAllEvent(result.error);
     commonUtils.endLocalDebugSession();
     // return non-zero value to let task "exit ${command:xxx}" to exit
     return "1";


### PR DESCRIPTION
Remove `remote` property because only local debug sends these events.

E2E TEST: https://github.com/OfficeDev/TeamsFx-UI-Test/blob/main/src/ui-test/localdebug/localdebug-bot.test.ts

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14549235