### PR TITLE
chore: workaround app service provision failure in V3 api

### DIFF
--- a/packages/fx-core/templates/bicep/azureFunction.provision.module.bicep
+++ b/packages/fx-core/templates/bicep/azureFunction.provision.module.bicep
@@ -17,6 +17,7 @@ resource serverfarm 'Microsoft.Web/serverfarms@2021-02-01' = {
   sku: {
     name: functionAppSKU
   }
+  properties: {}
 }
 
 // Azure Function that host your app

--- a/packages/fx-core/templates/bicep/azureWebApp.provision.module.bicep
+++ b/packages/fx-core/templates/bicep/azureWebApp.provision.module.bicep
@@ -15,6 +15,7 @@ resource serverfarm 'Microsoft.Web/serverfarms@2021-02-01' = {
   sku: {
     name: webAppSKU
   }
+  properties: {}
 }
 
 // Web App that hosts your app


### PR DESCRIPTION
Just realize we also need to add app service provision failure workaround to V3 code.