### PR TITLE
feat(sdk): add dotnet sdk for adaptive card actions

### DIFF
--- a/packages/dotnet-sdk/src/TeamsFx.Test/Conversation/CardActionBotTest.cs
+++ b/packages/dotnet-sdk/src/TeamsFx.Test/Conversation/CardActionBotTest.cs
@@ -1,0 +1,69 @@
+﻿namespace Microsoft.TeamsFx.Test.Conversation
+{
+    using Microsoft.Bot.Builder;
+    using Microsoft.TeamsFx.Conversation;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    [TestClass]
+    public class CardActionBotTest
+    {
+        [TestMethod]
+        public void CreateCardActionBot_ShouldUseMiddleware()
+        {
+            // Arrange
+            var _mockAdapter = new Mock<BotAdapter>();
+
+            // Act
+            var bot = new CardActionBot(_mockAdapter.Object,
+                new CardActionOptions()
+                {
+                    Actions = new List<IAdaptiveCardActionHandler> { new Mock<IAdaptiveCardActionHandler>().Object }
+                });
+
+            // Assert
+            Assert.IsNotNull(bot.CardActionHandlers);
+            Assert.AreEqual(1, bot.CardActionHandlers.Count);
+            Assert.IsNotNull(_mockAdapter.Object.MiddlewareSet);
+            Assert.AreEqual(1, _mockAdapter.Object.MiddlewareSet.Count());
+            Assert.IsTrue(_mockAdapter.Object.MiddlewareSet.First() is CardActionMiddleware);
+        }
+
+        [TestMethod]
+        public void RegisterHandler_ShouldSucceed()
+        {
+            // Arrange
+            var _mockAdapter = new Mock<BotAdapter>();
+            var bot = new CardActionBot(_mockAdapter.Object, new CardActionOptions());
+
+            // Act
+            bot.RegisterHandler(new Mock<IAdaptiveCardActionHandler>().Object);
+
+            // Assert
+            Assert.IsNotNull(bot.CardActionHandlers);
+            Assert.AreEqual(1, bot.CardActionHandlers.Count);
+        }
+
+        [TestMethod]
+        public void RegisterHandlers_ShouldSucceed()
+        {
+            // Arrange
+            var _mockAdapter = new Mock<BotAdapter>();
+            var bot = new CardActionBot(_mockAdapter.Object, new CardActionOptions());
+            var handlers = new List<IAdaptiveCardActionHandler>
+            {
+                new Mock<IAdaptiveCardActionHandler>().Object,
+                new Mock<IAdaptiveCardActionHandler>().Object
+            };
+
+            // Act
+            bot.RegisterHandlers(handlers);
+
+            // Assert
+            Assert.IsNotNull(bot.CardActionHandlers);
+            Assert.AreEqual(2, bot.CardActionHandlers.Count);
+        }
+    }
+}

--- a/packages/dotnet-sdk/src/TeamsFx.Test/Conversation/CardActionMiddlewareTest.cs
+++ b/packages/dotnet-sdk/src/TeamsFx.Test/Conversation/CardActionMiddlewareTest.cs
@@ -43,7 +43,7 @@
         }
 
         [TestMethod]
