### PR TITLE
fix: remove trailing slash for source addr and dist addr

### DIFF
--- a/packages/fx-core/src/plugins/solution/fx-solution/debug/util/ngrok.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/debug/util/ngrok.ts
@@ -35,10 +35,12 @@ export async function getNgrokHttpUrl(addr: string | number): Promise<string | u
           for (const tunnel of tunnels) {
             if (typeof addr === "number" || Number.isInteger(Number.parseInt(addr))) {
               addr = `http://localhost:${addr}`;
-            } else {
-              addr = removeTrailingSlash(addr);
             }
-            if (tunnel.config.addr === addr && tunnel.proto === "https") {
+
+            if (
+              removeTrailingSlash(tunnel.config.addr) === removeTrailingSlash(addr) &&
+              tunnel.proto === "https"
+            ) {
               return tunnel.public_url;
             }
           }

--- a/packages/fx-core/tests/plugins/solution/debug/util/ngrok.test.ts
+++ b/packages/fx-core/tests/plugins/solution/debug/util/ngrok.test.ts
@@ -67,4 +67,18 @@ describe("ngrok", () => {
     const result = await ngrok.getNgrokHttpUrl("http://localhost:4041/");
     expect(result).equals("test_url");
   });
+
+  it("could get ngrok url by addr number and trailing slash", async () => {
+    stub(axios, "get").callsFake(async () => {
+      return {
+        data: {
+          tunnels: [
+            { public_url: "test_url", proto: "https", config: { addr: "http://localhost:4041/" } },
+          ],
+        },
+      };
+    });
+    const result = await ngrok.getNgrokHttpUrl(4041);
+    expect(result).equals("test_url");
+  });
 });


### PR DESCRIPTION
Remove the trailing slash for `config.addr`.
E2E TEST: none