### PR TITLE
fix(cli): use add-feature instead of add-capability

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -2491,7 +2491,7 @@
     "clone": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg=="
     },
     "clone-deep": {
       "version": "4.0.1",
@@ -2885,7 +2885,7 @@
     "defaults": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "integrity": "sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==",
       "requires": {
         "clone": "^1.0.2"
       }
@@ -6304,7 +6304,7 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g=="
     },
     "p-limit": {
       "version": "3.1.0",
@@ -7981,7 +7981,7 @@
     "wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
       "requires": {
         "defaults": "^1.0.3"
       }

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -3,7 +3,7 @@
 
 "use strict";
 
-import { QTreeNode } from "@microsoft/teamsfx-api";
+import { Inputs, Platform, QTreeNode, Stage } from "@microsoft/teamsfx-api";
 import { sampleProvider } from "@microsoft/teamsfx-core";
 
 export const cliSource = "TeamsfxCLI";
@@ -62,3 +62,10 @@ export const azureSolutionGroupNodeName = "azure-solution-group";
 export class FeatureFlags {
   static readonly InsiderPreview = "__TEAMSFX_INSIDER_PREVIEW";
 }
+
+export const CLIHelpInputs: Inputs = { platform: Platform.CLI_HELP };
+
+export const AddFeatureFunc = {
+  namespace: "fx-solution-azure",
+  method: Stage.addFeature,
+};

--- a/packages/cli/src/yargsCommand.ts
+++ b/packages/cli/src/yargsCommand.ts
@@ -45,7 +45,7 @@ export abstract class YargsCommand {
    * builds the command using supplied yargs handle.
    * @param yargs the yargs handle
    */
-  abstract builder(yargs: Argv): Argv<any>;
+  abstract builder(yargs: Argv<any>): Argv<any> | Promise<Argv<any>>;
 
   /**
    * before running command, some command may modify the arguments that users input.

--- a/packages/cli/tests/e2e/bot/TabAddCommandBot.ts
+++ b/packages/cli/tests/e2e/bot/TabAddCommandBot.ts
@@ -34,7 +34,6 @@ describe("Regression test for bug 14739454", function () {
     });
     console.log(`[Successfully] scaffold to ${projectPath}`);
 
-    // provision
     await execAsyncWithRetry(`teamsfx add command-and-response`, {
       cwd: projectPath,
       env: env,
@@ -42,6 +41,14 @@ describe("Regression test for bug 14739454", function () {
     });
 
     console.log(`[Successfully] add feature for ${projectPath}`);
+
+    /// for bug 14924542
+    const result = await execAsyncWithRetry(`teamsfx add command-and-response`, {
+      cwd: projectPath,
+      env: env,
+      timeout: 0,
+    });
+    chai.assert.isNotEmpty(result.stderr);
 
     // Validate Bot scaffold
     await BotValidator.validateScaffold(projectPath, "typescript", "src");

--- a/packages/cli/tests/unit/cmds/capability.tests.ts
+++ b/packages/cli/tests/unit/cmds/capability.tests.ts
@@ -75,16 +75,13 @@ describe("Capability Command Tests", function () {
     sandbox
       .stub(FxCore.prototype, "executeUserTask")
       .callsFake(async (func: Func, inputs: Inputs) => {
-        expect(func).deep.equals({
-          namespace: "fx-solution-azure",
-          method: "addCapability",
-        });
+        expect(func).deep.equals(constants.AddFeatureFunc);
         if (inputs.projectPath?.includes("real")) return ok("");
         else return err(NotSupportedProjectType());
       });
-    sandbox.stub(FxCore.prototype, "getProjectConfig").callsFake(async (inputs: Inputs) => {
+    sandbox.stub(FxCore.prototype, "getProjectConfigV3").callsFake(async (inputs: Inputs) => {
       if (inputs.projectPath?.includes("real")) {
-        return ok({});
+        return ok({ projectSettings: { appName: "test", projectId: "" }, envInfos: {} });
       } else {
         return err(NotSupportedProjectType());
       }

--- a/packages/fx-core/.nycrc
+++ b/packages/fx-core/.nycrc
@@ -1,7 +1,10 @@
 {
   "extends": "@istanbuljs/nyc-config-typescript",
   "all": true,
-  "include": ["src/**/*.ts", "src/**/*.js"],
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.js"
+  ],
   "exclude": [
     "src/core/pvm/type.ts",
     "src/common/deps-checker/**/*",
@@ -24,7 +27,12 @@
     "src/plugins/resource/appstudio/interfaces/**/*",
     "src/plugins/resource/function/v3/error.ts"
   ],
-  "reporter": ["text", "html", "json-summary", "cobertura"],
+  "reporter": [
+    "text",
+    "html",
+    "json-summary",
+    "cobertura"
+  ],
   "check-coverage": true,
-  "lines": 72.8
+  "lines": 72.7
 }

--- a/packages/fx-core/package-lock.json
+++ b/packages/fx-core/package-lock.json
@@ -2753,7 +2753,7 @@
     "clone-response": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
