### PR TITLE
chore: enable m365 action

### DIFF
--- a/packages/fx-core/src/component/coordinator/index.ts
+++ b/packages/fx-core/src/component/coordinator/index.ts
@@ -165,6 +165,7 @@ const M365Actions = [
   "aadApp/create",
   "aadApp/update",
   "botFramework/create",
+  "m365Title/acquire",
 ];
 const AzureActions = ["arm/deploy"];
 const AzureDeployActions = [

--- a/packages/fx-core/src/component/driver/index.ts
+++ b/packages/fx-core/src/component/driver/index.ts
@@ -22,3 +22,4 @@ import "./prerequisite/installDriver";
 import "./file/updateEnv";
 import "./file/appsettingsGenerate";
 import "./botFramework/createOrUpdateBot";
+import "./m365/acquire";


### PR DESCRIPTION
- Enable `m365Title/acquire` action.
- This requires m365 account so add to `M365Actions`

work item: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/16764452/