### PR TITLE
chore: clear cache when encountering error in tenant login

### DIFF
--- a/packages/cli/src/commonlib/codeFlowTenantLogin.ts
+++ b/packages/cli/src/commonlib/codeFlowTenantLogin.ts
@@ -225,6 +225,8 @@ export class CodeFlowTenantLogin {
               LogLevel.Error,
               "[Login] silent acquire token : " + error.message
             );
+            await this.logout();
+            (this.msalTokenCache as any).storage.setCache({});
             const accessToken = await this.login();
             return accessToken;
           });


### PR DESCRIPTION
1.Clear cache when encountering error in tenant login