### PR TITLE
fix: run yeoman by generator name when checker disabled

### DIFF
--- a/packages/fx-core/src/component/code/spfxTabCode.ts
+++ b/packages/fx-core/src/component/code/spfxTabCode.ts
@@ -145,7 +145,9 @@ export async function scaffoldSPFx(
         env: yoEnv,
       },
       "yo",
-      spGeneratorChecker.getSpGeneratorPath(),
+      isGeneratorCheckerEnabled()
+        ? spGeneratorChecker.getSpGeneratorPath()
+        : "@microsoft/sharepoint",
       "--skip-install",
       "true",
       "--component-type",


### PR DESCRIPTION
E2E TEST: NA