### PR TITLE
chore: adjust return value of notification APIs

### DIFF
--- a/docs/sdk/teamsfx.channel.sendadaptivecard.md
+++ b/docs/sdk/teamsfx.channel.sendadaptivecard.md
@@ -9,7 +9,7 @@ Send an adaptive card message.
 <b>Signature:</b>
 
 ```typescript
-sendAdaptiveCard(card: unknown): Promise<void>;
+sendAdaptiveCard(card: unknown): Promise<MessageResponse>;
 ```
 
 ## Parameters
@@ -20,7 +20,7 @@ sendAdaptiveCard(card: unknown): Promise<void>;
 
 <b>Returns:</b>
 
-Promise&lt;void&gt;
+Promise&lt;MessageResponse&gt;
 
-A `Promise` representing the asynchronous operation.
+the response of sending adaptive card message.
 

--- a/docs/sdk/teamsfx.channel.sendmessage.md
+++ b/docs/sdk/teamsfx.channel.sendmessage.md
@@ -9,7 +9,7 @@ Send a plain text message.
 <b>Signature:</b>
 
 ```typescript
-sendMessage(text: string): Promise<void>;
+sendMessage(text: string): Promise<MessageResponse>;
 ```
 
 ## Parameters
@@ -20,7 +20,7 @@ sendMessage(text: string): Promise<void>;
 
 <b>Returns:</b>
 
-Promise&lt;void&gt;
+Promise&lt;MessageResponse&gt;
 
-A `Promise` representing the asynchronous operation.
+the response of sending message.
 

--- a/docs/sdk/teamsfx.member.sendadaptivecard.md
+++ b/docs/sdk/teamsfx.member.sendadaptivecard.md
@@ -9,7 +9,7 @@ Send an adaptive card message.
 <b>Signature:</b>
 
 ```typescript
-sendAdaptiveCard(card: unknown): Promise<void>;
+sendAdaptiveCard(card: unknown): Promise<MessageResponse>;
 ```
 
 ## Parameters
@@ -20,7 +20,7 @@ sendAdaptiveCard(card: unknown): Promise<void>;
 
 <b>Returns:</b>
 
-Promise&lt;void&gt;
+Promise&lt;MessageResponse&gt;
 
-A `Promise` representing the asynchronous operation.
+the response of sending adaptive card message.
 

--- a/docs/sdk/teamsfx.member.sendmessage.md
+++ b/docs/sdk/teamsfx.member.sendmessage.md
@@ -9,7 +9,7 @@ Send a plain text message.
 <b>Signature:</b>
 
 ```typescript
-sendMessage(text: string): Promise<void>;
+sendMessage(text: string): Promise<MessageResponse>;
 ```
 
 ## Parameters
@@ -20,7 +20,7 @@ sendMessage(text: string): Promise<void>;
 
 <b>Returns:</b>
 
-Promise&lt;void&gt;
+Promise&lt;MessageResponse&gt;
 
-A `Promise` representing the asynchronous operation.
+the response of sending message.
 

--- a/docs/sdk/teamsfx.notificationtarget.sendadaptivecard.md
+++ b/docs/sdk/teamsfx.notificationtarget.sendadaptivecard.md
@@ -9,7 +9,7 @@ Send an adaptive card message.
 <b>Signature:</b>
 
 ```typescript
-sendAdaptiveCard(card: unknown): Promise<void>;
+sendAdaptiveCard(card: unknown): Promise<MessageResponse>;
 ```
 
 ## Parameters
@@ -20,5 +20,7 @@ sendAdaptiveCard(card: unknown): Promise<void>;
 
 <b>Returns:</b>
 
-Promise&lt;void&gt;
+Promise&lt;MessageResponse&gt;
+
+the response of sending adaptive card message.
 

--- a/docs/sdk/teamsfx.notificationtarget.sendmessage.md
+++ b/docs/sdk/teamsfx.notificationtarget.sendmessage.md
@@ -9,7 +9,7 @@ Send a plain text message.
 <b>Signature:</b>
 
 ```typescript
-sendMessage(text: string): Promise<void>;
+sendMessage(text: string): Promise<MessageResponse>;
 ```
 
 ## Parameters
