### PR TITLE
chore(debug-v3): support remote launch for m365 v3 templates

### DIFF
--- a/packages/vscode-extension/src/debug/teamsfxDebugProvider.ts
+++ b/packages/vscode-extension/src/debug/teamsfxDebugProvider.ts
@@ -13,13 +13,14 @@ import { environmentManager } from "@microsoft/teamsfx-core/build/core/environme
 
 import VsCodeLogInstance from "../commonlib/log";
 import M365TokenInstance from "../commonlib/m365Login";
-import { showError } from "../handlers";
+import { getSystemInputs, showError } from "../handlers";
 import { TelemetryEvent, TelemetryProperty } from "../telemetry/extTelemetryEvents";
 import * as commonUtils from "./commonUtils";
 import { Host, Hub, sideloadingDisplayMessages } from "./constants";
 import { localTelemetryReporter, sendDebugAllEvent } from "./localTelemetryReporter";
-import { getTeamsAppInternalId } from "./teamsAppInstallation";
+import { getTeamsAppInternalId, showInstallAppInTeamsMessage } from "./teamsAppInstallation";
 import { terminateAllRunningTeamsfxTasks } from "./teamsfxTaskHandler";
+import { core } from "../handlers";
 
 export interface TeamsfxDebugConfiguration extends vscode.DebugConfiguration {
   teamsfxIsRemote?: boolean;
@@ -37,6 +38,7 @@ enum SideloadingType {
   v3Local,
   v3Remote,
   v3M365Local,
+  v3M365Remote,
 }
 
 export class TeamsfxDebugProvider implements vscode.DebugConfigurationProvider {
@@ -118,8 +120,16 @@ export class TeamsfxDebugProvider implements vscode.DebugConfigurationProvider {
 
       const v3M365MatchPattern = /\$\{(.+):teamsAppInternalId\}/;
       const v3M365MatchResult = url.match(v3M365MatchPattern);
-      if (isV3Enabled() && (v3M365MatchResult || host === Host.outlook || host === Host.office)) {
+      if (isV3Enabled() && v3M365MatchResult) {
         sideloadingType = SideloadingType.v3M365Local;
+      }
+
+      if (host === Host.outlook || host === Host.office) {
+        sideloadingType =
+          typeof debugConfiguration.name === "string" &&
+          debugConfiguration.name.startsWith("Launch Remote")
+            ? SideloadingType.v3M365Remote
+            : SideloadingType.v3M365Local;
       }
 
       if (sideloadingType === SideloadingType.unknown) {
@@ -170,7 +180,17 @@ export class TeamsfxDebugProvider implements vscode.DebugConfigurationProvider {
             } else if (v3M365MatchResult) {
               env = v3M365MatchResult[1];
             } else if (host === Host.outlook || host === Host.office) {
-              env = environmentManager.getLocalEnvName();
+              if (sideloadingType === SideloadingType.v3M365Local) {
+                env = environmentManager.getLocalEnvName();
+              } else if (sideloadingType === SideloadingType.v3M365Remote) {
+                const inputs = getSystemInputs();
+                inputs.ignoreEnvInfo = false;
+                const envResult = await core.getSelectedEnv(inputs);
+                if (envResult.isErr()) {
+                  return undefined;
+                }
+                env = envResult.value;
+              }
             }
             appId = await commonUtils.getV3TeamsAppId(folder.uri.fsPath, env!);
           }
@@ -208,6 +228,18 @@ export class TeamsfxDebugProvider implements vscode.DebugConfigurationProvider {
               break;
             case SideloadingType.v3M365Local:
               {
+                const internalId = await getTeamsAppInternalId(appId);
+                if (internalId !== undefined) {
+                  url = url.replace(v3M365MatchPattern, internalId);
+                }
+              }
+              break;
+            case SideloadingType.v3M365Remote:
+              {
+                const shouldContinue = await showInstallAppInTeamsMessage(env!, appId);
+                if (!shouldContinue) {
+                  return undefined;
+                }
                 const internalId = await getTeamsAppInternalId(appId);
                 if (internalId !== undefined) {
                   url = url.replace(v3M365MatchPattern, internalId);

--- a/templates/scenarios/js/m365-message-extension/.vscode/launch.json
+++ b/templates/scenarios/js/m365-message-extension/.vscode/launch.json
@@ -2,6 +2,50 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Launch Remote in Teams (Edge)",
+            "type": "pwa-msedge",
+            "request": "launch",
+            "url": "https://teams.microsoft.com/l/app/${dev:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
+            "presentation": {
+                "group": "group 1: Teams",
+                "order": 3
+            },
+            "internalConsoleOptions": "neverOpen"
+        },
+        {
+            "name": "Launch Remote in Teams (Chrome)",
+            "type": "pwa-chrome",
+            "request": "launch",
+            "url": "https://teams.microsoft.com/l/app/${dev:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
+            "presentation": {
+                "group": "group 1: Teams",
+                "order": 3
+            },
+            "internalConsoleOptions": "neverOpen"
+        },
+        {
+            "name": "Launch Remote in Outlook (Edge)",
+            "type": "pwa-msedge",
+            "request": "launch",
+            "url": "https://outlook.office.com/mail?${account-hint}",
+            "presentation": {
+                "group": "group 2: Outlook",
+                "order": 3
+            },
+            "internalConsoleOptions": "neverOpen"
+        },
+        {
+            "name": "Launch Remote in Outlook (Chrome)",
+            "type": "pwa-chrome",
+            "request": "launch",
+            "url": "https://outlook.office.com/mail?${account-hint}",
+            "presentation": {
+                "group": "group 2: Outlook",
+                "order": 3
+            },
+            "internalConsoleOptions": "neverOpen"
+        },
+        {
             "name": "Launch Bot in Teams (Edge)",
             "type": "pwa-msedge",
             "request": "launch",

--- a/templates/scenarios/js/m365-tab/.vscode/launch.json
+++ b/templates/scenarios/js/m365-tab/.vscode/launch.json
@@ -2,6 +2,72 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Launch Remote in Teams (Edge)",
+            "type": "pwa-msedge",
+            "request": "launch",
+            "url": "https://teams.microsoft.com/l/app/${dev:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
+            "presentation": {
+                "group": "group 1: Teams",
+                "order": 3
+            },
+            "internalConsoleOptions": "neverOpen"
+        },
+        {
+            "name": "Launch Remote in Teams (Chrome)",
+            "type": "pwa-chrome",
+            "request": "launch",
+            "url": "https://teams.microsoft.com/l/app/${dev:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
+            "presentation": {
+                "group": "group 1: Teams",
+                "order": 3
+            },
+            "internalConsoleOptions": "neverOpen"
+        },
+        {
+            "name": "Launch Remote in Outlook (Edge)",
+            "type": "pwa-msedge",
+            "request": "launch",
+            "url": "https://outlook.office.com/host/${dev:teamsAppInternalId}?${account-hint}",
+            "presentation": {
+                "group": "group 2: Outlook",
+                "order": 3
+            },
+            "internalConsoleOptions": "neverOpen"
+        },
+        {
+            "name": "Launch Remote in Outlook (Chrome)",
+            "type": "pwa-chrome",
+            "request": "launch",
+            "url": "https://outlook.office.com/host/${dev:teamsAppInternalId}?${account-hint}",
+            "presentation": {
+                "group": "group 2: Outlook",
+                "order": 3
+            },
+            "internalConsoleOptions": "neverOpen"
+        },
+        {
+            "name": "Launch Remote in Office (Edge)",
+            "type": "pwa-msedge",
+            "request": "launch",
+            "url": "https://www.office.com/m365apps/${dev:teamsAppInternalId}?auth=2&${account-hint}",
+            "presentation": {
+                "group": "group 3: Office",
+                "order": 3
+            },
+            "internalConsoleOptions": "neverOpen"
+        },
+        {
+            "name": "Launch Remote in Office (Chrome)",
+            "type": "pwa-chrome",
+            "request": "launch",
+            "url": "https://www.office.com/m365apps/${dev:teamsAppInternalId}?auth=2&${account-hint}",
+            "presentation": {
+                "group": "group 3: Office",
+                "order": 3
+            },
+            "internalConsoleOptions": "neverOpen"
+        },
+        {
             "name": "Attach to Frontend in Teams (Edge)",
             "type": "pwa-msedge",
             "request": "launch",

--- a/templates/scenarios/ts/m365-message-extension/.vscode/launch.json
+++ b/templates/scenarios/ts/m365-message-extension/.vscode/launch.json
@@ -2,6 +2,50 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Launch Remote in Teams (Edge)",
+            "type": "pwa-msedge",
+            "request": "launch",
+            "url": "https://teams.microsoft.com/l/app/${dev:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
+            "presentation": {
+                "group": "group 1: Teams",
+                "order": 3
+            },
+            "internalConsoleOptions": "neverOpen"
+        },
+        {
+            "name": "Launch Remote in Teams (Chrome)",
+            "type": "pwa-chrome",
+            "request": "launch",
+            "url": "https://teams.microsoft.com/l/app/${dev:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
+            "presentation": {
+                "group": "group 1: Teams",
+                "order": 3
+            },
+            "internalConsoleOptions": "neverOpen"
+        },
+        {
+            "name": "Launch Remote in Outlook (Edge)",
+            "type": "pwa-msedge",
+            "request": "launch",
+            "url": "https://outlook.office.com/mail?${account-hint}",
+            "presentation": {
+                "group": "group 2: Outlook",
+                "order": 3
+            },
+            "internalConsoleOptions": "neverOpen"
+        },
+        {
+            "name": "Launch Remote in Outlook (Chrome)",
+            "type": "pwa-chrome",
+            "request": "launch",
+            "url": "https://outlook.office.com/mail?${account-hint}",
+            "presentation": {
+                "group": "group 2: Outlook",
+                "order": 3
+            },
+            "internalConsoleOptions": "neverOpen"
+        },
+        {
             "name": "Launch Bot in Teams (Edge)",
             "type": "pwa-msedge",
             "request": "launch",

--- a/templates/scenarios/ts/m365-tab/.vscode/launch.json
+++ b/templates/scenarios/ts/m365-tab/.vscode/launch.json
@@ -2,6 +2,72 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Launch Remote in Teams (Edge)",
+            "type": "pwa-msedge",
+            "request": "launch",
+            "url": "https://teams.microsoft.com/l/app/${dev:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
+            "presentation": {
+                "group": "group 1: Teams",
+                "order": 3
+            },
+            "internalConsoleOptions": "neverOpen"
+        },
+        {
+            "name": "Launch Remote in Teams (Chrome)",
+            "type": "pwa-chrome",
+            "request": "launch",
+            "url": "https://teams.microsoft.com/l/app/${dev:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
+            "presentation": {
+                "group": "group 1: Teams",
+                "order": 3
+            },
+            "internalConsoleOptions": "neverOpen"
+        },
+        {
+            "name": "Launch Remote in Outlook (Edge)",
+            "type": "pwa-msedge",
+            "request": "launch",
+            "url": "https://outlook.office.com/host/${dev:teamsAppInternalId}?${account-hint}",
+            "presentation": {
+                "group": "group 2: Outlook",
+                "order": 3
+            },
+            "internalConsoleOptions": "neverOpen"
+        },
+        {
+            "name": "Launch Remote in Outlook (Chrome)",
+            "type": "pwa-chrome",
+            "request": "launch",
+            "url": "https://outlook.office.com/host/${dev:teamsAppInternalId}?${account-hint}",
+            "presentation": {
+                "group": "group 2: Outlook",
+                "order": 3
+            },
+            "internalConsoleOptions": "neverOpen"
+        },
+        {
+            "name": "Launch Remote in Office (Edge)",
+            "type": "pwa-msedge",
+            "request": "launch",
+            "url": "https://www.office.com/m365apps/${dev:teamsAppInternalId}?auth=2&${account-hint}",
+            "presentation": {
+                "group": "group 3: Office",
+                "order": 3
+            },
+            "internalConsoleOptions": "neverOpen"
+        },
+        {
+            "name": "Launch Remote in Office (Chrome)",
+            "type": "pwa-chrome",
+            "request": "launch",
+            "url": "https://www.office.com/m365apps/${dev:teamsAppInternalId}?auth=2&${account-hint}",
+            "presentation": {
+                "group": "group 3: Office",
+                "order": 3
+            },
+            "internalConsoleOptions": "neverOpen"
+        },
+        {
             "name": "Attach to Frontend in Teams (Edge)",
             "type": "pwa-msedge",
             "request": "launch",


### PR DESCRIPTION
Fix https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/16740084.

![image](https://user-images.githubusercontent.com/37978464/211778730-12324fde-cb81-41e2-9058-40759ce3cd12.png)
