### PR TITLE
fix: hide debug console for teams web client

### DIFF
--- a/packages/fx-core/src/plugins/solution/fx-solution/debug/util/launch.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/debug/util/launch.ts
@@ -132,6 +132,7 @@ export function generateSpfxConfigurations(): Record<string, unknown>[] {
       presentation: {
         hidden: true,
       },
+      internalConsoleOptions: "neverOpen",
     },
     {
       name: "Start Teams workbench (Chrome)",
@@ -150,6 +151,7 @@ export function generateSpfxConfigurations(): Record<string, unknown>[] {
       presentation: {
         hidden: true,
       },
+      internalConsoleOptions: "neverOpen",
     },
   ];
   return configurations;
@@ -202,6 +204,7 @@ function launchRemote(
       group: "remote",
       order: order,
     },
+    internalConsoleOptions: "neverOpen",
   };
 }
 
@@ -229,6 +232,7 @@ function startAndAttachToFrontend(
       group: "all",
       hidden: true,
     },
+    internalConsoleOptions: "neverOpen",
   };
 }
 
@@ -251,6 +255,7 @@ function launchBot(
       group: "all",
       hidden: true,
     },
+    internalConsoleOptions: "neverOpen",
   };
 }
 

--- a/packages/fx-core/src/plugins/solution/fx-solution/debug/util/launchNext.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/debug/util/launchNext.ts
@@ -250,6 +250,7 @@ function launchRemote(
       group: "remote",
       order: order,
     },
+    internalConsoleOptions: "neverOpen",
   };
 }
 
@@ -279,6 +280,7 @@ function attachToFrontend(
       group: "all",
       hidden: true,
     },
+    internalConsoleOptions: "neverOpen",
   };
 }
 
@@ -307,6 +309,7 @@ function attachToFrontendM365(
       group: "all",
       hidden: true,
     },
+    internalConsoleOptions: "neverOpen",
   };
 }
 
@@ -358,6 +361,7 @@ function launchBot(
       group: "all",
       hidden: true,
     },
+    internalConsoleOptions: "neverOpen",
   };
 }
 
@@ -381,6 +385,7 @@ function launchBotM365(
       group: "all",
       hidden: true,
     },
+    internalConsoleOptions: "neverOpen",
   };
 }
 


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/15525732/
Hide debug console for all browser "launch" sessions. (Keep debug console for bot/backend services).

E2E TEST: N/A (covered by UI test)