### PR TITLE
chore: disable validate to avoid json schema error

### DIFF
--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -1214,6 +1214,7 @@
   "driver.teamsApp.summary.publishTeamsAppSuccess": "Teams app %s successfully published to the admin portal.",
   "driver.teamsApp.summary.copyAppPackageSuccess": "Teams app %s was successfully copyed to %s.",
   "driver.teamsApp.summary.copyIconSuccess": "%s icon(s) were successfully updated under %s.",
+  "driver.teamsApp.validate.skip": "%s action is currently skipped, will be updated in the future version.",
   "driver.teamsApp.invalidParameter": "Following parameter is missing or invalid for %s action: %s.",
   "driver.botFramework.error.invalidParameter": "Following parameter is missing or invalid for %s action: %s.",
   "driver.botFramework.error.unhandledError": "Unhandled error happened in %s action: %s",

--- a/packages/fx-core/src/component/driver/teamsApp/validate.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/validate.ts
@@ -105,13 +105,13 @@ export class ValidateTeamsAppDriver implements StepDriver {
         "https://aka.ms/teamsfx-actions/teamsapp-validate"
       );
       return err(validationFailed);
-    }
-    const validationSuccess = getLocalizedString("plugins.appstudio.validationSucceedNotice");
-    if (context.platform === Platform.VS) {
-      context.logProvider.info(validationSuccess);
-    } else {
-      context.ui?.showMessage("info", validationSuccess, false);
     }*/
+    const validationNotice = getLocalizedString("driver.teamsApp.validate.skip", actionName);
+    if (context.platform === Platform.VS) {
+      context.logProvider.warning(validationNotice);
+    } else {
+      context.ui?.showMessage("warn", validationNotice, false);
+    }
     return ok(new Map());
   }
 

--- a/templates/scenarios/common/init-debug-vs-bot/teamsapp.local.yml
+++ b/templates/scenarios/common/init-debug-vs-bot/teamsapp.local.yml
@@ -34,7 +34,7 @@ provision:
         - name: msteams
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value

--- a/templates/scenarios/common/init-debug-vsc-bot/teamsapp.local.yml
+++ b/templates/scenarios/common/init-debug-vsc-bot/teamsapp.local.yml
@@ -27,7 +27,7 @@ provision:
         - name: msteams
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
 

--- a/templates/scenarios/common/init-debug-vsc-spfx-tab/teamsapp.local.yml
+++ b/templates/scenarios/common/init-debug-vsc-spfx-tab/teamsapp.local.yml
@@ -10,7 +10,7 @@ registerApp:
     # TEAMS_APP_ID: the id of Teams app
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.template.local.json # Path to manifest template
 

--- a/templates/scenarios/common/init-debug-vsc-tab/teamsapp.local.yml
+++ b/templates/scenarios/common/init-debug-vsc-tab/teamsapp.local.yml
@@ -15,7 +15,7 @@ configureApp:
       envs:
         TAB_DOMAIN: localhost:53000
         TAB_ENDPOINT: https://localhost:53000
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value

--- a/templates/scenarios/common/init-infra-vs-bot/teamsapp.yml
+++ b/templates/scenarios/common/init-infra-vs-bot/teamsapp.yml
@@ -46,7 +46,7 @@ registerApp:
 
 # Triggered when 'teamsfx provision' is executed
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value

--- a/templates/scenarios/common/init-infra-vs-tab/teamsapp.yml
+++ b/templates/scenarios/common/init-infra-vs-tab/teamsapp.yml
@@ -58,7 +58,7 @@ configureApp:
   # Output: following environment variable will be persisted in current environment's .env file.
   # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value

--- a/templates/scenarios/common/init-infra-vsc-bot/teamsapp.yml
+++ b/templates/scenarios/common/init-infra-vsc-bot/teamsapp.yml
@@ -45,7 +45,7 @@ registerApp:
 
 # Triggered when 'teamsfx provision' is executed
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
@@ -61,7 +61,7 @@ configureApp:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/templates/scenarios/common/init-infra-vsc-spfx-tab/teamsapp.yml
+++ b/templates/scenarios/common/init-infra-vsc-spfx-tab/teamsapp.yml
@@ -43,7 +43,7 @@ configureApp:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/templates/scenarios/common/init-infra-vsc-tab/teamsapp.yml
+++ b/templates/scenarios/common/init-infra-vsc-tab/teamsapp.yml
@@ -69,7 +69,7 @@ configureApp:
   # Output: following environment variable will be persisted in current environment's .env file.
   # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
