### PR TITLE
fix: azure display name empty when sign out and sign in again

### DIFF
--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -3260,7 +3260,7 @@ export async function signinAzureCallback(args?: any[]): Promise<Result<null, Fx
   const accountInfo = token?.token ? ConvertTokenToJson(token?.token) : {};
   if (token && node) {
     const needSelectSubscription = await node.setSignedIn(
-      (accountInfo as any).email ?? (accountInfo as any).username ?? ""
+      (accountInfo as any).email ?? (accountInfo as any).upn ?? ""
     );
     if (needSelectSubscription) {
       const solutionSettings = await getAzureSolutionSettings();


### PR DESCRIPTION
ADO:
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/15833260/

Screenshot:
Before:
![image](https://user-images.githubusercontent.com/73154171/195530741-7b0f77d0-87f7-4e4c-8050-1abfdfc3dfd5.png)
After:
After Azure sign in and sign out, the account displays correctly
![image](https://user-images.githubusercontent.com/73154171/195530011-155bee94-6475-43f2-b396-73059e89e03f.png)

E2E TEST: NA
