### PR TITLE
chore: imporve UX for AAD drivers

### DIFF
--- a/packages/fx-core/src/component/driver/aad/utility/aadAppClient.ts
+++ b/packages/fx-core/src/component/driver/aad/utility/aadAppClient.ts
@@ -50,6 +50,7 @@ export class AadAppClient {
   public async createAadApp(displayName: string): Promise<AADApplication> {
     const requestBody: IAADDefinition = {
       displayName: displayName,
+      signInAudience: "AzureADMyOrg", // Create single tenant by default, can be changed using manifest with aadApp/update action
     }; // Create an AAD app without setting anything
 
     const response = await this.axios.post("applications", requestBody);


### PR DESCRIPTION
1. Create single tenant AAD app by default. This can be changed by manifest later.
2. Output actual manifest first when update AAD app for better troubleshooting experience.