### PR TITLE
chore: validate aad manifest before update

### DIFF
--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -1049,6 +1049,7 @@
   "driver.aadApp.error.generateSecretFailed": "Cannot generate client secret.",
   "driver.aadApp.error.unhandledError": "Unhandled error happened in %s action: %s",
   "driver.aadApp.error.invalidFieldInManifest": "Field %s is missing or invalid in AAD app manifest.",
+  "driver.aadApp.error.generateManifestFailed": "Failed to generate AAD app manifest.",
   "driver.aadApp.progressBar.createAadAppTitle": "Creating AAD application",
   "driver.aadApp.progressBar.createAadAppStepMessage": "Creating AAD application",
   "driver.aadApp.progressBar.generateClientSecretSetpMessage": "Generating client secret",

--- a/packages/fx-core/tests/component/driver/aad/testAssets/manifestWithMissingEnv.json
+++ b/packages/fx-core/tests/component/driver/aad/testAssets/manifestWithMissingEnv.json
@@ -1,0 +1,54 @@
+{
+    "id": "${{AAD_APP_OBJECT_ID}}",
+    "appId": "${{AAD_APP_CLIENT_ID}}",
+    "name": "${{AAD_APP_NAME}}",
+    "accessTokenAcceptedVersion": 2,
+    "signInAudience": "AzureADMyOrg",
+    "optionalClaims": {
+        "idToken": [],
+        "accessToken": [
+            {
+                "name": "idtyp",
+                "source": null,
+                "essential": false,
+                "additionalProperties": []
+            }
+        ],
+        "saml2Token": []
+    },
+    "requiredResourceAccess": [
+        {
+            "resourceAppId": "Microsoft Graph",
+            "resourceAccess": [
+                {
+                    "id": "User.Read",
+                    "type": "Scope"
+                }
+            ]
+        }
+    ],
+    "oauth2Permissions": [
+        {
+            "adminConsentDescription": "Allows Teams to call the ${{APPLICATION_NAME}} web APIs as the current user.",
+            "adminConsentDisplayName": "Teams can access app's web APIs",
+            "id": "${{AAD_APP_ACCESS_AS_USER_PERMISSION_ID}}",
+            "isEnabled": true,
+            "type": "User",
+            "userConsentDescription": "Enable Teams to call this app's web APIs with the same rights that you have",
+            "userConsentDisplayName": "Teams can access app's web APIs and make requests on your behalf",
+            "value": "access_as_user"
+        }
+    ],
+    "preAuthorizedApplications": [
+        {
+            "appId": "1fec8e78-bce4-4aaf-ab1b-5451cc387264",
+            "permissionIds": [
+                "${{AAD_APP_ACCESS_AS_USER_PERMISSION_ID}}"
+            ]
+        }
+    ],
+    "identifierUris": [
+    ],
+    "replyUrlsWithType": [
+    ]
+}


### PR DESCRIPTION
Tell user a environment variable required by the manifest is missing to help better understand the error:
![image](https://user-images.githubusercontent.com/16605901/202115941-8b056be2-6f66-4819-a077-a4b5054997bf.png)