### PR TITLE
chore(localdebug): migrate teamsfx:ngrok-start to v3

### DIFF
--- a/packages/fx-core/src/core/middleware/projectMigratorV3.ts
+++ b/packages/fx-core/src/core/middleware/projectMigratorV3.ts
@@ -70,7 +70,8 @@ import {
   migrateSetUpBot,
   migrateValidateDependencies,
   migrateValidateLocalPrerequisites,
-  migrateNgrokStart,
+  migrateNgrokStartTask,
+  migrateNgrokStartCommand,
 } from "./utils/debug/taskMigrator";
 import { AppLocalYmlGenerator } from "./utils/debug/appLocalYmlGenerator";
 import { EOL } from "os";
@@ -570,7 +571,8 @@ export async function debugMigration(context: MigrationContext): Promise<void> {
     migratePrepareManifest,
     migrateValidateDependencies,
     migrateValidateLocalPrerequisites,
-    migrateNgrokStart,
+    migrateNgrokStartTask,
+    migrateNgrokStartCommand,
   ];
 
   const oldProjectSettings = await loadProjectSettings(context.projectPath);

--- a/packages/fx-core/src/core/middleware/projectMigratorV3.ts
+++ b/packages/fx-core/src/core/middleware/projectMigratorV3.ts
@@ -70,6 +70,7 @@ import {
   migrateSetUpBot,
   migrateValidateDependencies,
   migrateValidateLocalPrerequisites,
+  migrateNgrokStart,
 } from "./utils/debug/taskMigrator";
 import { AppLocalYmlGenerator } from "./utils/debug/appLocalYmlGenerator";
 import { EOL } from "os";
@@ -569,6 +570,7 @@ export async function debugMigration(context: MigrationContext): Promise<void> {
     migratePrepareManifest,
     migrateValidateDependencies,
     migrateValidateLocalPrerequisites,
+    migrateNgrokStart,
   ];
 
   const oldProjectSettings = await loadProjectSettings(context.projectPath);

--- a/packages/fx-core/src/core/middleware/utils/debug/taskMigrator.ts
+++ b/packages/fx-core/src/core/middleware/utils/debug/taskMigrator.ts
@@ -21,7 +21,6 @@ import {
 } from "./debugV3MigrationUtils";
 import { InstallToolArgs } from "../../../../component/driver/prerequisite/interfaces/InstallToolArgs";
 import { BuildArgs } from "../../../../component/driver/interface/buildAndDeployArgs";