@@ -20,5 +20,7 @@ sendMessage(text: string): Promise<void>;
 
 <b>Returns:</b>
 
-Promise&lt;void&gt;
+Promise&lt;MessageResponse&gt;
+
+the response of sending message.
 

--- a/docs/sdk/teamsfx.sendadaptivecard.md
+++ b/docs/sdk/teamsfx.sendadaptivecard.md
@@ -9,7 +9,7 @@ Send an adaptive card message to a notification target.
 <b>Signature:</b>
 
 ```typescript
-export declare function sendAdaptiveCard(target: NotificationTarget, card: unknown): Promise<void>;
+export declare function sendAdaptiveCard(target: NotificationTarget, card: unknown): Promise<MessageResponse>;
 ```
 
 ## Parameters
@@ -21,7 +21,7 @@ export declare function sendAdaptiveCard(target: NotificationTarget, card: unkno
 
 <b>Returns:</b>
 
-Promise&lt;void&gt;
+Promise&lt;MessageResponse&gt;
 
-A `Promise` representing the asynchronous operation.
+the response of sending adaptive card message.
 

--- a/docs/sdk/teamsfx.sendmessage.md
+++ b/docs/sdk/teamsfx.sendmessage.md
@@ -9,7 +9,7 @@ Send a plain text message to a notification target.
 <b>Signature:</b>
 
 ```typescript
-export declare function sendMessage(target: NotificationTarget, text: string): Promise<void>;
+export declare function sendMessage(target: NotificationTarget, text: string): Promise<MessageResponse>;
 ```
 
 ## Parameters
@@ -21,7 +21,7 @@ export declare function sendMessage(target: NotificationTarget, text: string): P
 
 <b>Returns:</b>
 
-Promise&lt;void&gt;
+Promise&lt;MessageResponse&gt;
 
-A `Promise` representing the asynchronous operation.
+the response of sending message.
 

--- a/docs/sdk/teamsfx.teamsbotinstallation.sendadaptivecard.md
+++ b/docs/sdk/teamsfx.teamsbotinstallation.sendadaptivecard.md
@@ -9,7 +9,7 @@ Send an adaptive card message.
 <b>Signature:</b>
 
 ```typescript
-sendAdaptiveCard(card: unknown): Promise<void>;
+sendAdaptiveCard(card: unknown): Promise<MessageResponse>;
 ```
 
 ## Parameters
@@ -20,7 +20,7 @@ sendAdaptiveCard(card: unknown): Promise<void>;
 
 <b>Returns:</b>
 
-Promise&lt;void&gt;
+Promise&lt;MessageResponse&gt;
 
-A `Promise` representing the asynchronous operation.
+the response of sending adaptive card message.
 

--- a/docs/sdk/teamsfx.teamsbotinstallation.sendmessage.md
+++ b/docs/sdk/teamsfx.teamsbotinstallation.sendmessage.md
@@ -9,7 +9,7 @@ Send a plain text message.
 <b>Signature:</b>
 
 ```typescript
-sendMessage(text: string): Promise<void>;
+sendMessage(text: string): Promise<MessageResponse>;
 ```
 
 ## Parameters
@@ -20,7 +20,7 @@ sendMessage(text: string): Promise<void>;
 
 <b>Returns:</b>
 
-Promise&lt;void&gt;
+Promise&lt;MessageResponse&gt;
 
-A `Promise` representing the asynchronous operation.
+the response of sending message.
 

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/INotificationTarget.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/INotificationTarget.cs
@@ -18,15 +18,15 @@ namespace Microsoft.TeamsFx.Conversation
         /// </summary>
         /// <param name="message">The plain text message.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>The task object representing the asynchronous operation.</returns>
-        Task SendMessage(string message, CancellationToken cancellationToken = default);
+        /// <returns>The response of sending message.</returns>
+        Task<MessageResponse> SendMessage(string message, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Send an adaptive card message.
         /// </summary>
         /// <param name="card">The adaptive card object.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>The task object representing the asynchronous operation.</returns>
-        Task SendAdaptiveCard(object card, CancellationToken cancellationToken = default);
+        /// <returns>The response of sending adaptive card message.</returns>
+        Task<MessageResponse> SendAdaptiveCard(object card, CancellationToken cancellationToken = default);
     }
 }

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/MessageResponse.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/MessageResponse.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.TeamsFx.Conversation
+{
+    /// <summary>
+    /// Defines a contract that represents a message response.
+    /// E.g., returned by <see cref="INotificationTarget.SendAdaptiveCard"/> or <see cref="INotificationTarget.SendMessage"/>.
+    /// </summary>
+    public class MessageResponse
+    {
+        /// <summary>
+        /// The message ID.
+        /// </summary>
+        public string Id { get; set; }
+    }
+}

