### PR TITLE
fix(localdebug): support relative path in npm install task

### DIFF
--- a/packages/vscode-extension/src/debug/prerequisitesHandler.ts
+++ b/packages/vscode-extension/src/debug/prerequisitesHandler.ts
@@ -13,6 +13,7 @@ import {
   UserError,
   UserErrorOptions,
   Void,
+  PathNotExistError,
 } from "@microsoft/teamsfx-api";
 import {
   AppStudioScopes,
@@ -36,6 +37,7 @@ import {
   LocalEnvProvider,
 } from "@microsoft/teamsfx-core";
 
+import * as fs from "fs-extra";
 import * as os from "os";
 import * as path from "path";
 import * as util from "util";
@@ -1005,6 +1007,16 @@ function checkNpmInstall(
       VsCodeLogInstance.outputChannel.appendLine(
         `${prefix} ${ProgressMessage[Checker.NpmInstall](displayName)} ...`
       );
+
+      if (!(await fs.pathExists(folder))) {
+        return {
+          checker: Checker.NpmInstall,
+          result: ResultStatus.warn,
+          successMsg: doctorConstant.NpmInstallSuccess.split("@app").join(displayName),
+          failureMsg: doctorConstant.NpmInstallFailure.split("@app").join(displayName),
+          error: new PathNotExistError(ExtensionSource, folder),
+        };
+      }
 
       let installed = false;
       if (!forceUpdate) {

--- a/packages/vscode-extension/src/debug/taskTerminal/npmInstallTaskTerminal.ts
+++ b/packages/vscode-extension/src/debug/taskTerminal/npmInstallTaskTerminal.ts
@@ -37,13 +37,11 @@ export class NpmInstallTaskTerminal extends BaseTaskTerminal {
         throw BaseTaskTerminal.taskDefinitionError("cwd");
       }
 
-      let resolvedCwd = BaseTaskTerminal.resolveTeamsFxVariables(projectOption.cwd);
-      if (!path.isAbsolute(resolvedCwd)) {
-        resolvedCwd = path.join(globalVariables.workspaceUri?.fsPath ?? "", resolvedCwd);
-      }
-
       return {
-        cwd: path.normalize(resolvedCwd),
+        cwd: path.resolve(
+          globalVariables.workspaceUri?.fsPath ?? "",
+          BaseTaskTerminal.resolveTeamsFxVariables(projectOption.cwd)
+        ),
         args: projectOption.npmInstallArgs,
         forceUpdate: this.args.forceUpdate,
       };

--- a/packages/vscode-extension/src/debug/taskTerminal/npmInstallTaskTerminal.ts
+++ b/packages/vscode-extension/src/debug/taskTerminal/npmInstallTaskTerminal.ts
@@ -7,6 +7,7 @@ import * as path from "path";
 import { FxError, Result, ok, Void } from "@microsoft/teamsfx-api";
 import { BaseTaskTerminal } from "./baseTaskTerminal";
 import { checkAndInstallNpmPackagesForTask } from "../prerequisitesHandler";
+import * as globalVariables from "../../globalVariables";
 
 export interface NpmInstallArgs {
   projects?: ProjectOptions[];
@@ -36,8 +37,13 @@ export class NpmInstallTaskTerminal extends BaseTaskTerminal {
         throw BaseTaskTerminal.taskDefinitionError("cwd");
       }
 
+      let resolvedCwd = BaseTaskTerminal.resolveTeamsFxVariables(projectOption.cwd);
+      if (!path.isAbsolute(resolvedCwd)) {
+        resolvedCwd = path.join(globalVariables.workspaceUri?.fsPath ?? "", resolvedCwd);
+      }
+
       return {
-        cwd: path.normalize(BaseTaskTerminal.resolveTeamsFxVariables(projectOption.cwd)),
+        cwd: path.normalize(resolvedCwd),
         args: projectOption.npmInstallArgs,
         forceUpdate: this.args.forceUpdate,
       };


### PR DESCRIPTION
Support relative path in `cwd` of npm install task

E2E TEST: none