### PR TITLE
chore(debug-migration): revert wrap indexPath with quotes

### DIFF
--- a/packages/fx-core/templates/core/v3Migration/js.ts.app.local.yml
+++ b/packages/fx-core/templates/core/v3Migration/js.ts.app.local.yml
@@ -40,7 +40,7 @@ configureApp:
       envs:
         {{../../placeholderMappings.tabDomain}}: {{domain}}
         {{../../placeholderMappings.tabEndpoint}}: {{endpoint}}
-        {{../../placeholderMappings.tabIndexPath}}: "\"/index.html#\""
+        {{../../placeholderMappings.tabIndexPath}}: /index.html#
 
   {{/tab}}
   {{#if aad}}

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-sso-tab/expected/app.local.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-sso-tab/expected/app.local.yml
@@ -16,7 +16,7 @@ configureApp:
       envs:
         PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__DOMAIN: localhost:53000
         PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__ENDPOINT: https://localhost:53000
-        PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH: "\"/index.html#\""
+        PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH: /index.html#
 
   - uses: aadApp/update
     with:

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-tab-bot-func/expected/app.local.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-tab-bot-func/expected/app.local.yml
@@ -28,7 +28,7 @@ configureApp:
       envs:
         PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__DOMAIN: localhost:53000
         PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__ENDPOINT: https://localhost:53000
-        PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH: "\"/index.html#\""
+        PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH: /index.html#
 
   - uses: aadApp/update
     with:

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-tab/expected/app.local.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-tab/expected/app.local.yml
@@ -11,7 +11,7 @@ configureApp:
       envs:
         PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__DOMAIN: localhost:53000
         PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__ENDPOINT: https://localhost:53000
-        PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH: "\"/index.html#\""
+        PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH: /index.html#
 
   - uses: teamsApp/validate
     with:


### PR DESCRIPTION
This reverts commit 19856c41b8661c4c4f5037491fd846aa4593b1cd.

Revert this change because `#` in `.env` is well handled by #7244.