### PR TITLE
fix: missing tab state configs in vs

### DIFF
--- a/packages/fx-core/src/component/feature/tab.ts
+++ b/packages/fx-core/src/component/feature/tab.ts
@@ -219,15 +219,13 @@ export class TeamsTab {
     }),
   ])
   async provision(context: ResourceContextV3): Promise<Result<undefined, FxError>> {
-    if (context.envInfo.envName === "local") {
-      context.envInfo.state[ComponentNames.TeamsTab] =
-        context.envInfo.state[ComponentNames.TeamsTab] || {};
-      if (isVSProject(context.projectSetting)) {
-        context.envInfo.state[ComponentNames.TeamsTab][StorageOutputs.indexPath.key] = "";
-      } else {
-        context.envInfo.state[ComponentNames.TeamsTab][StorageOutputs.indexPath.key] =
-          Constants.FrontendIndexPath;
-      }
+    context.envInfo.state[ComponentNames.TeamsTab] =
+      context.envInfo.state[ComponentNames.TeamsTab] || {};
+    if (isVSProject(context.projectSetting)) {
+      context.envInfo.state[ComponentNames.TeamsTab][StorageOutputs.indexPath.key] = "/";
+    } else {
+      context.envInfo.state[ComponentNames.TeamsTab][StorageOutputs.indexPath.key] =
+        Constants.FrontendIndexPath;
     }
     return ok(undefined);
   }

--- a/packages/fx-core/templates/bicep/azureWebApp.provision.orchestration.bicep
+++ b/packages/fx-core/templates/bicep/azureWebApp.provision.orchestration.bicep
@@ -16,6 +16,9 @@ output azureWebApp{{scenario}}Output object = {
   appServicePlanName: azureWebApp{{scenario}}Provision.outputs.appServicePlanName
   resourceId: azureWebApp{{scenario}}Provision.outputs.resourceId
   siteEndpoint: azureWebApp{{scenario}}Provision.outputs.siteEndpoint
+  {{#if (equals "Tab" scenario )}}
+  endpoint: azureWebApp{{scenario}}Provision.outputs.siteEndpoint
+  {{/if}}
 }
 
 output {{scenario}}Output object = {

--- a/packages/fx-core/tests/component/feature/tab.test.ts
+++ b/packages/fx-core/tests/component/feature/tab.test.ts
@@ -155,7 +155,7 @@ describe("Tab Feature", () => {
     const res = await component.provision(context as ResourceContextV3, inputs);
     assert.isTrue(res.isOk());
     const tabState = context.envInfo.state?.[ComponentNames.TeamsTab];
-    assert.equal(tabState?.[StorageOutputs.indexPath.key], "");
+    assert.equal(tabState?.[StorageOutputs.indexPath.key], "/");
   });
   it("configure sso blazor tab", async () => {
     const appSettings = [


### PR DESCRIPTION
E2E TEST: https://github.com/OfficeDev/TeamsFx/blob/dev/packages/cli/tests/e2e/frontend/BlazorAppHappyPath.tests.ts#L46