### PR TITLE
chore: prepare templates for cicd how to guides

### DIFF
--- a/.github/detect/excludes.txt
+++ b/.github/detect/excludes.txt
@@ -25,6 +25,7 @@ templates/bot/js/default/adaptiveCards/learn.json
 templates/bot/ts/default/adaptiveCards/learn.json
 docs/cicd/README.md
 docs/cicd_insider/README.md
+docs/cicd/azdo/*.yml
 .github/scripts/download-simpleauth.sh
 packages/fx-core/tests/common/local/localCertificateManager.test.ts
 packages/sdk/test/unit/node/appCredential.spec.ts

--- a/docs/cicd/azdo/cd.azure.yml
+++ b/docs/cicd/azdo/cd.azure.yml
@@ -1,0 +1,50 @@
+# This is just an example workflow for continuous deployment.
+# You should customize it to meet your own requirements.
+trigger:
+# When new commits are pushed onto the main branch.
+- main 
+
+pool:
+  vmImage: ubuntu-latest
+
+steps:
+# Setup environment.
+- task: NodeTool@0
+  inputs:
+    versionSpec: '14.17.0'
+    checkLatest: true
+
+- task: Bash@3
+  env:
+    # To enable M365 account login by environment variables and non-interactive mode.
+    CI_ENABLED: 'true'
+    # To specify the environment name which will be used as an option below.
+    # You can change it to use your own environment name.
+    TEAMSFX_ENV_NAME: 'dev'
+    # To specify the version of TTK CLI for use.
+    TEAMSFX_CLI_VERSION: 1.*
+  inputs:
+    targetType: 'inline'
+    script: |
+      set -evuxo pipefail
+      
+      # Install the TTK CLI for later use.
+      npm install @microsoft/teamsfx-cli@${TEAMSFX_CLI_VERSION}
+
+      # Build the project.
+      # The way to build the current project depends on how you scaffold it.
+      # Different folder structures require different commands set.
+      # 'npm ci' may be used here to install dependencies and it depends on package-lock.json.
+      # If you prefer to use 'npm ci', please make sure to commit package-lock.json first, or just change it to 'npm install'.  
+      # cd bot; npm install; cd -;
+
+      # Run unit test.
+      # Currently, no opinioned solution for unit test provided during scaffolding, so,
+      # set up any unit test framework you prefer (for example, mocha or jest) and update the commands accordingly in below.
+      # npm run test
+
+      # Login Azure by service principal
+      npx teamsfx account login azure --service-principal --username $(AZURE_SERVICE_PRINCIPAL_NAME) --password $(AZURE_SERVICE_PRINCIPAL_PASSWORD) --tenant $(AZURE_TENANT_ID)
+
+      # Deploy to hosting environment.
+      npx teamsfx deploy --env ${TEAMSFX_ENV_NAME}

--- a/docs/cicd/azdo/cd.spfx.yml
+++ b/docs/cicd/azdo/cd.spfx.yml
@@ -1,0 +1,50 @@
+# This is just an example workflow for continuous deployment.
+# You should customize it to meet your own requirements.
+trigger:
+# When new commits are pushed onto the main branch.
+- main 
+
+pool:
+  vmImage: ubuntu-latest
+
+steps:
+# Setup environment.
+- task: NodeTool@0
+  inputs:
+    versionSpec: '14.17.0'
+    checkLatest: true
+
+- task: Bash@3
+  env:
+    M365_ACCOUNT_NAME: $(M365_ACCOUNT_NAME)
+    M365_ACCOUNT_PASSWORD: $(M365_ACCOUNT_PASSWORD)
+    M365_TENANT_ID: $(M365_TENANT_ID)
+    # To enable M365 account login by environment variables and non-interactive mode.
+    CI_ENABLED: 'true'
+    # To specify the environment name which will be used as an option below.
+    # You can change it to use your own environment name.
+    TEAMSFX_ENV_NAME: 'dev'
+    # To specify the version of TTK CLI for use.
+    TEAMSFX_CLI_VERSION: 1.*
+  inputs:
+    targetType: 'inline'
+    script: |
+      set -evuxo pipefail
+      
+      # Install the TTK CLI for later use.
+      npm install @microsoft/teamsfx-cli@${TEAMSFX_CLI_VERSION}
+
+      # Build the project.
+      # The way to build the current project depends on how you scaffold it.
+      # Different folder structures require different commands set.
+      # 'npm ci' may be used here to install dependencies and it depends on package-lock.json.
+      # If you prefer to use 'npm ci', please make sure to commit package-lock.json first, or just change it to 'npm install'.  
+      # cd bot; npm install; cd -;
+
+      # Run unit test.
+      # Currently, no opinioned solution for unit test provided during scaffolding, so,
+      # set up any unit test framework you prefer (for example, mocha or jest) and update the commands accordingly in below.
+      # npm run test
+
+      # Deploy to hosting environment.
+      npx teamsfx deploy --env ${TEAMSFX_ENV_NAME}

--- a/docs/cicd/azdo/ci.yml
+++ b/docs/cicd/azdo/ci.yml
@@ -1,0 +1,36 @@
+# This is just an example workflow for continuous integration.
+# You should customize it to meet your own requirements.
+pr:
+# When pull requests targeting the dev branch created.
+- dev 
+
+pool:
+  vmImage: ubuntu-latest
+
+steps:
+# Setup environment.
+- task: NodeTool@0
+  inputs:
+    versionSpec: '14.17.0'
+    checkLatest: true
+  
+- task: Bash@3
+  inputs:
+    targetType: 'inline'
+    script: |
+      set -evuxo pipefail
+
+      # This is just an example workflow for continuous integration.
+      # You should customize it to meet your own requirements.
+
+      # Build the project.
+      # The way to build the current project depends on how you scaffold it.
+      # Different folder structures require different commands set.
+      # 'npm ci' may be used here to install dependencies and it depends on package-lock.json.
+      # If you prefer to use 'npm ci', please make sure to commit package-lock.json first, or just change it to 'npm install'.
+      # cd bot; npm install; cd -;
+
+      # Run unit test.
+      # Currently, no opinionated solution for unit test provided during scaffolding, so,
+      # set up any unit test framework you prefer (for example, mocha or jest) and update the commands accordingly in below.
+      # npm run test

--- a/docs/cicd/azdo/provision.azure.yml
+++ b/docs/cicd/azdo/provision.azure.yml
@@ -1,0 +1,52 @@
+# This is just an example workflow for provision.
+# You should customize it to meet your own requirements.
+trigger: none
+# Manually trigger this workflow, and you should pick the right branch.
+
+pool:
+  vmImage: ubuntu-latest
+
+steps:
+# Setup environment.
+- task: NodeTool@0
+  inputs:
+    versionSpec: '14.17.0'
+    checkLatest: true
+
+# Check out
+- checkout: self
+  persistCredentials: true
+
+- task: Bash@3
+  env:
+    M365_ACCOUNT_NAME: $(M365_ACCOUNT_NAME)
+    M365_ACCOUNT_PASSWORD: $(M365_ACCOUNT_PASSWORD)
+    M365_TENANT_ID: $(M365_TENANT_ID)
+    CI_ENABLED: 'true'
+    # To specify the environment name which will be used as an option below.
+    # You can change it to use your own environment name.
+    TEAMSFX_ENV_NAME: 'dev' 
+    # To specify the version of TTK CLI for use.
+    TEAMSFX_CLI_VERSION: 1.*
+  inputs:
+    targetType: 'inline'
+    script: |
+      set -evuxo pipefail
+      
+      # Install the TTK CLI for later use.
+      npm install @microsoft/teamsfx-cli@${TEAMSFX_CLI_VERSION}
+  
+      # Login Azure by service principal
+      npx teamsfx account login azure --service-principal --username $(AZURE_SERVICE_PRINCIPAL_NAME) --password $(AZURE_SERVICE_PRINCIPAL_PASSWORD) --tenant $(AZURE_TENANT_ID)
+
+      # We suggest to do the `teamsfx provision` step manually or in a separate workflow. The following steps are for your reference.
+      # After provisioning, you should commit necessary files under .fx into the repository. 
+      npx teamsfx provision --subscription $(AZURE_SUBSCRIPTION_ID) --env ${TEAMSFX_ENV_NAME}
+
+      # Commit provision configs if necessary.
+      # To enable scripts to run git commands, check https://docs.microsoft.com/en-us/azure/devops/pipelines/scripts/git-commands?view=azure-devops&tabs=yaml
+      git config user.name "azdo-agent"
+      git config user.email "azdo-agent@azure.com"
+      git add .
+      git commit -m "chore: commit provision configs"
+      git push origin HEAD:${BUILD_SOURCEBRANCHNAME}

--- a/docs/cicd/azdo/provision.spfx.yml
+++ b/docs/cicd/azdo/provision.spfx.yml
@@ -1,0 +1,49 @@
+# This is just an example workflow for provision.
+# You should customize it to meet your own requirements.
+trigger: none
+# Manually trigger this workflow, and you should pick the right branch.
+
+pool:
+  vmImage: ubuntu-latest
+
+steps:
+# Setup environment.
+- task: NodeTool@0
+  inputs:
+    versionSpec: '14.17.0'
+    checkLatest: true
+
+# Check out
+- checkout: self
+  persistCredentials: true
+
+- task: Bash@3
+  env:
+    M365_ACCOUNT_NAME: $(M365_ACCOUNT_NAME)
+    M365_ACCOUNT_PASSWORD: $(M365_ACCOUNT_PASSWORD)
+    M365_TENANT_ID: $(M365_TENANT_ID)
+    CI_ENABLED: 'true'
+    # To specify the environment name which will be used as an option below.
+    # You can change it to use your own environment name.
+    TEAMSFX_ENV_NAME: 'dev'
+    # To specify the version of TTK CLI for use.
+    TEAMSFX_CLI_VERSION: 1.*
+  inputs:
+    targetType: 'inline'
+    script: |
+      set -evuxo pipefail
+      
+      # Install the TTK CLI for later use.
+      npm install @microsoft/teamsfx-cli@${TEAMSFX_CLI_VERSION}
+
+      # We suggest to do the `teamsfx provision` step manually or in a separate workflow. The following steps are for your reference.
+      # After provisioning, you should commit necessary files into the repository. 
+      npx teamsfx provision --env ${TEAMSFX_ENV_NAME}
+
+      # Commit provision configs if necessary.
+      # To enable scripts to run git commands, check https://docs.microsoft.com/en-us/azure/devops/pipelines/scripts/git-commands?view=azure-devops&tabs=yaml
+      git config user.name "azdo-agent"
+      git config user.email "azdo-agent@azure.com"
+      git add .
+      git commit -m "chore: commit provision configs"
+      git push origin HEAD:${BUILD_SOURCEBRANCHNAME}

--- a/docs/cicd/azdo/publish.yml
+++ b/docs/cicd/azdo/publish.yml
@@ -1,0 +1,46 @@
+# This is just an example workflow for publishing Teams app.
+# You should customize it to meet your own requirements.
+trigger: none
+# Manually trigger this workflow, and you should pick the right branch.
+
+pool:
+  vmImage: ubuntu-latest
+
+steps:
+# Setup environment.
+- task: NodeTool@0
+  inputs:
+    versionSpec: '14.17.0'
+    checkLatest: true
+
+- task: Bash@3
+  env:
+    M365_ACCOUNT_NAME: $(M365_ACCOUNT_NAME)
+    M365_ACCOUNT_PASSWORD: $(M365_ACCOUNT_PASSWORD)
+    M365_TENANT_ID: $(M365_TENANT_ID)
+    # To enable M365 account login by non-interactive mode. 
+    CI_ENABLED: 'true'
+    # To specify the environment name which will be used as an option below.
+    # You can change it to use your own environment name.
+    TEAMSFX_ENV_NAME: 'dev'
+    # To specify the version of TTK CLI for use.
+    TEAMSFX_CLI_VERSION: 1.*
+  inputs:
+    targetType: 'inline'
+    script: |
+      set -evuxo pipefail
+      
+      # Install the TTK CLI for later use.
+      npm install @microsoft/teamsfx-cli@${TEAMSFX_CLI_VERSION}
+
+      # This step is to pack the Teams App as zip file,
+      # which can be used to be uploaded onto Teams Client for installation.
+      # Build Teams App's Package.
+      npx teamsfx package --env ${TEAMSFX_ENV_NAME}
+
+      # Upload Teams App's Package as artifacts.
+      # Choose what your workflow/pipeline platform provided to
+      # upload build/appPackage/appPackage.staging.zip as artifacts.
+
+      # Publish Teams App.
+      npx teamsfx publish --env ${TEAMSFX_ENV_NAME} 

--- a/docs/cicd/github/cd.azure.yml
+++ b/docs/cicd/github/cd.azure.yml
@@ -1,0 +1,62 @@
+# This is just an example workflow for continuous deployment.
+# You should customize it to meet your own requirements.
+name: 'Continuous Deployment'
+on:
+  # When new commits are pushed onto the main branch.
+  push:
+    branches:
+      - main
+jobs:
+  buildAndDeploy:
+    runs-on: ubuntu-latest
+    # You can uncomment the line below to use environments (refer to https://docs.github.com/en/actions/reference/environments). 
+    #environment: test_environment
+    env:
+      # To specify the environment name which will be used as an option below.
+      # You can change it to use your own environment name.
+      TEAMSFX_ENV_NAME: 'dev'
+      # To specify the version of TTK CLI for use.
+      TEAMSFX_CLI_VERSION: 1.*
+
+    steps:
+      # Setup environment.
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+          
+      - name: Checkout the code
+        uses: actions/checkout@v2
+        
+      # Build the project.
+      # The way to build the current project depends on how you scaffold it.
+      # Different folder structures require different commands set.
+      # 'npm ci' is used here to install dependencies and it depends on package-lock.json.
+      # If you prefer to use 'npm ci', please make sure to commit package-lock.json first, or just change it to 'npm install'.
+      # - name: Build the project
+      #   run: cd bot; npm install; cd -;
+
+      # Run unit test.
+      # Currently, no opinionated solution for unit test provided during scaffolding, so,
+      # set up any unit test framework you prefer (for example, mocha or jest) and update the commands accordingly in below.
+      # - name: Run Unit Test
+      #   run: npm run test
+
+      # Login Azure by service principal.
+      # Service principal for Azure is used, and to create Azure service principal for use, refer to https://github.com/OfficeDev/TeamsFx/tree/dev/docs/cicd_insider#how-to-create-azure-service-principals-for-use.
+      - name: Login Azure by service principal 
+        uses: OfficeDev/teamsfx-cli-action@v1
+        with:
+          cli-version: ${{env.TEAMSFX_CLI_VERSION}}
+          commands: account login azure 
+          service-principal: true
+          username: ${{secrets.AZURE_SERVICE_PRINCIPAL_NAME}}
+          password: ${{secrets.AZURE_SERVICE_PRINCIPAL_PASSWORD}}
+          tenant: ${{secrets.AZURE_TENANT_ID}}
+      
+      - name: Deploy to hosting environment
+        uses: OfficeDev/teamsfx-cli-action@v1
+        with:
+          cli-version: ${{env.TEAMSFX_CLI_VERSION}}
+          commands: deploy
+          env: ${{env.TEAMSFX_ENV_NAME}}
+

--- a/docs/cicd/github/cd.spfx.yml
+++ b/docs/cicd/github/cd.spfx.yml
@@ -1,0 +1,53 @@
+# This is just an example workflow for continuous deployment.
+# You should customize it to meet your own requirements.
+name: 'Continuous Deployment'
+on:
+  # When new commits are pushed onto the main branch.
+  push:
+    branches:
+      - main
+jobs:
+  buildAndDeploy:
+    runs-on: ubuntu-latest
+    # You can uncomment the line below to use environments (refer to https://docs.github.com/en/actions/reference/environments). 
+    #environment: test_environment
+    env:
+      M365_ACCOUNT_NAME: ${{secrets.M365_ACCOUNT_NAME}}
+      M365_ACCOUNT_PASSWORD: ${{secrets.M365_ACCOUNT_PASSWORD}}
+      M365_TENANT_ID: ${{secrets.M365_TENANT_ID}}
+      # To specify the environment name which will be used as an option below.
+      # You can change it to use your own environment name.
+      TEAMSFX_ENV_NAME: 'dev'
+      # To specify the version of TTK CLI for use.
+      TEAMSFX_CLI_VERSION: 1.*
+
+    steps:
+      # Setup environment.
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+          
+      - name: Checkout the code
+        uses: actions/checkout@v2
+        
+      # Build the project.
+      # The way to build the current project depends on how you scaffold it.
+      # Different folder structures require different commands set.
+      # 'npm ci' is used here to install dependencies and it depends on package-lock.json.
+      # If you prefer to use 'npm ci', please make sure to commit package-lock.json first, or just change it to 'npm install'.
+      # - name: Build the project
+      #   run: cd bot; npm install; cd -;
+
+      # Run unit test.
+      # Currently, no opinionated solution for unit test provided during scaffolding, so,
+      # set up any unit test framework you prefer (for example, mocha or jest) and update the commands accordingly in below.
+      # - name: Run Unit Test
+      #   run: npm run test
+
+      - name: Deploy to hosting environment
+        uses: OfficeDev/teamsfx-cli-action@v1
+        with:
+          cli-version: ${{env.TEAMSFX_CLI_VERSION}}
+          commands: deploy
+          env: ${{env.TEAMSFX_ENV_NAME}}
+

--- a/docs/cicd/github/ci.yml
+++ b/docs/cicd/github/ci.yml
@@ -1,0 +1,33 @@
+# This is just an example workflow for continuous integration.
+# You should customize it to meet your own requirements.
+name: 'Continuous Integration'
+on:
+  # When pull requests targeting the dev branch created.
+  pull_request:
+    branches:
+      - dev
+jobs:
+  buildAndTest:
+    runs-on: ubuntu-latest
+    steps:
+      # Setup environment.
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: Checkout the code
+        uses: actions/checkout@v2
+ 
+      # Build the project.
+      # The way to build the current project depends on how you scaffold it.
+      # Different folder structures require different commands set.
+      # 'npm ci' is prefered to be used here to install dependencies and it depends on package-lock.json.
+      # If you prefer to use 'npm ci', please make sure to commit package-lock.json first, or just change it to 'npm install'.
+      # - name: Build the project
+      #   run: cd bot; npm install; cd -;
+
+      # Run unit test.
+      # Currently, no opinionated solution for unit test provided during scaffolding, so,
+      # set up any unit test framework you prefer (for example, mocha or jest) and update the commands accordingly in below.
+      # - name: Run Unit Test
+      #   run: npm run test

--- a/docs/cicd/github/provision.azure.yml
+++ b/docs/cicd/github/provision.azure.yml
@@ -1,0 +1,61 @@
+# This is just an example workflow for provision.
+# You should customize it to meet your own requirements.
+name: 'Provision'
+on:
+  # Manually trigger this workflow, and you should pick the right branch.
+  workflow_dispatch:
+jobs:
+  provision:
+    runs-on: ubuntu-latest
+    # You can uncomment the line below to use environments (refer to https://docs.github.com/en/actions/reference/environments). 
+    #environment: test_environment
+    env:
+      M365_ACCOUNT_NAME: ${{secrets.M365_ACCOUNT_NAME}}
+      M365_ACCOUNT_PASSWORD: ${{secrets.M365_ACCOUNT_PASSWORD}}
+      M365_TENANT_ID: ${{secrets.M365_TENANT_ID}}
+      # To specify the environment name which will be used as an option below.
+      # You can change it to use your own environment name.
+      TEAMSFX_ENV_NAME: 'dev'
+      # To specify the version of TTK CLI for use.
+      TEAMSFX_CLI_VERSION: 1.*
+
+    steps:
+      # Setup environment.
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+          
+      - name: Checkout the code
+        uses: actions/checkout@v2
+
+      # Login Azure by service principal.
+      # Service principal for Azure is used, and to create Azure service principal for use, refer to https://github.com/OfficeDev/TeamsFx/tree/dev/docs/cicd_insider#how-to-create-azure-service-principals-for-use.
+      - name: Login Azure by service principal 
+        uses: OfficeDev/teamsfx-cli-action@v1
+        with:
+          cli-version: ${{env.TEAMSFX_CLI_VERSION}}
+          commands: account login azure 
+          service-principal: true
+          username: ${{secrets.AZURE_SERVICE_PRINCIPAL_NAME}}
+          password: ${{secrets.AZURE_SERVICE_PRINCIPAL_PASSWORD}}
+          tenant: ${{secrets.AZURE_TENANT_ID}}
+
+      # We suggest to do the `teamsfx provision` step manually or in a separate workflow. The following steps are for your reference.
+      # After provisioning, you should commit necessary files into the repository.
+      - name: Provision hosting environment
+        uses: OfficeDev/teamsfx-cli-action@v1
+        with:
+          cli-version: ${{env.TEAMSFX_CLI_VERSION}}
+          commands: provision
+          subscription: ${{secrets.AZURE_SUBSCRIPTION_ID}}
+          env: ${{env.TEAMSFX_ENV_NAME}}
+
+      - name: Commit provision configs if necessary
+        env:
+          BRANCH: ${{github.ref}}
+        run: |
+          git config user.name "github-agent"
+          git config user.email "github-agent@github.com"
+          git add .
+          git commit -m "chore: commit provision configs"
+          git push origin ${BRANCH}

--- a/docs/cicd/github/provision.spfx.yml
+++ b/docs/cicd/github/provision.spfx.yml
@@ -1,0 +1,48 @@
+# This is just an example workflow for provision.
+# You should customize it to meet your own requirements.
+name: 'Provision'
+on:
+  # Manually trigger this workflow, and you should pick the right branch.
+  workflow_dispatch:
+jobs:
+  provision:
+    runs-on: ubuntu-latest
+    # You can uncomment the line below to use environments (refer to https://docs.github.com/en/actions/reference/environments). 
+    #environment: test_environment
+    env:
+      M365_ACCOUNT_NAME: ${{secrets.M365_ACCOUNT_NAME}}
+      M365_ACCOUNT_PASSWORD: ${{secrets.M365_ACCOUNT_PASSWORD}}
+      M365_TENANT_ID: ${{secrets.M365_TENANT_ID}}
+      # To specify the environment name which will be used as an option below.
+      # You can change it to use your own environment name.
+      TEAMSFX_ENV_NAME: 'dev'
+      # To specify the version of TTK CLI for use.
+      TEAMSFX_CLI_VERSION: 1.*
+
+    steps:
+      # Setup environment.
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+          
+      - name: Checkout the code
+        uses: actions/checkout@v2
+
+      # We suggest to do the `teamsfx provision` step manually or in a separate workflow. The following steps are for your reference.
+      # After provisioning, you should commit necessary files into the repository.
+      - name: Provision hosting environment
+        uses: OfficeDev/teamsfx-cli-action@v1
+        with:
+          cli-version: ${{env.TEAMSFX_CLI_VERSION}}
+          commands: provision
+          env: ${{env.TEAMSFX_ENV_NAME}}
+
+      - name: Commit provision configs if necessary
+        env:
+          BRANCH: ${{github.ref}}
+        run: |
+          git config user.name "github-agent"
+          git config user.email "github-agent@github.com"
+          git add .
+          git commit -m "chore: commit provision configs"
+          git push origin ${BRANCH}

--- a/docs/cicd/github/publish.yml
+++ b/docs/cicd/github/publish.yml
@@ -1,0 +1,51 @@
+# This is just an example workflow for publishing Teams app.
+# You should customize it to meet your own requirements.
+name: 'Publish Teams App'
+on:
+  # Manually trigger this workflow, and you should pick the right branch.
+  workflow_dispatch:
+jobs:
+  publishTeamsApp:
+    runs-on: ubuntu-latest
+    # You can uncomment the line below to use environments (refer to https://docs.github.com/en/actions/reference/environments). 
+    #environment: test_environment
+    env:
+      M365_ACCOUNT_NAME: ${{secrets.M365_ACCOUNT_NAME}}
+      M365_ACCOUNT_PASSWORD: ${{secrets.M365_ACCOUNT_PASSWORD}}
+      M365_TENANT_ID: ${{secrets.M365_TENANT_ID}}
+      # To specify the environment name which will be used as an option below.
+      # You can change it to use your own environment name.
+      TEAMSFX_ENV_NAME: 'dev'
+      # To specify the version of TTK CLI for use.
+      TEAMSFX_CLI_VERSION: 1.*
+
+    steps:
+      # Setup environment.
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+          
+      - name: Checkout the code
+        uses: actions/checkout@v2
+
+      # This step is to pack the Teams App as zip file,
+      # which can be used to be uploaded onto Teams Client for installation.
+      - name: Package Teams App for publishing
+        uses: OfficeDev/teamsfx-cli-action@v1
+        with:
+          cli-version: ${{env.TEAMSFX_CLI_VERSION}}
+          commands: package
+          env: ${{env.TEAMSFX_ENV_NAME}}
+
+      - name: Upload Teams App's package as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: appPackage
+          path: build/appPackage/appPackage.${{env.TEAMSFX_ENV_NAME}}.zip
+
+      - name: Publish Teams App
+        uses: OfficeDev/teamsfx-cli-action@v1
+        with:
+          cli-version: ${{env.TEAMSFX_CLI_VERSION}}
+          commands: publish
+          env: ${{env.TEAMSFX_ENV_NAME}}

--- a/docs/cicd/jenkins/Jenkinsfile.azure.cd
+++ b/docs/cicd/jenkins/Jenkinsfile.azure.cd
@@ -1,0 +1,70 @@
+// This is just an example workflow for continuous deployment.
+// The example workflow is expected to run on Ubuntu stable versions, for example, 20.04lts and later.
+// You should customize it to meet your own requirements.
+pipeline {
+    // To customize the agent field, please refer to https://www.jenkins.io/doc/book/pipeline/syntax/#agent.
+    agent any
+
+    // To customize triggers, please refer to https://www.jenkins.io/doc/book/pipeline/syntax/#triggers.
+    triggers { pollSCM('H */4 * * 1-5') }
+
+    // To learn more about environment, please refer to https://www.jenkins.io/doc/book/pipeline/syntax/#environment.
+    environment {
+        // To enable M365 account login by environment variables and non-interactive mode. 
+        CI_ENABLED = 'true'
+        // To specify the environment name which will be used as an option below.
+        // You can change it to use your own environment name.
+        TEAMSFX_ENV_NAME = 'dev'
+        // To specify the version of TTK CLI for use.
+        TEAMSFX_CLI_VERSION = '1.*'
+    }
+
+    stages {
+        // Setup environment.
+        stage('Setup environment') {
+            steps {
+                // Install the TTK CLI for later use.
+                sh 'npm install @microsoft/teamsfx-cli@${TEAMSFX_CLI_VERSION}'
+                // Check the version of teamsfx.
+                sh 'npx teamsfx -v'
+            }
+        }
+
+        // Build the project.
+        // The way to build the current project depends on how you scaffold it.
+        // Different folder structures require different commands set.
+        // 'npm ci' may be used here to install dependencies and it depends on package-lock.json.
+        // If you prefer to use 'npm ci', please make sure to commit package-lock.json first, or just change it to 'npm install'.
+        stage('Build the project') {
+            steps {
+                // sh 'cd bot; npm install; cd -;'
+            }
+        }
+
+        // Run unit test.
+        // Currently, no opinionated solution for unit test provided during scaffolding, so,
+        // set up any unit test framework you prefer (for example, mocha or jest) and update the commands accordingly in below.
+        // stage('Run unit test') {
+        //     steps {
+        //         sh 'npm run test'
+        //     }
+        // }
+
+        stage('Login Azure by service principal') {
+            environment {
+              SP_NAME = credentials('AZURE_SERVICE_PRINCIPAL_NAME') 
+              SP_PASSWORD = credentials('AZURE_SERVICE_PRINCIPAL_PASSWORD') 
+              TENANT_ID = credentials('AZURE_TENANT_ID') 
+            }
+            steps {
+                sh 'npx teamsfx account login azure --service-principal --username ${SP_NAME} --password ${SP_PASSWORD} --tenant ${TENANT_ID}'
+            } 
+        }
+
+        stage('Deploy to hosting environment') {
+            steps {
+                sh 'npx teamsfx deploy --env ${TEAMSFX_ENV_NAME}'
+            }
+        }
+    }
+}

