### PR TITLE
chore: hide debug console for bot

### DIFF
--- a/packages/fx-core/src/plugins/solution/fx-solution/debug/util/launch.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/debug/util/launch.ts
@@ -271,6 +271,7 @@ function attachToBot(): Record<string, unknown> {
       group: "all",
       hidden: true,
     },
+    internalConsoleOptions: "neverOpen",
   };
 }
 

--- a/packages/fx-core/src/plugins/solution/fx-solution/debug/util/launchNext.ts
+++ b/packages/fx-core/src/plugins/solution/fx-solution/debug/util/launchNext.ts
@@ -324,6 +324,7 @@ function attachToBot() {
       group: "all",
       hidden: true,
     },
+    internalConsoleOptions: "neverOpen",
   };
 }
 


### PR DESCRIPTION
Totally hide debug console.
There's a corner case that due to sequence, the browser debug console still shows when bot debug console is activated, so hide bot debug console as well to avoid such case.