### PR TITLE
chore: run.js supports new structure

### DIFF
--- a/packages/run-utils/package-lock.json
+++ b/packages/run-utils/package-lock.json
@@ -2255,10 +2255,9 @@
       "dev": true
     },
     "yaml": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.3.tgz",
-      "integrity": "sha512-AacA8nRULjKMX2DvWvOAdBZMOfQlypSFkjcOcu9FalllIDJ1kvlREzcdIZmidQUqqeMv7jorHjq2HlLv/+c2lg==",
-      "dev": true
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.1.tgz",
+      "integrity": "sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw=="
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/packages/run-utils/package.json
+++ b/packages/run-utils/package.json
@@ -23,7 +23,8 @@
   "dependencies": {
     "cryptr": "^6.0.3",
     "dotenv": "^16.0.3",
-    "fs-extra": "^10.1.0"
+    "fs-extra": "^10.1.0",
+    "yaml": "^2.2.0"
   },
   "devDependencies": {
     "@types/cryptr": "^4.0.1",

--- a/packages/run-utils/src/index.ts
+++ b/packages/run-utils/src/index.ts
@@ -11,7 +11,7 @@ const settingsFolderName = "teamsfx";
 const settingsFileName = "settings.json";
 const projectYamlName = "teamsapp.yml";
 
-async function readSettings(filePath: string): Promise<string> {
+async function readTrackingIdFromSettings(filePath: string): Promise<string> {
   if (!(await fs.pathExists(filePath))) {
     throw new Error(`${filePath} does not exist.`);
   }
@@ -20,7 +20,7 @@ async function readSettings(filePath: string): Promise<string> {
   return settings.trackingId;
 }
 
-async function readYaml(filePath: string): Promise<string> {
+async function readProjectIdFromYaml(filePath: string): Promise<string> {
   if (!(await fs.pathExists(filePath))) {
     throw new Error(`${filePath} does not exist.`);
   }
@@ -54,12 +54,12 @@ export async function loadEnv(
   const yamlPath = path.join(projectPath, projectYamlName);
   let projectId = "";
   if (await fs.pathExists(settingsPath)) {
-    projectId = await readSettings(settingsPath);
+    projectId = await readTrackingIdFromSettings(settingsPath);
     if (!projectId) {
       throw new Error(`trackingId is missing in ${settingsFileName}`);
     }
   } else if (await fs.pathExists(yamlPath)) {
-    projectId = await readYaml(yamlPath);
+    projectId = await readProjectIdFromYaml(yamlPath);
     if (!projectId) {
       throw new Error(`projectId is missing in ${projectYamlName}`);
     }


### PR DESCRIPTION
Make run-utils to support new folder structure.
Follow the same logic as #7321 to load `projectId` as key.