### PR TITLE
chore: add display message when encountering login cache error

### DIFF
--- a/packages/vscode-extension/package.nls.json
+++ b/packages/vscode-extension/package.nls.json
@@ -242,7 +242,7 @@
     "teamstoolkit.handlers.loginFailed": "Login failed, the operation is terminated.",
     "teamstoolkit.handlers.m365SignIn": "Successfully signed in to Microsoft 365 account.",
     "teamstoolkit.handlers.m365SignOut": "Successfully signed out of Microsoft 365 account.",
-    "teamstoolkit.handlers.loginCacheFailed": "Failed to get login account token from cache. You could try signing out and signing back in to your Azure Account using Teamsfx tree view or command palette",
+    "teamstoolkit.handlers.loginCacheFailed": "Failed to get login account token from cache. You could try signing out and signing back in to your Azure Account using Teams Toolkit tree view or command palette",
     "teamstoolkit.handlers.noOpenWorkspace": "No open workspace",
     "teamstoolkit.handlers.openFolderTitle": "Open folder",
     "teamstoolkit.handlers.operationNotSupport": "Operation not support: %s",

--- a/packages/vscode-extension/package.nls.json
+++ b/packages/vscode-extension/package.nls.json
@@ -242,6 +242,7 @@
     "teamstoolkit.handlers.loginFailed": "Login failed, the operation is terminated.",
     "teamstoolkit.handlers.m365SignIn": "Successfully signed in to Microsoft 365 account.",
     "teamstoolkit.handlers.m365SignOut": "Successfully signed out of Microsoft 365 account.",
+    "teamstoolkit.handlers.loginCacheFailed": "Failed to get login account token from cache. You could try signing out and signing back in to your Azure Account using Teamsfx tree view or command palette",
     "teamstoolkit.handlers.noOpenWorkspace": "No open workspace",
     "teamstoolkit.handlers.openFolderTitle": "Open folder",
     "teamstoolkit.handlers.operationNotSupport": "Operation not support: %s",

--- a/packages/vscode-extension/src/error.ts
+++ b/packages/vscode-extension/src/error.ts
@@ -48,4 +48,5 @@ export enum ExtensionErrors {
   SetUpBotError = "SetUpBotError",
   SetUpSSOError = "SetUpSSOError",
   PrepareManifestError = "PrepareManifestError",
+  LoginCacheError = "LoginCacheError",
 }


### PR DESCRIPTION
Add display message when encountering Azure account cache problem.

Fix: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_dashboards/dashboard/b7e7b190-a7fb-4c70-89f1-e63796c991c5
