### PR TITLE
fix(localdebug): add missing import in baseTaskTerminal

### DIFF
--- a/packages/vscode-extension/src/debug/taskTerminal/baseTaskTerminal.ts
+++ b/packages/vscode-extension/src/debug/taskTerminal/baseTaskTerminal.ts
@@ -13,6 +13,7 @@ import { getDefaultString, localize } from "../../utils/localizeUtils";
 import { sendDebugAllEvent } from "../localTelemetryReporter";
 import * as commonUtils from "../commonUtils";
 import { TelemetryProperty } from "../../telemetry/extTelemetryEvents";
+import { performance } from "perf_hooks";
 
 const ControlCodes = {
   CtrlC: "\u0003",


### PR DESCRIPTION
detail: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/15801223
E2E TEST: https://github.com/OfficeDev/TeamsFx-UI-Test/blob/64c2a05105bba54198d6c4e2f1372d7fecbdb8d7/src/ui-test/localdebug/localdebug-bot.test.ts#L29