### PR TITLE
fix: .env.teamsfx.local path for video filter app for cert

### DIFF
--- a/packages/cli/src/cmds/preview/preview.ts
+++ b/packages/cli/src/cmds/preview/preview.ts
@@ -366,7 +366,7 @@ export default class Preview extends YargsCommand {
 
         // check cert
         if (includeFrontend) {
-          const certRes = await this.resolveLocalCertificate(localEnvManager);
+          const certRes = await this.resolveLocalCertificate(workspaceFolder, localEnvManager);
           if (certRes.isErr()) {
             return err(certRes.error);
           }
@@ -1513,6 +1513,7 @@ export default class Preview extends YargsCommand {
   }
 
   private async resolveLocalCertificate(
+    workspaceFolder: string,
     localEnvManager: LocalEnvManager
   ): Promise<Result<null, FxError>> {
     return localTelemetryReporter.runWithTelemetry(
@@ -1526,7 +1527,10 @@ export default class Preview extends YargsCommand {
         await certBar.next(ProgressMessage[Checker.LocalCertificate]);
         try {
           const trustDevCert = await isTrustDevCertEnabled();
-          const localCertResult = await localEnvManager.resolveLocalCertificate(trustDevCert);
+          const localCertResult = await localEnvManager.resolveLocalCertificate(
+            workspaceFolder,
+            trustDevCert
+          );
           // trust cert telemetry properties
           ctx.properties[TelemetryProperty.PreviewDevCertStatus] = !trustDevCert
             ? TelemetryPreviewDevCertStatus.Disabled

--- a/packages/fx-core/src/common/local/constants.ts
+++ b/packages/fx-core/src/common/local/constants.ts
@@ -7,6 +7,7 @@ export class FolderName {
   static readonly Bot = "bot";
   static readonly Function = "api";
   static readonly SPFx = "SPFx";
+  static readonly VideoFilter = "app";
 }
 
 export const baseNpmInstallCommand = "npm install";

--- a/packages/fx-core/src/component/debugHandler/localEnvProvider.ts
+++ b/packages/fx-core/src/component/debugHandler/localEnvProvider.ts
@@ -65,6 +65,13 @@ export const LocalEnvKeys = Object.freeze({
       SqlIdentityId: "IDENTITY_ID",
     },
   },
+  videoFilterApp: {
+    template: {
+      SslCrtFile: "SSL_CRT_FILE",
+      SslKeyFile: "SSL_KEY_FILE",
+    },
+    teamsfx: {},
+  },
 });
 
 const frontendTemplateComment =
@@ -75,6 +82,8 @@ const teamsfxComment =
   "# TeamsFx will overwrite the following variable values when running debug. They are used by TeamsFx SDK.";
 const customizedComment =
   "# Following variables can be customized or you can add your owns." + os.EOL + "# FOO=BAR";
+const videoFilterAppTemplateComment =
+  "# TeamsFx will overwrite the following variable values when running debug. They are used by Vite.";
 
 export class LocalEnvProvider {
   public static readonly LocalEnvFileName: string = ".env.teamsfx.local";
@@ -109,6 +118,14 @@ export class LocalEnvProvider {
     );
   }
 
+  public async loadVideoFilterLocalEnvs(): Promise<LocalEnvs> {
+    return await this.loadLocalEnvFile(
+      path.join(this.projectPath, FolderName.VideoFilter, LocalEnvProvider.LocalEnvFileName),
+      Object.values(LocalEnvKeys.videoFilterApp.template),
+      Object.values(LocalEnvKeys.videoFilterApp.teamsfx)
+    );
+  }
+
   public async saveFrontendLocalEnvs(envs: LocalEnvs): Promise<string> {
     return await this.saveLocalEnvFile(
       path.join(this.projectPath, FolderName.Frontend),
@@ -134,6 +151,16 @@ export class LocalEnvProvider {
       path.join(this.projectPath, FolderName.Bot),
       envs,
       botTemplateComment,
+      teamsfxComment,
+      customizedComment
+    );
+  }
+
+  public async saveVideoFilterLocalEnvs(envs: LocalEnvs): Promise<string> {
+    return await this.saveLocalEnvFile(
+      path.join(this.projectPath, FolderName.VideoFilter),
+      envs,
+      videoFilterAppTemplateComment,
       teamsfxComment,
       customizedComment
     );

--- a/packages/vscode-extension/src/debug/prerequisitesHandler.ts
+++ b/packages/vscode-extension/src/debug/prerequisitesHandler.ts
@@ -986,6 +986,7 @@ async function resolveLocalCertificate(
         const workspacePath = globalVariables.workspaceUri!.fsPath;
         const localEnvProvider = new LocalEnvProvider(workspacePath);
         const localCertResult = await localEnvManager.resolveLocalCertificate(
+          workspacePath,
           trustDevCert,
           localEnvProvider
         );


### PR DESCRIPTION
Previously after F5, `.env.teamsfx.local` will be generated in `tabs` folder which should be in `app` folder for video filter. This will cause ssl cert not loaded in Vite which cause video filter failing to load.

![img](https://user-images.githubusercontent.com/9698542/207227874-e7a6a956-182f-4119-b5fd-9348c36d3595.png)

Tested on Windows
![img](https://user-images.githubusercontent.com/9698542/207227976-0d26dd23-fc2a-4c14-9a1d-3f31f7542f21.png)
