### PR TITLE
fix(bot): mask url in api error event

### DIFF
--- a/packages/fx-core/src/plugins/resource/bot/appStudio/appStudio.ts
+++ b/packages/fx-core/src/plugins/resource/bot/appStudio/appStudio.ts
@@ -14,16 +14,8 @@ import { CommonStrings, ConfigNames } from "../resources/strings";
 import { RetryHandler } from "../utils/retryHandler";
 import { Messages } from "../resources/messages";
 import { Logger } from "../logger";
-/**
- * Get app studio endpoint for prod/int environment, mainly for ux e2e test
- */
-export function getAppStudioEndpoint(): string {
-  if (process.env.APP_STUDIO_ENV && process.env.APP_STUDIO_ENV === "int") {
-    return "https://dev-int.teams.microsoft.com";
-  } else {
-    return "https://dev.teams.microsoft.com";
-  }
-}
+import { getAppStudioEndpoint } from "../../../../common/tools";
+
 export class AppStudio {
   private static baseUrl = getAppStudioEndpoint();
 


### PR DESCRIPTION
1. The url property is recognized as a user file path.
![MicrosoftTeams-image (2)](https://user-images.githubusercontent.com/49138419/177453179-1524a565-2a7e-420d-bb46-768663d5f6b3.png)
2. To avoid dependency cycle, use the `getAppStudioEndpoint()` in common