### PR TITLE
feat: enable switch tenant for local debug

### DIFF
--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -46,7 +46,7 @@
   "core.generateArmTemplate.failNotice": "'%s' Failed to create ARM template for required Azure services.",
   "core.updateArmTemplate.failNotice": "'%s' Failed to update ARM template for required Azure services.",
   "core.updateArmTemplate.successNotice": "The Azure resource template is updated based on your resource and capability selection.",
-  "core.localDebug.tenantConfirmNotice": "You already run local debug for the Teams app in another tenant '%s'. You can sign out %s and sign in with the matched M365 account to re-use the previous local debug resource. If you really want to switch tenant for local debug, you can delete the local file(s) (%s) and re-run local debug.",
+  "core.localDebug.tenantConfirmNotice": "You already run local debug for the Teams app in another tenant '%s'. If you really want to switch tenant for local debug, you can delete the local file(s) (%s) and re-run local debug.",
   "core.migrationToArmAndMultiEnv.Message": "Teams Toolkit will upgrade your project configuration files to support the latest features. The upgrade process will not change your custom code and create the backup files in case revert is needed.\nNotice this upgrade is a must-have to continue to use current version Teams Toolkit. If you are not ready to upgrade and want to continue to use the old version, please find Teams Toolkit in Extension and install the version <= 2.10.0",
   "core.migrationToArmAndMultiEnv.SuccessMessage": "Upgrade succeeded. Your project is upgraded to new configuration files.",
   "core.migrationToArmAndMultiEnv.ErrorMessage": "Upgrade Failed. Please check the error message in Output window to troubleshoot and fix. You can also click Learn More for the FAQ and how to upgrade manually.",

