### PR TITLE
chore: add generate appsettings driver

### DIFF
--- a/packages/fx-core/src/component/driver/env/appsettingsGenerate.ts
+++ b/packages/fx-core/src/component/driver/env/appsettingsGenerate.ts
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as fs from "fs-extra";
+import { Service } from "typedi";
+
+import { hooks } from "@feathersjs/hooks/lib";
+import { FxError, Result, SystemError, UserError } from "@microsoft/teamsfx-api";
+
+import { getLocalizedString } from "../../../common/localizeUtils";
+import { wrapRun } from "../../utils/common";
+import { logMessageKeys } from "../aad/utility/constants";
+import { DriverContext } from "../interface/commonArgs";
+import { StepDriver } from "../interface/stepDriver";
+import { addStartAndEndTelemetry } from "../middleware/addStartAndEndTelemetry";
+import { InvalidParameterUserError } from "./error/invalidParameterUserError";
+import { UnhandledSystemError } from "./error/unhandledError";
+import { GenerateAppsettingsArgs } from "./interface/generateAppsettingsArgs";
+
+const actionName = "appsettings/generate";
+const helpLink = "https://aka.ms/teamsfx-actions/appsettings-generate";
+
+@Service(actionName) // DO NOT MODIFY the service name
+export class GenerateAppsettingsDriver implements StepDriver {
+  @hooks([addStartAndEndTelemetry(actionName, actionName)])
+  public async run(
+    args: GenerateAppsettingsArgs,
+    context: DriverContext
+  ): Promise<Result<Map<string, string>, FxError>> {
+    return wrapRun(() => this.handler(args, context));
+  }
+
+  private async handler(
+    args: GenerateAppsettingsArgs,
+    context: DriverContext
+  ): Promise<Map<string, string>> {
+    try {
+      this.validateArgs(args);
+
+      const appSettingsJson = JSON.parse(fs.readFileSync(args.target, "utf-8"));
+      const content = { ...appSettingsJson, ...args.appsettings };
+      await fs.writeFile(args.target, JSON.stringify(content, null, "\t"), "utf-8");
+
+      return new Map();
+    } catch (error) {
+      if (error instanceof UserError || error instanceof SystemError) {
+        context.logProvider?.error(
+          getLocalizedString(logMessageKeys.failExecuteDriver, actionName, error.displayMessage)
+        );
+        throw error;
+      }
+
+      const message = JSON.stringify(error);
+      context.logProvider?.error(
+        getLocalizedString(logMessageKeys.failExecuteDriver, actionName, message)
+      );
+      throw new UnhandledSystemError(actionName, message);
+    }
+  }
+
+  private validateArgs(args: GenerateAppsettingsArgs): void {
+    const invalidParameters: string[] = [];
+    if (args.target === undefined) {
+      invalidParameters.push("target");
+    } else if (
+      args.target !== undefined &&
+      (typeof args.target !== "string" || args.target.length === 0)
+    ) {
+      invalidParameters.push("target");
+    }
+
+    if (!args.appsettings || typeof args.appsettings !== "object") {
+      invalidParameters.push("appsettings");
+    }
+
+    for (const value of Object.values(args.appsettings)) {
+      if (!value) {
+        invalidParameters.push("appsettings");
+      }
+    }
+
+    if (invalidParameters.length > 0) {
+      throw new InvalidParameterUserError(actionName, invalidParameters, helpLink);
+    }
+  }
+}

--- a/packages/fx-core/src/component/driver/env/appsettingsGenerate.ts
+++ b/packages/fx-core/src/component/driver/env/appsettingsGenerate.ts
@@ -84,12 +84,15 @@ export class GenerateAppsettingsDriver implements StepDriver {
     }
   }
 
