### PR TITLE
chore(template): send error message for unhandled error in bot adapter

### DIFF
--- a/templates/bot/csharp/command-and-response/AdapterWithErrorHandler.cs.tpl
+++ b/templates/bot/csharp/command-and-response/AdapterWithErrorHandler.cs.tpl
@@ -18,7 +18,7 @@ namespace {{SafeProjectName}}
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user
-                await turnContext.SendActivityAsync("The bot encountered an error or bug.");
+                await turnContext.SendActivityAsync($"The bot encountered an unhandled error: {exception.Message}");
                 await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
 
                 // Send a trace activity

--- a/templates/bot/csharp/notification-function-base/AdapterWithErrorHandler.cs.tpl
+++ b/templates/bot/csharp/notification-function-base/AdapterWithErrorHandler.cs.tpl
@@ -18,7 +18,7 @@ namespace {{SafeProjectName}}
                 // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
                 // Send a message to the user
-                await turnContext.SendActivityAsync("The bot encountered an error or bug.");
+                await turnContext.SendActivityAsync($"The bot encountered an unhandled error: {exception.Message}");
                 await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
                 // Send a trace activity
                 await turnContext.TraceActivityAsync("OnTurnError Trace", exception.Message, "https://www.botframework.com/schemas/error", "TurnError");

--- a/templates/bot/csharp/notification-webapi/AdapterWithErrorHandler.cs.tpl
+++ b/templates/bot/csharp/notification-webapi/AdapterWithErrorHandler.cs.tpl
@@ -17,7 +17,7 @@ namespace {{SafeProjectName}}
                 // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
                 // Send a message to the user
-                await turnContext.SendActivityAsync("The bot encountered an error or bug.");
+                await turnContext.SendActivityAsync($"The bot encountered an unhandled error: {exception.Message}");
                 await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
                 // Send a trace activity
                 await turnContext.TraceActivityAsync("OnTurnError Trace", exception.Message, "https://www.botframework.com/schemas/error", "TurnError");

--- a/templates/bot/csharp/workflow/AdapterWithErrorHandler.cs.tpl
+++ b/templates/bot/csharp/workflow/AdapterWithErrorHandler.cs.tpl
@@ -18,7 +18,7 @@ namespace {{SafeProjectName}}
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
                 // Send a message to the user
-                await turnContext.SendActivityAsync("The bot encountered an error or bug.");
+                await turnContext.SendActivityAsync($"The bot encountered an unhandled error: {exception.Message}");
                 await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
 
                 // Send a trace activity


### PR DESCRIPTION
Fix  [Bug 15565115](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/15565115): [VisualStudio] If card is not found, bot fails with no good exception.

The bot will send an message activity with the error message if encounter an unhandled error. This is also align with the TS/JS template.

E2E TEST: N/A