### PR TITLE
chore: tweak dotnet workflow bot SDK and template

### DIFF
--- a/packages/dotnet-sdk/CHANGELOG.md
+++ b/packages/dotnet-sdk/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.2.0-rc
+- Support adaptive card universal action handler in conversation bot.
+
 # 1.1.0
 - Support Bot SSO
 

--- a/packages/dotnet-sdk/README.md
+++ b/packages/dotnet-sdk/README.md
@@ -262,15 +262,16 @@ catch (ExceptionWithCode e)
             return InvokeResponseFactory.TextMessage("[ACK] Successfully!");
 
             /**
-             * If you want to send invoke response with text message, you can:
+             * If you want to send invoke response with adaptive card, you can:
              *
              * return InvokeResponseFactory.AdaptiveCard(JsonConvert.DeserializeObject(<your-card-json>));
-            */
+             */
 
             /**
              * If you want to send invoke response with error message, you can:
              *
              * return InvokeResponseFactory.ErrorResponse(InvokeResponseErrorCode.BadRequest, "The incoming request is invalid.");
+             */
         }
     }
     ```

--- a/packages/dotnet-sdk/README.md
+++ b/packages/dotnet-sdk/README.md
@@ -234,6 +234,106 @@ catch (ExceptionWithCode e)
     }
     ```
 
+### Using Conversation Bot for Adaptive Card Actions
+
+1. Add your adaptive card action handler class which implements the `IAdaptiveCardActionHandler` interface.
+    - Set the `TriggerVerb` property, the value should be the same as the `verb` property of the `Action.Execute` action.
+    - Handle your action in `HandleActionInvokedAsync` function, and return an `InvokeResponse` as the action response.
+
+    ```csharp
+    public class DoStuffActionHandler : IAdaptiveCardActionHandler
+    {
+        /// <summary>
+        /// A global unique string associated with the `Action.Execute` action.
+        /// The value should be the same as the `verb` property which you define in your adaptive card JSON.
+        /// </summary>
+        public string TriggerVerb => "doStuff";
+
+        /// <summary>
+        /// Indicate how your acrion response card is sent in the conversation.
+        /// By default, the response card can only be updated for the interactor who trigger the action.
+        /// </summary>
+        public AdaptiveCardResponse AdaptiveCardResponse => AdaptiveCardResponse.ReplaceForInteractor;
+
+
+        public async Task<InvokeResponse> HandleActionInvokedAsync(ITurnContext turnContext, object cardData, CancellationToken cancellationToken = default)
+        {
+            // Send invoke response with text message
+            return InvokeResponseFactory.TextMessage("[ACK] Successfully!");
+
+            /**
+             * If you want to send invoke response with text message, you can:
+             *
+             * return InvokeResponseFactory.AdaptiveCard(JsonConvert.DeserializeObject(<your-card-json>));
+            */
+
+            /**
+             * If you want to send invoke response with error message, you can:
+             *
+             * return InvokeResponseFactory.ErrorResponse(InvokeResponseErrorCode.BadRequest, "The incoming request is invalid.");
+        }
+    }
+    ```
+
+2. Initialize your own bot adapter and the `ConversationBot` in your app's startup (usually it's in `Program.cs` or `Startup.cs`)
+    ```csharp
+    // create action handler instance
+    builder.Services.AddSingleton<DoStuffActionHandler>();
+
+    // create conversation bot with adaptive card action feature enabled.
+    builder.Services.AddSingleton(sp =>
+    {
+        var options = new ConversationOptions()
+        {
+            // NOTE: you need to register your CloudAdapter into your service before conversation bot initialization.
+            Adapter = sp.GetService<CloudAdapter>(),
+            CardAction = new CardActionOptions()
+            {
+                Actions = new List<IAdaptiveCardActionHandler> { sp.GetService<DoStuffActionHandler>() }
+            }
+        };
+
+        return new ConversationBot(options);
+    });
+    ```
+
+3. Reference the conversation bot in your bot message controller/handler to ensure it's initialized before handling any bot message
+    ```csharp
+    namespace SampleTeamsApp.Controllers
+    {
+        using Microsoft.AspNetCore.Mvc;
+        using Microsoft.Bot.Builder;
+        using Microsoft.Bot.Builder.Integration.AspNet.Core;
+        using Microsoft.TeamsFx.Conversation;
+
+        [Route("api/messages")]
+        [ApiController]
+        public class BotController : ControllerBase
+        {
+            private readonly ConversationBot _conversation;
+            private readonly IBot _bot;
+
+            public BotController(ConversationBot conversation, IBot bot)
+            {
+                _conversation = conversation;
+                _bot = bot;
+            }
+
+            [HttpPost]
+            public async Task PostAsync(CancellationToken cancellationToken = default)
+            {
+                await (_conversation.Adapter as CloudAdapter).ProcessAsync
+                (
+                    Request,
+                    Response,
+                    _bot,
+                    cancellationToken
+                );
+            }
+        }
+    }
+    ```
+
 ## SDK Upgrade Steps
 ### Upgrade from 0.1.0-rc to 0.3.0 (For projects created by Visual Studio 2019 toolkit)
 If there is an existing project created in VS2019, you can use the following steps to upgrade:

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/CardActionMiddleware.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/CardActionMiddleware.cs
@@ -66,10 +66,14 @@ namespace Microsoft.TeamsFx.Conversation
                                     throw new ExceptionWithCode(errorMessage, ExceptionCode.InvalidParameter);
                                 }
 
