### PR TITLE
docs: fix image path in doc

### DIFF
--- a/docs/fx-core/arm/arm-help.md
+++ b/docs/fx-core/arm/arm-help.md
@@ -18,7 +18,7 @@ List common errors as follows. You can find the common deployment error from sea
 ### Mitigation
 1. Search `Microsoft.Web/serverfarms` in all bicep files in your project
 1. Add `properties: {}` to the resource definition. Here is an example:
-    ![image](../../images/fx-core/arm/add-empty-properties.PNG)
+    ![image](../../images/fx-core/arm/add-empty-properties.png)
 
 ## The maximum number of Free App Service Plan allowed in a Subscription is xx.
 


### PR DESCRIPTION
CLI BREAKING CHANGE:
  

Extension-toolkit BREAKING CHANGE:
 

CLI feat commits:
  

Extension-toolkit feat commits:

Didn't find this as Windows is case insensitive. Update the path to ensure GitHub can display the image correctly.