### PR TITLE
chore: remove MessageBuilder from bot template

### DIFF
--- a/templates/bot/js/command-and-response/src/helloworldCommandHandler.js
+++ b/templates/bot/js/command-and-response/src/helloworldCommandHandler.js
@@ -1,5 +1,6 @@
 const helloWorldCard = require("./adaptiveCards/helloworldCommand.json");
-const { MessageBuilder } = require("@microsoft/teamsfx");
+const { AdaptiveCards } = require("@microsoft/adaptivecards-tools");
+const { CardFactory, MessageFactory } = require("botbuilder");
 
 class HelloWorldCommandHandler {
   triggerPatterns = "helloWorld";
@@ -16,7 +17,8 @@ class HelloWorldCommandHandler {
       body: "Congratulations! Your hello world bot is running. Click the documentation below to learn more about Bots and the Teams Toolkit.",
     };
 
-    return MessageBuilder.attachAdaptiveCard(helloWorldCard, cardData);
+    const cardJson = AdaptiveCards.declare(helloWorldCard).render(cardData);
+    return MessageFactory.attachment(CardFactory.adaptiveCard(cardJson));
   }
 }
 

--- a/templates/bot/js/workflow/src/commands/helloworldCommandHandler.js
+++ b/templates/bot/js/workflow/src/commands/helloworldCommandHandler.js
@@ -1,5 +1,6 @@
 const helloWorldCard = require("../adaptiveCards/helloworldCommandResponse.json");
-const { MessageBuilder } = require("@microsoft/teamsfx");
+const { AdaptiveCards } = require("@microsoft/adaptivecards-tools");
+const { CardFactory, MessageFactory } = require("botbuilder");
 
 class HelloWorldCommandHandler {
   triggerPatterns = "helloWorld";
@@ -13,7 +14,8 @@ class HelloWorldCommandHandler {
       body: "Congratulations! Your hello world bot is running. Click the documentation below to learn more about Bots and the Teams Toolkit.",
     };
 
-    return MessageBuilder.attachAdaptiveCard(helloWorldCard, cardData);
+    const cardJson = AdaptiveCards.declare(helloWorldCard).render(cardData);
+    return MessageFactory.attachment(CardFactory.adaptiveCard(cardJson));
   }
 }
 

--- a/templates/bot/ts/command-and-response/src/helloworldCommandHandler.ts
+++ b/templates/bot/ts/command-and-response/src/helloworldCommandHandler.ts
@@ -1,10 +1,6 @@
-import { Activity, TurnContext } from "botbuilder";
-import {
-  CommandMessage,
-  TeamsFxBotCommandHandler,
-  TriggerPatterns,
-  MessageBuilder,
-} from "@microsoft/teamsfx";
+import { Activity, CardFactory, MessageFactory, TurnContext } from "botbuilder";
+import { CommandMessage, TeamsFxBotCommandHandler, TriggerPatterns } from "@microsoft/teamsfx";
+import { AdaptiveCards } from "@microsoft/adaptivecards-tools";
 import helloWorldCard from "./adaptiveCards/helloworldCommand.json";
 import { CardData } from "./cardModels";
 
@@ -27,6 +23,7 @@ export class HelloWorldCommandHandler implements TeamsFxBotCommandHandler {
       body: "Congratulations! Your hello world bot is running. Click the documentation below to learn more about Bots and the Teams Toolkit.",
     };
 
-    return MessageBuilder.attachAdaptiveCard<CardData>(helloWorldCard, cardData);
+    const cardJson = AdaptiveCards.declare(helloWorldCard).render(cardData);
+    return MessageFactory.attachment(CardFactory.adaptiveCard(cardJson));
   }
 }

--- a/templates/bot/ts/workflow/src/commands/helloworldCommandHandler.ts
+++ b/templates/bot/ts/workflow/src/commands/helloworldCommandHandler.ts
@@ -1,10 +1,6 @@
-import { Activity, TurnContext } from "botbuilder";
-import {
-  CommandMessage,
-  TeamsFxBotCommandHandler,
-  TriggerPatterns,
-  MessageBuilder,
-} from "@microsoft/teamsfx";
+import { Activity, CardFactory, MessageFactory, TurnContext } from "botbuilder";
+import { CommandMessage, TeamsFxBotCommandHandler, TriggerPatterns } from "@microsoft/teamsfx";
+import { AdaptiveCards } from "@microsoft/adaptivecards-tools";
 import helloWorldCard from "../adaptiveCards/helloworldCommandResponse.json";
 import { CardData } from "../cardModels";
 
@@ -27,6 +23,7 @@ export class HelloWorldCommandHandler implements TeamsFxBotCommandHandler {
       body: "Congratulations! Your hello world bot is running. Click the button below to trigger an action.",
     };
 
-    return MessageBuilder.attachAdaptiveCard<CardData>(helloWorldCard, cardData);
+    const cardJson = AdaptiveCards.declare(helloWorldCard).render(cardData);
+    return MessageFactory.attachment(CardFactory.adaptiveCard(cardJson));
   }
 }


### PR DESCRIPTION
Replace `MessageBuilder` API with `MessageFactory` and `CardFactory` which is provided by the official bot-builder SDK.

E2E TEST: N/A