### PR TITLE
chore: improve concurrent localdebug telemetry

### DIFF
--- a/packages/vscode-extension/src/debug/localTelemetryReporter.ts
+++ b/packages/vscode-extension/src/debug/localTelemetryReporter.ts
@@ -42,10 +42,13 @@ export const localTelemetryReporter = new LocalTelemetryReporter(
   saveEventTime
 );
 
-export async function sendDebugAllStartEvent(): Promise<void> {
+export async function sendDebugAllStartEvent(additionalProperties: {
+  [key: string]: string;
+}): Promise<void> {
   const session = getLocalDebugSession();
   const components = await getProjectComponents();
   session.properties[TelemetryProperty.DebugProjectComponents] = components + "";
+  Object.assign(session.properties, additionalProperties);
 
   const properties = Object.assign(
     { [TelemetryProperty.CorrelationId]: session.id },

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -261,7 +261,8 @@ function registerInternalCommands(context: vscode.ExtensionContext) {
   // localdebug session starts from prerequisites checker
   const validatePrerequisitesCmd = vscode.commands.registerCommand(
     "fx-extension.validate-local-prerequisites",
-    () => Correlator.runWithId(startLocalDebugSession(), handlers.validateLocalPrerequisitesHandler)
+    // Do not run with Correlator because it is handled inside `validateLocalPrerequisitesHandler()`.
+    handlers.validateLocalPrerequisitesHandler
   );
   context.subscriptions.push(validatePrerequisitesCmd);
 

--- a/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
@@ -232,6 +232,8 @@ export enum TelemetryProperty {
   DebugPortsInUse = "debug-ports-in-use",
   DebugM365AccountStatus = "debug-m365-account-status",
   DebugIsSideloadingAllowed = "debug-is-sideloading-allowed",
+  DebugConcurrentCorrelationId = "debug-concurrent-correlation-id",
+  DebugConcurrentLastEventName = "debug-concurrent-last-event-name",
   Internal = "internal",
   InternalAlias = "internal-alias",
   OSArch = "os-arch",


### PR DESCRIPTION
Handle concurrent F5 telemetry (user stops debugging in preLaunchTasks and hits F5 again immediately).
Send `debug-concurrent-correlation-id` so we can check whether this property is empty in BI to determine concurrent cases.

![image](https://user-images.githubusercontent.com/9698542/177078325-96900315-2dec-4b30-8e15-e129acbfe59c.png)


E2E TEST: https://github.com/OfficeDev/TeamsFx-UI-Test/blob/main/src/ui-test/localdebug/localdebug-bot.test.ts