### PR TITLE
fix: missing await for local debug telemetry

### DIFF
--- a/packages/vscode-extension/src/debug/teamsfxTaskHandler.ts
+++ b/packages/vscode-extension/src/debug/teamsfxTaskHandler.ts
@@ -455,7 +455,7 @@ async function onDidStartDebugSessionHandler(event: vscode.DebugSession): Promis
         if (currentSession.id !== DebugNoSessionId && currentSession.failedServices.length > 0) {
           terminateAllRunningTeamsfxTasks();
           await vscode.debug.stopDebugging();
-          sendDebugAllEvent(
+          await sendDebugAllEvent(
             new UserError({
               source: ExtensionSource,
               name: ExtensionErrors.DebugServiceFailedBeforeStartError,


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14549235

E2E TEST: https://github.com/OfficeDev/TeamsFx-UI-Test/blob/main/src/ui-test/localdebug/localdebug-bot.test.ts