-      "integrity": "sha512-yjLXh88P599UOyPTFX0POsd7WxnbsVsGohcwzHOLspIhhpalPw1BcqED8NblyZLKcGrL8dTgMlcaZxV2jAD41Q==",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
       "requires": {
         "mimic-response": "^1.0.0"
       }
@@ -5881,9 +5881,9 @@
       "dev": true
     },
     "moment": {
-      "version": "2.29.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
-      "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg=="
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "ms": {
       "version": "2.1.2",

--- a/packages/fx-core/tests/plugins/solution/solution.getQuestions.test.ts
+++ b/packages/fx-core/tests/plugins/solution/solution.getQuestions.test.ts
@@ -54,10 +54,12 @@ import {
   ApiConnectionOptionItem,
   TabNonSsoItem,
   TabOptionItem,
+  SingleSignOnOptionItem,
 } from "../../../src/plugins/solution/fx-solution/question";
 import { ResourcePluginsV2 } from "../../../src/plugins/solution/fx-solution/ResourcePluginContainer";
 import {
   getQuestions,
+  getQuestionsForAddFeature,
   getQuestionsForScaffolding,
   getQuestionsForUserTask,
 } from "../../../src/plugins/solution/fx-solution/v2/getQuestions";
@@ -381,6 +383,71 @@ describe("getQuestionsForScaffolding()", async () => {
       if (res.isOk()) {
         const node = res.value;
         assert.isTrue(node !== undefined && node.data !== undefined);
+      }
+    }
+  });
+
+  it("getQuestionsForAddFeature - CLI_HELP", async () => {
+    sandbox.stub<any, any>(tool, "canAddCICDWorkflows").resolves(true);
+    const mockedCtx = new MockedV2Context(projectSettings);
+    const mockedInputs: Inputs = {
+      platform: Platform.CLI_HELP,
+      stage: Stage.grantPermission,
+      projectPath: "test path",
+    };
+    const func: Func = {
+      method: "addFeature",
+      namespace: "fx-solution-azure",
+    };
+    const appStudioPlugin = Container.get<AppStudioPluginV3>(BuiltInFeaturePluginNames.appStudio);
+    sandbox
+      .stub<any, any>(appStudioPlugin, "capabilityExceedLimit")
+      .callsFake(
+        async (
+          ctx: v2.Context,
+          inputs: v2.InputsWithProjectPath,
+          capability: "staticTab" | "configurableTab" | "Bot" | "MessageExtension"
+        ) => {
+          return ok(false);
+        }
+      );
+    (mockedCtx.projectSetting.solutionSettings as AzureSolutionSettings).hostType =
+      HostTypeOptionAzure.id;
+    const res = await getQuestionsForAddFeature(
+      mockedCtx,
+      mockedInputs,
+      func,
+      envInfo,
+      mockedProvider
+    );
+    assert.isTrue(res.isOk() && res.value && res.value !== undefined);
+    if (res.isOk()) {
+      const node = res.value;
+      assert.isTrue(
+        node && node.data && node.data.type === "singleSelect",
+        "option item count check"
+      );
+      if (node && node.data && node.data.type === "singleSelect") {
+        const options = (node.data as SingleSelectQuestion).staticOptions as OptionItem[];
+        assert.deepEqual(
+          options,
+          [
+            NotificationOptionItem,
+            CommandAndResponseOptionItem,
+            TabNewUIOptionItem,
+            TabNonSsoItem,
+            BotNewUIOptionItem,
+            MessageExtensionNewUIItem,
+            AzureResourceFunctionNewUI,
+            AzureResourceApimNewUI,
+            AzureResourceSQLNewUI,
+            AzureResourceKeyVaultNewUI,
+            SingleSignOnOptionItem,
+            ApiConnectionOptionItem,
+            CicdOptionItem,
+          ],
+          "option item should match"
+        );
       }
     }
   });

--- a/packages/vscode-extension/package-lock.json
+++ b/packages/vscode-extension/package-lock.json
@@ -8971,9 +8971,9 @@
       }
     },
     "moment": {
-      "version": "2.29.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
-      "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==",
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
       "dev": true
     },
     "ms": {
@@ -9717,8 +9717,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "resolved": "",
           "dev": true
         },
         "cliui": {
@@ -14633,8 +14632,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "resolved": "",
           "dev": true
         },
         "is-fullwidth-code-point": {


### PR DESCRIPTION
1. Refine the `add-feature` question generator in `fx-core` to support the `CLI_HELP` platform.
2. Use the `add-feature` stage in `fx-cli` instead of the `add-capability` stage.
3. Directly get questions in the `teamsfx add [capability]` builder function, not use `helpParamGenerator`.
4. Modify an E2E test case for the bug 14924542.

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14924542
E2E TEST: https://github.com/OfficeDev/TeamsFx/actions/runs/2654421779

![image](https://user-images.githubusercontent.com/15262146/178419207-33a29fe2-260e-4986-a08a-454db480b96c.png)
