### PR TITLE
chore: add dev:teamsfx back for cli preview

### DIFF
--- a/templates/scenarios/js/command-and-response/.vscode/tasks.json
+++ b/templates/scenarios/js/command-and-response/.vscode/tasks.json
@@ -81,7 +81,7 @@
         {
             "label": "Start bot",
             "type": "shell",
-            "command": "node teamsfx/script/run.js . teamsfx/.env.local",
+            "command": "npm run dev:teamsfx",
             "isBackground": true,
             "options": {
                 "cwd": "${workspaceFolder}"

--- a/templates/scenarios/js/command-and-response/package.json.tpl
+++ b/templates/scenarios/js/command-and-response/package.json.tpl
@@ -9,6 +9,7 @@
     "license": "MIT",
     "main": "./src/index.js",
     "scripts": {
+        "dev:teamsfx": "node teamsfx/script/run.js . teamsfx/.env.local",
         "dev": "nodemon --inspect=9239 --signal SIGINT ./src/index.js",
         "start": "node ./src/index.js",
         "watch": "nodemon ./src/index.js",

--- a/templates/scenarios/js/default-bot-message-extension/.vscode/tasks.json
+++ b/templates/scenarios/js/default-bot-message-extension/.vscode/tasks.json
@@ -81,7 +81,7 @@
         {
             "label": "Start bot",
             "type": "shell",
-            "command": "node teamsfx/script/run.js . teamsfx/.env.local",
+            "command": "npm run dev:teamsfx",
             "isBackground": true,
             "options": {
                 "cwd": "${workspaceFolder}"

--- a/templates/scenarios/js/default-bot-message-extension/package.json.tpl
+++ b/templates/scenarios/js/default-bot-message-extension/package.json.tpl
@@ -12,6 +12,7 @@
     "license": "MIT",
     "main": "index.js",
     "scripts": {
+        "dev:teamsfx": "node teamsfx/script/run.js . teamsfx/.env.local",
         "dev": "nodemon --inspect=9239 --signal SIGINT ./index.js",
         "start": "node ./index.js",
         "watch": "nodemon ./index.js",

--- a/templates/scenarios/js/default-bot/.vscode/tasks.json
+++ b/templates/scenarios/js/default-bot/.vscode/tasks.json
@@ -81,7 +81,7 @@
         {
             "label": "Start bot",
             "type": "shell",
-            "command": "node teamsfx/script/run.js . teamsfx/.env.local",
+            "command": "npm run dev:teamsfx",
             "isBackground": true,
             "options": {
                 "cwd": "${workspaceFolder}"

--- a/templates/scenarios/js/default-bot/package.json.tpl
+++ b/templates/scenarios/js/default-bot/package.json.tpl
@@ -12,6 +12,7 @@
     "license": "MIT",
     "main": "index.js",
     "scripts": {
+        "dev:teamsfx": "node teamsfx/script/run.js . teamsfx/.env.local",
         "dev": "nodemon --inspect=9239 --signal SIGINT ./index.js",
         "start": "node ./index.js",
         "watch": "nodemon ./index.js",

--- a/templates/scenarios/js/m365-message-extension/.vscode/tasks.json
+++ b/templates/scenarios/js/m365-message-extension/.vscode/tasks.json
@@ -93,7 +93,7 @@
         {
             "label": "Start bot",
             "type": "shell",
-            "command": "node teamsfx/script/run.js . teamsfx/.env.local",
+            "command": "npm run dev:teamsfx",
             "isBackground": true,
             "options": {
                 "cwd": "${workspaceFolder}"

--- a/templates/scenarios/js/m365-message-extension/package.json.tpl
+++ b/templates/scenarios/js/m365-message-extension/package.json.tpl
@@ -12,6 +12,7 @@
   "license": "MIT",
   "main": "index.js",
   "scripts": {
+    "dev:teamsfx": "node teamsfx/script/run.js . teamsfx/.env.local",
     "dev": "nodemon --inspect=9239 --signal SIGINT ./index.js",
     "start": "node ./index.js",
     "watch": "nodemon ./index.js"

--- a/templates/scenarios/js/m365-tab/.vscode/tasks.json
+++ b/templates/scenarios/js/m365-tab/.vscode/tasks.json
@@ -64,7 +64,7 @@
         {
             "label": "Start frontend",
             "type": "shell",
-            "command": "node teamsfx/script/run.js . teamsfx/.env.local",
+            "command": "npm run dev:teamsfx",
             "isBackground": true,
             "options": {
                 "cwd": "${workspaceFolder}"

--- a/templates/scenarios/js/m365-tab/package.json.tpl
+++ b/templates/scenarios/js/m365-tab/package.json.tpl
@@ -24,6 +24,7 @@
         "@microsoft/teamsfx-run-utils": "alpha"
     },
     "scripts": {
+        "dev:teamsfx": "node teamsfx/script/run.js . teamsfx/.env.local",
         "start": "react-scripts start",
         "build": "react-scripts build",
         "eject": "react-scripts eject",

--- a/templates/scenarios/js/message-extension/.vscode/tasks.json
+++ b/templates/scenarios/js/message-extension/.vscode/tasks.json
@@ -81,7 +81,7 @@
         {
             "label": "Start bot",
             "type": "shell",
-            "command": "node teamsfx/script/run.js . teamsfx/.env.local",
+            "command": "npm run dev:teamsfx",
             "isBackground": true,
             "options": {
                 "cwd": "${workspaceFolder}"

--- a/templates/scenarios/js/message-extension/package.json.tpl
+++ b/templates/scenarios/js/message-extension/package.json.tpl
@@ -12,6 +12,7 @@
   "license": "MIT",
   "main": "index.js",
   "scripts": {
+    "dev:teamsfx": "node teamsfx/script/run.js . teamsfx/.env.local",
     "dev": "nodemon --inspect=9239 --signal SIGINT ./index.js",
     "start": "node ./index.js",
     "watch": "nodemon ./index.js",

--- a/templates/scenarios/js/non-sso-tab/.vscode/tasks.json
+++ b/templates/scenarios/js/non-sso-tab/.vscode/tasks.json
@@ -62,7 +62,7 @@
         {
             "label": "Start frontend",
             "type": "shell",
-            "command": "node teamsfx/script/run.js . teamsfx/.env.local",
+            "command": "npm run dev:teamsfx",
             "isBackground": true,
             "options": {
                 "cwd": "${workspaceFolder}"

--- a/templates/scenarios/js/non-sso-tab/package.json.tpl
+++ b/templates/scenarios/js/non-sso-tab/package.json.tpl
@@ -20,6 +20,7 @@
         "@microsoft/teamsfx-run-utils": "alpha"
     },
     "scripts": {
+        "dev:teamsfx": "node teamsfx/script/run.js . teamsfx/.env.local",
         "start": "react-scripts start",
         "build": "react-scripts build",
         "eject": "react-scripts eject",

--- a/templates/scenarios/js/notification-http-timer-trigger/.vscode/tasks.json
+++ b/templates/scenarios/js/notification-http-timer-trigger/.vscode/tasks.json
@@ -81,7 +81,7 @@
         {
             "label": "Start bot",
             "type": "shell",
-            "command": "node teamsfx/script/run.js . teamsfx/.env.local",
+            "command": "npm run dev:teamsfx",
             "isBackground": true,
             "options": {
                 "cwd": "${workspaceFolder}",

--- a/templates/scenarios/js/notification-http-timer-trigger/package.json.tpl
+++ b/templates/scenarios/js/notification-http-timer-trigger/package.json.tpl
@@ -8,6 +8,7 @@
     "author": "Microsoft",
     "license": "MIT",
     "scripts": {
+        "dev:teamsfx": "node teamsfx/script/run.js . teamsfx/.env.local",
         "dev": "func start --javascript --language-worker=\"--inspect=9239\" --port \"3978\" --cors \"*\"",
         "prepare-storage:teamsfx": "azurite --silent --location ./_storage_emulator --debug ./_storage_emulator/debug.log",
         "start": "npx func start",

--- a/templates/scenarios/js/notification-http-trigger/.vscode/tasks.json
+++ b/templates/scenarios/js/notification-http-trigger/.vscode/tasks.json
@@ -81,7 +81,7 @@
         {
             "label": "Start bot",
             "type": "shell",
-            "command": "node teamsfx/script/run.js . teamsfx/.env.local",
+            "command": "npm run dev:teamsfx",
             "isBackground": true,
             "options": {
                 "cwd": "${workspaceFolder}",

--- a/templates/scenarios/js/notification-http-trigger/package.json.tpl
+++ b/templates/scenarios/js/notification-http-trigger/package.json.tpl
@@ -8,6 +8,7 @@
     "author": "Microsoft",
     "license": "MIT",
     "scripts": {
+        "dev:teamsfx": "node teamsfx/script/run.js . teamsfx/.env.local",
         "dev": "func start --javascript --language-worker=\"--inspect=9239\" --port \"3978\" --cors \"*\"",
         "prepare-storage:teamsfx": "azurite --silent --location ./_storage_emulator --debug ./_storage_emulator/debug.log",
         "start": "npx func start",

--- a/templates/scenarios/js/notification-restify/.vscode/tasks.json
+++ b/templates/scenarios/js/notification-restify/.vscode/tasks.json
@@ -81,7 +81,7 @@
         {
             "label": "Start bot",
             "type": "shell",
-            "command": "node teamsfx/script/run.js . teamsfx/.env.local",
+            "command": "npm run dev:teamsfx",
             "isBackground": true,
             "options": {
                 "cwd": "${workspaceFolder}"

--- a/templates/scenarios/js/notification-restify/package.json.tpl
+++ b/templates/scenarios/js/notification-restify/package.json.tpl
@@ -9,6 +9,7 @@
     "license": "MIT",
     "main": "./src/index.js",
     "scripts": {
+        "dev:teamsfx": "node teamsfx/script/run.js . teamsfx/.env.local",
         "dev": "nodemon --inspect=9239 --signal SIGINT ./src/index.js",
         "start": "node ./src/index.js",
         "watch": "nodemon ./src/index.js",

--- a/templates/scenarios/js/notification-timer-trigger/.vscode/tasks.json
+++ b/templates/scenarios/js/notification-timer-trigger/.vscode/tasks.json
@@ -81,7 +81,7 @@
         {
             "label": "Start bot",
             "type": "shell",
-            "command": "node teamsfx/script/run.js . teamsfx/.env.local",
+            "command": "npm run dev:teamsfx",
             "isBackground": true,
             "options": {
                 "cwd": "${workspaceFolder}",

--- a/templates/scenarios/js/notification-timer-trigger/package.json.tpl
+++ b/templates/scenarios/js/notification-timer-trigger/package.json.tpl
@@ -8,6 +8,7 @@
     "author": "Microsoft",
     "license": "MIT",
     "scripts": {
+        "dev:teamsfx": "node teamsfx/script/run.js . teamsfx/.env.local",
         "dev": "func start --javascript --language-worker=\"--inspect=9239\" --port \"3978\" --cors \"*\"",
         "prepare-storage:teamsfx": "azurite --silent --location ./_storage_emulator --debug ./_storage_emulator/debug.log",
         "start": "npx func start",

--- a/templates/scenarios/js/sso-tab/.vscode/tasks.json
+++ b/templates/scenarios/js/sso-tab/.vscode/tasks.json
@@ -53,7 +53,7 @@
         {
             "label": "Start frontend",
             "type": "shell",
-            "command": "node teamsfx/script/run.js . teamsfx/.env.local",
+            "command": "npm run dev:teamsfx",
             "isBackground": true,
             "options": {
                 "cwd": "${workspaceFolder}"

--- a/templates/scenarios/js/sso-tab/package.json.tpl
+++ b/templates/scenarios/js/sso-tab/package.json.tpl
@@ -24,6 +24,7 @@
         "@microsoft/teamsfx-run-utils": "alpha"
     },
     "scripts": {
+        "dev:teamsfx": "node teamsfx/script/run.js . teamsfx/.env.local",
         "start": "react-scripts start",
         "build": "react-scripts build",
         "eject": "react-scripts eject",

--- a/templates/scenarios/js/workflow/.vscode/tasks.json
+++ b/templates/scenarios/js/workflow/.vscode/tasks.json
@@ -81,7 +81,7 @@
         {
             "label": "Start bot",
             "type": "shell",
-            "command": "node teamsfx/script/run.js . teamsfx/.env.local",
+            "command": "npm run dev:teamsfx",
             "isBackground": true,
             "options": {
                 "cwd": "${workspaceFolder}"

--- a/templates/scenarios/js/workflow/package.json.tpl
+++ b/templates/scenarios/js/workflow/package.json.tpl
@@ -9,6 +9,7 @@
     "license": "MIT",
     "main": "./src/index.js",
     "scripts": {
+        "dev:teamsfx": "node teamsfx/script/run.js . teamsfx/.env.local",
         "dev": "nodemon --inspect=9239 --signal SIGINT ./src/index.js",
         "start": "node ./src/index.js",
         "watch": "nodemon ./src/index.js",

--- a/templates/scenarios/ts/command-and-response/.vscode/tasks.json
+++ b/templates/scenarios/ts/command-and-response/.vscode/tasks.json
@@ -81,7 +81,7 @@
         {
             "label": "Start bot",
             "type": "shell",
-            "command": "node teamsfx/script/run.js . teamsfx/.env.local",
+            "command": "npm run dev:teamsfx",
             "isBackground": true,
             "options": {
                 "cwd": "${workspaceFolder}"

--- a/templates/scenarios/ts/command-and-response/package.json.tpl
+++ b/templates/scenarios/ts/command-and-response/package.json.tpl
@@ -9,6 +9,7 @@
     "license": "MIT",
     "main": "./lib/index.js",
     "scripts": {
+        "dev:teamsfx": "node teamsfx/script/run.js . teamsfx/.env.local",
         "dev": "nodemon --watch ./src --exec node --inspect=9239 --signal SIGINT -r ts-node/register ./src/index.ts",
         "build": "tsc --build && shx cp -r ./src/adaptiveCards ./lib/src",
         "start": "node ./lib/src/index.js",

--- a/templates/scenarios/ts/default-bot-message-extension/.vscode/tasks.json
+++ b/templates/scenarios/ts/default-bot-message-extension/.vscode/tasks.json
@@ -81,7 +81,7 @@
         {
             "label": "Start bot",
             "type": "shell",
-            "command": "node teamsfx/script/run.js . teamsfx/.env.local",
+            "command": "npm run dev:teamsfx",
             "isBackground": true,
             "options": {
                 "cwd": "${workspaceFolder}"

--- a/templates/scenarios/ts/default-bot-message-extension/package.json.tpl
+++ b/templates/scenarios/ts/default-bot-message-extension/package.json.tpl
@@ -9,6 +9,7 @@
     "license": "MIT",
     "main": "./lib/index.js",
     "scripts": {
+        "dev:teamsfx": "node teamsfx/script/run.js . teamsfx/.env.local",
         "dev": "nodemon --exec node --inspect=9239 --signal SIGINT -r ts-node/register ./index.ts",
         "build": "tsc --build && shx cp -r ./adaptiveCards ./lib/",
         "start": "node ./lib/index.js",

--- a/templates/scenarios/ts/default-bot/.vscode/tasks.json
+++ b/templates/scenarios/ts/default-bot/.vscode/tasks.json
@@ -81,7 +81,7 @@
         {
             "label": "Start bot",
             "type": "shell",
-            "command": "node teamsfx/script/run.js . teamsfx/.env.local",
+            "command": "npm run dev:teamsfx",
             "isBackground": true,
             "options": {
                 "cwd": "${workspaceFolder}"

--- a/templates/scenarios/ts/default-bot/package.json.tpl
+++ b/templates/scenarios/ts/default-bot/package.json.tpl
@@ -9,6 +9,7 @@
     "license": "MIT",
     "main": "./lib/index.js",
     "scripts": {
+        "dev:teamsfx": "node teamsfx/script/run.js . teamsfx/.env.local",
         "dev": "nodemon --exec node --inspect=9239 --signal SIGINT -r ts-node/register ./index.ts",
         "build": "tsc --build && shx cp -r ./adaptiveCards ./lib/",
         "start": "node ./lib/index.js",

--- a/templates/scenarios/ts/m365-message-extension/.vscode/tasks.json
+++ b/templates/scenarios/ts/m365-message-extension/.vscode/tasks.json
@@ -93,7 +93,7 @@
         {
             "label": "Start bot",
             "type": "shell",
-            "command": "node teamsfx/script/run.js . teamsfx/.env.local",
+            "command": "npm run dev:teamsfx",
             "isBackground": true,
             "options": {
                 "cwd": "${workspaceFolder}"

--- a/templates/scenarios/ts/m365-message-extension/package.json.tpl
+++ b/templates/scenarios/ts/m365-message-extension/package.json.tpl
@@ -9,6 +9,7 @@
     "license": "MIT",
     "main": "./lib/index.js",
     "scripts": {
+        "dev:teamsfx": "node teamsfx/script/run.js . teamsfx/.env.local",
         "dev": "nodemon --exec node --inspect=9239 --signal SIGINT -r ts-node/register ./index.ts",
         "build": "tsc --build",
         "start": "node ./lib/index.js",

--- a/templates/scenarios/ts/m365-tab/.vscode/tasks.json
+++ b/templates/scenarios/ts/m365-tab/.vscode/tasks.json
@@ -64,7 +64,7 @@
         {
             "label": "Start frontend",
             "type": "shell",
-            "command": "node teamsfx/script/run.js . teamsfx/.env.local",
+            "command": "npm run dev:teamsfx",
             "isBackground": true,
             "options": {
                 "cwd": "${workspaceFolder}"

--- a/templates/scenarios/ts/m365-tab/package.json.tpl
+++ b/templates/scenarios/ts/m365-tab/package.json.tpl
@@ -29,6 +29,7 @@
         "typescript": "^4.1.2"
     },
     "scripts": {
+        "dev:teamsfx": "node teamsfx/script/run.js . teamsfx/.env.local",
         "start": "react-scripts start",
         "build": "react-scripts build",
         "eject": "react-scripts eject",

--- a/templates/scenarios/ts/message-extension/.vscode/tasks.json
+++ b/templates/scenarios/ts/message-extension/.vscode/tasks.json
@@ -81,7 +81,7 @@
         {
             "label": "Start bot",
             "type": "shell",
-            "command": "node teamsfx/script/run.js . teamsfx/.env.local",
+            "command": "npm run dev:teamsfx",
             "isBackground": true,
             "options": {
                 "cwd": "${workspaceFolder}"

--- a/templates/scenarios/ts/message-extension/package.json.tpl
+++ b/templates/scenarios/ts/message-extension/package.json.tpl
@@ -9,6 +9,7 @@
     "license": "MIT",
     "main": "./lib/index.js",
     "scripts": {
+        "dev:teamsfx": "node teamsfx/script/run.js . teamsfx/.env.local",
         "dev": "nodemon --exec node --inspect=9239 --signal SIGINT -r ts-node/register ./index.ts",
         "build": "tsc --build && shx cp -r ./adaptiveCards ./lib/",
         "start": "node ./lib/index.js",

--- a/templates/scenarios/ts/non-sso-tab/.vscode/tasks.json
+++ b/templates/scenarios/ts/non-sso-tab/.vscode/tasks.json
@@ -62,7 +62,7 @@
         {
             "label": "Start frontend",
             "type": "shell",
-            "command": "node teamsfx/script/run.js . teamsfx/.env.local",
+            "command": "npm run dev:teamsfx",
             "isBackground": true,
             "options": {
                 "cwd": "${workspaceFolder}"

--- a/templates/scenarios/ts/non-sso-tab/package.json.tpl
+++ b/templates/scenarios/ts/non-sso-tab/package.json.tpl
@@ -25,6 +25,7 @@
         "typescript": "^4.1.2"
     },
     "scripts": {
+        "dev:teamsfx": "node teamsfx/script/run.js . teamsfx/.env.local",
         "start": "react-scripts start",
         "build": "react-scripts build",
         "eject": "react-scripts eject",

--- a/templates/scenarios/ts/notification-http-timer-trigger/.vscode/tasks.json
+++ b/templates/scenarios/ts/notification-http-timer-trigger/.vscode/tasks.json
@@ -81,7 +81,7 @@
         {
             "label": "Start bot",
             "type": "shell",
-            "command": "node teamsfx/script/run.js . teamsfx/.env.local",
+            "command": "npm run dev:teamsfx",
             "isBackground": true,
             "options": {
                 "cwd": "${workspaceFolder}",

--- a/templates/scenarios/ts/notification-http-timer-trigger/package.json.tpl
+++ b/templates/scenarios/ts/notification-http-timer-trigger/package.json.tpl
@@ -8,6 +8,7 @@
     "author": "Microsoft",
     "license": "MIT",
     "scripts": {
+        "dev:teamsfx": "node teamsfx/script/run.js . teamsfx/.env.local",
         "dev": "func start --typescript --language-worker=\"--inspect=9239\" --port \"3978\" --cors \"*\"",
         "prepare-storage:teamsfx": "azurite --silent --location ./_storage_emulator --debug ./_storage_emulator/debug.log",
         "watch:teamsfx": "tsc --watch",

--- a/templates/scenarios/ts/notification-http-trigger/.vscode/tasks.json
+++ b/templates/scenarios/ts/notification-http-trigger/.vscode/tasks.json
@@ -81,7 +81,7 @@
         {
             "label": "Start bot",
             "type": "shell",
-            "command": "node teamsfx/script/run.js . teamsfx/.env.local",
+            "command": "npm run dev:teamsfx",
             "isBackground": true,
             "options": {
                 "cwd": "${workspaceFolder}",

--- a/templates/scenarios/ts/notification-http-trigger/package.json.tpl
+++ b/templates/scenarios/ts/notification-http-trigger/package.json.tpl
@@ -8,6 +8,7 @@
     "author": "Microsoft",
     "license": "MIT",
     "scripts": {
+        "dev:teamsfx": "node teamsfx/script/run.js . teamsfx/.env.local",
         "dev": "func start --typescript --language-worker=\"--inspect=9239\" --port \"3978\" --cors \"*\"",
         "prepare-storage:teamsfx": "azurite --silent --location ./_storage_emulator --debug ./_storage_emulator/debug.log",
         "watch:teamsfx": "tsc --watch",

--- a/templates/scenarios/ts/notification-restify/.vscode/tasks.json
+++ b/templates/scenarios/ts/notification-restify/.vscode/tasks.json
@@ -81,7 +81,7 @@
         {
             "label": "Start bot",
             "type": "shell",
-            "command": "node teamsfx/script/run.js . teamsfx/.env.local",
+            "command": "npm run dev:teamsfx",
             "isBackground": true,
             "options": {
                 "cwd": "${workspaceFolder}"

--- a/templates/scenarios/ts/notification-restify/package.json.tpl
+++ b/templates/scenarios/ts/notification-restify/package.json.tpl
@@ -9,6 +9,7 @@
     "license": "MIT",
     "main": "./lib/index.js",
     "scripts": {
+        "dev:teamsfx": "node teamsfx/script/run.js . teamsfx/.env.local",
         "dev": "nodemon --watch ./src --exec node --inspect=9239 --signal SIGINT -r ts-node/register ./src/index.ts",
         "build": "tsc --build && shx cp -r ./src/adaptiveCards ./lib/src",
         "start": "node ./lib/src/index.js",

--- a/templates/scenarios/ts/notification-timer-trigger/.vscode/tasks.json
+++ b/templates/scenarios/ts/notification-timer-trigger/.vscode/tasks.json
@@ -81,7 +81,7 @@
         {
             "label": "Start bot",
             "type": "shell",
-            "command": "node teamsfx/script/run.js . teamsfx/.env.local",
+            "command": "npm run dev:teamsfx",
             "isBackground": true,
             "options": {
                 "cwd": "${workspaceFolder}",

--- a/templates/scenarios/ts/notification-timer-trigger/package.json.tpl
+++ b/templates/scenarios/ts/notification-timer-trigger/package.json.tpl
@@ -8,6 +8,7 @@
     "author": "Microsoft",
     "license": "MIT",
     "scripts": {
+        "dev:teamsfx": "node teamsfx/script/run.js . teamsfx/.env.local",
         "dev": "func start --typescript --language-worker=\"--inspect=9239\" --port \"3978\" --cors \"*\"",
         "prepare-storage:teamsfx": "azurite --silent --location ./_storage_emulator --debug ./_storage_emulator/debug.log",
         "watch:teamsfx": "tsc --watch",

--- a/templates/scenarios/ts/sso-tab/.vscode/tasks.json
+++ b/templates/scenarios/ts/sso-tab/.vscode/tasks.json
@@ -53,7 +53,7 @@
         {
             "label": "Start frontend",
             "type": "shell",
-            "command": "node teamsfx/script/run.js . teamsfx/.env.local",
+            "command": "npm run dev:teamsfx",
             "isBackground": true,
             "options": {
                 "cwd": "${workspaceFolder}"

--- a/templates/scenarios/ts/sso-tab/package.json.tpl
+++ b/templates/scenarios/ts/sso-tab/package.json.tpl
@@ -29,6 +29,7 @@
         "typescript": "^4.1.2"
     },
     "scripts": {
+        "dev:teamsfx": "node teamsfx/script/run.js . teamsfx/.env.local",
         "start": "react-scripts start",
         "build": "react-scripts build",
         "eject": "react-scripts eject",

--- a/templates/scenarios/ts/workflow/.vscode/tasks.json
+++ b/templates/scenarios/ts/workflow/.vscode/tasks.json
@@ -81,7 +81,7 @@
         {
             "label": "Start bot",
             "type": "shell",
-            "command": "node teamsfx/script/run.js . teamsfx/.env.local",
+            "command": "npm run dev:teamsfx",
             "isBackground": true,
             "options": {
                 "cwd": "${workspaceFolder}"

--- a/templates/scenarios/ts/workflow/package.json.tpl
+++ b/templates/scenarios/ts/workflow/package.json.tpl
@@ -9,6 +9,7 @@
     "license": "MIT",
     "main": "./src/index.js",
     "scripts": {
+        "dev:teamsfx": "node teamsfx/script/run.js . teamsfx/.env.local",
         "dev": "nodemon --watch ./src --exec node --inspect=9239 --signal SIGINT -r ts-node/register ./src/index.ts",
         "build": "tsc --build && shx cp -r ./src/adaptiveCards ./lib/src",
         "start": "node ./lib/src/index.js",


### PR DESCRIPTION
Add npm script `dev:teamsfx` back to be called by both F5 and cli preview.

This only affects those single-capability V3 templates.
For multi-capabilities templates, still call run script directly. (CLI preview requires additional `run-command` input)
For SPFx templates, still call gulp script. (CLI preview requires additional `run-command` input)