### PR TITLE
fix(localdebug): make local debug task args can be empty

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -778,7 +778,7 @@
             ]
           },
           "args": {
-            "oneOf": [
+            "anyOf": [
               {
                 "type": "object",
                 "required": [


### PR DESCRIPTION
Update `args` schema to make it can be empty
![image](https://user-images.githubusercontent.com/49138419/197742590-c117b0cf-2e61-4cc0-961e-19953b01a6ab.png)
E2E TEST: none