-import { includes } from "lodash";
 
 export function migrateTransparentPrerequisite(context: DebugMigrationContext): void {
   for (const task of context.tasks) {

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/V3.5.0-V4.0.6-command/expected/tasks.json
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/V3.5.0-V4.0.6-command/expected/tasks.json
@@ -34,7 +34,31 @@
         },
         {
             "label": "start ngrok",
-            "dependsOn": "teamsfx: ngrok start"
+            "dependsOn": [
+                "Start local tunnel"
+            ]
+        },
+        {
+            // Start the local tunnel service to forward public ngrok URL to local port and inspect traffic.
+            // See https://aka.ms/teamsfx-local-tunnel-task for the detailed args definitions,
+            // as well as samples to:
+            //   - use your own ngrok command / configuration / binary
+            //   - use your own tunnel solution
+            //   - provide alternatives if ngrok does not work on your dev machine
+            "label": "Start local tunnel",
+            "type": "teamsfx",
+            "command": "debug-start-local-tunnel",
+            "args": {
+                "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
+                "env": "local",
+                "output": {
+                    // Keep consistency with migrated configuration.
+                    "endpoint": "PROVISIONOUTPUT__AZUREWEBAPPBOTOUTPUT__SITEENDPOINT",
+                    "domain": "PROVISIONOUTPUT__AZUREWEBAPPBOTOUTPUT__DOMAIN"
+                }
+            },
+            "isBackground": true,
+            "problemMatcher": "$teamsfx-local-tunnel-watch"
         },
         {
             "label": "prepare local environment",

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/V3.5.0-V4.0.6-notification-trigger/expected/tasks.json
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/V3.5.0-V4.0.6-notification-trigger/expected/tasks.json
@@ -34,7 +34,31 @@
         },
         {
             "label": "start ngrok",
-            "dependsOn": "teamsfx: ngrok start"
+            "dependsOn": [
+                "Start local tunnel"
+            ]
+        },
+        {
+            // Start the local tunnel service to forward public ngrok URL to local port and inspect traffic.
+            // See https://aka.ms/teamsfx-local-tunnel-task for the detailed args definitions,
+            // as well as samples to:
+            //   - use your own ngrok command / configuration / binary
+            //   - use your own tunnel solution
+            //   - provide alternatives if ngrok does not work on your dev machine
+            "label": "Start local tunnel",
+            "type": "teamsfx",
+            "command": "debug-start-local-tunnel",
+            "args": {
+                "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
+                "env": "local",
+                "output": {
+                    // Keep consistency with migrated configuration.
+                    "endpoint": "PROVISIONOUTPUT__AZUREFUNCTIONBOTOUTPUT__SITEENDPOINT",
+                    "domain": "PROVISIONOUTPUT__AZUREFUNCTIONBOTOUTPUT__DOMAIN"
+                }
+            },
+            "isBackground": true,
+            "problemMatcher": "$teamsfx-local-tunnel-watch"
         },
         {
             "label": "prepare local environment",

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/V3.5.0-V4.0.6-tab-bot-func/expected/tasks.json
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/V3.5.0-V4.0.6-tab-bot-func/expected/tasks.json
@@ -37,7 +37,31 @@
         },
         {
             "label": "start ngrok",
-            "dependsOn": "teamsfx: ngrok start"
+            "dependsOn": [
+                "Start local tunnel"
+            ]
+        },
+        {
+            // Start the local tunnel service to forward public ngrok URL to local port and inspect traffic.
+            // See https://aka.ms/teamsfx-local-tunnel-task for the detailed args definitions,
+            // as well as samples to:
+            //   - use your own ngrok command / configuration / binary
+            //   - use your own tunnel solution
+            //   - provide alternatives if ngrok does not work on your dev machine
+            "label": "Start local tunnel",
+            "type": "teamsfx",
+            "command": "debug-start-local-tunnel",
+            "args": {
+                "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
+                "env": "local",
+                "output": {
+                    // Keep consistency with migrated configuration.
+                    "endpoint": "PROVISIONOUTPUT__AZUREWEBAPPBOTOUTPUT__SITEENDPOINT",
+                    "domain": "PROVISIONOUTPUT__AZUREWEBAPPBOTOUTPUT__DOMAIN"
+                }
+            },
+            "isBackground": true,
+            "problemMatcher": "$teamsfx-local-tunnel-watch"
         },
         {
             "label": "prepare local environment",

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/beforeV3.4.0-bot/expected/tasks.json
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/beforeV3.4.0-bot/expected/tasks.json
@@ -29,13 +29,29 @@
             }
         },
         {
+            // Start the local tunnel service to forward public ngrok URL to local port and inspect traffic.
+            // See https://aka.ms/teamsfx-local-tunnel-task for the detailed args definitions,
+            // as well as samples to:
+            //   - use your own ngrok command / configuration / binary
+            //   - use your own tunnel solution
+            //   - provide alternatives if ngrok does not work on your dev machine
             "label": "start ngrok",
             "type": "teamsfx",
-            "command": "ngrok start",
+            "command": "debug-start-local-tunnel",
             "isBackground": true,
             "dependsOn": [
                 "bot npm install"
-            ]
+            ],
+            "args": {
+                "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
+                "env": "local",
+                "output": {
+                    // Keep consistency with migrated configuration.
+                    "endpoint": "PROVISIONOUTPUT__BOTOUTPUT__SITEENDPOINT",
+                    "domain": "PROVISIONOUTPUT__BOTOUTPUT__DOMAIN"
+                }
+            },
+            "problemMatcher": "$teamsfx-local-tunnel-watch"
         },
         {
             "label": "prepare dev env",

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/beforeV3.4.0-tab-bot-func/expected/tasks.json
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/beforeV3.4.0-tab-bot-func/expected/tasks.json
@@ -32,13 +32,29 @@
             }
         },
         {
+            // Start the local tunnel service to forward public ngrok URL to local port and inspect traffic.
+            // See https://aka.ms/teamsfx-local-tunnel-task for the detailed args definitions,
+            // as well as samples to:
+            //   - use your own ngrok command / configuration / binary
+            //   - use your own tunnel solution
+            //   - provide alternatives if ngrok does not work on your dev machine
             "label": "start ngrok",
             "type": "teamsfx",
-            "command": "ngrok start",
+            "command": "debug-start-local-tunnel",
             "isBackground": true,
             "dependsOn": [
                 "bot npm install"
-            ]
+            ],
+            "args": {
+                "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
+                "env": "local",
+                "output": {
+                    // Keep consistency with migrated configuration.
+                    "endpoint": "PROVISIONOUTPUT__BOTOUTPUT__SITEENDPOINT",
+                    "domain": "PROVISIONOUTPUT__BOTOUTPUT__DOMAIN"
+                }
+            },
+            "problemMatcher": "$teamsfx-local-tunnel-watch"
         },
         {
             "label": "prepare dev env",


### PR DESCRIPTION
V4.0.6 Source
```
        {
            "label": "start ngrok",
            "dependsOn": "teamsfx: ngrok start"
        },
```
V4.0.6 Target
```
        {
            "label": "start ngrok",
            "dependsOn": [
                "Start local tunnel"
            ]
        },
        {
            // Start the local tunnel service to forward public ngrok URL to local port and inspect traffic.
            // See https://aka.ms/teamsfx-local-tunnel-task for the detailed args definitions,
            // as well as samples to:
            //   - use your own ngrok command / configuration / binary
            //   - use your own tunnel solution
            //   - provide alternatives if ngrok does not work on your dev machine
            "label": "Start local tunnel",
            "type": "teamsfx",
            "command": "debug-start-local-tunnel",
            "args": {
                "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
                "env": "local",
                "output": {
                    // Keep consistency with migrated configuration.
                    "endpoint": "PROVISIONOUTPUT__AZUREWEBAPPBOTOUTPUT__SITEENDPOINT",
                    "domain": "PROVISIONOUTPUT__AZUREWEBAPPBOTOUTPUT__DOMAIN"
                }
            },
            "isBackground": true,
            "problemMatcher": "$teamsfx-local-tunnel-watch"
        },
```

V3.4.0 Source
```
    {
            "label": "start ngrok",
            "type": "teamsfx",
            "command": "ngrok start",
            "isBackground": true,
            "dependsOn": [
                "bot npm install"
            ]
    },
```
V3.4.0 Target
```
    {
            // Start the local tunnel service to forward public ngrok URL to local port and inspect traffic.
            // See https://aka.ms/teamsfx-local-tunnel-task for the detailed args definitions,
            // as well as samples to:
            //   - use your own ngrok command / configuration / binary
            //   - use your own tunnel solution
            //   - provide alternatives if ngrok does not work on your dev machine
            "label": "start ngrok",
            "type": "teamsfx",
            "command": "debug-start-local-tunnel",
            "isBackground": true,
            "dependsOn": [
                "bot npm install"
            ],
            "args": {
                "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
                "env": "local",
                "output": {
                    // Keep consistency with migrated configuration.
                    "endpoint": "PROVISIONOUTPUT__BOTOUTPUT__SITEENDPOINT",
                    "domain": "PROVISIONOUTPUT__BOTOUTPUT__DOMAIN"
                }
            },
            "problemMatcher": "$teamsfx-local-tunnel-watch"
    },
```