### PR TITLE
chore: block unsupport commands for video filter

### DIFF
--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -474,6 +474,7 @@
   "error.LocalBotEndpointNotConfigured": "Local bot endpoint is not configured. Set \"bot.siteEndpoint\" in \".fx/configs/config.local.json\" and try again.",
   "error.InvalidLocalBotEndpointFormat": "Local bot endpoint format is invalid: %s.",
   "error.NgrokTunnelNotConnected": "Ngrok tunnel is not connected. Check your network settings and try again.",
+  "error.VideoFilterAppNotRemoteSupported": "Video filter app in remote is not supported by Teams Toolkit. Please check the README.md file in project root folder.",
   "error.frontend.UnauthenticatedError": "Failed to get user login information.",
   "error.frontend.InvalidConfigError": "Get invalid %s.",
   "error.frontend.CheckResourceGroupError": "Failed to check resource group existence.",

--- a/packages/fx-core/src/common/tools.ts
+++ b/packages/fx-core/src/common/tools.ts
@@ -28,6 +28,7 @@ import {
   ProjectSettingsFileName,
   SettingsFileName,
   SettingsFolderName,
+  assembleError,
 } from "@microsoft/teamsfx-api";
 import axios from "axios";
 import { exec, ExecOptions } from "child_process";
@@ -76,6 +77,7 @@ import { getProjectTemplatesFolderPath } from "./utils";
 import * as path from "path";
 import { isMiniApp } from "./projectSettingsHelperV3";
 import { getAppStudioEndpoint } from "../component/resource/appManifest/constants";
