### PR TITLE
chore(debug): support configuring channels when creating or updating bot

### DIFF
--- a/packages/fx-core/src/component/driver/botFramework/createOrUpdateBot.ts
+++ b/packages/fx-core/src/component/driver/botFramework/createOrUpdateBot.ts
@@ -14,10 +14,16 @@ import { ExecutionResult, StepDriver } from "../interface/stepDriver";
 import { addStartAndEndTelemetry } from "../middleware/addStartAndEndTelemetry";
 import { InvalidParameterUserError } from "./error/invalidParameterUserError";
 import { UnhandledSystemError } from "./error/unhandledError";
-import { CreateOrUpdateBotFrameworkBotArgs } from "./interface/createOrUpdateBotFrameworkBotArgs";
+import {
+  CreateOrUpdateBotFrameworkBotArgs,
+  MicrosoftTeamsChannelSettings,
+} from "./interface/createOrUpdateBotFrameworkBotArgs";
 import { BotRegistration } from "../../resource/botService/botRegistration/botRegistration";
 import { LocalBotRegistration } from "../../resource/botService/botRegistration/localBotRegistration";
-import { IBotRegistration } from "../../resource/botService/appStudio/interfaces/IBotRegistration";
+import {
+  BotChannelType,
+  IBotRegistration,
+} from "../../resource/botService/appStudio/interfaces/IBotRegistration";
 
 const actionName = "botFramework/create";
 const helpLink = "https://aka.ms/teamsfx-actions/botFramework-create";
@@ -75,13 +81,29 @@ export class CreateOrUpdateBotFrameworkBotDriver implements StepDriver {
         getLocalizedString("driver.botFramework.progressBar.createOrUpdateBot")
       );
 
+      let callingEndpoint: string | undefined = undefined;
+      let configuredChannels: BotChannelType[] | undefined = undefined;
+      if (args.channels) {
+        configuredChannels = [];
+        for (const channel of args.channels) {
+          if (channel.name === BotChannelType.MicrosoftTeams) {
+            callingEndpoint = (channel as MicrosoftTeamsChannelSettings).callingWebhook;
+            if (channel.enable) {
+              configuredChannels.push(BotChannelType.MicrosoftTeams);
+            }
+          } else if (channel.name === BotChannelType.Outlook && channel.enable) {
+            configuredChannels.push(BotChannelType.Outlook);
+          }
+        }
+      }
       const botRegistrationData: IBotRegistration = {
         botId: args.botId,
         name: args.name,
         description: args.description ?? "",
         iconUrl: args.iconUrl ?? "",
         messagingEndpoint: args.messagingEndpoint,
-        callingEndpoint: "",
+        callingEndpoint: callingEndpoint ?? "",
+        configuredChannels,
       };
 
       const botRegistration: BotRegistration = new LocalBotRegistration();
