### PR TITLE
chore: use regional api

### DIFF
--- a/packages/fx-core/src/component/resource/appManifest/appStudioClient.ts
+++ b/packages/fx-core/src/component/resource/appManifest/appStudioClient.ts
@@ -14,6 +14,14 @@ import { TelemetryEventName, TelemetryUtils } from "./utils/telemetry";
 import { getAppStudioEndpoint } from "./constants";
 import { HelpLinks } from "../../../common/constants";
 import { getLocalizedString } from "../../../common/localizeUtils";
+import {
+  Component,
+  sendTelemetryErrorEvent,
+  sendTelemetryEvent,
+  TelemetryEvent,
+  TelemetryProperty,
+} from "../../../common/telemetry";
+import { waitSeconds } from "../../../common/tools";
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace AppStudioClient {
@@ -21,7 +29,11 @@ export namespace AppStudioClient {
 
   let region: string | undefined;
 
-  export function SetRegion(_region: string) {
+  /**
+   * Set user region
+   * @param _region e.g. https://dev.teams.microsoft.com/amer
+   */
+  export function setRegion(_region: string) {
     region = _region;
   }
 
@@ -30,9 +42,9 @@ export namespace AppStudioClient {
    * @param {string}  appStudioToken
    * @returns {AxiosInstance}
    */
-  function createRequesterWithToken(appStudioToken: string, _region?: string): AxiosInstance {
+  function createRequesterWithToken(appStudioToken: string, _regionalUrl?: string): AxiosInstance {
     const instance = axios.create({
-      baseURL: _region ? `${baseUrl}/${_region}` : baseUrl,
+      baseURL: _regionalUrl ?? baseUrl,
     });
     instance.defaults.headers.common["Authorization"] = `Bearer ${appStudioToken}`;
     instance.defaults.headers.common["Client-Source"] = "teamstoolkit";
@@ -131,17 +143,19 @@ export namespace AppStudioClient {
     appStudioToken: string,
     logProvider?: LogProvider
   ): Promise<AppDefinition> {
-    const requester = createRequesterWithToken(appStudioToken);
+    let requester: AxiosInstance;
     try {
       let response;
       if (region) {
+        requester = createRequesterWithToken(appStudioToken, region);
         try {
           response = await RetryHandler.Retry(() =>
-            requester.get(`/${region}/api/appdefinitions/${teamsAppId}`)
+            requester.get(`/api/appdefinitions/${teamsAppId}`)
           );
         } catch (e: any) {
           // Teams apps created by non-regional API cannot be found by regional API
           if (e.response?.status == 404) {
+            requester = createRequesterWithToken(appStudioToken);
             response = await RetryHandler.Retry(() =>
               requester.get(`/api/appdefinitions/${teamsAppId}`)
             );
@@ -150,6 +164,7 @@ export namespace AppStudioClient {
           }
         }
       } else {
+        requester = createRequesterWithToken(appStudioToken);
         response = await RetryHandler.Retry(() =>
           requester.get(`/api/appdefinitions/${teamsAppId}`)
         );
@@ -407,21 +422,24 @@ export namespace AppStudioClient {
     }
 
     app.userList?.push(newUser);
-    const requester = createRequesterWithToken(appStudioToken);
+    let requester: AxiosInstance;
     try {
       let response;
       if (region) {
         try {
-          response = await requester.post(`/${region}/api/appdefinitions/${teamsAppId}/owner`, app);
+          requester = createRequesterWithToken(appStudioToken, region);
+          response = await requester.post(`/api/appdefinitions/${teamsAppId}/owner`, app);
         } catch (e: any) {
           // Teams apps created by non-regional API cannot be found by regional API
           if (e.response?.status == 404) {
+            requester = createRequesterWithToken(appStudioToken);
             response = await requester.post(`/api/appdefinitions/${teamsAppId}/owner`, app);
           } else {
             throw e;
           }
         }
       } else {
+        requester = createRequesterWithToken(appStudioToken);
         response = await requester.post(`/api/appdefinitions/${teamsAppId}/owner`, app);
       }
       if (!response || !response.data || !checkUser(response.data as AppDefinition, newUser)) {
@@ -429,6 +447,7 @@ export namespace AppStudioClient {
       }
     } catch (err) {
       if (err?.message?.indexOf("Request failed with status code 400") >= 0) {
+        requester = createRequesterWithToken(appStudioToken, region);
         await requester.post(`/api/appdefinitions/${teamsAppId}/owner`, app.userList);
       } else {
         wrapException(err, APP_STUDIO_API_NAMES.UPDATE_OWNER);
@@ -468,5 +487,65 @@ export namespace AppStudioClient {
     } else {
       return false;
     }
+  }
+
+  export async function getSideloadingStatus(appStudioToken: string): Promise<boolean | undefined> {
+    const instance = axios.create({
+      baseURL: region ?? getAppStudioEndpoint(),
+      timeout: 30000,
+    });
+    instance.defaults.headers.common["Authorization"] = `Bearer ${appStudioToken}`;
+
+    let retry = 0;
+    const retryIntervalSeconds = 2;
+    do {
+      let response = undefined;
+      try {
+        response = await instance.get("/api/usersettings/mtUserAppPolicy");
+        let result: boolean | undefined;
+        if (response.status >= 400) {
+          result = undefined;
+        } else {
+          result = response.data?.value?.isSideloadingAllowed as boolean;
+        }
+
+        if (result !== undefined) {
+          sendTelemetryEvent(Component.core, TelemetryEvent.CheckSideloading, {
+            [TelemetryProperty.IsSideloadingAllowed]: result + "",
+          });
+        } else {
+          sendTelemetryErrorEvent(
+            Component.core,
+            TelemetryEvent.CheckSideloading,
+            new SystemError(
+              "M365Account",
+              "UnknownValue",
+              `AppStudio response code: ${response.status}, body: ${response.data}`
+            ),
+            {
+              [TelemetryProperty.CheckSideloadingStatusCode]: `${response.status}`,
+              [TelemetryProperty.CheckSideloadingMethod]: "get",
+              [TelemetryProperty.CheckSideloadingUrl]: "<check-sideloading-status>",
+            }
+          );
+        }
+
+        return result;
+      } catch (error) {
+        sendTelemetryErrorEvent(
+          Component.core,
+          TelemetryEvent.CheckSideloading,
+          new SystemError({ error, source: "M365Account" }),
+          {
+            [TelemetryProperty.CheckSideloadingStatusCode]: `${response?.status}`,
+            [TelemetryProperty.CheckSideloadingMethod]: "get",
+            [TelemetryProperty.CheckSideloadingUrl]: "<check-sideloading-status>",
+          }
+        );
+        await waitSeconds((retry + 1) * retryIntervalSeconds);
+      }
+    } while (++retry < 3);
+
+    return undefined;
   }
 }

--- a/packages/fx-core/src/component/resource/appManifest/authSvcClient.ts
+++ b/packages/fx-core/src/component/resource/appManifest/authSvcClient.ts
@@ -33,14 +33,14 @@ export namespace AuthSvcClient {
    * @param authSvcToken
    * @returns e.g. apac amer
    */
-  export async function getRegion(authSvcToken: string): Promise<string> {
+  export async function getRegion(authSvcToken: string): Promise<string | undefined> {
     const requester = createRequesterWithToken(authSvcToken);
     try {
       const response = await RetryHandler.Retry(() => requester.post(`/v1.0/users/region`));
-      return response?.data.region as string;
+      return response?.data?.regionGtms?.teamsDevPortal as string;
     } catch (e: any) {
-      const error = wrapException(e, "get-region");
-      throw error;
+      wrapException(e, "get-region");
+      return undefined;
     }
   }
 

--- a/packages/fx-core/src/component/resource/botService/appStudio/appStudioClient.ts
+++ b/packages/fx-core/src/component/resource/botService/appStudio/appStudioClient.ts
@@ -47,6 +47,14 @@ export class AppStudioClient {
     return instance;
   }
 
+  /**
+   * Set user region
+   * @param _region e.g. https://dev.teams.microsoft.com/amer
+   */
+  public static setRegion(region: string) {
+    AppStudioClient.baseUrl = region;
+  }
+
   public static async getBotRegistration(
     token: string,
     botId: string

--- a/packages/fx-core/tests/plugins/resource/appstudio/unit/authSvcClient.test.ts
+++ b/packages/fx-core/tests/plugins/resource/appstudio/unit/authSvcClient.test.ts
@@ -24,13 +24,15 @@ describe("Auth Service API Test", () => {
 
     const response = {
       data: {
-        region: "apac",
+        regionGtms: {
+          teamsDevPortal: "https://dev.teams.microsoft.com/amer",
+        },
       },
     };
     sinon.stub(fakeAxiosInstance, "post").resolves(response);
 
     const res = await AuthSvcClient.getRegion("fakeToken");
-    chai.assert.equal(res, response.data.region);
+    chai.assert.equal(res, response.data.regionGtms.teamsDevPortal);
   });
 
   it("API Failure", async () => {


### PR DESCRIPTION
Get region from AuthSvc API, response.data.regionGtms.teamsDevPortal

Set base url for:
1) AppStudioClient of app manifest
2) AppStudioClient of bot
3) getSideloadingStatus api

![image](https://user-images.githubusercontent.com/71362691/209774504-db24e927-7d91-4046-8118-8eedf801c97d.png)
