### PR TITLE
chore: use sendErrorTelemetry for error events in spfx plugin

### DIFF
--- a/packages/fx-core/src/plugins/resource/spfx/utils/telemetry-helper.ts
+++ b/packages/fx-core/src/plugins/resource/spfx/utils/telemetry-helper.ts
@@ -35,6 +35,6 @@ export class telemetryHelper {
     properties[TelemetryKey.ErrorMessage] = e.message;
     properties[TelemetryKey.ErrorCode] = e.name;
 
-    ctx.telemetryReporter?.sendTelemetryEvent(eventName, properties, measurements);
+    ctx.telemetryReporter?.sendTelemetryErrorEvent(eventName, properties, measurements);
   }
 }


### PR DESCRIPTION
Fix https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14949183