### PR TITLE
chore: revoke workaround: source map not found

### DIFF
--- a/templates/scenarios/js/m365-tab/package.json.tpl
+++ b/templates/scenarios/js/m365-tab/package.json.tpl
@@ -23,9 +23,9 @@
         "env-cmd": "^10.1.0"
     },
     "scripts": {
-        "start": "cross-env GENERATE_SOURCEMAP=false react-scripts start",
+        "start": "react-scripts start",
         "install:teamsfx": "npm install",
-        "build": "cross-env GENERATE_SOURCEMAP=false react-scripts build",
+        "build": "react-scripts build",
         "build:teamsfx": "cross-env-shell \"env-cmd -f .env.teamsfx.${TEAMS_FX_ENV} npm run build\"",
         "build:teamsfx:dev": "cross-env TEAMS_FX_ENV=dev npm run build:teamsfx",
         "eject": "react-scripts eject",

--- a/templates/scenarios/js/sso-tab/package.json.tpl
+++ b/templates/scenarios/js/sso-tab/package.json.tpl
@@ -22,9 +22,9 @@
         "cross-env": "^7.0.3"
     },
     "scripts": {
-        "start": "cross-env GENERATE_SOURCEMAP=false react-scripts start",
+        "start": "react-scripts start",
         "install:teamsfx": "npm install",
-        "build": "cross-env GENERATE_SOURCEMAP=false react-scripts build",
+        "build": "react-scripts build"
         "build:teamsfx": "cross-env-shell \"env-cmd -f .env.teamsfx.${TEAMS_FX_ENV} npm run build\"",
         "build:teamsfx:dev": "cross-env TEAMS_FX_ENV=dev npm run build:teamsfx",
         "eject": "react-scripts eject"

--- a/templates/scenarios/ts/m365-tab/package.json.tpl
+++ b/templates/scenarios/ts/m365-tab/package.json.tpl
@@ -28,9 +28,9 @@
         "typescript": "^4.1.2"
     },
     "scripts": {
-        "start": "cross-env GENERATE_SOURCEMAP=false react-scripts start",
+        "start": "react-scripts start",
         "install:teamsfx": "npm install",
-        "build": "cross-env GENERATE_SOURCEMAP=false react-scripts build",
+        "build": "react-scripts build",
         "build:teamsfx": "cross-env-shell \"env-cmd -f .env.teamsfx.${TEAMS_FX_ENV} npm run build\"",
         "build:teamsfx:dev": "cross-env TEAMS_FX_ENV=dev npm run build:teamsfx",
         "eject": "react-scripts eject"

--- a/templates/scenarios/ts/sso-tab/package.json.tpl
+++ b/templates/scenarios/ts/sso-tab/package.json.tpl
@@ -28,9 +28,9 @@
     },
     "scripts": {
         "dev:teamsfx": "env-cmd --silent -f .env.teamsfx.local npm run start",
-        "start": "cross-env GENERATE_SOURCEMAP=false react-scripts start",
+        "start": "react-scripts start",
         "install:teamsfx": "npm install",
-        "build": "cross-env GENERATE_SOURCEMAP=false react-scripts build",
+        "build": "react-scripts build",
         "build:teamsfx": "cross-env-shell \"env-cmd -f .env.teamsfx.${TEAMS_FX_ENV} npm run build\"",
         "build:teamsfx:dev": "cross-env TEAMS_FX_ENV=dev npm run build:teamsfx",
         "eject": "react-scripts eject"


### PR DESCRIPTION
This workaround is introduced by https://github.com/OfficeDev/TeamsFx/pull/4893
Latest `teamsfx-react` has resolved the issue.
