### PR TITLE
fix(adaptive-card): move @types/react to devDeps

### DIFF
--- a/packages/adaptivecards-tools-sdk/package.json
+++ b/packages/adaptivecards-tools-sdk/package.json
@@ -26,6 +26,7 @@
     "@rollup/plugin-node-resolve": "^8.0.0",
     "@rollup/plugin-replace": "^2.2.0",
     "@types/markdown-it": "^12.2.1",
+    "@types/react": "^17.0.14",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^4.13.0",
     "eslint": "^8.1.0",
@@ -42,7 +43,6 @@
     "typescript": "^4.1.2"
   },
   "dependencies": {
-    "@types/react": "^17.0.14",
     "adaptive-expressions": "^4.15.0",
     "adaptivecards": "~2.10.0",
     "adaptivecards-templating": "^2.1.0",

--- a/packages/adaptivecards-tools-sdk/src/AdaptiveCard.tsx
+++ b/packages/adaptivecards-tools-sdk/src/AdaptiveCard.tsx
@@ -13,13 +13,11 @@ export interface AdaptiveCardProps<D> {
 // TODO: plain payload without templating
 // TODO: better rendering to JSX instead of DOM manipulation directly
 // TODO: support themes and simulating renderers (Teams, Outlook, themes)
-export function AdaptiveCard<D = any>(props: AdaptiveCardProps<D>) {
+export function AdaptiveCard<D = any>(props: AdaptiveCardProps<D>): any {
   const { template, data } = props;
 
   try {
-    const payload = data
-      ? AdaptiveCards.renderWithData(template, data)
-      : template;
+    const payload = data ? AdaptiveCards.renderWithData(template, data) : template;
     return (
       <div
         className="ac-container"

--- a/packages/adaptivecards-tools-sdk/src/jsxExamples.tsx
+++ b/packages/adaptivecards-tools-sdk/src/jsxExamples.tsx
@@ -3,9 +3,9 @@
 
 import React from "react";
 
-export function TextBlock(p: { children: any }) {
+export function TextBlock(p: { children: any }): any {
   return <div></div>;
-};
-export function Bold(p: { children: any }) {
+}
+export function Bold(p: { children: any }): any {
   return <div></div>;
-};
+}


### PR DESCRIPTION
E2E TEST: none

TypeScript infers HTML element to be `JSX.Element` from @types/react, so we have to export @types/react as a dependency, which may cause the issue [15204137](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/15204137/).
Use `any` to avoid the type inference.

Reference: https://github.com/OfficeDev/TeamsFx/pull/4783