### PR TITLE
fix(core): use projectId in inputs if available

### DIFF
--- a/packages/fx-core/src/component/core.ts
+++ b/packages/fx-core/src/component/core.ts
@@ -310,6 +310,9 @@ export class TeamsfxCore {
     const projectSettings = newProjectSettings() as ProjectSettingsV3;
     projectSettings.appName = inputs["app-name"];
     projectSettings.components = [];
+    if (inputs.projectId) {
+      projectSettings.projectId = inputs.projectId;
+    }
     context.projectSetting = projectSettings;
     await fs.ensureDir(inputs.projectPath);
     await fs.ensureDir(path.join(inputs.projectPath, `.${ConfigFolderName}`));


### PR DESCRIPTION
@microsoft/teamsfx-cli	v1.1.3-rc.2
@microsoft/teamsfx-core	v1.17.0-rc.2
ms-teams-vscode-extension	v4.1.0-rc.2

CLI BREAKING CHANGE:
  

Extension-toolkit BREAKING CHANGE:
 

CLI feat commits:
  

Extension-toolkit feat commits:

E2E TEST: N/A