### PR TITLE
fix: stuck when extracting files with .asar suffix

### DIFF
--- a/packages/vscode-extension/webpack.config.js
+++ b/packages/vscode-extension/webpack.config.js
@@ -34,6 +34,7 @@ const config = {
   externals: {
     vscode: "commonjs vscode", // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
     keytar: "keytar",
+    ["original-fs"]: "commonjs original-fs", // original-fs package is builtin Electron package which we use to prevent special fs logic for .asar files, 📖 -> https://www.electronjs.org/docs/latest/tutorial/asar-archives#treating-an-asar-archive-as-a-normal-file
   },
   resolve: {
     // support reading TypeScript and JavaScript files, 📖 -> https://github.com/TypeStrong/ts-loader
@@ -82,7 +83,6 @@ const config = {
     new webpack.ContextReplacementPlugin(/ms-rest[\/\\]lib/, false, /$^/),
     new webpack.IgnorePlugin({ resourceRegExp: /@opentelemetry\/tracing/ }),
     new webpack.IgnorePlugin({ resourceRegExp: /applicationinsights-native-metrics/ }),
-    new webpack.IgnorePlugin({ resourceRegExp: /original-fs/ }),
     // ignore node-gyp/bin/node-gyp.js since it's not used in runtime
     new webpack.NormalModuleReplacementPlugin(
       /node-gyp[\/\\]bin[\/\\]node-gyp.js/,


### PR DESCRIPTION
Video filter test app will get stuck when first run in a clean environment.

It is because Electron has [special logic](https://www.electronjs.org/docs/latest/tutorial/asar-archives#node-api) for *.asar files when calling `fs` APIs like `fs.stat`, `fs.writeFile`. So when extracting a zip which contains files like app.asar, Adm Zip library fails on `fs.stat` and it doesn't handle the error so the promise never resolves or rejects. So it get stuck.

This issue can be solved by using `original-fs` (a Electron builtin package) instead of `fs` from [Electron document](https://www.electronjs.org/docs/latest/tutorial/asar-archives#treating-an-asar-archive-as-a-normal-file). 

AdmZip has already [added support](https://github.com/cthackers/adm-zip/pull/153) for this specific scenario. It will automatically use `original-fs` in Electron environment.

The reason it still doesn't work in our case is because our vscode extension use Webpack `IgnorePlugin` to ignore `original-fs` package, causing `AdmZip` to fail to `require("original-fs")`. And then it [falls back](https://github.com/cthackers/adm-zip/blob/bebbabf600a6ae5d64ee31cbc89a1274bd1d8c1f/util/fileSystem.js#L2-L10) to use the `fs` module which is contaminated by Electron.

https://github.com/OfficeDev/TeamsFx/blob/659173b8d3fe3d38e6c10a46d5bfc94bf705de4d/packages/vscode-extension/webpack.config.js#L85

So the solution is to mark `original-fs` as an external package so that webpack will not mess with it, leaving the original `require(xxx)` code in Adm Zip untouched.


Tested on Windows with local vsix packaing