### PR TITLE
fix(localdebug): return dotnet bin folder dir

### DIFF
--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -1401,9 +1401,9 @@ export async function getDotnetPathHandler(): Promise<string> {
     const depsManager = new DepsManager(vscodeLogger, vscodeTelemetry);
     const dotnetStatus = (await depsManager.getStatus([DepsType.Dotnet]))?.[0];
     if (dotnetStatus?.isInstalled && dotnetStatus?.details?.binFolders !== undefined) {
-      return `${path.delimiter}${dotnetStatus.details.binFolders.join(path.delimiter)}${
-        path.delimiter
-      }`;
+      return `${path.delimiter}${dotnetStatus.details.binFolders
+        .map((f: string) => path.dirname(f))
+        .join(path.delimiter)}${path.delimiter}`;
     }
   } catch (error: any) {
     showError(assembleError(error));

--- a/packages/vscode-extension/test/extension/handlers.test.ts
+++ b/packages/vscode-extension/test/extension/handlers.test.ts
@@ -825,7 +825,7 @@ describe("handlers", () => {
             isLinuxSupported: false,
             installVersion: "",
             supportedVersions: [],
-            binFolders: ["dotnet-bin-folder"],
+            binFolders: ["dotnet-bin-folder/dotnet"],
           },
         },
       ]);


### PR DESCRIPTION
Fix the bug of installing Azure Functions binding extension.
E2E TEST: https://github.com/OfficeDev/TeamsFx-UI-Test/blob/b9efaf1b8fb1da058ef01a8f08e2d0f390de2239/src/ui-test/localdebug/localdebug-function.test.ts#L11