-        public async Task OnTurnAsync_VerbMultipleMatch_OnlyTriggerTheFitstHandler()
+        public async Task OnTurnAsync_VerbMultipleMatch_OnlyTriggerTheFirstHandler()
         {
             // Arrange
             var mockHandler1 = CreateMockCardActionHandler("doStuff", InvokeResponseFactory.TextMessage("sample response"));
@@ -115,8 +115,8 @@
             await _middleware.OnTurnAsync(mockTurnContext.Object, (ct) => { return Task.CompletedTask; }, CancellationToken.None);
 
             // Assert
-            var expectedActiviyCount = 1; // invoke response sent in middleware
-            Assert.AreEqual(expectedActiviyCount, activites.Count);
+            var expectedActivityCount = 1; // invoke response sent in middleware
+            Assert.AreEqual(expectedActivityCount, activites.Count);
 
             var invokeResponse = activites[0].Value as InvokeResponse;
             Assert.IsNotNull(invokeResponse);
@@ -155,8 +155,8 @@
             await _middleware.OnTurnAsync(mockTurnContext.Object, (ct) => { return Task.CompletedTask; }, CancellationToken.None);
 
             // Assert
-            var expectedActiviyCount = 2;   // invoke response and updated activity sent in middleware
-            Assert.AreEqual(expectedActiviyCount, activites.Count);
+            var expectedActivityCount = 2;   // invoke response and updated activity sent in middleware
+            Assert.AreEqual(expectedActivityCount, activites.Count);
 
             var invokeResponse = activites[0].Value as InvokeResponse;
             Assert.IsNotNull(invokeResponse);
@@ -192,8 +192,8 @@
             await _middleware.OnTurnAsync(mockTurnContext.Object, (ct) => { return Task.CompletedTask; }, CancellationToken.None);
 
             // Assert
-            var expectedActiviyCount = 2;   // default invoke response and new message activity sent in middleware
-            Assert.AreEqual(expectedActiviyCount, activites.Count);
+            var expectedActivityCount = 2;   // default invoke response and new message activity sent in middleware
+            Assert.AreEqual(expectedActivityCount, activites.Count);
 
             var invokeResponse = activites[0].Value as InvokeResponse;
             Assert.IsNotNull(invokeResponse);
@@ -227,8 +227,8 @@
             await _middleware.OnTurnAsync(mockTurnContext.Object, (ct) => { return Task.CompletedTask; }, CancellationToken.None);
 
             // Assert
-            var expectedActiviyCount = 1;   // invoke response sent in middleware
-            Assert.AreEqual(expectedActiviyCount, activites.Count);
+            var expectedActivityCount = 1;   // invoke response sent in middleware
+            Assert.AreEqual(expectedActivityCount, activites.Count);
 
             var invokeResponse = activites[0].Value as InvokeResponse;
             Assert.IsNotNull(invokeResponse);
@@ -262,8 +262,8 @@
             await _middleware.OnTurnAsync(mockTurnContext.Object, (ct) => { return Task.CompletedTask; }, CancellationToken.None);
 
             // Assert
-            var expectedActiviyCount = 1;   // invoke response sent in middleware
-            Assert.AreEqual(expectedActiviyCount, activites.Count);
+            var expectedActivityCount = 1;   // invoke response sent in middleware
+            Assert.AreEqual(expectedActivityCount, activites.Count);
 
             var invokeResponse = activites[0].Value as InvokeResponse;
             Assert.IsNotNull(invokeResponse);

--- a/packages/dotnet-sdk/src/TeamsFx.Test/Conversation/CardActionMiddlewareTest.cs
+++ b/packages/dotnet-sdk/src/TeamsFx.Test/Conversation/CardActionMiddlewareTest.cs
@@ -1,0 +1,332 @@
+﻿namespace Microsoft.TeamsFx.Test.Conversation
+{
+    using AdaptiveCards;
+    using Microsoft.Bot.Builder;
+    using Microsoft.Bot.Schema;
+    using Microsoft.TeamsFx.Conversation;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+
+    [TestClass]
+    public class CardActionMiddlewareTest
+    {
+        private CardActionMiddleware _middleware;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            _middleware = new CardActionMiddleware();
+        }
+
+        [TestMethod]
+        public async Task OnTurnAsync_VerbMatch_ShouldTriggerHandler()
+        {
+            // Arrange
+            var mockHandler = CreateMockCardActionHandler("doStuff", InvokeResponseFactory.TextMessage("sample response"));
+
+            _middleware.CardActionHandlers.Add(mockHandler.Object);
+            var invokeActivity = CreateInvokeActivity("doStuff");
+
+            var mockTurnContext = new Mock<ITurnContext>();
+            mockTurnContext.Setup(tc => tc.Activity).Returns(invokeActivity);
+
+            // Act
+            await _middleware.OnTurnAsync(mockTurnContext.Object, (ct) => { return Task.CompletedTask; }, CancellationToken.None);
+
+            // Assert
+            mockHandler.Verify(
+                m => m.HandleActionInvokedAsync(
+                    It.IsAny<ITurnContext>(), It.IsAny<object>(), It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [TestMethod]
+        public async Task OnTurnAsync_VerbMultipleMatch_OnlyTriggerTheFitstHandler()
+        {
+            // Arrange
+            var mockHandler1 = CreateMockCardActionHandler("doStuff", InvokeResponseFactory.TextMessage("sample response"));
+            var mockHandler2 = CreateMockCardActionHandler("doStuff", InvokeResponseFactory.TextMessage("sample response"));
+
+            _middleware.CardActionHandlers.Add(mockHandler1.Object);
+            _middleware.CardActionHandlers.Add(mockHandler2.Object);
+            var invokeActivity = CreateInvokeActivity("doStuff");
+
+            var mockTurnContext = new Mock<ITurnContext>();
+            mockTurnContext.Setup(tc => tc.Activity).Returns(invokeActivity);
+
+            // Act
+            await _middleware.OnTurnAsync(mockTurnContext.Object, (ct) => { return Task.CompletedTask; }, CancellationToken.None);
+
+            // Assert
+            mockHandler1.Verify(
+                m => m.HandleActionInvokedAsync(
+                    It.IsAny<ITurnContext>(), It.IsAny<object>(), It.IsAny<CancellationToken>()),
+                Times.Once);
+            mockHandler2.Verify(
+                m => m.HandleActionInvokedAsync(
+                    It.IsAny<ITurnContext>(), It.IsAny<object>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [TestMethod]
+        public async Task OnTurnAsync_VerbNotMatch_ShouldNotTriggerHandler()
+        {
+            // Arrange
+            var mockHandler = CreateMockCardActionHandler("doStuff", InvokeResponseFactory.TextMessage("sample response"));
+
+            _middleware.CardActionHandlers.Add(mockHandler.Object);
+            var invokeActivity = CreateInvokeActivity("invalid-verb");
+
+            var mockTurnContext = new Mock<ITurnContext>();
+            mockTurnContext.Setup(tc => tc.Activity).Returns(invokeActivity);
+
+            // Act
+            await _middleware.OnTurnAsync(mockTurnContext.Object, (ct) => { return Task.CompletedTask; }, CancellationToken.None);
+
+            // Assert
+            mockHandler.Verify(
+                m => m.HandleActionInvokedAsync(
+                    It.IsAny<ITurnContext>(), It.IsAny<object>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [TestMethod]
+        public async Task OnTurnAsync_AdaptiveCard_ReplaceForInteractor_ShouldSendResponseSuccessfully()
+        {
+            // Arrange
+            var mockHandler = CreateMockCardActionHandler(
+                "doStuff",
+                InvokeResponseFactory.AdaptiveCard(JObject.Parse(GetAdaptiveCard())),
+                AdaptiveCardResponse.ReplaceForInteractor);
+
+            _middleware.CardActionHandlers.Add(mockHandler.Object);
+            var invokeActivity = CreateInvokeActivity("doStuff");
+
+            var activites = new List<Activity>();
+            var mockTurnContext = new Mock<ITurnContext>();
+            mockTurnContext.Setup(tc => tc.Activity).Returns(invokeActivity);
+            mockTurnContext
+                .Setup(tc => tc.SendActivityAsync(It.IsAny<IActivity>(), It.IsAny<CancellationToken>()))
+                .Callback<IActivity, CancellationToken>((activity, token) => { activites.Add(activity as Activity); });
+
+            // Act
+            await _middleware.OnTurnAsync(mockTurnContext.Object, (ct) => { return Task.CompletedTask; }, CancellationToken.None);
+
+            // Assert
+            var expectedActiviyCount = 1; // invoke response sent in middleware
+            Assert.AreEqual(expectedActiviyCount, activites.Count);
+
+            var invokeResponse = activites[0].Value as InvokeResponse;
+            Assert.IsNotNull(invokeResponse);
+            Assert.IsTrue(invokeResponse.IsSuccessStatusCode());
+
+            var responseBody = invokeResponse.Body as AdaptiveCardInvokeResponse;
+            Assert.IsNotNull(responseBody);
+            Assert.AreEqual(InvokeResponseContentType.AdaptiveCard, responseBody.Type);
+            Assert.IsNotNull(responseBody.Value);
+            Assert.AreEqual(GetAdaptiveCard(), JsonConvert.SerializeObject(responseBody.Value, Formatting.Indented));
+        }
+
+        [TestMethod]
+        public async Task OnTurnAsync_AdaptiveCard_ReplaceForAll_ShouldSendResponseSuccessfully()
+        {
+            // Arrange
+            var mockHandler = CreateMockCardActionHandler(
+                "doStuff",
+                InvokeResponseFactory.AdaptiveCard(JObject.Parse(GetAdaptiveCard())),
+                AdaptiveCardResponse.ReplaceForAll);
+
+            _middleware.CardActionHandlers.Add(mockHandler.Object);
+            var invokeActivity = CreateInvokeActivity("doStuff");
+
+            var activites = new List<Activity>();
+            var mockTurnContext = new Mock<ITurnContext>();
+            mockTurnContext.Setup(tc => tc.Activity).Returns(invokeActivity);
+            mockTurnContext
+                .Setup(tc => tc.SendActivityAsync(It.IsAny<IActivity>(), It.IsAny<CancellationToken>()))
+                .Callback<IActivity, CancellationToken>((activity, token) => { activites.Add(activity as Activity); });
+            mockTurnContext
+                .Setup(tc => tc.UpdateActivityAsync(It.IsAny<IActivity>(), It.IsAny<CancellationToken>()))
+                .Callback<IActivity, CancellationToken>((activity, token) => { activites.Add(activity as Activity); });
+
+            // Act
+            await _middleware.OnTurnAsync(mockTurnContext.Object, (ct) => { return Task.CompletedTask; }, CancellationToken.None);
+
+            // Assert
+            var expectedActiviyCount = 2;   // invoke response and updated activity sent in middleware
+            Assert.AreEqual(expectedActiviyCount, activites.Count);
+
+            var invokeResponse = activites[0].Value as InvokeResponse;
+            Assert.IsNotNull(invokeResponse);
+            Assert.IsTrue(invokeResponse.IsSuccessStatusCode());
+
+            var responseBody = invokeResponse.Body as AdaptiveCardInvokeResponse;
+            Assert.IsNotNull(responseBody);
+            Assert.AreEqual(InvokeResponseContentType.AdaptiveCard, responseBody.Type);
+            Assert.IsNotNull(responseBody.Value);
+            Assert.AreEqual(GetAdaptiveCard(), JsonConvert.SerializeObject(responseBody.Value, Formatting.Indented));
+        }
+
+        [TestMethod]
+        public async Task OnTurnAsync_AdaptiveCard_NewForAll_ShouldSendResponseSuccessfully()
+        {
+            // Arrange
+            var mockHandler = CreateMockCardActionHandler(
+                "doStuff",
+                InvokeResponseFactory.AdaptiveCard(JObject.Parse(GetAdaptiveCard())),
+                AdaptiveCardResponse.NewForAll);
+
+            _middleware.CardActionHandlers.Add(mockHandler.Object);
+            var invokeActivity = CreateInvokeActivity("doStuff");
+
+            var activites = new List<Activity>();
+            var mockTurnContext = new Mock<ITurnContext>();
+            mockTurnContext.Setup(tc => tc.Activity).Returns(invokeActivity);
+            mockTurnContext
+                .Setup(tc => tc.SendActivityAsync(It.IsAny<IActivity>(), It.IsAny<CancellationToken>()))
+                .Callback<IActivity, CancellationToken>((activity, token) => { activites.Add(activity as Activity); });
+
+            // Act
+            await _middleware.OnTurnAsync(mockTurnContext.Object, (ct) => { return Task.CompletedTask; }, CancellationToken.None);
+
+            // Assert
+            var expectedActiviyCount = 2;   // default invoke response and new message activity sent in middleware
+            Assert.AreEqual(expectedActiviyCount, activites.Count);
+
+            var invokeResponse = activites[0].Value as InvokeResponse;
+            Assert.IsNotNull(invokeResponse);
+            Assert.IsTrue(invokeResponse.IsSuccessStatusCode());
+
+            var responseBody = invokeResponse.Body as AdaptiveCardInvokeResponse;
+            Assert.IsNotNull(responseBody);
+            Assert.AreEqual(InvokeResponseContentType.Message, responseBody.Type);
+            Assert.IsNotNull(responseBody.Value);
+            Assert.AreEqual(_middleware.defaultMessage, responseBody.Value);
+        }
+
+        [TestMethod]
+        public async Task OnTurnAsync_TextMessage_ShouldSendResponseSuccessfully()
+        {
+            // Arrange
+            var testMessage = "This is a sample response";
+            var mockHandler = CreateMockCardActionHandler("doStuff", InvokeResponseFactory.TextMessage(testMessage));
+
+            _middleware.CardActionHandlers.Add(mockHandler.Object);
+            var invokeActivity = CreateInvokeActivity("doStuff");
+
+            var activites = new List<Activity>();
+            var mockTurnContext = new Mock<ITurnContext>();
+            mockTurnContext.Setup(tc => tc.Activity).Returns(invokeActivity);
+            mockTurnContext
+                .Setup(tc => tc.SendActivityAsync(It.IsAny<IActivity>(), It.IsAny<CancellationToken>()))
+                .Callback<IActivity, CancellationToken>((activity, token) => { activites.Add(activity as Activity); });
+
+            // Act
+            await _middleware.OnTurnAsync(mockTurnContext.Object, (ct) => { return Task.CompletedTask; }, CancellationToken.None);
+
+            // Assert
+            var expectedActiviyCount = 1;   // invoke response sent in middleware
+            Assert.AreEqual(expectedActiviyCount, activites.Count);
+
+            var invokeResponse = activites[0].Value as InvokeResponse;
+            Assert.IsNotNull(invokeResponse);
+            Assert.IsTrue(invokeResponse.IsSuccessStatusCode());
+
+            var responseBody = invokeResponse.Body as AdaptiveCardInvokeResponse;
+            Assert.IsNotNull(responseBody);
+            Assert.AreEqual(InvokeResponseContentType.Message, responseBody.Type);
+            Assert.IsNotNull(responseBody.Value);
+            Assert.AreEqual(testMessage, responseBody.Value);
+        }
+
+        [TestMethod]
+        public async Task OnTurnAsync_ErrorResponse_ShouldSendResponseSuccessfully()
+        {
+            // Arrange
+            var testMessage = "This is an error response";
+            var mockHandler = CreateMockCardActionHandler("doStuff", InvokeResponseFactory.ErrorResponse(InvokeResponseErrorCode.BadRequest, testMessage));
+
+            _middleware.CardActionHandlers.Add(mockHandler.Object);
+            var invokeActivity = CreateInvokeActivity("doStuff");
+
+            var activites = new List<Activity>();
+            var mockTurnContext = new Mock<ITurnContext>();
+            mockTurnContext.Setup(tc => tc.Activity).Returns(invokeActivity);
+            mockTurnContext
+                .Setup(tc => tc.SendActivityAsync(It.IsAny<IActivity>(), It.IsAny<CancellationToken>()))
+                .Callback<IActivity, CancellationToken>((activity, token) => { activites.Add(activity as Activity); });
+
+            // Act
+            await _middleware.OnTurnAsync(mockTurnContext.Object, (ct) => { return Task.CompletedTask; }, CancellationToken.None);
+
+            // Assert
+            var expectedActiviyCount = 1;   // invoke response sent in middleware
+            Assert.AreEqual(expectedActiviyCount, activites.Count);
+
+            var invokeResponse = activites[0].Value as InvokeResponse;
+            Assert.IsNotNull(invokeResponse);
+            Assert.IsTrue(invokeResponse.IsSuccessStatusCode());
+
+            var responseBody = invokeResponse.Body as AdaptiveCardInvokeResponse;
+            Assert.IsNotNull(responseBody);
+            Assert.AreEqual(InvokeResponseContentType.Error, responseBody.Type);
+            Assert.AreEqual((int)InvokeResponseErrorCode.BadRequest, responseBody.StatusCode);
+
+            var botError = responseBody.Value as Error;
+            Assert.IsNotNull(botError);
+            Assert.AreEqual(testMessage, botError.Message);
+            Assert.AreEqual(InvokeResponseErrorCode.BadRequest.ToString(), botError.Code);
+        }
+
+        private static Activity CreateInvokeActivity(string verb, object data = null)
+        {
+            var value = JObject.FromObject(
+                new AdaptiveCardInvokeValue
+                {
+                    Action = new AdaptiveCardInvokeAction
+                    {
+                        Type = "Action.Execute",
+                        Verb = verb,
+                        Data = data
+                    }
+                });
+
+            var activity = new Activity
+            {
+                Type = ActivityTypes.Invoke,
+                Name = "adaptiveCard/action",
+                Value = value
+            };
+
+            return activity;
+        }
+
+        private static Mock<IAdaptiveCardActionHandler> CreateMockCardActionHandler(string verb, InvokeResponse response, AdaptiveCardResponse adaptiveCardResponse = AdaptiveCardResponse.ReplaceForInteractor)
+        {
+            var mockHandler = new Mock<IAdaptiveCardActionHandler>();
+            mockHandler.Setup(_ => _.TriggerVerb).Returns(verb);
+            mockHandler.Setup(_ => _.AdaptiveCardResponse).Returns(adaptiveCardResponse);
+            mockHandler.Setup(_ => _.HandleActionInvokedAsync(
+                It.IsAny<ITurnContext>(),
+                It.IsAny<object>(),
+                It.IsAny<CancellationToken>())
+            ).ReturnsAsync(response);
+
+            return mockHandler;
+        }
+
+        private static string GetAdaptiveCard()
+        {
+            AdaptiveCard card = new AdaptiveCard(new AdaptiveSchemaVersion(1, 0));
+
+            card.Body.Add(new AdaptiveTextBlock()
+            {
+                Text = "This is a sample response card.",
+            });
+
+            return card.ToJson();
+        }
+    }
+}

--- a/packages/dotnet-sdk/src/TeamsFx.Test/Microsoft.TeamsFx.Test.csproj
+++ b/packages/dotnet-sdk/src/TeamsFx.Test/Microsoft.TeamsFx.Test.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AdaptiveCards" Version="2.7.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/AdaptiveCardResponse.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/AdaptiveCardResponse.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.TeamsFx.Conversation
+{
+    /// <summary>
+    /// Options used to control how the response card will be sent to users.
+    /// </summary>
+    public enum AdaptiveCardResponse
+    {
+        /// <summary>
+        /// The response card will be replaced the current one for the interactor who trigger the action.
+        /// </summary>
+        ReplaceForInteractor = 0,
+
+        /// <summary>
+        /// The response card will be replaced the current one for all users in the chat.
+        /// </summary>
+        ReplaceForAll,
+
+        /// <summary>
+        /// The response card will be sent as a new message for all users in the chat.
+        /// </summary>
+        NewForAll,
+    }
+}

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/CardActionBot.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/CardActionBot.cs
@@ -21,6 +21,7 @@ namespace Microsoft.TeamsFx.Conversation
         /// <summary>
         /// Initializes a new instance of the <see cref="CardActionBot"/> class.
         /// </summary>
+        /// <exception>
         /// <param name="adapter">The bot adapter.</param>
         /// <param name="options">The initialize options.</param>
         /// <paramref name="adapter"/> or <paramref name="options"/> is null.

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/CardActionBot.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/CardActionBot.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.TeamsFx.Conversation
+{
+    using Microsoft.Bot.Builder;
+
+    /// <summary>
+    /// Represents a bot to handle Adaptive Card Action Execute invoke activities.
+    /// </summary>
+    public class CardActionBot
+    {
+        private readonly BotAdapter _adapter;
+        private readonly CardActionMiddleware _middleware;
+
+        /// <summary>
+        /// Gets the registered card action handlers of this bot.
+        /// </summary>
+        public IList<IAdaptiveCardActionHandler> CardActionHandlers => _middleware.CardActionHandlers;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CardActionBot"/> class.
+        /// </summary>
+        /// <param name="adapter">The bot adapter.</param>
+        /// <param name="options">The initialize options.</param>
+        /// <paramref name="adapter"/> or <paramref name="options"/> is null.
+        /// </exception>
+        public CardActionBot(BotAdapter adapter, CardActionOptions options)
+        {
+            _adapter = adapter ?? throw new ArgumentNullException(nameof(adapter));
+
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            _middleware = new CardActionMiddleware(options.Actions);
+            _adapter.Use(_middleware);
+        }
+
+        /// <summary>
+        /// Registers an adaptive card action handler to the conversation bot.
+        /// </summary>
+        /// <param name="cardActionHandler">A card action handler implements <see cref="IAdaptiveCardActionHandler"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="cardActionHandler"/> is null.</exception>
+        public void RegisterHandler(IAdaptiveCardActionHandler cardActionHandler)
+        {
+            if (cardActionHandler == null)
+            {
+                throw new ArgumentNullException(nameof(cardActionHandler));
+            }
+
+            _middleware.CardActionHandlers.Add(cardActionHandler);
+        }
+
+        /// <summary>
+        /// Registers a set of adaptive card action handlers to the conversation bot.
+        /// </summary>
+        /// <param name="cardActionHandlers">A list of adaptive card action handlers to  be registered to the bot.</param>
+        /// <exception cref="ArgumentException"><paramref name="cardActionHandlers"/> is null or empty. </exception>
+        public void RegisterHandlers(IList<IAdaptiveCardActionHandler> cardActionHandlers)
+        {
+            if (cardActionHandlers == null || !cardActionHandlers.Any())
+            {
+                throw new ArgumentException("There is no card action handler to be registered.", nameof(cardActionHandlers));
+            }
+
+            foreach (var handler in cardActionHandlers)
+            {
+                _middleware.CardActionHandlers.Add(handler);
+            }
+        }
+    }
+}

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/CardActionMiddleware.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/CardActionMiddleware.cs
@@ -1,0 +1,126 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.TeamsFx.Conversation
+{
+    using Microsoft.Bot.Builder;
+    using Microsoft.Bot.Schema;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    internal class CardActionMiddleware : IMiddleware
+    {
+        internal readonly string defaultMessage = "Your response was sent to the app";
+
+        /// <summary>
+        /// Gets or sets the list of <see cref="IAdaptiveCardActionHandler"/> instances registered with the middleware.
+        /// </summary>
+        /// <value>
+        /// The list of <see cref="IAdaptiveCardActionHandler"/> instances registered with the middleware.
+        /// </value>
+        public IList<IAdaptiveCardActionHandler> CardActionHandlers { get; private set; } = new List<IAdaptiveCardActionHandler>();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CommandResponseMiddleware"/> class.
+        /// </summary>
+        /// <param name="cardActionHandlers">A list of command handlers.</param>
+        public CardActionMiddleware(IList<IAdaptiveCardActionHandler> cardActionHandlers = null)
+        {
+            if (cardActionHandlers != null && cardActionHandlers.Any())
+            {
+                CardActionHandlers = cardActionHandlers;
+            }
+        }
+
+        public async Task OnTurnAsync(ITurnContext turnContext, NextDelegate next, CancellationToken cancellationToken = default)
+        {
+            if (turnContext.Activity.Name == "adaptiveCard/action")
+            {
+                var actionActivity = JsonConvert.DeserializeObject<AdaptiveCardInvokeValue>(turnContext.Activity.Value.ToString());
+                string verb = actionActivity.Action.Verb;
+
+                foreach (var handler in CardActionHandlers)
+                {
+                    if (handler.TriggerVerb.ToLowerInvariant() == verb?.ToString().ToLowerInvariant())
+                    {
+                        var invokeResponse = await handler.HandleActionInvokedAsync(turnContext, actionActivity.Action.Data, cancellationToken).ConfigureAwait(false);
+
+                        if (invokeResponse != null)
+                        {
+                            var body = JObject.FromObject(invokeResponse.Body);
+                            var responseValue = JsonConvert.DeserializeObject<AdaptiveCardInvokeResponse>(body.ToString());
+                            string contentType = responseValue.Type;
+
+                            if (contentType == InvokeResponseContentType.AdaptiveCard)
+                            {
+                                var card = responseValue.Value;
+                                if (card == null)
+                                {
+                                    string errorMessage = "Adaptive card content cannot be null.";
+                                    await SendInvokeResponseAsync(
+                                        turnContext,
+                                        InvokeResponseFactory.ErrorResponse(InvokeResponseErrorCode.InternalServerError,
+                                        errorMessage), cancellationToken).ConfigureAwait(false);
+                                    throw new ExceptionWithCode(errorMessage, ExceptionCode.InvalidParameter);
+                                }
+
+                                var isRefresh = card.GetType().GetProperty("refresh") != null;
+                                if (isRefresh && handler.AdaptiveCardResponse != AdaptiveCardResponse.NewForAll)
+                                {
+                                    handler.AdaptiveCardResponse = AdaptiveCardResponse.NewForAll;
+                                }
+
+                                var messageActivity = MessageFactory.Attachment
+                                (
+                                    new Attachment
+                                    {
+                                        ContentType = "application/vnd.microsoft.card.adaptive",
+                                        Content = card,
+                                    }
+                                );
+
+                                switch (handler.AdaptiveCardResponse)
+                                {
+                                    case AdaptiveCardResponse.NewForAll:
+                                        await SendInvokeResponseAsync(turnContext, InvokeResponseFactory.TextMessage(defaultMessage), cancellationToken).ConfigureAwait(false);
+                                        await turnContext.SendActivityAsync(messageActivity, cancellationToken).ConfigureAwait(false);
+                                        break;
+                                    case AdaptiveCardResponse.ReplaceForAll:
+                                        await SendInvokeResponseAsync(turnContext, invokeResponse, cancellationToken).ConfigureAwait(false);
+                                        messageActivity.Id = turnContext.Activity.ReplyToId;
+                                        await turnContext.UpdateActivityAsync(messageActivity, cancellationToken).ConfigureAwait(false);
+                                        break;
+                                    case AdaptiveCardResponse.ReplaceForInteractor:
+                                        await SendInvokeResponseAsync(turnContext, invokeResponse, cancellationToken).ConfigureAwait(false);
+                                        break;
+                                }
+                            }
+                            else
+                            {
+                                // text message or error response
+                                await SendInvokeResponseAsync(turnContext, invokeResponse, cancellationToken).ConfigureAwait(false);
+                            }
+                        }
+ 
+                        break;
+                    }
+                }
+            }
+
+            await next(cancellationToken).ConfigureAwait(false);
+        }
+
+        private async static Task SendInvokeResponseAsync(ITurnContext context, InvokeResponse response, CancellationToken cancellationToken)
+        {
+            var invokeActivity = new Activity
+            {
+                Type = ActivityTypesEx.InvokeResponse,
+                Value = response
+            };
+
+            await context.SendActivityAsync(invokeActivity, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/CardActionOptions.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/CardActionOptions.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.TeamsFx.Conversation
+{
+    /// <summary>
+    /// Options to initialize a <see cref="CommandBot"/>.
+    /// </summary>
+    public class CardActionOptions
+    {
+        /// <summary>
+        /// Gets or sets a set of adaptive card action handlers used to process card actions for this bot.
+        /// </summary>
+        /// <value>
+        /// The card action handlers used to process command.
+        /// </value>
+        public IList<IAdaptiveCardActionHandler> Actions { get; set; }
+    }
+}

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/CommandBot.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/CommandBot.cs
@@ -21,9 +21,11 @@ namespace Microsoft.TeamsFx.Conversation
         /// <summary>
         /// Initializes a new instance of the <see cref="CommandBot"/> class.
         /// </summary>
-        /// <param name="adapter"></param>
-        /// <param name="options"></param>
-        /// <exception cref="ArgumentNullException"><paramref name="options"/> is null.</exception>
+        /// <param name="adapter">The bot adapter.</param>
+        /// <param name="options">The initialize options.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="adapter"/> or <paramref name="options"/> is null.
+        /// </exception>
         public CommandBot(BotAdapter adapter, CommandOptions options)
         {
             _adapter = adapter ?? throw new ArgumentNullException(nameof(adapter));
@@ -38,7 +40,7 @@ namespace Microsoft.TeamsFx.Conversation
         }
 
         /// <summary>
-        /// Register a command to the command bot.
+        /// Registers a command to the command bot.
         /// </summary>
         /// <param name="commandHandler">A command handler implements <seealso cref="ITeamsCommandHandler"/>.</param>
         /// <exception cref="ArgumentNullException"><paramref name="commandHandler"/>is null.</exception>
@@ -53,9 +55,9 @@ namespace Microsoft.TeamsFx.Conversation
         }
 
         /// <summary>
-        /// Register a set of commands to the command bot.
+        /// Registers a set of commands to the command bot.
         /// </summary>
-        /// <param name="commandHandlers"></param>
+        /// <param name="commandHandlers">A list of command handlers to be registered to the bot.</param>
         /// <exception cref="ArgumentException"><paramref name="commandHandlers"/> is null or empty. </exception>
         public void RegisterCommands(IList<ITeamsCommandHandler> commandHandlers)
         {

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/ConversationBot.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/ConversationBot.cs
@@ -42,6 +42,11 @@
         public CommandBot Command { get; private set; }
 
         /// <summary>
+        /// The entry point of adaptive card action.
+        /// </summary>
+        public CardActionBot CardAction { get; private set; }
+
+        /// <summary>
         /// Creates new instance of the <see cref="ConversationBot"/>.
         /// </summary>
         /// <param name="options">Initialize options.</param>
@@ -67,6 +72,11 @@
             if (options.Command != null)
             {
                 Command = new CommandBot(Adapter, options.Command);
+            }
+
+            if (options.CardAction != null)
+            {
+                CardAction = new CardActionBot(Adapter, options.CardAction);
             }
         }
     }

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/ConversationOptions.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/ConversationOptions.cs
@@ -24,5 +24,10 @@ namespace Microsoft.TeamsFx.Conversation
         /// Gets or sets the command option used to initialize the <see cref="ConversationBot.Command"/> .
         /// </summary>
         public CommandOptions Command { get; set; }
+
+        /// <summary>
+        /// Gets or sets the adaptive card action options used to initialize the <see cref="ConversationBot.CardAction"/> .
+        /// </summary>
+        public CardActionOptions CardAction { get; set; }
     }
 }

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/IAdaptiveCardActionHandler.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/IAdaptiveCardActionHandler.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.TeamsFx.Conversation
+{
+    using Microsoft.Bot.Builder;
+
+    /// <summary>
+    /// Represents an adaptive card action handler to respond to an adaptiveCard/action invoke activity.
+    /// </summary>
+    public interface IAdaptiveCardActionHandler
+    {
+        /// <summary>
+        /// The verb defined in adaptive card action that can trigger this handler.
+        /// The verb string here is case-insensitive.
+        /// </summary>
+        string TriggerVerb { get; set; }
+
+        /// <summary>
+        /// Indicates the behavior for how the card response will be sent in Teams conversation.
+        /// The default value is `AdaptiveCardResponse.ReplaceForInteractor`, which means the card
+        /// response will replace the current one only for the interactor.
+        /// </summary>
+        AdaptiveCardResponse AdaptiveCardResponse { get; set; }
+
+        /// <summary>
+        /// The handler function that will be invoked when the card action is executed.
+        /// </summary>
+        /// <param name="turnContext">The context object for this turn.</param>
+        /// <param name="cardData">The card data object associated with the action.</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>Async task with invoke response.</returns>
+        Task<InvokeResponse> HandleActionInvokedAsync(ITurnContext turnContext, object cardData, CancellationToken cancellationToken = default);
+    }
+}

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/InvokeResponseContentType.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/InvokeResponseContentType.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.TeamsFx.Conversation
+{
+    internal static class InvokeResponseContentType
+    {
+        public const string AdaptiveCard = "application/vnd.microsoft.card.adaptive";
+        public const string Message = "application/vnd.microsoft.activity.message";
+        public const string Error = "application/vnd.microsoft.error";
+    }
+}

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/InvokeResponseErrorCode.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/InvokeResponseErrorCode.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.TeamsFx.Conversation
+{
+    /// <summary>
+    /// Status code for an application/vnd.microsoft.error invoke response.
+    /// </summary>
+    public enum InvokeResponseErrorCode
+    {
+        /// <summary>
+        /// Invalid request.
+        /// </summary>
+        BadRequest = 400,
+
+        /// <summary>
+        /// Internal server error.
+        /// </summary>
+        InternalServerError = 500,
+    }
+}

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/InvokeResponseFactory.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/InvokeResponseFactory.cs
@@ -1,0 +1,117 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.TeamsFx.Conversation
+{
+    using Microsoft.Bot.Builder;
+    using Microsoft.Bot.Schema;
+    using System.Net;
+
+    /// <summary>
+    /// Contains utility methods for various invoke response types for an adaptiveCard/action invoke response.
+    /// </summary>
+    public static class InvokeResponseFactory
+    {
+        /// <summary>
+        /// Creates invoke response with an adaptive card.
+        /// </summary>
+        /// <param name="card">The adaptive card included in the response body.</param>
+        /// <returns>An instance of <see cref="InvokeResponse"/></returns>
+        public static InvokeResponse AdaptiveCard(object card)
+        {
+            var response = new AdaptiveCardInvokeResponse()
+            {
+                StatusCode = 200,
+                Type = InvokeResponseContentType.AdaptiveCard,
+                Value = card
+            };
+
+            return new InvokeResponse
+            {
+                Status = (int)HttpStatusCode.OK,
+                Body = response
+            };
+        }
+
+        /// <summary>
+        /// Creates invoke response with a text message.
+        /// </summary>
+        /// <param name="message">The text message included in the response body.</param>
+        /// <returns>An instance of <see cref="InvokeResponse"/>.</returns>
+        public static InvokeResponse TextMessage(string message)
+        {
+            if (string.IsNullOrWhiteSpace(message))
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
+            var response = new AdaptiveCardInvokeResponse()
+            {
+                StatusCode = 200,
+                Type = InvokeResponseContentType.Message,
+                Value = message
+            };
+
+            return new InvokeResponse
+            {
+                Status = (int)HttpStatusCode.OK,
+                Body = response
+            };
+        }
+
+        /// <summary>
+        /// Creates invoke response with error code and error message.
+        /// </summary>
+        /// <param name="errorCode">The status code indicates the bot processing error, available values:
+        /// <list type="bullet">
+        ///     <item>
+        ///         <description> 400 (BadRequest): indicate the incoming request was invalid.</description>
+        ///     </item>
+        ///     <item>
+        ///         <description> 500 (InternalServerError): indicate an unexpected error occurred.</description>
+        ///     </item>
+        /// </list>
+        /// </param>
+        /// <param name="errorMessage">The error message.</param>
+        /// <returns>An instance of <see cref="InvokeResponse"/></returns>
+        public static InvokeResponse ErrorResponse(InvokeResponseErrorCode errorCode, string errorMessage)
+        {
+            if (string.IsNullOrWhiteSpace(errorMessage))
+            {
+                throw new ArgumentNullException(nameof(errorMessage));
+            }
+
+            var response = new AdaptiveCardInvokeResponse()
+            {
+                StatusCode = (int)errorCode,
+                Type = InvokeResponseContentType.Error,
+                Value = new Error()
+                {
+                    Code = errorCode.ToString(),
+                    Message = errorMessage
+                }
+            };
+
+            return new InvokeResponse
+            {
+                Status = (int)HttpStatusCode.OK,
+                Body = response
+            };
+        }
+
+        /// <summary>
+        /// Creates invoke response with status code and response body.
+        /// </summary>
+        /// <param name="statusCode">The status code.</param>
+        /// <param name="response">The response body.</param>
+        /// <returns>An instance of <see cref="InvokeResponse"/>.</returns>
+        public static InvokeResponse CreateInvokeResponse(HttpStatusCode statusCode, object response)
+        {
+            return new InvokeResponse
+            {
+                Status = (int)statusCode,
+                Body = response
+            };
+        }
+    }
+}


### PR DESCRIPTION
Sample card action handler with the SDK:

```csharp
using AdaptiveCards.Templating;
using Microsoft.Bot.Builder;
using Microsoft.TeamsFx.Conversation;
using Newtonsoft.Json;
using VSWorkflowBot.Models;

namespace VSWorkflowBot.CardActions
{
    public class DoStuffActionHandler : IAdaptiveCardActionHandler
    {
        private string _triggerVerb = "doStuff";
        private AdaptiveCardResponse _adaptiveCardResponse = AdaptiveCardResponse.ReplaceForInteractor;
        private readonly string _responseCardFilePath = Path.Combine(".", "Resources", "DoStuffActionResponse.json");

        public string TriggerVerb
        {
            get => _triggerVerb;
            set => _triggerVerb = value;
        }

        public AdaptiveCardResponse AdaptiveCardResponse
        {
            get => _adaptiveCardResponse;
            set => _adaptiveCardResponse = value;
        }

        public async Task<InvokeResponse> HandleActionInvokedAsync(ITurnContext turnContext, object cardData, CancellationToken cancellationToken = default)
        {
            // Read adaptive card template
            var cardTemplate = await File.ReadAllTextAsync(_responseCardFilePath, cancellationToken);

            // Render adaptive card content
            var cardContent = new AdaptiveCardTemplate(cardTemplate).Expand
            (
                new HelloWorldModel
                {
                    Title = "Hello World Bot",
                    Body = "Congratulations! Your task is processed successfully. Click the button below to learn more about Bots and the Teams Toolkit.",
                }
            );

            // Adaptive card
            return InvokeResponseFactory.AdaptiveCard(JsonConvert.DeserializeObject(cardContent));
        }
    }
}

```
E2E TEST: N/A