### PR TITLE
chore(dotnet-sdk): tweak the notification bot sdk

### DIFF
--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/ITurnContextExtensions.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/ITurnContextExtensions.cs
@@ -20,7 +20,9 @@ namespace Microsoft.TeamsFx.Conversation
                     result = channelData?.Team?.Id;
                 }
 
-                if (result == null)
+                // Fallback to use conversation id.
+                // The conversation id is equal to team id only when the bot app is installed into the General channel.
+                if (result == null && activity.Conversation?.Name == null)
                 {
                     result = activity.Conversation?.Id;
                 }

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/NotificationBot.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/NotificationBot.cs
@@ -116,18 +116,18 @@ namespace Microsoft.TeamsFx.Conversation
         }
 
         /// <summary>
-        /// Returns the first <see cref="Member"/> where predicate is true, and undefined otherwise.
+        /// Returns the first <see cref="Member"/> where predicate is true, and null otherwise.
         /// </summary>
         /// <param name="predicate">
         /// Find calls predicate once for each member of the installation, 
         /// until it finds one where predicate returns true. If such a member is found, 
-        /// find immediately returns that member.Otherwise, find returns undefined.
+        /// find immediately returns that member.Otherwise, find returns null.
         /// </param>
         /// <param name="scope">The scope to find members from the installations. 
         /// (personal chat, group chat, Teams channel)
         /// </param>
         /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>The first <see cref="Member"/> where predicate is true, and undefined otherwise.</returns>
+        /// <returns>The first <see cref="Member"/> where predicate is true, and null otherwise.</returns>
         /// <exception cref="ArgumentNullException">Throws when predicate is null.</exception>
         public async Task<Member> FindMemberAsync(
             Func<Member, Task<bool>> predicate,
@@ -199,15 +199,16 @@ namespace Microsoft.TeamsFx.Conversation
         }
 
         /// <summary>
-        /// Returns the first <see cref="Channel"/> where predicate is true, and undefined otherwise.
+        /// Returns the first <see cref="Channel"/> where predicate is true, and null otherwise.
+        /// (Ensure the bot app is installed into the `General` channel, otherwise null will be returned.)
         /// </summary>
         /// <param name="predicate">
         /// Find calls predicate once for each channel of the installation, 
         /// until it finds one where predicate returns true. If such a channel is found, 
-        /// find immediately returns that channel.Otherwise, find returns undefined.
+        /// find immediately returns that channel.Otherwise, find returns null.
         /// </param>
         /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>The first <see cref="Channel"/> where predicate is true, and undefined otherwise.</returns>
+        /// <returns>The first <see cref="Channel"/> where predicate is true, and null otherwise.</returns>
         /// <exception cref="ArgumentNullException">Throws when predicate is null.</exception>
         public async Task<Channel> FindChannelAsync(
             Func<Channel, TeamDetails, Task<bool>> predicate,
@@ -240,6 +241,7 @@ namespace Microsoft.TeamsFx.Conversation
 
         /// <summary>
         /// Returns all <see cref="Channel"/> where predicate is true, and empty array otherwise.
+        /// (Ensure the bot app is installed into the `General` channel, otherwise empty array will be returned.)
         /// </summary>
         /// <param name="predicate">Predicate find calls predicate for each channel of the installation.</param>
         /// <param name="cancellationToken">The cancellation token.</param>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/TeamsBotInstallation.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/TeamsBotInstallation.cs
@@ -193,7 +193,7 @@ namespace Microsoft.TeamsFx.Conversation
         /// Get team details from this bot installation
         /// </summary>
         /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>The team details if bot is installed into a team, otherwise returns undefined.</returns>
+        /// <returns>The team details if bot is installed into a team, otherwise returns null.</returns>
         public async Task<TeamDetails> GetTeamDetailsAsync(CancellationToken cancellationToken = default)
         {
             if (Type != NotificationTargetType.Channel)


### PR DESCRIPTION
Fix the fallback logic to get teams id, related fix for node SDK: https://github.com/OfficeDev/TeamsFx/pull/6393