### PR TITLE
chore: add telemetry for code templates

### DIFF
--- a/packages/fx-core/src/common/telemetry.ts
+++ b/packages/fx-core/src/common/telemetry.ts
@@ -29,6 +29,10 @@ export enum TelemetryProperty {
   IsSideloadingAllowed = "is-sideloading-allowed",
   NeedMigrateAadManifest = "need-migrate-aad-manifest",
   CheckSideloadingHttpStatus = "check-sideloading-http-status",
+  TemplateGroup = "template-group",
+  TemplateLanguage = "template-language",
+  TemplateScenario = "template-scenario",
+  TemplateFallback = "template-fallback",
 }
 
 export enum TelemetryEvent {
@@ -82,6 +86,8 @@ export enum TelemetryEvent {
   DetectPortStart = "detect-port-start",
   DetectPort = "detect-port",
   FillProjectId = "fill-project-id",
+  ScaffoldFromTemplatesStart = "scaffold-from-templates-start",
+  ScaffoldFromTemplates = "scaffold-from-templates",
 }
 
 export enum TelemetrySuccess {

--- a/packages/fx-core/src/common/template-utils/templatesActions.ts
+++ b/packages/fx-core/src/common/template-utils/templatesActions.ts
@@ -30,6 +30,9 @@ export interface ScaffoldContext {
   // Used by fallback zip.
   templatesFolderPath?: string;
 
+  // To identify if fallback is triggered.
+  fallback?: boolean;
+
   // Used by rendering template file.
   fileNameReplaceFn?: (name: string, data: Buffer) => string;
   fileDataReplaceFn?: (name: string, data: Buffer) => string | Buffer;
@@ -157,6 +160,8 @@ export const fetchTemplateZipFromLocalAction: ScaffoldAction = {
       return;
     }
 
+    context.fallback = true;
+
     if (!context.group) {
       throw new Error(missKeyErrorInfo("group"));
     }
@@ -240,6 +245,6 @@ export async function scaffoldFromTemplates(
     [TelemetryProperty.TemplateGroup]: context.group ?? "",
     [TelemetryProperty.TemplateLanguage]: context.lang ?? "",
     [TelemetryProperty.TemplateScenario]: context.scenario ?? "",
-    [TelemetryProperty.TemplateFallback]: context.zip ? "false" : "true", // Track fallback cases.
+    [TelemetryProperty.TemplateFallback]: context.fallback ? "true" : "false", // Track fallback cases.
   });
 }

--- a/packages/fx-core/src/common/template-utils/templatesActions.ts
+++ b/packages/fx-core/src/common/template-utils/templatesActions.ts
@@ -216,22 +216,11 @@ export async function scaffoldFromTemplates(
   context: ScaffoldContext,
   actions: ScaffoldAction[] = defaultActionSeq
 ): Promise<void> {
-  if (!context.group) {
-    throw new Error(missKeyErrorInfo("group"));
-  }
-
-  if (!context.lang) {
-    throw new Error(missKeyErrorInfo("lang"));
-  }
-
-  if (!context.scenario) {
-    throw new Error(missKeyErrorInfo("scenario"));
-  }
   // To track code templates usage.
   sendTelemetryEvent(Component.core, TelemetryEvent.ScaffoldFromTemplatesStart, {
-    [TelemetryProperty.TemplateGroup]: context.group,
-    [TelemetryProperty.TemplateLanguage]: context.lang,
-    [TelemetryProperty.TemplateScenario]: context.scenario,
+    [TelemetryProperty.TemplateGroup]: context.group ?? "",
+    [TelemetryProperty.TemplateLanguage]: context.lang ?? "",
+    [TelemetryProperty.TemplateScenario]: context.scenario ?? "",
   });
 
   for (const action of actions) {
@@ -248,9 +237,9 @@ export async function scaffoldFromTemplates(
   }
 
   sendTelemetryEvent(Component.core, TelemetryEvent.ScaffoldFromTemplates, {
-    [TelemetryProperty.TemplateGroup]: context.group,
-    [TelemetryProperty.TemplateLanguage]: context.lang,
-    [TelemetryProperty.TemplateScenario]: context.scenario,
+    [TelemetryProperty.TemplateGroup]: context.group ?? "",
+    [TelemetryProperty.TemplateLanguage]: context.lang ?? "",
+    [TelemetryProperty.TemplateScenario]: context.scenario ?? "",
     [TelemetryProperty.TemplateFallback]: context.zip ? "false" : "true", // Track fallback cases.
   });
 }


### PR DESCRIPTION
1. Add central telemetry for code templates scaffolding.
2. Add telemetry property to detect fallback cases.

https://dev.azure.com/msazure/Microsoft%20Teams%20Extensibility/_workitems/edit/15066484