### PR TITLE
chore(localdebug): add new localdebug task variables

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -1091,6 +1091,30 @@
         }
       },
       {
+        "name": "teamsfx-local-tunnel-watch",
+        "label": "TeamsFx Local Tunnel Problems",
+        "owner": "Teams Toolkit",
+        "source": "teamsfx",
+        "applyTo": "allDocuments",
+        "fileLocation": [
+          "relative",
+          "${workspaceFolder}"
+        ],
+        "pattern": [
+          {
+            "regexp": "^.*$",
+            "file": 0,
+            "location": 1,
+            "message": 2
+          }
+        ],
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "Starting local tunnel service",
+          "endsPattern": "Local tunnel service is started successfully|Failed to start local tunnel service"
+        }
+      },
+      {
         "name": "teamsfx-bot-watch",
         "label": "TeamsFx Bot Problems",
         "owner": "Teams Toolkit",

--- a/packages/vscode-extension/src/debug/constants.ts
+++ b/packages/vscode-extension/src/debug/constants.ts
@@ -214,3 +214,9 @@ export const prepareManifestDisplayMessages: DisplayMessages = {
   errorMessageLink: "teamstoolkit.localDebug.outputPanel",
   errorHelpLink: "https://aka.ms/teamsfx-debug-prepare-manifest",
 };
+
+export const localTunnelDisplayMessages = Object.freeze({
+  startMessage: "Starting local tunnel service.",
+  successMessage: "Local tunnel service is started successfully.",
+  errorMessage: "Failed to start local tunnel service.",
+});

--- a/packages/vscode-extension/src/debug/taskTerminal/baseTaskTerminal.ts
+++ b/packages/vscode-extension/src/debug/taskTerminal/baseTaskTerminal.ts
@@ -55,7 +55,12 @@ export abstract class BaseTaskTerminal implements vscode.Pseudoterminal {
   protected abstract do(): Promise<Result<Void, FxError>>;
 
   public static resolveTeamsFxVariables(str: string): string {
-    return str.replace("${teamsfx:workspaceFolder}", globalVariables.workspaceUri?.fsPath ?? "");
+    // Background task cannot resolve variables in VSC. /packages/vscode-extension/src/debug/taskTerminal/baseTaskTerminal.ts
+    // Here Teams Toolkit resolve the workspaceFolder.
+    // TODO: remove one after decide to use which placeholder
+    str = str.replace("${teamsfx:workspaceFolder}", globalVariables.workspaceUri?.fsPath ?? "");
+    str = str.replace("${workspaceFolder}", globalVariables.workspaceUri?.fsPath ?? "");
+    return str;
   }
 
   public static taskDefinitionError(argName: string): UserError {

--- a/packages/vscode-extension/src/debug/taskTerminal/baseTaskTerminal.ts
+++ b/packages/vscode-extension/src/debug/taskTerminal/baseTaskTerminal.ts
@@ -55,7 +55,7 @@ export abstract class BaseTaskTerminal implements vscode.Pseudoterminal {
   protected abstract do(): Promise<Result<Void, FxError>>;
 
   public static resolveTeamsFxVariables(str: string): string {
-    // Background task cannot resolve variables in VSC. /packages/vscode-extension/src/debug/taskTerminal/baseTaskTerminal.ts
+    // Background task cannot resolve variables in VSC.
     // Here Teams Toolkit resolve the workspaceFolder.
     // TODO: remove one after decide to use which placeholder
     str = str.replace("${teamsfx:workspaceFolder}", globalVariables.workspaceUri?.fsPath ?? "");

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -57,6 +57,7 @@ import {
 import { loadLocalizedStrings } from "./utils/localizeUtils";
 import { ExtensionSurvey } from "./utils/survey";
 import { ExtensionUpgrade } from "./utils/upgrade";
+import { LocalTunnelTaskTerminal } from "./debug/taskTerminal/localTunnelTaskTerminal";
 
 export let VS_CODE_UI: VsCodeUI;
 
@@ -234,6 +235,19 @@ function registerInternalCommands(context: vscode.ExtensionContext) {
     Correlator.run(handlers.getDotnetPathHandler)
   );
   context.subscriptions.push(getDotnetPathCmd);
+
+  // TODO: remove one after decide to use which placeholder
+  const getNgrokPathCmd = vscode.commands.registerCommand("fx-extension.get-ngrok-path", () =>
+    Correlator.run(() => LocalTunnelTaskTerminal.getNgrokBinFolder())
+  );
+  context.subscriptions.push(getNgrokPathCmd);
+
+  // TODO: remove one after decide to use which placeholder
+  const getTunnelEndpointCmd = vscode.commands.registerCommand(
+    "fx-extension.get-local-tunnel-endpoint",
+    () => Correlator.run(() => LocalTunnelTaskTerminal.getNgrokEndpoint())
+  );
+  context.subscriptions.push(getTunnelEndpointCmd);
 
   const installAppInTeamsCmd = vscode.commands.registerCommand(
     "fx-extension.install-app-in-teams",


### PR DESCRIPTION
1. Use `$teamsfx-local-tunnel-watch` instead of `$teamsfx-ngrok-watch`
2. Both `${teamsfx:workspaceFolder}` and `${workspaceFolder}` can work. PS: vscode will auto resolve the  `${workspaceFolder}` when `isBackground = false`
3. Both `${command:fx-extension.get-ngrok-path}` and `${teamsfx:ngrokBinFolder}` can work
4. Add new command `${command:fx-extension.get-local-tunnel-endpoint}`