### PR TITLE
chore: get title id by manifest id

### DIFF
--- a/packages/cli/src/cmds/m365/m365.ts
+++ b/packages/cli/src/cmds/m365/m365.ts
@@ -99,9 +99,9 @@ class M365Unacquire extends YargsCommand {
         description: "Title ID of the acquired M365 App",
         type: "string",
       })
-      .option("file-path", {
+      .option("manifest-id", {
         require: false,
-        description: "Path to the App manifest zip package",
+        description: "Manifest ID of the acquired M365 App",
         type: "string",
       })
       .example(
@@ -109,8 +109,8 @@ class M365Unacquire extends YargsCommand {
         "Remove the acquired M365 App by Title ID"
       )
       .example(
-        "teamsfx m365 unacquire --file-path appPackage.zip",
-        "Remove the acquired M365 App by App Package"
+        "teamsfx m365 unacquire --manifest-id xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+        "Remove the acquired M365 App by Manifest ID"
       );
     return yargs.version(false);
   }
@@ -120,20 +120,20 @@ class M365Unacquire extends YargsCommand {
 
     const packageService = new PackageService(sideloadingServiceEndpoint);
     let titleId = args["title-id"];
-    const manifestPath = args["file-path"];
-    if (titleId === undefined && manifestPath === undefined) {
+    const manifestId = args["manifest-id"];
+    if (titleId === undefined && manifestId === undefined) {
       return err(
         new UserError(
           cliSource,
           "InvalidInput",
-          "Either `title-id` or `file-path` should be provided."
+          "Either `title-id` or `manifest-id` should be provided."
         )
       );
     }
 
     const tokenAndUpn = await getTokenAndUpn();
     if (titleId === undefined) {
-      titleId = await packageService.retrieveTitleId(tokenAndUpn[0], manifestPath);
+      titleId = await packageService.retrieveTitleId(tokenAndUpn[0], manifestId);
     }
     await packageService.unacquire(tokenAndUpn[0], titleId);
     return ok(Void);
@@ -152,9 +152,9 @@ class M365LaunchInfo extends YargsCommand {
         description: "Title ID of the acquired M365 App",
         type: "string",
       })
-      .option("file-path", {
+      .option("manifest-id", {
         require: false,
-        description: "Path to the App manifest zip package",
+        description: "Manifest ID of the acquired M365 App",
         type: "string",
       })
       .example(
@@ -162,8 +162,8 @@ class M365LaunchInfo extends YargsCommand {
         "Get launch information of the acquired M365 App by Title ID"
       )
       .example(
-        "teamsfx m365 launchinfo --file-path appPackage.zip",
-        "Get launch information of the acquired M365 App by App Package"
+        "teamsfx m365 launchinfo --manifest-id xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+        "Get launch information of the acquired M365 App by Manifest ID"
       );
     return yargs.version(false);
   }
@@ -173,20 +173,20 @@ class M365LaunchInfo extends YargsCommand {
 
     const packageService = new PackageService(sideloadingServiceEndpoint);
     let titleId = args["title-id"];
-    const manifestPath = args["file-path"];
-    if (titleId === undefined && manifestPath === undefined) {
+    const manifestId = args["manifest-id"];
+    if (titleId === undefined && manifestId === undefined) {
       return err(
         new UserError(
           cliSource,
           "InvalidInput",
-          "Either `title-id` or `file-path` should be provided."
+          "Either `title-id` or `manifest-id` should be provided."
         )
       );
     }
 
     const tokenAndUpn = await getTokenAndUpn();
     if (titleId === undefined) {
-      titleId = await packageService.retrieveTitleId(tokenAndUpn[0], manifestPath);
+      titleId = await packageService.retrieveTitleId(tokenAndUpn[0], manifestId);
     }
     await packageService.getLaunchInfo(tokenAndUpn[0], titleId);
     return ok(Void);

--- a/packages/cli/tests/unit/cmds/m365/m365.tests.ts
+++ b/packages/cli/tests/unit/cmds/m365/m365.tests.ts
@@ -137,15 +137,17 @@ describe("M365", () => {
     expect(finalLog).equals("Unacquiring done.");
   });
 
-  it("M365 Unacquire command (file-path)", async () => {
+  it("M365 Unacquire command (manifest-id)", async () => {
     const m365 = new M365();
     const unacquire = m365.subCommands.find((cmd) => cmd.commandHead === "unacquire");
     expect(unacquire).not.undefined;
 
-    axiosPostResponses["/dev/v1/users/packages"] = {
+    axiosPostResponses["/catalog/v1/users/titles/launchInfo"] = {
       data: {
-        titlePreview: {
-          titleId: "test-title-id",
+        acquisition: {
+          titleId: {
+            id: "test-title-id",
+          },
         },
       },
     };
@@ -153,7 +155,7 @@ describe("M365", () => {
       status: 200,
     };
 
-    await unacquire!.handler({ "file-path": "test" });
+    await unacquire!.handler({ "manifest-id": "test" });
     expect(logs.length).greaterThan(0);
     const finalLog = logs[logs.length - 1];
     expect(finalLog).equals("Unacquiring done.");
@@ -176,15 +178,17 @@ describe("M365", () => {
     expect(finalLog).equals(JSON.stringify({ foo: "bar" }));
   });
 
-  it("M365 LaunchInfo command (file-path)", async () => {
+  it("M365 LaunchInfo command (manifest-id)", async () => {
     const m365 = new M365();
     const launchInfo = m365.subCommands.find((cmd) => cmd.commandHead === "launchinfo");
     expect(launchInfo).not.undefined;
 
-    axiosPostResponses["/dev/v1/users/packages"] = {
+    axiosPostResponses["/catalog/v1/users/titles/launchInfo"] = {
       data: {
-        titlePreview: {
-          titleId: "test-title-id",
+        acquisition: {
+          titleId: {
+            id: "test-title-id",
+          },
         },
       },
     };
@@ -194,7 +198,7 @@ describe("M365", () => {
       },
     };
 
-    await launchInfo!.handler({ "file-path": "test" });
+    await launchInfo!.handler({ "manifest-id": "test" });
     expect(logs.length).greaterThan(0);
     const finalLog = logs[logs.length - 1];
     expect(finalLog).equals(JSON.stringify({ foo: "bar" }));

--- a/packages/cli/tests/unit/cmds/m365/m365.tests.ts
+++ b/packages/cli/tests/unit/cmds/m365/m365.tests.ts
@@ -203,4 +203,14 @@ describe("M365", () => {
     const finalLog = logs[logs.length - 1];
     expect(finalLog).equals(JSON.stringify({ foo: "bar" }));
   });
+
+  it("M365 LaunchInfo command (undefined)", async () => {
+    const m365 = new M365();
+    const launchInfo = m365.subCommands.find((cmd) => cmd.commandHead === "launchinfo");
+    expect(launchInfo).not.undefined;
+
+    const result = await launchInfo!.runCommand({});
+    expect(result).not.undefined;
+    expect(result.isErr()).to.be.true;
+  });
 });

--- a/packages/cli/tests/unit/cmds/m365/packageService.tests.ts
+++ b/packages/cli/tests/unit/cmds/m365/packageService.tests.ts
@@ -72,7 +72,7 @@ describe("Package Service", () => {
     const packageService = new PackageService("test-endpoint");
     let actualError: Error | undefined;
     try {
-      await packageService.retrieveTitleId("test-token", "test-path");
+      await packageService.retrieveTitleId("test-token", "test-manifest-id");
     } catch (error: any) {
       actualError = error;
     }


### PR DESCRIPTION
Package service has updated the API to support retrieving title id by manifest id.
So update our logic as well, to reduce API calls.