### PR TITLE
chore: authenticate downloading template

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -96,6 +96,8 @@ jobs:
       - name: Setup project
         run: |
           npm run setup
+        env: 
+          REQUEST_TOKEN: ${{ secrets.CD_PAT }}
 
       - name: Setup git
         run: |
@@ -257,11 +259,15 @@ jobs:
         if: ${{ github.ref == 'refs/heads/dev' }}
         run: |
           npx lerna publish from-package --dist-tag=alpha --yes --allow-branch dev
+        env: 
+          REQUEST_TOKEN: ${{ secrets.CD_PAT }}
 
       - name: publish beta release to npm org
         if: ${{ github.ref == 'refs/heads/ga' }}
         run: |
           npx lerna publish from-package --dist-tag=beta --yes --allow-branch ga
+        env: 
+          REQUEST_TOKEN: ${{ secrets.CD_PAT }}
 
       - name: update cli ai key
         if: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.preid == 'stable'||github.event.inputs.preid == 'rc') }}
@@ -289,11 +295,15 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.preid == 'rc' }}
         run: |
           npx lerna publish from-package --dist-tag=rc --yes
+        env: 
+          REQUEST_TOKEN: ${{ secrets.CD_PAT }}
 
       - name: publish stable npm packages to npmjs.org
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.preid == 'stable' }}
         run: |
           npx lerna publish from-package --yes
+        env: 
+          REQUEST_TOKEN: ${{ secrets.CD_PAT }}
 
       - name: pack server bits
         if: ${{ contains(steps.version-change.outputs.CHANGED, '@microsoft/teamsfx-server') }}


### PR DESCRIPTION
https://github.com/OfficeDev/TeamsFx/actions/runs/3709042721/jobs/6287239111
https://github.com/OfficeDev/TeamsFx/actions/runs/3690487224/jobs/6247536027
Downloading templates in cd pipeline sometimes failed for 403 error, which may cause by [GitHub API rate limit](https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#requests-from-github-actions).
Adding authorization header to the request may fix the issue.