### PR TITLE
chore(localdebug): remove duplicate port checker

### DIFF
--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -150,7 +150,6 @@ import {
   sendDebugAllEvent,
   sendDebugAllStartEvent,
 } from "./debug/localTelemetryReporter";
-import { validatePropertyDeps } from "ajv/dist/vocabularies/applicator/dependencies";
 
 export let core: FxCore;
 export let tools: Tools;


### PR DESCRIPTION
Move the port checker from `pre-debug-check` to `validate-dependencies`. So the port checker will be called once in both 2.x.x and 3.x.x, 4.x.x TeamsFx project.
Detail: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/14924654