### PR TITLE
fix: logout and reprovision in cli

### DIFF
--- a/packages/cli/src/activate.ts
+++ b/packages/cli/src/activate.ts
@@ -13,12 +13,21 @@ import CLILogProvider from "./commonlib/log";
 import { CliTelemetry } from "./telemetry/cliTelemetry";
 import CLIUIInstance from "./userInteraction";
 
-export default async function activate(rootPath?: string): Promise<Result<FxCore, FxError>> {
+export default async function activate(
+  rootPath?: string,
+  shouldIgnoreSubscriptionNotFoundError?: boolean
+): Promise<Result<FxCore, FxError>> {
   if (rootPath) {
     AzureAccountManager.setRootPath(rootPath);
     const subscriptionInfo = await AzureAccountManager.readSubscription();
     if (subscriptionInfo) {
-      await AzureAccountManager.setSubscription(subscriptionInfo.subscriptionId);
+      try {
+        await AzureAccountManager.setSubscription(subscriptionInfo.subscriptionId);
+      } catch (e) {
+        if (!shouldIgnoreSubscriptionNotFoundError) {
+          throw e;
+        }
+      }
     }
     CliTelemetry.setReporter(CliTelemetry.getReporter().withRootFolder(rootPath));
   }

--- a/packages/cli/src/cmds/provision.ts
+++ b/packages/cli/src/cmds/provision.ts
@@ -114,7 +114,7 @@ export default class Provision extends YargsCommand {
       inputs.targetResourceGroupName = args[this.resourceGroupParam];
     }
 
-    const result = await activate(rootFolder);
+    const result = await activate(rootFolder, true);
     if (result.isErr()) {
       CliTelemetry.sendTelemetryErrorEvent(TelemetryEvent.Provision, result.error);
       return err(result.error);

--- a/packages/cli/tests/e2e/solution/ProvisionWithInvalidSubscriptionInfoJsonContent.tests.ts
+++ b/packages/cli/tests/e2e/solution/ProvisionWithInvalidSubscriptionInfoJsonContent.tests.ts
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * @author Yuqi Zhou <yuqzho@microsoft.com>
+ */
+
+import path from "path";
+import { environmentManager, getUuid } from "@microsoft/teamsfx-core";
+import {
+  getSubscriptionId,
+  getTestFolder,
+  getUniqueAppName,
+  cleanUp,
+  setBotSkuNameToB1Bicep,
+  setSimpleAuthSkuNameToB1Bicep,
+  validateTabAndBotProjectProvision,
+  execAsync,
+  getActivePluginsFromProjectSetting,
+  getCapabilitiesFromProjectSetting,
+} from "../commonUtils";
+import { CliHelper } from "../../commonlib/cliHelper";
+import { Capability, PluginId, ProjectSettingKey, TestFilePath } from "../../commonlib/constants";
+import fs from "fs-extra";
+import { expect } from "chai";
+import { SubscriptionInfo } from "@microsoft/teamsfx-api";
+import { FrontendValidator } from "../../commonlib";
+
+describe("Provision with invalid subscription info", () => {
+  const testFolder = getTestFolder();
+  const appName = getUniqueAppName();
+  const projectPath = path.resolve(testFolder, appName);
+
+  const env = Object.assign({}, process.env);
+
+  after(async () => {
+    await cleanUp(appName, projectPath, true, true, false);
+  });
+
+  it("Provision non SSO Tab project", async () => {
+    // Arrange
+    await CliHelper.createProjectWithCapability(appName, testFolder, Capability.TabNonSso, env);
+
+    // Assert
+    const capabilities = await getCapabilitiesFromProjectSetting(projectPath);
+    expect(capabilities.includes(Capability.TabNonSso)).to.be.true;
+
+    const subscriptionInfoJsonFilePath = path.join(projectPath, ".fx/subscriptionInfo.json");
+    expect(await fs.pathExists(subscriptionInfoJsonFilePath)).to.be.true;
+
+    // Arrange
+    const subscriptionInfo: SubscriptionInfo = {
+      subscriptionName: "test",
+      subscriptionId: "b91424c7-bd0f-45a1-91e7-d8916efbbcdc",
+      tenantId: "b91424c7-bd0f-45a1-91e7-d8916efbbcdc",
+    };
+    fs.writeJSON(subscriptionInfoJsonFilePath, JSON.stringify(subscriptionInfo, null, 4));
+
+    await CliHelper.provisionProject(projectPath, "", env);
+
+    // Assert
+    const context = await fs.readJSON(`${projectPath}/.fx/states/state.dev.json`);
+
+    // Validate Tab Frontend
+    const frontend = FrontendValidator.init(context);
+    await FrontendValidator.validateProvision(frontend);
+  });
+});

--- a/packages/cli/tests/e2e/solution/ProvisionWithLoggedOutSubscriptionInfo.tests.ts
+++ b/packages/cli/tests/e2e/solution/ProvisionWithLoggedOutSubscriptionInfo.tests.ts
@@ -6,27 +6,20 @@
  */
 
 import path from "path";
-import { environmentManager, getUuid } from "@microsoft/teamsfx-core";
 import {
-  getSubscriptionId,
   getTestFolder,
   getUniqueAppName,
   cleanUp,
-  setBotSkuNameToB1Bicep,
-  setSimpleAuthSkuNameToB1Bicep,
-  validateTabAndBotProjectProvision,
-  execAsync,
-  getActivePluginsFromProjectSetting,
   getCapabilitiesFromProjectSetting,
 } from "../commonUtils";
 import { CliHelper } from "../../commonlib/cliHelper";
-import { Capability, PluginId, ProjectSettingKey, TestFilePath } from "../../commonlib/constants";
+import { Capability } from "../../commonlib/constants";
 import fs from "fs-extra";
 import { expect } from "chai";
 import { SubscriptionInfo } from "@microsoft/teamsfx-api";
 import { FrontendValidator } from "../../commonlib";
 
-describe("Provision with invalid subscription info", () => {
+describe("Provision with subscriptionInfo.json that has logged out", () => {
   const testFolder = getTestFolder();
   const appName = getUniqueAppName();
   const projectPath = path.resolve(testFolder, appName);

--- a/packages/cli/tests/unit/cmds/provision.tests.ts
+++ b/packages/cli/tests/unit/cmds/provision.tests.ts
@@ -125,7 +125,7 @@ describe("Provision Command Tests", function () {
     }
   });
 
-  it("Provision Command Running -- provisionResources error", async () => {
+  it("Provision Command Running -- provision with set subscription error", async () => {
     const cmd = new Provision();
     const args = {
       [constants.RootFolderNode.data.name as string]: "real",


### PR DESCRIPTION
Fix cli provision issue. 
Bug: if user signed into account A and set subscription sub1, and then logged out and logged in with account B, provision will fail since we will check whether user has access to sub1.

E2E TEST: https://github.com/OfficeDev/TeamsFx/runs/7534887528?check_suite_focus=true
https://github.com/OfficeDev/TeamsFx/runs/7534999345?check_suite_focus=true (new case)