### PR TITLE
feat: support create and add workflow bot in VSC toolkit

### DIFF
--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -528,6 +528,8 @@
   "core.Option.recommend": "Recommended",
   "core.CommandAndResponseOption.label": "Command bot",
   "core.CommandAndResponseOption.detail": "Respond to simple commands in Microsoft Teams chat",
+  "core.WorkflowOption.label": "Workflow bot",
+  "core.WorkflowOption.detail": "Automate repetitive workflows for common business processes in Microsoft Teams chat",
   "core.ExistingTabOption.label": "Embed existing web app",
   "core.ExistingTabOption.detail": "Bring your own static webpages and embed in Microsoft Teams",
   "core.ExistingTabEndpointQuestion.placeholder": "Input your existing tab endpoint",

--- a/packages/fx-core/src/component/feature/bot.ts
+++ b/packages/fx-core/src/component/feature/bot.ts
@@ -38,6 +38,7 @@ import {
   M365SearchAppOptionItem,
   MessageExtensionItem,
   NotificationOptionItem,
+  WorkflowOptionItem,
 } from "../../plugins/solution/fx-solution/question";
 import { BicepComponent } from "../bicep";
 import { BotCodeProvider } from "../code/botCode";
@@ -274,6 +275,8 @@ export class TeamsBot {
  *       group=bot, host=function, scenario=notification-function-base + [notification-trigger-http, notification-trigger-timer]
  *   capability = command-bot:
  *     group=bot, host=app-service, scenario=command-and-response
+ *   capability = workflow-bot:
+ *     group=bot, host=app-service, scenario=workflow
  *   capability = Bot
  *     group=bot, host=app-service, scenario=default
  *   capability = MessagingExtension
@@ -285,6 +288,7 @@ const featureToCapability: Map<string, string> = new Map([
   [M365SearchAppOptionItem.id, "message-extension"],
   [CommandAndResponseOptionItem.id, "command-response"],
   [NotificationOptionItem.id, "notification"],
+  [WorkflowOptionItem.id, "workflow"],
 ]);
 
 const featureToScenario: Map<string, (triggers?: string) => TemplateProjectsScenarios[]> = new Map([
@@ -294,6 +298,7 @@ const featureToScenario: Map<string, (triggers?: string) => TemplateProjectsScen
     CommandAndResponseOptionItem.id,
     () => [TemplateProjectsScenarios.COMMAND_AND_RESPONSE_SCENARIO_NAME],
   ],
+  [WorkflowOptionItem.id, () => [TemplateProjectsScenarios.WORKFLOW_SCENARIO_NAME]],
   [MessageExtensionItem.id, () => [TemplateProjectsScenarios.DEFAULT_SCENARIO_NAME]],
   [M365SearchAppOptionItem.id, () => [TemplateProjectsScenarios.M365_SCENARIO_NAME]],
 ]);