-                                var isRefresh = card.GetType().GetProperty("refresh") != null;
-                                if (isRefresh && handler.AdaptiveCardResponse != AdaptiveCardResponse.NewForAll)
+                                var isRefresh = ((JObject)card).ContainsKey("refresh");
+                                var adaptiveCardResponse = handler.AdaptiveCardResponse;
+
+                                if (isRefresh && handler.AdaptiveCardResponse == AdaptiveCardResponse.ReplaceForInteractor)
                                 {
-                                    handler.AdaptiveCardResponse = AdaptiveCardResponse.NewForAll;
+                                    // Ensure the base card for refresh action is able be viewed for all members
+                                    // Otherwise, the refresh won't be triggered when user see the base card in Teams.
+                                    adaptiveCardResponse = AdaptiveCardResponse.ReplaceForAll;
                                 }
 
                                 var messageActivity = MessageFactory.Attachment
@@ -81,7 +85,7 @@ namespace Microsoft.TeamsFx.Conversation
                                     }
                                 );
 
-                                switch (handler.AdaptiveCardResponse)
+                                switch (adaptiveCardResponse)
                                 {
                                     case AdaptiveCardResponse.NewForAll:
                                         await SendInvokeResponseAsync(turnContext, InvokeResponseFactory.TextMessage(defaultMessage), cancellationToken).ConfigureAwait(false);

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/IAdaptiveCardActionHandler.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/IAdaptiveCardActionHandler.cs
@@ -14,14 +14,14 @@ namespace Microsoft.TeamsFx.Conversation
         /// The verb defined in adaptive card action that can trigger this handler.
         /// The verb string here is case-insensitive.
         /// </summary>
-        string TriggerVerb { get; set; }
+        string TriggerVerb { get; }
 
         /// <summary>
         /// Indicates the behavior for how the card response will be sent in Teams conversation.
         /// The default value is `AdaptiveCardResponse.ReplaceForInteractor`, which means the card
         /// response will replace the current one only for the interactor.
         /// </summary>
-        AdaptiveCardResponse AdaptiveCardResponse { get; set; }
+        AdaptiveCardResponse AdaptiveCardResponse { get; }
 
         /// <summary>
         /// The handler function that will be invoked when the card action is executed.

--- a/packages/dotnet-sdk/src/TeamsFx/Microsoft.TeamsFx.csproj
+++ b/packages/dotnet-sdk/src/TeamsFx/Microsoft.TeamsFx.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Microsoft.TeamsFx</AssemblyName>
     <RootNamespace>Microsoft.TeamsFx</RootNamespace>
-    <Version>1.1.0</Version>
+    <Version>1.2.0-rc</Version>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
     <RepositoryUrl>https://github.com/OfficeDev/TeamsFx</RepositoryUrl>
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <SupportedPlatform Include="browser" />
-    <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/templates/bot/csharp/workflow/CardActions/DoStuffActionHandler.cs.tpl
+++ b/templates/bot/csharp/workflow/CardActions/DoStuffActionHandler.cs.tpl
@@ -8,21 +8,19 @@ namespace {{SafeProjectName}}.CardActions
 {
     public class DoStuffActionHandler : IAdaptiveCardActionHandler
     {
-        private string _triggerVerb = "doStuff";
-        private AdaptiveCardResponse _adaptiveCardResponse = AdaptiveCardResponse.ReplaceForInteractor;
         private readonly string _responseCardFilePath = Path.Combine(".", "Resources", "DoStuffActionResponse.json");
 
-        public string TriggerVerb
-        {
-            get => _triggerVerb;
-            set => _triggerVerb = value;
-        }
+        /// <summary>
+        /// A global unique string associated with the `Action.Execute` action.
+        /// The value should be the same as the `verb` property which you define in your adaptive card JSON.
+        /// </summary>
+        public string TriggerVerb => "doStuff";
 
-        public AdaptiveCardResponse AdaptiveCardResponse
-        {
-            get => _adaptiveCardResponse;
-            set => _adaptiveCardResponse = value;
-        }
+        /// <summary>
+        /// Indicate how your action response card is sent in the conversation.
+        /// By default, the response card can only be updated for the interactor who trigger the action.
+        /// </summary>
+        public AdaptiveCardResponse AdaptiveCardResponse => AdaptiveCardResponse.ReplaceForInteractor;
 
         public async Task<InvokeResponse> HandleActionInvokedAsync(ITurnContext turnContext, object cardData, CancellationToken cancellationToken = default)
         {
@@ -35,12 +33,24 @@ namespace {{SafeProjectName}}.CardActions
                 new HelloWorldModel
                 {
                     Title = "Hello World Bot",
-                    Body = "Congratulations! Your task is processed successfully.",
+                    Body = $"Congratulations! Your {TriggerVerb} action is processed successfully!",
                 }
             );
 
-            // Adaptive card
+            // Send invoke response with adaptive card
             return InvokeResponseFactory.AdaptiveCard(JsonConvert.DeserializeObject(cardContent));
+
+            /**
+             * If you want to send invoke response with text message, you can:
+             *
+             * return InvokeResponseFactory.TextMessage("[ACK] Successfully!");
+            */
+
+            /**
+             * If you want to send invoke response with error message, you can:
+             *
+             * return InvokeResponseFactory.ErrorResponse(InvokeResponseErrorCode.BadRequest, "The incoming request is invalid.");
+             */
         }
     }
 }

--- a/templates/bot/csharp/workflow/ProjectName.csproj.tpl
+++ b/templates/bot/csharp/workflow/ProjectName.csproj.tpl
@@ -19,7 +19,7 @@
     <PackageReference Include="AdaptiveCards.Templating" Version="1.2.2" />
     <PackageReference Include="Microsoft.Bot.Builder" Version="4.16.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.16.0" />
-    <PackageReference Include="Microsoft.TeamsFx" Version="1.0.0">
+    <PackageReference Include="Microsoft.TeamsFx" Version="1.2.0-rc">
       <!-- Exclude TeamsFx wwwroot static files which are for frontend only. -->
       <ExcludeAssets>contentFiles</ExcludeAssets>
     </PackageReference>


### PR DESCRIPTION
Changes:
1. Add usage document for adaptive card actions dotnet SDK.
2. Update dotnet SDK change log to prepare `1.2.0-rc` release
3. Simplify `IAdaptiveCardActionHandler` interface and update template accordingly

E2E TEST: N/A