### PR TITLE
chore: set teamsfx sdk to alpha version in workflow bot

### DIFF
--- a/templates/bot/ts/workflow/package.json
+++ b/templates/bot/ts/workflow/package.json
@@ -19,7 +19,7 @@
     },
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
-        "@microsoft/teamsfx": "^1.0.0",
+        "@microsoft/teamsfx": "1.1.2-alpha",
         "botbuilder": "~4.17.0",
         "restify": "^8.5.1"
     },


### PR DESCRIPTION
Set the `@microsoft/teamsfx` package version to `1.1.2-alpha`, will change to official version when it is ready for public release.