### PR TITLE
fix(e2e): increase the e2e test case timeout to 1200s

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -224,7 +224,7 @@ jobs:
             echo "can't find target case in $file"
             exit 1
           else
-            npx mocha --reporter mochawesome --timeout 900000 $file
+            npx mocha --reporter mochawesome --timeout 1200000 $file
           fi
 
       - name: get job id


### PR DESCRIPTION
The test case `tests/e2e/bot/ProvisionAppServiceNotificationBot.tests.ts` needs more than 900s.
Increare the timeout.

Success run: https://github.com/OfficeDev/TeamsFx/runs/8182676137?check_suite_focus=true

E2E TEST: https://github.com/OfficeDev/TeamsFx/blob/aafbd90da64e10da018013ab6d8cb4e85ad51b35/packages/cli/tests/e2e/bot/ProvisionAppServiceNotificationBot.v3.tests.ts#L11