### PR TITLE
fix: add hardcoded vs tab indexpath to migrated project

### DIFF
--- a/packages/fx-core/src/core/middleware/utils/appYmlGenerator.ts
+++ b/packages/fx-core/src/core/middleware/utils/appYmlGenerator.ts
@@ -136,6 +136,7 @@ export class AppYmlGenerator extends BaseAppYmlGenerator {
     this.setPlaceholderMapping("state.fx-resource-frontend-hosting.storageResourceId");
     this.setPlaceholderMapping("state.fx-resource-frontend-hosting.endpoint");
     this.setPlaceholderMapping("state.fx-resource-frontend-hosting.resourceId");
+    this.setPlaceholderMapping("state.fx-resource-frontend-hosting.indexPath");
     this.setPlaceholderMapping("state.fx-resource-bot.resourceId");
     this.setPlaceholderMapping("state.fx-resource-bot.functionAppResourceId");
     this.setPlaceholderMapping("state.fx-resource-function.functionAppResourceId");

--- a/packages/fx-core/templates/core/v3Migration/csharp.app.yml
+++ b/packages/fx-core/templates/core/v3Migration/csharp.app.yml
@@ -23,7 +23,7 @@ provision:
   - uses: file/updateEnv # Add additional item to .env file
     with:
       envs:
-        {{placeholderMappings.[state.fx-resource-frontend-hosting.indexPath]}}: '/' # This environment variable is required in your existing Teams app manifest
+        {{placeholderMappings.[state.fx-resource-frontend-hosting.indexPath]}}: '/' # Used in appPackage/manifest.template.json file.
 {{/if}}
 
 deploy:

--- a/packages/fx-core/templates/core/v3Migration/csharp.app.yml
+++ b/packages/fx-core/templates/core/v3Migration/csharp.app.yml
@@ -19,6 +19,12 @@ provision:
          deploymentName: teams_toolkit_deployment # Required when deploy ARM template
       bicepCliVersion: v0.4.613 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
     # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
+{{#if activePlugins.fx-resource-frontend-hosting}}
+  - uses: file/updateEnv # Add additional item to .env file
+    with:
+      envs:
+        {{placeholderMappings.[state.fx-resource-frontend-hosting.indexPath]}}: '/' # This environment variable is required in your existing Teams app manifest
+{{/if}}
 
 deploy:
   - uses: cli/runDotnetCommand

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/csharpNonSsoTab/expectedResult/app.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/csharpNonSsoTab/expectedResult/app.yml
@@ -14,7 +14,7 @@ provision:
   - uses: file/updateEnv # Add additional item to .env file
     with:
       envs:
-        PROVISIONOUTPUT__AZUREWEBAPPTABOUTPUT__INDEXPATH: '/' # This environment variable is required in your existing Teams app manifest
+        PROVISIONOUTPUT__AZUREWEBAPPTABOUTPUT__INDEXPATH: '/' # Used in appPackage/manifest.template.json file.
 
 deploy:
   - uses: cli/runDotnetCommand

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/csharpNonSsoTab/expectedResult/app.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/csharpNonSsoTab/expectedResult/app.yml
@@ -11,6 +11,10 @@ provision:
          deploymentName: teams_toolkit_deployment # Required when deploy ARM template
       bicepCliVersion: v0.4.613 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
     # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
+  - uses: file/updateEnv # Add additional item to .env file
+    with:
+      envs:
+        PROVISIONOUTPUT__AZUREWEBAPPTABOUTPUT__INDEXPATH: '/' # This environment variable is required in your existing Teams app manifest
 
 deploy:
   - uses: cli/runDotnetCommand

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/csharpSsoTab/expectedResult/app.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/csharpSsoTab/expectedResult/app.yml
@@ -14,7 +14,7 @@ provision:
   - uses: file/updateEnv # Add additional item to .env file
     with:
       envs:
-        PROVISIONOUTPUT__AZUREWEBAPPTABOUTPUT__INDEXPATH: '/' # This environment variable is required in your existing Teams app manifest
+        PROVISIONOUTPUT__AZUREWEBAPPTABOUTPUT__INDEXPATH: '/' # Used in appPackage/manifest.template.json file.
 
 deploy:
   - uses: cli/runDotnetCommand

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/csharpSsoTab/expectedResult/app.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/csharpSsoTab/expectedResult/app.yml
@@ -11,6 +11,10 @@ provision:
          deploymentName: teams_toolkit_deployment # Required when deploy ARM template
       bicepCliVersion: v0.4.613 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
     # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
+  - uses: file/updateEnv # Add additional item to .env file
+    with:
+      envs:
+        PROVISIONOUTPUT__AZUREWEBAPPTABOUTPUT__INDEXPATH: '/' # This environment variable is required in your existing Teams app manifest
 
 deploy:
   - uses: cli/runDotnetCommand


### PR DESCRIPTION
@microsoft/teamsfx-cli	v1.2.1-rc.0
@microsoft/teamsfx-core	v1.22.0-rc.1
@microsoft/teamsfx-react	v2.1.1-rc.0
ms-teams-vscode-extension	v4.2.1-rc.0

CLI BREAKING CHANGE:
  

Extension-toolkit BREAKING CHANGE:
 

CLI feat commits:
  

Extension-toolkit feat commits: