### PR TITLE
chore: upgrate restify to support node 18

### DIFF
--- a/templates/bot/js/command-and-response/package.json
+++ b/templates/bot/js/command-and-response/package.json
@@ -18,7 +18,7 @@
     },
     "dependencies": {
         "@microsoft/teamsfx": "^2.0.0",
-        "restify": "^8.5.1"
+        "restify": "^10.0.0"
     },
     "devDependencies": {
         "env-cmd": "^10.1.0",

--- a/templates/bot/js/default/package.json
+++ b/templates/bot/js/default/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@microsoft/adaptivecards-tools": "^1.0.0",
     "botbuilder": "^4.18.0",
-    "restify": "~8.5.1"
+    "restify": "~10.0.0"
   },
   "devDependencies": {
     "env-cmd": "^10.1.0",

--- a/templates/bot/js/default/package.json
+++ b/templates/bot/js/default/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@microsoft/adaptivecards-tools": "^1.0.0",
     "botbuilder": "^4.18.0",
-    "restify": "~10.0.0"
+    "restify": "^10.0.0"
   },
   "devDependencies": {
     "env-cmd": "^10.1.0",

--- a/templates/bot/js/m365/package.json
+++ b/templates/bot/js/m365/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "botbuilder": "~4.14.0",
-    "restify": "~8.5.1"
+    "restify": "~10.0.0"
   },
   "devDependencies": {
     "env-cmd": "^10.1.0",

--- a/templates/bot/js/m365/package.json
+++ b/templates/bot/js/m365/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "botbuilder": "~4.14.0",
-    "restify": "~10.0.0"
+    "restify": "^10.0.0"
   },
   "devDependencies": {
     "env-cmd": "^10.1.0",

--- a/templates/bot/js/notification-restify/package.json
+++ b/templates/bot/js/notification-restify/package.json
@@ -20,7 +20,7 @@
         "@microsoft/adaptivecards-tools": "^1.0.0",
         "@microsoft/teamsfx": "^2.0.0",
         "botbuilder": "^4.18.0",
-        "restify": "^8.5.1"
+        "restify": "^10.0.0"
     },
     "devDependencies": {
         "env-cmd": "^10.1.0",

--- a/templates/bot/js/workflow/package.json
+++ b/templates/bot/js/workflow/package.json
@@ -19,7 +19,7 @@
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
         "@microsoft/teamsfx": "^1.2.0",
-        "restify": "^8.5.1"
+        "restify": "^10.0.0"
     },
     "devDependencies": {
         "env-cmd": "^10.1.0",

--- a/templates/bot/ts/command-and-response/package.json
+++ b/templates/bot/ts/command-and-response/package.json
@@ -23,7 +23,7 @@
         "restify": "^10.0.0"
     },
     "devDependencies": {
-        "@types/restify": "8.4.2",
+        "@types/restify": "8.5.5",
         "env-cmd": "^10.1.0",
         "nodemon": "^2.0.7",
         "ts-node": "^10.4.0",

--- a/templates/bot/ts/command-and-response/package.json
+++ b/templates/bot/ts/command-and-response/package.json
@@ -20,7 +20,7 @@
     "dependencies": {
         "@microsoft/teamsfx": "^2.0.0",
         "botbuilder": "^4.18.0",
-        "restify": "^8.5.1"
+        "restify": "^10.0.0"
     },
     "devDependencies": {
         "@types/restify": "8.4.2",

--- a/templates/bot/ts/default/package.json
+++ b/templates/bot/ts/default/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@microsoft/adaptivecards-tools": "^1.0.0",
     "botbuilder": "^4.18.0",
-    "restify": "^8.5.1"
+    "restify": "^10.0.0"
   },
   "devDependencies": {
     "@types/restify": "8.4.2",

--- a/templates/bot/ts/default/package.json
+++ b/templates/bot/ts/default/package.json
@@ -23,7 +23,7 @@
     "restify": "^10.0.0"
   },
   "devDependencies": {
-    "@types/restify": "8.4.2",
+    "@types/restify": "8.5.5",
     "env-cmd": "^10.1.0",
     "ts-node": "^10.4.0",
     "typescript": "^4.4.4",

--- a/templates/bot/ts/m365/package.json
+++ b/templates/bot/ts/m365/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "botbuilder": "~4.14.0",
-    "restify": "^8.5.1"
+    "restify": "^10.0.0"
   },
   "devDependencies": {
     "@types/restify": "8.4.2",

--- a/templates/bot/ts/m365/package.json
+++ b/templates/bot/ts/m365/package.json
@@ -22,7 +22,7 @@
     "restify": "^10.0.0"
   },
   "devDependencies": {
-    "@types/restify": "8.4.2",
+    "@types/restify": "8.5.5",
     "env-cmd": "^10.1.0",
     "ts-node": "^10.4.0",
     "typescript": "^4.4.4",

--- a/templates/bot/ts/notification-restify/package.json
+++ b/templates/bot/ts/notification-restify/package.json
@@ -24,7 +24,7 @@
         "restify": "^10.0.0"
     },
     "devDependencies": {
-        "@types/restify": "8.4.2",
+        "@types/restify": "8.5.5",
         "env-cmd": "^10.1.0",
         "nodemon": "^2.0.7",
         "ts-node": "^10.4.0",

--- a/templates/bot/ts/notification-restify/package.json
+++ b/templates/bot/ts/notification-restify/package.json
@@ -21,7 +21,7 @@
         "@microsoft/adaptivecards-tools": "^1.0.0",
         "@microsoft/teamsfx": "^2.0.0",
         "botbuilder": "^4.18.0",
-        "restify": "^8.5.1"
+        "restify": "^10.0.0"
     },
     "devDependencies": {
         "@types/restify": "8.4.2",

--- a/templates/bot/ts/workflow/package.json
+++ b/templates/bot/ts/workflow/package.json
@@ -21,7 +21,7 @@
         "@microsoft/adaptivecards-tools": "^1.0.0",
         "@microsoft/teamsfx": "^1.2.0",
         "botbuilder": "^4.18.0",
-        "restify": "^8.5.1"
+        "restify": "^10.0.0"
     },
     "devDependencies": {
         "@types/restify": "8.4.2",

--- a/templates/bot/ts/workflow/package.json
+++ b/templates/bot/ts/workflow/package.json
@@ -24,7 +24,7 @@
         "restify": "^10.0.0"
     },
     "devDependencies": {
-        "@types/restify": "8.4.2",
+        "@types/restify": "8.5.5",
         "env-cmd": "^10.1.0",
         "nodemon": "^2.0.7",
         "shx": "^0.3.4",

--- a/templates/scenarios/js/command-and-response/package.json.tpl
+++ b/templates/scenarios/js/command-and-response/package.json.tpl
@@ -23,7 +23,7 @@
         "@microsoft/adaptivecards-tools": "^1.0.0",
         "@microsoft/teamsfx": "^2.0.0",
         "botbuilder": "^4.18.0",
-        "restify": "^8.5.1"
+        "restify": "^10.0.0"
     },
     "devDependencies": {
         "nodemon": "^2.0.7",

--- a/templates/scenarios/js/default-bot-message-extension/package.json.tpl
+++ b/templates/scenarios/js/default-bot-message-extension/package.json.tpl
@@ -21,7 +21,7 @@
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
         "botbuilder": "^4.18.0",
-        "restify": "~10.0.0"
+        "restify": "^10.0.0"
     },
     "devDependencies": {
         "@microsoft/teamsfx-run-utils": "alpha",

--- a/templates/scenarios/js/default-bot-message-extension/package.json.tpl
+++ b/templates/scenarios/js/default-bot-message-extension/package.json.tpl
@@ -21,7 +21,7 @@
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
         "botbuilder": "^4.18.0",
-        "restify": "~8.5.1"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "@microsoft/teamsfx-run-utils": "alpha",

--- a/templates/scenarios/js/default-bot/package.json.tpl
+++ b/templates/scenarios/js/default-bot/package.json.tpl
@@ -21,7 +21,7 @@
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
         "botbuilder": "^4.18.0",
-        "restify": "~10.0.0"
+        "restify": "^10.0.0"
     },
     "devDependencies": {
         "@microsoft/teamsfx-run-utils": "alpha",

--- a/templates/scenarios/js/default-bot/package.json.tpl
+++ b/templates/scenarios/js/default-bot/package.json.tpl
@@ -21,7 +21,7 @@
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
         "botbuilder": "^4.18.0",
-        "restify": "~8.5.1"
+        "restify": "~10.0.0"
     },
     "devDependencies": {
         "@microsoft/teamsfx-run-utils": "alpha",

--- a/templates/scenarios/js/m365-message-extension/package.json.tpl
+++ b/templates/scenarios/js/m365-message-extension/package.json.tpl
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "botbuilder": "~4.14.0",
-    "restify": "~8.5.1"
+    "restify": "~10.0.0"
   },
   "devDependencies": {
     "@microsoft/teamsfx-run-utils": "alpha",

--- a/templates/scenarios/js/m365-message-extension/package.json.tpl
+++ b/templates/scenarios/js/m365-message-extension/package.json.tpl
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "botbuilder": "~4.14.0",
-    "restify": "~10.0.0"
+    "restify": "^10.0.0"
   },
   "devDependencies": {
     "@microsoft/teamsfx-run-utils": "alpha",

--- a/templates/scenarios/js/message-extension/package.json.tpl
+++ b/templates/scenarios/js/message-extension/package.json.tpl
@@ -22,7 +22,7 @@
     "@microsoft/adaptivecards-tools": "^1.0.0",
     "botbuilder": "^4.18.0",
     "isomorphic-fetch": "^3.0.0",
-    "restify": "~10.0.0"
+    "restify": "^10.0.0"
   },
   "devDependencies": {
     "@microsoft/teamsfx-run-utils": "alpha",

--- a/templates/scenarios/js/message-extension/package.json.tpl
+++ b/templates/scenarios/js/message-extension/package.json.tpl
@@ -22,7 +22,7 @@
     "@microsoft/adaptivecards-tools": "^1.0.0",
     "botbuilder": "^4.18.0",
     "isomorphic-fetch": "^3.0.0",
-    "restify": "~8.5.1"
+    "restify": "~10.0.0"
   },
   "devDependencies": {
     "@microsoft/teamsfx-run-utils": "alpha",

--- a/templates/scenarios/js/non-sso-tab-default-bot/bot/package.json.tpl
+++ b/templates/scenarios/js/non-sso-tab-default-bot/bot/package.json.tpl
@@ -20,7 +20,7 @@
   "dependencies": {
     "@microsoft/adaptivecards-tools": "^1.0.0",
     "botbuilder": "^4.18.0",
-    "restify": "~8.5.1"
+    "restify": "~10.0.0"
   },
   "devDependencies": {
     "nodemon": "^2.0.7"

--- a/templates/scenarios/js/non-sso-tab-default-bot/bot/package.json.tpl
+++ b/templates/scenarios/js/non-sso-tab-default-bot/bot/package.json.tpl
@@ -20,7 +20,7 @@
   "dependencies": {
     "@microsoft/adaptivecards-tools": "^1.0.0",
     "botbuilder": "^4.18.0",
-    "restify": "~10.0.0"
+    "restify": "^10.0.0"
   },
   "devDependencies": {
     "nodemon": "^2.0.7"

--- a/templates/scenarios/js/notification-restify/package.json.tpl
+++ b/templates/scenarios/js/notification-restify/package.json.tpl
@@ -23,7 +23,7 @@
         "@microsoft/adaptivecards-tools": "^1.0.0",
         "@microsoft/teamsfx": "^2.0.0",
         "botbuilder": "^4.18.0",
-        "restify": "^8.5.1"
+        "restify": "^10.0.0"
     },
     "devDependencies": {
         "nodemon": "^2.0.7",

--- a/templates/scenarios/js/workflow/package.json.tpl
+++ b/templates/scenarios/js/workflow/package.json.tpl
@@ -22,7 +22,7 @@
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
         "@microsoft/teamsfx": "^1.2.0",
-        "restify": "^8.5.1"
+        "restify": "^10.0.0"
     },
     "devDependencies": {
         "@microsoft/teamsfx-run-utils": "alpha",

--- a/templates/scenarios/ts/command-and-response/package.json.tpl
+++ b/templates/scenarios/ts/command-and-response/package.json.tpl
@@ -27,7 +27,7 @@
     },
     "devDependencies": {
         "@microsoft/teamsfx-run-utils": "alpha",
-        "@types/restify": "8.4.2",
+        "@types/restify": "8.5.5",
         "nodemon": "^2.0.7",
         "ts-node": "^10.4.0",
         "typescript": "^4.4.4",

--- a/templates/scenarios/ts/command-and-response/package.json.tpl
+++ b/templates/scenarios/ts/command-and-response/package.json.tpl
@@ -23,7 +23,7 @@
     "dependencies": {
         "@microsoft/teamsfx": "^2.0.0",
         "botbuilder": "^4.18.0",
-        "restify": "^8.5.1"
+        "restify": "^10.0.0"
     },
     "devDependencies": {
         "@microsoft/teamsfx-run-utils": "alpha",

--- a/templates/scenarios/ts/default-bot-message-extension/package.json.tpl
+++ b/templates/scenarios/ts/default-bot-message-extension/package.json.tpl
@@ -23,7 +23,7 @@
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
         "botbuilder": "^4.17.0",
-        "restify": "^8.5.1"
+        "restify": "^10.0.0"
     },
     "devDependencies": {
         "@microsoft/teamsfx-run-utils": "alpha",

--- a/templates/scenarios/ts/default-bot-message-extension/package.json.tpl
+++ b/templates/scenarios/ts/default-bot-message-extension/package.json.tpl
@@ -27,7 +27,7 @@
     },
     "devDependencies": {
         "@microsoft/teamsfx-run-utils": "alpha",
-        "@types/restify": "8.4.2",
+        "@types/restify": "8.5.5",
         "ts-node": "^10.4.0",
         "typescript": "^4.4.4",
         "nodemon": "^2.0.7",

--- a/templates/scenarios/ts/default-bot/package.json.tpl
+++ b/templates/scenarios/ts/default-bot/package.json.tpl
@@ -23,7 +23,7 @@
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
         "botbuilder": "^4.17.0",
-        "restify": "^8.5.1"
+        "restify": "^10.0.0"
     },
     "devDependencies": {
         "@microsoft/teamsfx-run-utils": "alpha",

--- a/templates/scenarios/ts/default-bot/package.json.tpl
+++ b/templates/scenarios/ts/default-bot/package.json.tpl
@@ -27,7 +27,7 @@
     },
     "devDependencies": {
         "@microsoft/teamsfx-run-utils": "alpha",
-        "@types/restify": "8.4.2",
+        "@types/restify": "8.5.5",
         "ts-node": "^10.4.0",
         "typescript": "^4.4.4",
         "nodemon": "^2.0.7",

--- a/templates/scenarios/ts/m365-message-extension/package.json.tpl
+++ b/templates/scenarios/ts/m365-message-extension/package.json.tpl
@@ -26,7 +26,7 @@
     },
     "devDependencies": {
         "@microsoft/teamsfx-run-utils": "alpha",
-        "@types/restify": "8.4.2",
+        "@types/restify": "8.5.5",
         "ts-node": "^10.4.0",
         "typescript": "^4.4.4",
         "nodemon": "^2.0.7",

--- a/templates/scenarios/ts/m365-message-extension/package.json.tpl
+++ b/templates/scenarios/ts/m365-message-extension/package.json.tpl
@@ -22,7 +22,7 @@
     },
     "dependencies": {
         "botbuilder": "~4.14.0",
-        "restify": "^8.5.1"
+        "restify": "^10.0.0"
     },
     "devDependencies": {
         "@microsoft/teamsfx-run-utils": "alpha",

--- a/templates/scenarios/ts/message-extension/package.json.tpl
+++ b/templates/scenarios/ts/message-extension/package.json.tpl
@@ -28,7 +28,7 @@
     },
     "devDependencies": {
         "@microsoft/teamsfx-run-utils": "alpha",
-        "@types/restify": "8.4.2",
+        "@types/restify": "8.5.5",
         "ts-node": "^10.4.0",
         "typescript": "^4.4.4",
         "nodemon": "^2.0.7",

--- a/templates/scenarios/ts/message-extension/package.json.tpl
+++ b/templates/scenarios/ts/message-extension/package.json.tpl
@@ -24,7 +24,7 @@
         "@microsoft/adaptivecards-tools": "^1.0.0",
         "botbuilder": "^4.18.0",
         "isomorphic-fetch": "^3.0.0",
-        "restify": "^8.5.1"
+        "restify": "^10.0.0"
     },
     "devDependencies": {
         "@microsoft/teamsfx-run-utils": "alpha",

--- a/templates/scenarios/ts/non-sso-tab-default-bot/bot/package.json.tpl
+++ b/templates/scenarios/ts/non-sso-tab-default-bot/bot/package.json.tpl
@@ -22,7 +22,7 @@
   "dependencies": {
     "@microsoft/adaptivecards-tools": "^1.0.0",
     "botbuilder": "^4.17.0",
-    "restify": "^8.5.1"
+    "restify": "^10.0.0"
   },
   "devDependencies": {
     "@microsoft/teamsfx-run-utils": "alpha",

--- a/templates/scenarios/ts/non-sso-tab-default-bot/bot/package.json.tpl
+++ b/templates/scenarios/ts/non-sso-tab-default-bot/bot/package.json.tpl
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@microsoft/teamsfx-run-utils": "alpha",
-    "@types/restify": "8.4.2",
+    "@types/restify": "8.5.5",
     "ts-node": "^10.4.0",
     "typescript": "^4.4.4",
     "nodemon": "^2.0.7",

--- a/templates/scenarios/ts/notification-restify/package.json.tpl
+++ b/templates/scenarios/ts/notification-restify/package.json.tpl
@@ -24,7 +24,7 @@
         "@microsoft/adaptivecards-tools": "^1.0.0",
         "@microsoft/teamsfx": "^2.0.0",
         "botbuilder": "^4.18.0",
-        "restify": "^8.5.1"
+        "restify": "^10.0.0"
     },
     "devDependencies": {
         "@microsoft/teamsfx-run-utils": "alpha",

--- a/templates/scenarios/ts/notification-restify/package.json.tpl
+++ b/templates/scenarios/ts/notification-restify/package.json.tpl
@@ -28,7 +28,7 @@
     },
     "devDependencies": {
         "@microsoft/teamsfx-run-utils": "alpha",
-        "@types/restify": "8.4.2",
+        "@types/restify": "8.5.5",
         "nodemon": "^2.0.7",
         "ts-node": "^10.4.0",
         "typescript": "^4.4.4",

--- a/templates/scenarios/ts/workflow/package.json.tpl
+++ b/templates/scenarios/ts/workflow/package.json.tpl
@@ -23,7 +23,7 @@
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
         "@microsoft/teamsfx": "^1.2.0",
-        "restify": "^8.5.1"
+        "restify": "^10.0.0"
     },
     "devDependencies": {
         "@types/restify": "8.4.2",

--- a/templates/scenarios/ts/workflow/package.json.tpl
+++ b/templates/scenarios/ts/workflow/package.json.tpl
@@ -26,7 +26,7 @@
         "restify": "^10.0.0"
     },
     "devDependencies": {
-        "@types/restify": "8.4.2",
+        "@types/restify": "8.5.5",
         "@microsoft/teamsfx-run-utils": "alpha",
         "nodemon": "^2.0.7",
         "shx": "^0.3.4",


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/16598471/
https://github.com/restify/node-restify/releases/tag/v10.0.0

Update all bot templates to use `restify:10` which supports node 18