### PR TITLE
feat: allow reprovision in new sub 

### DIFF
--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -3,7 +3,7 @@
   "core.init.successNotice": "Your project has been successfully initialized to operate with TeamsFx.\n\nSome next steps:\nteamsfx add <feature> will allow you to add features like single sign on or Teams notification integration.\n\nPro tip:\nRead on aka.ms/teams-manifest to learn more about updating manifest file to connect with your existing launch page experience.",
   "core.provision.confirmNotice": "The Teams Toolkit will provision resources and register corresponding resource providers under Azure account (%s) with subscription (%s). Costs may incur according to the pricing calculator.",
   "core.provision.confirmEnvNotice": "Do you want to provision resources in %s environment?\nAzure account (%s) with subscription (%s) will be used to provision the resources. Cost may incur according to the usage.",
-  "core.provision.confirmSubscription": "Do you want to provision in %s which is different from the subscription %s you used in last provision? If there is any resources provisioned before in subscription %s, you have to delete them manually to avoid costs.",
+  "core.provision.confirmSubscription": "Do you want to provision in %s which is different from the subscription %s you used in last provision? If there is any resource provisioned before in subscription %s, you have to delete them manually to avoid costs.",
   "core.deploy.confirmEnvNotice": "Do you want to deploy resources in %s environment?\nAzure account (%s) with subscription (%s) will be used for deployment.",
   "core.provision.successAzure": "Azure resources successfully provisioned in the cloud.",
   "core.provision.successNotice": "'%s' successfully provisioned in the cloud.",

--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -3,6 +3,7 @@
   "core.init.successNotice": "Your project has been successfully initialized to operate with TeamsFx.\n\nSome next steps:\nteamsfx add <feature> will allow you to add features like single sign on or Teams notification integration.\n\nPro tip:\nRead on aka.ms/teams-manifest to learn more about updating manifest file to connect with your existing launch page experience.",
   "core.provision.confirmNotice": "The Teams Toolkit will provision resources and register corresponding resource providers under Azure account (%s) with subscription (%s). Costs may incur according to the pricing calculator.",
   "core.provision.confirmEnvNotice": "Do you want to provision resources in %s environment?\nAzure account (%s) with subscription (%s) will be used to provision the resources. Cost may incur according to the usage.",
+  "core.provision.confirmSubscription": "Do you want to provision in %s which is different from the subscription %s you used in last provision? If there is any resources provisioned before in subscription %s, you have to delete them manually to avoid costs.",
   "core.deploy.confirmEnvNotice": "Do you want to deploy resources in %s environment?\nAzure account (%s) with subscription (%s) will be used for deployment.",
   "core.provision.successAzure": "Azure resources successfully provisioned in the cloud.",
   "core.provision.successNotice": "'%s' successfully provisioned in the cloud.",

--- a/packages/fx-core/src/component/fx/preDeployAction.ts
+++ b/packages/fx-core/src/component/fx/preDeployAction.ts
@@ -11,10 +11,8 @@ import {
   ProvisionContextV3,
   Result,
 } from "@microsoft/teamsfx-api";