--- a/docs/cicd/jenkins/Jenkinsfile.azure.provision
+++ b/docs/cicd/jenkins/Jenkinsfile.azure.provision
@@ -1,0 +1,71 @@
+// This is just an example workflow for provision.
+// The example workflow is expected to run on Ubuntu stable versions, for example, 20.04lts and later.
+// You should customize it to meet your own requirements.
+pipeline {
+    // To customize the agent field, please refer to https://www.jenkins.io/doc/book/pipeline/syntax/#agent.
+    agent any
+
+    // Manually trigger this workflow.
+    // To customize triggers, please refer to https://www.jenkins.io/doc/book/pipeline/syntax/#triggers.
+    // triggers { pollSCM('H */4 * * 1-5') }
+
+    // To learn more about environment, please refer to https://www.jenkins.io/doc/book/pipeline/syntax/#environment.
+    environment {
+        M365_ACCOUNT_NAME = credentials('M365_ACCOUNT_NAME')
+        M365_ACCOUNT_PASSWORD = credentials('M365_ACCOUNT_PASSWORD')
+        M365_TENANT_ID = credentials('M365_TENANT_ID')
+        // To enable M365 account login by non-interactive mode. 
+        CI_ENABLED = 'true'
+
+        // To specify the environment name which will be used as an option below.
+        // You can change it to use your own environment name.
+        TEAMSFX_ENV_NAME = 'dev'
+        // To specify the version of TTK CLI for use.
+        TEAMSFX_CLI_VERSION = '1.*'
+    }
+
+    stages {
+        // Setup environment.
+        stage('Setup environment') {
+            steps {
+                // Install the TTK CLI for later use.
+                sh 'npm install @microsoft/teamsfx-cli@${TEAMSFX_CLI_VERSION}'
+                // Check the version of teamsfx.
+                sh 'npx teamsfx -v'
+            }
+        }
+
+        stage('Login Azure by service principal') {
+            environment {
+              SP_NAME = credentials('AZURE_SERVICE_PRINCIPAL_NAME') 
+              SP_PASSWORD = credentials('AZURE_SERVICE_PRINCIPAL_PASSWORD') 
+              TENANT_ID = credentials('AZURE_TENANT_ID') 
+            }
+            steps {
+                sh 'npx teamsfx account login azure --service-principal --username ${SP_NAME} --password ${SP_PASSWORD} --tenant ${TENANT_ID}'
+            } 
+        }
+
+        // We suggest to do the `npx teamsfx provision` step manually or in a separate pipeline. The following steps are for your reference.
+        // After provisioning, you should commit necessary files under .fx into the repository.
+        stage('Provision hosting environment') {        
+            environment {
+                AZURE_SUBSCRIPTION_ID = credentials('AZURE_SUBSCRIPTION_ID')
+            }
+            steps {
+                sh 'npx teamsfx provision --subscription ${AZURE_SUBSCRIPTION_ID} --env ${TEAMSFX_ENV_NAME}'
+            }
+        }
+
+        stage('Commit provision configs if necessary') {
+            steps {
+                sh 'git config user.name "azdo-agent"'
+                sh 'git config user.email "azdo-agent@azure.com"'
+                sh 'git add .'
+                sh 'git commit -m "chore: commit provision configs"'
+                // Using awk to extract origin and branch name.
+                sh 'git push `echo $GIT_BRANCH | awk -F\'/\' \'{print $1, "HEAD:"$2}\'`'
+            }
+        }
+    }
+}

