### PR TITLE
chore(abtest): update template wording for add feature

### DIFF
--- a/packages/fx-core/src/component/question.ts
+++ b/packages/fx-core/src/component/question.ts
@@ -251,6 +251,22 @@ export async function getQuestionsForAddFeatureV3(
   ctx: v2.Context,
   inputs: Inputs
 ): Promise<Result<QTreeNode | undefined, FxError>> {
+  // AB test for notification/command/workflow bot template naming
+  if (inputs?.taskOrientedTemplateNaming) {
+    NotificationOptionItem.label = `$(hubot) ${getLocalizedString(
+      "core.NotificationOption.label.abTest"
+    )}`;
+    NotificationOptionItem.detail = getLocalizedString("core.NotificationOption.detail.abTest");
+    CommandAndResponseOptionItem.label = `$(hubot) ${getLocalizedString(
+      "core.CommandAndResponseOption.label.abTest"
+    )}`;
+    CommandAndResponseOptionItem.detail = getLocalizedString(
+      "core.CommandAndResponseOption.detail.abTest"
+    );
+    WorkflowOptionItem.label = `$(hubot) ${getLocalizedString("core.WorkflowOption.label.abTest")}`;
+    WorkflowOptionItem.detail = getLocalizedString("core.WorkflowOption.detail.abTest");
+  }
+
   const question: SingleSelectQuestion = {
     name: AzureSolutionQuestionNames.Features,
     title: getLocalizedString("core.addFeatureQuestion.title"),

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -1190,6 +1190,7 @@ export async function runUserTask(
     inputs = getSystemInputs();
     inputs.ignoreEnvInfo = ignoreEnvInfo;
     inputs.env = envName;
+    inputs.taskOrientedTemplateNaming = TreatmentVariableValue.taskOrientedTemplateNaming;
     result = await core.executeUserTask(func, inputs);
   } catch (e) {
     result = wrapError(e);


### PR DESCRIPTION
Keep consistent behavior for `Add feature` and `Scaffold` naming AB test.

work item: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/16370676/