### PR TITLE
chore(v3): add, provision and deploy function api 

### DIFF
--- a/packages/fx-core/src/component/code/apiCode.ts
+++ b/packages/fx-core/src/component/code/apiCode.ts
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import {
+  Action,
+  ContextV3,
+  FxError,
+  InputsWithProjectPath,
+  MaybePromise,
+  ok,
+  ProjectSettingsV3,
+  ProvisionContextV3,
+  Result,
+  SourceCodeProvider,
+} from "@microsoft/teamsfx-api";
+import * as path from "path";
+import "reflect-metadata";
+import { Service } from "typedi";
+import { getComponent } from "../workflow";
+import { DefaultValues, FunctionPluginPathInfo } from "../../plugins/resource/function/constants";
+import { FunctionScaffold } from "../../plugins/resource/function/ops/scaffold";
+import { QuestionKey } from "../../plugins/resource/function/enums";
+import { ComponentNames } from "../constants";
+/**
+ * api scaffold
+ */
+@Service("api-code")
+export class ApiCodeProvider implements SourceCodeProvider {
+  name = "api-code";
+  generate(
+    context: ContextV3,
+    inputs: InputsWithProjectPath
+  ): MaybePromise<Result<Action | undefined, FxError>> {
+    const action: Action = {
+      name: "api-code.generate",
+      type: "function",
+      plan: (context: ContextV3, inputs: InputsWithProjectPath) => {
+        const folder = inputs.folder || FunctionPluginPathInfo.solutionFolderName;
+        return ok([`scaffold api source code in folder: ${path.join(inputs.projectPath, folder)}`]);
+      },
+      execute: async (ctx: ContextV3, inputs: InputsWithProjectPath) => {
+        const projectSettings = ctx.projectSetting as ProjectSettingsV3;
+        const appName = projectSettings.appName;
+        const language =
+          inputs?.["programming-language"] ||
+          context.projectSetting.programmingLanguage ||
+          "javascript";
+        const folder = inputs.folder || FunctionPluginPathInfo.solutionFolderName;
+        const workingDir = path.join(inputs.projectPath, folder);
+        const functionName =
+          (inputs?.[QuestionKey.functionName] as string) ?? DefaultValues.functionName;
+        const variables = {
+          appName: appName,
+          functionName: functionName,
+        };
+        await FunctionScaffold.scaffoldFunction(
+          workingDir,
+          language,
+          DefaultValues.functionTriggerType,
+          functionName,
+          variables
+        );
+        return ok([`scaffold api source code in folder: ${workingDir}`]);
+      },
+    };
+    return ok(action);
+  }
+  build(
+    context: ContextV3,
+    inputs: InputsWithProjectPath
+  ): MaybePromise<Result<Action | undefined, FxError>> {
+    const action: Action = {
+      name: "api-code.build",
+      type: "function",
+      plan: (context: ContextV3, inputs: InputsWithProjectPath) => {
+        const teamsApi = getComponent(context.projectSetting, ComponentNames.TeamsApi);
+        if (!teamsApi) return ok([]);
+        const apiDir = teamsApi?.folder;
+        if (!apiDir) return ok([]);
+        return ok([`build project: ${apiDir}`]);
+      },
+      execute: async (context: ContextV3, inputs: InputsWithProjectPath) => {
+        const ctx = context as ProvisionContextV3;
+        return ok([`build project`]);
+      },
+    };
+    return ok(action);
+  }
+}

--- a/packages/fx-core/src/component/code/tabCode.ts
+++ b/packages/fx-core/src/component/code/tabCode.ts
@@ -211,7 +211,18 @@ export class TabCodeProvider implements SourceCodeProvider {
       }
     };
 
-    // TODO: add environemnt variables for aad, simple auth and function api
+    const connections = getComponent(ctx.projectSetting, ComponentNames.TeamsTab)?.connections;
+    if (connections?.includes(ComponentNames.TeamsApi)) {
+      const teamsApi = getComponent(ctx.projectSetting, ComponentNames.TeamsApi);
+      addToEnvs(EnvKeys.FuncName, teamsApi?.functionNames[0]);
+      addToEnvs(
+        EnvKeys.FuncEndpoint,
+        // TODO: Read function app endpoint from inputs
+        ctx.envInfo?.state?.[ComponentNames.TeamsApi]?.functionEndpoint as string
+      );
+    }
+
+    // TODO: add environment variables for aad, simple auth
     addToEnvs(EnvKeys.StartLoginPage, DependentPluginInfo.StartLoginPageURL);
     return envs;
   }