--- a/docs/cicd/jenkins/Jenkinsfile.ci
+++ b/docs/cicd/jenkins/Jenkinsfile.ci
@@ -1,0 +1,33 @@
+// This is just an example workflow for continuous integration.
+// The example workflow is expected to run on Ubuntu stable versions, for example, 20.04lts and later.
+// You should customize it to meet your own requirements.
+// The file may be renamed to Jenkinsfile, and put into dev branch.
+pipeline {
+    // To customize the agent field, please refer to https://www.jenkins.io/doc/book/pipeline/syntax/#agent.
+    agent any
+
+    // To customize triggers, please refer to https://www.jenkins.io/doc/book/pipeline/syntax/#triggers.
+    triggers { pollSCM('H */4 * * 1-5') }
+
+    stages {
+        // Build the project.
+        // The way to build the current project depends on how you scaffold it.
+        // Different folder structures require different commands set.
+        // 'npm ci' may be used here to install dependencies and it depends on package-lock.json.
+        // If you prefer to use 'npm ci', please make sure to commit package-lock.json first, or just change it to 'npm install'.
+        stage('Build the project') {
+            steps {
+                // sh 'cd bot; npm install; cd -;'
+            }
+        }
+
+        // Run unit test.
+        // Currently, no opinionated solution for unit test provided during scaffolding, so,
+        // set up any unit test framework you prefer (for example, mocha or jest) and update the commands accordingly in below.
+        // stage('Run Unit Test') {
+        //    steps {
+        //        sh 'npm run test'
+        //    }
+        // }
+    }
+}

