### PR TITLE
fix(template): hotfix bot templates caused by adaptivecards dependenc…

### DIFF
--- a/templates/bot/js/command-and-response/package.json
+++ b/templates/bot/js/command-and-response/package.json
@@ -18,6 +18,7 @@
     },
     "dependencies": {
         "@microsoft/teamsfx": "^1.0.0",
+        "adaptivecards": "~2.10.0",
         "restify": "^8.5.1"
     },
     "devDependencies": {

--- a/templates/bot/js/default/package.json
+++ b/templates/bot/js/default/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@microsoft/adaptivecards-tools": "^1.0.0",
+    "adaptivecards": "~2.10.0",
     "botbuilder": "~4.14.0",
     "botbuilder-dialogs": "~4.14.0",
     "isomorphic-fetch": "^3.0.0",

--- a/templates/bot/js/notification-function-base/package.json
+++ b/templates/bot/js/notification-function-base/package.json
@@ -18,6 +18,7 @@
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
         "@microsoft/teamsfx": "^1.0.0",
+        "adaptivecards": "~2.10.0",
         "botbuilder": "~4.15.0"
     },
     "devDependencies": {

--- a/templates/bot/js/notification-restify/package.json
+++ b/templates/bot/js/notification-restify/package.json
@@ -19,6 +19,7 @@
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
         "@microsoft/teamsfx": "^1.0.0",
+        "adaptivecards": "~2.10.0",
         "botbuilder": "~4.15.0",
         "restify": "^8.5.1"
     },

--- a/templates/bot/ts/command-and-response/package.json
+++ b/templates/bot/ts/command-and-response/package.json
@@ -19,6 +19,7 @@
     },
     "dependencies": {
         "@microsoft/teamsfx": "^1.0.0",
+        "adaptivecards": "~2.10.0",
         "botbuilder": "~4.17.0",
         "restify": "^8.5.1"
     },

--- a/templates/bot/ts/default/package.json
+++ b/templates/bot/ts/default/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@microsoft/adaptivecards-tools": "^1.0.0",
+    "adaptivecards": "~2.10.0",
     "botbuilder": "~4.14.0",
     "botbuilder-dialogs": "~4.14.0",
     "isomorphic-fetch": "^3.0.0",

--- a/templates/bot/ts/notification-function-base/package.json
+++ b/templates/bot/ts/notification-function-base/package.json
@@ -22,6 +22,7 @@
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
         "@microsoft/teamsfx": "^1.0.0",
+        "adaptivecards": "~2.10.0",
         "botbuilder": "~4.15.0"
     },
     "devDependencies": {

--- a/templates/bot/ts/notification-restify/package.json
+++ b/templates/bot/ts/notification-restify/package.json
@@ -20,6 +20,7 @@
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
         "@microsoft/teamsfx": "^1.0.0",
+        "adaptivecards": "~2.10.0",
         "botbuilder": "~4.15.0",
         "restify": "^8.5.1"
     },


### PR DESCRIPTION
Fix issue: [Failed to start bot due to error caused by the adaptivecards dependency](https://github.com/OfficeDev/TeamsFx/issues/6127)

E2E TEST: N/A