### PR TITLE
fix(core): show success notification when adding bot + me

### DIFF
--- a/packages/fx-core/src/component/feature/bot/bot.ts
+++ b/packages/fx-core/src/component/feature/bot/bot.ts
@@ -98,6 +98,7 @@ export class TeamsBot {
         if (res.isErr()) return err(res.error);
         effects.push("add bot capability in app manifest");
       }
+      addFeatureNotify(inputs, context.userInteraction, "Capability", [inputs.features]);
       return ok(undefined);
     }
     const addedComponents: string[] = [];


### PR DESCRIPTION
Related bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/15874934

E2E TEST: N/A