### PR TITLE
chore: rename updateAppSettings to updateJson

### DIFF
--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -1148,7 +1148,7 @@
   "driver.file.progressBar.title": "file/updateEnv",
   "driver.file.progressBar.generate": "Generating the environment variables to .env file.",
   "driver.file.updateJson.description": "Add or update appsettings to JSON file.",
-  "driver.file.updateJson.summary.withTarget": "The appsettings has been generated successfully to %s.",
+  "driver.file.updateJson.summary.withTarget": "The value for appsettings has been generated successfully to %s.",
   "driver.env.error.folderNotExist": "Folder %s does not exist.",
   "driver.deploy.error.deployToAzureRemoteFailed": "Remote service error, upload failed.",
   "driver.deploy.error.unknownError": "Unknown error happened: %s",

--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -1147,6 +1147,8 @@
   "driver.file.summary.withTarget": "The environment variables has been generated successfully to %s.",
   "driver.file.progressBar.title": "file/updateEnv",
   "driver.file.progressBar.generate": "Generating the environment variables to .env file.",
+  "driver.file.updateJson.description": "Add or update appsettings to JSON file.",
+  "driver.file.updateJson.summary.withTarget": "The appsettings has been generated successfully to %s.",
   "driver.env.error.folderNotExist": "Folder %s does not exist.",
   "driver.deploy.error.deployToAzureRemoteFailed": "Remote service error, upload failed.",
   "driver.deploy.error.unknownError": "Unknown error happened: %s",

--- a/packages/fx-core/src/component/driver/file/updateJson.ts
+++ b/packages/fx-core/src/component/driver/file/updateJson.ts
@@ -17,12 +17,12 @@ import { InvalidParameterUserError } from "./error/invalidParameterUserError";
 import { UnhandledSystemError } from "./error/unhandledError";
 import { GenerateAppsettingsArgs } from "./interface/generateAppsettingsArgs";
 
-const actionName = "file/updateAppSettings";
-const helpLink = "https://aka.ms/teamsfx-actions/appsettings-generate";
+const actionName = "file/updateJson";
+const helpLink = "https://aka.ms/teamsfx-actions/file-updateJson";
 
 @Service(actionName) // DO NOT MODIFY the service name
