### PR TITLE
fix: create new teams app if account in same tenant

### DIFF
--- a/packages/fx-core/src/component/debugHandler/appManifest.ts
+++ b/packages/fx-core/src/component/debugHandler/appManifest.ts
@@ -179,10 +179,7 @@ export class AppManifestDebugHandler {
       this.envInfoV3.config.isLocalDebug = true;
 
       // Local debug if switching to a different account in same tenant
-      if (
-        this.envInfoV3.envName === environmentManager.getLocalEnvName() &&
-        !!this.envInfoV3.state[ComponentNames.AppManifest].teamsAppId
-      ) {
+      if (!!this.envInfoV3.state[ComponentNames.AppManifest].teamsAppId) {
         const checkAppInDifferentAccount = await checkIfAppInDifferentAcountSameTenant(
           this.envInfoV3.state[ComponentNames.AppManifest].teamsAppId,
           this.m365TokenProvider,

--- a/packages/fx-core/tests/component/debugHandler/appManifest.test.ts
+++ b/packages/fx-core/tests/component/debugHandler/appManifest.test.ts
@@ -29,7 +29,7 @@ import { MockM365TokenProvider, runDebugActions } from "./utils";
 import { MockLogProvider, MockTelemetryReporter, MockUserInteraction } from "../../core/utils";
 import * as utils from "../../../src/component/debugHandler/utils";
 
-describe.only("AppManifestDebugHandler", () => {
+describe("AppManifestDebugHandler", () => {
   const projectPath = path.resolve(__dirname, "data");
   const tenantId = "11111111-1111-1111-1111-111111111111";
   const m365TokenProvider = new MockM365TokenProvider(tenantId);

--- a/packages/fx-core/tests/component/resource/appManifest/appstudio.test.ts
+++ b/packages/fx-core/tests/component/resource/appManifest/appstudio.test.ts
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import "mocha";
+import * as chai from "chai";
+import sinon from "sinon";
+import { MockLogProvider, MockM365TokenProvider } from "../../../core/utils";
+import { err, ok, UserError } from "@microsoft/teamsfx-api";
+import { checkIfAppInDifferentAcountSameTenant } from "../../../../src/component/resource/appManifest/appStudio";
+import { AppStudioClient } from "../../../../src/component/resource/appManifest/appStudioClient";
+
+describe("appStudio", () => {
+  const sandbox = sinon.createSandbox();
+  describe("checkIfAppInDifferentAcountSameTenant", () => {
+    const logger = new MockLogProvider();
+    const teamsAppId = "teams";
+    const m365TokenProvider = new MockM365TokenProvider();
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it("get app successfully: returns false", async () => {
+      m365TokenProvider.getAccessToken = sandbox.stub().returns(ok("token"));
+      sandbox.stub(AppStudioClient, "getApp").resolves();
+
+      const res = await checkIfAppInDifferentAcountSameTenant(
+        teamsAppId,
+        m365TokenProvider,
+        logger
+      );
+      chai.assert.isTrue(res.isOk());
+
+      if (res.isOk()) {
+        chai.assert.isFalse(res.value);
+      }
+    });
+
+    it("get token error: returns error", async () => {
+      m365TokenProvider.getAccessToken = sandbox
+        .stub()
+        .returns(err(new UserError("token", "token", "", "")));
+
+      const res = await checkIfAppInDifferentAcountSameTenant(
+        teamsAppId,
+        m365TokenProvider,
+        logger
+      );
+      chai.assert.isTrue(res.isErr());
+      if (res.isErr()) {
+        chai.assert.equal(res.error.name, "token");
+      }
+    });
+
+    it("app in tenant but different account: returns true", async () => {
+      m365TokenProvider.getAccessToken = sandbox.stub().returns(ok("token"));
+      sandbox.stub(AppStudioClient, "getApp").throws({ message: "404" });
+      sandbox.stub(AppStudioClient, "checkExistsInTenant").returns(Promise.resolve(true));
+      const res = await checkIfAppInDifferentAcountSameTenant(
+        teamsAppId,
+        m365TokenProvider,
+        logger
+      );
+      chai.assert.isTrue(res.isOk());
+
+      if (res.isOk()) {
+        chai.assert.isTrue(res.value);
+      }
+    });
+
+    it("get app error (not 404): returns false", async () => {
+      m365TokenProvider.getAccessToken = sandbox.stub().returns(ok("token"));
+      sandbox.stub(AppStudioClient, "getApp").throws({ message: "401" });
+      const res = await checkIfAppInDifferentAcountSameTenant(
+        teamsAppId,
+        m365TokenProvider,
+        logger
+      );
+      chai.assert.isTrue(res.isOk());
+
+      if (res.isOk()) {
+        chai.assert.isFalse(res.value);
+      }
+    });
+  });
+});


### PR DESCRIPTION
- We used to generate a new Teams app id if local debug with a different account from same tenant. Add this logic back to the new local debug workflow.

E2E TEST: https://github.com/OfficeDev/TeamsFx/actions/runs/3317743455