--- a/docs/cicd/jenkins/Jenkinsfile.publish
+++ b/docs/cicd/jenkins/Jenkinsfile.publish
@@ -1,0 +1,57 @@
+// This is just an example workflow for publish.
+// The example workflow is expected to run on Ubuntu stable versions, for example, 20.04lts and later.
+// You should customize it to meet your own requirements.
+pipeline {
+    // To customize the agent field, please refer to https://www.jenkins.io/doc/book/pipeline/syntax/#agent.
+    agent any
+
+    // Manually trigger this workflow.
+    // To customize triggers, please refer to https://www.jenkins.io/doc/book/pipeline/syntax/#triggers.
+    // triggers { pollSCM('H */4 * * 1-5') }
+
+    // To learn more about environment, please refer to https://www.jenkins.io/doc/book/pipeline/syntax/#environment.
+    environment {
+        M365_ACCOUNT_NAME = credentials('M365_ACCOUNT_NAME')
+        M365_ACCOUNT_PASSWORD = credentials('M365_ACCOUNT_PASSWORD')
+        M365_TENANT_ID = credentials('M365_TENANT_ID')
+        // To enable M365 account login by non-interactive mode. 
+        CI_ENABLED = 'true'
+        // To specify the environment name which will be used as an option below.
+        // You can change it to use your own environment name.
+        TEAMSFX_ENV_NAME = 'dev'
+        // To specify the version of TTK CLI for use.
+        TEAMSFX_CLI_VERSION = '1.*'
+    }
+
+    stages {
+        // Setup environment.
+        stage('Setup environment') {
+            steps {
+                // Install the TTK CLI for later use.
+                sh 'npm install @microsoft/teamsfx-cli@${TEAMSFX_CLI_VERSION}'
+                // Check the version of teamsfx.
+                sh 'npx teamsfx -v'
+            }
+        }
+
+        // This step is to pack the Teams App as zip file,
+        // which can be used to be uploaded onto Teams Client for installation.
+        stage('Package Teams App for publishing') {
+            steps {
+                sh 'npx teamsfx package --env ${TEAMSFX_ENV_NAME}'
+            }
+        }
+
+        stage('Upload Teams App package as artifact') {
+            steps {
+                archiveArtifacts artifacts: 'build/appPackage/appPackage.${TEAMSFX_ENV_NAME}.zip'
+            }
+        }
+
+        stage('Publish Teams App') {
+            steps {
+                sh 'npx teamsfx publish --env ${TEAMSFX_ENV_NAME}'
+            }
+        }
+    }
+}