--- a/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/solution.ts
@@ -1089,9 +1089,11 @@ export class TeamsAppSolution implements Solution {
         LocalSettingsTeamsAppKeys.TenantId
       );
       const m365TenantMatches = await checkWhetherLocalDebugM365TenantMatches(
+        ctx.envInfo,
         localDebugTenantId,
         ctx.m365TokenProvider,
-        ctx.root
+        ctx.root,
+        true
       );
       if (m365TenantMatches.isErr()) {
         return m365TenantMatches;

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/provisionLocal.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/provisionLocal.ts
@@ -1,4 +1,4 @@
-import { FxError, Inputs, Json, SystemError, TokenProvider, v2 } from "@microsoft/teamsfx-api";
+import { FxError, Inputs, Json, SystemError, TokenProvider, v2, v3 } from "@microsoft/teamsfx-api";
 import { isUndefined } from "lodash";
 import { Container } from "typedi";
 import { isExistingTabApp } from "../../../../common/projectSettingsHelper";
@@ -63,6 +63,7 @@ export async function provisionLocalResource(
   localDebugTenantId = envInfo?.state.solution.teamsAppTenantId;
 
   const m365TenantMatches = await checkWhetherLocalDebugM365TenantMatches(
+    envInfo as v3.EnvInfoV3,
     localDebugTenantId,
     tokenProvider.m365TokenProvider,
     inputs.projectPath

--- a/packages/fx-core/src/plugins/solution/fx-solution/v3/provision.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v3/provision.ts
@@ -29,7 +29,6 @@ import { v4 as uuidv4 } from "uuid";
 import { hasAzureResource } from "../../../../common";
 import { PluginDisplayName } from "../../../../common/constants";
 import { getDefaultString, getLocalizedString } from "../../../../common/localizeUtils";
-import { LocalStateAuthKeys, LocalStateBotKeys } from "../../../../common/localStateConstants";
 import {
   CustomizeResourceGroupType,
   TelemetryEvent,

--- a/packages/fx-core/src/plugins/solution/fx-solution/v3/provision.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v3/provision.ts
@@ -37,6 +37,7 @@ import {
 } from "../../../../common/telemetry";
 import { AppStudioScopes, getHashedEnv, getResourceGroupInPortal } from "../../../../common/tools";
 import { convertToAlphanumericOnly } from "../../../../common/utils";
+import { ComponentNames } from "../../../../component/constants";
 import { AppStudioPluginV3 } from "../../../resource/appstudio/v3";
 import arm, { updateResourceBaseName } from "../arm";
 import { ResourceGroupInfo } from "../commonQuestions";
@@ -444,17 +445,31 @@ function clearEnvInfoStateResource(envInfo: v3.EnvInfoV3): void {
   envInfo.state.solution.resourceGroupName = "";
   envInfo.state.solution.resourceNameSuffix = "";
 
-  // we need to have another bot id if provisioning a new azure bot service.
-  const botResource = envInfo.state[BuiltInFeaturePluginNames.bot] ?? envInfo.state["teams-bot"];
-  if (botResource) {
-    if (botResource[LocalStateBotKeys.BotId]) {
-      botResource[LocalStateBotKeys.BotId] = undefined;
+  const keysToClear = [
+    BuiltInFeaturePluginNames.bot,
+    BuiltInFeaturePluginNames.frontend,
+    BuiltInFeaturePluginNames.function,
+    BuiltInFeaturePluginNames.identity,
+    BuiltInFeaturePluginNames.keyVault,
+    BuiltInFeaturePluginNames.sql,
+    BuiltInFeaturePluginNames.simpleAuth,
+    ComponentNames.TeamsBot,
+    ComponentNames.TeamsTab,
+    ComponentNames.TeamsApi,
+    ComponentNames.Identity,
+    ComponentNames.KeyVault,
+    ComponentNames.AzureSQL,
+  ];
+
+  const keysToModify = [BuiltInFeaturePluginNames.apim, ComponentNames.APIM];
+  const keys = Object.keys(envInfo.state);
+  for (const key of keys) {
+    if (keysToClear.includes(key)) {
+      delete envInfo.state[key];
     }
-    if (botResource[LocalStateBotKeys.BotPassword]) {
-      botResource[LocalStateBotKeys.BotPassword] = undefined;
-    }
-    if (botResource[LocalStateAuthKeys.ObjectId]) {
-      botResource[LocalStateAuthKeys.ObjectId] = undefined;
+
+    if (keysToModify.includes(key)) {
+      delete envInfo.state[key]["serviceResourceId"];
     }
   }
 }

--- a/packages/fx-core/tests/component/workflow.test.ts
+++ b/packages/fx-core/tests/component/workflow.test.ts
@@ -9,7 +9,7 @@ import {
   ProvisionContextV3,
   Void,
 } from "@microsoft/teamsfx-api";
-import { assert, expect } from "chai";
+import { assert } from "chai";
 import fs from "fs-extra";
 import "mocha";
 import * as os from "os";

--- a/packages/fx-core/tests/component/workflow.test.ts
+++ b/packages/fx-core/tests/component/workflow.test.ts
@@ -9,7 +9,7 @@ import {
   ProvisionContextV3,
   Void,
 } from "@microsoft/teamsfx-api";
-import { assert } from "chai";
+import { assert, expect } from "chai";
 import fs from "fs-extra";
 import "mocha";
 import * as os from "os";
@@ -309,6 +309,77 @@ describe("Workflow test for v3", () => {
       console.log(provisionRes.error);
     }
     assert.isTrue(provisionRes.isOk());
+  });
+
+  it("fx.provision local debug after switching m365 tenant", async () => {
+    sandbox.stub(templateAction, "scaffoldFromTemplates").resolves();
+    sandbox.stub(tools.tokenProvider.m365TokenProvider, "getAccessToken").resolves(ok("fakeToken"));
+    sandbox
+      .stub(tools.tokenProvider.m365TokenProvider, "getJsonObject")
+      .resolves(ok({ tid: "mockSwitchedTid", upn: "mockUpn" }));
+    sandbox
+      .stub(tools.tokenProvider.azureAccountProvider, "getAccountCredentialAsync")
+      .resolves(TestHelper.fakeCredential);
+    sandbox.stub(AppStudioClient, "getApp").onFirstCall().throws({}).onSecondCall().resolves({});
+    sandbox.stub(AppStudioClient, "importApp").resolves({ teamsAppId: "mockTeamsAppId" });
+    sandbox.stub(clientFactory, "createResourceProviderClient").resolves({});
+    sandbox.stub(clientFactory, "ensureResourceProvider").resolves();
+    sandbox.stub(AADRegistration, "registerAADAppAndGetSecretByGraph").resolves({
+      clientId: "mockClientId",
+      clientSecret: "mockClientSecret",
+      objectId: "mockObjectId",
+    });
+    const appName = `unittest${randomAppName()}`;
+    const inputs: InputsWithProjectPath = {
+      projectPath: projectPath,
+      platform: Platform.VSCode,
+      features: "Bot",
+      language: "typescript",
+      "app-name": appName,
+      folder: path.join(os.homedir(), "TeamsApps"),
+      checkerInfo: {
+        skipNgrok: true,
+      },
+    };
+    const initRes = await fx.init(context, inputs);
+    if (initRes.isErr()) {
+      console.log(initRes.error);
+    }
+    assert.isTrue(initRes.isOk());
+
+    context.projectSetting.components = [
+      {
+        name: "teams-bot",
+        build: true,
+        capabilities: ["bot"],
+        deploy: true,
+        folder: "bot",
+        hosting: "azure-web-app",
+      },
+    ];
+    context.envInfo = newEnvInfoV3("local");
+    context.tokenProvider = tools.tokenProvider;
+    context.envInfo.state = {
+      solution: {
+        provisionSucceeded: true,
+        teamsAppTenantId: "mockTid",
+      },
+      "app-manifest": {
+        tenantId: "mockTid",
+        teamsAppId: "mockTeamsAppId",
+      },
+    };
+    context.envInfo.config.bot = {
+      siteEndpoint: "https://localtest:3978",
+    };
+    const provisionRes = await runActionByName("fx.provision", context, inputs);
+    if (provisionRes.isErr()) {
+      console.log(provisionRes.error);
+    }
+    assert.isTrue(provisionRes.isOk());
+    assert.isTrue(context.envInfo.state.solution.teamsAppTenantId === "mockSwitchedTid");
+    assert.isTrue(context.envInfo.state.solution.provisionSucceeded);
+    assert.isTrue(context.envInfo.state["app-manifest"]["tenantId"] === "mockSwitchedTid");
   });
 
   it("azure-storage.deploy", async () => {

--- a/packages/vscode-extension/src/debug/depsChecker/doctorConstant.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/doctorConstant.ts
@@ -24,6 +24,7 @@ export const doctorConstant = {
   Node12MatchFunction:
     "If you have your own Azure Functions Core Tools installed, make sure it works with new Node.js version. See (https://docs.microsoft.com/azure/azure-functions/functions-versions#languages) for Azure Functions supported Node versions.",
   SignInSuccess: `M365 Account (@account) is logged in and sideloading enabled`,
+  SignInSuccessWithNewAccount: `You have switched M365 account. M365 Account (@account) is logged in and sideloading enabled.`,
   Cert: "Development certificate for localhost",
   CertSuccess: "Development certificate for localhost is installed",
   NpmInstallSuccess: "NPM packages for @app are installed",


### PR DESCRIPTION
- Allow to switch m365 tenant when local debugging. 
- Updated vscode output when we found users switch m365 tenant. (words may be updated later.)

E2E TEST: https://github.com/OfficeDev/TeamsFx/actions/runs/2751657861