--- a/packages/fx-core/src/component/constants.ts
+++ b/packages/fx-core/src/component/constants.ts
@@ -4,6 +4,7 @@
 export const ComponentNames = {
   TeamsTab: "teams-tab",
   TeamsBot: "teams-bot",
+  TeamsApi: "teams-api",
   AppManifest: "app-manifest",
   AadApp: "aad-app",
   AzureWebApp: "azure-web-app",
@@ -16,6 +17,7 @@ export const ComponentNames = {
   AzureSQL: "azure-sql",
   TabCode: "tab-code",
   BotCode: "bot-code",
+  ApiCode: "api-code",
   Function: "azure-function",
   SimpleAuth: "simple-auth",
 };

--- a/packages/fx-core/src/component/core.ts
+++ b/packages/fx-core/src/component/core.ts
@@ -34,6 +34,7 @@ import "./resource/azureStorage";
 import "./resource/azureAppService/azureWebApp";
 import "./resource/botService";
 import "./resource/spfx";
+import "./feature/api";
 import "./feature/bot";
 import "./feature/sql";
 import "./feature/tab";

--- a/packages/fx-core/src/component/migrate.ts
+++ b/packages/fx-core/src/component/migrate.ts
@@ -85,7 +85,7 @@ export const EnvStateMigrationComponentNames = [
   ["fx-resource-identity", ComponentNames.Identity],
   ["fx-resource-azure-sql", ComponentNames.AzureSQL],
   ["fx-resource-aad-app-for-teams", ComponentNames.AadApp],
-  ["fx-resource-function", ComponentNames.Function],
+  ["fx-resource-function", ComponentNames.TeamsApi],
   ["fx-resource-apim", ComponentNames.APIM],
   ["fx-resource-key-vault", ComponentNames.KeyVault],
   ["fx-resource-bot", ComponentNames.TeamsBot],

--- a/packages/fx-core/src/component/resource/azureAppService/azureAppService.ts
+++ b/packages/fx-core/src/component/resource/azureAppService/azureAppService.ts
@@ -3,7 +3,6 @@
 
 import {
   Action,
-  Component,
   ContextV3,
   FxError,
   InputsWithProjectPath,

--- a/packages/fx-core/src/component/resource/azureAppService/azureFunction.ts
+++ b/packages/fx-core/src/component/resource/azureAppService/azureFunction.ts
@@ -20,13 +20,14 @@ export class AzureFunctionResource extends AzureAppService {
   readonly displayName = "Azure Functions";
   readonly bicepModuleName = "azureFunction";
   outputs = {
-    functionAppResourceId: {
+    resourceId: {
       key: "functionAppResourceId",
-      bicepVariable: "provisionOutputs.azureFunction{{componentName}}Output.value.resourceId",
+      bicepVariable:
+        "provisionOutputs.azureFunction{{componentName}}Output.value.functionAppResourceId",
     },
-    functionEndpoint: {
+    endpoint: {
       key: "functionEndpoint",
-      bicepVariable: "azureFunction{{componentName}}Provision.outputs.endpoint",
+      bicepVariable: "azureFunction{{componentName}}Provision.outputs.functionEndpoint",
     },
   };
   finalOutputKeys = ["resourceId", "endpoint"];

--- a/packages/fx-core/src/core/FxCore.ts
+++ b/packages/fx-core/src/core/FxCore.ts
@@ -58,17 +58,10 @@ import { getTemplatesFolder } from "../folder";
 import { getLocalAppName } from "../plugins/resource/appstudio/utils/utils";
 import { AppStudioPluginV3 } from "../plugins/resource/appstudio/v3";
 import {
-  BotOptionItem,
-  BotSsoItem,
-  CommandAndResponseOptionItem,
   ExistingTabOptionItem,
   M365SearchAppOptionItem,
   M365SsoLaunchPageOptionItem,
-  MessageExtensionItem,
-  NotificationOptionItem,
-  TabOptionItem,
   TabSPFxItem,
-  TabSsoItem,
   BotFeatureIds,
   TabFeatureIds,
   CicdOptionItem,
@@ -91,7 +84,6 @@ import {
   ObjectIsUndefinedError,
   OperationNotPermittedError,
   ProjectFolderExistError,
-  ProjectFolderInvalidError,
   TaskNotSupportError,
   WriteFileError,
 } from "./error";
@@ -110,10 +102,7 @@ import { EnvInfoWriterMW } from "./middleware/envInfoWriter";
 import { EnvInfoWriterMW_V3 } from "./middleware/envInfoWriterV3";
 import { ErrorHandlerMW } from "./middleware/errorHandler";
 import { ProjectMigratorMW } from "./middleware/projectMigrator";
-import {
-  getProjectSettingsPath,
-  ProjectSettingsLoaderMW,
-} from "./middleware/projectSettingsLoader";
+import { ProjectSettingsLoaderMW } from "./middleware/projectSettingsLoader";
 import { ProjectSettingsWriterMW } from "./middleware/projectSettingsWriter";
 import {
   getQuestionsForAddFeature,
@@ -129,7 +118,6 @@ import {
   QuestionModelMW,
 } from "./middleware/questionModel";
 import { SolutionLoaderMW } from "./middleware/solutionLoader";
-import { SolutionLoaderMW_V3 } from "./middleware/solutionLoaderV3";
 import {
   CoreQuestionNames,
   ProjectNamePattern,
@@ -147,7 +135,6 @@ import {
 import { CoreHookContext } from "./types";
 import { isPreviewFeaturesEnabled } from "../common";
 import { runAction } from "../component/workflow";
-import { TemplateProjectsScenarios } from "../plugins/resource/bot/constants";
 import { createContextV3 } from "../component/utils";
 import "../component/core";
 import { QuestionModelMW_V3 } from "./middleware/questionModelV3";
@@ -759,6 +746,8 @@ export class FxCore implements v3.ICore {
       res = await runAction("teams-bot.add", context, inputs as InputsWithProjectPath);
     } else if (TabFeatureIds.includes(feature)) {
       res = await runAction("teams-tab.add", context, inputs as InputsWithProjectPath);
+    } else if (feature === "function") {
+      res = await runAction("teams-api.add", context, inputs as InputsWithProjectPath);
     } else if (feature === CicdOptionItem.id) {
       res = await runAction("cicd.add", context, inputs as InputsWithProjectPath);
     } else if (feature === ApiConnectionOptionItem.id) {
@@ -896,6 +885,8 @@ export class FxCore implements v3.ICore {
         res = await runAction("teams-bot.add", context, inputs as InputsWithProjectPath);
       } else if (TabFeatureIds.includes(feature)) {
         res = await runAction("teams-tab.add", context, inputs as InputsWithProjectPath);
+      } else if (feature === "function") {
+        res = await runAction("teams-api.add", context, inputs as InputsWithProjectPath);
       } else {
         return err(new TaskNotSupportError(feature));
       }

--- a/packages/fx-core/src/core/middleware/questionModelV3.ts
+++ b/packages/fx-core/src/core/middleware/questionModelV3.ts
@@ -252,7 +252,7 @@ async function getQuestionsForAddFeature(
     options.push(ApiConnectionOptionItem);
   }
   // TODO: if (hasTab(projectSettingsV3) && hasAAD(projectSettingsV3)) {
-  if (hasTab(projectSettingsV3)) {
+  if (hasTab(projectSettingsV3) && !hasFunction(projectSettingsV3)) {
     options.push(AzureResourceFunctionNewUI);
   }
   const isCicdAddable = await canAddCICDWorkflows(inputs, ctx);

--- a/packages/fx-core/src/core/middleware/questionModelV3.ts
+++ b/packages/fx-core/src/core/middleware/questionModelV3.ts
@@ -5,7 +5,6 @@ import { Middleware, NextFunction } from "@feathersjs/hooks";
 import {
   DynamicPlatforms,
   err,
-  Func,
   FxError,
   Inputs,
   MultiSelectQuestion,
@@ -46,6 +45,7 @@ import {
   AzureResourceApimNewUI,
   AzureResourceKeyVaultNewUI,
   AzureResourceSQLNewUI,
+  AzureResourceFunctionNewUI,
   BotNewUIOptionItem,
   CicdOptionItem,
   CommandAndResponseOptionItem,
@@ -250,6 +250,10 @@ async function getQuestionsForAddFeature(
   }
   if (hasBot(projectSettingsV3) || hasFunction(projectSettingsV3)) {
     options.push(ApiConnectionOptionItem);
+  }
+  // TODO: if (hasTab(projectSettingsV3) && hasAAD(projectSettingsV3)) {
+  if (hasTab(projectSettingsV3)) {
+    options.push(AzureResourceFunctionNewUI);
   }
   const isCicdAddable = await canAddCICDWorkflows(inputs, ctx);
   if (isCicdAddable) {


### PR DESCRIPTION
A tab + api function project's component list will be like:
```
    "components": [
        {
            "name": "teams-tab",
            "hosting": "azure-storage",
            "build": true,
            "provision": true,
            "folder": "tabs",
            "connections": [
                "teams-api"
            ],
            "artifactFolder": "tabs\\build"
        },
        {
            "name": "azure-storage",
            "connections": [
                "teams-tab"
            ],
            "provision": true
        },
        {
            "name": "teams-api",
            "hosting": "azure-function",
            "functionNames": [
                "getUserProfile"
            ],
            "build": true,
            "folder": "api",
            "artifactFolder": "api"
        },
        {
            "name": "azure-function",
            "connections": [
                "teams-api"
            ]
        }
    ],
```