### PR TITLE
fix: making path concatenations work on other OS

### DIFF
--- a/packages/fx-core/src/plugins/resource/officeaddin/config/projectsJsonData.ts
+++ b/packages/fx-core/src/plugins/resource/officeaddin/config/projectsJsonData.ts
@@ -1,12 +1,13 @@
 import * as fs from "fs";
 import * as _ from "lodash";
+import * as path from "path";
 
 export default class projectsJsonData {
   m_projectJsonDataFile = "\\projectProperties.json";
   m_projectJsonData;
 
   constructor() {
-    const jsonData = fs.readFileSync(__dirname + this.m_projectJsonDataFile);
+    const jsonData = fs.readFileSync(path.join(__dirname, this.m_projectJsonDataFile));
     this.m_projectJsonData = JSON.parse(jsonData.toString());
   }
 


### PR DESCRIPTION
Using `path.join` instead of `+` to make it work on other OS

Tested the extension by creating an Office-Addin.