### PR TITLE
chore: download templates 403 for GitHub API rate limit

### DIFF
--- a/packages/fx-core/scripts/download-templates-zip.js
+++ b/packages/fx-core/scripts/download-templates-zip.js
@@ -60,6 +60,8 @@ function getTemplateDownloadPathPattern(tag) {
   return new RegExp(pattern, "g");
 }
 
+// Parse all template names from html instead of requesting /repos/{owner}/{repo}/releases/tags/{tag}.
+// Because API request to GitHub are subject to rate limits.
 async function getTemplates(tag) {
   const pattern = getTemplateDownloadPathPattern(tag);
   const url = `${config.templateReleaseURL}/${tag}`;

--- a/packages/fx-core/src/common/templates-config.json
+++ b/packages/fx-core/src/common/templates-config.json
@@ -3,5 +3,7 @@
     "tagPrefix": "templates@",
     "tagListURL": "https://github.com/OfficeDev/TeamsFx/releases/download/template-tag-list/template-tags.txt",
     "templateDownloadBaseURL": "https://github.com/OfficeDev/TeamsFx/releases/download",
-    "templateReleaseURL": "https://api.github.com/repos/OfficeDev/TeamsFx/releases/tags"
+    "templateReleaseURL": "https://github.com/OfficeDev/TeamsFx/releases/expanded_assets",
+    "templateDownloadBasePath": "/OfficeDev/TeamsFx/releases/download",
+    "templateExt": ".zip"
 }


### PR DESCRIPTION
Setup project may fail for 403 error because the API request over rate limit.
https://github.com/OfficeDev/TeamsFx/actions/runs/3709042721/jobs/6287239111