### PR TITLE
fix(bot): fix message extension cannot add default bot

### DIFF
--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/getQuestions.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/getQuestions.ts
@@ -854,7 +854,7 @@ async function getStaticOptionsForAddCapability(
   const isMEAddable = isBotNotificationEnabled()
     ? !meExceedRes.value && !hasNewBot
     : !meExceedRes.value;
-  if (!(isTabAddable || isScenarioBotAddable || isMEAddable)) {
+  if (!(isTabAddable || isDefaultBotAddable || isScenarioBotAddable || isMEAddable)) {
     ctx.userInteraction?.showMessage(
       "error",
       getLocalizedString("core.addCapability.exceedMaxLimit"),

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/getQuestions.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/getQuestions.ts
@@ -836,7 +836,8 @@ async function getStaticOptionsForAddCapability(
   }
 
   const hasMe = settings?.capabilities.includes(MessageExtensionItem.id);
-  const isBotAddable = !botExceedRes.value && !hasMe;
+  const isScenarioBotAddable = !botExceedRes.value && !hasMe;
+  const isDefaultBotAddable = !botExceedRes.value;
   const meExceedRes = await appStudioPlugin.capabilityExceedLimit(
     ctx,
     inputs as v2.InputsWithProjectPath,
@@ -853,7 +854,7 @@ async function getStaticOptionsForAddCapability(
   const isMEAddable = isBotNotificationEnabled()
     ? !meExceedRes.value && !hasNewBot
     : !meExceedRes.value;
-  if (!(isTabAddable || isBotAddable || isMEAddable)) {
+  if (!(isTabAddable || isScenarioBotAddable || isMEAddable)) {
     ctx.userInteraction?.showMessage(
       "error",
       getLocalizedString("core.addCapability.exceedMaxLimit"),
@@ -863,7 +864,7 @@ async function getStaticOptionsForAddCapability(
   }
 
   const options: OptionItem[] = [];
-  if (isBotAddable) {
+  if (isScenarioBotAddable) {
     options.push(NotificationOptionItem);
     options.push(CommandAndResponseOptionItem);
   }
@@ -876,7 +877,7 @@ async function getStaticOptionsForAddCapability(
       );
     }
   }
-  if (isBotAddable) {
+  if (isDefaultBotAddable) {
     options.push(BotNewUIOptionItem);
   }
   if (isMEAddable) {


### PR DESCRIPTION
E2E TEST: N/A

Fix: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14959889/