### PR TITLE
chore: use TeamsActivityHandler in csharp bot templates

### DIFF
--- a/templates/bot/csharp/command-and-response/TeamsBot.cs.tpl
+++ b/templates/bot/csharp/command-and-response/TeamsBot.cs.tpl
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Teams;
 
 namespace {{SafeProjectName}}
 {
@@ -6,9 +7,9 @@ namespace {{SafeProjectName}}
     /// An empty bot handler.
     /// You can add your customization code here to extend your bot logic if needed.
     /// </summary>
-    public class TeamsBot : IBot
+    public class TeamsBot : TeamsActivityHandler
     {
-        public Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default) =>
+        public override Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default) =>
             Task.CompletedTask;
     }
 }

--- a/templates/bot/csharp/notification-function-base/TeamsBot.cs.tpl
+++ b/templates/bot/csharp/notification-function-base/TeamsBot.cs.tpl
@@ -1,4 +1,5 @@
 using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Teams;
 
 namespace {{SafeProjectName}}
 {
@@ -6,9 +7,9 @@ namespace {{SafeProjectName}}
     /// An empty bot handler.
     /// You can add your customization code here to extend your bot logic if needed.
     /// </summary>
-    public class TeamsBot : IBot
+    public class TeamsBot : TeamsActivityHandler
     {
-        public Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default) =>
+        public override Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default) =>
             Task.CompletedTask;
     }
 }

--- a/templates/bot/csharp/notification-webapi/TeamsBot.cs.tpl
+++ b/templates/bot/csharp/notification-webapi/TeamsBot.cs.tpl
@@ -1,4 +1,5 @@
 using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Teams;
 
 namespace {{SafeProjectName}}
 {
@@ -6,9 +7,9 @@ namespace {{SafeProjectName}}
     /// An empty bot handler.
     /// You can add your customization code here to extend your bot logic if needed.
     /// </summary>
-    public class TeamsBot : IBot
+    public class TeamsBot : TeamsActivityHandler
     {
-        public Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default) =>
+        public override Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default) =>
             Task.CompletedTask;
     }
 }

--- a/templates/bot/csharp/workflow/TeamsBot.cs.tpl
+++ b/templates/bot/csharp/workflow/TeamsBot.cs.tpl
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Teams;
 
 namespace {{SafeProjectName}}
 {
@@ -6,9 +7,9 @@ namespace {{SafeProjectName}}
     /// An empty bot handler.
     /// You can add your customization code here to extend your bot logic if needed.
     /// </summary>
-    public class TeamsBot : IBot
+    public class TeamsBot : TeamsActivityHandler
     {
-        public Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default) =>
+        public override Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default) =>
             Task.CompletedTask;
     }
 }

--- a/templates/scenarios/csharp/command-and-response/TeamsBot.cs.tpl
+++ b/templates/scenarios/csharp/command-and-response/TeamsBot.cs.tpl
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Teams;
 
 namespace {%SafeProjectName%}
 {
@@ -6,9 +7,9 @@ namespace {%SafeProjectName%}
     /// An empty bot handler.
     /// You can add your customization code here to extend your bot logic if needed.
     /// </summary>
-    public class TeamsBot : IBot
+    public class TeamsBot : TeamsActivityHandler
     {
-        public Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default) =>
+        public override Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default) =>
             Task.CompletedTask;
     }
 }

--- a/templates/scenarios/csharp/notification-http-timer-trigger/TeamsBot.cs.tpl
+++ b/templates/scenarios/csharp/notification-http-timer-trigger/TeamsBot.cs.tpl
@@ -1,4 +1,5 @@
 using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Teams;
 
 namespace {%SafeProjectName%}
 {
@@ -6,9 +7,9 @@ namespace {%SafeProjectName%}
     /// An empty bot handler.
     /// You can add your customization code here to extend your bot logic if needed.
     /// </summary>
-    public class TeamsBot : IBot
+    public class TeamsBot : TeamsActivityHandler
     {
-        public Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default) =>
+        public override Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default) =>
             Task.CompletedTask;
     }
 }

--- a/templates/scenarios/csharp/notification-http-trigger/TeamsBot.cs.tpl
+++ b/templates/scenarios/csharp/notification-http-trigger/TeamsBot.cs.tpl
@@ -1,4 +1,5 @@
 using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Teams;
 
 namespace {%SafeProjectName%}
 {
@@ -6,9 +7,9 @@ namespace {%SafeProjectName%}
     /// An empty bot handler.
     /// You can add your customization code here to extend your bot logic if needed.
     /// </summary>
-    public class TeamsBot : IBot
+    public class TeamsBot : TeamsActivityHandler
     {
-        public Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default) =>
+        public override Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default) =>
             Task.CompletedTask;
     }
 }

--- a/templates/scenarios/csharp/notification-timer-trigger/TeamsBot.cs.tpl
+++ b/templates/scenarios/csharp/notification-timer-trigger/TeamsBot.cs.tpl
@@ -1,4 +1,5 @@
 using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Teams;
 
 namespace {%SafeProjectName%}
 {
@@ -6,9 +7,9 @@ namespace {%SafeProjectName%}
     /// An empty bot handler.
     /// You can add your customization code here to extend your bot logic if needed.
     /// </summary>
-    public class TeamsBot : IBot
+    public class TeamsBot : TeamsActivityHandler
     {
-        public Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default) =>
+        public override Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default) =>
             Task.CompletedTask;
     }
 }

--- a/templates/scenarios/csharp/notification-webapi/TeamsBot.cs.tpl
+++ b/templates/scenarios/csharp/notification-webapi/TeamsBot.cs.tpl
@@ -1,4 +1,5 @@
 using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Teams;
 
 namespace {%SafeProjectName%}
 {
@@ -6,9 +7,9 @@ namespace {%SafeProjectName%}
     /// An empty bot handler.
     /// You can add your customization code here to extend your bot logic if needed.
     /// </summary>
-    public class TeamsBot : IBot
+    public class TeamsBot : TeamsActivityHandler
     {
-        public Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default) =>
+        public override Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default) =>
             Task.CompletedTask;
     }
 }

--- a/templates/scenarios/csharp/workflow/TeamsBot.cs.tpl
+++ b/templates/scenarios/csharp/workflow/TeamsBot.cs.tpl
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Teams;
 
 namespace {%SafeProjectName%}
 {
@@ -6,9 +7,9 @@ namespace {%SafeProjectName%}
     /// An empty bot handler.
     /// You can add your customization code here to extend your bot logic if needed.
     /// </summary>
-    public class TeamsBot : IBot
+    public class TeamsBot : TeamsActivityHandler
     {
-        public Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default) =>
+        public override Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default) =>
             Task.CompletedTask;
     }
 }


### PR DESCRIPTION
Fix [Bug 16826718](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/16826718): VS Bot templates should inherit from TeamsActivityHandler instead of IBot.

E2E TEST: N/A