@@ -85,7 +85,7 @@ configureApp:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/templates/scenarios/csharp/command-and-response/teamsapp.local.yml.tpl
+++ b/templates/scenarios/csharp/command-and-response/teamsapp.local.yml.tpl
@@ -34,7 +34,7 @@ provision:
         - name: msteams
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value

--- a/templates/scenarios/csharp/command-and-response/teamsapp.yml.tpl
+++ b/templates/scenarios/csharp/command-and-response/teamsapp.yml.tpl
@@ -46,7 +46,7 @@ registerApp:
 
 # Triggered when 'teamsfx provision' is executed
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value

--- a/templates/scenarios/csharp/message-extension/teamsapp.local.yml.tpl
+++ b/templates/scenarios/csharp/message-extension/teamsapp.local.yml.tpl
@@ -34,7 +34,7 @@ provision:
         - name: msteams
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value

--- a/templates/scenarios/csharp/message-extension/teamsapp.yml.tpl
+++ b/templates/scenarios/csharp/message-extension/teamsapp.yml.tpl
@@ -46,7 +46,7 @@ registerApp:
 
 # Triggered when 'teamsfx provision' is executed
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value

--- a/templates/scenarios/csharp/non-sso-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/csharp/non-sso-tab/teamsapp.yml.tpl
@@ -39,7 +39,7 @@ registerApp:
 
 # Triggered when 'teamsfx provision' is executed
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value

--- a/templates/scenarios/csharp/notification-http-timer-trigger/teamsapp.local.yml.tpl
+++ b/templates/scenarios/csharp/notification-http-timer-trigger/teamsapp.local.yml.tpl
@@ -34,7 +34,7 @@ provision:
         - name: msteams
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value

--- a/templates/scenarios/csharp/notification-http-timer-trigger/teamsapp.yml.tpl
+++ b/templates/scenarios/csharp/notification-http-timer-trigger/teamsapp.yml.tpl
@@ -46,7 +46,7 @@ registerApp:
 
 # Triggered when 'teamsfx provision' is executed
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value

--- a/templates/scenarios/csharp/notification-http-trigger/teamsapp.local.yml.tpl
+++ b/templates/scenarios/csharp/notification-http-trigger/teamsapp.local.yml.tpl
@@ -34,7 +34,7 @@ provision:
         - name: msteams
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value

--- a/templates/scenarios/csharp/notification-http-trigger/teamsapp.yml.tpl
+++ b/templates/scenarios/csharp/notification-http-trigger/teamsapp.yml.tpl
@@ -46,7 +46,7 @@ registerApp:
 
 # Triggered when 'teamsfx provision' is executed
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value

--- a/templates/scenarios/csharp/notification-timer-trigger/teamsapp.local.yml.tpl
+++ b/templates/scenarios/csharp/notification-timer-trigger/teamsapp.local.yml.tpl
@@ -34,7 +34,7 @@ provision:
         - name: msteams
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value

--- a/templates/scenarios/csharp/notification-timer-trigger/teamsapp.yml.tpl
+++ b/templates/scenarios/csharp/notification-timer-trigger/teamsapp.yml.tpl
@@ -46,7 +46,7 @@ registerApp:
 
 # Triggered when 'teamsfx provision' is executed
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value

--- a/templates/scenarios/csharp/notification-webapi/teamsapp.local.yml.tpl
+++ b/templates/scenarios/csharp/notification-webapi/teamsapp.local.yml.tpl
@@ -34,7 +34,7 @@ provision:
         - name: msteams
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value

--- a/templates/scenarios/csharp/notification-webapi/teamsapp.yml.tpl
+++ b/templates/scenarios/csharp/notification-webapi/teamsapp.yml.tpl
@@ -46,7 +46,7 @@ registerApp:
 
 # Triggered when 'teamsfx provision' is executed
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value

--- a/templates/scenarios/csharp/sso-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/csharp/sso-tab/teamsapp.yml.tpl
@@ -58,7 +58,7 @@ configureApp:
   # Output: following environment variable will be persisted in current environment's .env file.
   # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value

--- a/templates/scenarios/csharp/workflow/teamsapp.local.yml.tpl
+++ b/templates/scenarios/csharp/workflow/teamsapp.local.yml.tpl
@@ -34,7 +34,7 @@ provision:
         - name: msteams
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value

