### PR TITLE
chore: fix macOS executable name for vxTestApp checker

### DIFF
--- a/packages/fx-core/src/common/deps-checker/internal/vxTestAppChecker.ts
+++ b/packages/fx-core/src/common/deps-checker/internal/vxTestAppChecker.ts
@@ -14,7 +14,7 @@ import { DepsCheckerError, VxTestAppCheckError } from "../depsError";
 import { DepsLogger } from "../depsLogger";
 import { DepsTelemetry } from "../depsTelemetry";
 import { DepsChecker, DependencyStatus, DepsType, InstallOptions } from "../depsChecker";
-import { isWindows } from "../util";
+import { isMacOS, isWindows } from "../util";
 import { Messages, vxTestAppInstallHelpLink } from "../constant";
 
 interface InstallOptionsSafe {
@@ -24,9 +24,13 @@ interface InstallOptionsSafe {
 
 const VxTestAppName = "Video Extensibility Test App";
 
+// https://www.electronjs.org/docs/latest/tutorial/application-distribution#manual-packaging
 const VxTestAppExecutableName = isWindows()
   ? "video-extensibility-test-app.exe"
+  : isMacOS()
+  ? "video-extensibility-test-app.app"
   : "video-extensibility-test-app";
+
 const VxTestAppDirRelPath = path.join(".tools", "video-extensibility-test-app");
 const VxTestAppGlobalBasePath = path.join(
   os.homedir(),


### PR DESCRIPTION
The executable file path of test app is different on macOS. [Also](https://www.electronjs.org/docs/latest/tutorial/application-distribution#with-prebuilt-binaries)

![image](https://user-images.githubusercontent.com/9698542/207240979-16dc4473-8221-401a-a019-baa393ca6055.png)
