### PR TITLE
chore: fix the telemetry property to new-project-id when download sample

### DIFF
--- a/packages/fx-core/src/common/telemetry.ts
+++ b/packages/fx-core/src/common/telemetry.ts
@@ -20,6 +20,7 @@ export enum TelemetryProperty {
   ErrorMessage = "error-message",
   SampleAppName = "sample-app-name",
   ProjectId = "project-id",
+  NewProjectId = "new-project-id",
   CorrelationId = "correlation-id",
   Env = "env",
   CustomizeResourceGroupType = "customize-resource-group-type",

--- a/packages/fx-core/src/core/downloadSample.ts
+++ b/packages/fx-core/src/core/downloadSample.ts
@@ -169,12 +169,12 @@ export async function downloadSample(
       projectSettings.projectId = inputs.projectId ? inputs.projectId : uuid.v4();
       projectSettings.isFromSample = true;
       inputs.projectId = projectSettings.projectId;
-      telemetryProperties[TelemetryProperty.ProjectId] = projectSettings.projectId;
+      telemetryProperties[TelemetryProperty.NewProjectId] = projectSettings.projectId;
       if (ctx) ctx.projectSettings = projectSettings;
       if (contextV3) contextV3.projectSetting = projectSettings as ProjectSettingsV3;
       inputs.projectPath = sampleAppPath;
     } else {
-      telemetryProperties[TelemetryProperty.ProjectId] =
+      telemetryProperties[TelemetryProperty.NewProjectId] =
         "unknown, failed to set projectId in projectSettings.json";
     }
     await progress.end(true);


### PR DESCRIPTION
ADO: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/16110752
E2E TEST: NA