### PR TITLE
chore: restore existing env var's value

### DIFF
--- a/packages/fx-core/src/component/middleware/envMW.ts
+++ b/packages/fx-core/src/component/middleware/envMW.ts
@@ -20,6 +20,8 @@ export const EnvLoaderMW: Middleware = async (ctx: CoreHookContext, next: NextFu
     for (const k of keys) {
       if (!(k in envBefore)) {
         delete process.env[k];
+      } else {
+        process.env[k] = envBefore[k];
       }
     }
   }

--- a/packages/fx-core/tests/component/envUtil.test.ts
+++ b/packages/fx-core/tests/component/envUtil.test.ts
@@ -138,9 +138,11 @@ describe("env utils", () => {
     if (process.env.SECRET_ABC || process.env.SECRET_ABC === undefined) {
       delete process.env.SECRET_ABC;
     }
+    process.env.ENV_VAR = "1";
     class MyClass {
       async myMethod(inputs: Inputs): Promise<Result<any, FxError>> {
         assert.equal(process.env.SECRET_ABC, decrypted);
+        process.env.ENV_VAR = "2";
         return ok(undefined);
       }
     }
@@ -156,6 +158,7 @@ describe("env utils", () => {
     const res = await my.myMethod(inputs);
     assert.isTrue(res.isOk());
     assert.isUndefined(process.env.SECRET_ABC);
+    assert.equal(process.env.ENV_VAR, "1", "process.env.ENV_VAR should be restored to 1");
 
     const core = new FxCore(tools);
     const getDotEnvRes = await core.getDotEnv(inputs);


### PR DESCRIPTION
An improvement for https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/16198497 to restore env vars that exist before execution. 