### PR TITLE
fix(core): order of capability question options

### DIFF
--- a/packages/fx-core/src/core/question.ts
+++ b/packages/fx-core/src/core/question.ts
@@ -329,6 +329,7 @@ export function createCapabilityQuestionPreview(): SingleSelectQuestion {
     type: "singleSelect",
     staticOptions: staticOptions,
     placeholder: getLocalizedString("core.createCapabilityQuestion.placeholder"),
+    forgetLastValue: true,
   };
 }
 


### PR DESCRIPTION
Keep consistent sequence of capability options when creating a new project.

Related bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/15067351

E2E TEST: N/A