### PR TITLE
Clear needConsent flag after successful login

### DIFF
--- a/packages/sdk-react/src/useGraph.ts
+++ b/packages/sdk-react/src/useGraph.ts
@@ -30,6 +30,7 @@ export function useGraph<T>(
     if (needConsent) {
       try {
         await teamsfx.login(scope);
+        setNeedConsent(false);
         // Important: tokens are stored in sessionStorage, read more here: https://aka.ms/teamsfx-session-storage-notice
       } catch (err: unknown) {
         if (err instanceof ErrorWithCode && err.message?.includes("CancelledByUser")) {


### PR DESCRIPTION
When UIRequiredError occurs, needConsent is set to true so it calls teamsfx.login() at the next reload to ask for user consent. So far so good. The problem is: after the user gives the necessary consent, needConsent flag is not cleared, so subsequent reloads will keep calling teamsfx.login and showing popup window that will automatically disappear.

This change fixes the issue - when consent is granted, login function won't be called.