### PR TITLE
chore: add extensions content to manifest generation

### DIFF
--- a/packages/fx-core/src/plugins/resource/appstudio/constants.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/constants.ts
@@ -1,7 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { IBot, IComposeExtension, IConfigurableTab, IStaticTab } from "@microsoft/teamsfx-api";
+import {
+  IBot,
+  IComposeExtension,
+  IConfigurableTab,
+  IStaticTab,
+  devPreview,
+} from "@microsoft/teamsfx-api";
 export class Constants {
   public static readonly MANIFEST_FILE = "manifest.json";
   public static readonly PLUGIN_NAME = "AppStudioPlugin";
@@ -440,6 +446,127 @@ export const STATIC_TABS_TPL_LOCAL_DEBUG: IStaticTab[] = [
     websiteUrl:
       "{{{localSettings.frontend.tabEndpoint}}}{{{localSettings.frontend.tabIndexPath}}}/tab",
     scopes: ["personal"],
+  },
+];
+
+export const OFFICE_ADDIN_EXTENSIONS_LOCAL_DEBUG: devPreview.ElementExtensions = [
+  {
+    requirements: {
+      scopes: [],
+    },
+    runtimes: [
+      {
+        requirements: {},
+        id: "TaskPaneRuntime",
+        type: "general",
+        code: {
+          page: "https://localhost:3000/taskpane.html",
+        },
+        lifetime: "short",
+        actions: [
+          {
+            id: "TaskPaneRuntimeShow",
+            type: "openPage",
+            pinnable: false,
+          },
+        ],
+      },
+      {
+        id: "CommandsRuntime",
+        type: "general",
+        code: {
+          page: "https://localhost:3000/commands.html",
+          script: "https://localhost:3000/commands.js",
+        },
+        lifetime: "short",
+        actions: [
+          {
+            id: "action",
+            type: "executeFunction",
+          },
+        ],
+      },
+    ],
+    ribbons: [
+      {
+        contexts: [],
+        tabs: [
+          {
+            builtInTabId: "TabDefault",
+            groups: [
+              {
+                id: "msgReadGroup",
+                label: "Contoso Add-in",
+                icons: [
+                  {
+                    size: 16,
+                    file: "https://localhost:3000/assets/icon-16.png",
+                  },
+                  {
+                    size: 32,
+                    file: "https://localhost:3000/assets/icon-32.png",
+                  },
+                  {
+                    size: 80,
+                    file: "https://localhost:3000/assets/icon-80.png",
+                  },
+                ],
+                controls: [
+                  {
+                    id: "msgReadOpenPaneButton",
+                    type: "button",
+                    label: "Show Taskpane",
+                    icons: [
+                      {
+                        size: 16,
+                        file: "https://localhost:3000/assets/icon-16.png",
+                      },
+                      {
+                        size: 32,
+                        file: "https://localhost:3000/assets/icon-32.png",
+                      },
+                      {
+                        size: 80,
+                        file: "https://localhost:3000/assets/icon-80.png",
+                      },
+                    ],
+                    supertip: {
+                      title: "Show Taskpane",
+                      description: "Opens a pane displaying all available properties.",
+                    },
+                    actionId: "TaskPaneRuntimeShow",
+                  },
+                  {
+                    id: "ActionButton",
+                    type: "button",
+                    label: "Perform an action",
+                    icons: [
+                      {
+                        size: 16,
+                        file: "https://localhost:3000/assets/icon-16.png",
+                      },
+                      {
+                        size: 32,
+                        file: "https://localhost:3000/assets/icon-32.png",
+                      },
+                      {
+                        size: 80,
+                        file: "https://localhost:3000/assets/icon-80.png",
+                      },
+                    ],
+                    supertip: {
+                      title: "Perform an action",
+                      description: "Perform an action when clicked.",
+                    },
+                    actionId: "action",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
   },
 ];
 

--- a/packages/fx-core/src/plugins/resource/appstudio/devPreviewManifest.ts
+++ b/packages/fx-core/src/plugins/resource/appstudio/devPreviewManifest.ts
@@ -1,15 +1,46 @@
 import { Inputs, DevPreviewManifest } from "@microsoft/teamsfx-api";
 import { QuestionName } from "../officeaddin/questions";
+import { OFFICE_ADDIN_EXTENSIONS_LOCAL_DEBUG } from "./constants";
 
 export function createDevPreviewManifest(inputs?: Inputs): DevPreviewManifest | undefined {
   if (!inputs) {
     return undefined;
   }
   const host = inputs[QuestionName.OfficeHostQuestion];
-  const lang = inputs[QuestionName.AddinLanguageQuestion];
-  const template = inputs[QuestionName.AddinTemplateSelectQuestion];
-  const addinName = inputs[QuestionName.AddinNameQuestion];
+  // const lang = inputs[QuestionName.AddinLanguageQuestion];
+  // const template = inputs[QuestionName.AddinTemplateSelectQuestion];
+  // const addinName = inputs[QuestionName.AddinNameQuestion];
   // change the office add-in fields in manifest accordingly
   const manifest = new DevPreviewManifest();
+  Object.assign(manifest.extensions as [], OFFICE_ADDIN_EXTENSIONS_LOCAL_DEBUG);
+  manifest.extensions?.[0].requirements?.scopes?.push(getScope(host));
+  manifest.extensions?.[0].ribbons?.[0].contexts?.push(getContext());
+
   return manifest;
+}
+
+// TODO: update to get different contexts when support for them is implemented
+function getContext(): "mailRead" {
+  return "mailRead";
+}
+
+// TODO: update to handle different hosts when support for them is implemented
+type Scopes = "mail"; // | "document" | "notebook" | "presentation" | "project" | "workbook"
+function getScope(host: string): Scopes {
+  let scope: Scopes = "mail";
+  switch (host.toLowerCase()) {
+    // case "word":
+    //   scope = "document";
+    case "outlook":
+      scope = "mail";
+    // case "onenote":
+    //   scope = "notebook";
+    // case "powerpoint":
+    //   scope = "presentation";
+    // case "project":
+    //   scope = "project";
+    // case "excel":
+    //   scope = "workbook";
+  }
+  return scope;
 }

--- a/packages/fx-core/src/plugins/resource/officeaddin/config/projectProperties.json
+++ b/packages/fx-core/src/plugins/resource/officeaddin/config/projectProperties.json
@@ -1,148 +1,19 @@
 {
     "projectTypes": {
-        "taskpane": {
-            "displayname": "Office Add-in Task Pane project",
-            "manifestPath": "manifest.xml",
-            "templates": {
-                "javascript": {
-                    "repository": "https://github.com/OfficeDev/Office-Addin-TaskPane-JS",
-                    "branch": "yo-office",
-                    "prerelease": "yo-office-prerelease"
-                },
-                "typescript": {
-                    "repository": "https://github.com/OfficeDev/Office-Addin-TaskPane",
-                    "branch": "yo-office",
-                    "prerelease": "yo-office-prerelease"
-                }
-            },
-            "supportedHosts": [
-                    "Excel",
-                    "Onenote",
-                    "Outlook",
-                    "Powerpoint",
-                    "Project",
-                    "Word"]
-        },
-        "angular": {
-            "displayname": "Office Add-in Task Pane project using Angular framework",
-            "manifestPath": "manifest.xml",
-            "templates": {
-                "javascript": {
-                    "repository": "https://github.com/OfficeDev/Office-Addin-TaskPane-Angular-JS",
-                    "branch": "yo-office",
-                    "prerelease": "yo-office-prerelease"
-                },
-                "typescript": {
-                    "repository": "https://github.com/OfficeDev/Office-Addin-TaskPane-Angular",
-                    "branch": "yo-office",
-                    "prerelease": "yo-office-prerelease"
-                }
-            },
-            "supportedHosts": [
-                "Excel",
-                "Onenote",
-                "Outlook",
-                "Powerpoint",
-                "Project",
-                "Word"
-            ]
-        },
-        "react": {
-            "displayname": "Office Add-in Task Pane project using React framework",
-            "manifestPath": "manifest.xml",
-            "templates": {
-                "javascript": {
-                    "repository": "https://github.com/OfficeDev/Office-Addin-TaskPane-React-JS",
-                    "branch": "yo-office",
-                    "prerelease": "yo-office-prerelease"
-                },
-                "typescript": {
-                    "repository": "https://github.com/OfficeDev/Office-Addin-TaskPane-React",
-                    "branch": "yo-office",
-                    "prerelease": "yo-office-prerelease"
-                }
-            },
-            "supportedHosts": [
-                "Excel",
-                "Onenote",
-                "Outlook",
-                "Powerpoint",
-                "Project",
-                "Word"
-            ]
-        },
-        "single-sign-on": {
-            "displayname": "Office Add-in Task Pane project supporting single sign-on",
-            "manifestPath": "manifest.xml",
-            "templates": {
-                "javascript": {
-                    "repository": "https://github.com/OfficeDev/Office-Addin-TaskPane-SSO-JS",
-                    "branch": "yo-office",
-                    "prerelease": "yo-office-prerelease"
-                },
-                "typescript": {
-                    "repository": "https://github.com/OfficeDev/Office-Addin-Taskpane-SSO",
-                    "branch": "yo-office",
-                    "prerelease": "yo-office-prerelease"
-                }
-            },
-            "supportedHosts": [
-                "Excel",
-                "Outlook",
-                "Powerpoint",
-                "Word"
-            ]
-        },
-        "manifest": {
-            "displayname": "Office Add-in project containing the manifest only",
-            "manifestPath": "manifest.xml",
-            "templates": {
-                "manifestonly": {
-                    "repository": ""
-                }
-            },
-            "supportedHosts": [
-                "Excel",
-                "Onenote",
-                "Outlook",
-                "Powerpoint",
-                "Project",
-                "Word"
-            ]
-        },
-        "excel-functions": {
-            "displayname": "Excel Custom Functions Add-in project",
-            "manifestPath": "manifest.xml",
-            "templates": {
-                "javascript": {
-                    "repository": "https://github.com/OfficeDev/Excel-Custom-Functions-JS",
-                    "branch": "yo-office",
-                    "prerelease": "yo-office-prerelease"
-                },
-                "typescript": {
-                    "repository": "https://github.com/OfficeDev/Excel-Custom-Functions",
-                    "branch": "yo-office",
-                    "prerelease": "yo-office-prerelease"
-                }
-            },
-            "supportedHosts": [
-                "Excel"
-            ]
-        },
         "teams-manifest": {
-            "displayname": "Outlook Add-in with Teams Manifest (Developer preview)",
-            "manifestPath": "manifest/manifest.json",
+            "displayname": "Outlook Add-in with Teams Manifest (preview)",
+            "manifestPath": "manifest.json",
             "templates": {
                 "typescript": {
                     "repository": "https://github.com/OfficeDev/Office-Addin-TaskPane",
-                    "branch": "json-yo-office",
-                    "prerelease": "json-yo-office-prerelease"
+                    "branch": "json-preview-yo-office",
+                    "prerelease": "json-preview-yo-office-prerelease"
                 }
             },
             "supportedHosts": [
                 "Outlook"
             ]
-        }
+        },
     },
     "hostTypes": {
         "excel": {

--- a/packages/fx-core/src/plugins/resource/officeaddin/index.ts
+++ b/packages/fx-core/src/plugins/resource/officeaddin/index.ts
@@ -64,7 +64,7 @@ export class OfficeAddinPlugin implements v2.ResourcePlugin {
     process.chdir(addinRoot);
     try {
       const jsonData = new projectsJsonData();
-      const projectRepoBranchInfo = jsonData.getProjectRepoAndBranch(template, language, false);
+      const projectRepoBranchInfo = jsonData.getProjectRepoAndBranch(template, language, true);
 
       // Copy project template files from project repository
       if (projectRepoBranchInfo.repo) {
@@ -79,11 +79,8 @@ export class OfficeAddinPlugin implements v2.ResourcePlugin {
         await childProcessExec(cmdLine);
 
         // modify manifest guid and DisplayName
-        await OfficeAddinManifest.modifyManifestFile(
-          `${join(addinRoot, jsonData.getManifestPath(template) as string)}`,
-          "random",
-          `${name}`
-        );
+        const manifestPath = join(addinRoot, jsonData.getManifestPath(template) as string);
+        await OfficeAddinManifest.modifyManifestFile(manifestPath, "random", name);
       }
       process.chdir(workingDir);
       return ok(Void);

--- a/packages/manifest/src/manifest.ts
+++ b/packages/manifest/src/manifest.ts
@@ -545,7 +545,7 @@ export class DevPreviewManifest implements DevPreviewSchema {
   localizationInfo?: ILocalizationInfo;
 
   developer: IDeveloper = {
-    name: "Teams App, Inc.",
+    name: "Contoso",
     mpnId: "",
     websiteUrl: "https://localhost:3000",
     privacyUrl: "https://localhost:3000/privacy",


### PR DESCRIPTION
Add code to put in content into the extensions section of the manifest template based on the office-addin template (currently only json case one available).