--- a/packages/sdk/review/teamsfx.api.md
+++ b/packages/sdk/review/teamsfx.api.md
@@ -96,8 +96,9 @@ export class Channel implements NotificationTarget {
     constructor(parent: TeamsBotInstallation, info: ChannelInfo);
     readonly info: ChannelInfo;
     readonly parent: TeamsBotInstallation;
-    sendAdaptiveCard(card: unknown): Promise<void>;
-    sendMessage(text: string): Promise<void>;
+    sendAdaptiveCard(card: unknown): Promise<MessageResponse>;
+    // Warning: (ae-forgotten-export) The symbol "MessageResponse" needs to be exported by the entry point index.d.ts
+    sendMessage(text: string): Promise<MessageResponse>;
     readonly type: NotificationTargetType;
 }
 
@@ -221,8 +222,8 @@ export class Member implements NotificationTarget {
     constructor(parent: TeamsBotInstallation, account: TeamsChannelAccount);
     readonly account: TeamsChannelAccount;
     readonly parent: TeamsBotInstallation;
-    sendAdaptiveCard(card: unknown): Promise<void>;
-    sendMessage(text: string): Promise<void>;
+    sendAdaptiveCard(card: unknown): Promise<MessageResponse>;
+    sendMessage(text: string): Promise<MessageResponse>;
     readonly type: NotificationTargetType;
 }
 
@@ -259,8 +260,8 @@ export { NotificationOptions_2 as NotificationOptions }
 
 // @public
 export interface NotificationTarget {
-    sendAdaptiveCard(card: unknown): Promise<void>;
-    sendMessage(text: string): Promise<void>;
+    sendAdaptiveCard(card: unknown): Promise<MessageResponse>;
+    sendMessage(text: string): Promise<MessageResponse>;
     readonly type?: NotificationTargetType;
 }
 
@@ -289,10 +290,10 @@ export class OnBehalfOfUserCredential implements TokenCredential {
 }
 
 // @public
-export function sendAdaptiveCard(target: NotificationTarget, card: unknown): Promise<void>;
+export function sendAdaptiveCard(target: NotificationTarget, card: unknown): Promise<MessageResponse>;
 
 // @public
-export function sendMessage(target: NotificationTarget, text: string): Promise<void>;
+export function sendMessage(target: NotificationTarget, text: string): Promise<MessageResponse>;
 
 // @public
 export function setLogFunction(logFunction?: LogFunction): void;
@@ -310,8 +311,8 @@ export class TeamsBotInstallation implements NotificationTarget {
     channels(): Promise<Channel[]>;
     readonly conversationReference: Partial<ConversationReference>;
     members(): Promise<Member[]>;
-    sendAdaptiveCard(card: unknown): Promise<void>;
-    sendMessage(text: string): Promise<void>;
+    sendAdaptiveCard(card: unknown): Promise<MessageResponse>;
+    sendMessage(text: string): Promise<MessageResponse>;
     readonly type?: NotificationTargetType;
 }
 

