### PR TITLE
fix(v3): wrong build output path

### DIFF
--- a/packages/fx-core/src/component/code/tabCode.ts
+++ b/packages/fx-core/src/component/code/tabCode.ts
@@ -208,7 +208,7 @@ export class TabCodeProvider {
     } catch (e) {
       throw new CommandExecutionError(command, tabPath, e);
     }
-    return path.join("bin", "Release", "net6.0", "win-x86", "publish");
+    return path.join("publish");
   }
   private async doReactBuild(
     tabPath: string,


### PR DESCRIPTION
E2E TEST: https://github.com/OfficeDev/TeamsFx/blob/38aaa61289701fdc85c7f7d725ac0d4862488520/packages/cli/tests/e2e/frontend/BlazorAppHappyPath.v3.tests.ts#L34