### PR TITLE
fix: adapt cicd case for v3

### DIFF
--- a/packages/cli/tests/e2e/cicd/VerifyGeneratedTemplates.v3.tests.ts
+++ b/packages/cli/tests/e2e/cicd/VerifyGeneratedTemplates.v3.tests.ts
@@ -16,6 +16,7 @@ import { it } from "@microsoft/extra-shot-mocha";
 import Mustache from "mustache";
 import * as fs from "fs-extra";
 import { CICDProviderFactory } from "../../../../fx-core/src/component/feature/cicd/provider/factory";
+import { isV3Enabled } from "@microsoft/teamsfx-core";
 describe("Verify generated templates & readme V3", function () {
   const testFolder = getTestFolder();
   const appName = getUniqueAppName();
@@ -41,7 +42,7 @@ describe("Verify generated templates & readme V3", function () {
         getTemplatesFolder(),
         "plugins",
         "resource",
-        "cicd",
+        isV3Enabled() ? "cicd" : "cicd_v2",
         providerName
       );
       const templatePromises = ["ci", "cd", "provision", "publish"].map(async (template) => {


### PR DESCRIPTION
Adapt e2e case for v3.

E2E TEST: https://github.com/OfficeDev/TeamsFx/blob/c2ab6f418e38a877956cb9e429c0a6fadd924b51/packages/cli/tests/e2e/cicd/VerifyGeneratedTemplates.v3.tests.ts#L28