--- a/packages/sdk/src/conversation/interface.ts
+++ b/packages/sdk/src/conversation/interface.ts
@@ -5,6 +5,16 @@ import { BotFrameworkAdapter } from "botbuilder";
 import { Activity, TurnContext } from "botbuilder-core";
 
 /**
+ * The response of a message action, e.g., `sendMessage`, `sendAdaptiveCard`.
+ */
+export interface MessageResponse {
+  /**
+   * Id of the message.
+   */
+  id?: string;
+}
+
+/**
  * The target type where the notification will be sent to.
  *
  * @remarks
@@ -27,15 +37,19 @@ export interface NotificationTarget {
    * Send a plain text message.
    *
    * @param text - the plain text message.
+   *
+   * @returns the response of sending message.
    */
-  sendMessage(text: string): Promise<void>;
+  sendMessage(text: string): Promise<MessageResponse>;
 
   /**
    * Send an adaptive card message.
    *
    * @param card - the adaptive card raw JSON.
+   *
+   * @returns the response of sending adaptive card message.
    */
-  sendAdaptiveCard(card: unknown): Promise<void>;
+  sendAdaptiveCard(card: unknown): Promise<MessageResponse>;
 }
 
 /**

--- a/packages/sdk/src/conversation/notification.browser.ts
+++ b/packages/sdk/src/conversation/notification.browser.ts
@@ -9,7 +9,7 @@ import {
 } from "botbuilder";
 import { ErrorWithCode, ErrorCode, ErrorMessage } from "../core/errors";
 import { formatString } from "../util/utils";
-import { NotificationTarget, NotificationTargetType } from "./interface";
+import { MessageResponse, NotificationTarget, NotificationTargetType } from "./interface";
 import { ConversationReferenceStore } from "./storage";
 
 /**
@@ -104,9 +104,9 @@ export class Channel implements NotificationTarget {
    * Only work on server side.
    *
    * @param text - the plain text message.
-   * @returns A `Promise` representing the asynchronous operation.
+   * @returns the response of sending message.
    */
