### PR TITLE
chore: error result when only resource group name is provided in config file

### DIFF
--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -377,6 +377,7 @@
   "error.FailedToParseResourceIdError": "Failed to get '%s' from resource id: '%s'",
   "error.M365AccountNotMatch": "The signed in Microsoft 365 account does not match the Microsoft 365 tenant in config file for '%s' environment. Please sign out and sign in with the correct Microsoft 365 account.",
   "error.MissingStep": "Step \"%s\" is required before %s. Run the required step first.",
+  "error.MissingSubscriptionInConfig": "Please provide the subscrpition id of the resource group (%s) in (%s)",
   "error.NoSubscriptionFound": "User canceled. For Teams to trust the self-signed SSL certificate used by the toolkit, a self-signed certificate must be added to your certificate store.",
   "error.TrustCertificateCancelError": "Failed to find a subscription.",
   "error.ResourceGroupNotFound1": "Resource group '%s' does not exist, please specify an existing resource group.",

--- a/packages/fx-core/src/common/telemetry.ts
+++ b/packages/fx-core/src/common/telemetry.ts
@@ -38,6 +38,7 @@ export enum TelemetryProperty {
   TemplateFallback = "template-fallback",
   HasSwitchedSubscription = "has-switched-subscription",
   HasSwitchedM365Tenant = "has-switched-m365",
+  CustomizeSubscriptionType = "customize-subscription-type",
 }
 
 export enum TelemetryEvent {
@@ -136,6 +137,13 @@ export enum CustomizeResourceGroupType {
   InteractiveCreateCustomized = "interactive-create-customized",
   InteractiveUseExisting = "interactive-use-existing",
   FallbackDefault = "fallback-default",
+}
+
+export enum CustomizeSubscriptionType {
+  CommandLine = "command-line",
+  EnvConfig = "env-config",
+  EnvState = "env-state",
+  Default = "default",
 }
 
 export enum ProjectMigratorStatus {

--- a/packages/fx-core/src/component/provisionUtils.ts
+++ b/packages/fx-core/src/component/provisionUtils.ts
@@ -419,12 +419,12 @@ export class ProvisionUtils {
     tokenProvider: TokenProvider
   ): Promise<Result<FillInAzureConfigsResult, FxError>> {
     //1. check subscriptionId
-    const targetSubscriptionId = inputs.targetSubscriptionId;
+    const targetSubscriptionIdFromCLI = inputs.targetSubscriptionId;
     const subscriptionResult = await this.checkProvisionSubscription(
       ctx,
       envInfo,
       tokenProvider.azureAccountProvider,
-      targetSubscriptionId,
+      targetSubscriptionIdFromCLI,
       inputs.env
     );
 
@@ -502,7 +502,7 @@ export class ProvisionUtils {
           CustomizeResourceGroupType.CommandLine;
         resourceGroupInfo = getRes.value;
       }
-    } else if (resourceGroupNameFromEnvConfig) {
+    } else if (resourceGroupNameFromEnvConfig && !targetSubscriptionIdFromCLI) {
       const resourceGroupName = resourceGroupNameFromEnvConfig;
       const envFile = EnvConfigFileNameTemplate.replace(EnvNamePlaceholder, inputs.envName);
       if (!envInfo.config.azure?.subscriptionId) {
@@ -531,7 +531,11 @@ export class ProvisionUtils {
       telemetryProperties[TelemetryProperty.CustomizeResourceGroupType] =
         CustomizeResourceGroupType.EnvConfig;
       resourceGroupInfo = getRes.value;
-    } else if (resourceGroupNameFromState && resourceGroupLocationFromState) {
+    } else if (
+      resourceGroupNameFromState &&
+      resourceGroupLocationFromState &&
+      !targetSubscriptionIdFromCLI
+    ) {
       const checkRes = await resourceGroupHelper.checkResourceGroupExistence(
         resourceGroupNameFromState,
         rmClient

--- a/packages/fx-core/src/component/provisionUtils.ts
+++ b/packages/fx-core/src/component/provisionUtils.ts
@@ -29,7 +29,12 @@ import { v4 as uuidv4 } from "uuid";
 import { PluginDisplayName } from "../common/constants";
 import { getDefaultString, getLocalizedString } from "../common/localizeUtils";
 import { hasAzureResourceV3 } from "../common/projectSettingsHelperV3";
-import { CustomizeResourceGroupType, TelemetryEvent, TelemetryProperty } from "../common/telemetry";
+import {
+  CustomizeResourceGroupType,
+  CustomizeSubscriptionType,
+  TelemetryEvent,
+  TelemetryProperty,
+} from "../common/telemetry";
 import { getHashedEnv } from "../common/tools";
 import { convertToAlphanumericOnly } from "../common/utils";
 import { globalVars } from "../core";
@@ -204,7 +209,8 @@ export class ProvisionUtils {
     ctx: v2.Context,
     envInfo: v3.EnvInfoV3,
     azureAccountProvider: AzureAccountProvider,
-    targetSubscriptionIdFromCLI: string | undefined
+    targetSubscriptionIdFromCLI: string | undefined,
+    envName: string | undefined
   ): Promise<Result<ProvisionSubscriptionCheckResult, FxError>> {
     const subscriptionIdInConfig: string | undefined = envInfo.config.azure?.subscriptionId;
     const subscriptionNameInConfig: string | undefined =
@@ -213,6 +219,10 @@ export class ProvisionUtils {
     const subscriptionNameInState: string | undefined =
       envInfo.state.solution.subscriptionName || subscriptionIdInState;
 
+    ctx.telemetryReporter?.sendTelemetryEvent(
+      TelemetryEvent.CheckSubscriptionStart,
+      envName ? { [TelemetryProperty.Env]: getHashedEnv(envName) } : {}
+    );
     if (!subscriptionIdInState && !subscriptionIdInConfig && !targetSubscriptionIdFromCLI) {
       const subscriptionInAccount = await azureAccountProvider.getSelectedSubscription(true);
       if (!subscriptionInAccount) {
@@ -226,6 +236,11 @@ export class ProvisionUtils {
       } else {
         this.updateEnvInfoSubscription(envInfo, subscriptionInAccount);
         ctx.logProvider.info(`[${PluginDisplayName.Solution}] checkAzureSubscription pass!`);
+        ctx.telemetryReporter?.sendTelemetryEvent(TelemetryEvent.CheckSubscription, {
+          [TelemetryProperty.Env]: !envName ? "" : getHashedEnv(envName),
+          [TelemetryProperty.HasSwitchedSubscription]: "false",
+          [TelemetryProperty.CustomizeSubscriptionType]: CustomizeSubscriptionType.Default,
+        });
         return ok({ hasSwitchedSubscription: false });
       }
     }
@@ -251,7 +266,14 @@ export class ProvisionUtils {
       } else {
         this.updateEnvInfoSubscription(envInfo, targetSubscriptionInfo);
         ctx.logProvider.info(`[${PluginDisplayName.Solution}] checkAzureSubscription pass!`);
-        return ok({ hasSwitchedSubscription: false });
+        return this.compareWithStateSubscription(
+          ctx,
+          envInfo,
+          targetSubscriptionInfo,
+          subscriptionIdInState,
+          envName,
+          CustomizeSubscriptionType.CommandLine
+        );
       }
     }
 
@@ -276,7 +298,9 @@ export class ProvisionUtils {
           ctx,
           envInfo,
           targetConfigSubInfo,
-          subscriptionIdInState
+          subscriptionIdInState,
+          envName,
+          CustomizeSubscriptionType.EnvConfig
         );
       }
     } else {
@@ -304,7 +328,9 @@ export class ProvisionUtils {
           ctx,
           envInfo,
           subscriptionInAccount,
-          subscriptionIdInState
+          subscriptionIdInState,
+          envName,
+          CustomizeSubscriptionType.EnvState
         );
       }
     }
@@ -320,19 +346,30 @@ export class ProvisionUtils {
     ctx: v2.Context,
     envInfo: v3.EnvInfoV3,
     targetSubscriptionInfo: SubscriptionInfo,
-    subscriptionInStateId: string | undefined
+    subscriptionInStateId: string | undefined,
+    envName: string | undefined,
+    customizeSubscriptionType: CustomizeSubscriptionType
   ): Promise<Result<ProvisionSubscriptionCheckResult, FxError>> {
     const hasSwitchedSubscription =
       !!subscriptionInStateId && targetSubscriptionInfo.subscriptionId !== subscriptionInStateId;
     if (hasSwitchedSubscription) {
       this.updateEnvInfoSubscription(envInfo, targetSubscriptionInfo);
       this.clearEnvInfoStateResource(envInfo);
-
       ctx.logProvider.info(`[${PluginDisplayName.Solution}] checkAzureSubscription pass!`);
+      ctx.telemetryReporter?.sendTelemetryEvent(TelemetryEvent.CheckSubscription, {
+        [TelemetryProperty.Env]: !envName ? "" : getHashedEnv(envName),
+        [TelemetryProperty.HasSwitchedSubscription]: "true",
+        [TelemetryProperty.CustomizeSubscriptionType]: customizeSubscriptionType,
+      });
       return ok({ hasSwitchedSubscription: true });
     } else {
       this.updateEnvInfoSubscription(envInfo, targetSubscriptionInfo);
       ctx.logProvider.info(`[${PluginDisplayName.Solution}] checkAzureSubscription pass!`);
+      ctx.telemetryReporter?.sendTelemetryEvent(TelemetryEvent.CheckSubscription, {
+        [TelemetryProperty.Env]: !envName ? "" : getHashedEnv(envName),
+        [TelemetryProperty.HasSwitchedSubscription]: "false",
+        [TelemetryProperty.CustomizeSubscriptionType]: customizeSubscriptionType,
+      });
       return ok({ hasSwitchedSubscription: false });
     }
   }
@@ -382,28 +419,18 @@ export class ProvisionUtils {
     tokenProvider: TokenProvider
   ): Promise<Result<FillInAzureConfigsResult, FxError>> {
     //1. check subscriptionId
-    ctx.telemetryReporter?.sendTelemetryEvent(
-      TelemetryEvent.CheckSubscriptionStart,
-      inputs.env ? { [TelemetryProperty.Env]: getHashedEnv(inputs.env) } : {}
-    );
-
     const targetSubscriptionId = inputs.targetSubscriptionId;
     const subscriptionResult = await this.checkProvisionSubscription(
       ctx,
       envInfo,
       tokenProvider.azureAccountProvider,
-      targetSubscriptionId
+      targetSubscriptionId,
+      inputs.env
     );
 
     if (subscriptionResult.isErr()) {
       return err(subscriptionResult.error);
     }
-
-    ctx.telemetryReporter?.sendTelemetryEvent(TelemetryEvent.CheckSubscription, {
-      [TelemetryProperty.Env]: !inputs.env ? "" : getHashedEnv(inputs.env),
-      [TelemetryProperty.HasSwitchedSubscription]:
-        subscriptionResult.value.hasSwitchedSubscription.toString(),
-    });
 
     // Note setSubscription here will change the token returned by getAccountCredentialAsync according to the subscription selected.
     // So getting azureToken needs to precede setSubscription.
@@ -477,11 +504,22 @@ export class ProvisionUtils {
       }
     } else if (resourceGroupNameFromEnvConfig) {
       const resourceGroupName = resourceGroupNameFromEnvConfig;
+      const envFile = EnvConfigFileNameTemplate.replace(EnvNamePlaceholder, inputs.envName);
+      if (!envInfo.config.azure?.subscriptionId) {
+        return err(
+          new UserError(
+            SolutionSource,
+            SolutionError.MissingSubscriptionIdInConfig,
+            getDefaultString("error.MissingSubscriptionInConfig", resourceGroupName, envFile),
+            getLocalizedString("error.MissingSubscriptionInConfig", resourceGroupName, envFile)
+          )
+        );
+      }
+
       const getRes = await resourceGroupHelper.getResourceGroupInfo(resourceGroupName, rmClient);
       if (getRes.isErr()) return err(getRes.error);
       if (!getRes.value) {
         // Currently we do not support creating resource group by input config, so just throw an error.
-        const envFile = EnvConfigFileNameTemplate.replace(EnvNamePlaceholder, inputs.envName);
         return err(
           new UserError(
             SolutionSource,

--- a/packages/fx-core/src/core/middleware/envInfoWriter.ts
+++ b/packages/fx-core/src/core/middleware/envInfoWriter.ts
@@ -50,6 +50,7 @@ export function shouldSkipWriteEnvInfo(
     (res.error.name === "CancelProvision" ||
       res.error.name === SolutionError.FailedToUpdateAzureParameters ||
       res.error.name === SolutionError.FailedToBackupFiles ||
+      res.error.name === SolutionError.MissingSubscriptionIdInConfig ||
       (res.error.name === "UserCancel" &&
         (method === "provisionResourcesV2" || method === "provisionResourcesV3")))
   );

--- a/packages/fx-core/src/plugins/solution/fx-solution/constants.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/constants.ts
@@ -161,6 +161,7 @@ export enum SolutionError {
   FailedToCreateAuthFiles = "FailedToCreateAuthFiles",
   FailedToUpdateAzureParameters = "FailedToUpdateAzureParameters",
   FailedToBackupFiles = "FailedToBackupFiles",
+  MissingSubscriptionIdInConfig = "MissingSubscriptionIdInConfig",
 }
 
 export const LOCAL_DEBUG_TAB_ENDPOINT = "localTabEndpoint";

--- a/packages/fx-core/tests/component/provisionUtils.test.ts
+++ b/packages/fx-core/tests/component/provisionUtils.test.ts
@@ -1,31 +1,14 @@
-import {
-  LogLevel,
-  LogProvider,
-  ok,
-  Ok,
-  ProjectSettings,
-  ResourceContextV3,
-} from "@microsoft/teamsfx-api";
+import { ok, Platform, v2 } from "@microsoft/teamsfx-api";
 import chai from "chai";
-import p from "proxyquire";
 import * as sinon from "sinon";
 import { provisionUtils } from "../../src/component/provisionUtils";
 import { createContextV3 } from "../../src/component/utils";
 import { SolutionError } from "../../src/plugins/solution";
+import { resourceGroupHelper } from "../../src/plugins/solution/fx-solution/utils/ResourceGroupHelper";
 import { MockAzureAccountProvider } from "../core/utils";
 import { TestHelper } from "../plugins/resource/frontend/helper";
 
 const expect = chai.expect;
-
-function MockContext(): any {
-  return {
-    envInfo: {
-      envName: "test",
-      config: {},
-      state: { solution: {} },
-    },
-  };
-}
 
 describe("checkProvisionSubscription", () => {
   const mocker = sinon.createSandbox();
@@ -58,7 +41,8 @@ describe("checkProvisionSubscription", () => {
       context,
       envInfo,
       azureAccountProvider,
-      "cli-sub"
+      "cli-sub",
+      "test"
     );
 
     expect(res.isOk()).equal(true);
@@ -92,7 +76,8 @@ describe("checkProvisionSubscription", () => {
       context,
       envInfo,
       azureAccountProvider,
-      "cli-sub"
+      "cli-sub",
+      "test"
     );
 
     expect(res.isErr()).equal(true);
@@ -130,7 +115,8 @@ describe("checkProvisionSubscription", () => {
       context,
       envInfo,
       azureAccountProvider,
-      undefined
+      undefined,
+      "test"
     );
 
     expect(res.isErr()).equal(true);
@@ -168,7 +154,8 @@ describe("checkProvisionSubscription", () => {
       context,
       envInfo,
       azureAccountProvider,
-      undefined
+      undefined,
+      "test"
     );
 
     expect(res.isOk()).equal(true);
@@ -176,5 +163,243 @@ describe("checkProvisionSubscription", () => {
       console.log(res.error);
     }
     expect((envInfo.state.solution as any).subscriptionId).equal("mockSub");
+  });
+});
+
+describe("fillInAzureConfigs", () => {
+  const mocker = sinon.createSandbox();
+
+  afterEach(() => {
+    mocker.restore();
+  });
+
+  it("provision with CLI parameters succeeds", async () => {
+    const context = createContextV3();
+    const azureAccountProvider = new MockAzureAccountProvider();
+    const envInfo = {
+      envName: "test",
+      config: {},
+      state: { solution: {} },
+    };
+    const inputs: v2.InputsWithProjectPath = {
+      platform: Platform.CLI,
+      projectPath: "path",
+      targetSubscriptionId: "cli-sub",
+      targetResourceGroupName: "cli-rg",
+    };
+    mocker.stub(context.logProvider, "log").resolves(true);
+    mocker
+      .stub(azureAccountProvider, "getAccountCredentialAsync")
+      .resolves(TestHelper.fakeCredential);
+    mocker.stub(resourceGroupHelper, "getResourceGroupInfo").resolves(
+      ok({
+        createNewResourceGroup: false,
+        name: "cli-rg",
+        location: "East US",
+      })
+    );
+    mocker.stub(azureAccountProvider, "listSubscriptions").resolves([
+      {
+        subscriptionName: "mockSubName",
+        subscriptionId: "cli-sub",
+        tenantId: "mockTenantId",
+      },
+    ]);
+    const tokenProvider = { azureAccountProvider };
+
+    const res = await provisionUtils.fillInAzureConfigs(
+      context,
+      inputs,
+      envInfo,
+      tokenProvider as any
+    );
+
+    if (res.isErr()) {
+      console.log(res.error);
+    }
+    expect(res.isOk()).equal(true);
+    expect((envInfo.state.solution as any).subscriptionId).equal("cli-sub");
+    expect((envInfo.state.solution as any).resourceGroupName).equal("cli-rg");
+  });
+
+  it("provision with CLI parameters resource group not exist", async () => {
+    const context = createContextV3();
+    const azureAccountProvider = new MockAzureAccountProvider();
+    const envInfo = {
+      envName: "test",
+      config: {},
+      state: { solution: {} },
+    };
+    const inputs: v2.InputsWithProjectPath = {
+      platform: Platform.CLI,
+      projectPath: "path",
+      targetSubscriptionId: "cli-sub",
+      targetResourceGroupName: "cli-rg",
+    };
+    mocker.stub(context.logProvider, "log").resolves(true);
+    mocker
+      .stub(azureAccountProvider, "getAccountCredentialAsync")
+      .resolves(TestHelper.fakeCredential);
+    mocker.stub(resourceGroupHelper, "getResourceGroupInfo").resolves(ok(undefined));
+    mocker.stub(azureAccountProvider, "listSubscriptions").resolves([
+      {
+        subscriptionName: "mockSubName",
+        subscriptionId: "cli-sub",
+        tenantId: "mockTenantId",
+      },
+    ]);
+    const tokenProvider = { azureAccountProvider };
+
+    const res = await provisionUtils.fillInAzureConfigs(
+      context,
+      inputs,
+      envInfo,
+      tokenProvider as any
+    );
+    expect(res.isErr()).equal(true);
+    if (res.isErr()) {
+      expect(res.error.name).equal(SolutionError.ResourceGroupNotFound);
+    }
+  });
+
+  it("provision with resource group name from config file succeeds", async () => {
+    const context = createContextV3();
+    const azureAccountProvider = new MockAzureAccountProvider();
+    const envInfo = {
+      envName: "test",
+      config: {
+        azure: {
+          subscriptionId: "mockSub",
+          resourceGroupName: "mockRg",
+        },
+      },
+      state: { solution: {} },
+    };
+    const inputs: v2.InputsWithProjectPath = {
+      platform: Platform.CLI,
+      projectPath: "path",
+    };
+    mocker.stub(context.logProvider, "log").resolves(true);
+    mocker
+      .stub(azureAccountProvider, "getAccountCredentialAsync")
+      .resolves(TestHelper.fakeCredential);
+    mocker.stub(resourceGroupHelper, "getResourceGroupInfo").resolves(
+      ok({
+        createNewResourceGroup: false,
+        name: "mockRg",
+        location: "East US",
+      })
+    );
+    mocker.stub(azureAccountProvider, "listSubscriptions").resolves([
+      {
+        subscriptionName: "mockSubName",
+        subscriptionId: "mockSub",
+        tenantId: "mockTenantId",
+      },
+    ]);
+    const tokenProvider = { azureAccountProvider };
+
+    const res = await provisionUtils.fillInAzureConfigs(
+      context,
+      inputs,
+      envInfo,
+      tokenProvider as any
+    );
+
+    expect(res.isOk()).equal(true);
+    expect((envInfo.state.solution as any).subscriptionId).equal("mockSub");
+    expect((envInfo.state.solution as any).resourceGroupName).equal("mockRg");
+  });
+
+  it("provision with resource group name from config file not exist", async () => {
+    const context = createContextV3();
+    const azureAccountProvider = new MockAzureAccountProvider();
+    const envInfo = {
+      envName: "test",
+      config: {
+        azure: {
+          subscriptionId: "mockSub",
+          resourceGroupName: "mockRg",
+        },
+      },
+      state: { solution: {} },
+    };
+    const inputs: v2.InputsWithProjectPath = {
+      platform: Platform.CLI,
+      projectPath: "path",
+    };
+    mocker.stub(context.logProvider, "log").resolves(true);
+    mocker
+      .stub(azureAccountProvider, "getAccountCredentialAsync")
+      .resolves(TestHelper.fakeCredential);
+    mocker.stub(resourceGroupHelper, "getResourceGroupInfo").resolves(ok(undefined));
+    mocker.stub(azureAccountProvider, "listSubscriptions").resolves([
+      {
+        subscriptionName: "mockSubName",
+        subscriptionId: "mockSub",
+        tenantId: "mockTenantId",
+      },
+    ]);
+    const tokenProvider = { azureAccountProvider };
+
+    const res = await provisionUtils.fillInAzureConfigs(
+      context,
+      inputs,
+      envInfo,
+      tokenProvider as any
+    );
+
+    expect(res.isErr()).equal(true);
+    if (res.isErr()) {
+      expect(res.error.name).equal(SolutionError.ResourceGroupNotFound);
+    }
+  });
+
+  it("provision with resource group name from config file but missing subscription id", async () => {
+    const context = createContextV3();
+    const azureAccountProvider = new MockAzureAccountProvider();
+    const envInfo = {
+      envName: "test",
+      config: {
+        azure: {
+          resourceGroupName: "mockRg",
+        },
+      },
+      state: { solution: {} },
+    };
+    const inputs: v2.InputsWithProjectPath = {
+      platform: Platform.CLI,
+      projectPath: "path",
+    };
+    mocker.stub(context.logProvider, "log").resolves(true);
+    mocker
+      .stub(azureAccountProvider, "getAccountCredentialAsync")
+      .resolves(TestHelper.fakeCredential);
+    mocker.stub(resourceGroupHelper, "getResourceGroupInfo").resolves(ok(undefined));
+    mocker.stub(azureAccountProvider, "listSubscriptions").resolves([
+      {
+        subscriptionName: "mockSubName",
+        subscriptionId: "mockSub",
+        tenantId: "mockTenantId",
+      },
+    ]);
+    mocker.stub(azureAccountProvider, "getSelectedSubscription").resolves({
+      subscriptionName: "mockSubName",
+      subscriptionId: "mockSub",
+      tenantId: "mockTenantId",
+    });
+    const tokenProvider = { azureAccountProvider };
+
+    const res = await provisionUtils.fillInAzureConfigs(
+      context,
+      inputs,
+      envInfo,
+      tokenProvider as any
+    );
+
+    expect(res.isErr()).equal(true);
+    if (res.isErr()) {
+      expect(res.error.name).equal(SolutionError.MissingSubscriptionIdInConfig);
+    }
   });
 });

--- a/packages/fx-core/tests/component/provisionUtils.test.ts
+++ b/packages/fx-core/tests/component/provisionUtils.test.ts
@@ -222,6 +222,54 @@ describe("fillInAzureConfigs", () => {
     expect((envInfo.state.solution as any).resourceGroupName).equal("cli-rg");
   });
 
+  it("provision with subscriptionId from CLI parameters succeeds", async () => {
+    const context = createContextV3();
+    const azureAccountProvider = new MockAzureAccountProvider();
+    const envInfo = {
+      envName: "test",
+      config: {},
+      state: { solution: { subscriptionId: "oldSubId", resourceGroupName: "oldRgName" } },
+    };
+    const inputs: v2.InputsWithProjectPath = {
+      platform: Platform.CLI,
+      projectPath: "path",
+      targetSubscriptionId: "cli-sub",
+    };
+    mocker.stub(context.logProvider, "log").resolves(true);
+    mocker
+      .stub(azureAccountProvider, "getAccountCredentialAsync")
+      .resolves(TestHelper.fakeCredential);
+    mocker.stub(resourceGroupHelper, "askResourceGroupInfo").resolves(
+      ok({
+        createNewResourceGroup: false,
+        name: "newRg",
+        location: "East US",
+      })
+    );
+    mocker.stub(azureAccountProvider, "listSubscriptions").resolves([
+      {
+        subscriptionName: "mockSubName",
+        subscriptionId: "cli-sub",
+        tenantId: "mockTenantId",
+      },
+    ]);
+    const tokenProvider = { azureAccountProvider };
+
+    const res = await provisionUtils.fillInAzureConfigs(
+      context,
+      inputs,
+      envInfo,
+      tokenProvider as any
+    );
+
+    if (res.isErr()) {
+      console.log(res.error);
+    }
+    expect(res.isOk()).equal(true);
+    expect((envInfo.state.solution as any).subscriptionId).equal("cli-sub");
+    expect((envInfo.state.solution as any).resourceGroupName).equal("newRg");
+  });
+
   it("provision with CLI parameters resource group not exist", async () => {
     const context = createContextV3();
     const azureAccountProvider = new MockAzureAccountProvider();
@@ -401,5 +449,57 @@ describe("fillInAzureConfigs", () => {
     if (res.isErr()) {
       expect(res.error.name).equal(SolutionError.MissingSubscriptionIdInConfig);
     }
+  });
+
+  it("provision with state", async () => {
+    const context = createContextV3();
+    const azureAccountProvider = new MockAzureAccountProvider();
+    const envInfo = {
+      envName: "test",
+      config: {},
+      state: {
+        solution: {
+          subscriptionId: "mockSub",
+          resourceGroupName: "mockRg",
+          location: "East US",
+        },
+      },
+    };
+    const inputs: v2.InputsWithProjectPath = {
+      platform: Platform.CLI,
+      projectPath: "path",
+    };
+    mocker.stub(context.logProvider, "log").resolves(true);
+    mocker
+      .stub(azureAccountProvider, "getAccountCredentialAsync")
+      .resolves(TestHelper.fakeCredential);
+    mocker.stub(resourceGroupHelper, "checkResourceGroupExistence").resolves(ok(true));
+    mocker.stub(azureAccountProvider, "getSelectedSubscription").resolves({
+      subscriptionName: "mockSubName",
+      subscriptionId: "mockSub",
+      tenantId: "mockTenantId",
+    });
+    mocker.stub(azureAccountProvider, "listSubscriptions").resolves([
+      {
+        subscriptionName: "mockSubName",
+        subscriptionId: "mockSub",
+        tenantId: "mockTenantId",
+      },
+    ]);
+    const tokenProvider = { azureAccountProvider };
+
+    const res = await provisionUtils.fillInAzureConfigs(
+      context,
+      inputs,
+      envInfo,
+      tokenProvider as any
+    );
+
+    if (res.isErr()) {
+      console.log(res.error);
+    }
+    expect(res.isOk()).equal(true);
+    expect((envInfo.state.solution as any).subscriptionId).equal("mockSub");
+    expect((envInfo.state.solution as any).resourceGroupName).equal("mockRg");
   });
 });


### PR DESCRIPTION
- return error if user just specify rg name in config file but miss subscription id of the resource group.
- add telemetry for subscription type