### PR TITLE
fix: local state file not found message is incorrect

### DIFF
--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -2920,7 +2920,7 @@ export async function openConfigStateFile(args: any[]): Promise<any> {
       ExtTelemetry.sendTelemetryErrorEvent(telemetryName, noEnvError);
       return err(noEnvError);
     } else {
-      const isLocalEnv = env.value === environmentManager.getLocalEnvName();
+      const isLocalEnv = env === environmentManager.getLocalEnvName();
       const message = isLocalEnv
         ? util.format(localize("teamstoolkit.handlers.localStateFileNotFound"), env)
         : util.format(localize("teamstoolkit.handlers.stateFileNotFound"), env);

--- a/packages/vscode-extension/test/extension/handlers.test.ts
+++ b/packages/vscode-extension/test/extension/handlers.test.ts
@@ -358,6 +358,10 @@ describe("handlers", () => {
     });
 
     it("openConfigStateFile() - local", async () => {
+      sinon.stub(localizeUtils, "localize").callsFake((key: string) => {
+        return key;
+      });
+
       const env = "local";
       const tmpDir = fs.mkdtempSync(path.resolve("./tmp"));
 


### PR DESCRIPTION
Fix this bug: 

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_sprints/taskboard/AuthAndData/Microsoft%20Teams%20Extensibility/CY22-11.1?workitem=16341439

E2E TEST: N/A