### PR TITLE
chore: remove BotAuthenticationOption from AddTeamsFx() method

### DIFF
--- a/packages/dotnet-sdk/src/TeamsFx/Configuration/ConfigurationMethods.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Configuration/ConfigurationMethods.cs
@@ -31,14 +31,6 @@ public static class TeamsFxConfigurationMethods
         services.AddScoped<TeamsUserCredential>();
 
         services.AddOptions<AuthenticationOptions>().Bind(namedConfigurationSection.GetSection(AuthenticationOptions.Authentication)).ValidateDataAnnotations();
-        services.AddOptions<BotAuthenticationOptions>().Configure<IOptions<AuthenticationOptions>> ((botAuthOption, authOptions) => {
-            AuthenticationOptions authOptionsValue = authOptions.Value;
-            botAuthOption.ClientId = authOptionsValue.ClientId;
-            botAuthOption.ClientSecret = authOptionsValue.ClientSecret;
-            botAuthOption.OAuthAuthority = authOptionsValue.OAuthAuthority;
-            botAuthOption.ApplicationIdUri = authOptionsValue.ApplicationIdUri;
-            botAuthOption.InitiateLoginEndpoint  = authOptionsValue.Bot.InitiateLoginEndpoint;
-        }).ValidateDataAnnotations();
         
         services.AddSingleton<IIdentityClientAdapter>(sp => {
             var authenticationOptions = sp.GetRequiredService<IOptions<AuthenticationOptions>>().Value;
@@ -70,14 +62,6 @@ public static class TeamsFxConfigurationMethods
         services.Configure(configureOptions);
         services.AddOptions<AuthenticationOptions>()
             .Configure(configureOptions).ValidateDataAnnotations();
-        services.AddOptions<BotAuthenticationOptions>().Configure<IOptions<AuthenticationOptions>>((botAuthOption, authOptions) => {
-                AuthenticationOptions authOptionsValue = authOptions.Value;
-                botAuthOption.ClientId = authOptionsValue.ClientId;
-                botAuthOption.ClientSecret = authOptionsValue.ClientSecret;
-                botAuthOption.OAuthAuthority = authOptionsValue.OAuthAuthority;
-                botAuthOption.ApplicationIdUri = authOptionsValue.ApplicationIdUri;
-                botAuthOption.InitiateLoginEndpoint  = authOptionsValue.Bot.InitiateLoginEndpoint;
-            }).ValidateDataAnnotations();
 
         services.AddSingleton<IIdentityClientAdapter>(sp => {
             var authenticationOptions = sp.GetRequiredService<IOptions<AuthenticationOptions>>().Value;
@@ -113,14 +97,6 @@ public static class TeamsFxConfigurationMethods
                 options.ClientSecret = userOptions.ClientSecret;
                 options.OAuthAuthority = userOptions.OAuthAuthority;
             }).ValidateDataAnnotations();
-        services.AddOptions<BotAuthenticationOptions>().Configure<IOptions<AuthenticationOptions>>((botAuthOption, authOptions) => {
-            AuthenticationOptions authOptionsValue = authOptions.Value;
-            botAuthOption.ClientId = authOptionsValue.ClientId;
-            botAuthOption.ClientSecret = authOptionsValue.ClientSecret;
-            botAuthOption.OAuthAuthority = authOptionsValue.OAuthAuthority;
-            botAuthOption.ApplicationIdUri = authOptionsValue.ApplicationIdUri;
-            botAuthOption.InitiateLoginEndpoint  = authOptionsValue.Bot.InitiateLoginEndpoint;
-        }).ValidateDataAnnotations();
 
         services.AddSingleton<IIdentityClientAdapter>(sp => {
             var authenticationOptions = sp.GetRequiredService<IOptions<AuthenticationOptions>>().Value;


### PR DESCRIPTION
Temporary remove BotAuthenticationOption from AddTeamsFx() method.
This method requires RazorPages service so we may need further discussion on whether we should let users call AddTeamsFx() for every projects that uses TeamsFx SDK. The major concern is user might not use RazorPages and cause error during initialization.
We can add BotAuthenticationOption back if that's OK after discussion.