### PR TITLE
feat: add empty teams activity handler for node bot templates

### DIFF
--- a/templates/bot/js/command-and-response/README.md
+++ b/templates/bot/js/command-and-response/README.md
@@ -43,6 +43,7 @@ The following files can be customized and demonstrate an example implementation 
 | File | Contents |
 | - | - |
 | `src/index.js` | Application entry point and `restify` handlers for command and response |
+| `src/teamsBot.js`| An empty teams activity handler for bot customization |
 | `src/adaptiveCards/helloworldCommand.json` | A generated Adaptive Card that is sent to Teams |
 | `src/helloworldCommandHandler.js` | The business logic to handle a command |
 

--- a/templates/bot/js/command-and-response/src/index.js
+++ b/templates/bot/js/command-and-response/src/index.js
@@ -1,6 +1,7 @@
 // Create HTTP server.
 const restify = require("restify");
 const { commandBot } = require("./internal/initialize");
+const { TeamsBot } = require("./teamsBot");
 
 // This template uses `restify` to serve HTTP responses.
 // Create a restify server.
@@ -16,6 +17,9 @@ server.listen(process.env.port || process.env.PORT || 3978, () => {
 // The Teams Toolkit bot registration configures the bot with `/api/messages` as the
 // Bot Framework endpoint. If you customize this route, update the Bot registration
 // in `templates/azure/provision/botservice.bicep`.
+const teamsBot = new TeamsBot();
 server.post("/api/messages", async (req, res) => {
-  await commandBot.requestHandler(req, res);
+  await commandBot.requestHandler(req, res, async (context) => {
+    await teamsBot.run(context);
+  });
 });

--- a/templates/bot/js/command-and-response/src/teamsBot.js
+++ b/templates/bot/js/command-and-response/src/teamsBot.js
@@ -1,0 +1,11 @@
+const { TeamsActivityHandler } = require("botbuilder");
+
+// An empty teams activity handler.
+// You can add your customization code here to extend your bot logic if needed.
+class TeamsBot extends TeamsActivityHandler {
+  constructor() {
+    super();
+  }
+}
+
+module.exports.TeamsBot = TeamsBot;

--- a/templates/bot/js/notification-function-base/README.md
+++ b/templates/bot/js/notification-function-base/README.md
@@ -46,6 +46,7 @@ The following files can be customized and demonstrate an example implementation 
 | - | - |
 | `*Trigger/function.json` | Azure Function bindings for the notification trigger |
 | `src/*Trigger.js` | Notification trigger implementation |
+| `src/teamsBot.js`| An empty teams activity handler for bot customization |
 | `src/adaptiveCards/notification-default.json` | A generated Adaptive Card that is sent to Teams |
 
 The following files implement the core notification on the Bot Framework. You generally will not need to customize these files.

--- a/templates/bot/js/notification-function-base/src/internal/messageHandler.js
+++ b/templates/bot/js/notification-function-base/src/internal/messageHandler.js
@@ -1,8 +1,12 @@
+const { TeamsBot } = require("../teamsBot");
 const { bot } = require("./initialize");
 const { ResponseWrapper } = require("./responseWrapper");
 
 module.exports = async function (context, req) {
   const res = new ResponseWrapper(context.res);
-  await bot.requestHandler(req, res);
+  const teamsBot = new TeamsBot();
+  await bot.requestHandler(req, res, async (context) => {
+    await teamsBot.run(context);
+  });
   return res.body;
 };

--- a/templates/bot/js/notification-function-base/src/teamsBot.js
+++ b/templates/bot/js/notification-function-base/src/teamsBot.js
@@ -1,0 +1,11 @@
+const { TeamsActivityHandler } = require("botbuilder");
+
+// An empty teams activity handler.
+// You can add your customization code here to extend your bot logic if needed.
+class TeamsBot extends TeamsActivityHandler {
+  constructor() {
+    super();
+  }
+}
+
+module.exports.TeamsBot = TeamsBot;

--- a/templates/bot/js/notification-restify/README.md
+++ b/templates/bot/js/notification-restify/README.md
@@ -45,6 +45,7 @@ The following files can be customized and demonstrate an example implementation 
 | File | Contents |
 | - | - |
 | `src/index.js` | Application entry point and `restify` handlers for notifications |
+| `src/teamsBot.js`| An empty teams activity handler for bot customization |
 | `src/adaptiveCards/notification-default.json` | A generated Adaptive Card that is sent to Teams |
 
 ## Extend the notification bot template

--- a/templates/bot/js/notification-restify/src/index.js
+++ b/templates/bot/js/notification-restify/src/index.js
@@ -1,6 +1,7 @@
 const notificationTemplate = require("./adaptiveCards/notification-default.json");
 const { bot } = require("./internal/initialize");
 const { AdaptiveCards } = require("@microsoft/adaptivecards-tools");
+const { TeamsBot } = require("./teamsBot");
 const restify = require("restify");
 
 // Create HTTP server.
@@ -88,6 +89,9 @@ server.post(
 );
 
 // Bot Framework message handler.
+const teamsBot = new TeamsBot();
 server.post("/api/messages", async (req, res) => {
-  await bot.requestHandler(req, res);
+  await bot.requestHandler(req, res, async (context) => {
+    await teamsBot.run(context);
+  });
 });

--- a/templates/bot/js/notification-restify/src/teamsBot.js
+++ b/templates/bot/js/notification-restify/src/teamsBot.js
@@ -1,0 +1,11 @@
+const { TeamsActivityHandler } = require("botbuilder");
+
+// An empty teams activity handler.
+// You can add your customization code here to extend your bot logic if needed.
+class TeamsBot extends TeamsActivityHandler {
+  constructor() {
+    super();
+  }
+}
+
+module.exports.TeamsBot = TeamsBot;

--- a/templates/bot/js/workflow/README.md
+++ b/templates/bot/js/workflow/README.md
@@ -50,6 +50,7 @@ The following files can be customized and demonstrate an example implementation 
 | File | Contents |
 | - | - |
 | `src/index.js` | Application entry point and `restify` handlers for the Workflow bot |
+| `src/teamsBot.js`| An empty teams activity handler for bot customization |
 | `src/commands/helloworldCommandHandler.js` | Implementation that handles responding to a chat command |
 | `src/adaptiveCards/helloworldCommandResponse.json` | Defines the Adaptive Card (UI) that is displayed in response to a chat command |
 | `src/adaptiveCards/doStuffActionResponse.json` | A generated Adaptive Card that is sent to Teams for the response of "doStuff" action |

--- a/templates/bot/js/workflow/src/index.js
+++ b/templates/bot/js/workflow/src/index.js
@@ -1,6 +1,7 @@
 // Create HTTP server.
 const restify = require("restify");
-const { conversationBot } = require("./internal/initialize");
+const { workflowApp } = require("./internal/initialize");
+const { TeamsBot } = require("./teamsBot");
 
 // This template uses `restify` to serve HTTP responses.
 // Create a restify server.
@@ -16,6 +17,9 @@ server.listen(process.env.port || process.env.PORT || 3978, () => {
 // The Teams Toolkit bot registration configures the bot with `/api/messages` as the
 // Bot Framework endpoint. If you customize this route, update the Bot registration
 // in `templates/azure/provision/botservice.bicep`.
+const teamsBot = new TeamsBot();
 server.post("/api/messages", async (req, res) => {
-  await conversationBot.requestHandler(req, res);
+  await workflowApp.requestHandler(req, res, async (context) => {
+    await teamsBot.run(context);
+  });
 });

--- a/templates/bot/js/workflow/src/internal/initialize.js
+++ b/templates/bot/js/workflow/src/internal/initialize.js
@@ -5,7 +5,7 @@ const { HelloWorldCommandHandler } = require("../commands/helloworldCommandHandl
 const config = require("./config");
 
 // Create the conversation bot and register the command and card action handlers for your app.
-const conversationBot = new ConversationBot({
+const workflowApp = new ConversationBot({
   // The bot id and password to create CloudAdapter.
   // See https://aka.ms/about-bot-adapter to learn more about adapters.
   adapterConfig: {
@@ -24,5 +24,5 @@ const conversationBot = new ConversationBot({
 });
 
 module.exports = {
-  conversationBot,
+  workflowApp,
 };

--- a/templates/bot/js/workflow/src/teamsBot.js
+++ b/templates/bot/js/workflow/src/teamsBot.js
@@ -1,0 +1,11 @@
+const { TeamsActivityHandler } = require("botbuilder");
+
+// An empty teams activity handler.
+// You can add your customization code here to extend your bot logic if needed.
+class TeamsBot extends TeamsActivityHandler {
+  constructor() {
+    super();
+  }
+}
+
+module.exports.TeamsBot = TeamsBot;

--- a/templates/bot/ts/command-and-response/README.md
+++ b/templates/bot/ts/command-and-response/README.md
@@ -43,6 +43,7 @@ The following files can be customized and demonstrate an example implementation 
 | File | Contents |
 | - | - |
 | `src/index.ts` | Application entry point and `restify` handlers for command and response |
+| `src/teamsBot.ts`| An empty teams activity handler for bot customization |
 | `src/adaptiveCards/helloworldCommand.json` | A generated Adaptive Card that is sent to Teams |
 | `src/helloworldCommandHandler.ts` | The business logic to handle a command |
 | `src/cardModels.ts` | The default Adaptive Card data model |

--- a/templates/bot/ts/command-and-response/src/index.ts
+++ b/templates/bot/ts/command-and-response/src/index.ts
@@ -1,5 +1,6 @@
 import * as restify from "restify";
 import { commandBot } from "./internal/initialize";
+import { TeamsBot } from "./teamsBot";
 
 // This template uses `restify` to serve HTTP responses.
 // Create a restify server.
@@ -15,6 +16,9 @@ server.listen(process.env.port || process.env.PORT || 3978, () => {
 // The Teams Toolkit bot registration configures the bot with `/api/messages` as the
 // Bot Framework endpoint. If you customize this route, update the Bot registration
 // in `templates/azure/provision/botservice.bicep`.
+const teamsBot = new TeamsBot();
 server.post("/api/messages", async (req, res) => {
-  await commandBot.requestHandler(req, res);
+  await commandBot.requestHandler(req, res, async (context) => {
+    await teamsBot.run(context);
+  });
 });

--- a/templates/bot/ts/command-and-response/src/teamsBot.ts
+++ b/templates/bot/ts/command-and-response/src/teamsBot.ts
@@ -1,0 +1,9 @@
+import { TeamsActivityHandler } from "botbuilder";
+
+// An empty teams activity handler.
+// You can add your customization code here to extend your bot logic if needed.
+export class TeamsBot extends TeamsActivityHandler {
+  constructor() {
+    super();
+  }
+}

--- a/templates/bot/ts/notification-function-base/README.md
+++ b/templates/bot/ts/notification-function-base/README.md
@@ -46,6 +46,7 @@ The following files can be customized and demonstrate an example implementation 
 | - | - |
 | `*Trigger/function.json` | Azure Function bindings for the notification trigger |
 | `src/*Trigger.ts` | Notification trigger implementation |
+| `src/teamsBot.ts`| An empty teams activity handler for bot customization |
 | `src/adaptiveCards/notification-default.json` | A generated Adaptive Card that is sent to Teams |
 | `src/cardModels.ts` | The default Adaptive Card data model |
 

--- a/templates/bot/ts/notification-function-base/src/internal/messageHandler.ts
+++ b/templates/bot/ts/notification-function-base/src/internal/messageHandler.ts
@@ -1,4 +1,5 @@
 import { AzureFunction, Context, HttpRequest } from "@azure/functions";
+import { TeamsBot } from "../teamsBot";
 import { bot } from "./initialize";
 import { ResponseWrapper } from "./responseWrapper";
 
@@ -7,7 +8,10 @@ const httpTrigger: AzureFunction = async function (
   req: HttpRequest
 ): Promise<any> {
   const res = new ResponseWrapper(context.res);
-  await bot.requestHandler(req, res);
+  const teamsBot = new TeamsBot();
+  await bot.requestHandler(req, res, async (context) => {
+    await teamsBot.run(context);
+  });
   return res.body;
 };
 

--- a/templates/bot/ts/notification-function-base/src/teamsBot.ts
+++ b/templates/bot/ts/notification-function-base/src/teamsBot.ts
@@ -1,0 +1,9 @@
+import { TeamsActivityHandler } from "botbuilder";
+
+// An empty teams activity handler.
+// You can add your customization code here to extend your bot logic if needed.
+export class TeamsBot extends TeamsActivityHandler {
+  constructor() {
+    super();
+  }
+}

--- a/templates/bot/ts/notification-restify/README.md
+++ b/templates/bot/ts/notification-restify/README.md
@@ -45,6 +45,7 @@ The following files can be customized and demonstrate an example implementation 
 | File | Contents |
 | - | - |
 | `src/index.ts` | Application entry point and `restify` handlers for notifications |
+| `src/teamsBot.ts`| An empty teams activity handler for bot customization |
 | `src/adaptiveCards/notification-default.json` | A generated Adaptive Card that is sent to Teams |
 | `src/cardModels.ts` | The default Adaptive Card data model |
 

--- a/templates/bot/ts/notification-restify/src/index.ts
+++ b/templates/bot/ts/notification-restify/src/index.ts
@@ -3,6 +3,7 @@ import * as restify from "restify";
 import notificationTemplate from "./adaptiveCards/notification-default.json";
 import { bot } from "./internal/initialize";
 import { CardData } from "./cardModels";
+import { TeamsBot } from "./teamsBot";
 
 // Create HTTP server.
 const server = restify.createServer();
@@ -111,6 +112,9 @@ server.post(
 // The Teams Toolkit bot registration configures the bot with `/api/messages` as the
 // Bot Framework endpoint. If you customize this route, update the Bot registration
 // in `/templates/provision/bot.bicep`.
+const teamsBot = new TeamsBot();
 server.post("/api/messages", async (req, res) => {
-  await bot.requestHandler(req, res);
+  await bot.requestHandler(req, res, async (context) => {
+    await teamsBot.run(context);
+  });
 });

--- a/templates/bot/ts/notification-restify/src/teamsBot.ts
+++ b/templates/bot/ts/notification-restify/src/teamsBot.ts
@@ -1,0 +1,9 @@
+import { TeamsActivityHandler } from "botbuilder";
+
+// An empty teams activity handler.
+// You can add your customization code here to extend your bot logic if needed.
+export class TeamsBot extends TeamsActivityHandler {
+  constructor() {
+    super();
+  }
+}

--- a/templates/bot/ts/workflow/README.md
+++ b/templates/bot/ts/workflow/README.md
@@ -50,6 +50,7 @@ The following files can be customized and demonstrate an example implementation 
 | File | Contents |
 | - | - |
 | `src/index.ts` | Application entry point and `restify` handlers for the Workflow bot |
+| `src/teamsBot.ts`| An empty teams activity handler for bot customization |
 | `src/commands/helloworldCommandHandler.ts` | Implementation that handles responding to a chat command |
 | `src/adaptiveCards/helloworldCommandResponse.json` | Defines the Adaptive Card (UI) that is displayed in response to a chat command |
 | `src/adaptiveCards/doStuffActionResponse.json` | A generated Adaptive Card that is sent to Teams for the response of "doStuff" action |

--- a/templates/bot/ts/workflow/src/index.ts
+++ b/templates/bot/ts/workflow/src/index.ts
@@ -1,12 +1,24 @@
 import * as restify from "restify";
-import { conversationBot } from "./internal/initialize";
+import { workflowApp } from "./internal/initialize";
+import { TeamsBot } from "./teamsBot";
 
+// This template uses `restify` to serve HTTP responses.
+// Create a restify server.
 const server = restify.createServer();
 server.use(restify.plugins.bodyParser());
 server.listen(process.env.port || process.env.PORT || 3978, () => {
   console.log(`\nBot Started, ${server.name} listening to ${server.url}`);
 });
 
+// Register an API endpoint with `restify`. Teams sends messages to your application
+// through this endpoint.
+//
+// The Teams Toolkit bot registration configures the bot with `/api/messages` as the
+// Bot Framework endpoint. If you customize this route, update the Bot registration
+// in `templates/azure/provision/botservice.bicep`.
+const teamsBot = new TeamsBot();
 server.post("/api/messages", async (req, res) => {
-  await conversationBot.requestHandler(req, res);
+  await workflowApp.requestHandler(req, res, async (context) => {
+    await teamsBot.run(context);
+  });
 });

--- a/templates/bot/ts/workflow/src/internal/initialize.ts
+++ b/templates/bot/ts/workflow/src/internal/initialize.ts
@@ -5,7 +5,7 @@ import ConversationBot = BotBuilderCloudAdapter.ConversationBot;
 import config from "./config";
 
 // Create the conversation bot and register the command and card action handlers for your app.
-export const conversationBot = new ConversationBot({
+export const workflowApp = new ConversationBot({
   // The bot id and password to create CloudAdapter.
   // See https://aka.ms/about-bot-adapter to learn more about adapters.
   adapterConfig: {

--- a/templates/bot/ts/workflow/src/teamsBot.ts
+++ b/templates/bot/ts/workflow/src/teamsBot.ts
@@ -1,0 +1,9 @@
+import { TeamsActivityHandler } from "botbuilder";
+
+// An empty teams activity handler.
+// You can add your customization code here to extend your bot logic if needed.
+export class TeamsBot extends TeamsActivityHandler {
+  constructor() {
+    super();
+  }
+}

--- a/templates/scenarios/js/command-and-response/README.md
+++ b/templates/scenarios/js/command-and-response/README.md
@@ -60,6 +60,7 @@ The following files can be customized and demonstrate an example implementation 
 | File                                       | Contents                                                                |
 | ------------------------------------------ | ----------------------------------------------------------------------- |
 | `src/index.js`                             | Application entry point and `restify` handlers for command and response |
+| `src/teamsBot.js`                          | An empty teams activity handler for bot customization                   |
 | `src/adaptiveCards/helloworldCommand.json` | A generated Adaptive Card that is sent to Teams                         |
 | `src/helloworldCommandHandler.js`          | The business logic to handle a command                                  |
 

--- a/templates/scenarios/js/command-and-response/src/index.js
+++ b/templates/scenarios/js/command-and-response/src/index.js
@@ -1,6 +1,7 @@
 // Create HTTP server.
 const restify = require("restify");
 const { commandApp } = require("./internal/initialize");
+const { TeamsBot } = require("./teamsBot");
 
 // This template uses `restify` to serve HTTP responses.
 // Create a restify server.
@@ -16,6 +17,9 @@ server.listen(process.env.port || process.env.PORT || 3978, () => {
 // The Teams Toolkit bot registration configures the bot with `/api/messages` as the
 // Bot Framework endpoint. If you customize this route, update the Bot registration
 // in `templates/azure/provision/botservice.bicep`.
+const teamsBot = new TeamsBot();
 server.post("/api/messages", async (req, res) => {
-  await commandApp.requestHandler(req, res);
+  await commandApp.requestHandler(req, res, async (context) => {
+    await teamsBot.run(context);
+  });
 });

--- a/templates/scenarios/js/command-and-response/src/teamsBot.js
+++ b/templates/scenarios/js/command-and-response/src/teamsBot.js
@@ -1,0 +1,11 @@
+const { TeamsActivityHandler } = require("botbuilder");
+
+// An empty teams activity handler.
+// You can add your customization code here to extend your bot logic if needed.
+class TeamsBot extends TeamsActivityHandler {
+  constructor() {
+    super();
+  }
+}
+
+module.exports.TeamsBot = TeamsBot;

--- a/templates/scenarios/js/notification-http-timer-trigger/README.md
+++ b/templates/scenarios/js/notification-http-timer-trigger/README.md
@@ -65,6 +65,7 @@ The following files can be customized and demonstrate an example implementation 
 | - | - |
 | `*Trigger/function.json` | Azure Function bindings for the notification trigger |
 | `src/*Trigger.js` | Notification trigger implementation |
+| `src/teamsBot.js` | An empty teams activity handler for bot customization |
 | `src/adaptiveCards/notification-default.json` | A generated Adaptive Card that is sent to Teams |
 | `src/cardModels.js` | The default Adaptive Card data model |
 

--- a/templates/scenarios/js/notification-http-timer-trigger/src/internal/messageHandler.js
+++ b/templates/scenarios/js/notification-http-timer-trigger/src/internal/messageHandler.js
@@ -1,8 +1,12 @@
+const { TeamsBot } = require("../teamsBot");
 const { bot } = require("./initialize");
 const { ResponseWrapper } = require("./responseWrapper");
 
 module.exports = async function (context, req) {
   const res = new ResponseWrapper(context.res);
-  await bot.requestHandler(req, res);
+  const teamsBot = new TeamsBot();
+  await bot.requestHandler(req, res, async (context) => {
+    await teamsBot.run(context);
+  });
   return res.body;
 };

--- a/templates/scenarios/js/notification-http-timer-trigger/src/teamsBot.js
+++ b/templates/scenarios/js/notification-http-timer-trigger/src/teamsBot.js
@@ -1,0 +1,11 @@
+const { TeamsActivityHandler } = require("botbuilder");
+
+// An empty teams activity handler.
+// You can add your customization code here to extend your bot logic if needed.
+class TeamsBot extends TeamsActivityHandler {
+  constructor() {
+    super();
+  }
+}
+
+module.exports.TeamsBot = TeamsBot;

--- a/templates/scenarios/js/notification-http-trigger/README.md
+++ b/templates/scenarios/js/notification-http-trigger/README.md
@@ -65,6 +65,7 @@ The following files can be customized and demonstrate an example implementation 
 | - | - |
 | `*Trigger/function.json` | Azure Function bindings for the notification trigger |
 | `src/*Trigger.js` | Notification trigger implementation |
+| `src/teamsBot.js` | An empty teams activity handler for bot customization |
 | `src/adaptiveCards/notification-default.json` | A generated Adaptive Card that is sent to Teams |
 | `src/cardModels.js` | The default Adaptive Card data model |
 

--- a/templates/scenarios/js/notification-http-trigger/src/internal/messageHandler.js
+++ b/templates/scenarios/js/notification-http-trigger/src/internal/messageHandler.js
@@ -1,8 +1,12 @@
+const { TeamsBot } = require("../teamsBot");
 const { bot } = require("./initialize");
 const { ResponseWrapper } = require("./responseWrapper");
 
 module.exports = async function (context, req) {
   const res = new ResponseWrapper(context.res);
-  await bot.requestHandler(req, res);
+  const teamsBot = new TeamsBot();
+  await bot.requestHandler(req, res, async (context) => {
+    await teamsBot.run(context);
+  });
   return res.body;
 };

--- a/templates/scenarios/js/notification-http-trigger/src/teamsBot.js
+++ b/templates/scenarios/js/notification-http-trigger/src/teamsBot.js
@@ -1,0 +1,11 @@
+const { TeamsActivityHandler } = require("botbuilder");
+
+// An empty teams activity handler.
+// You can add your customization code here to extend your bot logic if needed.
+class TeamsBot extends TeamsActivityHandler {
+  constructor() {
+    super();
+  }
+}
+
+module.exports.TeamsBot = TeamsBot;

--- a/templates/scenarios/js/notification-restify/README.md
+++ b/templates/scenarios/js/notification-restify/README.md
@@ -64,6 +64,7 @@ The following files can be customized and demonstrate an example implementation 
 | File | Contents |
 | - | - |
 | `src/index.js` | Application entry point and `restify` handlers for notifications |
+| `src/teamsBot.js`| An empty teams activity handler for bot customization |
 | `src/adaptiveCards/notification-default.json` | A generated Adaptive Card that is sent to Teams |
 | `src/cardModels.js` | The default Adaptive Card data model |
 

--- a/templates/scenarios/js/notification-restify/src/index.js
+++ b/templates/scenarios/js/notification-restify/src/index.js
@@ -1,6 +1,7 @@
 const notificationTemplate = require("./adaptiveCards/notification-default.json");
 const { notificationApp } = require("./internal/initialize");
 const { AdaptiveCards } = require("@microsoft/adaptivecards-tools");
+const { TeamsBot } = require("./teamsBot");
 const restify = require("restify");
 
 // Create HTTP server.
@@ -88,6 +89,9 @@ server.post(
 );
 
 // Bot Framework message handler.
+const teamsBot = new TeamsBot();
 server.post("/api/messages", async (req, res) => {
-  await notificationApp.requestHandler(req, res);
+  await notificationApp.requestHandler(req, res, async (context) => {
+    await teamsBot.run(context);
+  });
 });

--- a/templates/scenarios/js/notification-restify/src/teamsBot.js
+++ b/templates/scenarios/js/notification-restify/src/teamsBot.js
@@ -1,0 +1,11 @@
+const { TeamsActivityHandler } = require("botbuilder");
+
+// An empty teams activity handler.
+// You can add your customization code here to extend your bot logic if needed.
+class TeamsBot extends TeamsActivityHandler {
+  constructor() {
+    super();
+  }
+}
+
+module.exports.TeamsBot = TeamsBot;

--- a/templates/scenarios/js/notification-timer-trigger/README.md
+++ b/templates/scenarios/js/notification-timer-trigger/README.md
@@ -65,6 +65,7 @@ The following files can be customized and demonstrate an example implementation 
 | - | - |
 | `*Trigger/function.json` | Azure Function bindings for the notification trigger |
 | `src/*Trigger.js` | Notification trigger implementation |
+| `src/teamsBot.js` | An empty teams activity handler for bot customization |
 | `src/adaptiveCards/notification-default.json` | A generated Adaptive Card that is sent to Teams |
 | `src/cardModels.js` | The default Adaptive Card data model |
 

--- a/templates/scenarios/js/notification-timer-trigger/src/internal/messageHandler.js
+++ b/templates/scenarios/js/notification-timer-trigger/src/internal/messageHandler.js
@@ -1,8 +1,12 @@
+const { TeamsBot } = require("../teamsBot");
 const { bot } = require("./initialize");
 const { ResponseWrapper } = require("./responseWrapper");
 
 module.exports = async function (context, req) {
   const res = new ResponseWrapper(context.res);
-  await bot.requestHandler(req, res);
+  const teamsBot = new TeamsBot();
+  await bot.requestHandler(req, res, async (context) => {
+    await teamsBot.run(context);
+  });
   return res.body;
 };

--- a/templates/scenarios/js/notification-timer-trigger/src/teamsBot.js
+++ b/templates/scenarios/js/notification-timer-trigger/src/teamsBot.js
@@ -1,0 +1,11 @@
+const { TeamsActivityHandler } = require("botbuilder");
+
+// An empty teams activity handler.
+// You can add your customization code here to extend your bot logic if needed.
+class TeamsBot extends TeamsActivityHandler {
+  constructor() {
+    super();
+  }
+}
+
+module.exports.TeamsBot = TeamsBot;

--- a/templates/scenarios/js/workflow/README.md
+++ b/templates/scenarios/js/workflow/README.md
@@ -67,6 +67,7 @@ The following files can be customized and demonstrate an example implementation 
 | File                                               | Contents                                                                             |
 | -------------------------------------------------- | ------------------------------------------------------------------------------------ |
 | `src/index.js`                                     | Application entry point and `restify` handlers for the Workflow bot                  |
+| `src/teamsBot.js`                                  | An empty teams activity handler for bot customization                                |
 | `src/commands/helloworldCommandHandler.js`         | Implementation that handles responding to a chat command                             |
 | `src/adaptiveCards/helloworldCommandResponse.json` | Defines the Adaptive Card (UI) that is displayed in response to a chat command       |
 | `src/adaptiveCards/doStuffActionResponse.json`     | A generated Adaptive Card that is sent to Teams for the response of "doStuff" action |

--- a/templates/scenarios/js/workflow/src/index.js
+++ b/templates/scenarios/js/workflow/src/index.js
@@ -1,13 +1,14 @@
 // Create HTTP server.
 const restify = require("restify");
-const { conversationBot } = require("./internal/initialize");
+const { workflowApp } = require("./internal/initialize");
+const { TeamsBot } = require("./teamsBot");
 
 // This template uses `restify` to serve HTTP responses.
 // Create a restify server.
 const server = restify.createServer();
 server.use(restify.plugins.bodyParser());
 server.listen(process.env.port || process.env.PORT || 3978, () => {
-  console.log(`\nBot Started, ${server.name} listening to ${server.url}`);
+  console.log(`\nApp Started, ${server.name} listening to ${server.url}`);
 });
 
 // Register an API endpoint with `restify`. Teams sends messages to your application
@@ -16,6 +17,9 @@ server.listen(process.env.port || process.env.PORT || 3978, () => {
 // The Teams Toolkit bot registration configures the bot with `/api/messages` as the
 // Bot Framework endpoint. If you customize this route, update the Bot registration
 // in `templates/azure/provision/botservice.bicep`.
+const teamsBot = new TeamsBot();
 server.post("/api/messages", async (req, res) => {
-  await conversationBot.requestHandler(req, res);
+  await workflowApp.requestHandler(req, res, async (context) => {
+    await teamsBot.run(context);
+  });
 });

--- a/templates/scenarios/js/workflow/src/internal/initialize.js
+++ b/templates/scenarios/js/workflow/src/internal/initialize.js
@@ -5,7 +5,7 @@ const { HelloWorldCommandHandler } = require("../commands/helloworldCommandHandl
 const config = require("./config");
 
 // Create the conversation bot and register the command and card action handlers for your app.
-const conversationBot = new ConversationBot({
+const workflowApp = new ConversationBot({
   // The bot id and password to create CloudAdapter.
   // See https://aka.ms/about-bot-adapter to learn more about adapters.
   adapterConfig: {
@@ -24,5 +24,5 @@ const conversationBot = new ConversationBot({
 });
 
 module.exports = {
-  conversationBot,
+  workflowApp,
 };

--- a/templates/scenarios/js/workflow/src/teamsBot.js
+++ b/templates/scenarios/js/workflow/src/teamsBot.js
@@ -1,0 +1,11 @@
+const { TeamsActivityHandler } = require("botbuilder");
+
+// An empty teams activity handler.
+// You can add your customization code here to extend your bot logic if needed.
+class TeamsBot extends TeamsActivityHandler {
+  constructor() {
+    super();
+  }
+}
+
+module.exports.TeamsBot = TeamsBot;

--- a/templates/scenarios/ts/command-and-response/README.md
+++ b/templates/scenarios/ts/command-and-response/README.md
@@ -60,6 +60,7 @@ The following files can be customized and demonstrate an example implementation 
 | File                                       | Contents                                                                |
 | ------------------------------------------ | ----------------------------------------------------------------------- |
 | `src/index.ts`                             | Application entry point and `restify` handlers for command and response |
+| `src/teamsBot.ts`                          | An empty teams activity handler for bot customization                   |
 | `src/adaptiveCards/helloworldCommand.json` | A generated Adaptive Card that is sent to Teams                         |
 | `src/helloworldCommandHandler.ts`          | The business logic to handle a command                                  |
 | `src/cardModels.ts`                        | The default Adaptive Card data model                                    |

--- a/templates/scenarios/ts/command-and-response/src/index.ts
+++ b/templates/scenarios/ts/command-and-response/src/index.ts
@@ -1,5 +1,6 @@
 import * as restify from "restify";
 import { commandApp } from "./internal/initialize";
+import { TeamsBot } from "./teamsBot";
 
 // This template uses `restify` to serve HTTP responses.
 // Create a restify server.
@@ -15,6 +16,9 @@ server.listen(process.env.port || process.env.PORT || 3978, () => {
 // The Teams Toolkit bot registration configures the bot with `/api/messages` as the
 // Bot Framework endpoint. If you customize this route, update the Bot registration
 // in `templates/azure/provision/botservice.bicep`.
+const teamsBot = new TeamsBot();
 server.post("/api/messages", async (req, res) => {
-  await commandApp.requestHandler(req, res);
+  await commandApp.requestHandler(req, res, async (context) => {
+    await teamsBot.run(context);
+  });
 });

--- a/templates/scenarios/ts/command-and-response/src/teamsBot.ts
+++ b/templates/scenarios/ts/command-and-response/src/teamsBot.ts
@@ -1,0 +1,9 @@
+import { TeamsActivityHandler } from "botbuilder";
+
+// An empty teams activity handler.
+// You can add your customization code here to extend your bot logic if needed.
+export class TeamsBot extends TeamsActivityHandler {
+  constructor() {
+    super();
+  }
+}

--- a/templates/scenarios/ts/notification-http-timer-trigger/README.md
+++ b/templates/scenarios/ts/notification-http-timer-trigger/README.md
@@ -65,6 +65,7 @@ The following files can be customized and demonstrate an example implementation 
 | - | - |
 | `*Trigger/function.json` | Azure Function bindings for the notification trigger |
 | `src/*Trigger.ts` | Notification trigger implementation |
+| `src/teamsBot.ts`| An empty teams activity handler for bot customization |
 | `src/adaptiveCards/notification-default.json` | A generated Adaptive Card that is sent to Teams |
 | `src/cardModels.ts` | The default Adaptive Card data model |
 

--- a/templates/scenarios/ts/notification-http-timer-trigger/src/internal/messageHandler.ts
+++ b/templates/scenarios/ts/notification-http-timer-trigger/src/internal/messageHandler.ts
@@ -1,4 +1,5 @@
 import { AzureFunction, Context, HttpRequest } from "@azure/functions";
+import { TeamsBot } from "../teamsBot";
 import { bot } from "./initialize";
 import { ResponseWrapper } from "./responseWrapper";
 
@@ -7,7 +8,10 @@ const httpTrigger: AzureFunction = async function (
   req: HttpRequest
 ): Promise<any> {
   const res = new ResponseWrapper(context.res);
-  await bot.requestHandler(req, res);
+  const teamsBot = new TeamsBot();
+  await bot.requestHandler(req, res, async (context) => {
+    await teamsBot.run(context);
+  });
   return res.body;
 };
 

--- a/templates/scenarios/ts/notification-http-timer-trigger/src/teamsBot.ts
+++ b/templates/scenarios/ts/notification-http-timer-trigger/src/teamsBot.ts
@@ -1,0 +1,9 @@
+import { TeamsActivityHandler } from "botbuilder";
+
+// An empty teams activity handler.
+// You can add your customization code here to extend your bot logic if needed.
+export class TeamsBot extends TeamsActivityHandler {
+  constructor() {
+    super();
+  }
+}

--- a/templates/scenarios/ts/notification-http-trigger/README.md
+++ b/templates/scenarios/ts/notification-http-trigger/README.md
@@ -65,6 +65,7 @@ The following files can be customized and demonstrate an example implementation 
 | - | - |
 | `*Trigger/function.json` | Azure Function bindings for the notification trigger |
 | `src/*Trigger.ts` | Notification trigger implementation |
+| `src/teamsBot.ts`| An empty teams activity handler for bot customization |
 | `src/adaptiveCards/notification-default.json` | A generated Adaptive Card that is sent to Teams |
 | `src/cardModels.ts` | The default Adaptive Card data model |
 

--- a/templates/scenarios/ts/notification-http-trigger/src/internal/messageHandler.ts
+++ b/templates/scenarios/ts/notification-http-trigger/src/internal/messageHandler.ts
@@ -1,4 +1,5 @@
 import { AzureFunction, Context, HttpRequest } from "@azure/functions";
+import { TeamsBot } from "../teamsBot";
 import { bot } from "./initialize";
 import { ResponseWrapper } from "./responseWrapper";
 
@@ -7,7 +8,10 @@ const httpTrigger: AzureFunction = async function (
   req: HttpRequest
 ): Promise<any> {
   const res = new ResponseWrapper(context.res);
-  await bot.requestHandler(req, res);
+  const teamsBot = new TeamsBot();
+  await bot.requestHandler(req, res, async (context) => {
+    await teamsBot.run(context);
+  });
   return res.body;
 };
 

--- a/templates/scenarios/ts/notification-http-trigger/src/teamsBot.ts
+++ b/templates/scenarios/ts/notification-http-trigger/src/teamsBot.ts
@@ -1,0 +1,9 @@
+import { TeamsActivityHandler } from "botbuilder";
+
+// An empty teams activity handler.
+// You can add your customization code here to extend your bot logic if needed.
+export class TeamsBot extends TeamsActivityHandler {
+  constructor() {
+    super();
+  }
+}

--- a/templates/scenarios/ts/notification-restify/README.md
+++ b/templates/scenarios/ts/notification-restify/README.md
@@ -64,6 +64,7 @@ The following files can be customized and demonstrate an example implementation 
 | File | Contents |
 | - | - |
 | `src/index.ts` | Application entry point and `restify` handlers for notifications |
+| `src/teamsBot.ts`| An empty teams activity handler for bot customization |
 | `src/adaptiveCards/notification-default.json` | A generated Adaptive Card that is sent to Teams |
 | `src/cardModels.ts` | The default Adaptive Card data model |
 

--- a/templates/scenarios/ts/notification-restify/src/index.ts
+++ b/templates/scenarios/ts/notification-restify/src/index.ts
@@ -3,6 +3,7 @@ import * as restify from "restify";
 import notificationTemplate from "./adaptiveCards/notification-default.json";
 import { notificationApp } from "./internal/initialize";
 import { CardData } from "./cardModels";
+import { TeamsBot } from "./teamsBot";
 
 // Create HTTP server.
 const server = restify.createServer();
@@ -111,6 +112,9 @@ server.post(
 // The Teams Toolkit bot registration configures the bot with `/api/messages` as the
 // Bot Framework endpoint. If you customize this route, update the Bot registration
 // in `/templates/provision/bot.bicep`.
+const teamsBot = new TeamsBot();
 server.post("/api/messages", async (req, res) => {
-  await notificationApp.requestHandler(req, res);
+  await notificationApp.requestHandler(req, res, async (context) => {
+    await teamsBot.run(context);
+  });
 });

--- a/templates/scenarios/ts/notification-restify/src/teamsBot.ts
+++ b/templates/scenarios/ts/notification-restify/src/teamsBot.ts
@@ -1,0 +1,9 @@
+import { TeamsActivityHandler } from "botbuilder";
+
+// An empty teams activity handler.
+// You can add your customization code here to extend your bot logic if needed.
+export class TeamsBot extends TeamsActivityHandler {
+  constructor() {
+    super();
+  }
+}

--- a/templates/scenarios/ts/notification-timer-trigger/README.md
+++ b/templates/scenarios/ts/notification-timer-trigger/README.md
@@ -65,6 +65,7 @@ The following files can be customized and demonstrate an example implementation 
 | - | - |
 | `*Trigger/function.json` | Azure Function bindings for the notification trigger |
 | `src/*Trigger.ts` | Notification trigger implementation |
+| `src/teamsBot.ts`| An empty teams activity handler for bot customization |
 | `src/adaptiveCards/notification-default.json` | A generated Adaptive Card that is sent to Teams |
 | `src/cardModels.ts` | The default Adaptive Card data model |
 

--- a/templates/scenarios/ts/notification-timer-trigger/src/internal/messageHandler.ts
+++ b/templates/scenarios/ts/notification-timer-trigger/src/internal/messageHandler.ts
@@ -1,4 +1,5 @@
 import { AzureFunction, Context, HttpRequest } from "@azure/functions";
+import { TeamsBot } from "../teamsBot";
 import { bot } from "./initialize";
 import { ResponseWrapper } from "./responseWrapper";
 
@@ -7,7 +8,10 @@ const httpTrigger: AzureFunction = async function (
   req: HttpRequest
 ): Promise<any> {
   const res = new ResponseWrapper(context.res);
-  await bot.requestHandler(req, res);
+  const teamsBot = new TeamsBot();
+  await bot.requestHandler(req, res, async (context) => {
+    await teamsBot.run(context);
+  });
   return res.body;
 };
 

--- a/templates/scenarios/ts/notification-timer-trigger/src/teamsBot.ts
+++ b/templates/scenarios/ts/notification-timer-trigger/src/teamsBot.ts
@@ -1,0 +1,9 @@
+import { TeamsActivityHandler } from "botbuilder";
+
+// An empty teams activity handler.
+// You can add your customization code here to extend your bot logic if needed.
+export class TeamsBot extends TeamsActivityHandler {
+  constructor() {
+    super();
+  }
+}

--- a/templates/scenarios/ts/workflow/README.md
+++ b/templates/scenarios/ts/workflow/README.md
@@ -67,6 +67,7 @@ The following files can be customized and demonstrate an example implementation 
 | File                                               | Contents                                                                             |
 | -------------------------------------------------- | ------------------------------------------------------------------------------------ |
 | `src/index.ts`                                     | Application entry point and `restify` handlers for the Workflow bot                  |
+| `src/teamsBot.ts`                                  | An empty teams activity handler for bot customization                                |
 | `src/commands/helloworldCommandHandler.ts`         | Implementation that handles responding to a chat command                             |
 | `src/adaptiveCards/helloworldCommandResponse.json` | Defines the Adaptive Card (UI) that is displayed in response to a chat command       |
 | `src/adaptiveCards/doStuffActionResponse.json`     | A generated Adaptive Card that is sent to Teams for the response of "doStuff" action |

--- a/templates/scenarios/ts/workflow/src/index.ts
+++ b/templates/scenarios/ts/workflow/src/index.ts
@@ -1,12 +1,24 @@
 import * as restify from "restify";
-import { conversationBot } from "./internal/initialize";
+import { workflowApp } from "./internal/initialize";
+import { TeamsBot } from "./teamsBot";
 
+// This template uses `restify` to serve HTTP responses.
+// Create a restify server.
 const server = restify.createServer();
 server.use(restify.plugins.bodyParser());
 server.listen(process.env.port || process.env.PORT || 3978, () => {
   console.log(`\nBot Started, ${server.name} listening to ${server.url}`);
 });
 
+// Register an API endpoint with `restify`. Teams sends messages to your application
+// through this endpoint.
+//
+// The Teams Toolkit bot registration configures the bot with `/api/messages` as the
+// Bot Framework endpoint. If you customize this route, update the Bot registration
+// in `/templates/provision/bot.bicep`.
+const teamsBot = new TeamsBot();
 server.post("/api/messages", async (req, res) => {
-  await conversationBot.requestHandler(req, res);
+  await workflowApp.requestHandler(req, res, async (context) => {
+    await teamsBot.run(context);
+  });
 });

--- a/templates/scenarios/ts/workflow/src/internal/initialize.ts
+++ b/templates/scenarios/ts/workflow/src/internal/initialize.ts
@@ -5,7 +5,7 @@ import ConversationBot = BotBuilderCloudAdapter.ConversationBot;
 import config from "./config";
 
 // Create the conversation bot and register the command and card action handlers for your app.
-export const conversationBot = new ConversationBot({
+export const workflowApp = new ConversationBot({
   // The bot id and password to create CloudAdapter.
   // See https://aka.ms/about-bot-adapter to learn more about adapters.
   adapterConfig: {

--- a/templates/scenarios/ts/workflow/src/teamsBot.ts
+++ b/templates/scenarios/ts/workflow/src/teamsBot.ts
@@ -1,0 +1,9 @@
+import { TeamsActivityHandler } from "botbuilder";
+
+// An empty teams activity handler.
+// You can add your customization code here to extend your bot logic if needed.
+export class TeamsBot extends TeamsActivityHandler {
+  constructor() {
+    super();
+  }
+}


### PR DESCRIPTION
According to [this feedback](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/16826746), update all node bot templates to include an empty `TeamsActivityHandler`, which is also consistent with csharp bot template.

E2E TEST: N/A