### PR TITLE
fix: output bicep issue if there is no teamsfx folder

### DIFF
--- a/packages/fx-core/src/component/utils.ts
+++ b/packages/fx-core/src/component/utils.ts
@@ -118,7 +118,7 @@ export async function persistConfigBicep(
       const value = configBicep.Modules[module];
       if (value) {
         const filePath = path.join(templateFolder, "teamsFx", `${module}.bicep`);
-        fs.writeFileSync(filePath, value.replace(/\r?\n/g, os.EOL).trim(), { encoding: "utf-8" });
+        fs.outputFileSync(filePath, value.replace(/\r?\n/g, os.EOL).trim(), { encoding: "utf-8" });
       }
     }
   }


### PR DESCRIPTION
@microsoft/teamsfx-cli	v1.2.2-rc.1
@microsoft/teamsfx-core	v1.23.0-rc.1
ms-teams-vscode-extension	v4.2.2-rc.1

CLI BREAKING CHANGE:
  

Extension-toolkit BREAKING CHANGE:
 

CLI feat commits:
  

Extension-toolkit feat commits:

E2E TEST: N/A

Fix this bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/16986609