-  public sendMessage(text: string): Promise<void> {
+  public sendMessage(text: string): Promise<MessageResponse> {
     throw new ErrorWithCode(
       formatString(ErrorMessage.BrowserRuntimeNotSupported, "Channel"),
       ErrorCode.RuntimeNotSupported
@@ -120,9 +120,9 @@ export class Channel implements NotificationTarget {
    * Only work on server side.
    *
    * @param card - the adaptive card raw JSON.
-   * @returns A `Promise` representing the asynchronous operation.
+   * @returns the response of sending adaptive card message.
    */
-  public async sendAdaptiveCard(card: unknown): Promise<void> {
+  public async sendAdaptiveCard(card: unknown): Promise<MessageResponse> {
     throw new ErrorWithCode(
       formatString(ErrorMessage.BrowserRuntimeNotSupported, "Channel"),
       ErrorCode.RuntimeNotSupported
@@ -188,9 +188,9 @@ export class Member implements NotificationTarget {
    * Only work on server side.
    *
    * @param text - the plain text message.
-   * @returns A `Promise` representing the asynchronous operation.
+   * @returns the response of sending message.
    */
-  public sendMessage(text: string): Promise<void> {
+  public sendMessage(text: string): Promise<MessageResponse> {
     throw new ErrorWithCode(
       formatString(ErrorMessage.BrowserRuntimeNotSupported, "Member"),
       ErrorCode.RuntimeNotSupported
@@ -204,9 +204,9 @@ export class Member implements NotificationTarget {
    * Only work on server side.
    *
    * @param card - the adaptive card raw JSON.
-   * @returns A `Promise` representing the asynchronous operation.
+   * @returns the response of sending adaptive card message.
    */
-  public async sendAdaptiveCard(card: unknown): Promise<void> {
+  public async sendAdaptiveCard(card: unknown): Promise<MessageResponse> {
     throw new ErrorWithCode(
       formatString(ErrorMessage.BrowserRuntimeNotSupported, "Member"),
       ErrorCode.RuntimeNotSupported
@@ -278,9 +278,9 @@ export class TeamsBotInstallation implements NotificationTarget {
    * Only work on server side.
    *
    * @param text - the plain text message.
-   * @returns A `Promise` representing the asynchronous operation.
+   * @returns the response of sending message.
    */
-  public sendMessage(text: string): Promise<void> {
+  public sendMessage(text: string): Promise<MessageResponse> {
     throw new ErrorWithCode(
       formatString(ErrorMessage.BrowserRuntimeNotSupported, "TeamsBotInstallation"),
       ErrorCode.RuntimeNotSupported
@@ -294,9 +294,9 @@ export class TeamsBotInstallation implements NotificationTarget {
    * Only work on server side.
    *
    * @param card - the adaptive card raw JSON.
-   * @returns A `Promise` representing the asynchronous operation.
+   * @returns the response of sending adaptive card message.
    */
-  public sendAdaptiveCard(card: unknown): Promise<void> {
+  public sendAdaptiveCard(card: unknown): Promise<MessageResponse> {
     throw new ErrorWithCode(
       formatString(ErrorMessage.BrowserRuntimeNotSupported, "TeamsBotInstallation"),
       ErrorCode.RuntimeNotSupported

--- a/packages/sdk/src/conversation/notification.ts
+++ b/packages/sdk/src/conversation/notification.ts
@@ -13,7 +13,12 @@ import {
 } from "botbuilder";
 import { ConnectorClient } from "botframework-connector";
 import * as path from "path";
-import { NotificationTarget, NotificationTargetType, NotificationOptions } from "./interface";
+import {
+  NotificationTarget,
+  NotificationTargetType,
+  NotificationOptions,
+  MessageResponse,
+} from "./interface";
 import { NotificationMiddleware } from "./middleware";
 import { ConversationReferenceStore, LocalFileStorage } from "./storage";
 import * as utils from "./utils";
@@ -23,9 +28,9 @@ import * as utils from "./utils";
  *
  * @param target - the notification target.
  * @param text - the plain text message.
- * @returns A `Promise` representing the asynchronous operation.
+ * @returns the response of sending message.
  */
-export function sendMessage(target: NotificationTarget, text: string): Promise<void> {
+export function sendMessage(target: NotificationTarget, text: string): Promise<MessageResponse> {
   return target.sendMessage(text);
 }
 
@@ -34,9 +39,12 @@ export function sendMessage(target: NotificationTarget, text: string): Promise<v
  *
  * @param target - the notification target.
  * @param card - the adaptive card raw JSON.
- * @returns A `Promise` representing the asynchronous operation.
+ * @returns the response of sending adaptive card message.
  */
-export function sendAdaptiveCard(target: NotificationTarget, card: unknown): Promise<void> {
+export function sendAdaptiveCard(
+  target: NotificationTarget,
+  card: unknown
+): Promise<MessageResponse> {
   return target.sendAdaptiveCard(card);
 }
 
@@ -80,38 +88,44 @@ export class Channel implements NotificationTarget {
    * Send a plain text message.
    *
    * @param text - the plain text message.
-   * @returns A `Promise` representing the asynchronous operation.
+   * @returns the response of sending message.
    */
-  public sendMessage(text: string): Promise<void> {
-    return this.parent.adapter.continueConversation(
+  public async sendMessage(text: string): Promise<MessageResponse> {
+    const response: MessageResponse = {};
+    await this.parent.adapter.continueConversation(
       this.parent.conversationReference,
       async (context) => {
         const conversation = await this.newConversation(context);
         await this.parent.adapter.continueConversation(conversation, async (ctx: TurnContext) => {
-          await ctx.sendActivity(text);
+          const res = await ctx.sendActivity(text);
+          response.id = res?.id;
         });
       }
     );
+    return response;
   }
 
   /**
    * Send an adaptive card message.
    *
    * @param card - the adaptive card raw JSON.
-   * @returns A `Promise` representing the asynchronous operation.
+   * @returns the response of sending adaptive card message.
    */
-  public async sendAdaptiveCard(card: unknown): Promise<void> {
-    return this.parent.adapter.continueConversation(
+  public async sendAdaptiveCard(card: unknown): Promise<MessageResponse> {
+    const response: MessageResponse = {};
+    await this.parent.adapter.continueConversation(
       this.parent.conversationReference,
       async (context) => {
         const conversation = await this.newConversation(context);
         await this.parent.adapter.continueConversation(conversation, async (ctx: TurnContext) => {
-          await ctx.sendActivity({
+          const res = await ctx.sendActivity({
             attachments: [CardFactory.adaptiveCard(card)],
           });
+          response.id = res?.id;
         });
       }
     );
+    return response;
   }
 
   /**
@@ -166,38 +180,44 @@ export class Member implements NotificationTarget {
    * Send a plain text message.
    *
    * @param text - the plain text message.
-   * @returns A `Promise` representing the asynchronous operation.
+   * @returns the response of sending message.
    */
-  public sendMessage(text: string): Promise<void> {
-    return this.parent.adapter.continueConversation(
+  public async sendMessage(text: string): Promise<MessageResponse> {
+    const response: MessageResponse = {};
+    await this.parent.adapter.continueConversation(
       this.parent.conversationReference,
       async (context) => {
         const conversation = await this.newConversation(context);
         await this.parent.adapter.continueConversation(conversation, async (ctx: TurnContext) => {
-          await ctx.sendActivity(text);
+          const res = await ctx.sendActivity(text);
+          response.id = res?.id;
         });
       }
     );
+    return response;
   }
 
   /**
    * Send an adaptive card message.
    *
    * @param card - the adaptive card raw JSON.
-   * @returns A `Promise` representing the asynchronous operation.
+   * @returns the response of sending adaptive card message.
    */
-  public async sendAdaptiveCard(card: unknown): Promise<void> {
-    return this.parent.adapter.continueConversation(
+  public async sendAdaptiveCard(card: unknown): Promise<MessageResponse> {
+    const response: MessageResponse = {};
+    await this.parent.adapter.continueConversation(
       this.parent.conversationReference,
       async (context) => {
         const conversation = await this.newConversation(context);
         await this.parent.adapter.continueConversation(conversation, async (ctx: TurnContext) => {
-          await ctx.sendActivity({
+          const res = await ctx.sendActivity({
             attachments: [CardFactory.adaptiveCard(card)],
           });
+          response.id = res?.id;
         });
       }
     );
+    return response;
   }
 
   /**
@@ -272,26 +292,32 @@ export class TeamsBotInstallation implements NotificationTarget {
    * Send a plain text message.
    *
    * @param text - the plain text message.
-   * @returns A `Promise` representing the asynchronous operation.
+   * @returns the response of sending message.
    */
-  public sendMessage(text: string): Promise<void> {
-    return this.adapter.continueConversation(this.conversationReference, async (context) => {
-      await context.sendActivity(text);
+  public async sendMessage(text: string): Promise<MessageResponse> {
+    const response: MessageResponse = {};
+    await this.adapter.continueConversation(this.conversationReference, async (context) => {
+      const res = await context.sendActivity(text);
+      response.id = res?.id;
     });
+    return response;
   }
 
   /**
    * Send an adaptive card message.
    *
    * @param card - the adaptive card raw JSON.
-   * @returns A `Promise` representing the asynchronous operation.
+   * @returns the response of sending adaptive card message.
    */
-  public sendAdaptiveCard(card: unknown): Promise<void> {
-    return this.adapter.continueConversation(this.conversationReference, async (context) => {
-      await context.sendActivity({
+  public async sendAdaptiveCard(card: unknown): Promise<MessageResponse> {
+    const response: MessageResponse = {};
+    await this.adapter.continueConversation(this.conversationReference, async (context) => {
+      const res = await context.sendActivity({
         attachments: [CardFactory.adaptiveCard(card)],
       });
+      response.id = res?.id;
     });
+    return response;
   }
 
   /**

--- a/packages/sdk/test/unit/node/conversation/notification.spec.ts
+++ b/packages/sdk/test/unit/node/conversation/notification.spec.ts
@@ -47,14 +47,16 @@ describe("Notification Tests - Node", () => {
     const sandbox = sinon.createSandbox();
     let botInstallation: TeamsBotInstallation;
     let content: any;
+    let activityResponse: any;
 
     beforeEach(() => {
       content = "";
+      activityResponse = {};
       const stubContext = sandbox.createStubInstance(TurnContext);
       stubContext.sendActivity.callsFake((activityOrText, speak, inputHint) => {
         return new Promise((resolve) => {
           content = activityOrText;
-          resolve(undefined);
+          resolve(activityResponse);
         });
       });
       const stubAdapter = sandbox.createStubInstance(BotFrameworkAdapter);
@@ -82,8 +84,15 @@ describe("Notification Tests - Node", () => {
     it("sendMessage should send correct text", async () => {
       const channel = new Channel(botInstallation, { id: "1" } as ChannelInfo);
       assert.strictEqual(channel.type, "Channel");
-      await channel.sendMessage("text");
+      activityResponse = {
+        id: "message-x",
+      };
+      let res = await channel.sendMessage("text");
       assert.strictEqual(content, "text");
+      assert.deepStrictEqual(res, { id: "message-x" });
+      activityResponse = undefined;
+      res = await channel.sendMessage("text");
+      assert.deepStrictEqual(res, { id: undefined });
     });
 
     it("sendAdaptiveCard should send correct card", async () => {
@@ -92,7 +101,10 @@ describe("Notification Tests - Node", () => {
       });
       const channel = new Channel(botInstallation, { id: "1" } as ChannelInfo);
       assert.strictEqual(channel.type, "Channel");
-      await channel.sendAdaptiveCard({ foo: "bar" });
+      activityResponse = {
+        id: "message-x",
+      };
+      let res = await channel.sendAdaptiveCard({ foo: "bar" });
       assert.deepStrictEqual(content, {
         attachments: [
           {
@@ -102,6 +114,10 @@ describe("Notification Tests - Node", () => {
           },
         ],
       });
+      assert.deepStrictEqual(res, { id: "message-x" });
+      activityResponse = undefined;
+      res = await channel.sendAdaptiveCard({ foo: "bar" });
+      assert.deepStrictEqual(res, { id: undefined });
     });
   });
 
@@ -109,9 +125,11 @@ describe("Notification Tests - Node", () => {
     const sandbox = sinon.createSandbox();
     let botInstallation: TeamsBotInstallation;
     let content: any;
+    let activityResponse: any;
 
     beforeEach(() => {
       content = "";
+      activityResponse = {};
       const stubConversations = sandbox.createStubInstance(Conversations);
       stubConversations.createConversation.resolves({
         id: "1",
@@ -124,7 +142,7 @@ describe("Notification Tests - Node", () => {
       stubContext.sendActivity.callsFake((activityOrText, speak, inputHint) => {
         return new Promise((resolve) => {
           content = activityOrText;
-          resolve(undefined);
+          resolve(activityResponse);
         });
       });
       sandbox.stub(TurnContext.prototype, "turnState").get(() => stubTurnState);
@@ -161,8 +179,15 @@ describe("Notification Tests - Node", () => {
     it("sendMessage should send correct text", async () => {
       const member = new Member(botInstallation, { id: "1" } as TeamsChannelAccount);
       assert.strictEqual(member.type, "Person");
-      await member.sendMessage("text");
+      activityResponse = {
+        id: "message-y",
+      };
+      let res = await member.sendMessage("text");
       assert.strictEqual(content, "text");
+      assert.deepStrictEqual(res, { id: "message-y" });
+      activityResponse = undefined;
+      res = await member.sendMessage("text");
+      assert.deepStrictEqual(res, { id: undefined });
     });
 
     it("sendAdaptiveCard should send correct card", async () => {
@@ -171,7 +196,10 @@ describe("Notification Tests - Node", () => {
       });
       const member = new Member(botInstallation, { id: "1" } as TeamsChannelAccount);
       assert.strictEqual(member.type, "Person");
-      await member.sendAdaptiveCard({ foo: "bar" });
+      activityResponse = {
+        id: "message-y",
+      };
+      let res = await member.sendAdaptiveCard({ foo: "bar" });
       assert.deepStrictEqual(content, {
         attachments: [
           {
@@ -181,6 +209,10 @@ describe("Notification Tests - Node", () => {
           },
         ],
       });
+      assert.deepStrictEqual(res, { id: "message-y" });
+      activityResponse = undefined;
+      res = await member.sendAdaptiveCard({ foo: "bar" });
+      assert.deepStrictEqual(res, { id: undefined });
     });
   });
 
@@ -189,9 +221,11 @@ describe("Notification Tests - Node", () => {
     let adapter: BotFrameworkAdapter;
     let context: TurnContext;
     let content: any;
+    let activityResponse: any;
 
     beforeEach(() => {
       content = "";
+      activityResponse = {};
       const stubAdapter = sandbox.createStubInstance(BotFrameworkAdapter);
       (
         stubAdapter.continueConversation as unknown as sinon.SinonStub<
@@ -206,7 +240,7 @@ describe("Notification Tests - Node", () => {
       stubContext.sendActivity.callsFake((activityOrText, speak, inputHint) => {
         return new Promise((resolve) => {
           content = activityOrText;
-          resolve(undefined);
+          resolve(activityResponse);
         });
       });
       context = stubContext;
@@ -224,8 +258,15 @@ describe("Notification Tests - Node", () => {
       };
       const installation = new TeamsBotInstallation(adapter, conversationRef as any);
       assert.strictEqual(installation.type, "Channel");
-      await installation.sendMessage("text");
+      activityResponse = {
+        id: "message-a",
+      };
+      let res = await installation.sendMessage("text");
       assert.strictEqual(content, "text");
+      assert.deepStrictEqual(res, { id: "message-a" });
+      activityResponse = undefined;
+      res = await installation.sendMessage("text");
+      assert.deepStrictEqual(res, { id: undefined });
     });
 
     it("sendAdaptiveCard should send correct card", async () => {
@@ -239,7 +280,10 @@ describe("Notification Tests - Node", () => {
       };
       const installation = new TeamsBotInstallation(adapter, conversationRef as any);
       assert.strictEqual(installation.type, "Channel");
-      await installation.sendAdaptiveCard({ foo: "bar" });
+      activityResponse = {
+        id: "message-a",
+      };
+      let res = await installation.sendAdaptiveCard({ foo: "bar" });
       assert.deepStrictEqual(content, {
         attachments: [
           {
@@ -249,6 +293,10 @@ describe("Notification Tests - Node", () => {
           },
         ],
       });
+      assert.deepStrictEqual(res, { id: "message-a" });
+      activityResponse = undefined;
+      res = await installation.sendAdaptiveCard({ foo: "bar" });
+      assert.deepStrictEqual(res, { id: undefined });
     });
 
     it("channels should return correct channels", async () => {

--- a/packages/sdk/test/unit/node/conversation/testUtils.ts
+++ b/packages/sdk/test/unit/node/conversation/testUtils.ts
@@ -5,6 +5,7 @@ import { TurnContext } from "botbuilder-core";
 import { Activity } from "botframework-schema";
 import {
   CommandMessage,
+  MessageResponse,
   NotificationTarget,
   NotificationTargetStorage,
   NotificationTargetType,
@@ -43,16 +44,16 @@ export class TestStorage implements NotificationTargetStorage {
 export class TestTarget implements NotificationTarget {
   public content: any;
   public type?: NotificationTargetType | undefined;
-  public sendMessage(text: string): Promise<void> {
+  public sendMessage(text: string): Promise<MessageResponse> {
     return new Promise((resolve) => {
       this.content = text;
-      resolve();
+      resolve({});
     });
   }
-  public sendAdaptiveCard(card: unknown): Promise<void> {
+  public sendAdaptiveCard(card: unknown): Promise<MessageResponse> {
     return new Promise((resolve) => {
       this.content = card;
-      resolve();
+      resolve({});
     });
   }
 }


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/15087878/

Add `MessageResponse` to represent the return value of `sendMessage` and `sendAdaptiveCard` calls.
Applied to both Node.js and .NET SDKs.