### PR TITLE
fix: bot only project developer

### DIFF
--- a/packages/fx-core/src/component/resource/appManifest/constants.ts
+++ b/packages/fx-core/src/component/resource/appManifest/constants.ts
@@ -10,6 +10,8 @@ const TAB_STATE_KEY = ComponentNames.TeamsTab;
 const BOT_STATE_KEY = ComponentNames.TeamsBot;
 const APP_MANIFEST_KEY = ComponentNames.AppManifest;
 
+export const manifestStateDataRegex = /{{{?state\.[a-zA-Z-_]+\.\w+}}}?/g;
+
 export const TEAMS_APP_MANIFEST_TEMPLATE = `{
   "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.14/MicrosoftTeams.schema.json",
   "manifestVersion": "1.14",

--- a/packages/fx-core/src/component/resource/appManifest/utils/ManifestUtils.ts
+++ b/packages/fx-core/src/component/resource/appManifest/utils/ManifestUtils.ts
@@ -37,6 +37,7 @@ import {
   CONFIGURABLE_TABS_TPL_V3,
   STATIC_TABS_TPL_V3,
   WEB_APPLICATION_INFO_V3,
+  manifestStateDataRegex,
 } from "../constants";
 import {
   BotScenario,
@@ -444,7 +445,9 @@ export class ManifestUtils {
     const hasFrontend =
       capabilities.value.includes("staticTab") || capabilities.value.includes("configurableTab");
     const tabEndpoint = envInfo.state[ComponentNames.TeamsTab]?.endpoint;
-    if (!tabEndpoint && !hasFrontend) {
+    const hasUnresolvedPlaceholders =
+      JSON.stringify(templateJson.developer).match(manifestStateDataRegex) !== null;
+    if (!tabEndpoint && !hasFrontend && hasUnresolvedPlaceholders) {
       templateJson.developer = DEFAULT_DEVELOPER;
     }
 
@@ -554,18 +557,6 @@ export class ManifestUtils {
       manifest.staticTabs = [];
       manifest.webApplicationInfo = undefined;
       manifest.validDomains = [];
-    }
-
-    // Adjust template for samples with unnecessary placeholders
-    const capabilities = manifestUtils._getCapabilities(manifest);
-    if (capabilities.isErr()) {
-      return err(capabilities.error);
-    }
-    const hasFrontend =
-      capabilities.value.includes("staticTab") || capabilities.value.includes("configurableTab");
-    const tabEndpoint = state.TAB_ENDPOINT;
-    if (!tabEndpoint && !hasFrontend) {
-      manifest.developer = DEFAULT_DEVELOPER;
     }
 
     const manifestTemplateString = JSON.stringify(manifest);

--- a/packages/fx-core/tests/component/resource/appManifest/manifestUtils.test.ts
+++ b/packages/fx-core/tests/component/resource/appManifest/manifestUtils.test.ts
@@ -468,7 +468,7 @@ describe("getManifest V3", () => {
       "packageName": "com.microsoft.teams.extension",
       "developer": {
           "name": "Teams App, Inc.",
-          "websiteUrl": "https://www.example.com",
+          "websiteUrl": "{{{state.fx-resource-frontend-hosting.endpoint}}}",
           "privacyUrl": "https://www.example.com/termofuse",
           "termsOfUseUrl": "https://www.example.com/privacy"
       },

--- a/packages/fx-core/tests/component/resource/appManifest/manifestUtils.test.ts
+++ b/packages/fx-core/tests/component/resource/appManifest/manifestUtils.test.ts
@@ -487,27 +487,6 @@ describe("getManifest V3", () => {
       "accentColor": "#FFFFFF",
       "bots": [],
       "composeExtensions": [],
-      "configurableTabs": [
-          {
-              "configurationUrl": "{{{state.fx-resource-frontend-hosting.endpoint}}}{{{state.fx-resource-frontend-hosting.indexPath}}}/config",
-              "canUpdateConfiguration": true,
-              "scopes": [
-                  "team",
-                  "groupchat"
-              ]
-          }
-      ],
-      "staticTabs": [
-          {
-              "entityId": "index0",
-              "name": "Personal Tab",
-              "contentUrl": "{{{state.fx-resource-frontend-hosting.endpoint}}}{{{state.fx-resource-frontend-hosting.indexPath}}}/tab",
-              "websiteUrl": "{{{state.fx-resource-frontend-hosting.endpoint}}}{{{state.fx-resource-frontend-hosting.indexPath}}}/tab",
-              "scopes": [
-                  "personal"
-              ]
-          }
-      ],
       "permissions": [
           "identity",
           "messageTeamMembers"


### PR DESCRIPTION
1) Only set default developer when placeholder exists and without endpoint.

2) V3 do not need this logic, as samples/templates don't have placeholders for developer.