--- a/docs/cicd/jenkins/Jenkinsfile.spfx.cd
+++ b/docs/cicd/jenkins/Jenkinsfile.spfx.cd
@@ -1,0 +1,62 @@
+// This is just an example workflow for continuous deployment.
+// The example workflow is expected to run on Ubuntu stable versions, for example, 20.04lts and later.
+// You should customize it to meet your own requirements.
+pipeline {
+    // To customize the agent field, please refer to https://www.jenkins.io/doc/book/pipeline/syntax/#agent.
+    agent any
+
+    // To customize triggers, please refer to https://www.jenkins.io/doc/book/pipeline/syntax/#triggers.
+    triggers { pollSCM('H */4 * * 1-5') }
+
+    // To learn more about environment, please refer to https://www.jenkins.io/doc/book/pipeline/syntax/#environment.
+    environment {
+        M365_ACCOUNT_NAME = credentials('M365_ACCOUNT_NAME')
+        M365_ACCOUNT_PASSWORD = credentials('M365_ACCOUNT_PASSWORD')
+        M365_TENANT_ID = credentials('M365_TENANT_ID')
+        // To enable M365 account login by environment variables and non-interactive mode. 
+        CI_ENABLED = 'true'
+        // To specify the environment name which will be used as an option below.
+        // You can change it to use your own environment name.
+        TEAMSFX_ENV_NAME = 'dev'
+        // To specify the version of TTK CLI for use.
+        TEAMSFX_CLI_VERSION = '1.*'
+    }
+
+    stages {
+        // Setup environment.
+        stage('Setup environment') {
+            steps {
+                // Install the TTK CLI for later use.
+                sh 'npm install @microsoft/teamsfx-cli@${TEAMSFX_CLI_VERSION}'
+                // Check the version of teamsfx.
+                sh 'npx teamsfx -v'
+            }
+        }
+
+        // Build the project.
+        // The way to build the current project depends on how you scaffold it.
+        // Different folder structures require different commands set.
+        // 'npm ci' may be used here to install dependencies and it depends on package-lock.json.
+        // If you prefer to use 'npm ci', please make sure to commit package-lock.json first, or just change it to 'npm install'.
+        stage('Build the project') {
+            steps {
+                // sh 'cd bot; npm install; cd -;'
+            }
+        }
+
+        // Run unit test.
+        // Currently, no opinionated solution for unit test provided during scaffolding, so,
+        // set up any unit test framework you prefer (for example, mocha or jest) and update the commands accordingly in below.
+        // stage('Run unit test') {
+        //     steps {
+        //         sh 'npm run test'
+        //     }
+        // }
+
+        stage('Deploy to hosting environment') {
+            steps {
+                sh 'npx teamsfx deploy --env ${TEAMSFX_ENV_NAME}'
+            }
+        }
+    }
+}

