### PR TITLE
feat: notification when switch account for local debug in vs code

### DIFF
--- a/packages/vscode-extension/package.nls.json
+++ b/packages/vscode-extension/package.nls.json
@@ -284,6 +284,7 @@
     "teamstoolkit.localDebug.portsAlreadyInUse": "Ports: %s are already in use. Close these ports and try again.",
     "teamstoolkit.localDebug.portWarning": "Changing port(s) in package.json may break local debug. Ensure all port changes are expected or refer to documentation by clicking `Learn More` button. (%s package.json location: %s)",
     "teamstoolkit.localDebug.prerequisitesCheckFailure": "Prerequisites Check Failed. Please check the %s to see the details. If you wish to bypass checking and installing any prerequisites, you can disable them in Visual Studio Code settings.",
+    "teamstoolkit.localDebug.switchM365AccountWarning": "You are now using a different Microsoft 365 account from what you previously used.",
     "teamstoolkit.migrateTeamsManifest.progressTitle": "Upgrade Teams Manifest to Extend in Outlook and Office",
     "teamstoolkit.migrateTeamsManifest.selectFileConfig.name": "Select Teams Manifest to Upgrade",
     "teamstoolkit.migrateTeamsManifest.selectFileConfig.title": "Select Teams Manifest to Upgrade",

--- a/packages/vscode-extension/src/debug/depsChecker/doctorConstant.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/doctorConstant.ts
@@ -24,7 +24,7 @@ export const doctorConstant = {
   Node12MatchFunction:
     "If you have your own Azure Functions Core Tools installed, make sure it works with new Node.js version. See (https://docs.microsoft.com/azure/azure-functions/functions-versions#languages) for Azure Functions supported Node versions.",
   SignInSuccess: `M365 Account (@account) is logged in and sideloading enabled`,
-  SignInSuccessWithNewAccount: `M365 Account (@account) is logged in and sideloading enabled. Please note that you are now using a different Microsoft 365 account from what you previously used.`,
+  SignInSuccessWithNewAccount: `You are now using a different Microsoft 365 account. M365 Account (@account) is logged in and sideloading enabled.`,
   Cert: "Development certificate for localhost",
   CertSuccess: "Development certificate for localhost is installed",
   NpmInstallSuccess: "NPM packages for @app are installed",

--- a/packages/vscode-extension/src/debug/depsChecker/doctorConstant.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/doctorConstant.ts
@@ -24,7 +24,7 @@ export const doctorConstant = {
   Node12MatchFunction:
     "If you have your own Azure Functions Core Tools installed, make sure it works with new Node.js version. See (https://docs.microsoft.com/azure/azure-functions/functions-versions#languages) for Azure Functions supported Node versions.",
   SignInSuccess: `M365 Account (@account) is logged in and sideloading enabled`,
-  SignInSuccessWithNewAccount: `You have switched M365 account. M365 Account (@account) is logged in and sideloading enabled.`,
+  SignInSuccessWithNewAccount: `M365 Account (@account) is logged in and sideloading enabled. Please note that you are now using a different Microsoft 365 account from what you previously used.`,
   Cert: "Development certificate for localhost",
   CertSuccess: "Development certificate for localhost is installed",
   NpmInstallSuccess: "NPM packages for @app are installed",

--- a/packages/vscode-extension/src/debug/prerequisitesHandler.ts
+++ b/packages/vscode-extension/src/debug/prerequisitesHandler.ts
@@ -619,7 +619,6 @@ function checkM365Account(prefix: string, showLoginPage: boolean): Promise<Check
         }
       );
 
-      let hasSwitchedM365Tenant = false;
       if (
         localEnvInfo &&
         localEnvInfo["state"] &&
@@ -628,22 +627,41 @@ function checkM365Account(prefix: string, showLoginPage: boolean): Promise<Check
         !!tenantId &&
         localEnvInfo["state"]["solution"]["teamsAppTenantId"] != tenantId
       ) {
-        hasSwitchedM365Tenant = true;
+        showNotification(
+          localize("teamstoolkit.localDebug.switchM365AccountWarning"),
+          "https://docs.microsoft.com/en-us/microsoftteams/platform/toolkit/provision" // todo: update doc link
+        );
       }
       return {
         checker: Checker.M365Account,
         result: result,
         successMsg:
           result && loginHint
-            ? hasSwitchedM365Tenant
-              ? doctorConstant.SignInSuccessWithNewAccount.split("@account").join(`${loginHint}`)
-              : doctorConstant.SignInSuccess.split("@account").join(`${loginHint}`)
+            ? doctorConstant.SignInSuccess.split("@account").join(`${loginHint}`)
             : Checker.M365Account,
         failureMsg: failureMsg,
         error: error,
       };
     }
   );
+}
+
+function showNotification(message: string, url: string): void {
+  VS_CODE_UI.showMessage(
+    "warn",
+    message,
+    false,
+    localize("teamstoolkit.localDebug.learnMore")
+  ).then(async (result) => {
+    if (result.isOk()) {
+      if (result.value === localize("teamstoolkit.localDebug.learnMore")) {
+        ExtTelemetry.sendTelemetryEvent(
+          TelemetryEvent.ClickLearnMoreWhenSwitchAccountForLocalDebug
+        );
+        await VS_CODE_UI.openUrl(url);
+      }
+    }
+  });
 }
 
 async function checkNode(

--- a/packages/vscode-extension/src/debug/prerequisitesHandler.ts
+++ b/packages/vscode-extension/src/debug/prerequisitesHandler.ts
@@ -619,6 +619,7 @@ function checkM365Account(prefix: string, showLoginPage: boolean): Promise<Check
         }
       );
 
+      let hasSwitchedM365Tenant = false;
       if (
         localEnvInfo &&
         localEnvInfo["state"] &&
@@ -627,6 +628,7 @@ function checkM365Account(prefix: string, showLoginPage: boolean): Promise<Check
         !!tenantId &&
         localEnvInfo["state"]["solution"]["teamsAppTenantId"] != tenantId
       ) {
+        hasSwitchedM365Tenant = true;
         showNotification(
           localize("teamstoolkit.localDebug.switchM365AccountWarning"),
           "https://docs.microsoft.com/en-us/microsoftteams/platform/toolkit/provision" // todo: update doc link
@@ -637,7 +639,9 @@ function checkM365Account(prefix: string, showLoginPage: boolean): Promise<Check
         result: result,
         successMsg:
           result && loginHint
-            ? doctorConstant.SignInSuccess.split("@account").join(`${loginHint}`)
+            ? hasSwitchedM365Tenant
+              ? doctorConstant.SignInSuccessWithNewAccount.split("@account").join(`${loginHint}`)
+              : doctorConstant.SignInSuccess.split("@account").join(`${loginHint}`)
             : Checker.M365Account,
         failureMsg: failureMsg,
         error: error,

--- a/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
@@ -171,6 +171,7 @@ export enum TelemetryEvent {
   ShowLocalDebugNotification = "show-local-debug-notification",
   ShowLocalPreviewNotification = "show-local-preview-notification",
   ClickLocalDebug = "click-local-debug",
+  ClickLearnMoreWhenSwitchAccountForLocalDebug = "local-debug-switch-account-click-learn-more",
   ClickLocalPreview = "click-local-preview",
   PreviewAdaptiveCard = "open-adaptivecard-preview",
 


### PR DESCRIPTION
Show notification in VS Code if user chooses to use another account for local debug.

E2E TEST: N/A