### PR TITLE
chore: add environmentFolderPath support to parser

### DIFF
--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -1090,6 +1090,7 @@
   "configManager.error.yamlParsing": "Error parsing yaml file at path %s. Reason: %s",
   "configManager.error.invalidLifecycle": "The schema of lifecycle %s is invalid. It is expected to be an array of actions. If you want to remove all actions inside it, please remove the whole lifecyle.",
   "configManager.error.invalidEnvField": "The env field of action %s in lifecycle %s is invalid.",
+  "configManager.error.invalidEnvFolderPath": "The environmentFolderPath field is invalid.",
   "botRegistration.ProgressBar.creatingBotAadApp": "Creating bot aad app.",
   "botRegistration.log.startCreateBotAadApp": "Creating bot aad app.",
   "botRegistration.log.successCreateBotAadApp": "Bot aad app created successfully.",

--- a/packages/fx-core/src/component/configManager/error.ts
+++ b/packages/fx-core/src/component/configManager/error.ts
@@ -50,6 +50,20 @@ export class InvalidLifecycleError extends UserError {
   }
 }
 
+export class InvalidEnvFolderPath extends UserError {
+  constructor() {
+    const key = "configManager.error.invalidEnvFolderPath";
+    const errorOptions: UserErrorOptions = {
+      source: component,
+      name: "InvalidEnvFolderPathError",
+      message: getDefaultString(key),
+      displayMessage: getLocalizedString(key),
+    };
+    errorOptions.helpLink = "https://aka.ms/teamsfx-actions/invalid-env-folder-error";
+    super(errorOptions);
+  }
+}
+
 export class InvalidEnvFieldError extends UserError {
   constructor(actionName: string, lifecycle: LifecycleName) {
     const key = "configManager.error.invalidEnvField";

--- a/packages/fx-core/src/component/configManager/interface.ts
+++ b/packages/fx-core/src/component/configManager/interface.ts
@@ -8,6 +8,7 @@ export type RawProjectModel = {
   configureApp?: DriverDefinition[];
   deploy?: DriverDefinition[];
   publish?: DriverDefinition[];
+  environmentFolderPath?: string;
 };
 
 export type ProjectModel = {
@@ -16,6 +17,7 @@ export type ProjectModel = {
   configureApp?: ILifecycle;
   deploy?: ILifecycle;
   publish?: ILifecycle;
+  environmentFolderPath?: string;
 };
 
 export type DriverDefinition = {

--- a/packages/fx-core/tests/component/configManager/parser.test.ts
+++ b/packages/fx-core/tests/component/configManager/parser.test.ts
@@ -126,4 +126,24 @@ describe("v3 yaml parser", () => {
       assert(result.isOk());
     });
   });
+
+  describe(`when parsing yml with valid envrionmentFolderPath`, async () => {
+    it("should return ok", async () => {
+      const parser = new YamlParser();
+      const result = await parser.parse(
+        path.resolve(__dirname, "testing_data", "valid_env_folder_path.yml")
+      );
+      assert(result.isOk() && result.value.environmentFolderPath === "/home/xxx");
+    });
+  });
+
+  describe(`when parsing yml with invalid `, async () => {
+    it("should return ok", async () => {
+      const parser = new YamlParser();
+      const result = await parser.parse(
+        path.resolve(__dirname, "testing_data", "invalid_env_folder_path.yml")
+      );
+      assert(result.isErr() && result.error.name === "InvalidEnvFolderPathError");
+    });
+  });
 });

--- a/packages/fx-core/tests/component/configManager/testing_data/invalid_env_folder_path.yml
+++ b/packages/fx-core/tests/component/configManager/testing_data/invalid_env_folder_path.yml
@@ -1,0 +1,1 @@
+environmentFolderPath: 111

--- a/packages/fx-core/tests/component/configManager/testing_data/valid_env_folder_path.yml
+++ b/packages/fx-core/tests/component/configManager/testing_data/valid_env_folder_path.yml
@@ -1,0 +1,1 @@
+environmentFolderPath: "/home/xxx"


### PR DESCRIPTION
Fixes https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_sprints/taskboard/Teams%20Extensibility%20E2E%20Team/Microsoft%20Teams%20Extensibility/CY22-12.2?workitem=16624820