--- a/docs/cicd/jenkins/Jenkinsfile.spfx.provision
+++ b/docs/cicd/jenkins/Jenkinsfile.spfx.provision
@@ -1,0 +1,57 @@
+// This is just an example workflow for provision.
+// The example workflow is expected to run on Ubuntu stable versions, for example, 20.04lts and later.
+// You should customize it to meet your own requirements.
+pipeline {
+    // To customize the agent field, please refer to https://www.jenkins.io/doc/book/pipeline/syntax/#agent.
+    agent any
+
+    // Manually trigger this workflow.
+    // To customize triggers, please refer to https://www.jenkins.io/doc/book/pipeline/syntax/#triggers.
+    // triggers { pollSCM('H */4 * * 1-5') }
+
+    // To learn more about environment, please refer to https://www.jenkins.io/doc/book/pipeline/syntax/#environment.
+    environment {
+        M365_ACCOUNT_NAME = credentials('M365_ACCOUNT_NAME')
+        M365_ACCOUNT_PASSWORD = credentials('M365_ACCOUNT_PASSWORD')
+        M365_TENANT_ID = credentials('M365_TENANT_ID')
+        // To enable M365 account login by non-interactive mode. 
+        CI_ENABLED = 'true'
+
+        // To specify the environment name which will be used as an option below.
+        // You can change it to use your own environment name.
+        TEAMSFX_ENV_NAME = 'dev'
+        // To specify the version of TTK CLI for use.
+        TEAMSFX_CLI_VERSION = '1.*'
+    }
+
+    stages {
+        // Setup environment.
+        stage('Setup environment') {
+            steps {
+                // Install the TTK CLI for later use.
+                sh 'npm install @microsoft/teamsfx-cli@${TEAMSFX_CLI_VERSION}'
+                // Check the version of teamsfx.
+                sh 'npx teamsfx -v'
+            }
+        }
+
+        // We suggest to do the `npx teamsfx provision` step manually or in a separate pipeline. The following steps are for your reference.
+        // After provisioning, you should commit necessary files under .fx into the repository.
+        stage('Provision hosting environment') {
+            steps {
+                sh 'npx teamsfx provision --env ${TEAMSFX_ENV_NAME}'
+            }
+        }
+
+        stage('Commit provision configs if necessary') {
+            steps {
+                sh 'git config user.name "azdo-agent"'
+                sh 'git config user.email "azdo-agent@azure.com"'
+                sh 'git add .'
+                sh 'git commit -m "chore: commit provision configs"'
+                // Using awk to extract origin and branch name.
+                sh 'git push `echo $GIT_BRANCH | awk -F\'/\' \'{print $1, "HEAD:"$2}\'`'
+            }
+        }
+    }
+}

