### PR TITLE
fix: bot runtime error caused by latest adaptivecards npm pacckage

### DIFF
--- a/docs/sdk/teamsfx.invokeresponsefactory.adaptivecard.md
+++ b/docs/sdk/teamsfx.invokeresponsefactory.adaptivecard.md
@@ -11,18 +11,18 @@ The type of the invoke response is `application/vnd.microsoft.card.adaptive` ind
 <b>Signature:</b>
 
 ```typescript
-static adaptiveCard(card: IAdaptiveCard): InvokeResponse;
+static adaptiveCard(card: unknown): InvokeResponse;
 ```
 
 ## Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  card | IAdaptiveCard | The adaptive card JSON payload. |
+|  card | unknown | The adaptive card JSON payload. |
 
 <b>Returns:</b>
 
 InvokeResponse
 
-{<!-- -->InvokeResponse<!-- -->} An InvokeResponse object.
+An InvokeResponse object.
 

--- a/docs/sdk/teamsfx.invokeresponsefactory.createinvokeresponse.md
+++ b/docs/sdk/teamsfx.invokeresponsefactory.createinvokeresponse.md
@@ -23,5 +23,5 @@ static createInvokeResponse(statusCode: StatusCodes, body?: unknown): InvokeResp
 
 InvokeResponse
 
-{<!-- -->InvokeResponse<!-- -->} An InvokeResponse object.
+An InvokeResponse object.
 

--- a/docs/sdk/teamsfx.invokeresponsefactory.errorresponse.md
+++ b/docs/sdk/teamsfx.invokeresponsefactory.errorresponse.md
@@ -25,5 +25,5 @@ static errorResponse(errorCode: InvokeResponseErrorCode, errorMessage: string): 
 
 InvokeResponse
 
-{<!-- -->InvokeResponse<!-- -->} An InvokeResponse object.
+ An InvokeResponse object.
 

--- a/docs/sdk/teamsfx.invokeresponsefactory.md
+++ b/docs/sdk/teamsfx.invokeresponsefactory.md
@@ -20,7 +20,7 @@ This example sends an invoke response that contains an adaptive card.
 
 ```typescript
 
-const myCard: IAdaptiveCard = {
+const myCard = {
    type: "AdaptiveCard",
    body: [
     {

--- a/docs/sdk/teamsfx.invokeresponsefactory.textmessage.md
+++ b/docs/sdk/teamsfx.invokeresponsefactory.textmessage.md
@@ -16,11 +16,11 @@ static textMessage(message: string): InvokeResponse;
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  message | string | A text message included in a invoke response. |
+|  message | string | A text message included in an invoke response. |
 
 <b>Returns:</b>
 
 InvokeResponse
 
-{<!-- -->InvokeResponse<!-- -->} An InvokeResponse object.
+An InvokeResponse object.
 

--- a/packages/adaptivecards-tools-sdk/package.json
+++ b/packages/adaptivecards-tools-sdk/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@types/react": "^17.0.14",
     "adaptive-expressions": "^4.15.0",
-    "adaptivecards": "^2.10.0",
+    "adaptivecards": "~2.10.0",
     "adaptivecards-templating": "^2.1.0",
     "markdown-it": "^12.2.0",
     "react": "^17.0.2"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -51,7 +51,6 @@
     "@azure/msal-node": "~1.1.0",
     "@microsoft/adaptivecards-tools": "^1.0.1",
     "@microsoft/microsoft-graph-client": "^3.0.1",
-    "adaptivecards": "^2.10.0",
     "axios": "^0.27.2",
     "botbuilder": ">=4.15.0 <5.0.0",
     "botbuilder-dialogs": ">=4.15.0 <5.0.0",

--- a/packages/sdk/review/teamsfx.api.md
+++ b/packages/sdk/review/teamsfx.api.md
@@ -26,7 +26,6 @@ import { DialogContext } from 'botbuilder-dialogs';
 import { DialogTurnResult } from 'botbuilder-dialogs';
 import { GetTokenOptions } from '@azure/identity';
 import { HeroCard } from 'botbuilder';
-import { IAdaptiveCard } from 'adaptivecards';
 import { InvokeResponse } from 'botbuilder';
 import { MessagingExtensionResponse } from 'botbuilder';
 import { O365ConnectorCard } from 'botbuilder';
@@ -294,7 +293,7 @@ export enum InvokeResponseErrorCode {
 
 // @public
 export class InvokeResponseFactory {
-    static adaptiveCard(card: IAdaptiveCard): InvokeResponse;
+    static adaptiveCard(card: unknown): InvokeResponse;
     static createInvokeResponse(statusCode: StatusCodes, body?: unknown): InvokeResponse;
     static errorResponse(errorCode: InvokeResponseErrorCode, errorMessage: string): InvokeResponse;
     static textMessage(message: string): InvokeResponse;

--- a/packages/sdk/src/conversation/invokeResponseFactory.ts
+++ b/packages/sdk/src/conversation/invokeResponseFactory.ts
@@ -1,4 +1,3 @@
-import { IAdaptiveCard } from "adaptivecards";
 import { InvokeResponse, StatusCodes } from "botbuilder";
 import { InvokeResponseErrorCode } from "./interface";
 
@@ -23,7 +22,7 @@ export enum InvokeResponseType {
  *
  * ```typescript
  *
