### PR TITLE
feat(sdk): add methods to find member/channel

### DIFF
--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/SearchScope.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/SearchScope.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.TeamsFx.Conversation
+{
+    /// <summary>
+    /// The search scope when calling <see cref="NotificationBot.FindMemberAsync"/> and <see cref="NotificationBot.FindAllMembersAsync"/>.
+    /// The search scope is a flagged enum and it can be combined with `|`.
+    /// For example, to search from personal chat and group chat, use `SearchScope.Person | SearchScope.Group`.
+    /// </summary>
+    [Flags]
+    public enum SearchScope
+    {
+        /// <summary>
+        /// Search members from the installations in personal chat only.
+        /// </summary>
+        Person = 1,
+
+        /// <summary>
+        /// Search members from the installations in group chat only.
+        /// </summary>
+        Group = 2,
+
+        /// <summary>
+        /// Search members from the installations in Teams channel only.
+        /// </summary>
+        Channel = 4,
+
+        /// <summary>
+        /// Search members from all installations including personal chat, group chat and Teams channel.
+        /// </summary>
+        All = Person | Group | Channel
+    }
+}


### PR DESCRIPTION
Work item: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/15344675/

Add following methods to notification bot:
* `FindMemberAsync`
* `FindAllMembersAsync`
* `FindChannelAsync`
* `FindAllChannelsAsync`

E2E TEST: N/A