### PR TITLE
chore(localdebug): add more properties in localdebug telemetry

### DIFF
--- a/packages/fx-core/src/common/tools.ts
+++ b/packages/fx-core/src/common/tools.ts
@@ -864,8 +864,9 @@ export async function getSideloadingStatus(token: string): Promise<boolean | und
   let retry = 0;
   const retryIntervalSeconds = 2;
   do {
+    let response = undefined;
     try {
-      const response = await instance.get("/api/usersettings/mtUserAppPolicy");
+      response = await instance.get("/api/usersettings/mtUserAppPolicy");
       let result: boolean | undefined;
       if (response.status >= 400) {
         result = undefined;
@@ -899,7 +900,12 @@ export async function getSideloadingStatus(token: string): Promise<boolean | und
       sendTelemetryErrorEvent(
         Component.core,
         TelemetryEvent.CheckSideloading,
-        new SystemError({ error, source: "M365Account" })
+        new SystemError({ error, source: "M365Account" }),
+        {
+          [TelemetryProperty.CheckSideloadingStatusCode]: `${response?.status}`,
+          [TelemetryProperty.CheckSideloadingMethod]: "get",
+          [TelemetryProperty.CheckSideloadingUrl]: "<check-sideloading-status>",
+        }
       );
       await waitSeconds((retry + 1) * retryIntervalSeconds);
     }

--- a/packages/vscode-extension/src/debug/prerequisitesHandler.ts
+++ b/packages/vscode-extension/src/debug/prerequisitesHandler.ts
@@ -174,13 +174,6 @@ type PrerequisiteOrderedChecker = {
   fastFail: boolean;
 };
 
-async function runWithCheckResultTelemetry(
-  eventName: string,
-  action: (ctx: TelemetryContext) => Promise<CheckResult>
-): Promise<CheckResult> {
-  return runWithCheckResultTelemetryProperties(eventName, {}, action);
-}
-
 async function runWithCheckResultTelemetryProperties(
   eventName: string,
   initialProperties: { [key: string]: string },
@@ -199,6 +192,7 @@ async function runWithCheckResultTelemetryProperties(
 async function runWithCheckResultsTelemetry(
   eventName: string,
   errorName: string, // unified error name of multiple errors in CheckResult[]
+  initialProperties: { [key: string]: string },
   action: (ctx: TelemetryContext) => Promise<CheckResult[]>
 ): Promise<CheckResult[]> {
   return await localTelemetryReporter.runWithTelemetryGeneric(
@@ -222,7 +216,8 @@ async function runWithCheckResultsTelemetry(
           name: errorName,
         });
       }
-    }
+    },
+    initialProperties
   );
 }
 
