### PR TITLE
fix(localdebug): support whitespaces in the ngrok path

### DIFF
--- a/packages/vscode-extension/src/debug/taskTerminal/localTunnelTaskTerminal.ts
+++ b/packages/vscode-extension/src/debug/taskTerminal/localTunnelTaskTerminal.ts
@@ -573,7 +573,7 @@ export class LocalTunnelTaskTerminal extends BaseTaskTerminal {
       ngrokArgs.push("--log-format=logfmt");
     }
 
-    return `${ngrokPath} ${ngrokArgs.join(" ")}`;
+    return `"${ngrokPath}" ${ngrokArgs.join(" ")}`;
   }
 
   private static includeOption(args: string[], option: string): boolean {


### PR DESCRIPTION
Fix issue: https://github.com/OfficeDev/TeamsFx/issues/7354
E2E TEST: https://github.com/OfficeDev/TeamsFx-UI-Test/blob/39cfd2d02c2d331930a7bb53325ec29e709ae781/src/ui-test/localdebug/localdebug-bot.test.ts#L13