### PR TITLE
chore: ignore manifest file and app package in tab build output folder

### DIFF
--- a/templates/scenarios/js/sso-tab/.appserviceIgnore
+++ b/templates/scenarios/js/sso-tab/.appserviceIgnore
@@ -15,3 +15,5 @@ tsconfig.json
 node_modules/.bin
 node_modules/ts-node
 node_modules/typescript
+aad.manifest.*.json
+appPackage/*

--- a/templates/scenarios/js/sso-tab/teamsfx/app.yml
+++ b/templates/scenarios/js/sso-tab/teamsfx/app.yml
@@ -34,7 +34,7 @@ deploy:
   - uses: azureStorage/deploy # Deploy bits to Azure Storage Static Website
     with:
       workingDirectory: .
-      distributionPath: ./build # Deploy base folder
+      distributionPath: ./build # Deploy base folder, please ensure you ignore manifest file for AAD app and Teams App in this folder in the ignoreFile
       ignoreFile: ./.appserviceIgnore # Can be changed to any ignore file location, leave blank will ignore nothing
       resourceId: ${{TAB_AZURE_STORAGE_RESOURCE_ID}} # The resource id of the cloud resource to be deployed to
 

--- a/templates/scenarios/js/sso-tab/teamsfx/app.yml
+++ b/templates/scenarios/js/sso-tab/teamsfx/app.yml
@@ -34,7 +34,7 @@ deploy:
   - uses: azureStorage/deploy # Deploy bits to Azure Storage Static Website
     with:
       workingDirectory: .
-      distributionPath: ./build # Deploy base folder, please ensure you ignore manifest file for AAD app and Teams App in this folder in the ignoreFile
+      distributionPath: ./build # Deploy base folder. This folder includes manifest files for AAD app and Teams app that should be ignored using the ignoreFile.
       ignoreFile: ./.appserviceIgnore # Can be changed to any ignore file location, leave blank will ignore nothing
       resourceId: ${{TAB_AZURE_STORAGE_RESOURCE_ID}} # The resource id of the cloud resource to be deployed to
 


### PR DESCRIPTION
The Teams app / AAD app output folder is same with tab app, ignore their output