### PR TITLE
chore: respect existing bot aad for localdebug

### DIFF
--- a/packages/fx-core/src/plugins/resource/bot/configs/localDebugConfig.ts
+++ b/packages/fx-core/src/plugins/resource/bot/configs/localDebugConfig.ts
@@ -38,6 +38,10 @@ export class LocalDebugConfig {
     this.localRedirectUri = context.localSettings?.bot?.get(
       LocalSettingsBotKeys.BotRedirectUri
     ) as string;
+
+    // To respect existing Bot AAD.
+    this.localBotId = context.envInfo.config.bot?.appId ?? this.localBotId;
+    this.localBotPassword = context.envInfo.config.bot?.appPassword ?? this.localBotPassword;
   }
 
   public saveConfigIntoContext(context: PluginContext): void {

--- a/packages/fx-core/src/plugins/resource/bot/plugin.ts
+++ b/packages/fx-core/src/plugins/resource/bot/plugin.ts
@@ -444,7 +444,7 @@ export class TeamsBotImpl implements PluginImpl {
       botAuthCreds.clientSecret = this.ctx?.envInfo.state
         .get(ResourcePlugins.Bot)
         .get(PluginBot.BOT_PASSWORD);
-      botAuthCreds.clientSecret = this.ctx?.envInfo.state
+      botAuthCreds.objectId = this.ctx?.envInfo.state
         .get(ResourcePlugins.Bot)
         .get(PluginBot.OBJECT_ID);
       Logger.debug(Messages.SuccessfullyGetExistingBotAadAppCredential);


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14937591

Bot plugin didn't respect existing bot aads in local debug stage.