### PR TITLE
fix(template): hotfix bot runtime error due to adaptivecards dependency

### DIFF
--- a/templates/bot/js/command-and-response/package.json
+++ b/templates/bot/js/command-and-response/package.json
@@ -17,6 +17,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
+        "adaptivecards": "~2.10.0",
         "@microsoft/teamsfx": "^1.0.0",
         "restify": "^8.5.1"
     },

--- a/templates/bot/js/default/package.json
+++ b/templates/bot/js/default/package.json
@@ -16,6 +16,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
+    "adaptivecards": "~2.10.0",
     "@microsoft/adaptivecards-tools": "^1.0.0",
     "botbuilder": "~4.14.0",
     "botbuilder-dialogs": "~4.14.0",

--- a/templates/bot/js/notification-function-base/package.json
+++ b/templates/bot/js/notification-function-base/package.json
@@ -16,6 +16,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
+        "adaptivecards": "~2.10.0",
         "@microsoft/adaptivecards-tools": "^1.0.0",
         "@microsoft/teamsfx": "^1.0.0",
         "botbuilder": "^4.17.0"

--- a/templates/bot/js/notification-restify/package.json
+++ b/templates/bot/js/notification-restify/package.json
@@ -17,6 +17,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
+        "adaptivecards": "~2.10.0",
         "@microsoft/adaptivecards-tools": "^1.0.0",
         "@microsoft/teamsfx": "^1.0.0",
         "botbuilder": "^4.17.0",

--- a/templates/bot/js/workflow/package.json
+++ b/templates/bot/js/workflow/package.json
@@ -17,6 +17,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
+        "adaptivecards": "~2.10.0",
         "@microsoft/adaptivecards-tools": "^1.0.0",
         "@microsoft/teamsfx": "1.2.0-rc.0",
         "restify": "^8.5.1"

--- a/templates/bot/ts/command-and-response/package.json
+++ b/templates/bot/ts/command-and-response/package.json
@@ -18,6 +18,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
+        "adaptivecards": "~2.10.0",
         "@microsoft/teamsfx": "^1.0.0",
         "botbuilder": "^4.17.0",
         "restify": "^8.5.1"

--- a/templates/bot/ts/default/package.json
+++ b/templates/bot/ts/default/package.json
@@ -18,6 +18,7 @@
     "url": "https://github.com"
   },
   "dependencies": {
+    "adaptivecards": "~2.10.0",
     "@microsoft/adaptivecards-tools": "^1.0.0",
     "botbuilder": "~4.14.0",
     "botbuilder-dialogs": "~4.14.0",

--- a/templates/bot/ts/notification-function-base/package.json
+++ b/templates/bot/ts/notification-function-base/package.json
@@ -20,6 +20,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
+        "adaptivecards": "~2.10.0",
         "@microsoft/adaptivecards-tools": "^1.0.0",
         "@microsoft/teamsfx": "^1.0.0",
         "botbuilder": "^4.17.0"

--- a/templates/bot/ts/notification-restify/package.json
+++ b/templates/bot/ts/notification-restify/package.json
@@ -18,6 +18,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
+        "adaptivecards": "~2.10.0",
         "@microsoft/adaptivecards-tools": "^1.0.0",
         "@microsoft/teamsfx": "^1.0.0",
         "botbuilder": "^4.17.0",

--- a/templates/bot/ts/workflow/package.json
+++ b/templates/bot/ts/workflow/package.json
@@ -18,6 +18,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
+        "adaptivecards": "~2.10.0",
         "@microsoft/adaptivecards-tools": "^1.0.0",
         "@microsoft/teamsfx": "1.2.0-rc.0",
         "botbuilder": "^4.17.0",


### PR DESCRIPTION
Fix issue: [Failed to start bot due to error caused by the adaptivecards dependency](https://github.com/OfficeDev/TeamsFx/issues/6127)

E2E TEST: N/A