### PR TITLE
chore: update endspattern for init debug

### DIFF
--- a/templates/scenarios/common/init-debug-vsc-bot/{%dotVscodeFolderName%}/tasks.json
+++ b/templates/scenarios/common/init-debug-vsc-bot/{%dotVscodeFolderName%}/tasks.json
@@ -101,8 +101,8 @@
                 ],
                 "background": {
                     "activeOnStart": true,
-                    "beginsPattern": "[nodemon] starting",
-                    "endsPattern": "restify listening to|Bot/ME service listening at|[nodemon] app crashed"
+                    "beginsPattern": ".*", // the output/signal that service is starting
+                    "endsPattern": ".*" // the output/signal that service is started
                 }
             }
         }

--- a/templates/scenarios/common/init-debug-vsc-tab/{%dotVscodeFolderName%}/tasks.json
+++ b/templates/scenarios/common/init-debug-vsc-tab/{%dotVscodeFolderName%}/tasks.json
@@ -76,8 +76,8 @@
                 },
                 "background": {
                     "activeOnStart": true,
-                    "beginsPattern": ".*",
-                    "endsPattern": "Compiled|Failed|compiled|failed"
+                    "beginsPattern": ".*", // the output/signal that service is starting
+                    "endsPattern": ".*" // the output/signal that service is started
                 }
             }
         }


### PR DESCRIPTION
Use `.*` as endsPattern to not block F5.
More doc will be added to `init debug` wiki.
Help link will be added after wiki aka link is ready.