--- a/templates/scenarios/csharp/workflow/teamsapp.yml.tpl
+++ b/templates/scenarios/csharp/workflow/teamsapp.yml.tpl
@@ -46,7 +46,7 @@ registerApp:
 
 # Triggered when 'teamsfx provision' is executed
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value

--- a/templates/scenarios/js/command-and-response/teamsapp.local.yml.tpl
+++ b/templates/scenarios/js/command-and-response/teamsapp.local.yml.tpl
@@ -27,7 +27,7 @@ provision:
         - name: msteams
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
 

--- a/templates/scenarios/js/command-and-response/teamsapp.yml.tpl
+++ b/templates/scenarios/js/command-and-response/teamsapp.yml.tpl
@@ -45,7 +45,7 @@ registerApp:
 
 # Triggered when 'teamsfx provision' is executed
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
@@ -61,7 +61,7 @@ configureApp:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/templates/scenarios/js/dashboard-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/js/dashboard-tab/teamsapp.local.yml.tpl
@@ -15,7 +15,7 @@ configureApp:
       envs:
         TAB_DOMAIN: localhost:53000
         TAB_ENDPOINT: https://localhost:53000
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value

--- a/templates/scenarios/js/dashboard-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/js/dashboard-tab/teamsapp.yml.tpl
@@ -47,7 +47,7 @@ registerApp:
 
 # Triggered when 'teamsfx provision' is executed
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
@@ -63,7 +63,7 @@ configureApp:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/templates/scenarios/js/default-bot-message-extension/teamsapp.local.yml.tpl
+++ b/templates/scenarios/js/default-bot-message-extension/teamsapp.local.yml.tpl
@@ -27,7 +27,7 @@ provision:
         - name: msteams
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
 

--- a/templates/scenarios/js/default-bot-message-extension/teamsapp.yml.tpl
+++ b/templates/scenarios/js/default-bot-message-extension/teamsapp.yml.tpl
@@ -45,7 +45,7 @@ registerApp:
 
 # Triggered when 'teamsfx provision' is executed
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
@@ -61,7 +61,7 @@ configureApp:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/templates/scenarios/js/default-bot/teamsapp.local.yml.tpl
+++ b/templates/scenarios/js/default-bot/teamsapp.local.yml.tpl
@@ -27,7 +27,7 @@ provision:
         - name: msteams
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
 

--- a/templates/scenarios/js/default-bot/teamsapp.yml.tpl
+++ b/templates/scenarios/js/default-bot/teamsapp.yml.tpl
@@ -45,7 +45,7 @@ registerApp:
 
 # Triggered when 'teamsfx provision' is executed
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
@@ -61,7 +61,7 @@ configureApp:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/templates/scenarios/js/m365-message-extension/teamsapp.local.yml.tpl
+++ b/templates/scenarios/js/m365-message-extension/teamsapp.local.yml.tpl
@@ -28,7 +28,7 @@ provision:
         - name: m365extensions
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
 

--- a/templates/scenarios/js/m365-message-extension/teamsapp.yml.tpl
+++ b/templates/scenarios/js/m365-message-extension/teamsapp.yml.tpl
@@ -45,7 +45,7 @@ registerApp:
 
 # Triggered when 'teamsfx provision' is executed
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
@@ -61,7 +61,7 @@ configureApp:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/templates/scenarios/js/m365-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/js/m365-tab/teamsapp.yml.tpl
@@ -82,7 +82,7 @@ configureApp:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/templates/scenarios/js/message-extension/teamsapp.local.yml.tpl
+++ b/templates/scenarios/js/message-extension/teamsapp.local.yml.tpl
@@ -27,7 +27,7 @@ provision:
         - name: msteams
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
 

--- a/templates/scenarios/js/message-extension/teamsapp.yml.tpl
+++ b/templates/scenarios/js/message-extension/teamsapp.yml.tpl
@@ -45,7 +45,7 @@ registerApp:
 
 # Triggered when 'teamsfx provision' is executed
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
@@ -61,7 +61,7 @@ configureApp:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/templates/scenarios/js/non-sso-tab-default-bot/teamsapp.local.yml.tpl
+++ b/templates/scenarios/js/non-sso-tab-default-bot/teamsapp.local.yml.tpl
@@ -32,7 +32,7 @@ configureApp:
       envs:
         TAB_DOMAIN: localhost:53000
         TAB_ENDPOINT: https://localhost:53000
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value