- * const myCard: IAdaptiveCard = {
+ * const myCard = {
  *    type: "AdaptiveCard",
  *    body: [
  *     {
@@ -47,9 +46,9 @@ export class InvokeResponseFactory {
    * The type of the invoke response is `application/vnd.microsoft.activity.message`
    * indicates the request was successfully processed.
    *
-   * @param message A text message included in a invoke response.
+   * @param message A text message included in an invoke response.
    *
-   * @returns {InvokeResponse} An InvokeResponse object.
+   * @returns An InvokeResponse object.
    */
   public static textMessage(message: string): InvokeResponse {
     if (!message) {
@@ -75,9 +74,9 @@ export class InvokeResponseFactory {
    *
    * @param card The adaptive card JSON payload.
    *
-   * @returns {InvokeResponse} An InvokeResponse object.
+   * @returns An InvokeResponse object.
    */
-  public static adaptiveCard(card: IAdaptiveCard): InvokeResponse {
+  public static adaptiveCard(card: unknown): InvokeResponse {
     if (!card) {
       throw new Error("The adaptive card content cannot be null or undefined");
     }
@@ -103,7 +102,7 @@ export class InvokeResponseFactory {
    *  - 500 (InternalServerError): indicate an unexpected error occurred.
    * @param errorMessage The error message.
    *
-   * @returns {InvokeResponse} An InvokeResponse object.
+   * @returns {@link InvokeResponse} An InvokeResponse object.
    */
   public static errorResponse(
     errorCode: InvokeResponseErrorCode,
@@ -127,7 +126,7 @@ export class InvokeResponseFactory {
    * @param statusCode The status code.
    * @param body The value of the response body.
    *
-   * @returns {InvokeResponse} An InvokeResponse object.
+   * @returns An InvokeResponse object.
    */
   public static createInvokeResponse(statusCode: StatusCodes, body?: unknown): InvokeResponse {
     return {

--- a/packages/sdk/test/unit/node/conversation/cardAction.spec.ts
+++ b/packages/sdk/test/unit/node/conversation/cardAction.spec.ts
@@ -8,7 +8,6 @@ import {
   MockCardActionHandler,
   MockCardActionHandlerWithErrorResponse,
 } from "./testUtils";
-import { IAdaptiveCard } from "adaptivecards";
 import { InvokeResponseErrorCode } from "../../../../src/conversation/interface";
 
 describe("Card Action Handler - Node", () => {
@@ -23,7 +22,7 @@ describe("Card Action Handler - Node", () => {
   });
 
   it("handler should send adaptive card response correctly", async () => {
-    const responseCard: IAdaptiveCard = {
+    const responseCard = {
       version: "1.0.0",
       type: "AdaptiveCard",
       body: [
@@ -88,7 +87,7 @@ describe("Card Action Handler - Node", () => {
   });
 });
 
-describe("ard Action Bot Tests - Node", () => {
+describe("Card Action Bot Tests - Node", () => {
   const sandbox = sinon.createSandbox();
   let adapter: BotFrameworkAdapter;
   let middlewares: any[];

--- a/packages/sdk/test/unit/node/conversation/testUtils.ts
+++ b/packages/sdk/test/unit/node/conversation/testUtils.ts
@@ -2,8 +2,6 @@
 // Licensed under the MIT license.
 
 import { Storage, StoreItems, TurnContext } from "botbuilder";
-import { IAdaptiveCard } from "adaptivecards";
-
 import { Activity, InvokeResponse, StatusCodes } from "botframework-schema";
 import {
   AdaptiveCardResponse,
@@ -115,7 +113,7 @@ export class MockCardActionHandler implements TeamsFxAdaptiveCardActionHandler {
   invokeResponse: InvokeResponse;
   actionData: any;
 
-  constructor(verb: string, response?: string | IAdaptiveCard) {
+  constructor(verb: string, response?: any) {
     this.triggerVerb = verb;
     if (!response) {
       this.invokeResponse = InvokeResponseFactory.textMessage("Your response was sent to the app");


### PR DESCRIPTION
Scaffold and run all bot project will got the following runtime error:
![image](https://user-images.githubusercontent.com/10163840/190852590-46f88a89-b3ab-40d1-9c7e-4fcd5e109705.png)

This is caused by the latest `adaptivecards` npm package which is just released on **9/17**.

To fix this issue, update the `adaptivecards-tools` sdk to keep using `adaptivecards@2.10.0`

E2E TEST: N/A