### PR TITLE
chore: remove uri from hover message

### DIFF
--- a/packages/manifest/src/manifest.ts
+++ b/packages/manifest/src/manifest.ts
@@ -349,11 +349,11 @@ export type AppManifest = Record<string, any>;
  */
 export class TeamsAppManifest implements AppManifest {
   $schema?: string =
-    "https://developer.microsoft.com/en-us/json-schemas/teams/v1.13/MicrosoftTeams.schema.json";
+    "https://developer.microsoft.com/en-us/json-schemas/teams/v1.15/MicrosoftTeams.schema.json";
   /**
    * The version of the schema this manifest is using.
    */
-  manifestVersion = "1.13";
+  manifestVersion = "1.15";
   /**
    * The version of the app. Changes to your manifest should cause a version change. This version string must follow the semver standard (http://semver.org).
    */

--- a/packages/manifest/test/index.test.ts
+++ b/packages/manifest/test/index.test.ts
@@ -95,11 +95,11 @@ describe("Manifest manipulation", async () => {
       // schema has version 1.11
       const schema = await loadSchema();
       const manifest = new TeamsAppManifest();
-      chai.expect(manifest.manifestVersion).equals("1.13");
+      chai.expect(manifest.manifestVersion).equals("1.15");
       const result = await ManifestUtil.validateManifestAgainstSchema(manifest, schema);
       chai.expect(result).not.to.be.empty;
       chai.expect(result.length).equals(1);
-      // 1.13 doesn't match 1.11, so it should return an error
+      // 1.15 doesn't match 1.11, so it should return an error
       chai.expect(result[0]).to.contain("/manifestVersion");
     });
   });

--- a/packages/vscode-extension/src/hoverProvider.ts
+++ b/packages/vscode-extension/src/hoverProvider.ts
@@ -13,6 +13,7 @@ import {
 } from "./constants";
 import { core, getSystemInputs } from "./handlers";
 import { getProvisionSucceedFromEnv } from "./utils/commonUtils";
+import { TelemetryProperty, TelemetryTriggerFrom } from "./telemetry/extTelemetryEvents";
 import { DotenvParseOutput } from "dotenv";
 
 export class ManifestTemplateHoverProvider implements vscode.HoverProvider {
@@ -91,8 +92,7 @@ export class ManifestTemplateHoverProvider implements vscode.HoverProvider {
       if (value) {
         message = `**${envName}**: ${value} \n\n`;
       } else {
-        const commandUri = vscode.Uri.parse("command:fx-extension.pre-debug-check");
-        message = `**${envName}**: [Trigger debug to see placeholder value](${commandUri}) \n\n`;
+        message += `**${envName}** Trigger debug to see placeholder value \n\n`;
       }
       args = [{ type: "env", env: envName }];
     } else {
@@ -103,8 +103,12 @@ export class ManifestTemplateHoverProvider implements vscode.HoverProvider {
           message += `**${envName}**: ${value} \n\n`;
         } else {
           if (envName === environmentManager.getLocalEnvName()) {
-            const commandUri = vscode.Uri.parse("command:fx-extension.pre-debug-check");
-            message += `**${envName}**: [Trigger debug to see placeholder value](${commandUri}) \n\n`;
+            if (isV3Enabled()) {
+              message += `**${envName}** Trigger debug to see placeholder value \n\n`;
+            } else {
+              const commandUri = vscode.Uri.parse("command:fx-extension.pre-debug-check");
+              message += `**${envName}**: [Trigger debug to see placeholder value](${commandUri}) \n\n`;
+            }
           } else {
             const commandUri = vscode.Uri.parse("command:fx-extension.provision");
             message += `**${envName}**: [Trigger Teams: Provision in the cloud command to see placeholder value](${commandUri}) \n\n`;

--- a/packages/vscode-extension/src/hoverProvider.ts
+++ b/packages/vscode-extension/src/hoverProvider.ts
@@ -13,7 +13,6 @@ import {
 } from "./constants";
 import { core, getSystemInputs } from "./handlers";
 import { getProvisionSucceedFromEnv } from "./utils/commonUtils";
-import { TelemetryProperty, TelemetryTriggerFrom } from "./telemetry/extTelemetryEvents";
 import { DotenvParseOutput } from "dotenv";
 
 export class ManifestTemplateHoverProvider implements vscode.HoverProvider {


### PR DESCRIPTION
1) upgrade manifest version to 1.15
2) Remove command from local hover, as the previous command is deprecated.