### PR TITLE
chore: hide core log for local debug

### DIFF
--- a/packages/vscode-extension/src/debug/commonUtils.ts
+++ b/packages/vscode-extension/src/debug/commonUtils.ts
@@ -121,6 +121,8 @@ export async function getDebugConfig(
 ): Promise<{ appId: string; env?: string } | undefined> {
   try {
     const inputs = getSystemInputs();
+    // hide core log by default
+    inputs.loglevel = "Debug";
     const getConfigRes = await core.getProjectConfigV3(inputs);
     if (getConfigRes.isErr()) throw getConfigRes.error;
     const config = getConfigRes.value;


### PR DESCRIPTION
Hide core log "start task:getProjectConfigV3" during F5.