### PR TITLE
chore: add utility to expand environment variables

### DIFF
--- a/packages/fx-core/src/component/utils/common.ts
+++ b/packages/fx-core/src/component/utils/common.ts
@@ -55,3 +55,21 @@ export function asFactory<T>(keyValidators: KeyValidators<T>) {
     throw PrerequisiteError.somethingIllegal("Deploy", "data", "plugins.bot.InvalidData");
   };
 }
+
+// Expand environment variables in content. The format of referencing environment variable is: ${{ENV_NAME}}
+export function expandEnvironmentVariable(content: string): string {
+  const placeholderRegex = /\${{[a-zA-Z_][a-zA-Z0-9_]*}}/g;
+  const placeholders = content.match(placeholderRegex);
+
+  if (placeholders) {
+    for (const placeholder of placeholders) {
+      const envName = placeholder.slice(3, -2); // removes `${{` and `}}`
+      const envValue = process.env[envName];
+      if (envValue) {
+        content = content.replace(placeholder, envValue);
+      }
+    }
+  }
+
+  return content;
+}

--- a/packages/fx-core/src/component/utils/common.ts
+++ b/packages/fx-core/src/component/utils/common.ts
@@ -58,12 +58,12 @@ export function asFactory<T>(keyValidators: KeyValidators<T>) {
 
 // Expand environment variables in content. The format of referencing environment variable is: ${{ENV_NAME}}
 export function expandEnvironmentVariable(content: string): string {
-  const placeholderRegex = /\${{[a-zA-Z_][a-zA-Z0-9_]*}}/g;
+  const placeholderRegex = /\${{ *[a-zA-Z_][a-zA-Z0-9_]* *}}/g;
   const placeholders = content.match(placeholderRegex);
 
   if (placeholders) {
     for (const placeholder of placeholders) {
-      const envName = placeholder.slice(3, -2); // removes `${{` and `}}`
+      const envName = placeholder.slice(3, -2).trim(); // removes `${{` and `}}`
       const envValue = process.env[envName];
       if (envValue) {
         content = content.replace(placeholder, envValue);

--- a/packages/fx-core/tests/component/utils.test.ts
+++ b/packages/fx-core/tests/component/utils.test.ts
@@ -1,3 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import "mocha";
 import { InputsWithProjectPath, Platform, v3, ok } from "@microsoft/teamsfx-api";
 import { expect } from "chai";
 import { convertContext } from "../../src/component/resource/aadApp/utils";
@@ -22,6 +26,9 @@ import { setTools } from "../../src/core/globalVars";
 import { newEnvInfoV3 } from "../../src/core/environment";
 import fs from "fs-extra";
 import { MyTokenCredential } from "../plugins/solution/util";
+import { expandEnvironmentVariable } from "../../src/component/utils/common";
+import mockedEnv, { RestoreFn } from "mocked-env";
+
 describe("resetEnvInfoWhenSwitchM365", () => {
   const sandbox = sinon.createSandbox();
   const tools = new MockTools();
@@ -251,5 +258,58 @@ describe("resetEnvInfoWhenSwitchM365", () => {
       },
     ];
     await scaffoldRootReadme(projectSettings, ".");
+  });
+});
+
+describe("expandEnvironmentVariable", () => {
+  const template = "ENV_A value:${{ENV_A}}" + "ENV_B value:${{ENV_B}}";
+
+  let envRestore: RestoreFn | undefined;
+
+  afterEach(() => {
+    if (envRestore) {
+      envRestore();
+      envRestore = undefined;
+    }
+  });
+
+  it("should expand all environment variables", () => {
+    envRestore = mockedEnv({
+      ENV_A: "A",
+      ENV_B: "B",
+    });
+
+    const result = expandEnvironmentVariable(template);
+
+    expect(result).to.equal("ENV_A value:A" + "ENV_B value:B");
+  });
+
+  it("should not expand placeholder when specified environment variable not exist", () => {
+    envRestore = mockedEnv({
+      ENV_A: "A",
+    });
+
+    const result = expandEnvironmentVariable(template);
+
+    expect(result).to.equal("ENV_A value:A" + "ENV_B value:${{ENV_B}}");
+  });
+
+  it("should not modify original string", () => {
+    envRestore = mockedEnv({
+      ENV_A: "A",
+      ENV_B: "B",
+    });
+
+    expandEnvironmentVariable(template);
+
+    expect(template).to.equal("ENV_A value:${{ENV_A}}" + "ENV_B value:${{ENV_B}}");
+  });
+
+  it("should do nothing with non valid placeholder", () => {
+    const stringWithNonValidPlaceholder = "placeholder:${{}}";
+
+    const result = expandEnvironmentVariable(stringWithNonValidPlaceholder);
+
+    expect(result).to.equal("placeholder:${{}}");
   });
 });

--- a/packages/fx-core/tests/component/utils.test.ts
+++ b/packages/fx-core/tests/component/utils.test.ts
@@ -306,10 +306,22 @@ describe("expandEnvironmentVariable", () => {
   });
 
   it("should do nothing with non valid placeholder", () => {
-    const stringWithNonValidPlaceholder = "placeholder:${{}}";
+    const template = "placeholder:${{}}";
 
-    const result = expandEnvironmentVariable(stringWithNonValidPlaceholder);
+    const result = expandEnvironmentVariable(template);
 
     expect(result).to.equal("placeholder:${{}}");
+  });
+
+  it("should allow leading and trailing whitespaces in environment variable name", () => {
+    const template = "placeholder: ${{ ENV_A }}";
+
+    envRestore = mockedEnv({
+      ENV_A: "A",
+    });
+
+    const result = expandEnvironmentVariable(template);
+
+    expect(result).to.equal("placeholder: A");
   });
 });


### PR DESCRIPTION
Add utility to expand environment variables for V3's new placeholder syntax.
It doesn't support escaping for now. We can enrich the functionality in the future if there's explicit requirement.