-export class GenerateAppsettingsDriver implements StepDriver {
-  description = getLocalizedString("driver.generateAppsettings.description");
+export class UpdateJsonDriver implements StepDriver {
+  description = getLocalizedString("driver.file.updateJson.description");
 
   @hooks([addStartAndEndTelemetry(actionName, actionName)])
   public async run(
@@ -75,9 +75,7 @@ export class GenerateAppsettingsDriver implements StepDriver {
       await fs.writeFile(appsettingsPath, JSON.stringify(appSettingsJson, null, "\t"), "utf-8");
       return {
         output: new Map<string, string>(),
-        summaries: [
-          getLocalizedString("driver.generateAppsettings.summary.withTarget", args.target),
-        ],
+        summaries: [getLocalizedString("driver.file.updateJson.summary.withTarget", args.target)],
       };
     } catch (error) {
       if (error instanceof UserError || error instanceof SystemError) {

--- a/packages/fx-core/src/component/driver/file/updateJson.ts
+++ b/packages/fx-core/src/component/driver/file/updateJson.ts
@@ -61,7 +61,7 @@ export class UpdateJsonDriver implements StepDriver {
     try {
       this.validateArgs(args);
       const appsettingsPath = getAbsolutePath(args.target, context.projectPath);
-      if (!fs.existsSync(appsettingsPath)) {
+      if (!(await fs.pathExists(appsettingsPath))) {
         // try to copy appsettings.json
         const appsettingsTemplatePath = getAbsolutePath("appsettings.json", context.projectPath);
         if (!fs.existsSync(appsettingsTemplatePath)) {

--- a/packages/fx-core/src/component/driver/index.ts
+++ b/packages/fx-core/src/component/driver/index.ts
@@ -20,6 +20,6 @@ import "./script/npmBuildDriver";
 import "./script/npxBuildDriver";
 import "./prerequisite/installDriver";
 import "./file/updateEnv";
-import "./file/appsettingsGenerate";
+import "./file/updateJson";
 import "./botFramework/createOrUpdateBot";
 import "./m365/acquire";

--- a/packages/fx-core/templates/core/v3Migration/csharp.app.local.yml
+++ b/packages/fx-core/templates/core/v3Migration/csharp.app.local.yml
@@ -34,7 +34,7 @@ provision:
       name: {{appName}}
       messagingEndpoint: $\{{BOT_ENDPOINT}}/api/messages
       description: ""
-  - uses: file/updateAppSettings
+  - uses: file/updateJson
     with:
       target: ./appsettings.Development.json
       appsettings:
@@ -58,7 +58,7 @@ configureApp:
         {{placeholderMappings.tabEndpoint}}: https://localhost:44302
         {{placeholderMappings.tabIndexPath}}: '#'
   {{#if activePlugins.fx-resource-aad-app-for-teams}}
-  - uses: file/updateAppSettings
+  - uses: file/updateJson
     with:
       target: ./appsettings.Development.json
       appsettings:

--- a/packages/fx-core/templates/core/v3Migration/js.ts.app.local.yml
+++ b/packages/fx-core/templates/core/v3Migration/js.ts.app.local.yml
@@ -202,7 +202,7 @@ deploy:
 
   {{/frontendStart}}
   {{#authStart}}
-  - uses: file/updateAppSettings
+  - uses: file/updateJson
     with:
       target: {{appsettingsPath}}
       appsettings:

--- a/packages/fx-core/tests/component/driver/file/generateAppsettings.test.ts
+++ b/packages/fx-core/tests/component/driver/file/generateAppsettings.test.ts
@@ -14,7 +14,7 @@ import { UpdateJsonDriver } from "../../../../src/component/driver/file/updateJs
 import { DriverContext } from "../../../../src/component/driver/interface/commonArgs";
 import { MockedLogProvider } from "../../../plugins/solution/util";
 
-describe("AppsettingsGenerateDriver", () => {
+describe("UpdateJsonDriver", () => {
   const mockedDriverContext = {
     logProvider: new MockedLogProvider(),
   } as DriverContext;
@@ -74,6 +74,7 @@ describe("AppsettingsGenerateDriver", () => {
     });
 
     it("exception", async () => {
+      sinon.stub(fs, "pathExists").rejects(new Error("exception"));
       sinon.stub(fs, "existsSync").throws(new Error("exception"));
       const args: any = {
         target: "path",
@@ -103,6 +104,7 @@ describe("AppsettingsGenerateDriver", () => {
         content = data;
         return;
       });
+      sinon.stub(fs, "pathExists").resolves(true);
       sinon.stub(fs, "existsSync").callsFake((path) => {
         return true;
       });
@@ -137,6 +139,7 @@ describe("AppsettingsGenerateDriver", () => {
         content = data;
         return;
       });
+      sinon.stub(fs, "pathExists").resolves(true);
       sinon.stub(fs, "existsSync").callsFake((path) => {
         return true;
       });
@@ -174,6 +177,7 @@ describe("AppsettingsGenerateDriver", () => {
         content = data;
         return;
       });
+      sinon.stub(fs, "pathExists").resolves(true);
       sinon.stub(fs, "existsSync").callsFake((path) => {
         return true;
       });
@@ -211,6 +215,12 @@ describe("AppsettingsGenerateDriver", () => {
       sinon.stub(fs, "writeFile").callsFake(async (path, data) => {
         content = data;
         return;
+      });
+      sinon.stub(fs, "pathExists").callsFake(async (path: fs.PathLike) => {
+        if (path.toString().indexOf(target) >= 0) {
+          return false;
+        }
+        return true;
       });
       sinon.stub(fs, "existsSync").callsFake((path) => {
         if (path.toString().indexOf(target) >= 0) {
@@ -253,6 +263,7 @@ describe("AppsettingsGenerateDriver", () => {
       content = data;
       return;
     });
+    sinon.stub(fs, "pathExists").resolves(false);
     sinon.stub(fs, "existsSync").callsFake((path) => {
       return false;
     });

--- a/packages/fx-core/tests/component/driver/file/generateAppsettings.test.ts
+++ b/packages/fx-core/tests/component/driver/file/generateAppsettings.test.ts
@@ -10,8 +10,7 @@ import * as util from "util";
 
 import * as localizeUtils from "../../../../src/common/localizeUtils";
 import { InvalidParameterUserError } from "../../../../src/component/driver/file/error/invalidParameterUserError";
-import { UnhandledSystemError } from "../../../../src/component/driver/file/error/unhandledError";
-import { GenerateAppsettingsDriver } from "../../../../src/component/driver/file/appsettingsGenerate";
+import { UpdateJsonDriver } from "../../../../src/component/driver/file/updateJson";
 import { DriverContext } from "../../../../src/component/driver/interface/commonArgs";
 import { MockedLogProvider } from "../../../plugins/solution/util";
 
@@ -19,7 +18,7 @@ describe("AppsettingsGenerateDriver", () => {
   const mockedDriverContext = {
     logProvider: new MockedLogProvider(),
   } as DriverContext;
-  const driver = new GenerateAppsettingsDriver();
+  const driver = new UpdateJsonDriver();
 
   beforeEach(() => {
     sinon.stub(localizeUtils, "getDefaultString").callsFake((key, ...params) => {
@@ -54,7 +53,7 @@ describe("AppsettingsGenerateDriver", () => {
       if (result.isErr()) {
         chai.assert(result.error instanceof InvalidParameterUserError);
         const message =
-          "Following parameter is missing or invalid for file/updateAppSettings action: target.";
+          "Following parameter is missing or invalid for file/updateJson action: target.";
         chai.assert.equal(result.error.message, message);
       }
     });
@@ -69,7 +68,7 @@ describe("AppsettingsGenerateDriver", () => {
       if (result.isErr()) {
         chai.assert(result.error instanceof InvalidParameterUserError);
         const message =
-          "Following parameter is missing or invalid for file/updateAppSettings action: appsettings.";
+          "Following parameter is missing or invalid for file/updateJson action: appsettings.";
         chai.assert.equal(result.error.message, message);
       }
     });

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/beforeV3.4.0-tab-bot-func/expected/app.local.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/beforeV3.4.0-tab-bot-func/expected/app.local.yml
@@ -85,7 +85,7 @@ deploy:
         REACT_APP_FUNC_ENDPOINT: http://localhost:7071
         REACT_APP_FUNC_NAME: getUserProfile
 
-  - uses: file/updateAppSettings
+  - uses: file/updateJson
     with:
       target: SIMPLE_AUTH_APPSETTINGS_PATH
       appsettings:

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/beforeV3.4.0-tab/expected/app.local.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/beforeV3.4.0-tab/expected/app.local.yml
@@ -62,7 +62,7 @@ deploy:
         REACT_APP_START_LOGIN_PAGE_URL: ${{PROVISIONOUTPUT__FRONTENDHOSTINGOUTPUT__ENDPOINT}}/auth-start.html
         REACT_APP_TEAMSFX_ENDPOINT: http://localhost:55000
 
-  - uses: file/updateAppSettings
+  - uses: file/updateJson
     with:
       target: SIMPLE_AUTH_APPSETTINGS_PATH
       appsettings:

--- a/templates/scenarios/common/init-debug-vs-bot/teamsapp.local.yml
+++ b/templates/scenarios/common/init-debug-vs-bot/teamsapp.local.yml
@@ -17,7 +17,7 @@ provision:
     # BOT_ID: the AAD app client id created for bot
     # SECRET_BOT_PASSWORD: the AAD app client secret created for bot
 
-  - uses: file/updateAppSettings
+  - uses: file/updateJson # Generate runtime appsettings to JSON file
     with:
       target: ./appsettings.Development.json
       appsettings:

--- a/templates/scenarios/csharp/command-and-response/teamsapp.local.yml.tpl
+++ b/templates/scenarios/csharp/command-and-response/teamsapp.local.yml.tpl
@@ -17,7 +17,7 @@ provision:
     # BOT_ID: the AAD app client id created for bot
     # SECRET_BOT_PASSWORD: the AAD app client secret created for bot
 
-  - uses: file/updateAppSettings
+  - uses: file/updateJson # Generate runtime appsettings to JSON file
     with:
       target: ./appsettings.Development.json
       appsettings:

--- a/templates/scenarios/csharp/message-extension/teamsapp.local.yml.tpl
+++ b/templates/scenarios/csharp/message-extension/teamsapp.local.yml.tpl
@@ -17,7 +17,7 @@ provision:
     # BOT_ID: the AAD app client id created for bot
     # SECRET_BOT_PASSWORD: the AAD app client secret created for bot
 
-  - uses: file/updateAppSettings
+  - uses: file/updateJson # Generate runtime appsettings to JSON file
     with:
       target: ./appsettings.Development.json
       appsettings:

--- a/templates/scenarios/csharp/notification-http-timer-trigger/teamsapp.local.yml.tpl
+++ b/templates/scenarios/csharp/notification-http-timer-trigger/teamsapp.local.yml.tpl
@@ -17,7 +17,7 @@ provision:
     # BOT_ID: the AAD app client id created for bot
     # SECRET_BOT_PASSWORD: the AAD app client secret created for bot
 
-  - uses: file/updateAppSettings
+  - uses: file/updateJson # Generate runtime appsettings to JSON file
     with:
       target: ./appsettings.Development.json
       appsettings:

--- a/templates/scenarios/csharp/notification-http-trigger/teamsapp.local.yml.tpl
+++ b/templates/scenarios/csharp/notification-http-trigger/teamsapp.local.yml.tpl
@@ -17,7 +17,7 @@ provision:
     # BOT_ID: the AAD app client id created for bot
     # SECRET_BOT_PASSWORD: the AAD app client secret created for bot
 
-  - uses: file/updateAppSettings
+  - uses: file/updateJson # Generate runtime appsettings to JSON file
     with:
       target: ./appsettings.Development.json
       appsettings:

--- a/templates/scenarios/csharp/notification-timer-trigger/teamsapp.local.yml.tpl
+++ b/templates/scenarios/csharp/notification-timer-trigger/teamsapp.local.yml.tpl
@@ -17,7 +17,7 @@ provision:
     # BOT_ID: the AAD app client id created for bot
     # SECRET_BOT_PASSWORD: the AAD app client secret created for bot
 
-  - uses: file/updateAppSettings
+  - uses: file/updateJson # Generate runtime appsettings to JSON file
     with:
       target: ./appsettings.Development.json
       appsettings:

--- a/templates/scenarios/csharp/notification-webapi/teamsapp.local.yml.tpl
+++ b/templates/scenarios/csharp/notification-webapi/teamsapp.local.yml.tpl
@@ -17,7 +17,7 @@ provision:
     # BOT_ID: the AAD app client id created for bot
     # SECRET_BOT_PASSWORD: the AAD app client secret created for bot
 
-  - uses: file/updateAppSettings
+  - uses: file/updateJson # Generate runtime appsettings to JSON file
     with:
       target: ./appsettings.Development.json
       appsettings:

--- a/templates/scenarios/csharp/sso-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/csharp/sso-tab/teamsapp.local.yml.tpl
@@ -28,7 +28,7 @@ configureApp:
         TAB_DOMAIN: localhost:44302
         TAB_ENDPOINT: https://localhost:44302
 
-  - uses: file/updateAppSettings
+  - uses: file/updateJson # Generate runtime appsettings to JSON file
     with:
       target: ./appsettings.Development.json
       appsettings:

--- a/templates/scenarios/csharp/workflow/teamsapp.local.yml.tpl
+++ b/templates/scenarios/csharp/workflow/teamsapp.local.yml.tpl
@@ -17,7 +17,7 @@ provision:
     # BOT_ID: the AAD app client id created for bot
     # SECRET_BOT_PASSWORD: the AAD app client secret created for bot
 
-  - uses: file/updateAppSettings
+  - uses: file/updateJson # Generate runtime appsettings to JSON file
     with:
       target: ./appsettings.Development.json
       appsettings:


### PR DESCRIPTION
Better name `file/updateAppSettings` to `file/updateJson` since it actually can output any settings to JSON format.
Then this action can be used by `init debug` for those Node.js projects which use JSON file as config (e.g., [app-hello-world](https://github.com/OfficeDev/Microsoft-Teams-Samples/tree/main/samples/app-hello-world/nodejs))