### PR TITLE
chore: remove appinsights service dependency

### DIFF
--- a/templates/bot/csharp/notification-function-base/Properties/serviceDependencies.json
+++ b/templates/bot/csharp/notification-function-base/Properties/serviceDependencies.json
@@ -1,8 +1,5 @@
 {
   "dependencies": {
-    "appInsights1": {
-      "type": "appInsights"
-    },
     "storage1": {
       "type": "storage",
       "connectionId": "AzureWebJobsStorage"

--- a/templates/bot/csharp/notification-function-base/Properties/serviceDependencies.local.json
+++ b/templates/bot/csharp/notification-function-base/Properties/serviceDependencies.local.json
@@ -1,8 +1,5 @@
 {
   "dependencies": {
-    "appInsights1": {
-      "type": "appInsights.sdk"
-    },
     "storage1": {
       "type": "storage.emulator",
       "connectionId": "AzureWebJobsStorage"


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/15789527/

Remove appinsights from VS notification bot, since we do not provision app insights instance, and local debug does not require it as well.