### PR TITLE
fix(debug): fix resolving msedge configuration

### DIFF
--- a/packages/vscode-extension/src/debug/teamsfxDebugProvider.ts
+++ b/packages/vscode-extension/src/debug/teamsfxDebugProvider.ts
@@ -81,7 +81,7 @@ export class TeamsfxDebugProvider implements vscode.DebugConfigurationProvider {
       // For backend and bot debug sessions, debugConfiguration.url is undefined so we need to set correlation id early.
       debugConfiguration.teamsfxCorrelationId = commonUtils.getLocalDebugSessionId();
 
-      if (debugConfiguration.url === undefined) {
+      if (debugConfiguration.url === undefined || debugConfiguration.url === null) {
         return debugConfiguration;
       }
       let url: string = debugConfiguration.url as string;


### PR DESCRIPTION
From practice, if debug configuration type is `msedge`, `resolveDebugConfiguration` will be called twice. The type of the configuration in first time is `msedge` but `pwa-msedge` in second time.

If `url` is not specified in the configuration, the `url` in first time is `undefined` but `null` in second time.