### PR TITLE
fix(command-bot): shouldTrigger should return false if input is null

### DIFF
--- a/packages/dotnet-sdk/src/TeamsFx.Test/Conversation/CommandResponseMiddlewareTest.cs
+++ b/packages/dotnet-sdk/src/TeamsFx.Test/Conversation/CommandResponseMiddlewareTest.cs
@@ -123,6 +123,7 @@
         [DataRow("SampleTest extra-input")]
         [DataRow("Invalid input")]
         [DataRow("A Test !@#$%^")]
+        [DataRow(null)]
         public async Task OnTurnAsync_InputNotMatch_ShouldSkipped(string input)
         {
             // Arrange

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/RegExpTrigger.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/RegExpTrigger.cs
@@ -44,6 +44,11 @@ namespace Microsoft.TeamsFx.Conversation
         /// <inheritdoc/>
         public bool ShouldTrigger(string input)
         {
+            if (string.IsNullOrEmpty(input))
+            {
+                return false;
+            }
+
             return Pattern.IsMatch(input);
         }
     }


### PR DESCRIPTION
The command trigger should return `false` if the input is `null`.
E2E TEST: N/A (covered by UI test)