### PR TITLE
fix: teamsBotSsoPrompt e2e test failed

### DIFF
--- a/packages/sdk/test/e2e/node/teamsBotSsoPrompt.spec.ts
+++ b/packages/sdk/test/e2e/node/teamsBotSsoPrompt.spec.ts
@@ -193,11 +193,6 @@ describe("TeamsBotSsoPrompt Tests - Node", () => {
     assert.strictEqual(activity.attachments![0].content.buttons[0].type, ActionTypes.Signin);
     assert.strictEqual(activity.attachments![0].content.buttons[0].title, "Teams SSO Sign In");
     assert.strictEqual(
-      activity.attachments![0].content.tokenExchangeResource.uri,
-      `api://localhost/${process.env.SDK_INTEGRATION_TEST_M365_AAD_CLIENT_ID}/access_as_user`
-    );
-
-    assert.strictEqual(
       activity.attachments![0].content.buttons[0].value,
       `${initiateLoginEndpoint}?scope=${encodeURI(scopes.join(" "))}&clientId=${
         process.env.SDK_INTEGRATION_TEST_M365_AAD_CLIENT_ID


### PR DESCRIPTION
E2E TEST: https://github.com/OfficeDev/TeamsFx/actions/runs/3247829129

`tokenExchangeResource.uri` is not used any more for sso bot, so remove this check to fix e2e test failed


