### PR TITLE
chore: render template with app name

### DIFF
--- a/templates/scenarios/js/sso-tab/aad.manifest.template.json.tpl
+++ b/templates/scenarios/js/sso-tab/aad.manifest.template.json.tpl
@@ -1,7 +1,10 @@
+{{=<% %>=}}
 {
     "id": "${{AAD_APP_OBJECT_ID}}",
     "appId": "${{AAD_APP_CLIENT_ID}}",
-    "name": "sso-tab-aad",
+<%={{ }}=%>
+    "name": "{{appName}}-aad",
+{{=<% %>=}}
     "accessTokenAcceptedVersion": 2,
     "signInAudience": "AzureADMyOrg",
     "optionalClaims": {
@@ -107,3 +110,4 @@
         }
     ]
 }
+<%={{ }}=%>

--- a/templates/scenarios/js/sso-tab/appPackage/manifest.template.json.tpl
+++ b/templates/scenarios/js/sso-tab/appPackage/manifest.template.json.tpl
@@ -1,3 +1,4 @@
+{{=<% %>=}}
 {
     "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.14/MicrosoftTeams.schema.json",
     "manifestVersion": "1.14",
@@ -14,14 +15,16 @@
         "color": "resources/color.png",
         "outline": "resources/outline.png"
     },
+<%={{ }}=%>
     "name": {
-        "short": "sso-tab",
-        "full": "Full name for sso-tab"
+        "short": "{{appName}}",
+        "full": "Full name for {{appName}}"
     },
     "description": {
-        "short": "Short description of sso-tab",
-        "full": "Full description of sso-tab"
+        "short": "Short description of {{appName}}",
+        "full": "Full description of {{appName}}"
     },
+{{=<% %>=}}
     "accentColor": "#FFFFFF",
     "bots": [],
     "composeExtensions": [],
@@ -58,3 +61,4 @@
         "resource": "api://${{TAB_DOMAIN}}/${{AAD_APP_CLIENT_ID}}"
     }
 }
+<%={{ }}=%>

--- a/templates/scenarios/js/sso-tab/teamsfx/app.local.yml.tpl
+++ b/templates/scenarios/js/sso-tab/teamsfx/app.local.yml.tpl
@@ -3,7 +3,7 @@ version: 1.0.0
 registerApp:
   - uses: aadApp/create # Creates a new AAD app to authenticate users if AAD_APP_CLIENT_ID environment variable is empty
     with:
-      name: sso-tab-aad # Note: when you run configure/aadApp, the AAD app name will be updated based on the definition of manifest. If you don't want to change the name, ensure the name in AAD manifest is same with the name defined here.
+      name: {{appName}}-aad # Note: when you run configure/aadApp, the AAD app name will be updated based on the definition of manifest. If you don't want to change the name, ensure the name in AAD manifest is same with the name defined here.
       generateClientSecret: true # If the value is false, the action will not generate client secret for you
     # Output: following environment variable will be persisted in current environment's .env file.
     # AAD_APP_CLIENT_ID: the client id of AAD app
@@ -15,10 +15,11 @@ registerApp:
 
   - uses: teamsApp/create # Creates a Teams app
     with:
-      name: sso-tab # Teams app name
+      name: {{appName}} # Teams app name
     # Output: following environment variable will be persisted in current environment's .env file.
     # TEAMS_APP_ID: the id of Teams app
 
+{{=<% %>=}}
 configureApp:
   - uses: env/generate # Generate env to .env file
     with:
@@ -60,4 +61,4 @@ deploy:
     with:
       workingDirectory: .
       args: install --no-audit
-
+<%={{ }}=%>

--- a/templates/scenarios/js/sso-tab/teamsfx/app.yml.tpl
+++ b/templates/scenarios/js/sso-tab/teamsfx/app.yml.tpl
@@ -1,3 +1,4 @@
+{{=<% %>=}}
 version: 1.0.0
 
 provision:
@@ -38,10 +39,11 @@ deploy:
       ignoreFile: ./.appserviceIgnore # Can be changed to any ignore file location, leave blank will ignore nothing
       resourceId: ${{TAB_AZURE_STORAGE_RESOURCE_ID}} # The resource id of the cloud resource to be deployed to
 
+<%={{ }}=%>
 registerApp:
   - uses: aadApp/create # Creates a new AAD app to authenticate users if AAD_APP_CLIENT_ID environment variable is empty
     with:
-      name: sso-tab-aad # Note: when you run configure/aadApp, the AAD app name will be updated based on the definition of manifest. If you don't want to change the name, ensure the name in AAD manifest is same with the name defined here.
+      name: {{appName}}-aad # Note: when you run configure/aadApp, the AAD app name will be updated based on the definition of manifest. If you don't want to change the name, ensure the name in AAD manifest is same with the name defined here.
       generateClientSecret: true # If the value is false, the action will not generate client secret for you
     # Output: following environment variable will be persisted in current environment's .env file.
     # AAD_APP_CLIENT_ID: the client id of AAD app
@@ -53,10 +55,11 @@ registerApp:
 
   - uses: teamsApp/create # Creates a Teams app
     with:
-      name: sso-tab # Teams app name
+      name: {{appName}} # Teams app name
     # Output: following environment variable will be persisted in current environment's .env file.
     # TEAMS_APP_ID: the id of Teams app
 
+{{=<% %>=}}
 configureApp:
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:
@@ -93,3 +96,4 @@ publish:
       appPackagePath: ./build/appPackage/appPackage.${{TEAMSFX_ENV}}.zip
   # Output: following environment variable will be persisted in current environment's .env file.
   # TEAMS_APP_PUBLISHED_APP_ID: app id in Teams tenant app catalog.
+<%={{ }}=%>


### PR DESCRIPTION
1) Render manifest/aad template and yml with app name:
![image](https://user-images.githubusercontent.com/71362691/201581756-8d4494d5-aefd-4342-b1f2-ce4edcce9b11.png)

2) Avoid environment variables with ${{env_name}} pattern being rendered to $