### PR TITLE
chore: delete published app

### DIFF
--- a/packages/cli/tests/e2e/commonUtils.ts
+++ b/packages/cli/tests/e2e/commonUtils.ts
@@ -29,6 +29,7 @@ import {
   AadValidator,
   BotValidator,
   FrontendValidator,
+  AppStudioValidator,
 } from "../commonlib";
 import {
   StateConfigKey,
@@ -354,7 +355,8 @@ export async function cleanUp(
   hasAadPlugin = true,
   hasBotPlugin = false,
   hasApimPlugin = false,
-  envName = "dev"
+  envName = "dev",
+  teamsAppId?: string
 ) {
   const cleanUpAadAppPromise = cleanUpAadApp(
     projectPath,
@@ -370,6 +372,8 @@ export async function cleanUp(
     cleanUpResourceGroup(appName, envName),
     // remove project
     cleanUpLocalProject(projectPath, cleanUpAadAppPromise),
+    // cancel stagged app
+    AppStudioValidator.cancelStagedAppInTeamsAppCatalog(teamsAppId),
   ]);
 }
 

--- a/packages/cli/tests/e2e/function/TestAddFunction.tests.ts
+++ b/packages/cli/tests/e2e/function/TestAddFunction.tests.ts
@@ -6,7 +6,7 @@
  */
 
 import * as path from "path";
-
+import * as chai from "chai";
 import { AadValidator, FunctionValidator, AppStudioValidator } from "../../commonlib";
 import { environmentManager, isV3Enabled } from "@microsoft/teamsfx-core";
 import {

--- a/packages/cli/tests/e2e/function/TestAddFunction.tests.ts
+++ b/packages/cli/tests/e2e/function/TestAddFunction.tests.ts
@@ -7,7 +7,7 @@
 
 import * as path from "path";
 
-import { AadValidator, FunctionValidator } from "../../commonlib";
+import { AadValidator, FunctionValidator, AppStudioValidator } from "../../commonlib";
 import { environmentManager, isV3Enabled } from "@microsoft/teamsfx-core";
 import {
   execAsyncWithRetry,
@@ -17,6 +17,7 @@ import {
   cleanUp,
   setSimpleAuthSkuNameToB1Bicep,
   readContextMultiEnv,
+  loadContext,
 } from "../commonUtils";
 import M365Login from "../../../src/commonlib/m365Login";
 import { CliHelper } from "../../commonlib/cliHelper";
@@ -30,6 +31,7 @@ describe("Test Add Function", function () {
   let subscription: string;
   let projectPath: string;
   let env: string;
+  let teamsAppId: string | undefined;
 
   // Should succeed on the 3rd try
   this.retries(2);
@@ -45,7 +47,7 @@ describe("Test Add Function", function () {
   afterEach(async () => {
     // clean up
     console.log(`[Successfully] start to clean up for ${projectPath}`);
-    await cleanUp(appName, projectPath, true, false, false);
+    await cleanUp(appName, projectPath, true, false, false, teamsAppId);
   });
 
   it(`Create Tab Then Add Function`, { testPlanCaseId: 10306830 }, async function () {
@@ -110,19 +112,24 @@ describe("Test Add Function", function () {
       /// TODO: add check for package
     }
 
-    /// TODO: Publish broken: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/9856390
-    // // publish
-    // await execAsyncWithRetry(
-    //   `teamsfx publish`,
-    //   {
-    //     cwd: projectPath,
-    //     env: process.env,
-    //     timeout: 0
-    //   }
-    // );
+    // publish
+    await execAsyncWithRetry(`teamsfx publish`, {
+      cwd: projectPath,
+      env: process.env,
+      timeout: 0,
+    });
 
-    // {
-    //   /// TODO: add check for publish
-    // }
+    {
+      // Validate publish result
+      const contextResult = await loadContext(projectPath, env);
+      if (contextResult.isErr()) {
+        throw contextResult.error;
+      }
+      const context = contextResult.value;
+      const appStudioObject = AppStudioValidator.init(context);
+      teamsAppId = appStudioObject.teamsAppId;
+      chai.assert.isNotNull(teamsAppId);
+      await AppStudioValidator.validatePublish(teamsAppId!);
+    }
   });
 });

--- a/packages/cli/tests/e2e/multienv/TestRemoteHappyPath.tests.ts
+++ b/packages/cli/tests/e2e/multienv/TestRemoteHappyPath.tests.ts
@@ -44,6 +44,7 @@ describe("Multi Env Happy Path for Azure", function () {
   const subscription = getSubscriptionId();
   const projectPath = path.resolve(testFolder, appName);
   const processEnv = mockTeamsfxMultiEnvFeatureFlag();
+  let teamsAppId: string | undefined;
 
   it(
     `Can create/provision/deploy/build/validate/launch remote a azure tab/function/sql/bot project`,
@@ -244,9 +245,9 @@ describe("Multi Env Happy Path for Azure", function () {
           }
           const context = contextResult.value;
           const appStudioObject = AppStudioValidator.init(context);
-          const appId = appStudioObject.teamsAppId;
-          chai.assert.isNotNull(appId);
-          await AppStudioValidator.validatePublish(appId!);
+          teamsAppId = appStudioObject.teamsAppId;
+          chai.assert.isNotNull(teamsAppId);
+          await AppStudioValidator.validatePublish(teamsAppId!);
         }
       } catch (e) {
         console.log("Unexpected exception is thrown when running test: " + e);
@@ -258,6 +259,6 @@ describe("Multi Env Happy Path for Azure", function () {
 
   after(async () => {
     // clean up
-    await cleanUp(appName, projectPath, true, true, false, env);
+    await cleanUp(appName, projectPath, true, true, false, env, teamsAppId);
   });
 });

--- a/packages/cli/tests/e2e/multienv/TestRemoteHappyPathSPFx.tests.ts
+++ b/packages/cli/tests/e2e/multienv/TestRemoteHappyPathSPFx.tests.ts
@@ -32,6 +32,7 @@ describe("Multi Env Happy Path for SPFx", function () {
   const processEnv = mockTeamsfxMultiEnvFeatureFlag();
   const env = "e2e";
   let appId: string;
+  let teamsAppId: string | undefined;
 
   it(
     "Can create/provision/deploy/validate/package/publish an SPFx project",
@@ -167,18 +168,25 @@ describe("Multi Env Happy Path for SPFx", function () {
         expect(await fs.pathExists(file)).to.be.true;
       }
 
-      // Temporarily disable publish
       // publish
-      /*
-    result = await execAsyncWithRetry(`teamsfx publish --env ${env}`, {
-      cwd: projectPath,
-      env: processEnv,
-      timeout: 0,
-    });
- 
-    {
-      expect(result.stderr).to.be.empty;
-    }*/
+      result = await execAsyncWithRetry(`teamsfx publish --env ${env}`, {
+        cwd: projectPath,
+        env: processEnv,
+        timeout: 0,
+      });
+
+      {
+        // Validate publish result
+        const contextResult = await loadContext(projectPath, env);
+        if (contextResult.isErr()) {
+          throw contextResult.error;
+        }
+        const context = contextResult.value;
+        const appStudioObject = AppStudioValidator.init(context);
+        teamsAppId = appStudioObject.teamsAppId;
+        chai.assert.isNotNull(teamsAppId);
+        await AppStudioValidator.validatePublish(teamsAppId!);
+      }
     }
   );
 
@@ -186,5 +194,6 @@ describe("Multi Env Happy Path for SPFx", function () {
     // clean up
     await cleanUpLocalProject(projectPath);
     await cleanupSharePointPackage(appId);
+    await AppStudioValidator.cancelStagedAppInTeamsAppCatalog(teamsAppId);
   });
 });

--- a/packages/cli/tests/e2e/multienv/TestRemoteHappyPathSPFx.tests.ts
+++ b/packages/cli/tests/e2e/multienv/TestRemoteHappyPathSPFx.tests.ts
@@ -8,7 +8,7 @@
 
 import * as fs from "fs-extra";
 import * as path from "path";
-import { expect } from "chai";
+import { expect, assert } from "chai";
 
 import {
   cleanUpLocalProject,
@@ -184,7 +184,7 @@ describe("Multi Env Happy Path for SPFx", function () {
         const context = contextResult.value;
         const appStudioObject = AppStudioValidator.init(context);
         teamsAppId = appStudioObject.teamsAppId;
-        chai.assert.isNotNull(teamsAppId);
+        assert.isNotNull(teamsAppId);
         await AppStudioValidator.validatePublish(teamsAppId!);
       }
     }


### PR DESCRIPTION
Enable publish test case, clean up stagged app from Teams app catalog to avoid BadRequest error.