### PR TITLE
perf(migrationV3): use default output instead of throwing error when …

### DIFF
--- a/packages/fx-core/src/core/middleware/utils/MigrationUtils.ts
+++ b/packages/fx-core/src/core/middleware/utils/MigrationUtils.ts
@@ -229,21 +229,9 @@ export function namingConverterV3(
       }) &&
       bicepContent
     ) {
-      const res = provisionOutputNamingConverterV3(name, bicepContent);
-      return ok(res);
+      return ok(provisionOutputNamingConverterV3(name, bicepContent, type));
     } else {
-      const res = commonNamingConverterV3(name);
-      switch (type) {
-        case FileType.CONFIG:
-          return ok(`${configPrefix}${res}`);
-        case FileType.USERDATA:
-          if (res.startsWith("STATE__"))
-            return ok(`${secretPrefix}${res.substring(res.indexOf("STATE__") + 7)}`);
-          else return ok(`${secretPrefix}${res}`);
-        case FileType.STATE:
-        default:
-          return ok(res);
-      }
+      return ok(commonNamingConverterV3(name, type));
     }
   } catch (error: any) {
     return err(new SystemError(CoreSource, "FailedToConvertV2ConfigNameToV3", error?.message));
@@ -251,12 +239,27 @@ export function namingConverterV3(
 }
 
 // convert x-xx.xxx.xxx to x_xx__xxx__xxx
-function commonNamingConverterV3(name: string): string {
+function commonNamingConverterV3(name: string, type: FileType): string {
   const names = name.split(".");
-  return names.join("__").replace(/\-/g, "_").toUpperCase();
+  const res = names.join("__").replace(/\-/g, "_").toUpperCase();
+  switch (type) {
+    case FileType.CONFIG:
+      return `${configPrefix}${res}`;
+    case FileType.USERDATA:
+      if (res.startsWith("STATE__"))
+        return `${secretPrefix}${res.substring(res.indexOf("STATE__") + 7)}`;
+      else return `${secretPrefix}${res}`;
+    case FileType.STATE:
+    default:
+      return res;
+  }
 }
 
-function provisionOutputNamingConverterV3(name: string, bicepContent: string): string {
+function provisionOutputNamingConverterV3(
+  name: string,
+  bicepContent: string,
+  type: FileType
+): string {
   const names = name.split(".");
   const pluginNames = [names[1], pluginIdMappingV3[names[1]]];
   const keyName = names[2];
@@ -297,7 +300,7 @@ function provisionOutputNamingConverterV3(name: string, bicepContent: string): s
   }
 
   if (!outputName) {
-    throw new Error(`Failed to find matching output in provision.bicep for key ${name}`);
+    return commonNamingConverterV3(name, type);
   }
 
   return `${provisionOutputPrefix}${outputName}__${keyName}`.toUpperCase();

--- a/packages/fx-core/tests/core/middleware/migrationUtilsV3.test.ts
+++ b/packages/fx-core/tests/core/middleware/migrationUtilsV3.test.ts
@@ -14,10 +14,13 @@ import {
 import { randomAppName } from "../utils";
 import * as os from "os";
 import * as path from "path";
-import { Inputs, Platform } from "@microsoft/teamsfx-api";
+import * as v3MigrationUtils from "../../../src/core/middleware/utils/v3MigrationUtils";
+import * as migrationUtils from "../../../src/core/middleware/utils/MigrationUtils";
+import { err, Inputs, Platform, SystemError } from "@microsoft/teamsfx-api";
 import { MigrationContext } from "../../../src/core/middleware/utils/migrationContext";
 import { mockMigrationContext } from "./projectMigrationV3.test";
 import sinon from "sinon";
+import { getPlaceholderMappings } from "../../../src/core/middleware/utils/debug/debugV3MigrationUtils";
 
 describe("MigrationUtilsV3", () => {
   it("happy path for fixed namings", () => {
@@ -310,5 +313,29 @@ describe("MigrationUtils: needMigrateToAadManifest", async () => {
       .withArgs(path.join(projectPath, "permissions.json"), () => {})
       .resolves(false);
     assert.isTrue(!(await needMigrateToAadManifest(migrationContext)));
+  });
+});
+
+describe("Migration: getPlaceholderMappings", () => {
+  const sandbox = sinon.createSandbox();
+  const appName = randomAppName();
+  const projectPath = path.join(os.tmpdir(), appName);
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("failed due to naming converter throws error", async () => {
+    sandbox.stub(v3MigrationUtils, "readBicepContent").resolves("");
+    sandbox
+      .stub(migrationUtils, "namingConverterV3")
+      .returns(err(new SystemError("source", "name", "message")));
+    const migrationContext = await mockMigrationContext(projectPath);
+    const res = await getPlaceholderMappings(migrationContext);
+    assert.equal(res.botDomain, undefined);
+    assert.equal(res.tabIndexPath, undefined);
+    assert.equal(res.tabEndpoint, undefined);
+    assert.equal(res.tabDomain, undefined);
+    assert.equal(res.botEndpoint, undefined);
   });
 });

--- a/packages/fx-core/tests/core/middleware/migrationUtilsV3.test.ts
+++ b/packages/fx-core/tests/core/middleware/migrationUtilsV3.test.ts
@@ -129,12 +129,7 @@ describe("MigrationUtilsV3", () => {
       FileType.STATE,
       bicepContent
     );
-    assert.isTrue(
-      res.isErr() &&
-        res.error.message ===
-          "Failed to find matching output in provision.bicep for key state.fx-resource-azure-sql.databaseName_test3" &&
-        res.error.name == "FailedToConvertV2ConfigNameToV3"
-    );
+    assert.isTrue(res.isOk() && res.value === "STATE__FX_RESOURCE_AZURE_SQL__DATABASENAME_TEST3");
   });
 });
 


### PR DESCRIPTION
…cannot find key in bicep