### PR TITLE
fix: fix compatibility issue with restify

### DIFF
--- a/templates/bot/ts/command-and-response/tsconfig.json
+++ b/templates/bot/ts/command-and-response/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "target": "es2016",
+    "target": "es2017",
     "module": "commonjs",
     "outDir": "./lib",
     "rootDir": "./",

--- a/templates/bot/ts/default/tsconfig.json
+++ b/templates/bot/ts/default/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "target": "es2016",
+    "target": "es2017",
     "module": "commonjs",
     "outDir": "./lib",
     "rootDir": "./",

--- a/templates/bot/ts/m365/tsconfig.json
+++ b/templates/bot/ts/m365/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "target": "es2016",
+    "target": "es2017",
     "module": "commonjs",
     "outDir": "./lib",
     "rootDir": "./",

--- a/templates/bot/ts/notification-restify/tsconfig.json
+++ b/templates/bot/ts/notification-restify/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "target": "es2016",
+    "target": "es2017",
     "module": "commonjs",
     "outDir": "./lib",
     "rootDir": "./",

--- a/templates/bot/ts/workflow/tsconfig.json
+++ b/templates/bot/ts/workflow/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "target": "es2016",
+    "target": "es2017",
     "module": "commonjs",
     "outDir": "./lib",
     "rootDir": "./",

--- a/templates/scenarios/ts/command-and-response/tsconfig.json
+++ b/templates/scenarios/ts/command-and-response/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "target": "es2016",
+    "target": "es2017",
     "module": "commonjs",
     "outDir": "./lib",
     "rootDir": "./",

--- a/templates/scenarios/ts/default-bot-message-extension/tsconfig.json
+++ b/templates/scenarios/ts/default-bot-message-extension/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "target": "es2016",
+    "target": "es2017",
     "module": "commonjs",
     "outDir": "./lib",
     "rootDir": "./",

--- a/templates/scenarios/ts/default-bot/tsconfig.json
+++ b/templates/scenarios/ts/default-bot/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "target": "es2016",
+    "target": "es2017",
     "module": "commonjs",
     "outDir": "./lib",
     "rootDir": "./",

--- a/templates/scenarios/ts/m365-message-extension/tsconfig.json
+++ b/templates/scenarios/ts/m365-message-extension/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "target": "es2016",
+    "target": "es2017",
     "module": "commonjs",
     "outDir": "./lib",
     "rootDir": "./",

--- a/templates/scenarios/ts/message-extension/tsconfig.json
+++ b/templates/scenarios/ts/message-extension/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "target": "es2016",
+    "target": "es2017",
     "module": "commonjs",
     "outDir": "./lib",
     "rootDir": "./",

--- a/templates/scenarios/ts/non-sso-tab-default-bot/bot/tsconfig.json
+++ b/templates/scenarios/ts/non-sso-tab-default-bot/bot/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "target": "es2016",
+    "target": "es2017",
     "module": "commonjs",
     "outDir": "./lib",
     "rootDir": "./",

--- a/templates/scenarios/ts/notification-restify/tsconfig.json
+++ b/templates/scenarios/ts/notification-restify/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "target": "es2016",
+    "target": "es2017",
     "module": "commonjs",
     "outDir": "./lib",
     "rootDir": "./",

--- a/templates/scenarios/ts/workflow/tsconfig.json
+++ b/templates/scenarios/ts/workflow/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "target": "es2016",
+    "target": "es2017",
     "module": "commonjs",
     "outDir": "./lib",
     "rootDir": "./",


### PR DESCRIPTION
Related to https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/16598471/
Use `es2017` in ts bot templates to ensure `async function` is kept during building, which is required by `restify:10`.
Otherwise it throws:
<img width="512" alt="image" src="https://user-images.githubusercontent.com/7642967/208626203-770a0b19-692b-492d-a579-63a78757808c.png">

E2E TEST: N/A