### PR TITLE
chore: add bot get failed error message

### DIFF
--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -878,6 +878,7 @@
   "plugins.bot.SomethingNotFound": "%s is not found.",
   "plugins.bot.SomethingNotExisting": "%s is not existing.",
   "plugins.bot.FailedToCreate": "Failed to create %s",
+  "plugins.bot.FailedToGetAlreadyCreatedBot": "Could not get bot with id %s which was created before. \nThis could happen if the bot was created by another account. Visit %s to learn more.",
   "plugins.bot.FailedToProvision": "Failed to provision %s.",
   "plugins.bot.FailedToUpdateConfigs": "Failed to update configs for %s",
   "plugins.bot.FailedListPublishingCredentials": "Failed to list publishing credentials.",

--- a/packages/fx-core/src/common/constants.ts
+++ b/packages/fx-core/src/common/constants.ts
@@ -8,7 +8,7 @@ export class ConstantString {
 export class HelpLinks {
   static readonly WhyNeedProvision = "https://aka.ms/teamsfx/whyneedprovision";
   static readonly ArmHelpLink = "https://aka.ms/teamsfx-arm-help";
-  static readonly SwtichTenantOrSub = "https://aka.ms/teamsfx-switch-tenant-or-subscription-help";
+  static readonly SwitchAccountOrSub = "https://aka.ms/teamsfx-switch-account-or-subscription-help";
 
   // TODO: short link to the docs
   static readonly HowToAddCapability = "https://aka.ms/teamsfx-how-to-add-capability";

--- a/packages/fx-core/src/component/resource/appManifest/appStudioClient.ts
+++ b/packages/fx-core/src/component/resource/appManifest/appStudioClient.ts
@@ -104,7 +104,7 @@ export namespace AppStudioClient {
         const error = AppStudioResultFactory.UserError(
           AppStudioError.TeamsAppCreateConflictError.name,
           AppStudioError.TeamsAppCreateConflictError.message(),
-          HelpLinks.SwtichTenantOrSub
+          HelpLinks.SwitchAccountOrSub
         );
         throw error;
       }


### PR DESCRIPTION
- Add error message when get bot failed but the bot id is from env
- Also created a new aka.ms link which pointed to the same help doc while keeping the old aka.ms link valid also.
TODO: update doc