--- a/templates/scenarios/js/non-sso-tab-default-bot/teamsapp.yml.tpl
+++ b/templates/scenarios/js/non-sso-tab-default-bot/teamsapp.yml.tpl
@@ -60,7 +60,7 @@ registerApp:
 
 # Triggered when 'teamsfx provision' is executed
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
@@ -76,7 +76,7 @@ configureApp:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/templates/scenarios/js/non-sso-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/js/non-sso-tab/teamsapp.local.yml.tpl
@@ -15,7 +15,7 @@ configureApp:
       envs:
         TAB_DOMAIN: localhost:53000
         TAB_ENDPOINT: https://localhost:53000
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value

--- a/templates/scenarios/js/non-sso-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/js/non-sso-tab/teamsapp.yml.tpl
@@ -47,7 +47,7 @@ registerApp:
 
 # Triggered when 'teamsfx provision' is executed
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
@@ -63,7 +63,7 @@ configureApp:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/templates/scenarios/js/notification-http-timer-trigger/teamsapp.local.yml.tpl
+++ b/templates/scenarios/js/notification-http-timer-trigger/teamsapp.local.yml.tpl
@@ -27,7 +27,7 @@ provision:
         - name: msteams
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
 

--- a/templates/scenarios/js/notification-http-timer-trigger/teamsapp.yml.tpl
+++ b/templates/scenarios/js/notification-http-timer-trigger/teamsapp.yml.tpl
@@ -61,7 +61,7 @@ configureApp:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/templates/scenarios/js/notification-http-trigger/teamsapp.local.yml.tpl
+++ b/templates/scenarios/js/notification-http-trigger/teamsapp.local.yml.tpl
@@ -27,7 +27,7 @@ provision:
         - name: msteams
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
 

--- a/templates/scenarios/js/notification-http-trigger/teamsapp.yml.tpl
+++ b/templates/scenarios/js/notification-http-trigger/teamsapp.yml.tpl
@@ -61,7 +61,7 @@ configureApp:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/templates/scenarios/js/notification-restify/teamsapp.local.yml.tpl
+++ b/templates/scenarios/js/notification-restify/teamsapp.local.yml.tpl
@@ -27,7 +27,7 @@ provision:
         - name: msteams
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value

--- a/templates/scenarios/js/notification-restify/teamsapp.yml.tpl
+++ b/templates/scenarios/js/notification-restify/teamsapp.yml.tpl
@@ -45,7 +45,7 @@ registerApp:
 
 # Triggered when 'teamsfx provision' is executed
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
@@ -61,7 +61,7 @@ configureApp:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/templates/scenarios/js/notification-timer-trigger/teamsapp.local.yml.tpl
+++ b/templates/scenarios/js/notification-timer-trigger/teamsapp.local.yml.tpl
@@ -27,7 +27,7 @@ provision:
         - name: msteams
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
 

--- a/templates/scenarios/js/notification-timer-trigger/teamsapp.yml.tpl
+++ b/templates/scenarios/js/notification-timer-trigger/teamsapp.yml.tpl
@@ -61,7 +61,7 @@ configureApp:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/templates/scenarios/js/sso-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/js/sso-tab/teamsapp.local.yml.tpl
@@ -35,7 +35,7 @@ configureApp:
   # Output: following environment variable will be persisted in current environment's .env file.
   # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value

--- a/templates/scenarios/js/sso-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/js/sso-tab/teamsapp.yml.tpl
@@ -69,7 +69,7 @@ configureApp:
   # Output: following environment variable will be persisted in current environment's .env file.
   # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
@@ -85,7 +85,7 @@ configureApp:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/templates/scenarios/js/workflow/teamsapp.local.yml.tpl
+++ b/templates/scenarios/js/workflow/teamsapp.local.yml.tpl
@@ -27,7 +27,7 @@ provision:
         - name: msteams
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
 

--- a/templates/scenarios/js/workflow/teamsapp.yml.tpl
+++ b/templates/scenarios/js/workflow/teamsapp.yml.tpl
@@ -45,7 +45,7 @@ registerApp:
 
 # Triggered when 'teamsfx provision' is executed
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
@@ -61,7 +61,7 @@ configureApp:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/templates/scenarios/ts/command-and-response/teamsapp.local.yml.tpl
+++ b/templates/scenarios/ts/command-and-response/teamsapp.local.yml.tpl
@@ -27,7 +27,7 @@ provision:
         - name: msteams
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
 

