### PR TITLE
chore: detect env for package service

### DIFF
--- a/packages/cli/src/cmds/m365/packageService.ts
+++ b/packages/cli/src/cmds/m365/packageService.ts
@@ -14,11 +14,35 @@ import { sleep } from "../../utils";
 
 export class PackageService {
   private readonly axiosInstance;
+  private readonly initEndpoint;
+
   public constructor(endpoint: string) {
     this.axiosInstance = axios.create({
-      baseURL: endpoint,
       timeout: 30000,
     });
+    this.initEndpoint = endpoint;
+  }
+
+  private async getTitleServiceUrl(token: string): Promise<string> {
+    try {
+      const envInfo = await this.axiosInstance.get("/config/v1/environment", {
+        baseURL: this.initEndpoint,
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+      CLILogProvider.debug(JSON.stringify(envInfo.data));
+      return envInfo.data.titlesServiceUrl;
+    } catch (error: any) {
+      CLILogProvider.necessaryLog(LogLevel.Error, "Get ServiceUrl failed.");
+      if (error.response) {
+        CLILogProvider.necessaryLog(LogLevel.Error, JSON.stringify(error.response.data));
+      } else {
+        CLILogProvider.necessaryLog(LogLevel.Error, error.message);
+      }
+
+      throw error;
+    }
   }
 
   public async sideLoading(token: string, manifestPath: string): Promise<void> {
@@ -26,6 +50,7 @@ export class PackageService {
       const data = await fs.readFile(manifestPath);
       const content = new FormData();
       content.append("package", data);
+      const serviceUrl = await this.getTitleServiceUrl(token);
       CLILogProvider.necessaryLog(LogLevel.Info, "Uploading package ...");
       const uploadHeaders = content.getHeaders();
       uploadHeaders["Authorization"] = `Bearer ${token}`;
@@ -33,6 +58,7 @@ export class PackageService {
         "/dev/v1/users/packages",
         content.getBuffer(),
         {
+          baseURL: serviceUrl,
           headers: uploadHeaders,
         }
       );
@@ -48,6 +74,7 @@ export class PackageService {
           operationId: operationId,
         },
         {
+          baseURL: serviceUrl,
           headers: {
             Authorization: `Bearer ${token}`,
           },
@@ -62,6 +89,7 @@ export class PackageService {
         const statusResponse = await this.axiosInstance.get(
           `/dev/v1/users/packages/status/${statusId}`,
           {
+            baseURL: serviceUrl,
             headers: { Authorization: `Bearer ${token}` },
           }
         );
@@ -79,6 +107,7 @@ export class PackageService {
       const launchInfo = await this.axiosInstance.get(
         `/catalog/v1/users/titles/${titleId}/launchInfo`,
         {
+          baseURL: serviceUrl,
           params: {
             SupportedElementTypes:
               // eslint-disable-next-line no-secrets/no-secrets
@@ -104,6 +133,7 @@ export class PackageService {
 
   public async retrieveTitleId(token: string, manifestId: string): Promise<string> {
     try {
+      const serviceUrl = await this.getTitleServiceUrl(token);
       CLILogProvider.necessaryLog(LogLevel.Info, "Retrieve TitleId ...");
       const launchInfo = await this.axiosInstance.post(
         `/catalog/v1/users/titles/launchInfo`,
@@ -130,6 +160,7 @@ export class PackageService {
           },
         },
         {
+          baseURL: serviceUrl,
           headers: {
             Authorization: `Bearer ${token}`,
           },
@@ -155,8 +186,10 @@ export class PackageService {
 
   public async unacquire(token: string, titleId: string): Promise<void> {
     try {
+      const serviceUrl = await this.getTitleServiceUrl(token);
       CLILogProvider.necessaryLog(LogLevel.Info, `Unacquiring package with TitleId ${titleId} ...`);
       await this.axiosInstance.delete(`/catalog/v1/users/acquisitions/${titleId}`, {
+        baseURL: serviceUrl,
         headers: {
           Authorization: `Bearer ${token}`,
         },
@@ -176,10 +209,12 @@ export class PackageService {
 
   public async getLaunchInfo(token: string, titleId: string): Promise<unknown> {
     try {
+      const serviceUrl = await this.getTitleServiceUrl(token);
       CLILogProvider.necessaryLog(LogLevel.Info, `Getting LaunchInfo with TitleId ${titleId} ...`);
       const launchInfo = await this.axiosInstance.get(
         `/catalog/v1/users/titles/${titleId}/launchInfo`,
         {
+          baseURL: serviceUrl,
           params: {
             SupportedElementTypes:
               // eslint-disable-next-line no-secrets/no-secrets

--- a/packages/cli/src/cmds/m365/packageService.ts
+++ b/packages/cli/src/cmds/m365/packageService.ts
@@ -34,13 +34,7 @@ export class PackageService {
       CLILogProvider.debug(JSON.stringify(envInfo.data));
       return envInfo.data.titlesServiceUrl;
     } catch (error: any) {
-      CLILogProvider.necessaryLog(LogLevel.Error, "Get ServiceUrl failed.");
-      if (error.response) {
-        CLILogProvider.necessaryLog(LogLevel.Error, JSON.stringify(error.response.data));
-      } else {
-        CLILogProvider.necessaryLog(LogLevel.Error, error.message);
-      }
-
+      CLILogProvider.necessaryLog(LogLevel.Error, `Get ServiceUrl failed. ${error.message}`);
       throw error;
     }
   }

--- a/packages/cli/tests/unit/cmds/m365/m365.tests.ts
+++ b/packages/cli/tests/unit/cmds/m365/m365.tests.ts
@@ -94,6 +94,11 @@ describe("M365", () => {
     const sideloading = m365.subCommands.find((cmd) => cmd.commandHead === "sideloading");
     expect(sideloading).not.undefined;
 
+    axiosGetResponses["/config/v1/environment"] = {
+      data: {
+        titlesServiceUrl: "test-url",
+      },
+    };
     axiosPostResponses["/dev/v1/users/packages"] = {
       data: {
         operationId: "test-operation-id",
@@ -127,6 +132,11 @@ describe("M365", () => {
     const unacquire = m365.subCommands.find((cmd) => cmd.commandHead === "unacquire");
     expect(unacquire).not.undefined;
 
+    axiosGetResponses["/config/v1/environment"] = {
+      data: {
+        titlesServiceUrl: "test-url",
+      },
+    };
     axiosDeleteResponses["/catalog/v1/users/acquisitions/test-title-id"] = {
       status: 200,
     };
@@ -142,6 +152,11 @@ describe("M365", () => {
     const unacquire = m365.subCommands.find((cmd) => cmd.commandHead === "unacquire");
     expect(unacquire).not.undefined;
 
+    axiosGetResponses["/config/v1/environment"] = {
+      data: {
+        titlesServiceUrl: "test-url",
+      },
+    };
     axiosPostResponses["/catalog/v1/users/titles/launchInfo"] = {
       data: {
         acquisition: {
@@ -166,6 +181,11 @@ describe("M365", () => {
     const launchInfo = m365.subCommands.find((cmd) => cmd.commandHead === "launchinfo");
     expect(launchInfo).not.undefined;
 
+    axiosGetResponses["/config/v1/environment"] = {
+      data: {
+        titlesServiceUrl: "test-url",
+      },
+    };
     axiosGetResponses["/catalog/v1/users/titles/test-title-id/launchInfo"] = {
       data: {
         foo: "bar",
@@ -183,6 +203,11 @@ describe("M365", () => {
     const launchInfo = m365.subCommands.find((cmd) => cmd.commandHead === "launchinfo");
     expect(launchInfo).not.undefined;
 
+    axiosGetResponses["/config/v1/environment"] = {
+      data: {
+        titlesServiceUrl: "test-url",
+      },
+    };
     axiosPostResponses["/catalog/v1/users/titles/launchInfo"] = {
       data: {
         acquisition: {

--- a/packages/cli/tests/unit/cmds/m365/packageService.tests.ts
+++ b/packages/cli/tests/unit/cmds/m365/packageService.tests.ts
@@ -26,6 +26,13 @@ describe("Package Service", () => {
       return Promise.reject(new Error("test-delete"));
     },
     get: function <T = any, R = AxiosResponse<T>>(url: string): Promise<R> {
+      if (url.includes("config/v1/environment")) {
+        return Promise.resolve({
+          data: {
+            titlesServiceUrl: "test-url",
+          },
+        } as any);
+      }
       return Promise.reject(new Error("test-get"));
     },
     post: function <T = any, R = AxiosResponse<T>>(

--- a/packages/cli/tests/unit/cmds/m365/packageService.tests.ts
+++ b/packages/cli/tests/unit/cmds/m365/packageService.tests.ts
@@ -13,6 +13,7 @@ import { PackageService } from "../../../../src/cmds/m365/packageService";
 describe("Package Service", () => {
   const sandbox = sinon.createSandbox();
   let logs: string[] = [];
+  let serviceUrlError: Error | undefined = undefined;
   const testAxiosInstance = {
     defaults: {
       headers: {
@@ -27,11 +28,13 @@ describe("Package Service", () => {
     },
     get: function <T = any, R = AxiosResponse<T>>(url: string): Promise<R> {
       if (url.includes("config/v1/environment")) {
-        return Promise.resolve({
-          data: {
-            titlesServiceUrl: "test-url",
-          },
-        } as any);
+        return serviceUrlError !== undefined
+          ? Promise.reject(serviceUrlError)
+          : Promise.resolve({
+              data: {
+                titlesServiceUrl: "test-url",
+              },
+            } as any);
       }
       return Promise.reject(new Error("test-get"));
     },
@@ -50,6 +53,7 @@ describe("Package Service", () => {
 
   beforeEach(() => {
     logs = [];
+    serviceUrlError = undefined;
     sandbox.stub(CLILogProvider, "necessaryLog").callsFake((level: LogLevel, message: string) => {
       logs.push(message);
     });
@@ -112,5 +116,19 @@ describe("Package Service", () => {
 
     expect(actualError).not.undefined;
     expect(actualError?.message).equals("test-get");
+  });
+
+  it("getTitleServiceUrl throws expected error", async () => {
+    serviceUrlError = new Error("test-service-url-error");
+    const packageService = new PackageService("test-endpoint");
+    let actualError: Error | undefined;
+    try {
+      await packageService.getLaunchInfo("test-token", "test-title-id");
+    } catch (error: any) {
+      actualError = error;
+    }
+
+    expect(actualError).not.undefined;
+    expect(actualError?.message).equals("test-service-url-error");
   });
 });


### PR DESCRIPTION
According to package service, need to call `/config/v1/environment` to detect service url by tenant.