### PR TITLE
chore: expose dashboard tutorial entry in v3

### DIFF
--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -3376,24 +3376,20 @@ export async function selectTutorialsHandler(args?: any[]): Promise<Result<unkno
           },
         ],
       },
-      ...(isV3Enabled()
-        ? []
-        : [
-            {
-              id: "dashboardApp",
-              label: `${localize("teamstoolkit.guides.dashboardApp.label")}`,
-              detail: localize("teamstoolkit.guides.dashboardApp.detail"),
-              groupName: localize("teamstoolkit.guide.scenario"),
-              data: "https://aka.ms/teamsfx-dashboard-app",
-              buttons: [
-                {
-                  iconPath: "file-symlink-file",
-                  tooltip: localize("teamstoolkit.guide.tooltip.github"),
-                  command: "fx-extension.openTutorial",
-                },
-              ],
-            },
-          ]),
+      {
+        id: "dashboardApp",
+        label: `${localize("teamstoolkit.guides.dashboardApp.label")}`,
+        detail: localize("teamstoolkit.guides.dashboardApp.detail"),
+        groupName: localize("teamstoolkit.guide.scenario"),
+        data: "https://aka.ms/teamsfx-dashboard-app",
+        buttons: [
+          {
+            iconPath: "file-symlink-file",
+            tooltip: localize("teamstoolkit.guide.tooltip.github"),
+            command: "fx-extension.openTutorial",
+          },
+        ],
+      },
       ...(isV3Enabled()
         ? [
             {

--- a/packages/vscode-extension/test/extension/handlers.test.ts
+++ b/packages/vscode-extension/test/extension/handlers.test.ts
@@ -371,7 +371,7 @@ describe("handlers", () => {
 
       const result = await handlers.selectTutorialsHandler();
 
-      chai.assert.equal(tutorialOptions.length, 14);
+      chai.assert.equal(tutorialOptions.length, 15);
       chai.assert.isTrue(result.isOk());
     });
   });


### PR DESCRIPTION
Since the dashboard scenario was only supported in v2, and the tutorial portal was not visible in v3, but now that the dashboard v3 migration has been completed, the dashboard tutorial entry can be exposed.

E2E TEST: N/A