### PR TITLE
chore(vsc): lazy load in non-teamsfx project

### DIFF
--- a/packages/vscode-extension/package-lock.json
+++ b/packages/vscode-extension/package-lock.json
@@ -2675,9 +2675,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.65.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.65.0.tgz",
-      "integrity": "sha512-wQhExnh2nEzpjDMSKhUvnNmz3ucpd3E+R7wJkOhBNK3No6fG3VUdmVmMOKD0A8NDZDDDiQcLNxe3oGmX5SjJ5w==",
+      "version": "1.66.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.66.0.tgz",
+      "integrity": "sha512-ZfJck4M7nrGasfs4A4YbUoxis3Vu24cETw3DERsNYtDZmYSYtk6ljKexKFKhImO/ZmY6ZMsmegu2FPkXoUFImA==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "engines": {
-    "vscode": "^1.65.0"
+    "vscode": "^1.66.0"
   },
   "license": "MIT",
   "keywords": [
@@ -40,7 +40,6 @@
     "out/**/*"
   ],
   "activationEvents": [
-    "onStartupFinished",
     "onCommand:fx-extension.create",
     "onCommand:fx-extension.createFromWalkthrough",
     "onCommand:fx-extension.openDeploymentTreeview",
@@ -1318,10 +1317,7 @@
     ],
     "languages": [
       {
-        "id": "teamsfx-toolkit-output",
-        "mimetypes": [
-          "text/x-code-output"
-        ]
+        "id": "teamsfx-toolkit-output"
       }
     ],
     "grammars": [
@@ -1427,6 +1423,7 @@
     "@commitlint/config-conventional": "^12.0.1",
     "@fluentui/react": "^8.5.1",
     "@istanbuljs/nyc-config-typescript": "^1.0.2",
+    "@microsoft/eslint-plugin-teamsfx": "^0.0.1",
     "@types/adm-zip": "^0.4.33",
     "@types/chai": "^4.2.14",
     "@types/chai-as-promised": "^7.1.3",
@@ -1450,7 +1447,7 @@
     "@types/underscore": "^1.11.0",
     "@types/uuid": "^8.3.0",
     "@types/validator": "^13.1.1",
-    "@types/vscode": "^1.65.0",
+    "@types/vscode": "^1.66.0",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
     "@vscode/codicons": "0.0.21",
@@ -1466,7 +1463,6 @@
     "eslint-plugin-import": "^2.25.2",
     "eslint-plugin-no-secrets": "^0.8.9",
     "eslint-plugin-prettier": "^4.0.0",
-    "@microsoft/eslint-plugin-teamsfx": "^0.0.1",
     "find-process": "^1.4.4",
     "fs-extra": "^9.0.1",
     "glob": "^8.0.3",

--- a/packages/vscode-extension/src/commonlib/log.ts
+++ b/packages/vscode-extension/src/commonlib/log.ts
@@ -14,7 +14,10 @@ export class VsCodeLogProvider implements LogProvider {
   private static instance: VsCodeLogProvider;
 
   private constructor() {
-    this.outputChannel = vscode.window.createOutputChannel(outputChannelDisplayName);
+    this.outputChannel = vscode.window.createOutputChannel(
+      outputChannelDisplayName,
+      "teamsfx-toolkit-output"
+    );
   }
 
   /**

--- a/packages/vscode-extension/src/commonlib/log.ts
+++ b/packages/vscode-extension/src/commonlib/log.ts
@@ -16,6 +16,7 @@ export class VsCodeLogProvider implements LogProvider {
   private constructor() {
     this.outputChannel = vscode.window.createOutputChannel(
       outputChannelDisplayName,
+      // Align with languages:id in package.json for colorized output.
       "teamsfx-toolkit-output"
     );
   }


### PR DESCRIPTION
1. Upgrade to VS Code 1.66 to leverage new feature [Output channel with custom language ID](https://code.visualstudio.com/updates/v1_66#_output-channel-with-custom-language-id)
2. Remove activationEvents "onStartupFinished" so that our extension will be activated automatically in non-teamsfx project.
3. Remove languages/mimetypes to prevent auto-onLanguage activation.

Related task: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/17137840