### PR TITLE
fix: differentiate manual publish

### DIFF
--- a/packages/fx-core/src/plugins/resource/appstudio/index.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/index.ts
@@ -354,7 +354,7 @@ export class AppStudioPlugin implements Plugin {
       const answer = ctx.answers![Constants.BUILD_OR_PUBLISH_QUESTION] as string;
       if (answer === manuallySubmitOption.id) {
         const properties: { [key: string]: string } = {};
-        properties[TelemetryPropertyKey.TriggerFrom] = TelemetryEventName.publish;
+        properties[TelemetryPropertyKey.manual] = String(true);
         try {
           const appPackagePath = await this.appStudioPluginImpl.buildTeamsAppPackage(ctx, false);
           const msg = getLocalizedString(
@@ -367,10 +367,10 @@ export class AppStudioPlugin implements Plugin {
               ctx.ui?.openUrl(Constants.PUBLISH_GUIDE);
             }
           });
-          TelemetryUtils.sendSuccessEvent(TelemetryEventName.buildTeamsPackage, properties);
+          TelemetryUtils.sendSuccessEvent(TelemetryEventName.publish, properties);
           return ok(appPackagePath);
         } catch (error) {
-          TelemetryUtils.sendErrorEvent(TelemetryEventName.buildTeamsPackage, error, properties);
+          TelemetryUtils.sendErrorEvent(TelemetryEventName.publish, error, properties);
           return err(
             AppStudioResultFactory.UserError(
               AppStudioError.TeamsPackageBuildError.name,

--- a/packages/fx-core/src/plugins/resource/appstudio/index.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/index.ts
@@ -353,7 +353,8 @@ export class AppStudioPlugin implements Plugin {
     if (ctx.answers?.platform === Platform.VSCode) {
       const answer = ctx.answers![Constants.BUILD_OR_PUBLISH_QUESTION] as string;
       if (answer === manuallySubmitOption.id) {
-        //const appDirectory = `${ctx.root}/.${ConfigFolderName}`;
+        const properties: { [key: string]: string } = {};
+        properties[TelemetryPropertyKey.TriggerFrom] = TelemetryEventName.publish;
         try {
           const appPackagePath = await this.appStudioPluginImpl.buildTeamsAppPackage(ctx, false);
           const msg = getLocalizedString(
@@ -366,10 +367,10 @@ export class AppStudioPlugin implements Plugin {
               ctx.ui?.openUrl(Constants.PUBLISH_GUIDE);
             }
           });
-          TelemetryUtils.sendSuccessEvent(TelemetryEventName.publish);
+          TelemetryUtils.sendSuccessEvent(TelemetryEventName.buildTeamsPackage, properties);
           return ok(appPackagePath);
         } catch (error) {
-          TelemetryUtils.sendErrorEvent(TelemetryEventName.publish, error);
+          TelemetryUtils.sendErrorEvent(TelemetryEventName.buildTeamsPackage, error, properties);
           return err(
             AppStudioResultFactory.UserError(
               AppStudioError.TeamsPackageBuildError.name,

--- a/packages/fx-core/src/plugins/resource/appstudio/utils/telemetry.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/utils/telemetry.ts
@@ -18,6 +18,7 @@ export enum TelemetryPropertyKey {
   tenantId = "tenant-id",
   publishedAppId = "published-app-id",
   customizedKeys = "customized-manifest-keys",
+  TriggerFrom = "trigger-from",
 }
 
 enum TelemetryPropertyValue {

--- a/packages/fx-core/src/plugins/resource/appstudio/utils/telemetry.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/utils/telemetry.ts
@@ -18,7 +18,7 @@ export enum TelemetryPropertyKey {
   tenantId = "tenant-id",
   publishedAppId = "published-app-id",
   customizedKeys = "customized-manifest-keys",
-  TriggerFrom = "trigger-from",
+  manual = "manual",
 }
 
 enum TelemetryPropertyValue {


### PR DESCRIPTION
There is a question for publish, which only build the package. Update telemetry to treat it as build event.
![image](https://user-images.githubusercontent.com/71362691/176604557-7e1987f4-04fc-4d52-89d5-49e989c953a3.png)
