### PR TITLE
fix(vsc): select workspace folder canceled in WSL

### DIFF
--- a/packages/vscode-extension/src/qm/vsc_ui.ts
+++ b/packages/vscode-extension/src/qm/vsc_ui.ts
@@ -475,6 +475,7 @@ export class VsCodeUI implements UserInteraction {
             },
           ];
 
+          let hideByDialog = false;
           const onDidAccept = async () => {
             const selectedItems = quickPick.selectedItems;
             if (selectedItems && selectedItems.length > 0) {
@@ -485,6 +486,7 @@ export class VsCodeUI implements UserInteraction {
               if (item.id === "default") {
                 resolve(ok({ type: "success", result: config.default }));
               } else {
+                hideByDialog = true;
                 const uriList: Uri[] | undefined = await window.showOpenDialog({
                   defaultUri: config.default ? Uri.file(config.default) : undefined,
                   canSelectFiles: false,
@@ -504,6 +506,11 @@ export class VsCodeUI implements UserInteraction {
 
           disposables.push(
             quickPick.onDidAccept(onDidAccept),
+            quickPick.onDidHide(() => {
+              if (!hideByDialog) {
+                resolve(err(UserCancelError));
+              }
+            }),
             quickPick.onDidTriggerButton((button) => {
               if (button === QuickInputButtons.Back) resolve(ok({ type: "back" }));
             })

--- a/packages/vscode-extension/src/qm/vsc_ui.ts
+++ b/packages/vscode-extension/src/qm/vsc_ui.ts
@@ -504,9 +504,6 @@ export class VsCodeUI implements UserInteraction {
 
           disposables.push(
             quickPick.onDidAccept(onDidAccept),
-            quickPick.onDidHide(() => {
-              resolve(err(UserCancelError));
-            }),
             quickPick.onDidTriggerButton((button) => {
               if (button === QuickInputButtons.Back) resolve(ok({ type: "back" }));
             })

--- a/packages/vscode-extension/test/extension/userInterface.test.ts
+++ b/packages/vscode-extension/test/extension/userInterface.test.ts
@@ -98,23 +98,23 @@ describe("UI Unit Tests", async () => {
 
       const mockQuickPick = stubInterface<QuickPick<FxQuickPickItem>>();
       const mockDisposable = stubInterface<Disposable>();
-      let hideListener: (e: void) => any;
+      let acceptListener: (e: void) => any;
       mockQuickPick.onDidAccept.callsFake((listener: (e: void) => unknown) => {
-        return mockDisposable;
-      });
-      mockQuickPick.onDidHide.callsFake((listener: (e: void) => unknown) => {
-        hideListener = listener;
+        acceptListener = listener;
         return mockDisposable;
       });
       mockQuickPick.onDidTriggerButton.callsFake((listener: (e: QuickInputButton) => unknown) => {
         return mockDisposable;
       });
       mockQuickPick.show.callsFake(() => {
-        hideListener();
+        mockQuickPick.selectedItems = [{ id: "browse" } as FxQuickPickItem];
+        acceptListener();
       });
       sinon.stub(window, "createQuickPick").callsFake(() => {
         return mockQuickPick;
       });
+      sinon.stub(window, "showOpenDialog").resolves(undefined);
+      sinon.stub(ExtTelemetry, "sendTelemetryEvent");
 
       const result = await ui.selectFolder(config);
 

--- a/packages/vscode-extension/test/extension/userInterface.test.ts
+++ b/packages/vscode-extension/test/extension/userInterface.test.ts
@@ -103,6 +103,9 @@ describe("UI Unit Tests", async () => {
         acceptListener = listener;
         return mockDisposable;
       });
+      mockQuickPick.onDidHide.callsFake((listener: (e: void) => unknown) => {
+        return mockDisposable;
+      });
       mockQuickPick.onDidTriggerButton.callsFake((listener: (e: QuickInputButton) => unknown) => {
         return mockDisposable;
       });

--- a/packages/vscode-extension/test/mocks/vscode-mock.ts
+++ b/packages/vscode-extension/test/mocks/vscode-mock.ts
@@ -120,6 +120,7 @@ mockedVSCode.TaskRevealKind = vscodeMocks.vscMockExtHostedTypes.TaskRevealKind;
     return await task({ report: () => {} }, new vscodeMocks.CancellationToken());
   },
   createQuickPick: () => {},
+  showOpenDialog: () => {},
 };
 (mockedVSCode as any).workspace = {
   workspaceFolders: undefined,


### PR DESCRIPTION
Related bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/15772677

E2E TEST: N/A