@@ -270,10 +265,12 @@ function addCheckResultsForTelemetry(
 async function checkPort(
   localEnvManager: LocalEnvManager,
   ports: number[],
-  displayMessage: string
+  displayMessage: string,
+  additionalTelemetryProperties: { [key: string]: string }
 ): Promise<CheckResult> {
-  return await runWithCheckResultTelemetry(
+  return await runWithCheckResultTelemetryProperties(
     TelemetryEvent.DebugPrereqsCheckPorts,
+    additionalTelemetryProperties,
     async (ctx: TelemetryContext) => {
       VsCodeLogInstance.outputChannel.appendLine(displayMessage);
       const portsInUse = await localEnvManager.getPortsInUse(ports);
@@ -314,7 +311,9 @@ async function checkPort(
 export async function checkPrerequisitesForGetStarted(): Promise<Result<void, FxError>> {
   const nodeChecker = await getOrderedCheckersForGetStarted();
   ExtTelemetry.sendTelemetryEvent(TelemetryEvent.GetStartedPrerequisitesStart);
-  const res = await _checkAndInstall(prerequisiteCheckForGetStartedDisplayMessages, nodeChecker);
+  const res = await _checkAndInstall(prerequisiteCheckForGetStartedDisplayMessages, nodeChecker, {
+    [TelemetryProperty.DebugIsTransparentTask]: "false",
+  });
   if (res.error) {
     ExtTelemetry.sendTelemetryErrorEvent(TelemetryEvent.GetStartedPrerequisites, res.error);
     return err(res.error);
@@ -326,13 +325,15 @@ export async function checkAndInstall(): Promise<Result<void, FxError>> {
   const projectComponents = await commonUtils.getProjectComponents();
   const orderedCheckers = await getOrderedCheckers();
 
+  // projectComponents is already serialized JSON string
+  const additionalTelemetryProperties = {
+    [TelemetryProperty.DebugProjectComponents]: `${projectComponents}`,
+    [TelemetryProperty.DebugIsTransparentTask]: "false",
+  };
+
   return await localTelemetryReporter.runWithTelemetryProperties(
     TelemetryEvent.DebugPrerequisites,
-    // projectComponents is already serialized JSON string
-    {
-      [TelemetryProperty.DebugProjectComponents]: `${projectComponents}`,
-      [TelemetryProperty.DebugIsTransparentTask]: "false",
-    },
+    additionalTelemetryProperties,
     async (ctx: TelemetryContext) => {
       // terminate all running teamsfx tasks
       if (allRunningTeamsfxTasks.size > 0) {
@@ -340,7 +341,11 @@ export async function checkAndInstall(): Promise<Result<void, FxError>> {
         terminateAllRunningTeamsfxTasks();
       }
 
-      const res = await _checkAndInstall(prerequisiteCheckDisplayMessages, orderedCheckers);
+      const res = await _checkAndInstall(
+        prerequisiteCheckDisplayMessages,
+        orderedCheckers,
+        additionalTelemetryProperties
+      );
       if (res.error) {
         const debugSession = commonUtils.getLocalDebugSession();
         addCheckResultsForTelemetry(
@@ -358,15 +363,22 @@ export async function checkAndInstall(): Promise<Result<void, FxError>> {
 
 export async function checkAndInstallForTask(
   prerequisites: string[],
-  ports?: number[]
+  ports: number[] | undefined,
+  telemetryProperties: { [key: string]: string }
 ): Promise<Result<Void, FxError>> {
   const orderedCheckers = await getOrderedCheckersForTask(prerequisites, ports);
+  const projectComponents = await commonUtils.getProjectComponents();
 
-  return await localTelemetryReporter.runWithTelemetryProperties(
-    TelemetryEvent.DebugPrerequisites,
+  const additionalTelemetryProperties = Object.assign(
     {
+      [TelemetryProperty.DebugProjectComponents]: `${projectComponents}`,
       [TelemetryProperty.DebugIsTransparentTask]: "true",
     },
+    telemetryProperties
+  );
+  return await localTelemetryReporter.runWithTelemetryProperties(
+    TelemetryEvent.DebugPrerequisites,
+    additionalTelemetryProperties,
     async (ctx: TelemetryContext) => {
       // terminate all running teamsfx tasks
       if (allRunningTeamsfxTasks.size > 0) {
@@ -374,7 +386,11 @@ export async function checkAndInstallForTask(
         terminateAllRunningTeamsfxTasks();
       }
 
-      const res = await _checkAndInstall(prerequisiteCheckTaskDisplayMessages, orderedCheckers);
+      const res = await _checkAndInstall(
+        prerequisiteCheckTaskDisplayMessages,
+        orderedCheckers,
+        additionalTelemetryProperties
+      );
       if (res.error) {
         const debugSession = commonUtils.getLocalDebugSession();
         addCheckResultsForTelemetry(
@@ -395,8 +411,18 @@ export async function checkAndInstallNpmPackagesForTask(
     cwd: string;
     args?: string[];
     forceUpdate?: boolean;
-  }[]
+  }[],
+  telemetryProperties: { [key: string]: string }
 ): Promise<Result<Void, FxError>> {
+  const projectComponents = await commonUtils.getProjectComponents();
+
+  const additionalTelemetryProperties = Object.assign(
+    {
+      [TelemetryProperty.DebugProjectComponents]: `${projectComponents}`,
+      [TelemetryProperty.DebugIsTransparentTask]: "true",
+    },
+    telemetryProperties
+  );
   const checkers = projectOptions.map<NpmInstallCheckerInfo>((p) => {
     const cwdBaseName = path.basename(p.cwd);
     return {
@@ -408,13 +434,16 @@ export async function checkAndInstallNpmPackagesForTask(
     };
   });
 
-  // TODO: Add telemetry
-  const res = await _checkAndInstall(npmInstallDisplayMessages, [
-    {
-      info: checkers,
-      fastFail: false,
-    },
-  ]);
+  const res = await _checkAndInstall(
+    npmInstallDisplayMessages,
+    [
+      {
+        info: checkers,
+        fastFail: false,
+      },
+    ],
+    additionalTelemetryProperties
+  );
   if (res.error) {
     return err(res.error);
   }
@@ -424,7 +453,8 @@ export async function checkAndInstallNpmPackagesForTask(
 
 async function _checkAndInstall(
   displayMessages: DisplayMessages,
-  orderedCheckers: PrerequisiteOrderedChecker[]
+  orderedCheckers: PrerequisiteOrderedChecker[],
+  additionalTelemetryProperties: { [key: string]: string }
 ): Promise<{ checkResults: CheckResult[]; error?: FxError }> {
   let progressHelper: ProgressHelper | undefined;
   const checkResults: CheckResult[] = [];
@@ -471,11 +501,18 @@ async function _checkAndInstall(
         await runWithCheckResultsTelemetry(
           TelemetryEvent.DebugPrereqsInstallPackages,
           ExtensionErrors.PrerequisitesInstallPackagesError,
+          additionalTelemetryProperties,
           async () => {
             const checkPromises = [];
             for (const orderedCheckerInfo of orderedCheckerInfoArr) {
               checkPromises.push(
-                getCheckPromise(orderedCheckerInfo, depsManager, localEnvManager, step).finally(
+                getCheckPromise(
+                  orderedCheckerInfo,
+                  depsManager,
+                  localEnvManager,
+                  step,
+                  additionalTelemetryProperties
+                ).finally(
                   async () =>
                     await progressHelper?.end(
                       orderedCheckerInfo.checker === Checker.NpmInstall
@@ -504,7 +541,8 @@ async function _checkAndInstall(
           orderedCheckerInfo,
           depsManager,
           localEnvManager,
-          step
+          step,
+          additionalTelemetryProperties
         ).finally(
           async () =>
             await progressHelper?.end(
@@ -532,21 +570,36 @@ function getCheckPromise(
   checkerInfo: PrerequisiteCheckerInfo,
   depsManager: DepsManager,
   localEnvManager: LocalEnvManager,
-  step: Step
+  step: Step,
+  additionalTelemetryProperties: { [key: string]: string }
 ): Promise<CheckResult> {
   switch (checkerInfo.checker) {
     case DepsType.AzureNode:
     case DepsType.SpfxNode:
     case DepsType.SpfxNodeV1_16:
-      return checkNode(checkerInfo.checker, depsManager, step.getPrefix());
+      return checkNode(
+        checkerInfo.checker,
+        depsManager,
+        step.getPrefix(),
+        additionalTelemetryProperties
+      );
     case Checker.M365Account:
-      return checkM365Account(step.getPrefix(), true);
+      return checkM365Account(step.getPrefix(), true, additionalTelemetryProperties);
     case Checker.LocalCertificate:
-      return resolveLocalCertificate(localEnvManager, step.getPrefix());
+      return resolveLocalCertificate(
+        localEnvManager,
+        step.getPrefix(),
+        additionalTelemetryProperties
+      );
     case DepsType.Dotnet:
     case DepsType.FuncCoreTools:
     case DepsType.Ngrok:
-      return checkDependency(checkerInfo.checker, depsManager, step.getPrefix());
+      return checkDependency(
+        checkerInfo.checker,
+        depsManager,
+        step.getPrefix(),
+        additionalTelemetryProperties
+      );
     case Checker.AzureFunctionsExtension:
       return resolveBackendExtension(depsManager, step.getPrefix());
     case Checker.NpmInstall:
@@ -557,13 +610,15 @@ function getCheckPromise(
         step.getPrefix(),
         npmInstalChecherInfo.cwd,
         npmInstalChecherInfo.args,
+        additionalTelemetryProperties,
         npmInstalChecherInfo.forceUpdate
       );
     case Checker.Ports:
       return checkPort(
         localEnvManager,
         (checkerInfo as PortCheckerInfo)?.ports ?? [],
-        `${step.getPrefix()} ${ProgressMessage[Checker.Ports]} ...`
+        `${step.getPrefix()} ${ProgressMessage[Checker.Ports]} ...`,
+        additionalTelemetryProperties
       );
   }
 }
@@ -665,9 +720,14 @@ async function ensureM365Account(
   return m365Result;
 }
 
-function checkM365Account(prefix: string, showLoginPage: boolean): Promise<CheckResult> {
-  return runWithCheckResultTelemetry(
+function checkM365Account(
+  prefix: string,
+  showLoginPage: boolean,
+  additionalTelemetryProperties: { [key: string]: string }
+): Promise<CheckResult> {
+  return runWithCheckResultTelemetryProperties(
     TelemetryEvent.DebugPrereqsCheckM365Account,
+    additionalTelemetryProperties,
     async (): Promise<CheckResult> => {
       let result = ResultStatus.success;
       let error = undefined;
@@ -754,46 +814,52 @@ function showNotification(message: string, url: string): void {
 async function checkNode(
   nodeDep: DepsType,
   depsManager: DepsManager,
-  prefix: string
+  prefix: string,
+  additionalTelemetryProperties: { [key: string]: string }
 ): Promise<CheckResult> {
-  return await runWithCheckResultTelemetry(TelemetryEvent.DebugPrereqsCheckNode, async () => {
-    try {
-      VsCodeLogInstance.outputChannel.appendLine(`${prefix} ${ProgressMessage[nodeDep]} ...`);
-      const nodeStatus = (
-        await depsManager.ensureDependencies([nodeDep], {
-          fastFail: false,
-          doctor: true,
-        })
-      )[0];
-      return {
-        checker: nodeStatus.name,
-        result: nodeStatus.isInstalled
-          ? nodeStatus.error
-            ? ResultStatus.warn
-            : ResultStatus.success
-          : ResultStatus.failed,
-        successMsg: nodeStatus.isInstalled
-          ? doctorConstant.NodeSuccess.split("@Version").join(nodeStatus.details.installVersion)
-          : nodeStatus.name,
-        failureMsg: nodeStatus.name,
-        error: handleDepsCheckerError(nodeStatus.error, nodeStatus),
-      };
-    } catch (error: unknown) {
-      return {
-        checker: DepsDisplayName[nodeDep],
-        result: ResultStatus.failed,
-        successMsg: DepsDisplayName[nodeDep],
-        failureMsg: DepsDisplayName[nodeDep],
-        error: handleDepsCheckerError(error),
-      };
+  return await runWithCheckResultTelemetryProperties(
+    TelemetryEvent.DebugPrereqsCheckNode,
+    additionalTelemetryProperties,
+    async () => {
+      try {
+        VsCodeLogInstance.outputChannel.appendLine(`${prefix} ${ProgressMessage[nodeDep]} ...`);
+        const nodeStatus = (
+          await depsManager.ensureDependencies([nodeDep], {
+            fastFail: false,
+            doctor: true,
+          })
+        )[0];
+        return {
+          checker: nodeStatus.name,
+          result: nodeStatus.isInstalled
+            ? nodeStatus.error
+              ? ResultStatus.warn
+              : ResultStatus.success
+            : ResultStatus.failed,
+          successMsg: nodeStatus.isInstalled
+            ? doctorConstant.NodeSuccess.split("@Version").join(nodeStatus.details.installVersion)
+            : nodeStatus.name,
+          failureMsg: nodeStatus.name,
+          error: handleDepsCheckerError(nodeStatus.error, nodeStatus),
+        };
+      } catch (error: unknown) {
+        return {
+          checker: DepsDisplayName[nodeDep],
+          result: ResultStatus.failed,
+          successMsg: DepsDisplayName[nodeDep],
+          failureMsg: DepsDisplayName[nodeDep],
+          error: handleDepsCheckerError(error),
+        };
+      }
     }
-  });
+  );
 }
 
 async function checkDependency(
   nonNodeDep: DepsType,
   depsManager: DepsManager,
-  prefix: string
+  prefix: string,
+  additionalTelemetryProperties: { [key: string]: string }
 ): Promise<CheckResult> {
   try {
     VsCodeLogInstance.outputChannel.appendLine(`${prefix} ${ProgressMessage[nonNodeDep]} ...`);
@@ -823,7 +889,8 @@ async function checkDependency(
           });
         }
         return error !== undefined ? assembleError(error) : undefined;
-      }
+      },
+      additionalTelemetryProperties
     );
 
     if (depsStatus.length == 0) {
@@ -880,10 +947,12 @@ async function resolveBackendExtension(
 
 async function resolveLocalCertificate(
   localEnvManager: LocalEnvManager,
-  prefix: string
+  prefix: string,
+  additionalTelemetryProperties: { [key: string]: string }
 ): Promise<CheckResult> {
-  return await runWithCheckResultTelemetry(
+  return await runWithCheckResultTelemetryProperties(
     TelemetryEvent.DebugPrereqsCheckCert,
+    additionalTelemetryProperties,
     async (ctx: TelemetryContext) => {
       let result = ResultStatus.success;
       let error = undefined;
@@ -991,12 +1060,16 @@ function checkNpmInstall(
   prefix: string,
   folder: string,
   args: string[],
+  additionalTelemetryProperties: { [key: string]: string },
   forceUpdate?: boolean
 ): Promise<CheckResult> {
   const taskName = `${component} npm install`;
   return runWithCheckResultTelemetryProperties(
     TelemetryEvent.DebugPrereqsCheckNpmInstall,
-    { [TelemetryProperty.DebugNpmInstallName]: taskName },
+    Object.assign(
+      { [TelemetryProperty.DebugNpmInstallName]: taskName },
+      additionalTelemetryProperties
+    ),
     async (ctx: TelemetryContext) => {
       VsCodeLogInstance.outputChannel.appendLine(
         `${prefix} ${ProgressMessage[Checker.NpmInstall](displayName, folder)} ...`

--- a/packages/vscode-extension/src/debug/taskTerminal/localTunnelTaskTerminal.ts
+++ b/packages/vscode-extension/src/debug/taskTerminal/localTunnelTaskTerminal.ts
@@ -71,6 +71,7 @@ export class LocalTunnelTaskTerminal extends BaseTaskTerminal {
 
   private childProc: cp.ChildProcess | undefined;
   private isOutputSummary: boolean;
+  private log: string;
 
   private readonly args: LocalTunnelArgs;
   private readonly status: LocalTunnelTaskStatus;
@@ -83,6 +84,7 @@ export class LocalTunnelTaskTerminal extends BaseTaskTerminal {
     this.isOutputSummary = false;
     this.progressHandler = new ProgressHandler(localTunnelDisplayMessages.taskName, 1, "terminal");
     this.step = new Step(1);
+    this.log = "";
 
     for (const task of LocalTunnelTaskTerminal.ngrokTaskTerminals.values()) {
       task.terminal.close();
@@ -166,6 +168,7 @@ export class LocalTunnelTaskTerminal extends BaseTaskTerminal {
 
       this.childProc.stdout?.setEncoding("utf-8");
       this.childProc.stdout?.on("data", (data: string | Buffer) => {
+        this.log += data.toString();
         const line = data.toString().replace(/\n/g, "\r\n");
         this.writeEmitter.fire(line);
         const res = this.saveNgrokEndpointFromLog(line);
@@ -403,6 +406,7 @@ export class LocalTunnelTaskTerminal extends BaseTaskTerminal {
         [TelemetryProperty.DebugTaskId]: this.taskTerminalId,
         [TelemetryProperty.Success]: TelemetrySuccess.No,
         [TelemetryProperty.DebugTaskArgs]: this.generateTaskArgsTelemetry(),
+        [TelemetryProperty.DebugNgrokLog]: this.log,
       },
       {
         [LocalTelemetryReporter.PropertyDuration]: this.getDurationInSeconds() ?? -1,

--- a/packages/vscode-extension/src/debug/taskTerminal/localTunnelTaskTerminal.ts
+++ b/packages/vscode-extension/src/debug/taskTerminal/localTunnelTaskTerminal.ts
@@ -112,21 +112,7 @@ export class LocalTunnelTaskTerminal extends BaseTaskTerminal {
         TelemetryEvent.DebugStartLocalTunnelTask,
         {
           [TelemetryProperty.DebugTaskId]: this.taskTerminalId,
-          [TelemetryProperty.DebugTaskArgs]: JSON.stringify({
-            ngrokArgs: maskValue(
-              Array.isArray(this.args.ngrokArgs)
-                ? this.args.ngrokArgs.join(" ")
-                : this.args.ngrokArgs,
-              [
-                {
-                  value: TaskDefaultValue.startLocalTunnel.ngrokArgs,
-                  mask: DefaultPlaceholder,
-                },
-              ]
-            ),
-            ngrokPath: maskValue(this.args.ngrokPath, ["ngrok"]),
-            tunnelInspection: maskValue(this.args.tunnelInspection),
-          }),
+          [TelemetryProperty.DebugTaskArgs]: this.generateTaskArgsTelemetry(),
         },
         () => this._do()
       )
@@ -385,6 +371,7 @@ export class LocalTunnelTaskTerminal extends BaseTaskTerminal {
       {
         [TelemetryProperty.DebugTaskId]: this.taskTerminalId,
         [TelemetryProperty.Success]: TelemetrySuccess.Yes,
+        [TelemetryProperty.DebugTaskArgs]: this.generateTaskArgsTelemetry(),
       },
       {
         [LocalTelemetryReporter.PropertyDuration]: duration ?? -1,
@@ -415,11 +402,28 @@ export class LocalTunnelTaskTerminal extends BaseTaskTerminal {
       {
         [TelemetryProperty.DebugTaskId]: this.taskTerminalId,
         [TelemetryProperty.Success]: TelemetrySuccess.No,
+        [TelemetryProperty.DebugTaskArgs]: this.generateTaskArgsTelemetry(),
       },
       {
         [LocalTelemetryReporter.PropertyDuration]: this.getDurationInSeconds() ?? -1,
       }
     );
+  }
+
+  private generateTaskArgsTelemetry(): string {
+    return JSON.stringify({
+      ngrokArgs: maskValue(
+        Array.isArray(this.args.ngrokArgs) ? this.args.ngrokArgs.join(" ") : this.args.ngrokArgs,
+        [
+          {
+            value: TaskDefaultValue.startLocalTunnel.ngrokArgs,
+            mask: DefaultPlaceholder,
+          },
+        ]
+      ),
+      ngrokPath: maskValue(this.args.ngrokPath, ["ngrok"]),
+      tunnelInspection: maskValue(this.args.tunnelInspection),
+    });
   }
 
   public static async getNgrokEndpoint(): Promise<string> {

--- a/packages/vscode-extension/src/debug/taskTerminal/setUpBotTaskTerminal.ts
+++ b/packages/vscode-extension/src/debug/taskTerminal/setUpBotTaskTerminal.ts
@@ -44,7 +44,7 @@ export class SetUpBotTaskTerminal extends BaseTaskTerminal {
             botMessagingEndpoint: maskValue(this.args.botMessagingEndpoint, [
               { value: TaskDefaultValue.setUpBot.botMessagingEndpoint, mask: DefaultPlaceholder },
             ]),
-            botPassword: maskValue(this.args.botPassword),
+            botPwd: maskValue(this.args.botPassword),
           }),
         },
         () => this._do()

--- a/packages/vscode-extension/src/debug/taskTerminal/setUpBotTaskTerminal.ts
+++ b/packages/vscode-extension/src/debug/taskTerminal/setUpBotTaskTerminal.ts
@@ -44,7 +44,6 @@ export class SetUpBotTaskTerminal extends BaseTaskTerminal {
             botMessagingEndpoint: maskValue(this.args.botMessagingEndpoint, [
               { value: TaskDefaultValue.setUpBot.botMessagingEndpoint, mask: DefaultPlaceholder },
             ]),
-            botPwd: maskValue(this.args.botPassword),
           }),
         },
         () => this._do()

--- a/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
@@ -261,6 +261,7 @@ export enum TelemetryProperty {
   DebugTaskId = "debug-task-id",
   DebugTaskArgs = "debug-task-args",
   DebugPrelaunchTaskInfo = "debug-prelaunch-task-info",
+  DebugNgrokLog = "debug-ngrok-log",
   DebugConfigName = "debug-config-name",
   Internal = "internal",
   InternalAlias = "internal-alias",

--- a/packages/vscode-extension/test/localdebug/data/oldTab/.vscode/tasks.json
+++ b/packages/vscode-extension/test/localdebug/data/oldTab/.vscode/tasks.json
@@ -1,0 +1,46 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Pre Debug Check & Start All",
+            "dependsOn": [
+                "validate local prerequisites",
+                "prepare local environment",
+                "Start All"
+            ],
+            "dependsOrder": "sequence"
+        },
+        {
+            "label": "validate local prerequisites",
+            "type": "shell",
+            "command": "exit ${command:fx-extension.validate-local-prerequisites}",
+            "presentation": {
+                "reveal": "never"
+            }
+        },
+        {
+            "label": "prepare local environment",
+            "type": "shell",
+            "command": "exit ${command:fx-extension.pre-debug-check}",
+            "presentation": {
+                "reveal": "never"
+            }
+        },
+        {
+            "label": "Start All",
+            "dependsOn": [
+                "Start Frontend"
+            ]
+        },
+        {
+            "label": "Start Frontend",
+            "type": "shell",
+            "command": "npm run dev:teamsfx",
+            "isBackground": true,
+            "problemMatcher": "$teamsfx-frontend-watch",
+            "options": {
+                "cwd": "${workspaceFolder}/tabs"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
1. Add `method` and `status-code` of check sideloading permission api into event `CheckSideloading`
2. Update the condition of `debug-is-transparent-task`  (task.json includes any teamsfx command)
3. Add `debug-task-args` and `task-id` into prerequisite check events
4. Add `debug-task-args` to `debug-start-local-tunnel-task-started` event
5. Add `debug-ngrok-log` (error message in the terminal) to the `debug-start-local-tunnel-task-started` error event
5. remove `bot-password` in the `debug-task-args` 