--- a/docs/cicd/others/cd.azure.sh
+++ b/docs/cicd/others/cd.azure.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -evuxo pipefail
+
+# This is just an example workflow for continuous deployment.
+# You should customize it to meet your own requirements.
+# Also you should export the following environment variables for Azure/M365 login:
+# export AZURE_SERVICE_PRINCIPAL_NAME={AZURE_SERVICE_PRINCIPAL_NAME}
+# export AZURE_SERVICE_PRINCIPAL_PASSWORD={AZURE_SERVICE_PRINCIPAL_PASSWORD}
+# export AZURE_TENANT_ID={AZURE_TENANT_ID}
+# export TEAMSFX_CLI_VERSION={TEAMSFX_CLI_VERSION}
+# export TEAMSFX_ENV_NAME={TEAMSFX_ENV_NAME}
+
+# To enable @microsoft/teamsfx-cli running in CI mode, turn on CI_ENABLED like below.
+# In CI mode, @microsoft/teamsfx-cli is friendly for CI/CD. 
+export CI_ENABLED=true
+
+# Setup environment.
+# Sufficient permissions are required to run the commands below.
+apt install -y nodejs npm git
+
+# Checkout the code.
+# Update the placeholder of {RepositoryEndpoint} to your repository's endpoint.
+git clone {RepositoryEndpoint}
+
+# Update the placeholder of {FolderName} to your repository's folder name after git clone.
+cd {FolderName}
+      
+# Install the TTK CLI for later use.
+npm install @microsoft/teamsfx-cli@${TEAMSFX_CLI_VERSION}
+
+# Build the project.
+# The way to build the current project depends on how you scaffold it.
+# Different folder structures require different commands set.
+# 'npm ci' may be used here to install dependencies and it depends on package-lock.json.
+# If you prefer to use 'npm ci', please make sure to commit package-lock.json first, or just change it to 'npm install'.  
+# cd bot; npm install; cd -;
+
+# Run unit test.
+# Currently, no opinioned solution for unit test provided during scaffolding, so,
+# set up any unit test framework you prefer (for example, mocha or jest) and update the commands accordingly in below.
+# npm run test
+
+# Login Azure by service principal
+npx teamsfx account login azure --service-principal --username ${AZURE_SERVICE_PRINCIPAL_NAME} --password ${AZURE_SERVICE_PRINCIPAL_PASSWORD} --tenant ${AZURE_TENANT_ID}
+
+# Deploy to hosting environment.
+npx teamsfx deploy --env ${TEAMSFX_ENV_NAME}

--- a/docs/cicd/others/cd.spfx.sh
+++ b/docs/cicd/others/cd.spfx.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -evuxo pipefail
+
+# This is just an example workflow for continuous deployment.
+# You should customize it to meet your own requirements.
+# Also you should export the following environment variables for Azure/M365 login:
+# export M365_ACCOUNT_NAME={M365_ACCOUNT_NAME}
+# export M365_ACCOUNT_PASSWORD={M365_ACCOUNT_PASSWORD}
+# export M365_TENANT_ID={M365_TENANT_ID}
+# export TEAMSFX_CLI_VERSION={TEAMSFX_CLI_VERSION}
+# export TEAMSFX_ENV_NAME={TEAMSFX_ENV_NAME}
+
+# To enable @microsoft/teamsfx-cli running in CI mode, turn on CI_ENABLED like below.
+# In CI mode, @microsoft/teamsfx-cli is friendly for CI/CD. 
+export CI_ENABLED=true
+
+# Setup environment.
+# Sufficient permissions are required to run the commands below.
+apt install -y nodejs npm git
+
+# Checkout the code.
+# Update the placeholder of {RepositoryEndpoint} to your repository's endpoint.
+git clone {RepositoryEndpoint}
+
+# Update the placeholder of {FolderName} to your repository's folder name after git clone.
+cd {FolderName}
+      
+# Install the TTK CLI for later use.
+npm install @microsoft/teamsfx-cli@${TEAMSFX_CLI_VERSION}
+
+# Build the project.
+# The way to build the current project depends on how you scaffold it.
+# Different folder structures require different commands set.
+# 'npm ci' may be used here to install dependencies and it depends on package-lock.json.
+# If you prefer to use 'npm ci', please make sure to commit package-lock.json first, or just change it to 'npm install'.  
+# cd bot; npm install; cd -;
+
+# Run unit test.
+# Currently, no opinioned solution for unit test provided during scaffolding, so,
+# set up any unit test framework you prefer (for example, mocha or jest) and update the commands accordingly in below.
+# npm run test
+
+# Deploy to hosting environment.
+npx teamsfx deploy --env ${TEAMSFX_ENV_NAME}

