### PR TITLE
chore: deprecate getTediousConnectionConfig

### DIFF
--- a/docs/sdk/teamsfx.gettediousconnectionconfig.md
+++ b/docs/sdk/teamsfx.gettediousconnectionconfig.md
@@ -4,6 +4,11 @@
 
 ## getTediousConnectionConfig() function
 
+> Warning: This API is now obsolete.
+> 
+> we recommend you compose your own Tedious configuration for better flexibility.
+> 
+
 Generate connection configuration consumed by tedious.
 
 <b>Signature:</b>

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 2.0.1
 - Support Teams JS SDK 2.0.
 - Add error details when projects not running inside Teams.
+- `getTediousConnectionConfig` is now deprecated. We recommend you compose your own Tedious configuration for better flexibility.
 
 # 0.6.0
 - Breaking: Remove loadConfiguration() function and add TeamsFx class

--- a/packages/sdk/review/teamsfx.api.md
+++ b/packages/sdk/review/teamsfx.api.md
@@ -273,7 +273,7 @@ export interface GetTeamsUserTokenOptions extends GetTokenOptions {
     resources?: string[];
 }
 
-// @public
+// @public @deprecated
 export function getTediousConnectionConfig(teamsfx: TeamsFx, databaseName?: string): Promise<ConnectionConfig>;
 
 // @public

--- a/packages/sdk/src/core/defaultTediousConnectionConfiguration.browser.ts
+++ b/packages/sdk/src/core/defaultTediousConnectionConfiguration.browser.ts
@@ -8,6 +8,9 @@ import { formatString } from "../util/utils";
 
 /**
  * Generate connection configuration consumed by tedious.
+ *
+ * @deprecated we recommend you compose your own Tedious configuration for better flexibility.
+ *
  * @remarks
  * Only works in in server side.
  */

--- a/packages/sdk/src/core/defaultTediousConnectionConfiguration.ts
+++ b/packages/sdk/src/core/defaultTediousConnectionConfiguration.ts
@@ -16,6 +16,8 @@ const defaultSQLScope = "https://database.windows.net/";
 /**
  * Generate connection configuration consumed by tedious.
  *
+ * @deprecated we recommend you compose your own Tedious configuration for better flexibility.
+ *
  * @param {TeamsFx} teamsfx - Used to provide configuration and auth
  * @param { string? } databaseName - specify database name to override default one if there are multiple databases.
  *


### PR DESCRIPTION
Since SDK 2.0 wants to keep backward compatibility to let users easily upgrade the package, will deprecate SQL support instead of remove it in SDK 2.0.