### PR TITLE
fix: print standard output to error channel when error occurs

### DIFF
--- a/packages/fx-core/src/component/code/utils.ts
+++ b/packages/fx-core/src/component/code/utils.ts
@@ -42,15 +42,15 @@ export function execute(
     logger?.info(`Start to run command: "${command}" on path: "${workingDir}".`);
 
     exec(command, { cwd: workingDir, env: { ...process.env, ...env } }, (error, stdout, stderr) => {
-      logger?.debug(stdout);
       if (error) {
         logger?.error(`Failed to run command: "${command}" on path: "${workingDir}".`);
+        logger?.error(stdout);
         if (stderr) {
           logger?.error(stderr);
         }
-        logger?.error(error.message);
         reject(error);
       }
+      logger?.debug(stdout);
       resolve(stdout);
     });
   });


### PR DESCRIPTION
* Error message is logged twice. Stop logging `error.message` in execute method.
* Npm pushes error message to standard output, log it to output channel as error message error occurs.
https://github.com/OfficeDev/TeamsFx/issues/6202

E2E TEST: no need