@@ -143,6 +165,35 @@ export class CreateOrUpdateBotFrameworkBotDriver implements StepDriver {
 
     if (args.iconUrl && typeof args.iconUrl !== "string") {
       invalidParameters.push("iconUrl");
+    }
+
+    if (args.channels) {
+      if (!Array.isArray(args.channels)) {
+        invalidParameters.push("channels");
+      } else {
+        for (const channel of args.channels) {
+          if (
+            !channel.name ||
+            typeof channel.name !== "string" ||
+            (channel.name !== BotChannelType.MicrosoftTeams &&
+              channel.name !== BotChannelType.Outlook)
+          ) {
+            invalidParameters.push("channels");
+            break;
+          }
+          if (typeof channel.enable !== "boolean") {
+            invalidParameters.push("channels");
+            break;
+          }
+          if (channel.name === BotChannelType.MicrosoftTeams) {
+            const callingWebhook = (channel as MicrosoftTeamsChannelSettings).callingWebhook;
+            if (callingWebhook && typeof callingWebhook !== "string") {
+              invalidParameters.push("channels");
+              break;
+            }
+          }
+        }
+      }
     }
 
     if (invalidParameters.length > 0) {

--- a/packages/fx-core/src/component/driver/botFramework/createOrUpdateBot.ts
+++ b/packages/fx-core/src/component/driver/botFramework/createOrUpdateBot.ts
@@ -88,10 +88,8 @@ export class CreateOrUpdateBotFrameworkBotDriver implements StepDriver {
         for (const channel of args.channels) {
           if (channel.name === BotChannelType.MicrosoftTeams) {
             callingEndpoint = (channel as MicrosoftTeamsChannelSettings).callingWebhook;
-            if (channel.enable) {
-              configuredChannels.push(BotChannelType.MicrosoftTeams);
-            }
-          } else if (channel.name === BotChannelType.Outlook && channel.enable) {
+            configuredChannels.push(BotChannelType.MicrosoftTeams);
+          } else if (channel.name === BotChannelType.Outlook) {
             configuredChannels.push(BotChannelType.Outlook);
           }
         }
@@ -178,10 +176,6 @@ export class CreateOrUpdateBotFrameworkBotDriver implements StepDriver {
             (channel.name !== BotChannelType.MicrosoftTeams &&
               channel.name !== BotChannelType.Outlook)
           ) {
-            invalidParameters.push("channels");
-            break;
-          }
-          if (typeof channel.enable !== "boolean") {
             invalidParameters.push("channels");
             break;
           }

--- a/packages/fx-core/src/component/driver/botFramework/interface/createOrUpdateBotFrameworkBotArgs.ts
+++ b/packages/fx-core/src/component/driver/botFramework/interface/createOrUpdateBotFrameworkBotArgs.ts
@@ -3,7 +3,6 @@
 
 export interface BotChannelSettings {
   name: string;
-  enable: boolean;
 }
 
 export interface MicrosoftTeamsChannelSettings extends BotChannelSettings {

--- a/packages/fx-core/src/component/driver/botFramework/interface/createOrUpdateBotFrameworkBotArgs.ts
+++ b/packages/fx-core/src/component/driver/botFramework/interface/createOrUpdateBotFrameworkBotArgs.ts
@@ -1,10 +1,20 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+export interface BotChannelSettings {
+  name: string;
+  enable: boolean;
+}
+
+export interface MicrosoftTeamsChannelSettings extends BotChannelSettings {
+  callingWebhook?: string;
+}
+
 export interface CreateOrUpdateBotFrameworkBotArgs {
   botId: string;
   name: string;
   messagingEndpoint: string;
   description?: string;
   iconUrl?: string;
+  channels?: BotChannelSettings[];
 }

--- a/packages/fx-core/src/component/resource/botService/appStudio/interfaces/IBotRegistration.ts
+++ b/packages/fx-core/src/component/resource/botService/appStudio/interfaces/IBotRegistration.ts
@@ -1,6 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+export enum BotChannelType {
+  MicrosoftTeams = "msteams",
+  Outlook = "outlook",
+}
+
 export interface IBotRegistration {
   botId?: string;
   name: string;
@@ -8,4 +13,5 @@ export interface IBotRegistration {
   iconUrl: string;
   messagingEndpoint: string;
   callingEndpoint: string;
+  configuredChannels?: BotChannelType[];
 }

--- a/packages/fx-core/src/component/resource/botService/botRegistration/utils.ts
+++ b/packages/fx-core/src/component/resource/botService/botRegistration/utils.ts
@@ -15,6 +15,7 @@ export class Utils {
       iconUrl: local.iconUrl || remote.iconUrl,
       messagingEndpoint: local.messagingEndpoint || remote.messagingEndpoint,
       callingEndpoint: local.callingEndpoint || remote.callingEndpoint,
+      configuredChannels: local.configuredChannels || remote.configuredChannels,
     };
   }
 }

--- a/packages/fx-core/tests/component/driver/botFramework/createOrUpdateBot.test.ts
+++ b/packages/fx-core/tests/component/driver/botFramework/createOrUpdateBot.test.ts
@@ -127,6 +127,90 @@ describe("CreateOrUpdateM365BotDriver", () => {
       }
     });
 
+    it("invalid args: channels not list", async () => {
+      const args: any = {
+        botId: "11111111-1111-1111-1111-111111111111",
+        name: "test-bot",
+        messagingEndpoint: "https://test.ngrok.io/api/messages",
+        channels: "channels",
+      };
+      const result = await driver.run(args, mockedDriverContext);
+      chai.assert(result.isErr());
+      if (result.isErr()) {
+        chai.assert(result.error instanceof InvalidParameterUserError);
+        const message =
+          "Following parameter is missing or invalid for botFramework/create action: channels.";
+        chai.assert.equal(result.error.message, message);
+      }
+    });
+
+    it("invalid args: channel name invalid", async () => {
+      const args: any = {
+        botId: "11111111-1111-1111-1111-111111111111",
+        name: "test-bot",
+        messagingEndpoint: "https://test.ngrok.io/api/messages",
+        channels: [
+          {
+            name: "name",
+            enable: true,
+          },
+        ],
+      };
+      const result = await driver.run(args, mockedDriverContext);
+      chai.assert(result.isErr());
+      if (result.isErr()) {
+        chai.assert(result.error instanceof InvalidParameterUserError);
+        const message =
+          "Following parameter is missing or invalid for botFramework/create action: channels.";
+        chai.assert.equal(result.error.message, message);
+      }
+    });
+
+    it("invalid args: channel enable is not boolean", async () => {
+      const args: any = {
+        botId: "11111111-1111-1111-1111-111111111111",
+        name: "test-bot",
+        messagingEndpoint: "https://test.ngrok.io/api/messages",
+        channels: [
+          {
+            name: "name",
+            enable: null,
+          },
+        ],
+      };
+      const result = await driver.run(args, mockedDriverContext);
+      chai.assert(result.isErr());
+      if (result.isErr()) {
+        chai.assert(result.error instanceof InvalidParameterUserError);
+        const message =
+          "Following parameter is missing or invalid for botFramework/create action: channels.";
+        chai.assert.equal(result.error.message, message);
+      }
+    });
+
+    it("invalid args: teams channel callingWebhook is not string", async () => {
+      const args: any = {
+        botId: "11111111-1111-1111-1111-111111111111",
+        name: "test-bot",
+        messagingEndpoint: "https://test.ngrok.io/api/messages",
+        channels: [
+          {
+            name: "msteams",
+            enable: true,
+            callingWebhook: 123,
+          },
+        ],
+      };
+      const result = await driver.run(args, mockedDriverContext);
+      chai.assert(result.isErr());
+      if (result.isErr()) {
+        chai.assert(result.error instanceof InvalidParameterUserError);
+        const message =
+          "Following parameter is missing or invalid for botFramework/create action: channels.";
+        chai.assert.equal(result.error.message, message);
+      }
+    });
+
     it("exception", async () => {
       sinon.stub(AppStudioClient, "getBotRegistration").throws(new Error("exception"));
       const args: any = {

--- a/packages/fx-core/tests/component/driver/botFramework/createOrUpdateBot.test.ts
+++ b/packages/fx-core/tests/component/driver/botFramework/createOrUpdateBot.test.ts
@@ -152,29 +152,6 @@ describe("CreateOrUpdateM365BotDriver", () => {
         channels: [
           {
             name: "name",
-            enable: true,
-          },
-        ],
-      };
-      const result = await driver.run(args, mockedDriverContext);
-      chai.assert(result.isErr());
-      if (result.isErr()) {
-        chai.assert(result.error instanceof InvalidParameterUserError);
-        const message =
-          "Following parameter is missing or invalid for botFramework/create action: channels.";
-        chai.assert.equal(result.error.message, message);
-      }
-    });
-
-    it("invalid args: channel enable is not boolean", async () => {
-      const args: any = {
-        botId: "11111111-1111-1111-1111-111111111111",
-        name: "test-bot",
-        messagingEndpoint: "https://test.ngrok.io/api/messages",
-        channels: [
-          {
-            name: "name",
-            enable: null,
           },
         ],
       };
@@ -196,7 +173,6 @@ describe("CreateOrUpdateM365BotDriver", () => {
         channels: [
           {
             name: "msteams",
-            enable: true,
             callingWebhook: 123,
           },
         ],
@@ -241,6 +217,15 @@ describe("CreateOrUpdateM365BotDriver", () => {
         botId: "11111111-1111-1111-1111-111111111111",
         name: "test-bot",
         messagingEndpoint: "https://test.ngrok.io/api/messages",
+        channels: [
+          {
+            name: "msteams",
+            callingWebhook: "",
+          },
+          {
+            name: "outlook",
+          },
+        ],
       };
       const result = await driver.run(args, mockedDriverContext);
       chai.assert(result.isOk());


### PR DESCRIPTION
```yml
  - uses: botFramework/create # Create or update the bot registration on dev.botframework.com
    with:
      botId: ${{BOT_ID}}
      name: bot
      messagingEndpoint: ${{BOT_ENDPOINT}}/api/messages
      description: ""
      channels:
        - name: msteams
        - name: outlook
```