+import { manifestUtils } from "../component/resource/appManifest/utils/ManifestUtils";
 
 Handlebars.registerHelper("contains", (value, array) => {
   array = array instanceof Array ? array : [array];
@@ -734,6 +736,22 @@ export function isSPFxProject(projectSettings?: ProjectSettings): boolean {
     return selectedPlugins && selectedPlugins.indexOf("fx-resource-spfx") !== -1;
   }
   return false;
+}
+
+export async function isVideoFilterProject(projectPath: string): Promise<Result<boolean, FxError>> {
+  let manifestResult;
+  try {
+    manifestResult = await manifestUtils.readAppManifest(projectPath);
+  } catch (e) {
+    return err(assembleError(e));
+  }
+  if (manifestResult.isErr()) {
+    return err(manifestResult.error);
+  }
+  const manifest = manifestResult.value;
+  return ok(
+    (manifest.meetingExtensionDefinition as any)?.videoFiltersConfigurationUrl !== undefined
+  );
 }
 
 export function getHashedEnv(envName: string): string {

--- a/packages/fx-core/src/core/FxCore.ts
+++ b/packages/fx-core/src/core/FxCore.ts
@@ -148,6 +148,7 @@ import "../component/driver/botFramework/createOrUpdateBot";
 import { settingsUtil } from "../component/utils/settingsUtil";
 import { DotenvParseOutput } from "dotenv";
 import { containsUnsupportedFeature } from "../component/resource/appManifest/utils/utils";
+import { VideoFilterAppBlockerMW } from "./middleware/videoFilterAppBlocker";
 
 export class FxCore implements v3.ICore {
   tools: Tools;
@@ -293,6 +294,7 @@ export class FxCore implements v3.ICore {
     AadManifestMigrationMW,
     ProjectVersionCheckerMW,
     ProjectSettingsLoaderMW,
+    VideoFilterAppBlockerMW,
     EnvInfoLoaderMW_V3(false),
     ContextInjectorMW,
     ProjectSettingsWriterMW,
@@ -372,6 +374,7 @@ export class FxCore implements v3.ICore {
     AadManifestMigrationMW,
     ProjectVersionCheckerMW,
     ProjectSettingsLoaderMW,
+    VideoFilterAppBlockerMW,
     EnvInfoLoaderMW_V3(false),
     ContextInjectorMW,
     ProjectSettingsWriterMW,
@@ -452,6 +455,7 @@ export class FxCore implements v3.ICore {
     AadManifestMigrationMW,
     ProjectVersionCheckerMW,
     ProjectSettingsLoaderMW,
+    VideoFilterAppBlockerMW,
     EnvInfoLoaderMW_V3(false),
     ContextInjectorMW,
     ProjectSettingsWriterMW,
@@ -516,6 +520,7 @@ export class FxCore implements v3.ICore {
     AadManifestMigrationMW,
     ProjectVersionCheckerMW,
     ProjectSettingsLoaderMW,
+    VideoFilterAppBlockerMW,
     EnvInfoLoaderMW_V3(false),
     ContextInjectorMW,
     ProjectSettingsWriterMW,

--- a/packages/fx-core/src/core/error.ts
+++ b/packages/fx-core/src/core/error.ts
@@ -399,3 +399,14 @@ export class NoAadManifestExistError extends UserError {
     });
   }
 }
+
+export class VideoFilterAppRemoteNotSupportedError extends UserError {
+  constructor() {
+    super({
+      source: CoreSource,
+      name: VideoFilterAppRemoteNotSupportedError.name,
+      message: getLocalizedString("error.VideoFilterAppNotRemoteSupported"),
+      displayMessage: getLocalizedString("error.VideoFilterAppNotRemoteSupported"),
+    });
+  }
+}

--- a/packages/fx-core/src/core/middleware/videoFilterAppBlocker.ts
+++ b/packages/fx-core/src/core/middleware/videoFilterAppBlocker.ts
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+"use strict";
+
+import { NextFunction } from "@feathersjs/hooks";
+import { Inputs, err, Func } from "@microsoft/teamsfx-api";
+import { isVideoFilterProject } from "../../common/tools";
+import { VideoFilterAppRemoteNotSupportedError } from "../error";
+import { CoreHookContext } from "../types";
+
+const userTasksToBlock: Func[] = [
+  // Teams: Add features
+  {
+    namespace: "fx-solution-azure",
+    method: "addFeature",
+  },
+  // Teams: Zip Teams metadata package
+  {
+    namespace: "fx-solution-azure",
+    method: "buildPackage",
+  },
+  // Teams: Validate manifest file
+  {
+    namespace: "fx-solution-azure",
+    method: "validateManifest",
+  },
+];
+
+async function shouldBlockExecution(ctx: CoreHookContext): Promise<boolean> {
+  const inputs = ctx.arguments[ctx.arguments.length - 1] as Inputs;
+  if (!inputs.projectPath) {
+    return false;
+  }
+
+  if (ctx.method === "executeUserTask") {
+    let shouldBlockUserTask = false;
+    const func: Partial<Func> = ctx.arguments[0];
+    for (const item of userTasksToBlock) {
+      if (func?.namespace === item.namespace && func?.method === item.method) {
+        shouldBlockUserTask = true;
+        break;
+      }
+    }
+    if (!shouldBlockUserTask) {
+      return false;
+    }
+  }
+
+  const result = await isVideoFilterProject(inputs.projectPath);
+  // Ignore errors and assume this project is not a video filter project
+  return result.isOk() && result.value;
+}
+
+/**
+ * This middleware will block remote operations (provision/deploy/...) since we don't support these operations for now.
+ */
+export const VideoFilterAppBlockerMW = async (ctx: CoreHookContext, next: NextFunction) => {
+  let shouldBlock: boolean;
+  try {
+    shouldBlock = await shouldBlockExecution(ctx);
+  } catch (e) {
+    // Ignore errors and assume this project is not a video filter project
+    shouldBlock = false;
+  }
+
+  if (shouldBlock) {
+    ctx.result = err(new VideoFilterAppRemoteNotSupportedError());
+    return;
+  } else {
+    await next();
+  }
+};

--- a/packages/fx-core/tests/common/tools.test.ts
+++ b/packages/fx-core/tests/common/tools.test.ts
@@ -5,7 +5,8 @@ import "mocha";
 import axios, { AxiosResponse } from "axios";
 import * as chai from "chai";
 import chaiAsPromised from "chai-as-promised";
-import * as sinon from "sinon";
+import Sinon, * as sinon from "sinon";
+import mockFs from "mock-fs";
 
 import {
   getSideloadingStatus,
@@ -15,6 +16,7 @@ import {
   canAddCICDWorkflows,
   getSPFxVersion,
   getAppSPFxVersion,
+  isVideoFilterProject,
 } from "../../src/common/tools";
 import * as telemetry from "../../src/common/telemetry";
 import {
@@ -28,6 +30,7 @@ import {
 } from "@microsoft/teamsfx-api";
 import { TabSsoItem } from "../../src/component/constants";
 import * as featureFlags from "../../src/common/featureFlags";
+import * as path from "path";
 import fs from "fs-extra";
 import { environmentManager } from "../../src/core/environment";
 import { ExistingTemplatesStat } from "../../src/component/feature/cicd/existingTemplatesStat";
@@ -443,6 +446,103 @@ describe("tools", () => {
       const version = await getAppSPFxVersion("");
 
       chai.expect(version).equals("1.14.0");
+    });
+  });
+
+  describe("isVideoFilterProject", async () => {
+    let sandbox: Sinon.SinonSandbox;
+    const mockProjectRoot = "video-filter";
+    beforeEach(() => {
+      sandbox = sinon.createSandbox();
+    });
+    afterEach(() => {
+      sandbox.restore();
+      mockFs.restore();
+    });
+
+    it("Can recognize normal video filter project", async () => {
+      // Arrange
+      const manifest = {
+        meetingExtensionDefinition: {
+          videoFiltersConfigurationUrl: "https://a.b.c/",
+        },
+      };
+      mockFs({
+        [path.join(mockProjectRoot, "templates", "appPackage", "manifest.template.json")]:
+          JSON.stringify(manifest),
+      });
+
+      // Act
+      const result = await isVideoFilterProject(mockProjectRoot);
+
+      // Assert
+      chai.expect(result.isOk()).to.be.true;
+      chai.expect(result._unsafeUnwrap()).to.be.true;
+    });
+
+    it("Should not recognize tab project as video filter", async () => {
+      // Arrange
+      const manifest = {
+        $schema:
+          "https://developer.microsoft.com/en-us/json-schemas/teams/v1.14/MicrosoftTeams.schema.json",
+        manifestVersion: "1.14",
+        version: "1.0.0",
+        id: "{{state.fx-resource-appstudio.teamsAppId}}",
+        packageName: "com.microsoft.teams.extension",
+        developer: {
+          name: "Teams App, Inc.",
+          websiteUrl: "https://www.example.com",
+          privacyUrl: "https://www.example.com/termofuse",
+          termsOfUseUrl: "https://www.example.com/privacy",
+        },
+        icons: {
+          color: "{{config.manifest.icons.color}}",
+          outline: "{{config.manifest.icons.outline}}",
+        },
+        name: {
+          short: "{{config.manifest.appName.short}}",
+          full: "{{config.manifest.appName.full}}",
+        },
+        description: {
+          short: "{{config.manifest.description.short}}",
+          full: "{{config.manifest.description.full}}",
+        },
+        accentColor: "#FFFFFF",
+        bots: [],
+        composeExtensions: [],
+        configurableTabs: [
+          {
+            configurationUrl:
+              "{{{state.fx-resource-frontend-hosting.endpoint}}}{{{state.fx-resource-frontend-hosting.indexPath}}}/config",
+            canUpdateConfiguration: true,
+            scopes: ["team", "groupchat"],
+          },
+        ],
+        staticTabs: [
+          {
+            entityId: "index0",
+            name: "Personal Tab",
+            contentUrl:
+              "{{{state.fx-resource-frontend-hosting.endpoint}}}{{{state.fx-resource-frontend-hosting.indexPath}}}/tab",
+            websiteUrl:
+              "{{{state.fx-resource-frontend-hosting.endpoint}}}{{{state.fx-resource-frontend-hosting.indexPath}}}/tab",
+            scopes: ["personal"],
+          },
+        ],
+        permissions: ["identity", "messageTeamMembers"],
+        validDomains: ["{{state.fx-resource-frontend-hosting.domain}}"],
+      };
+      mockFs({
+        [path.join(mockProjectRoot, "templates", "appPackage", "manifest.template.json")]:
+          JSON.stringify(manifest),
+      });
+
+      // Act
+      const result = await isVideoFilterProject(mockProjectRoot);
+
+      // Assert
+      chai.expect(result.isOk()).to.be.true;
+      chai.expect(result._unsafeUnwrap()).to.be.false;
     });
   });
 });

--- a/packages/fx-core/tests/core/middleware/VideoFilterAppBlockerMW.test.ts
+++ b/packages/fx-core/tests/core/middleware/VideoFilterAppBlockerMW.test.ts
@@ -1,0 +1,189 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { hooks, NextFunction } from "@feathersjs/hooks/lib";
+import {
+  ConfigFolderName,
+  Context,
+  Func,
+  FxError,
+  InputConfigsFolderName,
+  Inputs,
+  ok,
+  Platform,
+  ProjectSettingsFileName,
+  Result,
+  SettingsFileName,
+  SettingsFolderName,
+} from "@microsoft/teamsfx-api";
+import { assert } from "chai";
+import fs from "fs-extra";
+import "mocha";
+import mockedEnv from "mocked-env";
+import * as os from "os";
+import * as path from "path";
+import sinon from "sinon";
+import mockFs from "mock-fs";
+import { setTools } from "../../../src/core/globalVars";
+import { ContextInjectorMW } from "../../../src/core/middleware/contextInjector";
+import { VideoFilterAppBlockerMW } from "../../../src/core/middleware/videoFilterAppBlocker";
+import { CoreHookContext } from "../../../src/core/types";
+import { MockProjectSettings, MockSettings, MockTools, randomAppName } from "../utils";
+import { VideoFilterAppRemoteNotSupportedError } from "../../../src/core/error";
+
+describe("Middleware - VideoFilterAppBlockerMW", () => {
+  function createMock(): {
+    nextMiddlewareCalled: boolean;
+    inputs: Inputs;
+    instance: { myMethod: (inputs: Inputs) => Promise<Result<boolean, FxError>> };
+  } {
+    setTools(new MockTools());
+    class MyClass {
+      async myMethod(inputs: Inputs): Promise<Result<boolean, FxError>> {
+        return ok(true);
+      }
+    }
+    const instance = new MyClass();
+
+    const result = {
+      nextMiddlewareCalled: false,
+      inputs: { platform: Platform.VSCode, projectPath: mockProjectRoot },
+      instance,
+    };
+    const TestMW = async (ctx: CoreHookContext, next: NextFunction) => {
+      result.nextMiddlewareCalled = true;
+      await next();
+    };
+    hooks(MyClass, {
+      myMethod: [VideoFilterAppBlockerMW, TestMW],
+    });
+    return result;
+  }
+
+  const mockProjectRoot = "video-filter";
+
+  afterEach(function () {
+    mockFs.restore();
+  });
+
+  it("blocks video filter project", async () => {
+    const mock = createMock();
+    mockFs({
+      [path.join(mockProjectRoot, "templates", "appPackage", "manifest.template.json")]:
+        JSON.stringify({
+          meetingExtensionDefinition: { videoFiltersConfigurationUrl: "https://a.b.c" },
+        }),
+    });
+
+    const result = await mock.instance.myMethod(mock.inputs);
+
+    assert.isTrue(result.isErr());
+    assert.equal(result._unsafeUnwrapErr().name, VideoFilterAppRemoteNotSupportedError.name);
+    assert.isFalse(mock.nextMiddlewareCalled);
+  });
+
+  it("ignores non-video project", async () => {
+    const mock = createMock();
+    mockFs({
+      [path.join(mockProjectRoot, "templates", "appPackage", "manifest.template.json")]:
+        JSON.stringify({
+          meetingExtensionDefinition: {},
+        }),
+    });
+
+    const result = await mock.instance.myMethod(mock.inputs);
+
+    assert.isTrue(result.isOk());
+    assert.isTrue(result._unsafeUnwrap());
+    assert.isTrue(mock.nextMiddlewareCalled);
+  });
+
+  it("ignores project with incorrect manifest", async () => {
+    const mock = createMock();
+    mockFs({
+      [path.join(mockProjectRoot, "templates", "appPackage", "manifest.template.json")]:
+        "invalid json",
+    });
+
+    const result = await mock.instance.myMethod(mock.inputs);
+
+    assert.isTrue(result.isOk());
+    assert.isTrue(result._unsafeUnwrap());
+    assert.isTrue(mock.nextMiddlewareCalled);
+  });
+
+  describe("user task", () => {
+    it("blocks build package", async () => {
+      setTools(new MockTools());
+      class MyClass {
+        async executeUserTask(
+          func: Func,
+          inputs: Inputs,
+          ctx?: CoreHookContext
+        ): Promise<Result<any, FxError>> {
+          return ok(true);
+        }
+      }
+      let nextMiddlewareCalled = false;
+      const instance = new MyClass();
+      const inputs = { platform: Platform.VSCode, projectPath: mockProjectRoot };
+      const TestMW = async (ctx: CoreHookContext, next: NextFunction) => {
+        nextMiddlewareCalled = true;
+        await next();
+      };
+      hooks(MyClass, {
+        executeUserTask: [VideoFilterAppBlockerMW, TestMW],
+      });
+      mockFs({
+        [path.join(mockProjectRoot, "templates", "appPackage", "manifest.template.json")]:
+          "invalid json",
+      });
+
+      const func = {
+        namespace: "fx-solution-azure",
+        method: "validateManifest",
+      };
+      const result = await instance.executeUserTask(func, inputs);
+
+      assert.isTrue(result.isOk());
+      assert.isTrue(result._unsafeUnwrap());
+      assert.isTrue(nextMiddlewareCalled);
+    });
+    it("doesn't block edit manifest", async () => {
+      setTools(new MockTools());
+      class MyClass {
+        async executeUserTask(
+          func: Func,
+          inputs: Inputs,
+          ctx?: CoreHookContext
+        ): Promise<Result<any, FxError>> {
+          return ok(true);
+        }
+      }
+      let nextMiddlewareCalled = false;
+      const instance = new MyClass();
+      const inputs = { platform: Platform.VSCode, projectPath: mockProjectRoot };
+      const TestMW = async (ctx: CoreHookContext, next: NextFunction) => {
+        nextMiddlewareCalled = true;
+        await next();
+      };
+      hooks(MyClass, {
+        executeUserTask: [VideoFilterAppBlockerMW, TestMW],
+      });
+      mockFs({
+        [path.join(mockProjectRoot, "templates", "appPackage", "manifest.template.json")]:
+          "invalid json",
+      });
+
+      const func = {
+        namespace: "fx-solution-azure/fx-resource-appstudio",
+        method: "getManifestTemplatePath",
+      };
+      const result = await instance.executeUserTask(func, inputs);
+
+      assert.isTrue(result.isOk());
+      assert.isTrue(result._unsafeUnwrap());
+      assert.isTrue(nextMiddlewareCalled);
+    });
+  });
+});


### PR DESCRIPTION
The list of blocked commands:
* Provision in the cloud
* Zip Teams metadata package
* Deploy to the cloud
* Publish to Teams
* Add features
* Validate manifest file


<img width="966" alt="image" src="https://user-images.githubusercontent.com/9698542/203241420-7bb20120-63c3-4973-b86c-030648c61f73.png">
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/16037816/