-import {
-  askForDeployConsent,
-  checkDeployAzureSubscription,
-} from "../../plugins/solution/fx-solution/v3/provision";
+import { checkDeployAzureSubscription } from "../../plugins/solution/fx-solution/v3/deploy";
+import { askForDeployConsent } from "../../plugins/solution/fx-solution/v3/provision";
 
 export class FxPreDeployForAzureAction implements FunctionAction {
   type: "function" = "function";

--- a/packages/fx-core/src/component/fx/preDeployAction.ts
+++ b/packages/fx-core/src/component/fx/preDeployAction.ts
@@ -13,7 +13,7 @@ import {
 } from "@microsoft/teamsfx-api";
 import {
   askForDeployConsent,
-  checkAzureSubscription,
+  checkDeployAzureSubscription,
 } from "../../plugins/solution/fx-solution/v3/provision";
 
 export class FxPreDeployForAzureAction implements FunctionAction {
@@ -24,7 +24,7 @@ export class FxPreDeployForAzureAction implements FunctionAction {
     inputs: InputsWithProjectPath
   ): Promise<Result<Effect[], FxError>> {
     const ctx = context as ProvisionContextV3;
-    const subscriptionResult = await checkAzureSubscription(
+    const subscriptionResult = await checkDeployAzureSubscription(
       ctx,
       ctx.envInfo,
       ctx.tokenProvider.azureAccountProvider

--- a/packages/fx-core/src/component/fx/preProvisionAction.ts
+++ b/packages/fx-core/src/component/fx/preProvisionAction.ts
@@ -66,14 +66,17 @@ export class FxPreProvisionAction implements FunctionAction {
       if (solutionConfigRes.isErr()) {
         return err(solutionConfigRes.error);
       }
-      // ask for provision consent
-      const consentResult = await askForProvisionConsent(
-        ctx,
-        ctx.tokenProvider.azureAccountProvider,
-        envInfo
-      );
-      if (consentResult.isErr()) {
-        return err(consentResult.error);
+
+      if (!solutionConfigRes.value.hasSwitchedSubscription) {
+        // ask for provision consent
+        const consentResult = await askForProvisionConsent(
+          ctx,
+          ctx.tokenProvider.azureAccountProvider,
+          envInfo
+        );
+        if (consentResult.isErr()) {
+          return err(consentResult.error);
+        }
       }
       // create resource group if needed
       if (solutionConfig.needCreateResourceGroup) {

--- a/packages/fx-core/src/component/fx/preProvisionAction.ts
+++ b/packages/fx-core/src/component/fx/preProvisionAction.ts
@@ -16,6 +16,7 @@ import {
 import { getLocalizedString } from "../../common/localizeUtils";
 import { hasAzureResourceV3 } from "../../common/projectSettingsHelperV3";
 import { globalVars } from "../../core";
+import { updateResourceBaseName } from "../../plugins/solution/fx-solution/arm";
 import { resourceGroupHelper } from "../../plugins/solution/fx-solution/utils/ResourceGroupHelper";
 import {
   askForProvisionConsent,
@@ -78,6 +79,7 @@ export class FxPreProvisionAction implements FunctionAction {
           return err(consentResult.error);
         }
       }
+
       // create resource group if needed
       if (solutionConfig.needCreateResourceGroup) {
         const createRgRes = await resourceGroupHelper.createNewResourceGroup(
@@ -89,6 +91,10 @@ export class FxPreProvisionAction implements FunctionAction {
         if (createRgRes.isErr()) {
           return err(createRgRes.error);
         }
+      }
+
+      if (solutionConfigRes.value.hasSwitchedSubscription) {
+        updateResourceBaseName(inputs.projectPath, ctx.projectSetting.appName, envInfo.envName);
       }
     }
     return ok([]);

--- a/packages/fx-core/src/plugins/resource/utils4v2.ts
+++ b/packages/fx-core/src/plugins/resource/utils4v2.ts
@@ -172,14 +172,6 @@ export async function provisionResourceAdapter(
   }
 
   const res = await plugin.provision(pluginContext);
-
-  // const fxError: FxError = {
-  //   source: "no idea",
-  //   timestamp: new Date(),
-  //   message: "test message",
-  //   name: "just an error",
-  // };
-  // return err(fxError);
   if (res.isErr()) {
     return err(res.error);
   }

--- a/packages/fx-core/src/plugins/resource/utils4v2.ts
+++ b/packages/fx-core/src/plugins/resource/utils4v2.ts
@@ -172,6 +172,14 @@ export async function provisionResourceAdapter(
   }
 
   const res = await plugin.provision(pluginContext);
+
+  // const fxError: FxError = {
+  //   source: "no idea",
+  //   timestamp: new Date(),
+  //   message: "test message",
+  //   name: "just an error",
+  // };
+  // return err(fxError);
   if (res.isErr()) {
     return err(res.error);
   }

--- a/packages/fx-core/src/plugins/solution/fx-solution/arm.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/arm.ts
@@ -747,6 +747,7 @@ export async function deployArmTemplatesV3(
   return result;
 }
 
+// Copy parameters Json -> could be used as reference for generating new resource base name (todo:)
 export async function copyParameterJson(
   projectPath: string,
   appName: string,
@@ -774,6 +775,29 @@ export async function copyParameterJson(
       generateResourceBaseName(appName, targetEnvName);
   }
 
+  await fs.ensureDir(parameterFolderPath);
+  await fs.writeFile(
+    targetParameterFilePath,
+    JSON.stringify(targetParameterContent, undefined, 2).replace(/\r?\n/g, os.EOL)
+  );
+}
+
+export async function updateResourceBaseName(
+  projectPath: string,
+  appName: string,
+  envName: string
+) {
+  if (!envName) {
+    return;
+  }
+
+  const parameterFolderPath = path.join(projectPath, configsFolder);
+  const targetParameterFileName = parameterFileNameTemplate.replace(EnvNamePlaceholder, envName);
+
+  const targetParameterFilePath = path.join(parameterFolderPath, targetParameterFileName);
+  const targetParameterContent = await fs.readJson(targetParameterFilePath);
+  targetParameterContent[parameterName].provisionParameters.value!.resourceBaseName =
+    generateResourceBaseName(appName, envName);
   await fs.ensureDir(parameterFolderPath);
   await fs.writeFile(
     targetParameterFilePath,

--- a/packages/fx-core/src/plugins/solution/fx-solution/arm.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/arm.ts
@@ -747,7 +747,6 @@ export async function deployArmTemplatesV3(
   return result;
 }
 
-// Copy parameters Json -> could be used as reference for generating new resource base name (todo:)
 export async function copyParameterJson(
   projectPath: string,
   appName: string,

--- a/packages/fx-core/src/plugins/solution/fx-solution/constants.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/constants.ts
@@ -330,3 +330,9 @@ export class AddSsoParameters {
 export class UserTaskFunctionName {
   static readonly ConnectExistingApi = "connectExistingApi";
 }
+
+export interface ProvisionSubscriptionCheckResult {
+  hasSwitchedSubscription: boolean;
+}
+
+export type FillInAzureConfigsResult = ProvisionSubscriptionCheckResult;

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/provision.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/provision.ts
@@ -172,14 +172,16 @@ async function provisionResourceImpl(
       return err(solutionConfigRes.error);
     }
 
-    // ask for provision consent
-    const consentResult = await askForProvisionConsent(
-      ctx,
-      tokenProvider.azureAccountProvider,
-      envInfo as v3.EnvInfoV3
-    );
-    if (consentResult.isErr()) {
-      return err(consentResult.error);
+    if (!solutionConfigRes.value.hasSwitchedSubscription) {
+      // ask for provision consent
+      const consentResult = await askForProvisionConsent(
+        ctx,
+        tokenProvider.azureAccountProvider,
+        envInfo as v3.EnvInfoV3
+      );
+      if (consentResult.isErr()) {
+        return err(consentResult.error);
+      }
     }
 
     // create resource group if needed

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/provision.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/provision.ts
@@ -39,7 +39,7 @@ import {
 import _, { isUndefined } from "lodash";
 import { PluginDisplayName } from "../../../../common/constants";
 import { ProvisionContextAdapter } from "./adaptor";
-import { deployArmTemplates } from "../arm";
+import { deployArmTemplates, updateResourceBaseName } from "../arm";
 import { Container } from "typedi";
 import { ResourcePluginsV2 } from "../ResourcePluginContainer";
 import { PermissionRequestFileProvider } from "../../../../core/permissionRequest";
@@ -195,6 +195,10 @@ async function provisionResourceImpl(
       if (createRgRes.isErr()) {
         return err(createRgRes.error);
       }
+    }
+
+    if (solutionConfigRes.value.hasSwitchedSubscription) {
+      updateResourceBaseName(inputs.projectPath, ctx.projectSetting.appName, envInfo.envName);
     }
   }
 

--- a/packages/fx-core/src/plugins/solution/fx-solution/v3/deploy.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v3/deploy.ts
@@ -2,7 +2,10 @@
 // Licensed under the MIT license.
 
 import {
+  AzureAccountProvider,
   AzureSolutionSettings,
+  EnvConfigFileNameTemplate,
+  EnvNamePlaceholder,
   err,
   FxError,
   Json,
@@ -11,6 +14,7 @@ import {
   QTreeNode,
   Result,
   TokenProvider,
+  UserError,
   v2,
   v3,
   Void,
@@ -20,6 +24,7 @@ import { PluginDisplayName } from "../../../../common/constants";
 import { executeConcurrently } from "../v2/executor";
 import { selectMultiPluginsQuestion } from "../../utils/questions";
 import { getLocalizedString } from "../../../../common/localizeUtils";
+import { SolutionError, SolutionSource } from "../constants";
 
 export async function getQuestionsForDeploy(
   ctx: v2.Context,
@@ -104,4 +109,63 @@ export async function deploy(
     ctx.logProvider.info(msg);
     return err(result.error);
   }
+}
+
+/**
+ * make sure subscription is correct before deployment
+ *
+ */
+export async function checkDeployAzureSubscription(
+  ctx: v2.Context,
+  envInfo: v3.EnvInfoV3,
+  azureAccountProvider: AzureAccountProvider
+): Promise<Result<Void, FxError>> {
+  const subscriptionIdInConfig =
+    envInfo.config.azure?.subscriptionId || (envInfo.state.solution.subscriptionId as string);
+  const subscriptionInAccount = await azureAccountProvider.getSelectedSubscription(true);
+  if (!subscriptionIdInConfig) {
+    if (subscriptionInAccount) {
+      envInfo.state.solution.subscriptionId = subscriptionInAccount.subscriptionId;
+      envInfo.state.solution.subscriptionName = subscriptionInAccount.subscriptionName;
+      envInfo.state.solution.tenantId = subscriptionInAccount.tenantId;
+      ctx.logProvider.info(`[${PluginDisplayName.Solution}] checkAzureSubscription pass!`);
+      return ok(Void);
+    } else {
+      return err(
+        new UserError(
+          SolutionSource,
+          SolutionError.SubscriptionNotFound,
+          "Failed to select subscription"
+        )
+      );
+    }
+  }
+  // make sure the user is logged in
+  await azureAccountProvider.getAccountCredentialAsync(true);
+  // verify valid subscription (permission)
+  const subscriptions = await azureAccountProvider.listSubscriptions();
+  const targetSubInfo = subscriptions.find(
+    (item) => item.subscriptionId === subscriptionIdInConfig
+  );
+  if (!targetSubInfo) {
+    return err(
+      new UserError(
+        SolutionSource,
+        SolutionError.SubscriptionNotFound,
+        `The subscription '${subscriptionIdInConfig}'(${
+          envInfo.state.solution.subscriptionName
+        }) for '${
+          envInfo.envName
+        }' environment is not found in the current account, please use the right Azure account or check the '${EnvConfigFileNameTemplate.replace(
+          EnvNamePlaceholder,
+          envInfo.envName
+        )}' file.`
+      )
+    );
+  }
+  envInfo.state.solution.subscriptionId = targetSubInfo.subscriptionId;
+  envInfo.state.solution.subscriptionName = targetSubInfo.subscriptionName;
+  envInfo.state.solution.tenantId = targetSubInfo.tenantId;
+  ctx.logProvider.info(`[${PluginDisplayName.Solution}] checkAzureSubscription pass!`);
+  return ok(Void);
 }

--- a/packages/fx-core/src/plugins/solution/fx-solution/v3/provision.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v3/provision.ts
@@ -21,6 +21,7 @@ import {
   v2,
   v3,
   Void,
+  SubscriptionInfo,
 } from "@microsoft/teamsfx-api";
 import { isUndefined, snakeCase } from "lodash";
 import { Container } from "typedi";
@@ -36,9 +37,14 @@ import {
 import { AppStudioScopes, getHashedEnv, getResourceGroupInPortal } from "../../../../common/tools";
 import { convertToAlphanumericOnly } from "../../../../common/utils";
 import { AppStudioPluginV3 } from "../../../resource/appstudio/v3";
-import arm from "../arm";
+import arm, { updateResourceBaseName } from "../arm";
 import { ResourceGroupInfo } from "../commonQuestions";
-import { SolutionError, SolutionSource } from "../constants";
+import {
+  FillInAzureConfigsResult,
+  SolutionError,
+  SolutionSource,
+  ProvisionSubscriptionCheckResult,
+} from "../constants";
 import { configLocalEnvironment, setupLocalEnvironment } from "../debug/provisionLocal";
 import { resourceGroupHelper } from "../utils/ResourceGroupHelper";
 import { executeConcurrently } from "../v2/executor";
@@ -133,14 +139,17 @@ export async function provisionResources(
       if (solutionConfigRes.isErr()) {
         return err(solutionConfigRes.error);
       }
-      // ask for provision consent
-      const consentResult = await askForProvisionConsent(
-        ctx,
-        tokenProvider.azureAccountProvider,
-        envInfo as v3.EnvInfoV3
-      );
-      if (consentResult.isErr()) {
-        return err(consentResult.error);
+
+      if (!solutionConfigRes.value.hasSwitchedSubscription) {
+        // ask for provision consent
+        const consentResult = await askForProvisionConsent(
+          ctx,
+          tokenProvider.azureAccountProvider,
+          envInfo as v3.EnvInfoV3
+        );
+        if (consentResult.isErr()) {
+          return err(consentResult.error);
+        }
       }
 
       // create resource group if needed
@@ -283,25 +292,24 @@ export async function provisionResources(
 }
 
 /**
- * make sure subscription is correct
+ * make sure subscription is correct before provision
  *
  */
-export async function checkAzureSubscription(
+export async function checkProvisionAzureSubscription(
   ctx: v2.Context,
   envInfo: v3.EnvInfoV3,
-  azureAccountProvider: AzureAccountProvider
-): Promise<Result<Void, FxError>> {
-  const subscriptionIdInConfig =
-    envInfo.config.azure?.subscriptionId || (envInfo.state.solution.subscriptionId as string);
+  azureAccountProvider: AzureAccountProvider,
+  projectPath: string
+): Promise<Result<ProvisionSubscriptionCheckResult, FxError>> {
+  const subscriptionIdInConfig: string | undefined = envInfo.config.azure?.subscriptionId;
+  const subscriptionNameInConfig: string = envInfo.config.azure?.subscriptionName ?? "";
+  const subscriptionIdInState: string | undefined = envInfo.state.solution.subscriptionId;
+  const subscriptionNameInState: string | undefined = envInfo.state.solution.subscriptionName;
+
   const subscriptionInAccount = await azureAccountProvider.getSelectedSubscription(true);
-  if (!subscriptionIdInConfig) {
-    if (subscriptionInAccount) {
-      envInfo.state.solution.subscriptionId = subscriptionInAccount.subscriptionId;
-      envInfo.state.solution.subscriptionName = subscriptionInAccount.subscriptionName;
-      envInfo.state.solution.tenantId = subscriptionInAccount.tenantId;
-      ctx.logProvider.info(`[${PluginDisplayName.Solution}] checkAzureSubscription pass!`);
-      return ok(Void);
-    } else {
+
+  if (!subscriptionIdInState && !subscriptionIdInConfig) {
+    if (!subscriptionInAccount) {
       return err(
         new UserError(
           SolutionSource,
@@ -309,35 +317,135 @@ export async function checkAzureSubscription(
           "Failed to select subscription"
         )
       );
+    } else {
+      updateEnvInfoSubscription(envInfo, subscriptionInAccount);
+      ctx.logProvider.info(`[${PluginDisplayName.Solution}] checkAzureSubscription pass!`);
+      return ok({ hasSwitchedSubscription: false });
     }
   }
+
   // make sure the user is logged in
   await azureAccountProvider.getAccountCredentialAsync(true);
   // verify valid subscription (permission)
   const subscriptions = await azureAccountProvider.listSubscriptions();
-  const targetSubInfo = subscriptions.find(
-    (item) => item.subscriptionId === subscriptionIdInConfig
-  );
-  if (!targetSubInfo) {
-    return err(
-      new UserError(
-        SolutionSource,
-        SolutionError.SubscriptionNotFound,
-        `The subscription '${subscriptionIdInConfig}'(${
-          envInfo.state.solution.subscriptionName
-        }) for '${
-          envInfo.envName
-        }' environment is not found in the current account, please use the right Azure account or check the '${EnvConfigFileNameTemplate.replace(
-          EnvNamePlaceholder,
-          envInfo.envName
-        )}' file.`
-      )
+
+  if (subscriptionIdInConfig) {
+    const targetConfigSubInfo = subscriptions.find(
+      (item) => item.subscriptionId === subscriptionIdInConfig
     );
+
+    if (!targetConfigSubInfo) {
+      return err(
+        new UserError(
+          SolutionSource,
+          SolutionError.SubscriptionNotFound,
+          `The subscription '${subscriptionIdInConfig}'(${subscriptionNameInConfig}) for '${
+            envInfo.envName
+          }' environment is not found in the current account, please use the right Azure account or check the '${EnvConfigFileNameTemplate.replace(
+            EnvNamePlaceholder,
+            envInfo.envName
+          )}' file.`
+        )
+      );
+    } else {
+      return compareWithStateSubscription(
+        ctx,
+        envInfo,
+        targetConfigSubInfo,
+        subscriptionIdInState,
+        subscriptionNameInState,
+        projectPath
+      );
+    }
+  } else {
+    const targetStateSubInfo = subscriptions.find(
+      (item) => item.subscriptionId === subscriptionIdInState
+    );
+
+    if (!subscriptionInAccount) {
+      if (targetStateSubInfo) {
+        updateEnvInfoSubscription(envInfo, targetStateSubInfo);
+        ctx.logProvider.info(`[${PluginDisplayName.Solution}] checkAzureSubscription pass!`);
+        return ok({ hasSwitchedSubscription: false });
+      } else {
+        return err(
+          new UserError(
+            SolutionSource,
+            SolutionError.SubscriptionNotFound,
+            `The subscription '${subscriptionIdInState}'(${subscriptionNameInState}) for '${envInfo.envName}' environment is not found in the current account, please use the right Azure account.`
+          )
+        );
+      }
+    } else {
+      return compareWithStateSubscription(
+        ctx,
+        envInfo,
+        subscriptionInAccount,
+        subscriptionIdInState,
+        subscriptionNameInState,
+        projectPath
+      );
+    }
   }
-  envInfo.state.solution.subscriptionId = targetSubInfo.subscriptionId;
-  envInfo.state.solution.subscriptionName = targetSubInfo.subscriptionName;
-  envInfo.state.solution.tenantId = targetSubInfo.tenantId;
-  ctx.logProvider.info(`[${PluginDisplayName.Solution}] checkAzureSubscription pass!`);
+}
+
+function updateEnvInfoSubscription(envInfo: v3.EnvInfoV3, subscriptionInfo: SubscriptionInfo) {
+  envInfo.state.solution.subscriptionId = subscriptionInfo.subscriptionId;
+  envInfo.state.solution.subscriptionName = subscriptionInfo.subscriptionName;
+  envInfo.state.solution.tenantId = subscriptionInfo.tenantId;
+}
+
+async function compareWithStateSubscription(
+  ctx: v2.Context,
+  envInfo: v3.EnvInfoV3,
+  targetSubscriptionInfo: SubscriptionInfo,
+  subscriptionInStateId: string | undefined,
+  subscriptionInStateName: string | undefined,
+  projectPath: string
+): Promise<Result<ProvisionSubscriptionCheckResult, FxError>> {
+  const shouldAskForSubscriptionConfirmation =
+    !!subscriptionInStateId && targetSubscriptionInfo.subscriptionId !== subscriptionInStateId;
+  if (shouldAskForSubscriptionConfirmation) {
+    const confirmResult = await askForSubscriptionConfirm(
+      ctx,
+      subscriptionInStateName ?? subscriptionInStateId,
+      targetSubscriptionInfo.subscriptionName ?? targetSubscriptionInfo.subscriptionId
+    );
+    if (confirmResult.isErr()) {
+      return err(confirmResult.error);
+    } else {
+      updateResourceBaseName(projectPath, ctx.projectSetting.appName, envInfo.envName);
+
+      updateEnvInfoSubscription(envInfo, targetSubscriptionInfo);
+      envInfo.state.solution.resourceNameSuffix = "";
+      envInfo.state.solution.resourceGroupName = "";
+      ctx.logProvider.info(`[${PluginDisplayName.Solution}] checkAzureSubscription pass!`);
+      return ok({ hasSwitchedSubscription: true });
+    }
+  } else {
+    updateEnvInfoSubscription(envInfo, targetSubscriptionInfo);
+    ctx.logProvider.info(`[${PluginDisplayName.Solution}] checkAzureSubscription pass!`);
+    return ok({ hasSwitchedSubscription: false });
+  }
+}
+
+async function askForSubscriptionConfirm(
+  ctx: v2.Context,
+  subscriptionInState: string,
+  subscriptionInAccount: string
+): Promise<Result<Void, FxError>> {
+  const msgNew = getLocalizedString(
+    "core.provision.confirmSubscription",
+    subscriptionInAccount,
+    subscriptionInState,
+    subscriptionInState
+  );
+  const confirmRes = await ctx.userInteraction.showMessage("warn", msgNew, true, "Provision");
+  const confirm = confirmRes?.isOk() ? confirmRes.value : undefined;
+
+  if (confirm !== "Provision") {
+    return err(new UserError(SolutionSource, "CancelProvision", "CancelProvision"));
+  }
   return ok(Void);
 }
 
@@ -350,12 +458,13 @@ export async function fillInAzureConfigs(
   inputs: v2.InputsWithProjectPath,
   envInfo: v3.EnvInfoV3,
   tokenProvider: TokenProvider
-): Promise<Result<Void, FxError>> {
+): Promise<Result<FillInAzureConfigsResult, FxError>> {
   //1. check subscriptionId
-  const subscriptionResult = await checkAzureSubscription(
+  const subscriptionResult = await checkProvisionAzureSubscription(
     ctx,
     envInfo,
-    tokenProvider.azureAccountProvider
+    tokenProvider.azureAccountProvider,
+    inputs.projectPath
   );
   if (subscriptionResult.isErr()) {
     return err(subscriptionResult.error);
@@ -504,7 +613,7 @@ export async function fillInAzureConfigs(
     uuidv4().substr(0, 6);
   envInfo.state.solution.resourceNameSuffix = resourceNameSuffix;
   ctx.logProvider?.info(`[${PluginDisplayName.Solution}] check resourceNameSuffix pass!`);
-  return ok(Void);
+  return ok({ hasSwitchedSubscription: subscriptionResult.value.hasSwitchedSubscription });
 }
 
 export async function askForDeployConsent(

--- a/packages/fx-core/src/plugins/solution/fx-solution/v3/provision.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v3/provision.ts
@@ -29,7 +29,7 @@ import { v4 as uuidv4 } from "uuid";
 import { hasAzureResource } from "../../../../common";
 import { PluginDisplayName } from "../../../../common/constants";
 import { getDefaultString, getLocalizedString } from "../../../../common/localizeUtils";
-import { LocalSettingsBotKeys } from "../../../../common/localSettingsConstants";
+import { LocalStateAuthKeys, LocalStateBotKeys } from "../../../../common/localStateConstants";
 import {
   CustomizeResourceGroupType,
   TelemetryEvent,
@@ -424,16 +424,17 @@ async function compareWithStateSubscription(
       envInfo.state.solution.resourceGroupName = "";
 
       // we need to have another bot id if provisioning a new azure bot service.
-      if (envInfo.state[BuiltInFeaturePluginNames.bot]) {
-        if (envInfo.state[BuiltInFeaturePluginNames.bot][LocalSettingsBotKeys.BotId]) {
-          envInfo.state[BuiltInFeaturePluginNames.bot][LocalSettingsBotKeys.BotId] = undefined;
+      const botResource =
+        envInfo.state[BuiltInFeaturePluginNames.bot] ?? envInfo.state["teams-bot"];
+      if (botResource) {
+        if (botResource[LocalStateBotKeys.BotId]) {
+          botResource[LocalStateBotKeys.BotId] = undefined;
         }
-        if (envInfo.state[BuiltInFeaturePluginNames.bot][LocalSettingsBotKeys.BotPassword]) {
-          envInfo.state[BuiltInFeaturePluginNames.bot][LocalSettingsBotKeys.BotPassword] =
-            undefined;
+        if (botResource[LocalStateBotKeys.BotPassword]) {
+          botResource[LocalStateBotKeys.BotPassword] = undefined;
         }
-        if (envInfo.state[BuiltInFeaturePluginNames.bot]["objectId"]) {
-          envInfo.state[BuiltInFeaturePluginNames.bot]["objectId"] = undefined;
+        if (botResource[LocalStateAuthKeys.ObjectId]) {
+          botResource[LocalStateAuthKeys.ObjectId] = undefined;
         }
       }
       ctx.logProvider.info(`[${PluginDisplayName.Solution}] checkAzureSubscription pass!`);

--- a/packages/fx-core/src/plugins/solution/fx-solution/v3/provision.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v3/provision.ts
@@ -165,6 +165,10 @@ export async function provisionResources(
           return err(createRgRes.error);
         }
       }
+
+      if (solutionConfigRes.value.hasSwitchedSubscription) {
+        updateResourceBaseName(inputs.projectPath, ctx.projectSetting.appName, envInfo.envName);
+      }
     }
 
     // 4. collect plugins and provisionResources
@@ -299,8 +303,7 @@ export async function provisionResources(
 export async function checkProvisionAzureSubscription(
   ctx: v2.Context,
   envInfo: v3.EnvInfoV3,
-  azureAccountProvider: AzureAccountProvider,
-  projectPath: string
+  azureAccountProvider: AzureAccountProvider
 ): Promise<Result<ProvisionSubscriptionCheckResult, FxError>> {
   const subscriptionIdInConfig: string | undefined = envInfo.config.azure?.subscriptionId;
   const subscriptionNameInConfig: string | undefined =
@@ -356,8 +359,7 @@ export async function checkProvisionAzureSubscription(
         envInfo,
         targetConfigSubInfo,
         subscriptionIdInState,
-        subscriptionNameInState,
-        projectPath
+        subscriptionNameInState
       );
     }
   } else {
@@ -385,8 +387,7 @@ export async function checkProvisionAzureSubscription(
         envInfo,
         subscriptionInAccount,
         subscriptionIdInState,
-        subscriptionNameInState,
-        projectPath
+        subscriptionNameInState
       );
     }
   }
@@ -403,8 +404,7 @@ async function compareWithStateSubscription(
   envInfo: v3.EnvInfoV3,
   targetSubscriptionInfo: SubscriptionInfo,
   subscriptionInStateId: string | undefined,
-  subscriptionInStateName: string | undefined,
-  projectPath: string
+  subscriptionInStateName: string | undefined
 ): Promise<Result<ProvisionSubscriptionCheckResult, FxError>> {
   const shouldAskForSubscriptionConfirmation =
     !!subscriptionInStateId && targetSubscriptionInfo.subscriptionId !== subscriptionInStateId;
@@ -417,8 +417,6 @@ async function compareWithStateSubscription(
     if (confirmResult.isErr()) {
       return err(confirmResult.error);
     } else {
-      updateResourceBaseName(projectPath, ctx.projectSetting.appName, envInfo.envName);
-
       updateEnvInfoSubscription(envInfo, targetSubscriptionInfo);
       envInfo.state.solution.resourceNameSuffix = "";
       envInfo.state.solution.resourceGroupName = "";
@@ -481,8 +479,7 @@ export async function fillInAzureConfigs(
   const subscriptionResult = await checkProvisionAzureSubscription(
     ctx,
     envInfo,
-    tokenProvider.azureAccountProvider,
-    inputs.projectPath
+    tokenProvider.azureAccountProvider
   );
   if (subscriptionResult.isErr()) {
     return err(subscriptionResult.error);

--- a/packages/fx-core/src/plugins/solution/fx-solution/v3/provision.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v3/provision.ts
@@ -38,7 +38,6 @@ import {
 import { AppStudioScopes, getHashedEnv, getResourceGroupInPortal } from "../../../../common/tools";
 import { convertToAlphanumericOnly } from "../../../../common/utils";
 import { AppStudioPluginV3 } from "../../../resource/appstudio/v3";
-import { envFileNamePrefix } from "../../../resource/frontend/env";
 import arm, { updateResourceBaseName } from "../arm";
 import { ResourceGroupInfo } from "../commonQuestions";
 import {

--- a/packages/fx-core/tests/component/workflow.test.ts
+++ b/packages/fx-core/tests/component/workflow.test.ts
@@ -224,8 +224,7 @@ describe("Workflow test for v3", () => {
       .resolves(TestHelper.fakeCredential);
     sandbox.stub(provisionV3, "fillInAzureConfigs").resolves(ok({ hasSwitchedSubscription: true }));
     sandbox.stub(AppStudioClient, "getApp").onFirstCall().throws({}).onSecondCall().resolves({});
-    sandbox.stub(AppStudioClient, "createApp").resolves({ teamsAppId: "mockTeamsAppId" });
-    sandbox.stub(AppStudioClient, "updateApp").resolves({ teamsAppId: "mockTeamsAppId" });
+    sandbox.stub(AppStudioClient, "importApp").resolves({ teamsAppId: "mockTeamsAppId" });
     sandbox.stub(clientFactory, "createResourceProviderClient").resolves({});
     sandbox.stub(clientFactory, "ensureResourceProvider").resolves();
     sandbox.stub(AADRegistration, "registerAADAppAndGetSecretByGraph").resolves({

--- a/packages/fx-core/tests/plugins/solutionv3/solution.provision.test.ts
+++ b/packages/fx-core/tests/plugins/solutionv3/solution.provision.test.ts
@@ -203,7 +203,8 @@ describe("SolutionV3 - provision", () => {
           return ok("Provision");
         }
       );
-    sandbox.stub(appStudio, "createOrUpdateTeamsApp").resolves(ok(uuid.v4()));
+    sandbox.stub(appStudio, "createTeamsApp").resolves(ok(uuid.v4()));
+    sandbox.stub(appStudio, "updateTeamsApp").resolves(ok(uuid.v4()));
 
     const envInfoV3: v3.EnvInfoV3 = {
       envName: "dev",
@@ -214,87 +215,6 @@ describe("SolutionV3 - provision", () => {
     assert.isTrue(res.isOk());
 
     if (res.isOk()) {
-      console.log(res.value);
-      assert.isTrue(res.value.state["fx-resource-appstudio"].tenantId === "mock-tenant-id");
-      assert.isTrue(res.value.state.solution.subscriptionId === "mockNewSubId");
-      assert.isTrue(res.value.state.solution.subscriptionName === "mockNewSubName");
-      assert.isTrue(res.value.state.solution.tenantId === "mockNewTenantId");
-    }
-  });
-
-  it("provision - has provisioned before in same account", async () => {
-    const projectSettings: ProjectSettings = {
-      appName: "my app",
-      projectId: uuid.v4(),
-      solutionSettings: {
-        name: BuiltInSolutionNames.azure,
-        version: "3.0.0",
-        capabilities: ["Tab"],
-        hostType: "Azure",
-        azureResources: [BuiltInFeaturePluginNames.identity],
-        activeResourcePlugins: ["fx-resource-identity"],
-      },
-    };
-    const ctx = new MockedV2Context(projectSettings);
-    const inputs: v2.InputsWithProjectPath = {
-      platform: Platform.VSCode,
-      projectPath: path.join(os.tmpdir(), randomAppName()),
-    };
-    const mockedTokenProvider: TokenProvider = {
-      azureAccountProvider: new MockedAzureAccountProvider(),
-      m365TokenProvider: new MockedM365Provider(),
-    };
-    const mockSub: SubscriptionInfo = {
-      subscriptionId: "mockSubId",
-      subscriptionName: "mockSubName",
-      tenantId: "mockTenantId",
-    };
-    const mockSwitchedSub: SubscriptionInfo = {
-      subscriptionId: "mockNewSubId",
-      subscriptionName: "mockNewSubName",
-      tenantId: "mockNewTenantId",
-    };
-    sandbox
-      .stub<any, any>(mockedTokenProvider.azureAccountProvider, "getSelectedSubscription")
-      .callsFake(async (): Promise<SubscriptionInfo> => {
-        return mockSwitchedSub;
-      });
-    sandbox
-      .stub<any, any>(mockedTokenProvider.azureAccountProvider, "listSubscriptions")
-      .callsFake(async (): Promise<SubscriptionInfo[]> => {
-        return [mockSub, mockSwitchedSub];
-      });
-    sandbox
-      .stub<any, any>(mockedTokenProvider.m365TokenProvider, "getJsonObject")
-      .callsFake(
-        async (tokenRequest: TokenRequest): Promise<Result<Record<string, unknown>, FxError>> => {
-          return ok({ tid: "mock-tenant-id" });
-        }
-      );
-    sandbox
-      .stub<any, any>(ctx.userInteraction, "showMessage")
-      .callsFake(
-        async (
-          level: "info" | "warn" | "error",
-          message: string,
-          modal: boolean,
-          ...items: string[]
-        ): Promise<Result<string | undefined, FxError>> => {
-          return ok("Provision");
-        }
-      );
-    sandbox.stub(appStudio, "createOrUpdateTeamsApp").resolves(ok(uuid.v4()));
-
-    const envInfoV3: v3.EnvInfoV3 = {
-      envName: "dev",
-      state: { solution: { ...mockSub }, "fx-resource-appstudio": {} },
-      config: {},
-    };
-    const res = await provisionResources(ctx, inputs, envInfoV3, mockedTokenProvider);
-    assert.isTrue(res.isOk());
-
-    if (res.isOk()) {
-      console.log(res.value);
       assert.isTrue(res.value.state["fx-resource-appstudio"].tenantId === "mock-tenant-id");
       assert.isTrue(res.value.state.solution.subscriptionId === "mockNewSubId");
       assert.isTrue(res.value.state.solution.subscriptionName === "mockNewSubName");

--- a/packages/fx-core/tests/plugins/solutionv3/solution.provision.test.ts
+++ b/packages/fx-core/tests/plugins/solutionv3/solution.provision.test.ts
@@ -20,7 +20,10 @@ import "mocha";
 import sinon from "sinon";
 import * as uuid from "uuid";
 import arm from "../../../src/plugins/solution/fx-solution/arm";
-import { BuiltInSolutionNames } from "../../../src/plugins/solution/fx-solution/v3/constants";
+import {
+  BuiltInFeaturePluginNames,
+  BuiltInSolutionNames,
+} from "../../../src/plugins/solution/fx-solution/v3/constants";
 import {
   getQuestionsForProvision,
   provisionResources,
@@ -136,6 +139,166 @@ describe("SolutionV3 - provision", () => {
     assert.isTrue(res.isOk());
     if (res.isOk()) {
       assert.isTrue(res.value.state["fx-resource-appstudio"].tenantId === "mock-tenant-id");
+    }
+  });
+
+  it("provision - has provisioned before in same account", async () => {
+    const projectSettings: ProjectSettings = {
+      appName: "my app",
+      projectId: uuid.v4(),
+      solutionSettings: {
+        name: BuiltInSolutionNames.azure,
+        version: "3.0.0",
+        capabilities: ["Tab"],
+        hostType: "Azure",
+        azureResources: [BuiltInFeaturePluginNames.identity],
+        activeResourcePlugins: ["fx-resource-identity"],
+      },
+    };
+    const ctx = new MockedV2Context(projectSettings);
+    const inputs: v2.InputsWithProjectPath = {
+      platform: Platform.VSCode,
+      projectPath: path.join(os.tmpdir(), randomAppName()),
+    };
+    const mockedTokenProvider: TokenProvider = {
+      azureAccountProvider: new MockedAzureAccountProvider(),
+      m365TokenProvider: new MockedM365Provider(),
+    };
+    const mockSub: SubscriptionInfo = {
+      subscriptionId: "mockSubId",
+      subscriptionName: "mockSubName",
+      tenantId: "mockTenantId",
+    };
+    const mockSwitchedSub: SubscriptionInfo = {
+      subscriptionId: "mockNewSubId",
+      subscriptionName: "mockNewSubName",
+      tenantId: "mockNewTenantId",
+    };
+    sandbox
+      .stub<any, any>(mockedTokenProvider.azureAccountProvider, "getSelectedSubscription")
+      .callsFake(async (): Promise<SubscriptionInfo> => {
+        return mockSwitchedSub;
+      });
+    sandbox
+      .stub<any, any>(mockedTokenProvider.azureAccountProvider, "listSubscriptions")
+      .callsFake(async (): Promise<SubscriptionInfo[]> => {
+        return [mockSub, mockSwitchedSub];
+      });
+    sandbox
+      .stub<any, any>(mockedTokenProvider.m365TokenProvider, "getJsonObject")
+      .callsFake(
+        async (tokenRequest: TokenRequest): Promise<Result<Record<string, unknown>, FxError>> => {
+          return ok({ tid: "mock-tenant-id" });
+        }
+      );
+    sandbox
+      .stub<any, any>(ctx.userInteraction, "showMessage")
+      .callsFake(
+        async (
+          level: "info" | "warn" | "error",
+          message: string,
+          modal: boolean,
+          ...items: string[]
+        ): Promise<Result<string | undefined, FxError>> => {
+          return ok("Provision");
+        }
+      );
+    sandbox.stub(appStudio, "createOrUpdateTeamsApp").resolves(ok(uuid.v4()));
+
+    const envInfoV3: v3.EnvInfoV3 = {
+      envName: "dev",
+      state: { solution: { ...mockSub }, "fx-resource-appstudio": {} },
+      config: {},
+    };
+    const res = await provisionResources(ctx, inputs, envInfoV3, mockedTokenProvider);
+    assert.isTrue(res.isOk());
+
+    if (res.isOk()) {
+      console.log(res.value);
+      assert.isTrue(res.value.state["fx-resource-appstudio"].tenantId === "mock-tenant-id");
+      assert.isTrue(res.value.state.solution.subscriptionId === "mockNewSubId");
+      assert.isTrue(res.value.state.solution.subscriptionName === "mockNewSubName");
+      assert.isTrue(res.value.state.solution.tenantId === "mockNewTenantId");
+    }
+  });
+
+  it("provision - has provisioned before in same account", async () => {
+    const projectSettings: ProjectSettings = {
+      appName: "my app",
+      projectId: uuid.v4(),
+      solutionSettings: {
+        name: BuiltInSolutionNames.azure,
+        version: "3.0.0",
+        capabilities: ["Tab"],
+        hostType: "Azure",
+        azureResources: [BuiltInFeaturePluginNames.identity],
+        activeResourcePlugins: ["fx-resource-identity"],
+      },
+    };
+    const ctx = new MockedV2Context(projectSettings);
+    const inputs: v2.InputsWithProjectPath = {
+      platform: Platform.VSCode,
+      projectPath: path.join(os.tmpdir(), randomAppName()),
+    };
+    const mockedTokenProvider: TokenProvider = {
+      azureAccountProvider: new MockedAzureAccountProvider(),
+      m365TokenProvider: new MockedM365Provider(),
+    };
+    const mockSub: SubscriptionInfo = {
+      subscriptionId: "mockSubId",
+      subscriptionName: "mockSubName",
+      tenantId: "mockTenantId",
+    };
+    const mockSwitchedSub: SubscriptionInfo = {
+      subscriptionId: "mockNewSubId",
+      subscriptionName: "mockNewSubName",
+      tenantId: "mockNewTenantId",
+    };
+    sandbox
+      .stub<any, any>(mockedTokenProvider.azureAccountProvider, "getSelectedSubscription")
+      .callsFake(async (): Promise<SubscriptionInfo> => {
+        return mockSwitchedSub;
+      });
+    sandbox
+      .stub<any, any>(mockedTokenProvider.azureAccountProvider, "listSubscriptions")
+      .callsFake(async (): Promise<SubscriptionInfo[]> => {
+        return [mockSub, mockSwitchedSub];
+      });
+    sandbox
+      .stub<any, any>(mockedTokenProvider.m365TokenProvider, "getJsonObject")
+      .callsFake(
+        async (tokenRequest: TokenRequest): Promise<Result<Record<string, unknown>, FxError>> => {
+          return ok({ tid: "mock-tenant-id" });
+        }
+      );
+    sandbox
+      .stub<any, any>(ctx.userInteraction, "showMessage")
+      .callsFake(
+        async (
+          level: "info" | "warn" | "error",
+          message: string,
+          modal: boolean,
+          ...items: string[]
+        ): Promise<Result<string | undefined, FxError>> => {
+          return ok("Provision");
+        }
+      );
+    sandbox.stub(appStudio, "createOrUpdateTeamsApp").resolves(ok(uuid.v4()));
+
+    const envInfoV3: v3.EnvInfoV3 = {
+      envName: "dev",
+      state: { solution: { ...mockSub }, "fx-resource-appstudio": {} },
+      config: {},
+    };
+    const res = await provisionResources(ctx, inputs, envInfoV3, mockedTokenProvider);
+    assert.isTrue(res.isOk());
+
+    if (res.isOk()) {
+      console.log(res.value);
+      assert.isTrue(res.value.state["fx-resource-appstudio"].tenantId === "mock-tenant-id");
+      assert.isTrue(res.value.state.solution.subscriptionId === "mockNewSubId");
+      assert.isTrue(res.value.state.solution.subscriptionName === "mockNewSubName");
+      assert.isTrue(res.value.state.solution.tenantId === "mockNewTenantId");
     }
   });
 


### PR DESCRIPTION
This PR is to allow users to reprovision azure resources in the new sub after switching sub since last provision. Previously, we will always use the subscription info from state so that users won't be able to provision resources in the new sub.
In this PR, we will
- Compare subscription from output (state file) with the sub id from user input. If different, we will ask users to confirm whether they will provision all resources in new sub. 
- To make sure reprovision can work successfully, we need new resource suffix and base name. We need a new aad app for bot service.
pass existing e2e test: https://github.com/OfficeDev/TeamsFx/actions/runs/2668858700
E2E TEST: NA