### PR TITLE
chore: rollback to 1.14 for outlook/office

### DIFF
--- a/templates/scenarios/csharp/command-and-response/appPackage/manifest.template.json.tpl
+++ b/templates/scenarios/csharp/command-and-response/appPackage/manifest.template.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.15/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.15",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.14/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.14",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "packageName": "com.microsoft.teams.extension",

--- a/templates/scenarios/csharp/message-extension/appPackage/manifest.template.json.tpl
+++ b/templates/scenarios/csharp/message-extension/appPackage/manifest.template.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.15/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.15",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.14/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.14",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "packageName": "com.microsoft.teams.extension",

--- a/templates/scenarios/csharp/non-sso-tab/appPackage/manifest.template.json.tpl
+++ b/templates/scenarios/csharp/non-sso-tab/appPackage/manifest.template.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.15/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.15",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.14/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.14",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "packageName": "com.microsoft.teams.extension",

--- a/templates/scenarios/csharp/notification-http-timer-trigger/appPackage/manifest.template.json.tpl
+++ b/templates/scenarios/csharp/notification-http-timer-trigger/appPackage/manifest.template.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.15/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.15",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.14/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.14",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "packageName": "com.microsoft.teams.extension",

--- a/templates/scenarios/csharp/notification-http-trigger/appPackage/manifest.template.json.tpl
+++ b/templates/scenarios/csharp/notification-http-trigger/appPackage/manifest.template.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.15/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.15",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.14/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.14",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "packageName": "com.microsoft.teams.extension",

--- a/templates/scenarios/csharp/notification-timer-trigger/appPackage/manifest.template.json.tpl
+++ b/templates/scenarios/csharp/notification-timer-trigger/appPackage/manifest.template.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.15/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.15",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.14/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.14",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "packageName": "com.microsoft.teams.extension",

--- a/templates/scenarios/csharp/notification-webapi/appPackage/manifest.template.json.tpl
+++ b/templates/scenarios/csharp/notification-webapi/appPackage/manifest.template.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.15/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.15",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.14/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.14",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "packageName": "com.microsoft.teams.extension",

--- a/templates/scenarios/csharp/sso-tab/appPackage/manifest.template.json.tpl
+++ b/templates/scenarios/csharp/sso-tab/appPackage/manifest.template.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.15/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.15",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.14/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.14",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "packageName": "com.microsoft.teams.extension",

--- a/templates/scenarios/csharp/workflow/appPackage/manifest.template.json.tpl
+++ b/templates/scenarios/csharp/workflow/appPackage/manifest.template.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.15/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.15",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.14/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.14",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "packageName": "com.microsoft.teams.extension",


### PR DESCRIPTION
downgrade to v1.14, as app with 1.15 manifest cannot be found in Outlook/Office.