### PR TITLE
chore: add interface method to support actions returning summary 

### DIFF
--- a/packages/fx-core/src/component/driver/interface/stepDriver.ts
+++ b/packages/fx-core/src/component/driver/interface/stepDriver.ts
@@ -4,11 +4,17 @@
 import { DriverContext } from "./commonArgs";
 import { FxError, Result } from "@microsoft/teamsfx-api";
 
+export type ExecutionResult = { result: Result<Map<string, string>, FxError>; summary: string };
+
 export interface StepDriver {
+  readonly description?: string;
+
   /**
    * Run the driver.
    * @param args Arguments from the `with` section in the yaml file.
    * @param context logger, telemetry, progress bar, etc.
    */
   run(args: unknown, context: DriverContext): Promise<Result<Map<string, string>, FxError>>;
+
+  execute?(args: unknown, ctx: DriverContext): Promise<ExecutionResult>;
 }


### PR DESCRIPTION
Add interface method to support actions returning summary.
related bugs
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_sprints/taskboard/Teams%20Extensibility%20E2E%20Team/Microsoft%20Teams%20Extensibility/CY22-11.1?workitem=16287774
and
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_sprints/taskboard/Teams%20Extensibility%20E2E%20Team/Microsoft%20Teams%20Extensibility/CY22-11.1?workitem=16288015