--- a/templates/scenarios/ts/command-and-response/teamsapp.yml.tpl
+++ b/templates/scenarios/ts/command-and-response/teamsapp.yml.tpl
@@ -48,7 +48,7 @@ registerApp:
 
 # Triggered when 'teamsfx provision' is executed
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
@@ -64,7 +64,7 @@ configureApp:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/templates/scenarios/ts/dashboard-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/ts/dashboard-tab/teamsapp.local.yml.tpl
@@ -15,7 +15,7 @@ configureApp:
       envs:
         TAB_DOMAIN: localhost:53000
         TAB_ENDPOINT: https://localhost:53000
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value

--- a/templates/scenarios/ts/dashboard-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/ts/dashboard-tab/teamsapp.yml.tpl
@@ -48,7 +48,7 @@ registerApp:
 
 # Triggered when 'teamsfx provision' is executed
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
@@ -64,7 +64,7 @@ configureApp:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/templates/scenarios/ts/default-bot-message-extension/teamsapp.local.yml.tpl
+++ b/templates/scenarios/ts/default-bot-message-extension/teamsapp.local.yml.tpl
@@ -27,7 +27,7 @@ provision:
         - name: msteams
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
 

--- a/templates/scenarios/ts/default-bot-message-extension/teamsapp.yml.tpl
+++ b/templates/scenarios/ts/default-bot-message-extension/teamsapp.yml.tpl
@@ -48,7 +48,7 @@ registerApp:
 
 # Triggered when 'teamsfx provision' is executed
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
@@ -64,7 +64,7 @@ configureApp:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/templates/scenarios/ts/default-bot/teamsapp.local.yml.tpl
+++ b/templates/scenarios/ts/default-bot/teamsapp.local.yml.tpl
@@ -27,7 +27,7 @@ provision:
         - name: msteams
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
 

--- a/templates/scenarios/ts/default-bot/teamsapp.yml.tpl
+++ b/templates/scenarios/ts/default-bot/teamsapp.yml.tpl
@@ -48,7 +48,7 @@ registerApp:
 
 # Triggered when 'teamsfx provision' is executed
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
@@ -64,7 +64,7 @@ configureApp:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/templates/scenarios/ts/m365-message-extension/teamsapp.local.yml.tpl
+++ b/templates/scenarios/ts/m365-message-extension/teamsapp.local.yml.tpl
@@ -28,7 +28,7 @@ provision:
         - name: m365extensions
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
 

--- a/templates/scenarios/ts/m365-message-extension/teamsapp.yml.tpl
+++ b/templates/scenarios/ts/m365-message-extension/teamsapp.yml.tpl
@@ -48,7 +48,7 @@ registerApp:
 
 # Triggered when 'teamsfx provision' is executed
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
@@ -64,7 +64,7 @@ configureApp:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/templates/scenarios/ts/m365-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/ts/m365-tab/teamsapp.yml.tpl
@@ -82,7 +82,7 @@ configureApp:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/templates/scenarios/ts/message-extension/teamsapp.local.yml.tpl
+++ b/templates/scenarios/ts/message-extension/teamsapp.local.yml.tpl
@@ -27,7 +27,7 @@ provision:
         - name: msteams
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
 

--- a/templates/scenarios/ts/message-extension/teamsapp.yml.tpl
+++ b/templates/scenarios/ts/message-extension/teamsapp.yml.tpl
@@ -48,7 +48,7 @@ registerApp:
 
 # Triggered when 'teamsfx provision' is executed
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
@@ -64,7 +64,7 @@ configureApp:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/templates/scenarios/ts/non-sso-tab-default-bot/teamsapp.local.yml.tpl
+++ b/templates/scenarios/ts/non-sso-tab-default-bot/teamsapp.local.yml.tpl
@@ -32,7 +32,7 @@ configureApp:
       envs:
         TAB_DOMAIN: localhost:53000
         TAB_ENDPOINT: https://localhost:53000
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value

--- a/templates/scenarios/ts/non-sso-tab-default-bot/teamsapp.yml.tpl
+++ b/templates/scenarios/ts/non-sso-tab-default-bot/teamsapp.yml.tpl
@@ -60,7 +60,7 @@ registerApp:
 
 # Triggered when 'teamsfx provision' is executed
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
@@ -76,7 +76,7 @@ configureApp:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/templates/scenarios/ts/non-sso-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/ts/non-sso-tab/teamsapp.local.yml.tpl
@@ -15,7 +15,7 @@ configureApp:
       envs:
         TAB_DOMAIN: localhost:53000
         TAB_ENDPOINT: https://localhost:53000
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value