-  private replaceProjectAppsettings(projectAppsettings: object, ymlAppsettings: object) {
+  private replaceProjectAppsettings(
+    projectAppsettings: Record<string, unknown>,
+    ymlAppsettings: Record<string, unknown>
+  ) {
     for (const item of Object.entries(ymlAppsettings)) {
       if (typeof item[1] === "string") {
         (projectAppsettings as any)[item[0]] = item[1];
-      } else if(typeof item[1] === "object") {
-        this.replaceProjectAppsettings((projectAppsettings as any)[item[0]], item[1]);
+      } else if (typeof item[1] === "object") {
+        this.replaceProjectAppsettings((projectAppsettings as any)[item[0]], item[1] as any);
       }
     }
   }

--- a/packages/fx-core/src/component/driver/env/appsettingsGenerate.ts
+++ b/packages/fx-core/src/component/driver/env/appsettingsGenerate.ts
@@ -38,8 +38,8 @@ export class GenerateAppsettingsDriver implements StepDriver {
       this.validateArgs(args);
 
       const appSettingsJson = JSON.parse(fs.readFileSync(args.target, "utf-8"));
-      const content = { ...appSettingsJson, ...args.appsettings };
-      await fs.writeFile(args.target, JSON.stringify(content, null, "\t"), "utf-8");
+      this.replaceProjectAppsettings(appSettingsJson, args.appsettings);
+      await fs.writeFile(args.target, JSON.stringify(appSettingsJson, null, "\t"), "utf-8");
 
       return new Map();
     } catch (error) {
@@ -81,6 +81,16 @@ export class GenerateAppsettingsDriver implements StepDriver {
 
     if (invalidParameters.length > 0) {
       throw new InvalidParameterUserError(actionName, invalidParameters, helpLink);
+    }
+  }
+
+  private replaceProjectAppsettings(projectAppsettings: object, ymlAppsettings: object) {
+    for (const item of Object.entries(ymlAppsettings)) {
+      if (typeof item[1] === "string") {
+        (projectAppsettings as any)[item[0]] = item[1];
+      } else if(typeof item[1] === "object") {
+        this.replaceProjectAppsettings((projectAppsettings as any)[item[0]], item[1]);
+      }
     }
   }
 }

--- a/packages/fx-core/src/component/driver/env/interface/generateAppsettingsArgs.ts
+++ b/packages/fx-core/src/component/driver/env/interface/generateAppsettingsArgs.ts
@@ -2,25 +2,7 @@
 // Licensed under the MIT license.
 
 export interface Appsettings {
-  BOT_ID?: string;
-  BOT_PASSWORD?: string;
-  TeamsFx?: TeamsFxArgs;
-}
-
-export interface TeamsFxArgs {
-  Authentication: AuthenticationArgs;
-}
-
-export interface AuthenticationArgs {
-  ClientId: string;
-  ClientSecret: string;
-  OAuthAuthority: string;
-  ApplicationIdUri?: string;
-  Bot?: BotArgs;
-}
-
-export interface BotArgs {
-  InitiateLoginEndpoint: string;
+  [key: string]: any;
 }
 
 export interface GenerateAppsettingsArgs {

--- a/packages/fx-core/src/component/driver/env/interface/generateAppsettingsArgs.ts
+++ b/packages/fx-core/src/component/driver/env/interface/generateAppsettingsArgs.ts
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export interface Appsettings {
+  BOT_ID?: string;
+  BOT_PASSWORD?: string;
+  TeamsFx?: TeamsFxArgs;
+}
+
+export interface TeamsFxArgs {
+  Authentication: AuthenticationArgs;
+}
+
+export interface AuthenticationArgs {
+  ClientId: string;
+  ClientSecret: string;
+  OAuthAuthority: string;
+  ApplicationIdUri?: string;
+  Bot?: BotArgs;
+}
+
+export interface BotArgs {
+  InitiateLoginEndpoint: string;
+}
+
+export interface GenerateAppsettingsArgs {
+  target: string; // The path of the appsettings file
+  appsettings: Appsettings;
+}

--- a/packages/fx-core/tests/component/driver/env/generateAppsettings.test.ts
+++ b/packages/fx-core/tests/component/driver/env/generateAppsettings.test.ts
@@ -119,7 +119,7 @@ describe("AppsettingsGenerateDriver", () => {
       const result = await driver.run(args, mockedDriverContext);
       chai.assert(result.isOk());
       if (result.isOk()) {
-        chai.assert.equal("{\n\t\"BOT_ID\": \"BOT_ID\",\n\t\"BOT_PASSWORD\": \"BOT_PASSWORD\"\n}", content);
+        chai.assert.equal('{\n\t"BOT_ID": "BOT_ID",\n\t"BOT_PASSWORD": "BOT_PASSWORD"\n}', content);
       }
     });
 
@@ -128,11 +128,10 @@ describe("AppsettingsGenerateDriver", () => {
       let content = {};
       const appsettings = {
         Foo: "Bar",
-        My:
-        {
-            BOT_ID: "$botId$",
-            Foo: "Bar"
-        }
+        My: {
+          BOT_ID: "$botId$",
+          Foo: "Bar",
+        },
       };
       sinon.stub(fs, "ensureFile").callsFake(async (path) => {
         return;
@@ -147,16 +146,18 @@ describe("AppsettingsGenerateDriver", () => {
       const args: any = {
         target,
         appsettings: {
-          My:
-          {
-              BOT_ID: "BOD_ID",
-          }
-        }
+          My: {
+            BOT_ID: "BOD_ID",
+          },
+        },
       };
       const result = await driver.run(args, mockedDriverContext);
       chai.assert(result.isOk());
       if (result.isOk()) {
-        chai.assert.equal("{\n\t\"Foo\": \"Bar\",\n\t\"My\": {\n\t\t\"BOT_ID\": \"BOD_ID\",\n\t\t\"Foo\": \"Bar\"\n\t}\n}", content);
+        chai.assert.equal(
+          '{\n\t"Foo": "Bar",\n\t"My": {\n\t\t"BOT_ID": "BOD_ID",\n\t\t"Foo": "Bar"\n\t}\n}',
+          content
+        );
       }
     });
   });

--- a/packages/fx-core/tests/component/driver/env/generateAppsettings.test.ts
+++ b/packages/fx-core/tests/component/driver/env/generateAppsettings.test.ts
@@ -1,0 +1,122 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import "mocha";
+
+import * as chai from "chai";
+import fs from "fs-extra";
+import * as os from "os";
+import * as sinon from "sinon";
+import * as util from "util";
+
+import * as localizeUtils from "../../../../src/common/localizeUtils";
+import { InvalidParameterUserError } from "../../../../src/component/driver/env/error/invalidParameterUserError";
+import { UnhandledSystemError } from "../../../../src/component/driver/env/error/unhandledError";
+import { GenerateAppsettingsDriver } from "../../../../src/component/driver/env/appsettingsGenerate";
+import { DriverContext } from "../../../../src/component/driver/interface/commonArgs";
+import { MockedLogProvider } from "../../../plugins/solution/util";
+
+describe("AppsettingsGenerateDriver", () => {
+  const mockedDriverContext = {
+    logProvider: new MockedLogProvider(),
+  } as DriverContext;
+  const driver = new GenerateAppsettingsDriver();
+
+  beforeEach(() => {
+    sinon.stub(localizeUtils, "getDefaultString").callsFake((key, ...params) => {
+      if (key === "driver.env.error.invalidParameter") {
+        return util.format(
+          "Following parameter is missing or invalid for %s action: %s.",
+          ...params
+        );
+      } else if (key === "driver.env.error.unhandledError") {
+        return util.format("Unhandled error happened in %s action: %s", ...params);
+      }
+      return "";
+    });
+    sinon.stub(localizeUtils, "getLocalizedString").returns("");
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("run", () => {
+    it("invalid args: empty target", async () => {
+      const args: any = {
+        target: null,
+        appsettings: {
+          BOT_ID: "BOT_ID",
+          BOT_PASSWORD: "BOT_PASSWORD",
+        },
+      };
+      const result = await driver.run(args, mockedDriverContext);
+      chai.assert(result.isErr());
+      if (result.isErr()) {
+        chai.assert(result.error instanceof InvalidParameterUserError);
+        const message =
+          "Following parameter is missing or invalid for appsettings/generate action: target.";
+        chai.assert.equal(result.error.message, message);
+      }
+    });
+
+    it("invalid args: appsettings is not object", async () => {
+      const args: any = {
+        target: "target",
+        appsettings: "value",
+      };
+      const result = await driver.run(args, mockedDriverContext);
+      chai.assert(result.isErr());
+      if (result.isErr()) {
+        chai.assert(result.error instanceof InvalidParameterUserError);
+        const message =
+          "Following parameter is missing or invalid for appsettings/generate action: appsettings.";
+        chai.assert.equal(result.error.message, message);
+      }
+    });
+
+    it("exception", async () => {
+      sinon.stub(fs, "ensureFile").throws(new Error("exception"));
+      const args: any = {
+        target: "path",
+        appsettings: {
+          BOT_ID: "BOT_ID",
+          BOT_PASSWORD: "BOT_PASSWORD",
+        },
+      };
+      const result = await driver.run(args, mockedDriverContext);
+      chai.assert(result.isErr());
+      if (result.isErr()) {
+        chai.assert(result.error instanceof UnhandledSystemError);
+        const message = "Unhandled error happened in appsettings/generate action: exception.";
+        chai.assert(result.error.message, message);
+      }
+    });
+
+    it("happy path: with target", async () => {
+      const target = "path";
+      const appsettings = {
+        BOT_ID: "$botId$",
+        BOT_PASSWORD: "$bot-password$",
+      };
+      sinon.stub(fs, "ensureFile").callsFake(async (path) => {
+        return;
+      });
+      sinon.stub(fs, "readFileSync").callsFake((path) => {
+        return Buffer.from(JSON.stringify(appsettings));
+      });
+      sinon.stub(fs, "writeFile").callsFake(async (path, data) => {
+        return;
+      });
+      const args: any = {
+        target,
+        appsettings: {
+          BOT_ID: "BOT_ID",
+          BOT_PASSWORD: "BOT_PASSWORD",
+        },
+      };
+      const result = await driver.run(args, mockedDriverContext);
+      chai.assert(result.isOk());
+    });
+  });
+});


### PR DESCRIPTION
Add generate appsettings driver for VS local debug.

Examples
- TAB
No need to add appsettings/generate

- SSO TAB
```
- uses: appsettings/generate
  with:
    target: <project-name>/appsettings.Development.json
    appsettings:
      TeamsFx:
        Authentication:
          ClientId: ${{Client_Id}}
          ClientSecret: ${{Client_Secret}}
          OAuthAuthority: ${{OAuth_Authority}}
```

- SSO BOT
```
- uses: appsettings/generate
  with:
    target: <project-name>/appsettings.Development.json
    appsettings:
        BOT_ID: ${{BOT_ID}}
        BOT_PASSWORD: ${{BOT_PASSWORD}}
        TeamsFx:
          Authentication:
            ClientId: ${{Client_Id}}
            ClientSecret: ${{Client_Secret}}
            OAuthAuthority: ${{OAuth_Authority}}
            ApplicationIdUri: ${{Application_Id_Uris}}
            Bot:
              InitiateLoginEndpoint: ${{Bot_Endpoint}}/bot-auth-start
```

This part has not been fully tested; I will test it in the VS local-debug lifecycle.