### PR TITLE
feat(sdk): add AuthenticatonConfiguration to customConfig

### DIFF
--- a/docs/sdk/teamsfx.teamsfx._constructor_.md
+++ b/docs/sdk/teamsfx.teamsfx._constructor_.md
@@ -9,7 +9,7 @@ Constructor of TeamsFx
 <b>Signature:</b>
 
 ```typescript
-constructor(identityType?: IdentityType, customConfig?: Record<string, string>);
+constructor(identityType?: IdentityType, customConfig?: Record<string, string> | AuthenticationConfiguration);
 ```
 
 ## Parameters
@@ -17,7 +17,7 @@ constructor(identityType?: IdentityType, customConfig?: Record<string, string>);
 |  Parameter | Type | Description |
 |  --- | --- | --- |
 |  identityType | [IdentityType](./teamsfx.identitytype.md) | Choose user or app identity |
-|  customConfig | Record&lt;string, string&gt; | key/value pairs of customized configuration that overrides default ones. |
+|  customConfig | Record&lt;string, string&gt; \| [AuthenticationConfiguration](./teamsfx.authenticationconfiguration.md) | key/value pairs of customized configuration that overrides default ones. |
 
 ## Exceptions
 

--- a/packages/sdk/review/teamsfx.api.md
+++ b/packages/sdk/review/teamsfx.api.md
@@ -383,7 +383,7 @@ export interface TeamsBotSsoPromptTokenResponse extends TokenResponse {
 
 // @public
 export class TeamsFx implements TeamsFxConfiguration {
-    constructor(identityType?: IdentityType, customConfig?: Record<string, string>);
+    constructor(identityType?: IdentityType, customConfig?: Record<string, string> | AuthenticationConfiguration);
     getConfig(key: string): string;
     getConfigs(): Record<string, string>;
     getCredential(): TokenCredential;

--- a/packages/sdk/src/core/teamsfx.browser.ts
+++ b/packages/sdk/src/core/teamsfx.browser.ts
@@ -9,6 +9,7 @@ import { formatString } from "../util/utils";
 import { ErrorWithCode, ErrorCode, ErrorMessage } from "../core/errors";
 import { internalLogger } from "../util/logger";
 import { TeamsFxConfiguration } from "../models/teamsfxConfiguration";
+import { AuthenticationConfiguration } from "../models/configuration";
 
 /**
  * A class providing credential and configuration.
@@ -18,7 +19,10 @@ export class TeamsFx implements TeamsFxConfiguration {
   private teamsUserCredential?: TeamsUserCredential;
   public identityType: IdentityType;
 
-  constructor(identityType?: IdentityType, customConfig?: Record<string, string>) {
+  constructor(
+    identityType?: IdentityType,
+    customConfig?: Record<string, string> | AuthenticationConfiguration
+  ) {
     this.identityType = identityType ?? IdentityType.User;
     if (this.identityType !== IdentityType.User) {
       const errorMsg = formatString(
@@ -32,8 +36,9 @@ export class TeamsFx implements TeamsFxConfiguration {
     this.configuration = new Map<string, string>();
     this.loadFromEnv();
     if (customConfig) {
-      for (const key of Object.keys(customConfig)) {
-        const value = customConfig[key];
+      const myConfig: Record<string, string> = { ...customConfig };
+      for (const key of Object.keys(myConfig)) {
+        const value = myConfig[key];
         if (value) {
           this.configuration.set(key, value);
         }

--- a/packages/sdk/src/core/teamsfx.ts
+++ b/packages/sdk/src/core/teamsfx.ts
@@ -10,6 +10,7 @@ import { formatString } from "../util/utils";
 import { ErrorWithCode, ErrorCode, ErrorMessage } from "../core/errors";
 import { internalLogger } from "../util/logger";
 import { TeamsFxConfiguration } from "../models/teamsfxConfiguration";
+import { AuthenticationConfiguration } from "../models/configuration";
 
 // Following keys are used by SDK internally
 const ReservedKey: Set<string> = new Set<string>([
@@ -45,13 +46,17 @@ export class TeamsFx implements TeamsFxConfiguration {
    *
    * @throws {@link ErrorCode|IdentityTypeNotSupported} when setting app identity in browser.
    */
-  constructor(identityType?: IdentityType, customConfig?: Record<string, string>) {
+  constructor(
+    identityType?: IdentityType,
+    customConfig?: Record<string, string> | AuthenticationConfiguration
+  ) {
     this.identityType = identityType ?? IdentityType.User;
     this.configuration = new Map<string, string>();
     this.loadFromEnv();
     if (customConfig) {
-      for (const key of Object.keys(customConfig)) {
-        const value = customConfig[key];
+      const myConfig: Record<string, string> = { ...customConfig };
+      for (const key of Object.keys(myConfig)) {
+        const value = myConfig[key];
         if (value) {
           this.configuration.set(key, value);
         }


### PR DESCRIPTION
E2E TEST: N/A
Add an AuthenticatonConfiguration to customConfig in constructor of TeamsFx, so that user can get some property prompts of configurations while creating an instance of TeamsFx class.