### PR TITLE
fix: missing app setting in bot bicep

### DIFF
--- a/packages/fx-core/src/component/telemetry.ts
+++ b/packages/fx-core/src/component/telemetry.ts
@@ -216,6 +216,7 @@ export function sendMigratedErrorEvent(
       componentName = inputs?.["Scenario"] === Scenarios.Api ? PluginNames.FUNC : PluginNames.BOT;
       break;
     case "BotService":
+    case "BT":
       componentName = PluginNames.BOT;
       telemetryHelper.fillAppStudioErrorProperty(error.innerError, props);
       break;

--- a/packages/fx-core/templates/bicep/azureFunction.provision.module.bicep
+++ b/packages/fx-core/templates/bicep/azureFunction.provision.module.bicep
@@ -67,7 +67,7 @@ resource functionApp 'Microsoft.Web/sites@2021-02-01' = {
           name: 'WEBSITE_RUN_FROM_PACKAGE'
           value: '1' // Run Azure Function from a package file
         }
-        {{#if (contains "teams-bot" connections)}}
+        {{#if (equals "Bot" scenario)}}
         {
           name: 'RUNNING_ON_AZURE'
           value: '1'


### PR DESCRIPTION
E2E TEST: https://github.com/OfficeDev/TeamsFx/blob/a60ccbd7382893af421723268230b21ca45d0482/packages/cli/tests/e2e/bot/ProvisionFuncHostedNotificationBot.dotnet.tests.ts#L9