### PR TITLE
fix: set error to warning when func v3 and node 16

### DIFF
--- a/packages/fx-core/src/common/deps-checker/internal/funcToolChecker.ts
+++ b/packages/fx-core/src/common/deps-checker/internal/funcToolChecker.ts
@@ -101,7 +101,7 @@ export class FuncToolChecker implements DepsChecker {
 
     const error = await this.checkGlobalFuncAndNode(installationInfo.globalFuncVersion);
     if (error) {
-      return await this.getDepsInfo(false, false, error);
+      installationInfo.error = error;
     }
 
     return installationInfo;


### PR DESCRIPTION
fix bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/15204559/