### PR TITLE
chore: sign in with loginHint

### DIFF
--- a/packages/fx-core/src/component/resource/appManifest/utils/utils.ts
+++ b/packages/fx-core/src/component/resource/appManifest/utils/utils.ts
@@ -82,6 +82,32 @@ export function containsUnsupportedFeature(appDefinition: AppDefinition): boolea
   return !!hasScene || !!hasConnector || !!hasActivies;
 }
 
+export function getFeaturesFromAppDefinition(appDefinition: AppDefinition): string[] {
+  const features = [];
+  const personalTab = "personal-tab";
+  const groupTab = "group-tab";
+  const bot = "bot";
+  const messageExtension = "messaging-extension";
+
+  if (isPersonalApp(appDefinition)) {
+    features.push(personalTab);
+  }
+
+  if (isGroupApp(appDefinition)) {
+    features.push(groupTab);
+  }
+
+  if (isBot(appDefinition)) {
+    features.push(bot);
+  }
+
+  if (isMessageExtension(appDefinition)) {
+    features.push(messageExtension);
+  }
+
+  return features;
+}
+
 export function hasMeetingExtension(appDefinition: AppDefinition): boolean {
   return (
     !!appDefinition.configurableTabs &&

--- a/packages/fx-core/src/core/telemetry.ts
+++ b/packages/fx-core/src/core/telemetry.ts
@@ -8,6 +8,7 @@ export const CoreTelemetryComponentName = "core";
 export enum CoreTelemetryEvent {
   CreateStart = "create-start",
   Create = "create",
+  CreateFromTdpStart = "create-tdp-start",
 }
 
 export enum CoreTelemetryProperty {
@@ -16,6 +17,8 @@ export enum CoreTelemetryProperty {
   Success = "success",
   ErrorCode = "error-code",
   ErrorMessage = "error-message",
+  TdpTeamsAppId = "tdp-teams-app-id",
+  TdpTeamsAppFeatures = "tdp-teams-app-features",
 }
 
 export enum CoreTelemetrySuccess {

--- a/packages/fx-core/tests/component/resource/appManifest/utils.test.ts
+++ b/packages/fx-core/tests/component/resource/appManifest/utils.test.ts
@@ -8,6 +8,7 @@ import { StaticTab } from "../../../../src/component/resource/appManifest/interf
 import {
   CommandScope,
   containsUnsupportedFeature,
+  getFeaturesFromAppDefinition,
   hasMeetingExtension,
   MeetingsContext,
   needBotCode,
@@ -356,6 +357,25 @@ describe("utils", () => {
 
       const res = containsUnsupportedFeature(appDefinition);
       chai.assert.isTrue(res);
+    });
+  });
+
+  describe("getFeaturesFromAppDefinition", () => {
+    it("get features", () => {
+      const appDefinition: AppDefinition = {
+        teamsAppId: "mockAppId",
+        tenantId: "mockTenantId",
+        configurableTabs: [validConfigurableTabForTabCode],
+        staticTabs: [validStaticTab],
+        bots: [validBot],
+        messagingExtensions: [validMessagingExtension],
+      };
+      const res = getFeaturesFromAppDefinition(appDefinition);
+      chai.assert.equal(res.length, 4);
+      chai.assert.isTrue(res.includes("personal-tab"));
+      chai.assert.isTrue(res.includes("group-tab"));
+      chai.assert.isTrue(res.includes("bot"));
+      chai.assert.isTrue(res.includes("messaging-extension"));
     });
   });
 });

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -168,6 +168,7 @@ import {
   isBot,
   isMessageExtension,
 } from "@microsoft/teamsfx-core/build/component/resource/appManifest/utils/utils";
+import { AppStudioClient } from "@microsoft/teamsfx-core/build/component/resource/appManifest/appStudioClient";
 
 export let core: FxCore;
 export let tools: Tools;
@@ -3640,13 +3641,8 @@ export async function scaffoldFromDeveloperPortalHandler(
     return ok(null);
   }
 
-  const personalTab = "personal-tab";
-  const groupTab = "group-tab";
-  const bot = "bot";
-  const messageExtension = "messaging-extension";
-
   const appId = args[0];
-  let properties: { [p: string]: string } = {
+  const properties: { [p: string]: string } = {
     teamsAppId: appId,
   };
   ExtTelemetry.sendTelemetryEvent(TelemetryEvent.HandleUrlFromDeveloperProtalStart, properties);
@@ -3656,15 +3652,15 @@ export async function scaffoldFromDeveloperPortalHandler(
     1
   );
   await progressBar.start();
-  let appDefinition = undefined;
+  let token = undefined;
   try {
-    const appDefinitionRes = await M365TokenInstance.signInWhenInitiatedFromTdp(
+    const tokenRes = await M365TokenInstance.signInWhenInitiatedFromTdp(
       { scopes: AppStudioScopes },
-      appId
+      loginHint
     );
-    if (appDefinitionRes.isErr()) {
-      if ((appDefinitionRes.error as any).displayMessage) {
-        window.showErrorMessage((appDefinitionRes.error as any).displayMessage);
+    if (tokenRes.isErr()) {
+      if ((tokenRes.error as any).displayMessage) {
+        window.showErrorMessage((tokenRes.error as any).displayMessage);
       } else {
         vscode.window.showErrorMessage(
           localize("teamstoolkit.devPortalIntegration.generalError.message")
@@ -3672,13 +3668,13 @@ export async function scaffoldFromDeveloperPortalHandler(
       }
       ExtTelemetry.sendTelemetryErrorEvent(
         TelemetryEvent.HandleUrlFromDeveloperProtal,
-        appDefinitionRes.error,
+        tokenRes.error,
         properties
       );
       await progressBar.end(false);
-      return err(appDefinitionRes.error);
+      return err(tokenRes.error);
     }
-    appDefinition = appDefinitionRes.value;
+    token = tokenRes.value;
     await progressBar.end(true);
   } catch (e) {
     vscode.window.showErrorMessage(
@@ -3691,29 +3687,25 @@ export async function scaffoldFromDeveloperPortalHandler(
       error,
       properties
     );
-    throw e;
+    return err(error);
+  }
+
+  let appDefinition;
+  try {
+    appDefinition = await AppStudioClient.getApp(appId, token, VsCodeLogInstance);
+  } catch (error: any) {
+    ExtTelemetry.sendTelemetryErrorEvent(
+      TelemetryEvent.HandleUrlFromDeveloperProtal,
+      error,
+      properties
+    );
+    vscode.window.showErrorMessage(
+      localize("teamstoolkit.devPortalIntegration.getTeamsAppError.message")
+    );
+    return err(error);
   }
 
   const res = await createNewProjectHandler([{ teamsAppFromTdp: appDefinition }]);
-  const features = [];
-
-  if (isPersonalApp(appDefinition)) {
-    features.push(personalTab);
-  }
-
-  if (isGroupApp(appDefinition)) {
-    features.push(groupTab);
-  }
-
-  if (isBot(appDefinition)) {
-    features.push(bot);
-  }
-
-  if (isMessageExtension(appDefinition)) {
-    features.push(messageExtension);
-  }
-
-  properties = { ...properties, features: features.join(",") };
 
   if (res.isErr()) {
     ExtTelemetry.sendTelemetryErrorEvent(

--- a/packages/vscode-extension/test/extension/handlers.test.ts
+++ b/packages/vscode-extension/test/extension/handlers.test.ts
@@ -60,6 +60,8 @@ import { VsCodeLogProvider } from "../../src/commonlib/log";
 import { ProgressHandler } from "../../src/progressHandler";
 import { TreatmentVariableValue } from "../../src/exp/treatmentVariables";
 import { assert } from "console";
+import { AppStudioClient } from "@microsoft/teamsfx-core/build/component/resource/appManifest/appStudioClient";
+import { AppDefinition } from "@microsoft/teamsfx-core/build/component/resource/appManifest/interfaces/appDefinition";
 
 describe("handlers", () => {
   describe("activate()", function () {
@@ -1185,135 +1187,160 @@ describe("handlers", () => {
     });
   });
 
-  // describe("scaffoldFromDeveloperPortalHandler", async () => {
-  //   beforeEach(() => {
-  //     sinon.stub(ExtTelemetry, "sendTelemetryEvent");
-  //     sinon.stub(ExtTelemetry, "sendTelemetryErrorEvent");
-  //   });
-  //   afterEach(() => {
-  //     sinon.restore();
-  //   });
-  //   it("missing args", async () => {
-  //     const progressHandler = new ProgressHandler("title", 1);
-  //     sinon.stub(extension, "VS_CODE_UI").value(new VsCodeUI(<vscode.ExtensionContext>{}));
-  //     const createProgressBar = sinon
-  //       .stub(extension.VS_CODE_UI, "createProgressBar")
-  //       .returns(progressHandler);
+  describe("scaffoldFromDeveloperPortalHandler", async () => {
+    beforeEach(() => {
+      sinon.stub(ExtTelemetry, "sendTelemetryEvent");
+      sinon.stub(ExtTelemetry, "sendTelemetryErrorEvent");
+    });
+    afterEach(() => {
+      sinon.restore();
+    });
+    it("missing args", async () => {
+      const progressHandler = new ProgressHandler("title", 1);
+      sinon.stub(extension, "VS_CODE_UI").value(new VsCodeUI(<vscode.ExtensionContext>{}));
+      const createProgressBar = sinon
+        .stub(extension.VS_CODE_UI, "createProgressBar")
+        .returns(progressHandler);
 
-  //     const res = await handlers.scaffoldFromDeveloperPortalHandler();
+      const res = await handlers.scaffoldFromDeveloperPortalHandler();
 
-  //     chai.assert.equal(res.isOk(), true);
-  //     chai.assert.equal(createProgressBar.notCalled, true);
-  //   });
+      chai.assert.equal(res.isOk(), true);
+      chai.assert.equal(createProgressBar.notCalled, true);
+    });
 
-  //   it("incorrect number of args", async () => {
-  //     const progressHandler = new ProgressHandler("title", 1);
-  //     sinon.stub(extension, "VS_CODE_UI").value(new VsCodeUI(<vscode.ExtensionContext>{}));
-  //     const createProgressBar = sinon
-  //       .stub(extension.VS_CODE_UI, "createProgressBar")
-  //       .returns(progressHandler);
+    it("incorrect number of args", async () => {
+      const progressHandler = new ProgressHandler("title", 1);
+      sinon.stub(extension, "VS_CODE_UI").value(new VsCodeUI(<vscode.ExtensionContext>{}));
+      const createProgressBar = sinon
+        .stub(extension.VS_CODE_UI, "createProgressBar")
+        .returns(progressHandler);
 
-  //     const res = await handlers.scaffoldFromDeveloperPortalHandler([]);
+      const res = await handlers.scaffoldFromDeveloperPortalHandler([]);
 
-  //     chai.assert.equal(res.isOk(), true);
-  //     chai.assert.equal(createProgressBar.notCalled, true);
-  //   });
+      chai.assert.equal(res.isOk(), true);
+      chai.assert.equal(createProgressBar.notCalled, true);
+    });
 
-  //   it("general error when signing in M365", async () => {
-  //     sinon.stub(extension, "VS_CODE_UI").value(new VsCodeUI(<vscode.ExtensionContext>{}));
-  //     const progressHandler = new ProgressHandler("title", 1);
-  //     const startProgress = sinon.stub(progressHandler, "start").resolves();
-  //     const endProgress = sinon.stub(progressHandler, "end").resolves();
-  //     sinon.stub(M365TokenInstance, "signInWhenInitiatedFromTdp").throws("error");
-  //     const createProgressBar = sinon
-  //       .stub(extension.VS_CODE_UI, "createProgressBar")
-  //       .returns(progressHandler);
-  //     const showErrorMessage = sinon.stub(vscode.window, "showErrorMessage");
-  //     let hasError = false;
+    it("general error when signing in M365", async () => {
+      sinon.stub(extension, "VS_CODE_UI").value(new VsCodeUI(<vscode.ExtensionContext>{}));
+      const progressHandler = new ProgressHandler("title", 1);
+      const startProgress = sinon.stub(progressHandler, "start").resolves();
+      const endProgress = sinon.stub(progressHandler, "end").resolves();
+      sinon.stub(M365TokenInstance, "signInWhenInitiatedFromTdp").throws("error1");
+      const createProgressBar = sinon
+        .stub(extension.VS_CODE_UI, "createProgressBar")
+        .returns(progressHandler);
+      const showErrorMessage = sinon.stub(vscode.window, "showErrorMessage");
 
-  //     await handlers.scaffoldFromDeveloperPortalHandler(["appId"]).catch((err) => {
-  //       hasError = true;
-  //       chai.assert.equal(err, "error");
-  //       chai.assert.equal(createProgressBar.calledOnce, true);
-  //       chai.assert.equal(startProgress.calledOnce, true);
-  //       chai.assert.equal(endProgress.calledOnceWithExactly(false), true);
-  //       chai.assert.equal(showErrorMessage.calledOnce, true);
-  //     });
+      const res = await handlers.scaffoldFromDeveloperPortalHandler(["appId"]);
+      chai.assert.isTrue(res.isErr());
+      chai.assert.isTrue(createProgressBar.calledOnce);
+      chai.assert.isTrue(startProgress.calledOnce);
+      chai.assert.isTrue(endProgress.calledOnceWithExactly(false));
+      chai.assert.isTrue(showErrorMessage.calledOnce);
+      if (res.isErr()) {
+        chai.assert.equal(res.error.name, "error1");
+      }
+    });
 
-  //     chai.assert.equal(hasError, true);
-  //   });
+    it("error when signing M365", async () => {
+      sinon.stub(extension, "VS_CODE_UI").value(new VsCodeUI(<vscode.ExtensionContext>{}));
+      const progressHandler = new ProgressHandler("title", 1);
+      const startProgress = sinon.stub(progressHandler, "start").resolves();
+      const endProgress = sinon.stub(progressHandler, "end").resolves();
+      sinon
+        .stub(M365TokenInstance, "signInWhenInitiatedFromTdp")
+        .resolves(err(new UserError("source", "name", "message", "displayMessage")));
+      const createProgressBar = sinon
+        .stub(extension.VS_CODE_UI, "createProgressBar")
+        .returns(progressHandler);
+      const showErrorMessage = sinon.stub(vscode.window, "showErrorMessage");
 
-  //   it("error when signing M365", async () => {
-  //     sinon.stub(extension, "VS_CODE_UI").value(new VsCodeUI(<vscode.ExtensionContext>{}));
-  //     const progressHandler = new ProgressHandler("title", 1);
-  //     const startProgress = sinon.stub(progressHandler, "start").resolves();
-  //     const endProgress = sinon.stub(progressHandler, "end").resolves();
-  //     sinon
-  //       .stub(M365TokenInstance, "signInWhenInitiatedFromTdp")
-  //       .resolves(err(new UserError("source", "name", "message", "displayMessage")));
-  //     const createProgressBar = sinon
-  //       .stub(extension.VS_CODE_UI, "createProgressBar")
-  //       .returns(progressHandler);
-  //     const showErrorMessage = sinon.stub(vscode.window, "showErrorMessage");
+      const res = await handlers.scaffoldFromDeveloperPortalHandler(["appId"]);
 
-  //     const res = await handlers.scaffoldFromDeveloperPortalHandler(["appId"]);
+      chai.assert.equal(res.isErr(), true);
+      chai.assert.equal(createProgressBar.calledOnce, true);
+      chai.assert.equal(startProgress.calledOnce, true);
+      chai.assert.equal(endProgress.calledOnceWithExactly(false), true);
+      chai.assert.equal(showErrorMessage.calledOnce, true);
+    });
 
-  //     chai.assert.equal(res.isErr(), true);
-  //     chai.assert.equal(createProgressBar.calledOnce, true);
-  //     chai.assert.equal(startProgress.calledOnce, true);
-  //     chai.assert.equal(endProgress.calledOnceWithExactly(false), true);
-  //     chai.assert.equal(showErrorMessage.calledOnce, true);
-  //   });
+    it("error when signing in M365 but missing display message", async () => {
+      sinon.stub(extension, "VS_CODE_UI").value(new VsCodeUI(<vscode.ExtensionContext>{}));
+      const progressHandler = new ProgressHandler("title", 1);
+      const startProgress = sinon.stub(progressHandler, "start").resolves();
+      const endProgress = sinon.stub(progressHandler, "end").resolves();
+      sinon
+        .stub(M365TokenInstance, "signInWhenInitiatedFromTdp")
+        .resolves(err(new UserError("source", "name", "", "")));
+      const createProgressBar = sinon
+        .stub(extension.VS_CODE_UI, "createProgressBar")
+        .returns(progressHandler);
+      const showErrorMessage = sinon.stub(vscode.window, "showErrorMessage");
 
-  //   it("error when signing in M365 but missing display message", async () => {
-  //     sinon.stub(extension, "VS_CODE_UI").value(new VsCodeUI(<vscode.ExtensionContext>{}));
-  //     const progressHandler = new ProgressHandler("title", 1);
-  //     const startProgress = sinon.stub(progressHandler, "start").resolves();
-  //     const endProgress = sinon.stub(progressHandler, "end").resolves();
-  //     sinon
-  //       .stub(M365TokenInstance, "signInWhenInitiatedFromTdp")
-  //       .resolves(err(new UserError("source", "name", "", "")));
-  //     const createProgressBar = sinon
-  //       .stub(extension.VS_CODE_UI, "createProgressBar")
-  //       .returns(progressHandler);
-  //     const showErrorMessage = sinon.stub(vscode.window, "showErrorMessage");
+      const res = await handlers.scaffoldFromDeveloperPortalHandler(["appId"]);
 
-  //     const res = await handlers.scaffoldFromDeveloperPortalHandler(["appId"]);
+      chai.assert.equal(res.isErr(), true);
+      chai.assert.equal(createProgressBar.calledOnce, true);
+      chai.assert.equal(startProgress.calledOnce, true);
+      chai.assert.equal(endProgress.calledOnceWithExactly(false), true);
+      chai.assert.equal(showErrorMessage.calledOnce, true);
+    });
 
-  //     chai.assert.equal(res.isErr(), true);
-  //     chai.assert.equal(createProgressBar.calledOnce, true);
-  //     chai.assert.equal(startProgress.calledOnce, true);
-  //     chai.assert.equal(endProgress.calledOnceWithExactly(false), true);
-  //     chai.assert.equal(showErrorMessage.calledOnce, true);
-  //   });
+    it("failed to get teams app", async () => {
+      sinon.stub(extension, "VS_CODE_UI").value(new VsCodeUI(<vscode.ExtensionContext>{}));
+      const progressHandler = new ProgressHandler("title", 1);
+      const startProgress = sinon.stub(progressHandler, "start").resolves();
+      const endProgress = sinon.stub(progressHandler, "end").resolves();
+      sinon.stub(M365TokenInstance, "signInWhenInitiatedFromTdp").resolves(ok("token"));
+      const createProgressBar = sinon
+        .stub(extension.VS_CODE_UI, "createProgressBar")
+        .returns(progressHandler);
+      sinon.stub(handlers, "core").value(new MockCore());
+      sinon.stub(commonUtils, "isExistingTabApp").returns(Promise.resolve(false));
+      sinon.stub(vscode.commands, "executeCommand");
+      sinon.stub(globalState, "globalStateUpdate");
+      sinon.stub(vscodeHelper, "checkerEnabled").returns(false);
+      const getApp = sinon.stub(AppStudioClient, "getApp").throws("error");
 
-  //   it("sign in M365 successfully", async () => {
-  //     sinon.stub(extension, "VS_CODE_UI").value(new VsCodeUI(<vscode.ExtensionContext>{}));
-  //     const progressHandler = new ProgressHandler("title", 1);
-  //     const startProgress = sinon.stub(progressHandler, "start").resolves();
-  //     const endProgress = sinon.stub(progressHandler, "end").resolves();
-  //     sinon
-  //       .stub(M365TokenInstance, "signInWhenInitiatedFromTdp")
-  //       .resolves(ok({ appId: "mock-id" }));
-  //     const createProgressBar = sinon
-  //       .stub(extension.VS_CODE_UI, "createProgressBar")
-  //       .returns(progressHandler);
-  //     sinon.stub(handlers, "core").value(new MockCore());
-  //     sinon.stub(commonUtils, "isExistingTabApp").returns(Promise.resolve(false));
-  //     const createProject = sinon.spy(handlers.core, "createProject");
-  //     sinon.stub(vscode.commands, "executeCommand");
-  //     sinon.stub(globalState, "globalStateUpdate");
-  //     sinon.stub(vscodeHelper, "checkerEnabled").returns(false);
+      const res = await handlers.scaffoldFromDeveloperPortalHandler(["appId"]);
 
-  //     const res = await handlers.scaffoldFromDeveloperPortalHandler(["appId"]);
+      chai.assert.isTrue(res.isErr());
+      chai.assert.isTrue(getApp.calledOnce);
+      chai.assert.isTrue(createProgressBar.calledOnce);
+      chai.assert.isTrue(startProgress.calledOnce);
+      chai.assert.isTrue(endProgress.calledOnceWithExactly(true));
+    });
 
-  //     chai.assert.equal(createProject.args[0][0].teamsAppFromTdp.appId, "mock-id");
-  //     chai.assert.equal(res.isOk(), true);
-  //     chai.assert.equal(createProgressBar.calledOnce, true);
-  //     chai.assert.equal(startProgress.calledOnce, true);
-  //     chai.assert.equal(endProgress.calledOnceWithExactly(true), true);
-  //   });
-  // });
+    it("happy path", async () => {
+      sinon.stub(extension, "VS_CODE_UI").value(new VsCodeUI(<vscode.ExtensionContext>{}));
+      const progressHandler = new ProgressHandler("title", 1);
+      const startProgress = sinon.stub(progressHandler, "start").resolves();
+      const endProgress = sinon.stub(progressHandler, "end").resolves();
+      sinon.stub(M365TokenInstance, "signInWhenInitiatedFromTdp").resolves(ok("token"));
+      const createProgressBar = sinon
+        .stub(extension.VS_CODE_UI, "createProgressBar")
+        .returns(progressHandler);
+      sinon.stub(handlers, "core").value(new MockCore());
+      sinon.stub(commonUtils, "isExistingTabApp").returns(Promise.resolve(false));
+      const createProject = sinon.spy(handlers.core, "createProject");
+      sinon.stub(vscode.commands, "executeCommand");
+      sinon.stub(globalState, "globalStateUpdate");
+      sinon.stub(vscodeHelper, "checkerEnabled").returns(false);
+      const appDefinition: AppDefinition = {
+        teamsAppId: "mock-id",
+      };
+      sinon.stub(AppStudioClient, "getApp").resolves(appDefinition);
+
+      const res = await handlers.scaffoldFromDeveloperPortalHandler(["appId", "testuser"]);
+
+      chai.assert.equal(createProject.args[0][0].teamsAppFromTdp.teamsAppId, "mock-id");
+      chai.assert.isTrue(res.isOk());
+      chai.assert.isTrue(createProgressBar.calledOnce);
+      chai.assert.isTrue(startProgress.calledOnce);
+      chai.assert.isTrue(endProgress.calledOnceWithExactly(true));
+    });
+  });
 
   describe("publishInDeveloperPortalHandler", async () => {
     afterEach(() => {

--- a/packages/vscode-extension/test/extension/handlers.test.ts
+++ b/packages/vscode-extension/test/extension/handlers.test.ts
@@ -1185,135 +1185,135 @@ describe("handlers", () => {
     });
   });
 
-  describe("scaffoldFromDeveloperPortalHandler", async () => {
-    beforeEach(() => {
-      sinon.stub(ExtTelemetry, "sendTelemetryEvent");
-      sinon.stub(ExtTelemetry, "sendTelemetryErrorEvent");
-    });
-    afterEach(() => {
-      sinon.restore();
-    });
-    it("missing args", async () => {
-      const progressHandler = new ProgressHandler("title", 1);
-      sinon.stub(extension, "VS_CODE_UI").value(new VsCodeUI(<vscode.ExtensionContext>{}));
-      const createProgressBar = sinon
-        .stub(extension.VS_CODE_UI, "createProgressBar")
-        .returns(progressHandler);
+  // describe("scaffoldFromDeveloperPortalHandler", async () => {
+  //   beforeEach(() => {
+  //     sinon.stub(ExtTelemetry, "sendTelemetryEvent");
+  //     sinon.stub(ExtTelemetry, "sendTelemetryErrorEvent");
+  //   });
+  //   afterEach(() => {
+  //     sinon.restore();
+  //   });
+  //   it("missing args", async () => {
+  //     const progressHandler = new ProgressHandler("title", 1);
+  //     sinon.stub(extension, "VS_CODE_UI").value(new VsCodeUI(<vscode.ExtensionContext>{}));
+  //     const createProgressBar = sinon
+  //       .stub(extension.VS_CODE_UI, "createProgressBar")
+  //       .returns(progressHandler);
 
-      const res = await handlers.scaffoldFromDeveloperPortalHandler();
+  //     const res = await handlers.scaffoldFromDeveloperPortalHandler();
 
-      chai.assert.equal(res.isOk(), true);
-      chai.assert.equal(createProgressBar.notCalled, true);
-    });
+  //     chai.assert.equal(res.isOk(), true);
+  //     chai.assert.equal(createProgressBar.notCalled, true);
+  //   });
 
-    it("incorrect number of args", async () => {
-      const progressHandler = new ProgressHandler("title", 1);
-      sinon.stub(extension, "VS_CODE_UI").value(new VsCodeUI(<vscode.ExtensionContext>{}));
-      const createProgressBar = sinon
-        .stub(extension.VS_CODE_UI, "createProgressBar")
-        .returns(progressHandler);
+  //   it("incorrect number of args", async () => {
+  //     const progressHandler = new ProgressHandler("title", 1);
+  //     sinon.stub(extension, "VS_CODE_UI").value(new VsCodeUI(<vscode.ExtensionContext>{}));
+  //     const createProgressBar = sinon
+  //       .stub(extension.VS_CODE_UI, "createProgressBar")
+  //       .returns(progressHandler);
 
-      const res = await handlers.scaffoldFromDeveloperPortalHandler([]);
+  //     const res = await handlers.scaffoldFromDeveloperPortalHandler([]);
 
-      chai.assert.equal(res.isOk(), true);
-      chai.assert.equal(createProgressBar.notCalled, true);
-    });
+  //     chai.assert.equal(res.isOk(), true);
+  //     chai.assert.equal(createProgressBar.notCalled, true);
+  //   });
 
-    it("general error when signing in M365", async () => {
-      sinon.stub(extension, "VS_CODE_UI").value(new VsCodeUI(<vscode.ExtensionContext>{}));
-      const progressHandler = new ProgressHandler("title", 1);
-      const startProgress = sinon.stub(progressHandler, "start").resolves();
-      const endProgress = sinon.stub(progressHandler, "end").resolves();
-      sinon.stub(M365TokenInstance, "signInWhenInitiatedFromTdp").throws("error");
-      const createProgressBar = sinon
-        .stub(extension.VS_CODE_UI, "createProgressBar")
-        .returns(progressHandler);
-      const showErrorMessage = sinon.stub(vscode.window, "showErrorMessage");
-      let hasError = false;
+  //   it("general error when signing in M365", async () => {
+  //     sinon.stub(extension, "VS_CODE_UI").value(new VsCodeUI(<vscode.ExtensionContext>{}));
+  //     const progressHandler = new ProgressHandler("title", 1);
+  //     const startProgress = sinon.stub(progressHandler, "start").resolves();
+  //     const endProgress = sinon.stub(progressHandler, "end").resolves();
+  //     sinon.stub(M365TokenInstance, "signInWhenInitiatedFromTdp").throws("error");
+  //     const createProgressBar = sinon
+  //       .stub(extension.VS_CODE_UI, "createProgressBar")
+  //       .returns(progressHandler);
+  //     const showErrorMessage = sinon.stub(vscode.window, "showErrorMessage");
+  //     let hasError = false;
 
-      await handlers.scaffoldFromDeveloperPortalHandler(["appId"]).catch((err) => {
-        hasError = true;
-        chai.assert.equal(err, "error");
-        chai.assert.equal(createProgressBar.calledOnce, true);
-        chai.assert.equal(startProgress.calledOnce, true);
-        chai.assert.equal(endProgress.calledOnceWithExactly(false), true);
-        chai.assert.equal(showErrorMessage.calledOnce, true);
-      });
+  //     await handlers.scaffoldFromDeveloperPortalHandler(["appId"]).catch((err) => {
+  //       hasError = true;
+  //       chai.assert.equal(err, "error");
+  //       chai.assert.equal(createProgressBar.calledOnce, true);
+  //       chai.assert.equal(startProgress.calledOnce, true);
+  //       chai.assert.equal(endProgress.calledOnceWithExactly(false), true);
+  //       chai.assert.equal(showErrorMessage.calledOnce, true);
+  //     });
 
-      chai.assert.equal(hasError, true);
-    });
+  //     chai.assert.equal(hasError, true);
+  //   });
 
-    it("error when signing M365", async () => {
-      sinon.stub(extension, "VS_CODE_UI").value(new VsCodeUI(<vscode.ExtensionContext>{}));
-      const progressHandler = new ProgressHandler("title", 1);
-      const startProgress = sinon.stub(progressHandler, "start").resolves();
-      const endProgress = sinon.stub(progressHandler, "end").resolves();
-      sinon
-        .stub(M365TokenInstance, "signInWhenInitiatedFromTdp")
-        .resolves(err(new UserError("source", "name", "message", "displayMessage")));
-      const createProgressBar = sinon
-        .stub(extension.VS_CODE_UI, "createProgressBar")
-        .returns(progressHandler);
-      const showErrorMessage = sinon.stub(vscode.window, "showErrorMessage");
+  //   it("error when signing M365", async () => {
+  //     sinon.stub(extension, "VS_CODE_UI").value(new VsCodeUI(<vscode.ExtensionContext>{}));
+  //     const progressHandler = new ProgressHandler("title", 1);
+  //     const startProgress = sinon.stub(progressHandler, "start").resolves();
+  //     const endProgress = sinon.stub(progressHandler, "end").resolves();
+  //     sinon
+  //       .stub(M365TokenInstance, "signInWhenInitiatedFromTdp")
+  //       .resolves(err(new UserError("source", "name", "message", "displayMessage")));
+  //     const createProgressBar = sinon
+  //       .stub(extension.VS_CODE_UI, "createProgressBar")
+  //       .returns(progressHandler);
+  //     const showErrorMessage = sinon.stub(vscode.window, "showErrorMessage");
 
-      const res = await handlers.scaffoldFromDeveloperPortalHandler(["appId"]);
+  //     const res = await handlers.scaffoldFromDeveloperPortalHandler(["appId"]);
 
-      chai.assert.equal(res.isErr(), true);
-      chai.assert.equal(createProgressBar.calledOnce, true);
-      chai.assert.equal(startProgress.calledOnce, true);
-      chai.assert.equal(endProgress.calledOnceWithExactly(false), true);
-      chai.assert.equal(showErrorMessage.calledOnce, true);
-    });
+  //     chai.assert.equal(res.isErr(), true);
+  //     chai.assert.equal(createProgressBar.calledOnce, true);
+  //     chai.assert.equal(startProgress.calledOnce, true);
+  //     chai.assert.equal(endProgress.calledOnceWithExactly(false), true);
+  //     chai.assert.equal(showErrorMessage.calledOnce, true);
+  //   });
 
-    it("error when signing in M365 but missing display message", async () => {
-      sinon.stub(extension, "VS_CODE_UI").value(new VsCodeUI(<vscode.ExtensionContext>{}));
-      const progressHandler = new ProgressHandler("title", 1);
-      const startProgress = sinon.stub(progressHandler, "start").resolves();
-      const endProgress = sinon.stub(progressHandler, "end").resolves();
-      sinon
-        .stub(M365TokenInstance, "signInWhenInitiatedFromTdp")
-        .resolves(err(new UserError("source", "name", "", "")));
-      const createProgressBar = sinon
-        .stub(extension.VS_CODE_UI, "createProgressBar")
-        .returns(progressHandler);
-      const showErrorMessage = sinon.stub(vscode.window, "showErrorMessage");
+  //   it("error when signing in M365 but missing display message", async () => {
+  //     sinon.stub(extension, "VS_CODE_UI").value(new VsCodeUI(<vscode.ExtensionContext>{}));
+  //     const progressHandler = new ProgressHandler("title", 1);
+  //     const startProgress = sinon.stub(progressHandler, "start").resolves();
+  //     const endProgress = sinon.stub(progressHandler, "end").resolves();
+  //     sinon
+  //       .stub(M365TokenInstance, "signInWhenInitiatedFromTdp")
+  //       .resolves(err(new UserError("source", "name", "", "")));
+  //     const createProgressBar = sinon
+  //       .stub(extension.VS_CODE_UI, "createProgressBar")
+  //       .returns(progressHandler);
+  //     const showErrorMessage = sinon.stub(vscode.window, "showErrorMessage");
 
-      const res = await handlers.scaffoldFromDeveloperPortalHandler(["appId"]);
+  //     const res = await handlers.scaffoldFromDeveloperPortalHandler(["appId"]);
 
-      chai.assert.equal(res.isErr(), true);
-      chai.assert.equal(createProgressBar.calledOnce, true);
-      chai.assert.equal(startProgress.calledOnce, true);
-      chai.assert.equal(endProgress.calledOnceWithExactly(false), true);
-      chai.assert.equal(showErrorMessage.calledOnce, true);
-    });
+  //     chai.assert.equal(res.isErr(), true);
+  //     chai.assert.equal(createProgressBar.calledOnce, true);
+  //     chai.assert.equal(startProgress.calledOnce, true);
+  //     chai.assert.equal(endProgress.calledOnceWithExactly(false), true);
+  //     chai.assert.equal(showErrorMessage.calledOnce, true);
+  //   });
 
-    it("sign in M365 successfully", async () => {
-      sinon.stub(extension, "VS_CODE_UI").value(new VsCodeUI(<vscode.ExtensionContext>{}));
-      const progressHandler = new ProgressHandler("title", 1);
-      const startProgress = sinon.stub(progressHandler, "start").resolves();
-      const endProgress = sinon.stub(progressHandler, "end").resolves();
-      sinon
-        .stub(M365TokenInstance, "signInWhenInitiatedFromTdp")
-        .resolves(ok({ appId: "mock-id" }));
-      const createProgressBar = sinon
-        .stub(extension.VS_CODE_UI, "createProgressBar")
-        .returns(progressHandler);
-      sinon.stub(handlers, "core").value(new MockCore());
-      sinon.stub(commonUtils, "isExistingTabApp").returns(Promise.resolve(false));
-      const createProject = sinon.spy(handlers.core, "createProject");
-      sinon.stub(vscode.commands, "executeCommand");
-      sinon.stub(globalState, "globalStateUpdate");
-      sinon.stub(vscodeHelper, "checkerEnabled").returns(false);
+  //   it("sign in M365 successfully", async () => {
+  //     sinon.stub(extension, "VS_CODE_UI").value(new VsCodeUI(<vscode.ExtensionContext>{}));
+  //     const progressHandler = new ProgressHandler("title", 1);
+  //     const startProgress = sinon.stub(progressHandler, "start").resolves();
+  //     const endProgress = sinon.stub(progressHandler, "end").resolves();
+  //     sinon
+  //       .stub(M365TokenInstance, "signInWhenInitiatedFromTdp")
+  //       .resolves(ok({ appId: "mock-id" }));
+  //     const createProgressBar = sinon
+  //       .stub(extension.VS_CODE_UI, "createProgressBar")
+  //       .returns(progressHandler);
+  //     sinon.stub(handlers, "core").value(new MockCore());
+  //     sinon.stub(commonUtils, "isExistingTabApp").returns(Promise.resolve(false));
+  //     const createProject = sinon.spy(handlers.core, "createProject");
+  //     sinon.stub(vscode.commands, "executeCommand");
+  //     sinon.stub(globalState, "globalStateUpdate");
+  //     sinon.stub(vscodeHelper, "checkerEnabled").returns(false);
 
-      const res = await handlers.scaffoldFromDeveloperPortalHandler(["appId"]);
+  //     const res = await handlers.scaffoldFromDeveloperPortalHandler(["appId"]);
 
-      chai.assert.equal(createProject.args[0][0].teamsAppFromTdp.appId, "mock-id");
-      chai.assert.equal(res.isOk(), true);
-      chai.assert.equal(createProgressBar.calledOnce, true);
-      chai.assert.equal(startProgress.calledOnce, true);
-      chai.assert.equal(endProgress.calledOnceWithExactly(true), true);
-    });
-  });
+  //     chai.assert.equal(createProject.args[0][0].teamsAppFromTdp.appId, "mock-id");
+  //     chai.assert.equal(res.isOk(), true);
+  //     chai.assert.equal(createProgressBar.calledOnce, true);
+  //     chai.assert.equal(startProgress.calledOnce, true);
+  //     chai.assert.equal(endProgress.calledOnceWithExactly(true), true);
+  //   });
+  // });
 
   describe("publishInDeveloperPortalHandler", async () => {
     afterEach(() => {


### PR DESCRIPTION
- When given loginHint (currently there should be only two scenarios, 1. user clicks a button on developer portal. 2. user is from ITP), we will redirect user to sign in with that account directly    
  - If we could find account in msal cache, will get token silently first and then acquire token interactively
  - If we could not find the account in msal cache, we will redirect to "login" page with the loginHint rather than "select-account"
- Move telemetry of features of teams app from Develop Portal from vscode-extension to core, so it will be reusable when we later work on VS.