--- a/packages/fx-core/src/component/questionV3.ts
+++ b/packages/fx-core/src/component/questionV3.ts
@@ -270,7 +270,8 @@ export async function getQuestionsForAddFeatureV3(
     const teamsBot = getComponent(ctx.projectSetting as ProjectSettingsV3, ComponentNames.TeamsBot);
     const alreadyHasNewBot =
       teamsBot?.capabilities?.includes("notification") ||
-      teamsBot?.capabilities?.includes("command-response");
+      teamsBot?.capabilities?.includes("command-response") ||
+      teamsBot?.capabilities?.includes("workflow");
     if (!botExceedLimit && !alreadyHasNewBot && !meExceedLimit) {
       options.push(NotificationOptionItem);
       options.push(CommandAndResponseOptionItem);

--- a/packages/fx-core/src/component/questionV3.ts
+++ b/packages/fx-core/src/component/questionV3.ts
@@ -70,6 +70,7 @@ import {
   TabNewUIOptionItem,
   TabNonSsoItem,
   TabSPFxNewUIItem,
+  WorkflowOptionItem,
 } from "../plugins/solution/fx-solution/question";
 import { getPluginCLIName } from "../plugins/solution/fx-solution/v2/getQuestions";
 import { checkWetherProvisionSucceeded } from "../plugins/solution/fx-solution/v2/utils";
@@ -234,6 +235,7 @@ export async function getQuestionsForAddFeatureV3(
   if (inputs.platform === Platform.CLI_HELP) {
     options.push(NotificationOptionItem);
     options.push(CommandAndResponseOptionItem);
+    options.push(WorkflowOptionItem);
     options.push(BotNewUIOptionItem);
     options.push(TabNewUIOptionItem, TabNonSsoItem);
     options.push(MessageExtensionNewUIItem);
@@ -272,6 +274,7 @@ export async function getQuestionsForAddFeatureV3(
     if (!botExceedLimit && !alreadyHasNewBot && !meExceedLimit) {
       options.push(NotificationOptionItem);
       options.push(CommandAndResponseOptionItem);
+      options.push(WorkflowOptionItem);
       options.push(BotNewUIOptionItem);
     }
     if (canAddTab) {
@@ -331,6 +334,7 @@ export async function getQuestionsForAddFeatureV3(
       enum: [
         NotificationOptionItem.id,
         CommandAndResponseOptionItem.id,
+        WorkflowOptionItem.id,
         TabNewUIOptionItem.id,
         TabNonSsoItem.id,
         BotNewUIOptionItem.id,
@@ -387,6 +391,7 @@ export async function getQuestionsForAddResourceV3(
       enum: [
         NotificationOptionItem.id,
         CommandAndResponseOptionItem.id,
+        WorkflowOptionItem.id,
         TabNewUIOptionItem.id,
         TabNonSsoItem.id,
         BotNewUIOptionItem.id,

--- a/packages/fx-core/src/component/resource/appManifest/utils.ts
+++ b/packages/fx-core/src/component/resource/appManifest/utils.ts
@@ -39,6 +39,7 @@ import {
   BotScenario,
   CommandAndResponseOptionItem,
   NotificationOptionItem,
+  WorkflowOptionItem,
 } from "../../../plugins/solution/fx-solution/question";
 export class ManifestUtils {
   async readAppManifest(projectPath: string): Promise<Result<TeamsAppManifest, FxError>> {
@@ -137,8 +138,11 @@ export class ManifestUtils {
               // inputs[CoreQuestionNames.Features]
               if (inputs.features) {
                 const feature = inputs.features;
-                if (feature === CommandAndResponseOptionItem.id) {
-                  // command and response bot
+                if (
+                  feature === CommandAndResponseOptionItem.id ||
+                  feature == WorkflowOptionItem.id
+                ) {
+                  // command and response bot or workflow bot
                   appManifest.bots = appManifest.bots.concat(BOTS_TPL_FOR_COMMAND_AND_RESPONSE_V3);
                 } else if (feature === NotificationOptionItem.id) {
                   // notification
@@ -150,8 +154,11 @@ export class ManifestUtils {
               } else if (inputs.scenarios) {
                 const scenariosRaw = inputs.scenarios;
                 const scenarios = Array.isArray(scenariosRaw) ? scenariosRaw : [];
-                if (scenarios.includes(BotScenario.CommandAndResponseBot)) {
-                  // command and response bot
+                if (
+                  scenarios.includes(BotScenario.CommandAndResponseBot) ||
+                  scenarios.includes(BotScenario.WorkflowBot)
+                ) {
+                  // command and response bot or workflow bot
                   appManifest.bots = appManifest.bots.concat(BOTS_TPL_FOR_COMMAND_AND_RESPONSE_V3);
                 } else if (scenarios.includes(BotScenario.NotificationBot)) {
                   // notification

--- a/packages/fx-core/src/core/question.ts
+++ b/packages/fx-core/src/core/question.ts
@@ -37,6 +37,7 @@ import {
   TabSPFxNewUIItem,
   MessageExtensionNewUIItem,
   BotNewUIOptionItem,
+  WorkflowOptionItem,
 } from "../plugins/solution/fx-solution/question";
 import { resourceGroupHelper } from "../plugins/solution/fx-solution/utils/ResourceGroupHelper";
 import { ResourceManagementClient } from "@azure/arm-resources";
@@ -262,7 +263,7 @@ export function createCapabilityQuestion(): MultiSelectQuestion {
   if (isBotNotificationEnabled()) {
     // new capabilities question order
     staticOptions = [
-      ...[CommandAndResponseOptionItem, NotificationOptionItem],
+      ...[CommandAndResponseOptionItem, NotificationOptionItem, WorkflowOptionItem],
       ...(isExistingTabAppEnabled() ? [ExistingTabOptionItem] : []),
       ...(isAadManifestEnabled() ? [TabNonSsoItem] : []),
       ...[TabNewUIOptionItem, TabSPFxNewUIItem, MessageExtensionNewUIItem],
@@ -313,6 +314,7 @@ export function createCapabilityQuestionPreview(): SingleSelectQuestion {
   const staticOptions: StaticOptions = [
     NotificationOptionItem,
     CommandAndResponseOptionItem,
+    WorkflowOptionItem,
     TabNewUIOptionItem,
     TabSPFxNewUIItem,
     TabNonSsoItem,
@@ -347,6 +349,7 @@ export function validateCapabilities(inputs: string[]): string | undefined {
       new Set([BotOptionItem.id, MessageExtensionItem.id]),
       new Set([NotificationOptionItem.id]),
       new Set([CommandAndResponseOptionItem.id]),
+      new Set([WorkflowOptionItem.id]),
     ],
     set
   );
@@ -360,6 +363,7 @@ export function validateCapabilities(inputs: string[]): string | undefined {
         MessageExtensionItem.id,
         NotificationOptionItem.id,
         CommandAndResponseOptionItem.id,
+        WorkflowOptionItem.id,
       ]),
       new Set([TabSPFxItem.id]),
     ],
@@ -378,6 +382,7 @@ export function validateCapabilities(inputs: string[]): string | undefined {
         MessageExtensionItem.id,
         NotificationOptionItem.id,
         CommandAndResponseOptionItem.id,
+        WorkflowOptionItem.id,
         ExistingTabOptionItem.id,
       ]),
       new Set([M365SsoLaunchPageOptionItem.id]),
@@ -397,6 +402,7 @@ export async function onChangeSelectionForCapabilities(
       new Set([BotOptionItem.id, MessageExtensionItem.id]),
       new Set([NotificationOptionItem.id]),
       new Set([CommandAndResponseOptionItem.id]),
+      new Set([WorkflowOptionItem.id]),
     ],
     previousSelectedIds,
     currentSelectedIds
@@ -410,6 +416,7 @@ export async function onChangeSelectionForCapabilities(
         MessageExtensionItem.id,
         NotificationOptionItem.id,
         CommandAndResponseOptionItem.id,
+        WorkflowOptionItem.id,
       ]),
       new Set([TabSPFxItem.id]),
       new Set([ExistingTabOptionItem.id]),

--- a/packages/fx-core/src/plugins/resource/appstudio/manifestTemplate.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/manifestTemplate.ts
@@ -253,8 +253,11 @@ export async function addCapabilities(
               const scenariosRaw = inputs[AzureSolutionQuestionNames.Scenarios];
               const scenarios = Array.isArray(scenariosRaw) ? scenariosRaw : [];
 
-              if (scenarios.includes(BotScenario.CommandAndResponseBot)) {
-                // command and response bot
+              if (
+                scenarios.includes(BotScenario.CommandAndResponseBot) ||
+                scenarios.includes(BotScenario.WorkflowBot)
+              ) {
+                // command and response bot or workflow bot
                 manifest.bots = manifest.bots.concat(BOTS_TPL_FOR_COMMAND_AND_RESPONSE);
               } else if (scenarios.includes(BotScenario.NotificationBot)) {
                 // notification

--- a/packages/fx-core/src/plugins/resource/bot/constants.ts
+++ b/packages/fx-core/src/plugins/resource/bot/constants.ts
@@ -39,6 +39,7 @@ export enum TemplateProjectsScenarios {
   NOTIFICATION_FUNCTION_TRIGGER_HTTP_SCENARIO_NAME = "notification-trigger-http",
   NOTIFICATION_FUNCTION_TRIGGER_TIMER_SCENARIO_NAME = "notification-trigger-timer",
   COMMAND_AND_RESPONSE_SCENARIO_NAME = "command-and-response",
+  WORKFLOW_SCENARIO_NAME = "workflow",
   M365_SCENARIO_NAME = "m365",
 }
 

--- a/packages/fx-core/src/plugins/resource/bot/enums/pluginActRoles.ts
+++ b/packages/fx-core/src/plugins/resource/bot/enums/pluginActRoles.ts
@@ -3,4 +3,5 @@ export enum PluginActRoles {
   MessageExtension = "MessagingExtension",
   Notification = "Notification",
   CommandAndResponse = "CommandAndResponse",
+  Workflow = "Workflow",
 }

--- a/packages/fx-core/src/plugins/resource/bot/resources/strings.ts
+++ b/packages/fx-core/src/plugins/resource/bot/resources/strings.ts
@@ -112,6 +112,7 @@ export class Commands {
 export const BotCapabilities = {
   NOTIFICATION: "notification",
   COMMAND_AND_RESPONSE: "command-response",
+  WORKFLOW: "workflow",
   BOT: "bot",
   MESSAGE_EXTENSION: "message-extension",
   M365_SEARCH_APP: "m365-search-app",
@@ -122,11 +123,13 @@ export type BotCapability = typeof BotCapabilities[keyof typeof BotCapabilities]
 export const QuestionBotScenarioToPluginActRoles = new Map<BotScenario, PluginActRoles>([
   [BotScenario.NotificationBot, PluginActRoles.Notification],
   [BotScenario.CommandAndResponseBot, PluginActRoles.CommandAndResponse],
+  [BotScenario.WorkflowBot, PluginActRoles.Workflow],
 ]);
 
 export const QuestionBotScenarioToBotCapability = new Map<BotScenario, BotCapability>([
   [BotScenario.NotificationBot, BotCapabilities.NOTIFICATION],
   [BotScenario.CommandAndResponseBot, BotCapabilities.COMMAND_AND_RESPONSE],
+  [BotScenario.WorkflowBot, BotCapabilities.WORKFLOW],
 ]);
 
 export const NotificationTriggers = {

--- a/packages/fx-core/src/plugins/resource/bot/v2/common.ts
+++ b/packages/fx-core/src/plugins/resource/bot/v2/common.ts
@@ -55,6 +55,9 @@ export function decideTemplateScenarios(ctx: Context, inputs: Inputs): Set<strin
       case BotScenario.CommandAndResponseBot:
         templateScenarios.add(TemplateProjectsScenarios.COMMAND_AND_RESPONSE_SCENARIO_NAME);
         break;
+      case BotScenario.WorkflowBot:
+        templateScenarios.add(TemplateProjectsScenarios.WORKFLOW_SCENARIO_NAME);
+        break;
       case BotScenario.NotificationBot:
         //! Will not scaffold any trigger when notificationTriggerType is undefined,
         const notificationTriggerType = (inputs[

--- a/packages/fx-core/src/plugins/solution/fx-solution/question.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/question.ts
@@ -88,6 +88,24 @@ export const CommandAndResponseOptionItem: OptionItem = {
   ],
 };
 
+export const WorkflowOptionItem: OptionItem = {
+  // id must match cli `yargsHelp`
+  id: "workflow-bot",
+  label: `$(hubot) ${getLocalizedString("core.WorkflowOption.label")}`,
+  description: getLocalizedString("core.Option.recommend"),
+  cliName: "workflow-bot",
+  detail: getLocalizedString("core.WorkflowOption.detail"),
+  groupName: getLocalizedString("core.options.separator.scenario"),
+  data: "https://aka.ms/teamsfx-create-workflow",
+  buttons: [
+    {
+      iconPath: "tasklist",
+      tooltip: getLocalizedString("core.option.tutorial"),
+      command: "fx-extension.openTutorial",
+    },
+  ],
+};
+
 export const ExistingTabOptionItem: OptionItem = {
   id: "ExistingTab",
   label: `$(browser) ${getLocalizedString("core.ExistingTabOption.label")}`,
@@ -303,6 +321,7 @@ export const CicdOptionItem: OptionItem = {
 export enum BotScenario {
   NotificationBot = "notificationBot",
   CommandAndResponseBot = "commandAndResponseBot",
+  WorkflowBot = "workflowBot",
 }
 
 export const BotNotificationTriggers = {
@@ -447,6 +466,7 @@ export const BotFeatureIds = [
   BotOptionItem.id,
   NotificationOptionItem.id,
   CommandAndResponseOptionItem.id,
+  WorkflowOptionItem.id,
   MessageExtensionItem.id,
   M365SearchAppOptionItem.id,
 ];

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/executeUserTask.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/executeUserTask.ts
@@ -77,6 +77,7 @@ import {
   TabOptionItem,
   TabSPFxNewUIItem,
   TabSsoItem,
+  WorkflowOptionItem,
 } from "../question";
 import { getAllV2ResourcePluginMap, ResourcePluginsV2 } from "../ResourcePluginContainer";
 import { sendErrorTelemetryThenReturnError } from "../utils/util";
@@ -343,11 +344,19 @@ export async function addCapability(
     capabilitiesAnswer[notificationIndex] = BotOptionItem.id;
     scenarios.push(BotScenario.NotificationBot);
   }
+
   const commandAndResponseIndex = capabilitiesAnswer.indexOf(CommandAndResponseOptionItem.id);
   if (commandAndResponseIndex !== -1) {
     capabilitiesAnswer[commandAndResponseIndex] = BotOptionItem.id;
     scenarios.push(BotScenario.CommandAndResponseBot);
   }
+
+  const workflowIndex = capabilitiesAnswer.indexOf(WorkflowOptionItem.id);
+  if (workflowIndex !== -1) {
+    capabilitiesAnswer[workflowIndex] = BotOptionItem.id;
+    scenarios.push(BotScenario.WorkflowBot);
+  }
+
   inputsNew[AzureSolutionQuestionNames.Scenarios] = scenarios;
   capabilitiesAnswer = [...new Set(capabilitiesAnswer)];
 

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/getQuestions.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/getQuestions.ts
@@ -51,6 +51,7 @@ import {
   TabSPFxItem,
   TabSPFxNewUIItem,
   TabSsoItem,
+  WorkflowOptionItem,
 } from "../question";
 import {
   getAllV2ResourcePluginMap,
@@ -108,6 +109,7 @@ export async function getQuestionsForScaffolding(
         BotOptionItem.id,
         NotificationOptionItem.id,
         CommandAndResponseOptionItem.id,
+        WorkflowOptionItem.id,
         MessageExtensionItem.id,
         ...(isAadManifestEnabled() ? [TabNonSsoItem.id] : []),
         M365SsoLaunchPageOptionItem.id,
@@ -190,7 +192,8 @@ export async function getQuestionsForScaffolding(
             cap.includes(BotOptionItem.id) ||
             cap.includes(MessageExtensionItem.id) ||
             cap.includes(NotificationOptionItem.id) ||
-            cap.includes(CommandAndResponseOptionItem.id)
+            cap.includes(CommandAndResponseOptionItem.id) ||
+            cap.includes(WorkflowOptionItem.id)
           ) {
             return undefined;
           }
@@ -224,6 +227,7 @@ export async function getQuestionsForScaffoldingPreview(
         BotOptionItem.id,
         NotificationOptionItem.id,
         CommandAndResponseOptionItem.id,
+        WorkflowOptionItem.id,
         MessageExtensionItem.id,
         ...(isAadManifestEnabled() ? [TabNonSsoItem.id] : []),
         M365SsoLaunchPageOptionItem.id,
@@ -304,7 +308,8 @@ export async function getQuestionsForScaffoldingPreview(
             cap === BotOptionItem.id ||
             cap === MessageExtensionItem.id ||
             cap === NotificationOptionItem.id ||
-            cap === CommandAndResponseOptionItem.id
+            cap === CommandAndResponseOptionItem.id ||
+            cap === WorkflowOptionItem.id
           ) {
             return undefined;
           }
@@ -605,7 +610,9 @@ export async function getQuestionsForAddCapability(
     addCapQuestion.staticOptions = [
       ...(isBotNotificationEnabled() ? [TabNewUIOptionItem] : [TabOptionItem]),
       ...[BotOptionItem],
-      ...(isBotNotificationEnabled() ? [NotificationOptionItem, CommandAndResponseOptionItem] : []),
+      ...(isBotNotificationEnabled()
+        ? [NotificationOptionItem, CommandAndResponseOptionItem, WorkflowOptionItem]
+        : []),
       ...(isBotNotificationEnabled() ? [MessageExtensionNewUIItem] : [MessageExtensionItem]),
       ...(isAadManifestEnabled() ? [TabNonSsoItem] : []),
     ];
@@ -677,6 +684,7 @@ export async function getQuestionsForAddCapability(
   if (isBotAddable) {
     if (isBotNotificationEnabled()) {
       options.push(CommandAndResponseOptionItem);
+      options.push(WorkflowOptionItem);
       options.push(NotificationOptionItem);
       options.push(BotOptionItem);
     } else {
@@ -818,6 +826,7 @@ async function getStaticOptionsForAddCapability(
     const options: OptionItem[] = [];
     options.push(NotificationOptionItem);
     options.push(CommandAndResponseOptionItem);
+    options.push(WorkflowOptionItem);
     options.push(TabNewUIOptionItem, TabNonSsoItem);
     options.push(BotNewUIOptionItem);
     options.push(MessageExtensionNewUIItem);
@@ -878,6 +887,7 @@ async function getStaticOptionsForAddCapability(
   if (isScenarioBotAddable) {
     options.push(NotificationOptionItem);
     options.push(CommandAndResponseOptionItem);
+    options.push(WorkflowOptionItem);
   }
   if (isTabAddable) {
     if (!settings?.capabilities.includes(TabOptionItem.id)) {
@@ -969,6 +979,7 @@ export async function getQuestionsForAddFeature(
       enum: [
         NotificationOptionItem.id,
         CommandAndResponseOptionItem.id,
+        WorkflowOptionItem.id,
         TabNewUIOptionItem.id,
         TabNonSsoItem.id,
         BotNewUIOptionItem.id,

--- a/packages/fx-core/src/plugins/solution/fx-solution/v2/utils.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/v2/utils.ts
@@ -47,6 +47,7 @@ import {
   TabOptionItem,
   TabSPFxItem,
   TabSsoItem,
+  WorkflowOptionItem,
 } from "../question";
 import { getActivatedV2ResourcePlugins, getAllV2ResourcePlugins } from "../ResourcePluginContainer";
 import { getPluginContext } from "../utils/util";
@@ -316,7 +317,8 @@ export function fillInSolutionSettings(
   let hostType = answers[AzureSolutionQuestionNames.HostType] as string;
   if (
     capabilities.includes(NotificationOptionItem.id) ||
-    capabilities.includes(CommandAndResponseOptionItem.id)
+    capabilities.includes(CommandAndResponseOptionItem.id) ||
+    capabilities.includes(WorkflowOptionItem.id)
   ) {
     // find and replace "NotificationOptionItem" and "CommandAndResponseOptionItem" to "BotOptionItem", so it does not impact capabilities in projectSettings.json
     const scenarios: BotScenario[] = [];
@@ -325,11 +327,19 @@ export function fillInSolutionSettings(
       capabilities[notificationIndex] = BotOptionItem.id;
       scenarios.push(BotScenario.NotificationBot);
     }
+
     const commandAndResponseIndex = capabilities.indexOf(CommandAndResponseOptionItem.id);
     if (commandAndResponseIndex !== -1) {
       capabilities[commandAndResponseIndex] = BotOptionItem.id;
       scenarios.push(BotScenario.CommandAndResponseBot);
     }
+
+    const workflowIndex = capabilities.indexOf(WorkflowOptionItem.id);
+    if (workflowIndex !== -1) {
+      capabilities[workflowIndex] = BotOptionItem.id;
+      scenarios.push(BotScenario.WorkflowBot);
+    }
+
     answers[AzureSolutionQuestionNames.Scenarios] = scenarios;
     // dedup
     capabilities = [...new Set(capabilities)];

--- a/packages/fx-core/tests/component/questionv3.test.ts
+++ b/packages/fx-core/tests/component/questionv3.test.ts
@@ -9,6 +9,19 @@ import {
   getQuestionsForAddResourceV3,
   getQuestionsForDeployV3,
 } from "../../src/component/questionV3";
+import {
+  AzureResourceApimNewUI,
+  AzureResourceFunctionNewUI,
+  AzureResourceKeyVaultNewUI,
+  AzureResourceSQLNewUI,
+  BotNewUIOptionItem,
+  CommandAndResponseOptionItem,
+  MessageExtensionNewUIItem,
+  NotificationOptionItem,
+  SingleSignOnOptionItem,
+  TabNonSsoItem,
+  WorkflowOptionItem,
+} from "../../src/plugins/solution/fx-solution/question";
 import { manifestUtils } from "../../src/component/resource/appManifest/utils";
 import {
   Inputs,
@@ -87,6 +100,7 @@ describe("question for v3", () => {
     const res = await getQuestionsForDeployV3(context, inputs, envInfo);
     assert.isTrue(res.isOk());
   });
+
   it("getQuestionsForAddFeatureV3 - CLI_HELP", async () => {
     const context = createContextV3();
     const inputs: InputsWithProjectPath = {
@@ -96,6 +110,7 @@ describe("question for v3", () => {
     const res = await getQuestionsForAddFeatureV3(context, inputs);
     assert.isTrue(res.isOk());
   });
+
   it("getQuestionsForAddFeatureV3 - VS Code", async () => {
     const manifest = new TeamsAppManifest();
     manifest.staticTabs = [];
@@ -135,6 +150,75 @@ describe("question for v3", () => {
     assert.isTrue(res.isOk());
   });
 
+  it("getQuestionsForAddFeatureV3 for tab - VS Code", async () => {
+    const manifest = new TeamsAppManifest();
+    manifest.staticTabs = [];
+    manifest.bots = [];
+    manifest.composeExtensions = [];
+    sandbox.stub(manifestUtils, "readAppManifest").resolves(ok(manifest));
+    const projectSettings = {
+      appName: "tabApp",
+      projectId: "112233",
+      version: "2.1.0",
+      isFromSample: false,
+      components: [
+        {
+          name: "teams-tab",
+          hosting: "azure-storage",
+          build: true,
+          folder: "tabs",
+        },
+        {
+          name: "azure-storage",
+          scenario: "Tab",
+          provision: true,
+        },
+        {
+          name: "identity",
+          provision: true,
+        },
+      ],
+      programmingLanguage: "typescript",
+    };
+    const inputs: InputsWithProjectPath = {
+      platform: Platform.VSCode,
+      projectPath: ".",
+    };
+    const context = createContextV3(projectSettings);
+    const res = await getQuestionsForAddFeatureV3(context, inputs);
+    assert.isTrue(res.isOk());
+    if (res.isOk()) {
+      const node = res.value;
+      assert.isTrue(
+        node &&
+          node.data &&
+          node.data.type === "singleSelect" &&
+          node.data.staticOptions.length === 11,
+        "option item count check"
+      );
+      if (node && node.data && node.data.type === "singleSelect") {
+        const options = (node.data as SingleSelectQuestion).staticOptions as OptionItem[];
+        assert.deepEqual(
+          options,
+          [
+            NotificationOptionItem,
+            CommandAndResponseOptionItem,
+            WorkflowOptionItem,
+            BotNewUIOptionItem,
+            TabNonSsoItem,
+            MessageExtensionNewUIItem,
+            AzureResourceApimNewUI,
+            AzureResourceSQLNewUI,
+            AzureResourceKeyVaultNewUI,
+            SingleSignOnOptionItem,
+            AzureResourceFunctionNewUI,
+          ],
+          "option item should match"
+        );
+      }
+    }
+  });
+
   it("getQuestionsForAddFeatureV3 for SPFx - VS Code", async () => {
     const manifest = new TeamsAppManifest();
     manifest.staticTabs = [];
@@ -169,17 +253,6 @@ describe("question for v3", () => {
     const context = createContextV3(projectSettings);
     const res = await getQuestionsForAddFeatureV3(context, inputs);
     assert.isTrue(res.isOk());
-    if (res.isOk()) {
-      const node = res.value;
-      assert.isTrue(
-        node && node.data && node.data.type === "singleSelect",
-        "result should be singleSelect"
-      );
-      if (node && node.data && node.data.type === "singleSelect") {
-        const options = (node.data as SingleSelectQuestion).staticOptions as OptionItem[];
-        assert.deepEqual(options, [CicdOptionItem], "option item should match");
-      }
-    }
   });
 
   it("getQuestionsForAddResourceV3 - CLI_HELP", async () => {

--- a/packages/fx-core/tests/component/resource/appManifest/manifestUtils.test.ts
+++ b/packages/fx-core/tests/component/resource/appManifest/manifestUtils.test.ts
@@ -251,6 +251,19 @@ describe("Add capability V3", () => {
     chai.assert.equal(manifest.bots?.length, 1);
     chai.assert.equal(manifest.bots?.[0].commandLists?.[0].commands?.[0].title, "helloWorld");
   });
+
+  it("Add workflow bot capability", async () => {
+    sandbox.stub(process, "env").value({
+      BOT_NOTIFICATION_ENABLED: "true",
+    });
+    const capabilities = [{ name: "Bot" as const }];
+    inputs[AzureSolutionQuestionNames.Scenarios] = [BotScenario.WorkflowBot];
+    const addCapabilityResult = await component.addCapability(inputs, capabilities);
+    chai.assert.isTrue(addCapabilityResult.isOk());
+    chai.assert.equal(manifest.bots?.length, 1);
+    chai.assert.equal(manifest.bots?.[0].commandLists?.[0].commands?.[0].title, "helloWorld");
+  });
+
   it("Add messaging extension success", async () => {
     const result = await component.addCapability(inputs, [{ name: "MessageExtension" }]);
     chai.assert.isTrue(result.isOk());

--- a/packages/fx-core/tests/core/question.test.ts
+++ b/packages/fx-core/tests/core/question.test.ts
@@ -24,6 +24,7 @@ import {
   TabOptionItem,
   TabSPFxItem,
   TabSPFxNewUIItem,
+  WorkflowOptionItem,
 } from "../../src/plugins/solution/fx-solution/question";
 import { getLocalizedString } from "../../src/common/localizeUtils";
 
@@ -168,6 +169,7 @@ describe("Capability Questions", () => {
       chai.assert.deepEqual(question.staticOptions, [
         NotificationOptionItem,
         CommandAndResponseOptionItem,
+        WorkflowOptionItem,
         TabNewUIOptionItem,
         TabSPFxNewUIItem,
         TabNonSsoItem,

--- a/packages/fx-core/tests/plugins/resource/bot/unit/configs/scaffoldConfig.test.ts
+++ b/packages/fx-core/tests/plugins/resource/bot/unit/configs/scaffoldConfig.test.ts
@@ -151,6 +151,7 @@ describe("Plugin Settings: 'capabilities'", () => {
       [BotCapabilities.COMMAND_AND_RESPONSE],
       "Scaffold command and response bot",
     ],
+    [true, {}, [BotScenario.WorkflowBot], [BotCapabilities.WORKFLOW], "Scaffold workflow bot"],
     [
       true,
       {},

--- a/packages/fx-core/tests/plugins/resource/bot/unit/question.test.ts
+++ b/packages/fx-core/tests/plugins/resource/bot/unit/question.test.ts
@@ -16,6 +16,7 @@ import {
   AzureSolutionQuestionNames,
   CommandAndResponseOptionItem,
   NotificationOptionItem,
+  WorkflowOptionItem,
 } from "../../../../../src/plugins/solution/fx-solution/question";
 
 describe("Test question", () => {
@@ -73,6 +74,16 @@ describe("Test question", () => {
       const inputs: Inputs = { platform: Platform.VSCode };
       // Act
       inputs[AzureSolutionQuestionNames.Capabilities] = CommandAndResponseOptionItem.id;
+      // Assert
+      chai.assert.isTrue(
+        showNotificationTriggerCondition.validFunc(undefined, inputs) !== undefined
+      );
+    });
+    it("Should not ask trigger questions for workflow bot", async () => {
+      // Arrange
+      const inputs: Inputs = { platform: Platform.VSCode };
+      // Act
+      inputs[AzureSolutionQuestionNames.Capabilities] = WorkflowOptionItem.id;
       // Assert
       chai.assert.isTrue(
         showNotificationTriggerCondition.validFunc(undefined, inputs) !== undefined

--- a/packages/fx-core/tests/plugins/resource/bot/unit/v2/common.test.ts
+++ b/packages/fx-core/tests/plugins/resource/bot/unit/v2/common.test.ts
@@ -15,6 +15,7 @@ import {
   M365SearchAppOptionItem,
   MessageExtensionNewUIItem,
   NotificationOptionItem,
+  WorkflowOptionItem,
 } from "../../../../../../src";
 import {
   QuestionNames,
@@ -135,6 +136,14 @@ describe("Bot Plugin v2", () => {
       );
     });
 
+    it("scenario for workflow bot", async () => {
+      inputs[AzureSolutionQuestionNames.Capabilities] = [WorkflowOptionItem.id];
+      fillInSolutionSettings(context.projectSetting, inputs);
+      const templateScenarios = decideTemplateScenarios(context, inputs);
+      chai.assert.equal(templateScenarios.size, 1);
+      chai.assert.isTrue(templateScenarios.has(TemplateProjectsScenarios.WORKFLOW_SCENARIO_NAME));
+    });
+
     it("scenario for default bot", async () => {
       inputs[AzureSolutionQuestionNames.Capabilities] = [BotOptionItem.id];
       fillInSolutionSettings(context.projectSetting, inputs);
@@ -185,6 +194,14 @@ describe("Bot Plugin v2", () => {
       const botCapabilities = resolveBotCapabilities(inputs);
       chai.assert.equal(botCapabilities.length, 1);
       chai.assert.isTrue(botCapabilities.includes(BotCapabilities.COMMAND_AND_RESPONSE));
+    });
+
+    it("bot capabilities for workflow bot", async () => {
+      inputs[AzureSolutionQuestionNames.Capabilities] = [WorkflowOptionItem.id];
+      fillInSolutionSettings(context.projectSetting, inputs);
+      const botCapabilities = resolveBotCapabilities(inputs);
+      chai.assert.equal(botCapabilities.length, 1);
+      chai.assert.isTrue(botCapabilities.includes(BotCapabilities.WORKFLOW));
     });
 
     it("bot capabilities for default bot", async () => {

--- a/packages/fx-core/tests/plugins/solution/solution.getQuestions.test.ts
+++ b/packages/fx-core/tests/plugins/solution/solution.getQuestions.test.ts
@@ -54,6 +54,7 @@ import {
   TabNonSsoItem,
   TabOptionItem,
   SingleSignOnOptionItem,
+  WorkflowOptionItem,
 } from "../../../src/plugins/solution/fx-solution/question";
 import { ResourcePluginsV2 } from "../../../src/plugins/solution/fx-solution/ResourcePluginContainer";
 import {
@@ -412,6 +413,7 @@ describe("getQuestionsForScaffolding()", async () => {
           [
             NotificationOptionItem,
             CommandAndResponseOptionItem,
+            WorkflowOptionItem,
             TabNewUIOptionItem,
             TabNonSsoItem,
             BotNewUIOptionItem,
@@ -456,11 +458,12 @@ describe("getQuestionsForScaffolding()", async () => {
     assert.isTrue(res.isOk() && res.value && res.value.data !== undefined);
     if (res.isOk()) {
       const node = res.value;
+      console.log(node?.data);
       assert.isTrue(
         node &&
           node.data &&
           node.data.type === "singleSelect" &&
-          node.data.staticOptions.length === 10,
+          node.data.staticOptions.length === 11,
         "option item count check"
       );
       if (node && node.data && node.data.type === "singleSelect") {
@@ -470,6 +473,7 @@ describe("getQuestionsForScaffolding()", async () => {
           [
             NotificationOptionItem,
             CommandAndResponseOptionItem,
+            WorkflowOptionItem,
             TabNonSsoItem,
             BotNewUIOptionItem,
             MessageExtensionNewUIItem,

--- a/packages/fx-core/tests/plugins/solution/solution.getQuestions.test.ts
+++ b/packages/fx-core/tests/plugins/solution/solution.getQuestions.test.ts
@@ -458,7 +458,6 @@ describe("getQuestionsForScaffolding()", async () => {
     assert.isTrue(res.isOk() && res.value && res.value.data !== undefined);
     if (res.isOk()) {
       const node = res.value;
-      console.log(node?.data);
       assert.isTrue(
         node &&
           node.data &&


### PR DESCRIPTION
- Support create a workflow bot project in VSC
   
   ![image](https://user-images.githubusercontent.com/10163840/187379407-fac94f52-af1f-4fdd-b194-9660fb7f4e31.png)

- Also, `Add Features` is supported to add a workflow bot to an existing TeamsFx project (e.g. tab)
  
  ![image](https://user-images.githubusercontent.com/10163840/187380328-99d024cd-a042-427b-ab24-7b10c7123b1c.png)

Note: currently only `TypeScript` is supported, and `JavaScript` project will be supported in the upcoming pr.

E2E TEST: N/A