### PR TITLE
fix: fix wording in bot template

### DIFF
--- a/templates/bot/csharp/command-and-response/GettingStarted.txt
+++ b/templates/bot/csharp/command-and-response/GettingStarted.txt
@@ -9,7 +9,7 @@ Quick Start
 to install the app to
 5. Press F5, or select the Debug > Start Debugging menu in Visual Studio
 6. In the launched browser, select the Add button to load the app in Teams
-7. In the chat bar, type and send "helloworld" to your app to trigger a response
+7. In the chat bar, type and send "helloWorld" to your app to trigger a response
 
 Learn more
 -------------------------

--- a/templates/bot/js/command-and-response/README.md
+++ b/templates/bot/js/command-and-response/README.md
@@ -60,7 +60,7 @@ The following files are project-related files. You generally will not need to cu
 
 # Customize your application
 
-By default a single command is generated that sends the `helloworldCommand.json` Adaptive Card when a user types `hello` in the private message chat with the bot.
+By default a single command is generated that sends the `helloworldCommand.json` Adaptive Card when a user types `helloWorld` in the private message chat with the bot.
 
 This section outlines some customization you can do to adopt the application for your needs.
 

--- a/templates/bot/js/command-and-response/src/index.js
+++ b/templates/bot/js/command-and-response/src/index.js
@@ -2,13 +2,19 @@
 const restify = require("restify");
 const { commandBot } = require("./internal/initialize");
 
-// Create HTTP server.
+// This template uses `restify` to serve HTTP responses.
+// Create a restify server.
 const server = restify.createServer();
 server.listen(process.env.port || process.env.PORT || 3978, () => {
   console.log(`\nBot Started, ${server.name} listening to ${server.url}`);
 });
 
-// Process Teams activity with Bot Framework.
+// Register an API endpoint with `restify`. Teams sends messages to your application
+// through this endpoint.
+//
+// The Teams Toolkit bot registration configures the bot with `/api/messages` as the
+// Bot Framework endpoint. If you customize this route, update the Bot registration
+// in `templates/azure/provision/botservice.bicep`.
 server.post("/api/messages", async (req, res) => {
   await commandBot.requestHandler(req, res);
 });

--- a/templates/bot/ts/command-and-response/src/index.ts
+++ b/templates/bot/ts/command-and-response/src/index.ts
@@ -13,7 +13,7 @@ server.listen(process.env.port || process.env.PORT || 3978, () => {
 //
 // The Teams Toolkit bot registration configures the bot with `/api/messages` as the
 // Bot Framework endpoint. If you customize this route, update the Bot registration
-// in `/templates/provision/bot.bicep`.
+// in `templates/azure/provision/botservice.bicep`.
 server.post("/api/messages", async (req, res) => {
   await commandBot.requestHandler(req, res);
 });


### PR DESCRIPTION
Fix bugs:
- [(P1) Out-of-date comments in Teams Toolkit bot example](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14897457)
- [(P2) [VS Bug Bash] helloWorld command is inconsistently defined](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14865374)

E2E TEST: N/A