### PR TITLE
fix: more than 1 configurable tab after spfx scaffolding

### DIFF
--- a/packages/fx-core/src/component/code/spfxTabCode.ts
+++ b/packages/fx-core/src/component/code/spfxTabCode.ts
@@ -255,14 +255,16 @@ export async function scaffoldSPFx(
     );
     const manifestProvider =
       (context as ContextV3).manifestProvider || new DefaultManifestProvider();
-    const addCapRes = await manifestProvider.addCapabilities(
-      (context as ContextV3).manifestProvider
-        ? (context as ContextV3)
-        : convert2Context(context as PluginContext, true).context,
-      inputs,
-      capabilitiesToAddManifest
-    );
-    if (addCapRes.isErr()) return err(addCapRes.error);
+    for (const capability of capabilitiesToAddManifest) {
+      const addCapRes = await manifestProvider.updateCapability(
+        (context as ContextV3).manifestProvider
+          ? (context as ContextV3)
+          : convert2Context(context as PluginContext, true).context,
+        inputs,
+        capability
+      );
+      if (addCapRes.isErr()) return err(addCapRes.error);
+    }
     await progressHandler?.end(true);
     return ok(undefined);
   } catch (error) {

--- a/packages/fx-core/tests/component/workflow.test.ts
+++ b/packages/fx-core/tests/component/workflow.test.ts
@@ -36,6 +36,7 @@ import {
   versionCheckQuestion,
 } from "../../src/plugins/resource/spfx/utils/questions";
 import * as spfxCode from "../../src/component/code/spfxTabCode";
+import { DefaultManifestProvider } from "../../src/component/resource/appManifest/manifestProvider";
 
 describe("Workflow test for v3", () => {
   const sandbox = sinon.createSandbox();
@@ -95,7 +96,8 @@ describe("Workflow test for v3", () => {
     sandbox.stub(fs, "rename").resolves();
     sandbox.stub(fs, "copyFile").resolves();
     sandbox.stub(versionCheckQuestion as FuncQuestion, "func").resolves(undefined);
-    // sandbox.stub(spfxCode, "scaffoldSPFx").resolves(ok(undefined));
+    sinon.stub(DefaultManifestProvider.prototype, "updateCapability").resolves(ok(Void));
+
     const inputs: InputsWithProjectPath = {
       projectPath: projectPath,
       platform: Platform.CLI,

--- a/packages/fx-core/tests/plugins/resource/spfx/unit/scaffold.test.ts
+++ b/packages/fx-core/tests/plugins/resource/spfx/unit/scaffold.test.ts
@@ -13,9 +13,7 @@ import { GeneratorChecker } from "../../../../../src/plugins/resource/spfx/depsC
 import { cpUtils } from "../../../../../src/plugins/solution/fx-solution/utils/depsChecker/cpUtils";
 import * as uuid from "uuid";
 import { ok, Void } from "@microsoft/teamsfx-api";
-import { Container } from "typedi";
-import * as appManifest from "../../../../../src/component/resource/appManifest/appManifest";
-import { BuiltInFeaturePluginNames } from "../../../../../src/plugins/solution/fx-solution/v3/constants";
+import { DefaultManifestProvider } from "../../../../../src/component/resource/appManifest/manifestProvider";
 
 describe("SPFxScaffold", function () {
   const testFolder = path.resolve("./tmp");
@@ -36,7 +34,9 @@ describe("SPFxScaffold", function () {
     sinon.stub(fs, "rename").resolves();
     sinon.stub(fs, "copyFile").resolves();
     sinon.stub(fs, "remove").resolves();
-    sinon.stub(appManifest, "addCapabilities").resolves(ok(undefined));
+    sinon.stub(fs, "pathExists").resolves(true);
+    sinon.stub(fs, "readJson").resolves({});
+    sinon.stub(DefaultManifestProvider.prototype, "updateCapability").resolves(ok(Void));
   });
 
   it("scaffold SPFx project without framework", async function () {


### PR DESCRIPTION
Fix this issue: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14937377

E2E TEST: tests/e2e/spfx/CreateSPFxProject.tests.ts