### PR TITLE
chore: apply isLocalDebug for env

### DIFF
--- a/packages/vscode-extension/src/debug/taskTerminal/lifecycleTaskTerminal.ts
+++ b/packages/vscode-extension/src/debug/taskTerminal/lifecycleTaskTerminal.ts
@@ -59,6 +59,7 @@ export class LifecycleTaskTerminal extends BaseTaskTerminal {
 
     const inputs = getSystemInputs();
     inputs.env = this.args.env;
+    inputs.isLocalDebug = true;
     inputs.workflowFilePath = path.resolve(
       globalVariables.workspaceUri?.fsPath ?? "",
       BaseTaskTerminal.resolveTeamsFxVariables(this.args.template)


### PR DESCRIPTION
Align with #7558 to create `.env` file if not exist on F5.