### PR TITLE
fix(acc): fix click sample card with keyboard doesnt go to detail pag…

### DIFF
--- a/packages/vscode-extension/src/controls/SampleGallery.tsx
+++ b/packages/vscode-extension/src/controls/SampleGallery.tsx
@@ -180,18 +180,11 @@ class SampleCard extends React.Component<SampleCardProps, any> {
       <div
         className={`sample-card box${this.props.order}`}
         tabIndex={0}
-        onClick={() => {
-          vscode.postMessage({
-            command: Commands.SendTelemetryEvent,
-            data: {
-              eventName: TelemetryEvent.ClickSampleCard,
-              properties: {
-                [TelemetryProperty.TriggerFrom]: TelemetryTriggerFrom.Webview,
-                [TelemetryProperty.SampleAppName]: this.props.sampleAppFolder,
-              },
-            },
-          });
-          this.props.highlightSample(this.props.sampleAppFolder);
+        onClick={this.onSampleCard}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            this.onSampleCard();
+          }
         }}
       >
         {this.props.suggested && (
@@ -260,4 +253,18 @@ class SampleCard extends React.Component<SampleCardProps, any> {
       </div>
     );
   }
+
+  onSampleCard = () => {
+    vscode.postMessage({
+      command: Commands.SendTelemetryEvent,
+      data: {
+        eventName: TelemetryEvent.ClickSampleCard,
+        properties: {
+          [TelemetryProperty.TriggerFrom]: TelemetryTriggerFrom.Webview,
+          [TelemetryProperty.SampleAppName]: this.props.sampleAppFolder,
+        },
+      },
+    });
+    this.props.highlightSample(this.props.sampleAppFolder);
+  };
 }


### PR DESCRIPTION
…e issue

ADO: 
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/15150652

Screenshot:
After the fix, user can press enter button to go to detail page with keyboard
![clicksamplecardwithkeyboard](https://user-images.githubusercontent.com/73154171/196106060-6a41154e-317c-455f-8925-6548db768b54.gif)

E2E TEST: NA
