### PR TITLE
chore(debug-migration): throw exception to stop debugging if migration is cancelled

### DIFF
--- a/packages/vscode-extension/src/debug/commonUtils.ts
+++ b/packages/vscode-extension/src/debug/commonUtils.ts
@@ -24,6 +24,7 @@ import { ExtensionErrors, ExtensionSource } from "../error";
 import { localize } from "../utils/localizeUtils";
 import * as util from "util";
 import { VS_CODE_UI } from "../extension";
+import * as vscode from "vscode";
 
 export async function getProjectRoot(
   folderPath: string,
@@ -415,7 +416,8 @@ export async function triggerV3Migration(): Promise<string | undefined> {
   const result = await core.phantomMigrationV3(getSystemInputs());
   if (result.isErr()) {
     showError(result.error);
-    return "1";
+    await vscode.debug.stopDebugging();
+    throw result.error;
   }
   // reload window to terminate debugging
   await VS_CODE_UI.reload();


### PR DESCRIPTION
Fix https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/16737880/.