### PR TITLE
feat: allow user to add spfx feature for spfx project

### DIFF
--- a/packages/fx-core/src/common/constants.ts
+++ b/packages/fx-core/src/common/constants.ts
@@ -73,11 +73,11 @@ export class FeatureFlagName {
   static readonly ExistingTabApp = "TEAMSFX_INIT_APP";
   static readonly AadManifest = "TEAMSFX_AAD_MANIFEST";
   static readonly DebugTemplate = "TEAMSFX_DEBUG_TEMPLATE";
-  static readonly YeomanScaffold = "YEOMAN_SCAFFOLD";
   static readonly BotNotification = "BOT_NOTIFICATION_ENABLED";
   static readonly M365App = "TEAMSFX_M365_APP";
   static readonly YoCheckerEnable = "TEAMSFX_YO_ENV_CHECKER_ENABLE";
   static readonly GeneratorCheckerEnable = "TEAMSFX_GENERATOR_ENV_CHECKER_ENABLE";
+  static readonly SPFxMultiTab = "TEAMSFX_SPFX_MULTI_TAB";
   static readonly ApiConnect = "TEAMSFX_API_CONNECT_ENABLE";
   static readonly DeployManifest = "TEAMSFX_DEPLOY_MANIFEST";
   static readonly Preview = "TEAMSFX_PREVIEW";

--- a/packages/fx-core/src/common/featureFlags.ts
+++ b/packages/fx-core/src/common/featureFlags.ts
@@ -36,3 +36,7 @@ export function isPreviewFeaturesEnabled(): boolean {
 export function isCLIDotNetEnabled(): boolean {
   return isFeatureFlagEnabled(FeatureFlagName.CLIDotNet, false);
 }
+
+export function isSPFxMultiTabEnabled(): boolean {
+  return isFeatureFlagEnabled(FeatureFlagName.SPFxMultiTab, false);
+}

--- a/packages/fx-core/src/plugins/resource/spfx/index.ts
+++ b/packages/fx-core/src/plugins/resource/spfx/index.ts
@@ -4,6 +4,7 @@
 import {
   AzureSolutionSettings,
   err,
+  Func,
   FxError,
   ok,
   Plugin,
@@ -17,7 +18,7 @@ import { Service } from "typedi";
 import { HostTypeOptionSPFx } from "../../solution/fx-solution/question";
 import { ResourcePlugins } from "../../solution/fx-solution/ResourcePluginContainer";
 import { SPFxPluginImpl } from "./plugin";
-import { TelemetryEvent } from "./utils/constants";
+import { TelemetryEvent, UserTasks } from "./utils/constants";
 import { ProgressHelper } from "./utils/progress-helper";
 import {
   frameworkQuestion,
@@ -58,6 +59,25 @@ export class SpfxPlugin implements Plugin {
     }
 
     return ok(spfx_frontend_host);
+  }
+
+  async getQuestionsForUserTask(
+    func: Func,
+    ctx: PluginContext
+  ): Promise<Result<QTreeNode | undefined, FxError>> {
+    if (func.method === UserTasks.AddFeature) {
+      const spfx_add_feature = new QTreeNode({
+        type: "group",
+      });
+
+      const spfx_version_check = new QTreeNode(versionCheckQuestion);
+      spfx_add_feature.addChild(spfx_version_check);
+
+      const spfx_webpart_name = new QTreeNode(webpartNameQuestion);
+      spfx_version_check.addChild(spfx_webpart_name);
+      return ok(spfx_add_feature);
+    }
+    return ok(undefined);
   }
 
   public async postScaffold(ctx: PluginContext): Promise<Result<any, FxError>> {

--- a/packages/fx-core/src/plugins/resource/spfx/utils/constants.ts
+++ b/packages/fx-core/src/plugins/resource/spfx/utils/constants.ts
@@ -101,3 +101,7 @@ export class ManifestTemplate {
   static readonly WEB_APP_INFO_RESOURCE = "https://{teamSiteDomain}";
   static readonly WEB_APP_INFO_ID = "00000003-0000-0ff1-ce00-000000000000";
 }
+
+export enum UserTasks {
+  AddFeature = "addFeature",
+}

--- a/packages/fx-core/src/plugins/resource/spfx/v2/index.ts
+++ b/packages/fx-core/src/plugins/resource/spfx/v2/index.ts
@@ -11,6 +11,7 @@ import {
   Void,
   TokenProvider,
   ProjectSettings,
+  Func,
 } from "@microsoft/teamsfx-api";
 import {
   Context,
@@ -28,6 +29,7 @@ import {
 import {
   deployAdapter,
   getQuestionsForScaffoldingAdapter,
+  getQuestionsForUserTaskAdapter,
   scaffoldSourceCodeAdapter,
 } from "../../utils4v2";
 
@@ -48,6 +50,23 @@ export class SpfxPluginV2 implements ResourcePlugin {
     inputs: Inputs
   ): Promise<Result<QTreeNode | undefined, FxError>> {
     return await getQuestionsForScaffoldingAdapter(ctx, inputs, this.plugin);
+  }
+
+  async getQuestionsForUserTask(
+    ctx: Context,
+    inputs: Inputs,
+    func: Func,
+    envInfo: DeepReadonly<EnvInfoV2>,
+    tokenProvider: TokenProvider
+  ): Promise<Result<QTreeNode | undefined, FxError>> {
+    return await getQuestionsForUserTaskAdapter(
+      ctx,
+      inputs,
+      func,
+      envInfo,
+      tokenProvider,
+      this.plugin
+    );
   }
 
   async scaffoldSourceCode(ctx: Context, inputs: Inputs): Promise<Result<Void, FxError>> {

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/executeUserTask.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/executeUserTask.ts
@@ -33,6 +33,7 @@ import {
   canAddSso,
   isAADEnabled,
   isAadManifestEnabled,
+  isSPFxMultiTabEnabled,
 } from "../../../../common";
 import { ResourcePlugins } from "../../../../common/constants";
 import { isExistingTabApp, isVSProject } from "../../../../common/projectSettingsHelper";
@@ -217,7 +218,7 @@ export function canAddCapability(
   settings: AzureSolutionSettings | undefined,
   telemetryReporter: TelemetryReporter
 ): Result<Void, FxError> {
-  if (settings && !(settings.hostType === HostTypeOptionAzure.id)) {
+  if (settings && !(settings.hostType === HostTypeOptionAzure.id) && !isSPFxMultiTabEnabled()) {
     const e = new UserError(
       SolutionSource,
       SolutionError.AddCapabilityNotSupport,

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/getQuestions.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/getQuestions.ts
@@ -51,6 +51,7 @@ import {
   TabNonSsoItem,
   TabOptionItem,
   TabSPFxItem,
+  TabSPFxNewUIItem,
   TabSsoItem,
 } from "../question";
 import {
@@ -73,10 +74,12 @@ import {
   isAadManifestEnabled,
   isDeployManifestEnabled,
   AppStudioScopes,
+  isSPFxProject,
 } from "../../../../common/tools";
 import {
   isBotNotificationEnabled,
   isPreviewFeaturesEnabled,
+  isSPFxMultiTabEnabled,
 } from "../../../../common/featureFlags";
 import {
   ProgrammingLanguageQuestion,
@@ -834,6 +837,13 @@ async function getStaticOptionsForAddCapability(
   if (tabExceedRes.isErr()) {
     return err(tabExceedRes.error);
   }
+
+  const isTabSPFxAddable =
+    !tabExceedRes.value && isSPFxProject(ctx.projectSetting) && isSPFxMultiTabEnabled();
+  if (isTabSPFxAddable) {
+    return ok([TabSPFxNewUIItem]);
+  }
+
   const isTabAddable = !tabExceedRes.value;
   const botExceedRes = await appStudioPlugin.capabilityExceedLimit(
     ctx,
@@ -988,6 +998,10 @@ export async function getQuestionsForAddFeature(
   if (inputs.platform === Platform.CLI_HELP || isApiConnectionAddable) {
     pluginsWithResources.push([ResourcePluginsV2.ApiConnectorPlugin, ApiConnectionOptionItem.id]);
   }
+  if (isSPFxMultiTabEnabled()) {
+    pluginsWithResources.push([ResourcePluginsV2.SpfxPlugin, TabSPFxItem.id]);
+  }
+
   const alreadyHaveFunction = settings?.azureResources.includes(AzureResourceFunction.id);
   for (const pair of pluginsWithResources) {
     const pluginName = pair[0];


### PR DESCRIPTION
1. Add feature flag for spfx multi-tab support feature: TEAMSFX_SPFX_MULTI_TAB
2. Allow users to add spfx tab when clicking 'Add feature' button for spfx project

Screenshot:
 1. v3: off + spfx_multi_tab: off + azure project
2. v3: off + spfx_multi_tab: on+ azure project
3. v3: on+ spfx_multi_tab: on+ azure project
![azure_v3off_multispfxon](https://user-images.githubusercontent.com/73154171/183855676-ea7483f5-4974-43ed-bf9f-8730a79ae09b.png)

1. v3: off + spfx_multi_tab: on+ spfx project
2. v3: on+ spfx_multi_tab: on+ spfx project
![spfx_v3on_multispfxon](https://user-images.githubusercontent.com/73154171/183855466-1de89dfd-430d-43bf-8313-dfdbc396d9b4.png)

1. v3: off + spfx_multi_tab: off + spfx project
![spfx_v3off_multispfxoff](https://user-images.githubusercontent.com/73154171/183855727-9c4ffc97-e63e-4167-97f2-58105aea6ec5.png)

E2E TEST: only for vsc extension