### PR TITLE
fix(template): command bot unable to be triggerred in R0 Teams client

### DIFF
--- a/templates/bot/csharp/command-and-response/Commands/HelloWorldCommandHandler.cs.tpl
+++ b/templates/bot/csharp/command-and-response/Commands/HelloWorldCommandHandler.cs.tpl
@@ -18,7 +18,8 @@
 
         public IEnumerable<ITriggerPattern> TriggerPatterns => new List<ITriggerPattern>
         {
-            new StringTrigger("helloworld")
+            // Used to trigger the command handler if the command text contains 'helloWorld'
+            new RegExpTrigger("helloWorld")
         };
 
         public HelloWorldCommandHandler(ILogger<HelloWorldCommandHandler> logger)


### PR DESCRIPTION
Fix [Bug 14865241](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14865241): [VS Bug Bash] Command handler code path not hit in default template

E2E TEST: N/A