### PR TITLE
fix(vsc): trigger-from when welcome page is shown after installation

### DIFF
--- a/packages/vscode-extension/src/controls/openWelcomePage.ts
+++ b/packages/vscode-extension/src/controls/openWelcomePage.ts
@@ -15,6 +15,6 @@ export async function openWelcomePageAfterExtensionInstallation(): Promise<void>
 
   // Let's show!
   await globalStateUpdate(welcomePageKey, true);
-  vscode.commands.executeCommand("fx-extension.openWelcome", TelemetryTriggerFrom.Other);
+  vscode.commands.executeCommand("fx-extension.openWelcome", TelemetryTriggerFrom.Auto);
   vscode.commands.executeCommand("workbench.view.extension.teamsfx");
 }


### PR DESCRIPTION
Related bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/15127861
E2E TEST: N/A