### PR TITLE
chore: should not use subscription id from config if user just pass resource group through cli

### DIFF
--- a/packages/fx-core/src/component/provisionUtils.ts
+++ b/packages/fx-core/src/component/provisionUtils.ts
@@ -428,7 +428,9 @@ export class ProvisionUtils {
       tokenProvider.azureAccountProvider,
       targetSubscriptionIdFromCLI,
       inputs.env,
-      !!inputs.targetResourceGroupName && !targetSubscriptionIdFromCLI
+      !!inputs.targetResourceGroupName &&
+        !targetSubscriptionIdFromCLI &&
+        inputs.platform === Platform.CLI
     );
 
     if (subscriptionResult.isErr()) {

--- a/packages/fx-core/src/component/provisionUtils.ts
+++ b/packages/fx-core/src/component/provisionUtils.ts
@@ -210,7 +210,8 @@ export class ProvisionUtils {
     envInfo: v3.EnvInfoV3,
     azureAccountProvider: AzureAccountProvider,
     targetSubscriptionIdFromCLI: string | undefined,
-    envName: string | undefined
+    envName: string | undefined,
+    isResourceGroupOnlyFromCLI: boolean
   ): Promise<Result<ProvisionSubscriptionCheckResult, FxError>> {
     const subscriptionIdInConfig: string | undefined = envInfo.config.azure?.subscriptionId;
     const subscriptionNameInConfig: string | undefined =
@@ -223,6 +224,7 @@ export class ProvisionUtils {
       TelemetryEvent.CheckSubscriptionStart,
       envName ? { [TelemetryProperty.Env]: getHashedEnv(envName) } : {}
     );
+
     if (!subscriptionIdInState && !subscriptionIdInConfig && !targetSubscriptionIdFromCLI) {
       const subscriptionInAccount = await azureAccountProvider.getSelectedSubscription(true);
       if (!subscriptionInAccount) {
@@ -277,7 +279,7 @@ export class ProvisionUtils {
       }
     }
 
-    if (subscriptionIdInConfig) {
+    if (subscriptionIdInConfig && !isResourceGroupOnlyFromCLI) {
       const targetConfigSubInfo = findSubscriptionFromList(subscriptionIdInConfig, subscriptions);
 
       if (!targetConfigSubInfo) {
@@ -425,7 +427,8 @@ export class ProvisionUtils {
       envInfo,
       tokenProvider.azureAccountProvider,
       targetSubscriptionIdFromCLI,
-      inputs.env
+      inputs.env,
+      !!inputs.targetResourceGroupName && !targetSubscriptionIdFromCLI
     );
 
     if (subscriptionResult.isErr()) {


### PR DESCRIPTION
- use selected subscription id if user is passing resource group name from cli parameter