### PR TITLE
test: remove auth endpoint in blazor app setting

### DIFF
--- a/packages/cli/tests/e2e/frontend/BlazorAppHappyPath.v3.tests.ts
+++ b/packages/cli/tests/e2e/frontend/BlazorAppHappyPath.v3.tests.ts
@@ -89,10 +89,6 @@ describe("Blazor App", function () {
       response[FrontendWebAppConfig.clientSecret],
       await getExpectedM365ClientSecret(context, projectPath, envName, activeResourcePlugins)
     );
-    chai.assert.include(
-      response[FrontendWebAppConfig.authEndpoint],
-      context[PluginId.FrontendHosting][StateConfigKey.frontendEndpoint]
-    );
     chai.assert.equal(
       response[FrontendWebAppConfig.authority],
       context[PluginId.Aad][StateConfigKey.oauthAuthority] as string


### PR DESCRIPTION
Auth endpoint app setting has been removed by this PR: https://github.com/OfficeDev/TeamsFx/pull/5984