### PR TITLE
chore: scaffold bot with message extension when from TDP

### DIFF
--- a/packages/fx-core/src/component/constants.ts
+++ b/packages/fx-core/src/component/constants.ts
@@ -870,6 +870,11 @@ export const TabNonSsoAndDefaultBotItem: OptionItem = {
   label: "", // No need to set display name as this option won't be shown in UI
 };
 
+export const DefaultBotAndMessageExtensionItem: OptionItem = {
+  id: "BotAndMessageExtension",
+  label: "", // No need to set display name as this option won't be shown in UI
+};
+
 export const M365SsoLaunchPageOptionItem: OptionItem = {
   id: "M365SsoLaunchPage",
   label: `$(browser) ${getLocalizedString("core.M365SsoLaunchPageOptionItem.label")}`,

--- a/packages/fx-core/src/component/coordinator/index.ts
+++ b/packages/fx-core/src/component/coordinator/index.ts
@@ -53,6 +53,7 @@ import {
   CoordinatorSource,
   BotOptionItem,
   TabNonSsoAndDefaultBotItem,
+  DefaultBotAndMessageExtensionItem,
 } from "../constants";
 import { ActionExecutionMW } from "../middleware/actionExecutionMW";
 import {
@@ -114,6 +115,7 @@ export enum TemplateNames {
   MessageExtension = "message-extension",
   M365MessageExtension = "m365-message-extension",
   TabAndDefaultBot = "non-sso-tab-default-bot",
+  BotAndMessageExtension = "default-bot-message-extension",
 }
 
 export const Feature2TemplateName: any = {
@@ -135,6 +137,7 @@ export const Feature2TemplateName: any = {
   [`${TabNonSsoItem.id}:undefined`]: TemplateNames.Tab,
   [`${M365SsoLaunchPageOptionItem.id}:undefined`]: TemplateNames.M365Tab,
   [`${TabNonSsoAndDefaultBotItem.id}:undefined`]: TemplateNames.TabAndDefaultBot,
+  [`${DefaultBotAndMessageExtensionItem.id}:undefined`]: TemplateNames.BotAndMessageExtension,
 };
 
 export const InitTemplateName: any = {

--- a/packages/fx-core/src/component/resource/appManifest/utils/utils.ts
+++ b/packages/fx-core/src/component/resource/appManifest/utils/utils.ts
@@ -70,6 +70,10 @@ export function isMessageExtension(appDefinition: AppDefinition): boolean {
   return !!appDefinition.messagingExtensions && appDefinition.messagingExtensions.length > 0;
 }
 
+export function isBotAndMessageExtension(appDefinition: AppDefinition): boolean {
+  return isBot(appDefinition) && isMessageExtension(appDefinition);
+}
+
 export function needBotCode(appDefinition: AppDefinition): boolean {
   return isBot(appDefinition) || isMessageExtension(appDefinition);
 }

--- a/packages/fx-core/src/core/middleware/questionModel.ts
+++ b/packages/fx-core/src/core/middleware/questionModel.ts
@@ -16,14 +16,7 @@ import { isCLIDotNetEnabled, isPreviewFeaturesEnabled } from "../../common/featu
 import { deepCopy, isExistingTabAppEnabled } from "../../common/tools";
 import { getSPFxScaffoldQuestion } from "../../component/feature/spfx";
 import { getNotificationTriggerQuestionNode } from "../../component/question";
-import {
-  BotOptionItem,
-  ExistingTabOptionItem,
-  TabNewUIOptionItem,
-  TabNonSsoAndDefaultBotItem,
-  TabNonSsoItem,
-  TabSPFxItem,
-} from "../../component/constants";
+import { ExistingTabOptionItem, TabSPFxItem } from "../../component/constants";
 import { getQuestionsForGrantPermission } from "../collaborator";
 import { TOOLS } from "../globalVars";
 import {
@@ -49,14 +42,10 @@ import {
   tabsWebsitetUrlQuestion,
 } from "../question";
 import { CoreHookContext } from "../types";
-import {
-  isPersonalApp,
-  needBotCode,
-  needTabAndBotCode,
-  needTabCode,
-} from "../../component/resource/appManifest/utils/utils";
+import { isPersonalApp, needBotCode } from "../../component/resource/appManifest/utils/utils";
 import { convertToAlphanumericOnly } from "../../common/utils";
 import { AppDefinition } from "../../component/resource/appManifest/interfaces/appDefinition";
+import { getTemplateId } from "../../component/developerPortalScaffoldUtils";
 
 /**
  * This middleware will help to collect input from question flow
@@ -120,13 +109,7 @@ async function getQuestionsForCreateProjectWithoutDotNet(
   if (inputs.teamsAppFromTdp) {
     // If toolkit is activated by a request from Developer Portal, we will always create a project from scratch.
     inputs[CoreQuestionNames.CreateFromScratch] = ScratchOptionYesVSC.id;
-    inputs[CoreQuestionNames.Capabilities] = needTabAndBotCode(inputs.teamsAppFromTdp)
-      ? TabNonSsoAndDefaultBotItem.id
-      : needTabCode(inputs.teamsAppFromTdp)
-      ? TabNonSsoItem.id
-      : needBotCode(inputs.teamsAppFromTdp)
-      ? BotOptionItem.id
-      : inputs[CoreQuestionNames.Capabilities];
+    inputs[CoreQuestionNames.Capabilities] = getTemplateId(inputs.teamsAppFromTdp);
   }
   const node = new QTreeNode(getCreateNewOrFromSampleQuestion(inputs.platform));
 

--- a/packages/fx-core/tests/component/coordinator.test.ts
+++ b/packages/fx-core/tests/component/coordinator.test.ts
@@ -226,34 +226,6 @@ describe("component coordinator test", () => {
     assert.equal(generator.args[0][2], TemplateNames.DefaultBot);
   });
 
-  it("create project for app with no features from Developer Portal", async () => {
-    sandbox.stub(fs, "ensureDir").resolves();
-    sandbox.stub(Generator, "generateTemplate").resolves(ok(undefined));
-    sandbox.stub(settingsUtil, "readSettings").resolves(ok({ trackingId: "mockId", version: "1" }));
-    sandbox.stub(settingsUtil, "writeSettings").resolves(ok(""));
-    sandbox.stub(developerPortalScaffoldUtils, "updateFilesForTdp").resolves(ok(undefined));
-    const appDefinition: AppDefinition = {
-      teamsAppId: "mock-id",
-      appId: "mock-id",
-    };
-
-    const inputs: Inputs = {
-      platform: Platform.VSCode,
-      folder: ".",
-      [CoreQuestionNames.AppName]: randomAppName(),
-      [CoreQuestionNames.Capabilities]: [TabOptionItem.id],
-      [CoreQuestionNames.ProgrammingLanguage]: "javascript",
-      teamsAppFromTdp: appDefinition,
-    };
-    const fxCore = new FxCore(tools);
-    const res = await fxCore.createProject(inputs);
-
-    if (res.isErr()) {
-      console.log(res.error);
-    }
-    assert.isTrue(res.isOk());
-  });
-
   it("create project for app with tab and bot features from Developer Portal", async () => {
     sandbox.stub(fs, "ensureDir").resolves();
     const generator = sandbox.stub(Generator, "generateTemplate").resolves(ok(undefined));

--- a/packages/fx-core/tests/component/developerPortalScaffoldUtils.test.ts
+++ b/packages/fx-core/tests/component/developerPortalScaffoldUtils.test.ts
@@ -36,7 +36,7 @@ import {
   TabNonSsoItem,
 } from "../../src/component/constants";
 
-describe.only("developPortalScaffoldUtils", () => {
+describe("developPortalScaffoldUtils", () => {
   describe("updateFilesForTdp", () => {
     const sandbox = sinon.createSandbox();
     class MockedWriteStream {

--- a/packages/fx-core/tests/component/developerPortalScaffoldUtils.test.ts
+++ b/packages/fx-core/tests/component/developerPortalScaffoldUtils.test.ts
@@ -5,19 +5,38 @@ import * as sinon from "sinon";
 import { createContextV3 } from "../../src/component/utils";
 import { MockedAzureAccountProvider, MockedM365Provider } from "../plugins/solution/util";
 import * as appStudio from "../../src/component/resource/appManifest/appStudio";
-import { developerPortalScaffoldUtils } from "../../src/component/developerPortalScaffoldUtils";
+import {
+  developerPortalScaffoldUtils,
+  getTemplateId,
+} from "../../src/component/developerPortalScaffoldUtils";
 import { AppDefinition } from "../../src/component/resource/appManifest/interfaces/appDefinition";
 import { ObjectIsUndefinedError } from "../../src/core/error";
 import fs from "fs-extra";
 import path from "path";
 import { CoreQuestionNames } from "../../src/core/question";
 import {
+  BOTS_TPL_V3,
   COMPOSE_EXTENSIONS_TPL_V3,
   DEFAULT_DEVELOPER,
 } from "../../src/component/resource/appManifest/constants";
 import { manifestUtils } from "../../src/component/resource/appManifest/utils/ManifestUtils";
+import { Bot } from "../../src/component/resource/appManifest/interfaces/bot";
+import { ConfigurableTab } from "../../src/component/resource/appManifest/interfaces/configurableTab";
+import {
+  CommandScope,
+  MeetingsContext,
+} from "../../src/component/resource/appManifest/utils/utils";
+import { StaticTab } from "../../src/component/resource/appManifest/interfaces/staticTab";
+import { MessagingExtension } from "../../src/component/resource/appManifest/interfaces/messagingExtension";
+import {
+  BotOptionItem,
+  DefaultBotAndMessageExtensionItem,
+  MessageExtensionNewUIItem,
+  TabNonSsoAndDefaultBotItem,
+  TabNonSsoItem,
+} from "../../src/component/constants";
 
-describe("developPortalScaffoldUtils", () => {
+describe.only("developPortalScaffoldUtils", () => {
   describe("updateFilesForTdp", () => {
     const sandbox = sinon.createSandbox();
     class MockedWriteStream {
@@ -167,7 +186,7 @@ describe("developPortalScaffoldUtils", () => {
       let updateColor = false;
       let updateOutline = false;
       let updatedManifestData = "";
-      const unexpectedFile = false;
+
       sandbox.stub(appStudio, "getAppPackage").resolves(
         ok({
           manifest: Buffer.from(JSON.stringify(manifest)),
@@ -396,16 +415,136 @@ describe("developPortalScaffoldUtils", () => {
           termsOfUseUrl: "",
           name: "developer-name",
         },
+        bots: [],
+        validDomains: ["valid-domain"],
+      };
+
+      let updateManifest = false;
+      let updateLanguage = false;
+      let updateColor = false;
+      let updateOutline = false;
+      let updatedManifestData = "";
+      sandbox.stub(appStudio, "getAppPackage").resolves(
+        ok({
+          manifest: Buffer.from(JSON.stringify(manifest)),
+          icons: { color: Buffer.from(""), outline: Buffer.from("") },
+          languages: { zh: Buffer.from(JSON.stringify({})) },
+        })
+      );
+      sandbox.stub(fs, "writeFile").callsFake((file: number | fs.PathLike, data: any) => {
+        if (file === path.join(ctx.projectPath!, "appPackage", "resources", "color.png")) {
+          updateColor = true;
+        } else if (file === path.join(ctx.projectPath!, "appPackage", "resources", "outline.png")) {
+          updateOutline = true;
+        } else if (file === path.join(ctx.projectPath!, "appPackage", "zh.json")) {
+          updateLanguage = true;
+        } else if (file === path.join(ctx.projectPath!, "appPackage", "manifest.template.json")) {
+          updateManifest = true;
+          updatedManifestData = data;
+        } else {
+          throw new Error("not support " + file);
+        }
+      });
+
+      const mockWriteStream = new MockedWriteStream();
+      sandbox.stub(fs, "createWriteStream").returns(mockWriteStream as any);
+      const writeSpy = sandbox.stub(mockWriteStream, "write").resolves();
+      sandbox.stub(mockWriteStream, "end").resolves();
+      sandbox.stub(fs, "readFile").callsFake((file: number | fs.PathLike) => {
+        if (file === path.join(ctx.projectPath!, "teamsfx", ".env.local")) {
+          return Promise.resolve(Buffer.from("TEAMS_APP_ID=\nENV=\n"));
+        } else {
+          throw new Error("not support " + file);
+        }
+      });
+      sandbox.stub(manifestUtils, "_readAppManifest").resolves(ok(existingManifest));
+      const res = await developerPortalScaffoldUtils.updateFilesForTdp(ctx, appDefinition, inputs);
+
+      chai.assert.isTrue(res.isOk());
+      chai.assert.isTrue(updateManifest);
+      chai.assert.isTrue(updateColor);
+      chai.assert.isTrue(updateOutline);
+      chai.assert.isTrue(updateLanguage);
+      const updatedManifest = JSON.parse(updatedManifestData) as TeamsAppManifest;
+      chai.assert.equal(updatedManifest.id, "${{TEAMS_APP_ID}}");
+      const expectedBots = BOTS_TPL_V3;
+      expectedBots[0].botId = "${{BOT_ID}}";
+      chai.assert.deepEqual(updatedManifest.bots![0], expectedBots[0]);
+      chai.assert.deepEqual(updatedManifest.composeExtensions![0], manifest.composeExtensions![0]);
+      chai.assert.equal(updatedManifest.developer.privacyUrl, DEFAULT_DEVELOPER.privacyUrl);
+      chai.assert.equal(updatedManifest.developer.termsOfUseUrl, DEFAULT_DEVELOPER.termsOfUseUrl);
+      chai.assert.equal(updatedManifest.developer.websiteUrl, DEFAULT_DEVELOPER.websiteUrl);
+      chai.assert.isTrue(updatedManifest.validDomains?.includes("valid-domain"));
+      chai.assert.isTrue(writeSpy.calledThrice);
+      chai.assert.isTrue(writeSpy.firstCall.firstArg.includes("TEAMS_APP_ID=mock-app-id"));
+    });
+
+    it("update bot id of message extension only", async () => {
+      const ctx = createContextV3();
+      ctx.tokenProvider = {
+        m365TokenProvider: new MockedM365Provider(),
+        azureAccountProvider: new MockedAzureAccountProvider(),
+      };
+      ctx.projectPath = "project-path";
+      const appDefinition: AppDefinition = {
+        appId: "mock-app-id",
+        teamsAppId: "mock-app-id",
+      };
+      const inputs: Inputs = {
+        platform: Platform.VSCode,
+        [CoreQuestionNames.ReplaceBotIds]: ["messageExtension"],
+      };
+      const manifest: TeamsAppManifest = {
+        manifestVersion: "version",
+        id: "mock-app-id",
+        name: { short: "short-name" },
+        description: { short: "", full: "" },
+        version: "version",
+        icons: { outline: "outline.png", color: "color.png" },
+        accentColor: "#ffffff",
+        developer: {
+          privacyUrl: "",
+          websiteUrl: "",
+          termsOfUseUrl: "",
+          name: "developer-name",
+        },
         bots: [
           {
-            botId: "{{BOT_ID}}",
-            scopes: ["personal", "team"],
-            supportsFiles: false,
-            isNotificationOnly: false,
-            commandLists: [
+            botId: "botId0",
+            scopes: ["personal"],
+            commandLists: [],
+          },
+        ],
+        composeExtensions: [
+          {
+            botId: "botId1",
+            commands: [],
+          },
+        ],
+      };
+
+      const existingManifest: TeamsAppManifest = {
+        manifestVersion: "version",
+        id: "mock-app-id",
+        name: { short: "short-name" },
+        description: { short: "", full: "" },
+        version: "version",
+        icons: { outline: "outline.png", color: "color.png" },
+        accentColor: "#ffffff",
+        developer: {
+          privacyUrl: "",
+          websiteUrl: "",
+          termsOfUseUrl: "",
+          name: "developer-name",
+        },
+        bots: [],
+        composeExtensions: [
+          {
+            botId: "botId1",
+            commands: [
               {
-                scopes: ["personal", "team", "groupchat"],
-                commands: [],
+                id: "commandId",
+                title: "commandTitle",
               },
             ],
           },
@@ -461,8 +600,11 @@ describe("developPortalScaffoldUtils", () => {
       chai.assert.isTrue(updateLanguage);
       const updatedManifest = JSON.parse(updatedManifestData) as TeamsAppManifest;
       chai.assert.equal(updatedManifest.id, "${{TEAMS_APP_ID}}");
-      chai.assert.deepEqual(updatedManifest.bots![0], existingManifest.bots![0]);
-      chai.assert.deepEqual(updatedManifest.composeExtensions![0], manifest.composeExtensions![0]);
+      chai.assert.deepEqual(updatedManifest.bots![0], manifest.bots![0]);
+      chai.assert.deepEqual(
+        updatedManifest.composeExtensions![0],
+        existingManifest.composeExtensions![0]
+      );
       chai.assert.equal(updatedManifest.developer.privacyUrl, DEFAULT_DEVELOPER.privacyUrl);
       chai.assert.equal(updatedManifest.developer.termsOfUseUrl, DEFAULT_DEVELOPER.termsOfUseUrl);
       chai.assert.equal(updatedManifest.developer.websiteUrl, DEFAULT_DEVELOPER.websiteUrl);
@@ -606,6 +748,110 @@ describe("developPortalScaffoldUtils", () => {
       chai.assert.isTrue(updatedManifest.validDomains?.includes("valid-domain"));
       chai.assert.isTrue(writeSpy.calledThrice);
       chai.assert.isTrue(writeSpy.firstCall.firstArg.includes("TEAMS_APP_ID=mock-app-id"));
+    });
+  });
+
+  describe("getTemplateId", () => {
+    const validBot: Bot = {
+      botId: "botId",
+      isNotificationOnly: false,
+      needsChannelSelector: false,
+      personalCommands: [{ title: "title", description: "description" }],
+      supportsFiles: false,
+      supportsCalling: false,
+      supportsVideo: false,
+      teamCommands: [{ title: "title", description: "description" }],
+      groupChatCommands: [{ title: "title", description: "description" }],
+      scopes: ["scope"],
+    };
+
+    const validConfigurableTabForTabCode: ConfigurableTab = {
+      objectId: "objId",
+      configurationUrl: "https://url",
+      canUpdateConfiguration: false,
+      scopes: [CommandScope.GroupChat],
+      context: [MeetingsContext.ChannelTab],
+      sharePointPreviewImage: "img",
+      supportedSharePointHosts: [],
+    };
+
+    const validStaticTab: StaticTab = {
+      objectId: "objId",
+      entityId: "entityId",
+      name: "tab",
+      contentUrl: "https://url",
+      websiteUrl: "https:/url",
+      scopes: [],
+      context: [],
+    };
+
+    const validMessagingExtension: MessagingExtension = {
+      objectId: "objId",
+      botId: "botId",
+      canUpdateConfiguration: true,
+      commands: [],
+      messageHandlers: [],
+    };
+
+    it("return TabNonSsoAndDefaultBot", () => {
+      const appDefinition: AppDefinition = {
+        teamsAppId: "id",
+        staticTabs: [validStaticTab],
+        messagingExtensions: [validMessagingExtension],
+      };
+
+      const res = getTemplateId(appDefinition);
+      chai.assert.equal(res, TabNonSsoAndDefaultBotItem.id);
+    });
+
+    it("return TabNonSso", () => {
+      const appDefinition: AppDefinition = {
+        teamsAppId: "id",
+        staticTabs: [validStaticTab],
+      };
+
+      const res = getTemplateId(appDefinition);
+      chai.assert.equal(res, TabNonSsoItem.id);
+    });
+
+    it("return DefaultBotAndMessageExtension", () => {
+      const appDefinition: AppDefinition = {
+        teamsAppId: "id",
+        bots: [validBot],
+        messagingExtensions: [validMessagingExtension],
+      };
+
+      const res = getTemplateId(appDefinition);
+      chai.assert.equal(res, DefaultBotAndMessageExtensionItem.id);
+    });
+
+    it("return MessageExtension", () => {
+      const appDefinition: AppDefinition = {
+        teamsAppId: "id",
+        messagingExtensions: [validMessagingExtension],
+      };
+
+      const res = getTemplateId(appDefinition);
+      chai.assert.equal(res, MessageExtensionNewUIItem.id);
+    });
+
+    it("return bot", () => {
+      const appDefinition: AppDefinition = {
+        teamsAppId: "id",
+        bots: [validBot],
+      };
+
+      const res = getTemplateId(appDefinition);
+      chai.assert.equal(res, BotOptionItem.id);
+    });
+
+    it("return undefined", () => {
+      const appDefinition: AppDefinition = {
+        teamsAppId: "id",
+      };
+
+      const res = getTemplateId(appDefinition);
+      chai.assert.isUndefined(res);
     });
   });
 });


### PR DESCRIPTION
- Since we have removed source code not required for bot from default-bot template, and removed code not needed for message extension from me template, we have added another template for a project with both bot and message extension capabilities. [chore: bot with me template by yuqizhou77 · Pull Request #7020 · OfficeDev/TeamsFx (github.com](https://github.com/OfficeDev/TeamsFx/pull/7020)
- This PR is to add this new template in code.