### PR TITLE
chore(release): merge hotfix into main branch

### DIFF
--- a/packages/fx-core/package-lock.json
+++ b/packages/fx-core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/teamsfx-core",
-  "version": "1.16.4-rc-hotfix.0",
+  "version": "1.16.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/fx-core/package-lock.json
+++ b/packages/fx-core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/teamsfx-core",
-  "version": "1.16.3",
+  "version": "1.16.4-rc-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/fx-core/package.json
+++ b/packages/fx-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/teamsfx-core",
-  "version": "1.16.4-rc-hotfix.0",
+  "version": "1.16.4",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "license": "MIT",

--- a/packages/fx-core/package.json
+++ b/packages/fx-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/teamsfx-core",
-  "version": "1.16.3",
+  "version": "1.16.4-rc-hotfix.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "license": "MIT",

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/teamsfx-server",
-  "version": "1.0.7-rc-hotfix.0",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/teamsfx-server",
-  "version": "1.0.6",
+  "version": "1.0.7-rc-hotfix.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/teamsfx-server",
-  "version": "1.0.7-rc-hotfix.0",
+  "version": "1.0.7",
   "author": "Microsoft Corporation",
   "description": "",
   "license": "MIT",
@@ -92,7 +92,7 @@
   "dependencies": {
     "@azure/identity": "^1.3.0",
     "@microsoft/teamsfx-api": "^0.20.6",
-    "@microsoft/teamsfx-core": "^1.16.4-rc-hotfix.0",
+    "@microsoft/teamsfx-core": "^1.16.4",
     "fs-extra": "^9.1.0",
     "underscore": "^1.12.1",
     "validator": "^13.7.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/teamsfx-server",
-  "version": "1.0.6",
+  "version": "1.0.7-rc-hotfix.0",
   "author": "Microsoft Corporation",
   "description": "",
   "license": "MIT",
@@ -92,7 +92,7 @@
   "dependencies": {
     "@azure/identity": "^1.3.0",
     "@microsoft/teamsfx-api": "^0.20.6",
-    "@microsoft/teamsfx-core": "^1.16.3",
+    "@microsoft/teamsfx-core": "^1.16.4-rc-hotfix.0",
     "fs-extra": "^9.1.0",
     "underscore": "^1.12.1",
     "validator": "^13.7.0",


### PR DESCRIPTION
@microsoft/adaptivecards-tools	v1.1.0-rc.0
@microsoft/teamsfx-api	v0.20.7-rc.0
@microsoft/teamsfx-cli	v1.1.3-rc.0
@microsoft/teamsfx-core	v1.17.0-rc.0
@microsoft/teamsfx	v1.2.1-rc.0
@microsoft/teamsfx-react	v1.0.6-rc.0
ms-teams-vscode-extension	v4.1.0-rc.0

CLI BREAKING CHANGE:
  

Extension-toolkit BREAKING CHANGE:
 

CLI feat commits:
  

Extension-toolkit feat commits:
 feat(vsc): add support for untrusted workspace (#6279) 540807041
feat(vsc): add tutorial for card action response (#6261) 242e92b52
feat: support both spfx 1.15 and 1.16 beta  (#6150) 0d532389e