### PR TITLE
perf: appCredential add missing authorityHost check

### DIFF
--- a/packages/sdk/src/credential/appCredential.ts
+++ b/packages/sdk/src/credential/appCredential.ts
@@ -112,7 +112,12 @@ export class AppCredential implements TokenCredential {
   private loadAndValidateConfig(config: AuthenticationConfiguration): AuthenticationConfiguration {
     internalLogger.verbose("Validate authentication configuration");
 
-    if (config.clientId && (config.clientSecret || config.certificateContent) && config.tenantId) {
+    if (
+      config.clientId &&
+      (config.clientSecret || config.certificateContent) &&
+      config.tenantId &&
+      config.authorityHost
+    ) {
       return config;
     }
 
@@ -128,6 +133,10 @@ export class AppCredential implements TokenCredential {
 
     if (!config.tenantId) {
       missingValues.push("tenantId");
+    }
+
+    if (!config.authorityHost) {
+      missingValues.push("authorityHost");
     }
 
     const errorMsg = formatString(

--- a/packages/sdk/test/unit/node/appCredential.spec.ts
+++ b/packages/sdk/test/unit/node/appCredential.spec.ts
@@ -88,7 +88,7 @@ fakeCert
     })
       .to.throw(
         ErrorWithCode,
-        "clientId, clientSecret or certificateContent, tenantId in configuration is invalid: undefined."
+        "clientId, clientSecret or certificateContent, tenantId, authorityHost in configuration is invalid: undefined."
       )
       .with.property("code", ErrorCode.InvalidConfiguration);
 
@@ -97,7 +97,7 @@ fakeCert
     })
       .to.throw(
         ErrorWithCode,
-        "clientSecret or certificateContent, tenantId in configuration is invalid: undefined."
+        "clientSecret or certificateContent, tenantId, authorityHost in configuration is invalid: undefined."
       )
       .with.property("code", ErrorCode.InvalidConfiguration);
 
@@ -106,7 +106,16 @@ fakeCert
     })
       .to.throw(
         ErrorWithCode,
-        "clientSecret or certificateContent in configuration is invalid: undefined."
+        "clientId, clientSecret or certificateContent, authorityHost in configuration is invalid: undefined."
+      )
+      .with.property("code", ErrorCode.InvalidConfiguration);
+
+    expect(() => {
+      new AppCredential({ authorityHost: authorityHost });
+    })
+      .to.throw(
+        ErrorWithCode,
+        "clientId, clientSecret or certificateContent, tenantId in configuration is invalid: undefined."
       )
       .with.property("code", ErrorCode.InvalidConfiguration);
   });


### PR DESCRIPTION
appCredential needs authorityHost URL,, however, currently implementation do not check whether authorityHost exists, this PR fix this issue