### PR TITLE
docs(manifest): rename teams app manifest in pre release docs

### DIFF
--- a/templates/scenarios/js/command-and-response/README.md
+++ b/templates/scenarios/js/command-and-response/README.md
@@ -74,7 +74,7 @@ Follow the steps below to add more commands and responses to extend the command 
 
 ### Step 1: Add a command definition in manifest
 
-You can edit the manifest template file `appPackage\manifest.template.json` to include definitions of a `doSomething` command with its title and description in the `commands` array:
+You can edit the manifest template file `appPackage\manifest.json` to include definitions of a `doSomething` command with its title and description in the `commands` array:
 
 ```json
 "commandLists": [

--- a/templates/scenarios/js/default-bot-message-extension/README.md
+++ b/templates/scenarios/js/default-bot-message-extension/README.md
@@ -41,7 +41,7 @@ This is a simple hello world application with both Bot and Message extension cap
 ## Edit the manifest
 
 You can find the Teams app manifest in `./appPackage` folder. The folder contains one manifest file:
-* `manifest.template.json`: Manifest file for Teams app running locally or running remotely (After deployed to Azure).
+* `manifest.json`: Manifest file for Teams app running locally or running remotely (After deployed to Azure).
 
 This file contains template arguments with `${{...}}` statements which will be replaced at build time. You may add any extra properties or permissions you require to this file. See the [schema reference](https://docs.microsoft.com/en-us/microsoftteams/platform/resources/schema/manifest-schema) for more information.
 

--- a/templates/scenarios/js/default-bot/README.md
+++ b/templates/scenarios/js/default-bot/README.md
@@ -37,7 +37,7 @@ This is a simple hello world application with Bot capabilities.
 ## Edit the manifest
 
 You can find the Teams app manifest in `./appPackage` folder. The folder contains one manifest file:
-* `manifest.template.json`: Manifest file for Teams app running locally or running remotely (After deployed to Azure).
+* `manifest.json`: Manifest file for Teams app running locally or running remotely (After deployed to Azure).
 
 This file contains template arguments with `${{...}}` statements which will be replaced at build time. You may add any extra properties or permissions you require to this file. See the [schema reference](https://docs.microsoft.com/en-us/microsoftteams/platform/resources/schema/manifest-schema) for more information.
 

--- a/templates/scenarios/js/message-extension/README.md
+++ b/templates/scenarios/js/message-extension/README.md
@@ -39,7 +39,7 @@ This is a simple hello world application with Message extension capabilities.
 ## Edit the manifest
 
 You can find the Teams app manifest in `./appPackage` folder. The folder contains one manifest file:
-* `manifest.template.json`: Manifest file for Teams app running locally or running remotely (After deployed to Azure).
+* `manifest.json`: Manifest file for Teams app running locally or running remotely (After deployed to Azure).
 
 This file contains template arguments with `${{...}}` statements which will be replaced at build time. You may add any extra properties or permissions you require to this file. See the [schema reference](https://docs.microsoft.com/en-us/microsoftteams/platform/resources/schema/manifest-schema) for more information.
 

--- a/templates/scenarios/js/non-sso-tab-default-bot/bot/README.md
+++ b/templates/scenarios/js/non-sso-tab-default-bot/bot/README.md
@@ -23,7 +23,7 @@ This is a simple hello world application with both Bot and Message extension cap
 ## Edit the manifest
 
 You can find the Teams app manifest in `../appPackage` folder. The folder contains one manifest file:
-* `manifest.template.json`: Manifest file for Teams app running locally or running remotely (After deployed to Azure).
+* `manifest.json`: Manifest file for Teams app running locally or running remotely (After deployed to Azure).
 
 This file contains template arguments with `${{...}}` statements which will be replaced at build time. You may add any extra properties or permissions you require to this file. See the [schema reference](https://docs.microsoft.com/en-us/microsoftteams/platform/resources/schema/manifest-schema) for more information.
 

--- a/templates/scenarios/js/non-sso-tab-default-bot/tab/README.md
+++ b/templates/scenarios/js/non-sso-tab-default-bot/tab/README.md
@@ -17,7 +17,7 @@ Microsoft Teams supports the ability to run web-based UI inside "custom tabs" th
 ## Edit the manifest
 
 You can find the Teams app manifest in `../appPackage` folder. The folder contains one manifest file:
-* `manifest.template.json`: Manifest file for Teams app running locally or running remotely (After deployed to Azure).
+* `manifest.json`: Manifest file for Teams app running locally or running remotely (After deployed to Azure).
 
 This file contains template arguments with `${{...}}` statements which will be replaced at build time. You may add any extra properties or permissions you require to this file. See the [schema reference](https://docs.microsoft.com/en-us/microsoftteams/platform/resources/schema/manifest-schema) for more information.
 

--- a/templates/scenarios/js/non-sso-tab/README.md
+++ b/templates/scenarios/js/non-sso-tab/README.md
@@ -35,7 +35,7 @@ Microsoft Teams supports the ability to run web-based UI inside "custom tabs" th
 ## Edit the manifest
 
 You can find the Teams app manifest in `./appPackage` folder. The folder contains one manifest file:
-* `manifest.template.json`: Manifest file for Teams app running locally or running remotely (After deployed to Azure).
+* `manifest.json`: Manifest file for Teams app running locally or running remotely (After deployed to Azure).
 
 This file contains template arguments with `${{...}}` statements which will be replaced at build time. You may add any extra properties or permissions you require to this file. See the [schema reference](https://docs.microsoft.com/en-us/microsoftteams/platform/resources/schema/manifest-schema) for more information.
 

--- a/templates/scenarios/js/sso-tab/README.md
+++ b/templates/scenarios/js/sso-tab/README.md
@@ -37,7 +37,7 @@ Microsoft Teams supports the ability to run web-based UI inside "custom tabs" th
 ## Edit the manifest
 
 You can find the Teams app manifest in `./appPackage` folder. The folder contains one manifest file:
-* `manifest.template.json`: Manifest file for Teams app running locally or running remotely (After deployed to Azure).
+* `manifest.json`: Manifest file for Teams app running locally or running remotely (After deployed to Azure).
 
 This file contains template arguments with `${{...}}` statements which will be replaced at build time. You may add any extra properties or permissions you require to this file. See the [schema reference](https://docs.microsoft.com/en-us/microsoftteams/platform/resources/schema/manifest-schema) for more information.
 

--- a/templates/scenarios/ts/command-and-response/README.md
+++ b/templates/scenarios/ts/command-and-response/README.md
@@ -75,7 +75,7 @@ Follow the steps below to add more commands and responses to extend the command 
 
 ### Step 1: Add a command definition in manifest
 
-You can edit the manifest template file `appPackage\manifest.template.json` to include definitions of a `doSomething` command with its title and description in the `commands` array:
+You can edit the manifest template file `appPackage\manifest.json` to include definitions of a `doSomething` command with its title and description in the `commands` array:
 
 ```json
 "commandLists": [

--- a/templates/scenarios/ts/default-bot-message-extension/README.md
+++ b/templates/scenarios/ts/default-bot-message-extension/README.md
@@ -41,7 +41,7 @@ This is a simple hello world application with both Bot and Message extension cap
 ## Edit the manifest
 
 You can find the Teams app manifest in `./appPackage` folder. The folder contains one manifest file:
-* `manifest.template.json`: Manifest file for Teams app running locally or running remotely (After deployed to Azure).
+* `manifest.json`: Manifest file for Teams app running locally or running remotely (After deployed to Azure).
 
 This file contains template arguments with `${{...}}` statements which will be replaced at build time. You may add any extra properties or permissions you require to this file. See the [schema reference](https://docs.microsoft.com/en-us/microsoftteams/platform/resources/schema/manifest-schema) for more information.
 

--- a/templates/scenarios/ts/default-bot/README.md
+++ b/templates/scenarios/ts/default-bot/README.md
@@ -37,7 +37,7 @@ This is a simple hello world application with Bot capabilities.
 ## Edit the manifest
 
 You can find the Teams app manifest in `./appPackage` folder. The folder contains one manifest file:
-* `manifest.template.json`: Manifest file for Teams app running locally or running remotely (After deployed to Azure).
+* `manifest.json`: Manifest file for Teams app running locally or running remotely (After deployed to Azure).
 
 This file contains template arguments with `${{...}}` statements which will be replaced at build time. You may add any extra properties or permissions you require to this file. See the [schema reference](https://docs.microsoft.com/en-us/microsoftteams/platform/resources/schema/manifest-schema) for more information.
 

--- a/templates/scenarios/ts/message-extension/README.md
+++ b/templates/scenarios/ts/message-extension/README.md
@@ -39,7 +39,7 @@ This is a simple hello world application with Message extension capabilities.
 ## Edit the manifest
 
 You can find the Teams app manifest in `./appPackage` folder. The folder contains one manifest file:
-* `manifest.template.json`: Manifest file for Teams app running locally or running remotely (After deployed to Azure).
+* `manifest.json`: Manifest file for Teams app running locally or running remotely (After deployed to Azure).
 
 This file contains template arguments with `${{...}}` statements which will be replaced at build time. You may add any extra properties or permissions you require to this file. See the [schema reference](https://docs.microsoft.com/en-us/microsoftteams/platform/resources/schema/manifest-schema) for more information.
 

--- a/templates/scenarios/ts/non-sso-tab-default-bot/bot/README.md
+++ b/templates/scenarios/ts/non-sso-tab-default-bot/bot/README.md
@@ -23,7 +23,7 @@ This is a simple hello world application with both Bot and Message extension cap
 ## Edit the manifest
 
 You can find the Teams app manifest in `../appPackage` folder. The folder contains one manifest file:
-* `manifest.template.json`: Manifest file for Teams app running locally or running remotely (After deployed to Azure).
+* `manifest.json`: Manifest file for Teams app running locally or running remotely (After deployed to Azure).
 
 This file contains template arguments with `${{...}}` statements which will be replaced at build time. You may add any extra properties or permissions you require to this file. See the [schema reference](https://docs.microsoft.com/en-us/microsoftteams/platform/resources/schema/manifest-schema) for more information.
 

--- a/templates/scenarios/ts/non-sso-tab-default-bot/tab/README.md
+++ b/templates/scenarios/ts/non-sso-tab-default-bot/tab/README.md
@@ -17,7 +17,7 @@ Microsoft Teams supports the ability to run web-based UI inside "custom tabs" th
 ## Edit the manifest
 
 You can find the Teams app manifest in `../appPackage` folder. The folder contains one manifest file:
-* `manifest.template.json`: Manifest file for Teams app running locally or running remotely (After deployed to Azure).
+* `manifest.json`: Manifest file for Teams app running locally or running remotely (After deployed to Azure).
 
 This file contains template arguments with `${{...}}` statements which will be replaced at build time. You may add any extra properties or permissions you require to this file. See the [schema reference](https://docs.microsoft.com/en-us/microsoftteams/platform/resources/schema/manifest-schema) for more information.
 

--- a/templates/scenarios/ts/non-sso-tab/README.md
+++ b/templates/scenarios/ts/non-sso-tab/README.md
@@ -35,7 +35,7 @@ Microsoft Teams supports the ability to run web-based UI inside "custom tabs" th
 ## Edit the manifest
 
 You can find the Teams app manifest in `./appPackage` folder. The folder contains one manifest file:
-* `manifest.template.json`: Manifest file for Teams app running locally or running remotely (After deployed to Azure).
+* `manifest.json`: Manifest file for Teams app running locally or running remotely (After deployed to Azure).
 
 This file contains template arguments with `${{...}}` statements which will be replaced at build time. You may add any extra properties or permissions you require to this file. See the [schema reference](https://docs.microsoft.com/en-us/microsoftteams/platform/resources/schema/manifest-schema) for more information.
 

--- a/templates/scenarios/ts/sso-tab/README.md
+++ b/templates/scenarios/ts/sso-tab/README.md
@@ -37,7 +37,7 @@ Microsoft Teams supports the ability to run web-based UI inside "custom tabs" th
 ## Edit the manifest
 
 You can find the Teams app manifest in `./appPackage` folder. The folder contains one manifest file:
-* `manifest.template.json`: Manifest file for Teams app running locally or running remotely (After deployed to Azure).
+* `manifest.json`: Manifest file for Teams app running locally or running remotely (After deployed to Azure).
 
 This file contains template arguments with `${{...}}` statements which will be replaced at build time. You may add any extra properties or permissions you require to this file. See the [schema reference](https://docs.microsoft.com/en-us/microsoftteams/platform/resources/schema/manifest-schema) for more information.
 


### PR DESCRIPTION
Fix bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/17144909