--- a/docs/cicd/others/ci.sh
+++ b/docs/cicd/others/ci.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# This is just an example workflow for continuous integration.
+# You should customize it to meet your own requirements.
+
+# Setup environment.
+# The `apt install` command is supposed to run inside the latest ubuntu system.
+# If you're using other platforms, please customize the command to set up your environment.
+# Sufficient permissions are required to run the command below.
+apt install -y nodejs npm
+
+# Checkout the code.
+# Update the placeholder of {RepositoryEndpoint} to your repository's endpoint.
+git clone {RepositoryEndpoint}
+# Update the placeholder of {FolderName} to your repository's folder name after git clone.
+cd {FolderName}
+
+# Build the project.
+# The way to build the current project depends on how you scaffold it.
+# Different folder structures require different commands set.
+# 'npm ci' is used here to install dependencies and it depends on package-lock.json.
+# If you prefer to use 'npm ci', please make sure to commit package-lock.json first, or just change it to 'npm install'.
+# cd bot && npm install && cd -
+
+# Run unit test.
+# Currently, no opinionated solution for unit test provided during scaffolding, so,
+# set up any unit test framework you prefer (for example, mocha or jest) and update the commands accordingly in below.
+# npm run test

--- a/docs/cicd/others/provision.azure.sh
+++ b/docs/cicd/others/provision.azure.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -evuxo pipefail
+
+# This is just an example workflow for continuous deployment.
+# You should customize it to meet your own requirements.
+# Also you should export the following environment variables for Azure/M365 login:
+# export AZURE_SERVICE_PRINCIPAL_NAME={AZURE_SERVICE_PRINCIPAL_NAME}
+# export AZURE_SERVICE_PRINCIPAL_PASSWORD={AZURE_SERVICE_PRINCIPAL_PASSWORD}
+# export AZURE_SUBSCRIPTION_ID={AZURE_SUBSCRIPTION_ID}
+# export AZURE_TENANT_ID={AZURE_TENANT_ID}
+# export M365_ACCOUNT_NAME={M365_ACCOUNT_NAME}
+# export M365_ACCOUNT_PASSWORD={M365_ACCOUNT_PASSWORD}
+
+# To enable @microsoft/teamsfx-cli running in CI mode, turn on CI_ENABLED like below.
+# In CI mode, @microsoft/teamsfx-cli is friendly for CI/CD. 
+export CI_ENABLED=true
+
+# Setup environment.
+# Sufficient permissions are required to run the commands below.
+apt install -y nodejs npm git
+
+# Checkout the code.
+# Update the placeholder of {RepositoryEndpoint} to your repository's endpoint.
+git clone {RepositoryEndpoint}
+
+# Update the placeholder of {FolderName} to your repository's folder name after git clone.
+cd {FolderName}
+
+# Install the TTK CLI for later use.
+npm install @microsoft/teamsfx-cli@${TEAMSFX_CLI_VERSION}
+
+# Login Azure by service principal
+npx teamsfx account login azure --service-principal --username ${AZURE_SERVICE_PRINCIPAL_NAME} --password ${AZURE_SERVICE_PRINCIPAL_PASSWORD} --tenant ${AZURE_TENANT_ID}
+
+# We suggest to do the `teamsfx provision` step manually or in a separate workflow. The following steps are for your reference.
+# After provisioning, you should commit necessary files into the repository. 
+npx teamsfx provision --subscription ${AZURE_SUBSCRIPTION_ID} --env ${TEAMSFX_ENV_NAME}
+
+# Commit provision configs if necessary.
+git config user.name "git-agent"
+git config user.email "git-agent@azure.com"
+git add .
+git commit -m "chore: commit provision configs"
+git push origin {YOUR_TARGET_BRANCH}

--- a/docs/cicd/others/provision.spfx.sh
+++ b/docs/cicd/others/provision.spfx.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -evuxo pipefail
+
+# This is just an example workflow for continuous deployment.
+# You should customize it to meet your own requirements.
+# Also you should export the following environment variables for Azure/M365 login:
+# export M365_ACCOUNT_NAME={M365_ACCOUNT_NAME}
+# export M365_ACCOUNT_PASSWORD={M365_ACCOUNT_PASSWORD}
+
+# To enable @microsoft/teamsfx-cli running in CI mode, turn on CI_ENABLED like below.
+# In CI mode, @microsoft/teamsfx-cli is friendly for CI/CD. 
+export CI_ENABLED=true
+
+# Setup environment.
+# Sufficient permissions are required to run the commands below.
+apt install -y nodejs npm git
+
+# Checkout the code.
+# Update the placeholder of {RepositoryEndpoint} to your repository's endpoint.
+git clone {RepositoryEndpoint}
+
+# Update the placeholder of {FolderName} to your repository's folder name after git clone.
+cd {FolderName}
+
+# Install the TTK CLI for later use.
+npm install @microsoft/teamsfx-cli@${TEAMSFX_CLI_VERSION}
+
+# We suggest to do the `teamsfx provision` step manually or in a separate workflow. The following steps are for your reference.
+# After provisioning, you should commit necessary files into the repository. 
+npx teamsfx provision --env ${TEAMSFX_ENV_NAME}
+
+# Commit provision configs if necessary.
+git config user.name "git-agent"
+git config user.email "git-agent@azure.com"
+git add .
+git commit -m "chore: commit provision configs"
+git push origin {YOUR_TARGET_BRANCH}

--- a/docs/cicd/others/publish.sh
+++ b/docs/cicd/others/publish.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# This is just an example workflow for continuous deployment.
+# You should customize it to meet your own requirements.
+# Also you should export the following environment variables for Azure/M365 login:
+# export M365_ACCOUNT_NAME={M365_ACCOUNT_NAME}
+# export M365_ACCOUNT_PASSWORD={M365_ACCOUNT_PASSWORD}
+
+# To enable @microsoft/teamsfx-cli running in CI mode, turn on CI_ENABLED like below.
+# In CI mode, @microsoft/teamsfx-cli is friendly for CI/CD. 
+export CI_ENABLED=true
+
+# Setup environment.
+# Sufficient permissions are required to run the commands below.
+apt install -y nodejs npm git
+
+# Checkout the code.
+# Update the placeholder of {RepositoryEndpoint} to your repository's endpoint.
+git clone {RepositoryEndpoint}
+
+# Update the placeholder of {FolderName} to your repository's folder name after git clone.
+cd {FolderName}
+
+# Install the TTK CLI for later use.
+npm install @microsoft/teamsfx-cli@${TEAMSFX_CLI_VERSION}
+
+# This step is to pack the Teams App as zip file,
+# which can be used to be uploaded onto Teams Client for installation.
+# Build Teams App's Package.
+npx teamsfx package --env ${TEAMSFX_ENV_NAME}
+
+# Upload Teams App's Package as artifacts.
+# Choose what your workflow/pipeline platform provided to
+# upload build/appPackage/appPackage.staging.zip as artifacts.
+
+# Publish Teams App.
+npx teamsfx publish --env ${TEAMSFX_ENV_NAME} 


### PR DESCRIPTION
**Split cicd templates into four categories:**
1. GitHub
2. Azure DevOps
3. Jenkins
4. Others (Based on scripts)

In each category, **split provsion and cd by azure and spfx** making two copies.

CICD Howto Guides will reference these templates directly.