### PR TITLE
chore: move using out of namespace

### DIFF
--- a/templates/bot/csharp/command-and-response/AdapterWithErrorHandler.cs.tpl
+++ b/templates/bot/csharp/command-and-response/AdapterWithErrorHandler.cs.tpl
@@ -1,9 +1,9 @@
-﻿namespace {{SafeProjectName}}
-{
-    using Microsoft.Bot.Builder.Integration.AspNet.Core;
-    using Microsoft.Bot.Builder.TraceExtensions;
-    using Microsoft.Bot.Connector.Authentication;
+﻿using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Bot.Builder.TraceExtensions;
+using Microsoft.Bot.Connector.Authentication;
 
+namespace {{SafeProjectName}}
+{
     public class AdapterWithErrorHandler : CloudAdapter
     {
         public AdapterWithErrorHandler(BotFrameworkAuthentication auth, ILogger<CloudAdapter> logger)

--- a/templates/bot/csharp/command-and-response/Commands/HelloWorldCommandHandler.cs.tpl
+++ b/templates/bot/csharp/command-and-response/Commands/HelloWorldCommandHandler.cs.tpl
@@ -1,12 +1,12 @@
-﻿namespace {{SafeProjectName}}.Commands
-{
-    using {{SafeProjectName}}.Models;
-    using AdaptiveCards.Templating;
-    using Microsoft.Bot.Builder;
-    using Microsoft.Bot.Schema;
-    using Microsoft.TeamsFx.Conversation;
-    using Newtonsoft.Json;
+﻿using {{SafeProjectName}}.Models;
+using AdaptiveCards.Templating;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Schema;
+using Microsoft.TeamsFx.Conversation;
+using Newtonsoft.Json;
 
+namespace {{SafeProjectName}}.Commands
+{
     /// <summary>
     /// The <see cref="HelloWorldCommandHandler"/> registers a pattern with the <see cref="ITeamsCommandHandler"/> and 
     /// responds with an Adaptive Card if the user types the <see cref="TriggerPatterns"/>.

--- a/templates/bot/csharp/command-and-response/Controllers/BotController.cs.tpl
+++ b/templates/bot/csharp/command-and-response/Controllers/BotController.cs.tpl
@@ -1,10 +1,10 @@
-﻿namespace {{SafeProjectName}}.Controllers
-{
-    using Microsoft.AspNetCore.Mvc;
-    using Microsoft.Bot.Builder;
-    using Microsoft.Bot.Builder.Integration.AspNet.Core;
-    using Microsoft.TeamsFx.Conversation;
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.TeamsFx.Conversation;
 
+namespace {{SafeProjectName}}.Controllers
+{
     [Route("api/messages")]
     [ApiController]
     public class BotController : ControllerBase

--- a/templates/bot/csharp/command-and-response/TeamsBot.cs.tpl
+++ b/templates/bot/csharp/command-and-response/TeamsBot.cs.tpl
@@ -1,9 +1,7 @@
-﻿namespace {{SafeProjectName}}
-{
-    using Microsoft.Bot.Builder;
-    using System.Threading;
-    using System.Threading.Tasks;
+﻿using Microsoft.Bot.Builder;
 
+namespace {{SafeProjectName}}
+{
     /// <summary>
     /// An empty bot handler.
     /// You can add your customization code here to extend your bot logic if needed.

--- a/templates/bot/csharp/notification-function-base/AdapterWithErrorHandler.cs.tpl
+++ b/templates/bot/csharp/notification-function-base/AdapterWithErrorHandler.cs.tpl
@@ -1,10 +1,10 @@
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Bot.Builder.TraceExtensions;
+using Microsoft.Bot.Connector.Authentication;
+using Microsoft.Extensions.Logging;
+
 namespace {{SafeProjectName}}
 {
-    using Microsoft.Bot.Builder.Integration.AspNet.Core;
-    using Microsoft.Bot.Builder.TraceExtensions;
-    using Microsoft.Bot.Connector.Authentication;
-    using Microsoft.Extensions.Logging;
-
     public class AdapterWithErrorHandler : CloudAdapter
     {
         public AdapterWithErrorHandler(BotFrameworkAuthentication auth, ILogger<CloudAdapter> logger)

--- a/templates/bot/csharp/notification-function-base/MessageHandler.cs.tpl
+++ b/templates/bot/csharp/notification-function-base/MessageHandler.cs.tpl
@@ -1,14 +1,14 @@
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Bot.Builder;
+using Microsoft.Extensions.Logging;
+using Microsoft.TeamsFx.Conversation;
+
 namespace {{SafeProjectName}}
 {
-    using Microsoft.Azure.WebJobs;
-    using Microsoft.Azure.WebJobs.Extensions.Http;
-    using Microsoft.AspNetCore.Http;
-    using Microsoft.AspNetCore.Mvc;
-    using Microsoft.Bot.Builder.Integration.AspNet.Core;
-    using Microsoft.Bot.Builder;
-    using Microsoft.Extensions.Logging;
-    using Microsoft.TeamsFx.Conversation;
-
     public sealed class MessageHandler
     {
         private readonly ConversationBot _conversation;

--- a/templates/bot/csharp/notification-function-base/TeamsBot.cs.tpl
+++ b/templates/bot/csharp/notification-function-base/TeamsBot.cs.tpl
@@ -1,7 +1,7 @@
+using Microsoft.Bot.Builder;
+
 namespace {{SafeProjectName}}
 {
-    using Microsoft.Bot.Builder;
-
     /// <summary>
     /// An empty bot handler.
     /// You can add your customization code here to extend your bot logic if needed.

--- a/templates/bot/csharp/notification-trigger-http/NotifyHttpTrigger.cs.tpl
+++ b/templates/bot/csharp/notification-trigger-http/NotifyHttpTrigger.cs.tpl
@@ -1,15 +1,17 @@
+using {{SafeProjectName}}.Models;
+using AdaptiveCards.Templating;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.TeamsFx.Conversation;
+using Newtonsoft.Json;
+
+using ExecutionContext = Microsoft.Azure.WebJobs.ExecutionContext;
+
 namespace {{SafeProjectName}}
 {
-    using {{SafeProjectName}}.Models;
-    using AdaptiveCards.Templating;
-    using Microsoft.Azure.WebJobs;
-    using Microsoft.Azure.WebJobs.Extensions.Http;
-    using Microsoft.AspNetCore.Http;
-    using Microsoft.AspNetCore.Mvc;
-    using Newtonsoft.Json;
-    using Microsoft.Extensions.Logging;
-    using Microsoft.TeamsFx.Conversation;
-
     public sealed class NotifyHttpTrigger
     {
         private readonly ConversationBot _conversation;
@@ -28,7 +30,7 @@ namespace {{SafeProjectName}}
 
             // Read adaptive card template
             var adaptiveCardFilePath = Path.Combine(context.FunctionAppDirectory, "Resources", "NotificationDefault.json");
-            var cardTemplate = await System.IO.File.ReadAllTextAsync(adaptiveCardFilePath, req.HttpContext.RequestAborted);
+            var cardTemplate = await File.ReadAllTextAsync(adaptiveCardFilePath, req.HttpContext.RequestAborted);
 
             var installations = await _conversation.Notification.GetInstallationsAsync(req.HttpContext.RequestAborted);
             foreach (var installation in installations)

--- a/templates/bot/csharp/notification-trigger-timer/NotifyTimerTrigger.cs.tpl
+++ b/templates/bot/csharp/notification-trigger-timer/NotifyTimerTrigger.cs.tpl
@@ -1,15 +1,17 @@
+using {{SafeProjectName}}.Models;
+using AdaptiveCards.Templating;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.TeamsFx.Conversation;
+using Newtonsoft.Json;
+
+using ExecutionContext = Microsoft.Azure.WebJobs.ExecutionContext;
+
 namespace {{SafeProjectName}}
 {
-    using {{SafeProjectName}}.Models;
-    using AdaptiveCards.Templating;
-    using Microsoft.Azure.WebJobs;
-    using Microsoft.Azure.WebJobs.Extensions.Http;
-    using Microsoft.AspNetCore.Http;
-    using Microsoft.AspNetCore.Mvc;
-    using Newtonsoft.Json;
-    using Microsoft.Extensions.Logging;
-    using Microsoft.TeamsFx.Conversation;
-
     public sealed class NotifyTimerTrigger
     {
         private readonly ConversationBot _conversation;

--- a/templates/bot/csharp/notification-webapi/AdapterWithErrorHandler.cs.tpl
+++ b/templates/bot/csharp/notification-webapi/AdapterWithErrorHandler.cs.tpl
@@ -1,9 +1,9 @@
-﻿namespace {{SafeProjectName}}
-{
-    using Microsoft.Bot.Builder.Integration.AspNet.Core;
-    using Microsoft.Bot.Builder.TraceExtensions;
-    using Microsoft.Bot.Connector.Authentication;
+﻿using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Bot.Builder.TraceExtensions;
+using Microsoft.Bot.Connector.Authentication;
 
+namespace {{SafeProjectName}}
+{
     public class AdapterWithErrorHandler : CloudAdapter
     {
         public AdapterWithErrorHandler(BotFrameworkAuthentication auth, ILogger<CloudAdapter> logger)

--- a/templates/bot/csharp/notification-webapi/Controllers/BotController.cs.tpl
+++ b/templates/bot/csharp/notification-webapi/Controllers/BotController.cs.tpl
@@ -1,10 +1,10 @@
-﻿namespace {{SafeProjectName}}.Controllers
-{
-    using Microsoft.AspNetCore.Mvc;
-    using Microsoft.Bot.Builder;
-    using Microsoft.Bot.Builder.Integration.AspNet.Core;
-    using Microsoft.TeamsFx.Conversation;
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.TeamsFx.Conversation;
 
+namespace {{SafeProjectName}}.Controllers
+{
     [Route("api/messages")]
     [ApiController]
     public class BotController : ControllerBase

--- a/templates/bot/csharp/notification-webapi/Controllers/NotificationController.cs.tpl
+++ b/templates/bot/csharp/notification-webapi/Controllers/NotificationController.cs.tpl
@@ -1,11 +1,11 @@
-﻿namespace {{SafeProjectName}}.Controllers
-{
-    using {{SafeProjectName}}.Models;
-    using AdaptiveCards.Templating;
-    using Microsoft.AspNetCore.Mvc;
-    using Microsoft.TeamsFx.Conversation;
-    using Newtonsoft.Json;
+﻿using {{SafeProjectName}}.Models;
+using AdaptiveCards.Templating;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.TeamsFx.Conversation;
+using Newtonsoft.Json;
 
+namespace {{SafeProjectName}}.Controllers
+{
     [Route("api/notification")]
     [ApiController]
     public class NotificationController : ControllerBase

--- a/templates/bot/csharp/notification-webapi/TeamsBot.cs.tpl
+++ b/templates/bot/csharp/notification-webapi/TeamsBot.cs.tpl
@@ -1,7 +1,7 @@
+using Microsoft.Bot.Builder;
+
 namespace {{SafeProjectName}}
 {
-    using Microsoft.Bot.Builder;
-
     /// <summary>
     /// An empty bot handler.
     /// You can add your customization code here to extend your bot logic if needed.


### PR DESCRIPTION
Work item - https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14865259/
To keep consistency with VS C# templates, move `using` statements out of namespace.