### PR TITLE
chore: remove the dashboard tutorial entry in V3

### DIFF
--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -3371,20 +3371,24 @@ export async function selectTutorialsHandler(args?: any[]): Promise<Result<unkno
           },
         ],
       },
-      {
-        id: "dashboardApp",
-        label: `${localize("teamstoolkit.guides.dashboardApp.label")}`,
-        detail: localize("teamstoolkit.guides.dashboardApp.detail"),
-        groupName: localize("teamstoolkit.guide.scenario"),
-        data: "https://aka.ms/teamsfx-dashboard-app",
-        buttons: [
-          {
-            iconPath: "file-symlink-file",
-            tooltip: localize("teamstoolkit.guide.tooltip.github"),
-            command: "fx-extension.openTutorial",
-          },
-        ],
-      },
+      ...(isV3Enabled()
+        ? []
+        : [
+            {
+              id: "dashboardApp",
+              label: `${localize("teamstoolkit.guides.dashboardApp.label")}`,
+              detail: localize("teamstoolkit.guides.dashboardApp.detail"),
+              groupName: localize("teamstoolkit.guide.scenario"),
+              data: "https://aka.ms/teamsfx-dashboard-app",
+              buttons: [
+                {
+                  iconPath: "file-symlink-file",
+                  tooltip: localize("teamstoolkit.guide.tooltip.github"),
+                  command: "fx-extension.openTutorial",
+                },
+              ],
+            },
+          ]),
       {
         id: "addTab",
         label: `${localize("teamstoolkit.guides.addTab.label")}`,


### PR DESCRIPTION
Since the user can't see the entrance of the dashboard tab in v3, it would be a bit strange if can still see the tutorial entrance.

For this reason, I would like to remove the dashboard tutorial entry in v3.

- In V2:
![image](https://user-images.githubusercontent.com/107838226/207266606-20062001-8ae3-4bf9-91c2-8e43a9cf35e1.png)

- In V3
![image](https://user-images.githubusercontent.com/107838226/207272188-b24c2a59-53ac-429e-9278-a44f431eeb4c.png)


E2E TEST: N/A