### PR TITLE
chore: add telemetry for sample gallery

### DIFF
--- a/packages/vscode-extension/src/controls/SampleGallery.tsx
+++ b/packages/vscode-extension/src/controls/SampleGallery.tsx
@@ -24,6 +24,11 @@ import GraphConnector from "../../img/webview/sample/graph-connector-app.gif";
 import IncomingWebhook from "../../img/webview/sample/incoming-webhook.gif";
 import AdaptiveCardNotification from "../../img/webview/sample/adaptive-card-notification.gif";
 import SendProactiveMsg from "../../img/webview/sample/send-proactive-messages.gif";
+import {
+  TelemetryEvent,
+  TelemetryProperty,
+  TelemetryTriggerFrom,
+} from "../telemetry/extTelemetryEvents";
 
 const imageMapping: { [p: string]: any } = {
   "todo-list-with-Azure-backend": ToDoList,
@@ -174,6 +179,16 @@ class SampleCard extends React.Component<SampleCardProps, any> {
         className={`sample-card box${this.props.order}`}
         tabIndex={0}
         onClick={() => {
+          vscode.postMessage({
+            command: Commands.SendTelemetryEvent,
+            data: {
+              eventName: TelemetryEvent.ClickSampleCard,
+              properties: {
+                [TelemetryProperty.TriggerFrom]: TelemetryTriggerFrom.Webview,
+                [TelemetryProperty.SampleAppName]: this.props.sampleAppFolder,
+              },
+            },
+          });
           this.props.highlightSample(this.props.sampleAppFolder);
         }}
       >
@@ -243,22 +258,4 @@ class SampleCard extends React.Component<SampleCardProps, any> {
       </div>
     );
   }
-
-  cloneSampleApp = (sampleAppName: string, sampleAppUrl: string, sampleAppFolder: string) => {
-    vscode.postMessage({
-      command: Commands.CloneSampleApp,
-      data: {
-        appName: sampleAppName,
-        appUrl: sampleAppUrl,
-        appFolder: sampleAppFolder,
-      },
-    });
-  };
-
-  viewSampleApp = (sampleAppFolder: string, sampleBaseUrl: string) => {
-    vscode.postMessage({
-      command: Commands.OpenExternalLink,
-      data: sampleBaseUrl + sampleAppFolder,
-    });
-  };
 }

--- a/packages/vscode-extension/src/controls/sampleDetailPage.tsx
+++ b/packages/vscode-extension/src/controls/sampleDetailPage.tsx
@@ -4,6 +4,11 @@ import "./sampleDetailPage.scss";
 import { VSCodeButton, VSCodeTag } from "@vscode/webview-ui-toolkit/react";
 import { Watch, Setting } from "./resources";
 import { Commands } from "./Commands";
+import {
+  TelemetryEvent,
+  TelemetryProperty,
+  TelemetryTriggerFrom,
+} from "../telemetry/extTelemetryEvents";
 
 export default class SampleDetailPage extends React.Component<SampleDetailProps, any> {
   constructor(props: SampleDetailProps) {
@@ -66,6 +71,16 @@ export default class SampleDetailPage extends React.Component<SampleDetailProps,
   };
 
   onViewGithub = () => {
+    vscode.postMessage({
+      command: Commands.SendTelemetryEvent,
+      data: {
+        eventName: TelemetryEvent.ViewSampleInGitHub,
+        properties: {
+          [TelemetryProperty.TriggerFrom]: TelemetryTriggerFrom.Webview,
+          [TelemetryProperty.SampleAppName]: this.props.sampleAppFolder,
+        },
+      },
+    });
     vscode.postMessage({
       command: Commands.OpenExternalLink,
       data: this.props.url + this.props.sampleAppFolder,

--- a/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
@@ -77,8 +77,12 @@ export enum TelemetryEvent {
 
   OpenAzurePortal = "open-azure-portal",
 
+  ClickSampleCard = "click-sample-card",
+
   DownloadSampleStart = "download-sample-start",
   DownloadSample = "download-sample",
+
+  ViewSampleInGitHub = "view-sample-in-github",
 
   WatchVideo = "watch-video",
   PauseVideo = "pause-video",


### PR DESCRIPTION
Add following telemetry events:
1> When user click sample app card with app id attached
2> When user click 'View in GitHub' button in sample detail page with app id attached