--- a/templates/scenarios/ts/non-sso-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/ts/non-sso-tab/teamsapp.yml.tpl
@@ -64,7 +64,7 @@ configureApp:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/templates/scenarios/ts/non-sso-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/ts/non-sso-tab/teamsapp.yml.tpl
@@ -48,7 +48,7 @@ registerApp:
 
 # Triggered when 'teamsfx provision' is executed
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value

--- a/templates/scenarios/ts/notification-http-timer-trigger/teamsapp.local.yml.tpl
+++ b/templates/scenarios/ts/notification-http-timer-trigger/teamsapp.local.yml.tpl
@@ -27,7 +27,7 @@ provision:
         - name: msteams
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
 

--- a/templates/scenarios/ts/notification-http-timer-trigger/teamsapp.yml.tpl
+++ b/templates/scenarios/ts/notification-http-timer-trigger/teamsapp.yml.tpl
@@ -64,7 +64,7 @@ configureApp:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/templates/scenarios/ts/notification-http-trigger/teamsapp.local.yml.tpl
+++ b/templates/scenarios/ts/notification-http-trigger/teamsapp.local.yml.tpl
@@ -27,7 +27,7 @@ provision:
         - name: msteams
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
 

--- a/templates/scenarios/ts/notification-http-trigger/teamsapp.yml.tpl
+++ b/templates/scenarios/ts/notification-http-trigger/teamsapp.yml.tpl
@@ -64,7 +64,7 @@ configureApp:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/templates/scenarios/ts/notification-restify/teamsapp.local.yml.tpl
+++ b/templates/scenarios/ts/notification-restify/teamsapp.local.yml.tpl
@@ -27,7 +27,7 @@ provision:
         - name: msteams
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
 

--- a/templates/scenarios/ts/notification-restify/teamsapp.yml.tpl
+++ b/templates/scenarios/ts/notification-restify/teamsapp.yml.tpl
@@ -48,7 +48,7 @@ registerApp:
 
 # Triggered when 'teamsfx provision' is executed
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
@@ -64,7 +64,7 @@ configureApp:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/templates/scenarios/ts/notification-timer-trigger/teamsapp.local.yml.tpl
+++ b/templates/scenarios/ts/notification-timer-trigger/teamsapp.local.yml.tpl
@@ -27,7 +27,7 @@ provision:
         - name: msteams
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
 

--- a/templates/scenarios/ts/notification-timer-trigger/teamsapp.yml.tpl
+++ b/templates/scenarios/ts/notification-timer-trigger/teamsapp.yml.tpl
@@ -64,7 +64,7 @@ configureApp:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/templates/scenarios/ts/spfx-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/ts/spfx-tab/teamsapp.local.yml.tpl
@@ -10,7 +10,7 @@ registerApp:
     # TEAMS_APP_ID: the id of Teams app
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.local.json # Path to manifest template
 

--- a/templates/scenarios/ts/spfx-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/ts/spfx-tab/teamsapp.yml.tpl
@@ -34,7 +34,7 @@ registerApp:
 
 # Triggered when 'teamsfx provision' is executed
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
@@ -51,7 +51,7 @@ configureApp:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/templates/scenarios/ts/sso-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/ts/sso-tab/teamsapp.local.yml.tpl
@@ -35,7 +35,7 @@ configureApp:
   # Output: following environment variable will be persisted in current environment's .env file.
   # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value

--- a/templates/scenarios/ts/sso-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/ts/sso-tab/teamsapp.yml.tpl
@@ -69,7 +69,7 @@ configureApp:
   # Output: following environment variable will be persisted in current environment's .env file.
   # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
@@ -85,7 +85,7 @@ configureApp:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/templates/scenarios/ts/workflow/teamsapp.local.yml.tpl
+++ b/templates/scenarios/ts/workflow/teamsapp.local.yml.tpl
@@ -27,7 +27,7 @@ provision:
         - name: msteams
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
 

--- a/templates/scenarios/ts/workflow/teamsapp.yml.tpl
+++ b/templates/scenarios/ts/workflow/teamsapp.yml.tpl
@@ -48,7 +48,7 @@ registerApp:
 
 # Triggered when 'teamsfx provision' is executed
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
@@ -64,7 +64,7 @@ configureApp:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validate # This action is currently skipped, will be updated in the future version.
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage


### PR DESCRIPTION
As manifest json schema changed, it's not source-of-truth. 
If we validate against the schema, the old projects will fail. So we will skip validate action for now, add comments to let user know it.
![image](https://user-images.githubusercontent.com/71362691/218628751-4b84fab8-acf0-4243-a59d-5646e734cc03.png)
