### PR TITLE
fix: update tab localhost URL if app from TDP

### DIFF
--- a/packages/fx-core/src/component/developerPortalScaffoldUtils.ts
+++ b/packages/fx-core/src/component/developerPortalScaffoldUtils.ts
@@ -357,8 +357,8 @@ export function updateScope(scopes: string[]): string[] {
   return scopes.map((o) => o.toLowerCase());
 }
 
-export function isFromDevPortalInVSC(inputs: Inputs): boolean {
-  return !!inputs.teamsAppFromTdp && inputs.platform === Platform.VSCode;
+export function isFromDevPortal(inputs: Inputs): boolean {
+  return !!inputs.teamsAppFromTdp;
 }
 
 export const developerPortalScaffoldUtils = new DeveloperPortalScaffoldUtils();

--- a/packages/fx-core/src/core/FxCoreImplementV3.ts
+++ b/packages/fx-core/src/core/FxCoreImplementV3.ts
@@ -71,7 +71,6 @@ import {
 import { QuestionMW } from "../component/middleware/questionMW";
 import { getQuestionsForCreateProjectV2 } from "./middleware/questionModel";
 import { getQuestionsForInit, getQuestionsForProvisionV3 } from "../component/question";
-import { isFromDevPortalInVSC } from "../component/developerPortalScaffoldUtils";
 import { buildAadManifest } from "../component/driver/aad/utility/buildAadManifest";
 import { MissingEnvInFileUserError } from "../component/driver/aad/error/missingEnvInFileError";
 import { getDefaultString, getLocalizedString } from "../common/localizeUtils";

--- a/packages/fx-core/src/core/middleware/questionModel.ts
+++ b/packages/fx-core/src/core/middleware/questionModel.ts
@@ -53,7 +53,7 @@ import { isPersonalApp, needBotCode } from "../../component/resource/appManifest
 import { convertToAlphanumericOnly } from "../../common/utils";
 import { AppDefinition } from "../../component/resource/appManifest/interfaces/appDefinition";
 import { getQuestionsForScaffolding } from "../../component/generator/officeAddin/question";
-import { getTemplateId, isFromDevPortalInVSC } from "../../component/developerPortalScaffoldUtils";
+import { getTemplateId, isFromDevPortal } from "../../component/developerPortalScaffoldUtils";
 
 /**
  * This middleware will help to collect input from question flow
@@ -114,10 +114,11 @@ export function traverseToCollectPasswordNodes(node: QTreeNode, names: Set<strin
 async function getQuestionsForCreateProjectWithoutDotNet(
   inputs: Inputs
 ): Promise<Result<QTreeNode | undefined, FxError>> {
-  if (isFromDevPortalInVSC(inputs)) {
+  if (isFromDevPortal(inputs)) {
     // If toolkit is activated by a request from Developer Portal, we will always create a project from scratch.
     inputs[CoreQuestionNames.CreateFromScratch] = ScratchOptionYesVSC().id;
-    inputs[CoreQuestionNames.Capabilities] = getTemplateId(inputs.teamsAppFromTdp);
+    inputs[CoreQuestionNames.Capabilities] =
+      inputs[CoreQuestionNames.Capabilities] ?? getTemplateId(inputs.teamsAppFromTdp);
   }
   const node = new QTreeNode(getCreateNewOrFromSampleQuestion(inputs.platform));
 
@@ -176,7 +177,7 @@ async function getQuestionsForCreateProjectWithoutDotNet(
     : convertToAlphanumericOnly(inputs.teamsAppFromTdp?.appName);
   createNew.addChild(new QTreeNode(createAppNameQuestion(defaultName)));
 
-  if (isFromDevPortalInVSC(inputs)) {
+  if (isFromDevPortal(inputs)) {
     const updateTabUrls = await getQuestionsForUpdateStaticTabUrls(inputs.teamsAppFromTdp);
     if (updateTabUrls) {
       createNew.addChild(updateTabUrls);

--- a/packages/fx-core/tests/component/developerPortalScaffoldUtils.test.ts
+++ b/packages/fx-core/tests/component/developerPortalScaffoldUtils.test.ts
@@ -136,6 +136,68 @@ describe("developPortalScaffoldUtils", () => {
       }
     });
 
+    it("missing manifest.json from template", async () => {
+      const ctx = createContextV3();
+      ctx.tokenProvider = {
+        m365TokenProvider: new MockedM365Provider(),
+        azureAccountProvider: new MockedAzureAccountProvider(),
+      };
+      ctx.projectPath = "project-path";
+      const appDefinition: AppDefinition = {
+        appId: "mock-app-id",
+        teamsAppId: "mock-app-id",
+      };
+      const inputs: Inputs = { platform: Platform.VSCode };
+
+      const manifest: TeamsAppManifest = {
+        manifestVersion: "version",
+        id: "mock-app-id",
+        name: { short: "short-name" },
+        description: { short: "", full: "" },
+        version: "version",
+        icons: { outline: "outline.png", color: "color.png" },
+        accentColor: "#ffffff",
+        developer: {
+          privacyUrl: "",
+          websiteUrl: "",
+          termsOfUseUrl: "",
+          name: "developer-name",
+        },
+        staticTabs: [
+          {
+            name: "name0",
+            entityId: "index0",
+            scopes: ["personal"],
+            contentUrl: "contentUrl0",
+            websiteUrl: "websiteUrl0",
+          },
+          {
+            name: "name1",
+            entityId: "index1",
+            scopes: ["personal"],
+            contentUrl: "contentUrl1",
+            websiteUrl: "websiteUrl1",
+          },
+        ],
+      };
+      sandbox.stub(appStudio, "getAppPackage").resolves(
+        ok({
+          manifest: Buffer.from(JSON.stringify(manifest)),
+          icons: { color: Buffer.from(""), outline: Buffer.from("") },
+          languages: { zh: Buffer.from(JSON.stringify({})) },
+        })
+      );
+      sandbox
+        .stub(manifestUtils, "_readAppManifest")
+        .resolves(ok(undefined as unknown as TeamsAppManifest));
+      const res = await developerPortalScaffoldUtils.updateFilesForTdp(ctx, appDefinition, inputs);
+
+      chai.assert.isTrue(res.isErr());
+      if (res.isErr()) {
+        chai.assert.isTrue(res.error instanceof ObjectIsUndefinedError);
+      }
+    });
+
     it("update files successfully", async () => {
       const ctx = createContextV3();
       ctx.tokenProvider = {
@@ -195,6 +257,31 @@ describe("developPortalScaffoldUtils", () => {
         ],
       };
 
+      const manifestTemplate: TeamsAppManifest = {
+        manifestVersion: "version",
+        id: "mock-app-id",
+        name: { short: "short-name" },
+        description: { short: "", full: "" },
+        version: "version",
+        icons: { outline: "outline.png", color: "color.png" },
+        accentColor: "#ffffff",
+        developer: {
+          privacyUrl: "",
+          websiteUrl: "",
+          termsOfUseUrl: "",
+          name: "developer-name",
+        },
+        staticTabs: [
+          {
+            name: "name0",
+            entityId: "index0",
+            scopes: ["personal"],
+            contentUrl: "localhost/content",
+            websiteUrl: "localhost/website",
+          },
+        ],
+      };
+
       let updateManifest = false;
       let updateLanguage = false;
       let updateColor = false;
@@ -234,7 +321,7 @@ describe("developPortalScaffoldUtils", () => {
           throw new Error("not support " + file);
         }
       });
-      sandbox.stub(manifestUtils, "_readAppManifest").resolves(ok(manifest));
+      sandbox.stub(manifestUtils, "_readAppManifest").resolves(ok(manifestTemplate));
       const res = await developerPortalScaffoldUtils.updateFilesForTdp(ctx, appDefinition, inputs);
 
       chai.assert.isTrue(res.isOk());
@@ -245,15 +332,9 @@ describe("developPortalScaffoldUtils", () => {
       const updatedManifest = JSON.parse(updatedManifestData) as TeamsAppManifest;
       chai.assert.equal(updatedManifest.id, "${{TEAMS_APP_ID}}");
       chai.assert.equal(updatedManifest.staticTabs![0].contentUrl, "contentUrl0");
-      chai.assert.equal(
-        updatedManifest.staticTabs![0].websiteUrl,
-        "${{TAB_ENDPOINT}}/index.html#/tab"
-      );
+      chai.assert.equal(updatedManifest.staticTabs![0].websiteUrl, "localhost/website");
       chai.assert.equal(updatedManifest.staticTabs![1].websiteUrl, "websiteUrl1");
-      chai.assert.equal(
-        updatedManifest.staticTabs![1].contentUrl,
-        "${{TAB_ENDPOINT}}/index.html#/tab"
-      );
+      chai.assert.equal(updatedManifest.staticTabs![1].contentUrl, "localhost/content");
       chai.assert.equal(updatedManifest.developer.privacyUrl, DEFAULT_DEVELOPER.privacyUrl);
       chai.assert.equal(updatedManifest.developer.termsOfUseUrl, DEFAULT_DEVELOPER.termsOfUseUrl);
       chai.assert.equal(updatedManifest.developer.websiteUrl, DEFAULT_DEVELOPER.websiteUrl);


### PR DESCRIPTION
- the default localhost URL for a tab project in C# is different from the value put in JS/TS project, so need to remove hard-code part and get the value from downloaded template.

E2E TEST: N/A