### PR TITLE
fix: env info writer

### DIFF
--- a/packages/fx-core/src/core/middleware/envInfoWriter.ts
+++ b/packages/fx-core/src/core/middleware/envInfoWriter.ts
@@ -23,7 +23,7 @@ export function EnvInfoWriterMW(skip = false): Middleware {
     try {
       await next();
       const res = ctx.result as Result<any, FxError>;
-      if (shouldSkipWriteEnvInfo(ctx, res)) {
+      if (shouldSkipWriteEnvInfo(ctx.method, res)) {
         return;
       }
     } catch (e) {
@@ -41,12 +41,15 @@ export function EnvInfoWriterMW(skip = false): Middleware {
   };
 }
 
-export function shouldSkipWriteEnvInfo(ctx: CoreHookContext, res: Result<any, FxError>): boolean {
+export function shouldSkipWriteEnvInfo(
+  method: string | undefined,
+  res: Result<any, FxError>
+): boolean {
   return (
     res.isErr() &&
     (res.error.name === "CancelProvision" ||
       (res.error.name === "UserCancel" &&
-        (ctx.method === "provisionResourcesV2" || ctx.method === "provisionResourcesV3")))
+        (method === "provisionResourcesV2" || method === "provisionResourcesV3")))
   );
 }
 

--- a/packages/fx-core/src/core/middleware/envInfoWriter.ts
+++ b/packages/fx-core/src/core/middleware/envInfoWriter.ts
@@ -23,7 +23,7 @@ export function EnvInfoWriterMW(skip = false): Middleware {
     try {
       await next();
       const res = ctx.result as Result<any, FxError>;
-      if (res.isErr() && res.error.name === "CancelProvision") {
+      if (shouldSkipWriteEnvInfo(ctx, res)) {
         return;
       }
     } catch (e) {
@@ -39,6 +39,15 @@ export function EnvInfoWriterMW(skip = false): Middleware {
     if (error1) throw error1;
     if (error2) throw error2;
   };
+}
+
+export function shouldSkipWriteEnvInfo(ctx: CoreHookContext, res: Result<any, FxError>): boolean {
+  return (
+    res.isErr() &&
+    (res.error.name === "CancelProvision" ||
+      (res.error.name === "UserCancel" &&
+        (ctx.method === "provisionResourcesV2" || ctx.method === "provisionResourcesV3")))
+  );
 }
 
 async function writeEnvInfo(ctx: CoreHookContext, skip: boolean) {

--- a/packages/fx-core/src/core/middleware/envInfoWriterV3.ts
+++ b/packages/fx-core/src/core/middleware/envInfoWriterV3.ts
@@ -7,6 +7,7 @@ import { FxError, Inputs, Result, StaticPlatforms } from "@microsoft/teamsfx-api
 import { environmentManager } from "../environment";
 import { TOOLS } from "../globalVars";
 import { CoreHookContext } from "../types";
+import { shouldSkipWriteEnvInfo } from "./envInfoWriter";
 import { shouldIgnored } from "./projectSettingsLoader";
 
 /**
@@ -18,7 +19,7 @@ export function EnvInfoWriterMW_V3(skip = false): Middleware {
     try {
       await next();
       const res = ctx.result as Result<any, FxError>;
-      if (res.isErr() && res.error.name === "CancelProvision") {
+      if (shouldSkipWriteEnvInfo(ctx, res)) {
         return;
       }
     } catch (e) {

--- a/packages/fx-core/src/core/middleware/envInfoWriterV3.ts
+++ b/packages/fx-core/src/core/middleware/envInfoWriterV3.ts
@@ -19,7 +19,7 @@ export function EnvInfoWriterMW_V3(skip = false): Middleware {
     try {
       await next();
       const res = ctx.result as Result<any, FxError>;
-      if (shouldSkipWriteEnvInfo(ctx, res)) {
+      if (shouldSkipWriteEnvInfo(ctx.method, res)) {
         return;
       }
     } catch (e) {


### PR DESCRIPTION
Users may cancel provision when selecting sub or rg before we ask for the provision consent. We should skip write env info in such cases.

E2E TEST: N/A
run e2e tests: https://github.com/OfficeDev/TeamsFx/actions/runs/2687957529