### PR TITLE
chore: align name length

### DIFF
--- a/packages/fx-core/src/component/resource/botService/botRegistration/localBotRegistration.ts
+++ b/packages/fx-core/src/component/resource/botService/botRegistration/localBotRegistration.ts
@@ -7,6 +7,7 @@ import { AppStudioScopes } from "../../../../common/tools";
 import { AppStudioClient } from "../appStudio/appStudioClient";
 import { BotRegistration, BotAuthType, BotAadCredentials } from "./botRegistration";
 import { Messages } from "../messages";
+import { MaxLengths } from "../constants";
 
 export class LocalBotRegistration extends BotRegistration {
   public async createBotRegistration(
@@ -34,9 +35,10 @@ export class LocalBotRegistration extends BotRegistration {
 
     const appStudioToken = appStudioTokenRes.value;
     // Register a new bot registration.
+    const botName = aadDisplayName.length > MaxLengths.BOT_NAME ? aadDisplayName.substr(aadDisplayName.length - MaxLengths.BOT_NAME): aadDisplayName; 
     const initialBotReg: IBotRegistration = {
       botId: botAadCredentials.botId,
-      name: aadDisplayName,
+      name: botName,
       description: "",
       iconUrl: "",
       messagingEndpoint: "",

--- a/packages/fx-core/src/component/resource/botService/botRegistration/localBotRegistration.ts
+++ b/packages/fx-core/src/component/resource/botService/botRegistration/localBotRegistration.ts
@@ -7,7 +7,7 @@ import { AppStudioScopes } from "../../../../common/tools";
 import { AppStudioClient } from "../appStudio/appStudioClient";
 import { BotRegistration, BotAuthType, BotAadCredentials } from "./botRegistration";
 import { Messages } from "../messages";
-import { MaxLengths } from "../constants";
+import { makeBotName } from "../common";
 
 export class LocalBotRegistration extends BotRegistration {
   public async createBotRegistration(
@@ -35,10 +35,9 @@ export class LocalBotRegistration extends BotRegistration {
 
     const appStudioToken = appStudioTokenRes.value;
     // Register a new bot registration.
-    const botName = aadDisplayName.length > MaxLengths.BOT_NAME ? aadDisplayName.substr(aadDisplayName.length - MaxLengths.BOT_NAME): aadDisplayName; 
     const initialBotReg: IBotRegistration = {
       botId: botAadCredentials.botId,
-      name: botName,
+      name: makeBotName(aadDisplayName),
       description: "",
       iconUrl: "",
       messagingEndpoint: "",

--- a/packages/fx-core/src/component/resource/botService/common.ts
+++ b/packages/fx-core/src/component/resource/botService/common.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 import { Uuid } from "node-ts-uuid";
+import { MaxLengths } from "./constants";
 
 export function genUUID(): string {
   return Uuid.generate();
@@ -8,4 +9,8 @@ export function genUUID(): string {
 
 export function isHttpCodeOkOrCreated(code: number): boolean {
   return [200, 201].includes(code);
+}
+
+export function makeBotName(raw: string): string {
+  return raw.length > MaxLengths.BOT_NAME ? raw.substr(raw.length - MaxLengths.BOT_NAME) : raw;
 }

--- a/packages/fx-core/src/component/resource/botService/constants.ts
+++ b/packages/fx-core/src/component/resource/botService/constants.ts
@@ -42,6 +42,7 @@ export class Alias {
 
 export class MaxLengths {
   public static readonly AAD_DISPLAY_NAME = 120;
+  public static readonly BOT_NAME = 42;
 }
 
 export class TelemetryKeys {

--- a/packages/fx-core/src/component/resource/botService/constants.ts
+++ b/packages/fx-core/src/component/resource/botService/constants.ts
@@ -42,7 +42,7 @@ export class Alias {
 
 export class MaxLengths {
   public static readonly AAD_DISPLAY_NAME = 120;
-  public static readonly BOT_NAME = 42;
+  public static readonly BOT_NAME = 35;
 }
 
 export class TelemetryKeys {

--- a/packages/fx-core/tests/component/resource/botService/common.test.ts
+++ b/packages/fx-core/tests/component/resource/botService/common.test.ts
@@ -17,4 +17,29 @@ describe("Common Utils", () => {
       chai.assert.isTrue(result);
     });
   });
+
+  describe("makeBotName", () => {
+    it("Happy Path", () => {
+      // Arrange
+      const raw = "testname";
+
+      // Act
+      const botName = utils.makeBotName(raw);
+
+      // Assert
+      chai.assert.isTrue(botName === raw);
+    });
+
+    it("Long name should be cut", () => {
+      // Arrange
+      const raw = "testname01234567890123456789012345678912345";
+      const expectedName = "01234567890123456789012345678912345";
+
+      // Act
+      const botName = utils.makeBotName(raw);
+
+      // Assert
+      chai.assert.isTrue(botName === expectedName);
+    });
+  });
 });


### PR DESCRIPTION
1. Length of local bot name has to be <= 35.
2. Length of remote bot handle has to be <= 42.
So min both -> 35.
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/16005991