### PR TITLE
chore(cli): teamsfx upgrade

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,6 +22,7 @@
 /packages/vscode-extension/PRERELEASE.md @therealjohn @sffamily
 
 /packages/cli @chagong @Alive-Fish
+/packages/cli/src/resource/strings.json @timngmsft @sffamily @therealjohn
 /packages/cli/src/commonlib @kimizhu @swatDong @kuojianlu @a1exwang @qinezh @XiaofuHuang @xiaolang124 @dooriya
 /packages/cli/src/commonlib/appStudioLoginUserPassword.ts @chagong @Alive-Fish
 /packages/cli/src/commonlib/azureLoginUserPassword.ts @chagong @Alive-Fish

--- a/packages/cli/.gitignore
+++ b/packages/cli/.gitignore
@@ -40,7 +40,7 @@ test-folder
 .env
 
 resource
-!resource/*Param.json
+!src/resource
 !src/cmds/preview/depsChecker/resource/
 templates
 *.tgz

--- a/packages/cli/src/cmds/index.ts
+++ b/packages/cli/src/cmds/index.ts
@@ -25,6 +25,7 @@ import M365 from "./m365/m365";
 import { ManifestValidate } from "./validate";
 import Update from "./update";
 import Init from "./init";
+import Upgrade from "./upgrade";
 
 export const commands: YargsCommand[] = [
   new Account(),
@@ -52,6 +53,7 @@ export function registerCommands(yargs: Argv): void {
   if (isV3Enabled()) {
     commands.push(new Init());
     commands.push(new Update());
+    commands.push(new Upgrade());
   }
 
   commands.forEach((command) => {

--- a/packages/cli/src/cmds/upgrade.ts
+++ b/packages/cli/src/cmds/upgrade.ts
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { Result, FxError, err, ok, Void } from "@microsoft/teamsfx-api";
+import path from "path";
+import { Argv } from "yargs";
+import activate from "../activate";
+import CliTelemetry from "../telemetry/cliTelemetry";
+import {
+  TelemetryEvent,
+  TelemetryProperty,
+  TelemetrySuccess,
+} from "../telemetry/cliTelemetryEvents";
+import userInteraction from "../userInteraction";
+import { getSystemInputs } from "../utils";
+import { YargsCommand } from "../yargsCommand";
+
+export default class Upgrade extends YargsCommand {
+  public readonly commandHead = `upgrade`;
+  public readonly command = `${this.commandHead}`;
+  public readonly description = "Upgrade the project to the latest version of Teams Toolkit.";
+
+  public readonly forceParam = "force";
+
+  builder(yargs: Argv): Argv<any> {
+    yargs.option(this.forceParam, {
+      description: "Force upgrade the project to the latest version of Teams Toolkit.",
+      type: "boolean",
+    });
+    return yargs.version(false).hide("interactive");
+  }
+
+  async runCommand(args: { [argName: string]: string }): Promise<Result<any, FxError>> {
+    const rootFolder = path.resolve(args.folder || "./");
+    CliTelemetry.withRootFolder(rootFolder).sendTelemetryEvent(TelemetryEvent.UpgradeStart);
+
+    const inputs = getSystemInputs(rootFolder, args.env);
+    inputs["skipUserConfirm"] = args.force;
+
+    const result = await activate(rootFolder);
+    if (result.isErr()) {
+      CliTelemetry.sendTelemetryErrorEvent(TelemetryEvent.Upgrade, result.error);
+      return err(result.error);
+    }
+
+    const core = result.value;
+    const upgradeResult = await core.phantomMigrationV3(inputs);
+    if (upgradeResult.isErr()) {
+      CliTelemetry.sendTelemetryErrorEvent(TelemetryEvent.Upgrade, upgradeResult.error);
+      return err(upgradeResult.error);
+    }
+
+    CliTelemetry.sendTelemetryEvent(TelemetryEvent.Upgrade, {
+      [TelemetryProperty.Success]: TelemetrySuccess.Yes,
+    });
+    await userInteraction.showMessage("info", "Upgrade successfully.", false);
+    return ok(Void);
+  }
+}

--- a/packages/cli/src/cmds/upgrade.ts
+++ b/packages/cli/src/cmds/upgrade.ts
@@ -5,6 +5,7 @@ import { Result, FxError, err, ok, Void } from "@microsoft/teamsfx-api";
 import path from "path";
 import { Argv } from "yargs";
 import activate from "../activate";
+import { strings } from "../resource";
 import CliTelemetry from "../telemetry/cliTelemetry";
 import {
   TelemetryEvent,
@@ -18,13 +19,13 @@ import { YargsCommand } from "../yargsCommand";
 export default class Upgrade extends YargsCommand {
   public readonly commandHead = `upgrade`;
   public readonly command = `${this.commandHead}`;
-  public readonly description = "Upgrade the project to the latest version of Teams Toolkit.";
+  public readonly description = strings.command.upgrade.description;
 
   public readonly forceParam = "force";
 
   builder(yargs: Argv): Argv<any> {
     yargs.option(this.forceParam, {
-      description: "Force upgrade the project to the latest version of Teams Toolkit.",
+      description: strings.command.upgrade.options.force,
       type: "boolean",
     });
     return yargs.version(false).hide("interactive");
@@ -53,7 +54,7 @@ export default class Upgrade extends YargsCommand {
     CliTelemetry.sendTelemetryEvent(TelemetryEvent.Upgrade, {
       [TelemetryProperty.Success]: TelemetrySuccess.Yes,
     });
-    await userInteraction.showMessage("info", "Upgrade successfully.", false);
+    await userInteraction.showMessage("info", strings.command.upgrade.success, false);
     return ok(Void);
   }
 }

--- a/packages/cli/src/error.ts
+++ b/packages/cli/src/error.ts
@@ -169,3 +169,13 @@ export class InvalidTemplateName extends UserError {
     });
   }
 }
+
+export class NotAllowedMigrationError extends UserError {
+  constructor() {
+    super({
+      source: constants.cliSource,
+      message: `Teams toolkit's pre-released version supports new project configuration and is incompatible with previous versions. \
+Please try it by creating a new project or run "teamsfx upgrade" to upgrade your project first.`,
+    });
+  }
+}

--- a/packages/cli/src/error.ts
+++ b/packages/cli/src/error.ts
@@ -5,6 +5,7 @@
 
 import { ConfigFolderName, StatesFolderName, SystemError, UserError } from "@microsoft/teamsfx-api";
 import * as constants from "./constants";
+import { strings } from "./resource";
 
 export function NotSupportedProjectType(): UserError {
   return new UserError(
@@ -174,8 +175,7 @@ export class NotAllowedMigrationError extends UserError {
   constructor() {
     super({
       source: constants.cliSource,
-      message: `Teams toolkit's pre-released version supports new project configuration and is incompatible with previous versions. \
-Please try it by creating a new project or run "teamsfx upgrade" to upgrade your project first.`,
+      message: strings.error.NotAllowedMigrationErrorMessage,
     });
   }
 }

--- a/packages/cli/src/resource/index.ts
+++ b/packages/cli/src/resource/index.ts
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as strings from "./strings.json";
+export { strings };

--- a/packages/cli/src/resource/strings.json
+++ b/packages/cli/src/resource/strings.json
@@ -1,0 +1,14 @@
+{
+  "error": {
+    "NotAllowedMigrationErrorMessage": "Teams toolkit's pre-released version supports new project configuration and is incompatible with previous versions. Please try it by creating a new project or run \"teamsfx upgrade\" to upgrade your project first."
+  },
+  "command": {
+    "upgrade": {
+      "description": "Upgrade the project to the latest version of Teams Toolkit.",
+      "options": {
+        "force": "Force to upgrade the project to the latest version of Teams Toolkit."
+      },
+      "success": "Upgrade project successfully."
+    }
+  }
+}

--- a/packages/cli/src/resource/strings.json
+++ b/packages/cli/src/resource/strings.json
@@ -1,12 +1,12 @@
 {
   "error": {
-    "NotAllowedMigrationErrorMessage": "Teams toolkit's pre-released version supports new project configuration and is incompatible with previous versions. Please try it by creating a new project or run \"teamsfx upgrade\" to upgrade your project first."
+    "NotAllowedMigrationErrorMessage": "Teams Toolkit's Pre-Release version supports new project configuration and is incompatible with previous versions. Try it by creating a new project or run \"teamsfx upgrade\" to upgrade your project first."
   },
   "command": {
     "upgrade": {
-      "description": "Upgrade the project to the latest version of Teams Toolkit.",
+      "description": "Upgrade the project to work with the latest version of Teams Toolkit.",
       "options": {
-        "force": "Force to upgrade the project to the latest version of Teams Toolkit."
+        "force": "Force upgrade the project to work with the latest version of Teams Toolkit."
       },
       "success": "Upgrade project successfully."
     }

--- a/packages/cli/src/telemetry/cliTelemetryEvents.ts
+++ b/packages/cli/src/telemetry/cliTelemetryEvents.ts
@@ -101,6 +101,9 @@ export enum TelemetryEvent {
 
   AddSsoStart = "add-sso-start",
   AddSso = "add-sso",
+
+  UpgradeStart = "upgrade-start",
+  Upgrade = "upgrade",
 }
 
 export enum TelemetryProperty {

--- a/packages/cli/src/userInteraction.ts
+++ b/packages/cli/src/userInteraction.ts
@@ -40,7 +40,12 @@ import {
 } from "@microsoft/teamsfx-api";
 
 import CLILogProvider from "./commonlib/log";
-import { EmptySubConfigOptions, NotValidInputValue, UnknownError } from "./error";
+import {
+  EmptySubConfigOptions,
+  NotAllowedMigrationError,
+  NotValidInputValue,
+  UnknownError,
+} from "./error";
 import { sleep, getColorizedString, toLocaleLowerCase } from "./utils";
 import { ChoiceOptions } from "./prompts";
 import Progress from "./console/progress";
@@ -514,6 +519,9 @@ export class CLIUserInteraction implements UserInteraction {
     modal: boolean,
     ...items: string[]
   ): Promise<Result<string | undefined, FxError>> {
+    if (!this.interactive && items.includes("Upgrade")) {
+      throw new NotAllowedMigrationError();
+    }
     let plainText: string;
     if (message instanceof Array) {
       plainText = message.map((x) => x.content).join("");

--- a/packages/cli/tests/unit/cmds/index.tests.ts
+++ b/packages/cli/tests/unit/cmds/index.tests.ts
@@ -56,6 +56,7 @@ describe("Register Commands Tests", function () {
     expect(registeredCommands).includes("preview");
     expect(registeredCommands).includes("init");
     expect(registeredCommands).includes("update");
+    expect(registeredCommands).includes("upgrade");
   });
 
   it("Register Commands Check", () => {

--- a/packages/cli/tests/unit/cmds/upgrade.tests.ts
+++ b/packages/cli/tests/unit/cmds/upgrade.tests.ts
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import "mocha";
+
+import sinon from "sinon";
+import yargs, { Options } from "yargs";
+import { err, FxError, ok, Void } from "@microsoft/teamsfx-api";
+import { FxCore } from "@microsoft/teamsfx-core";
+import HelpParamGenerator from "../../../src/helpParamGenerator";
+import {
+  TelemetryEvent,
+  TelemetryProperty,
+  TelemetrySuccess,
+} from "../../../src/telemetry/cliTelemetryEvents";
+import CliTelemetry from "../../../src/telemetry/cliTelemetry";
+import Upgrade from "../../../src/cmds/upgrade";
+import { expect, TestFolder } from "../utils";
+import { NonTeamsFxProjectFolder } from "../../../src/error";
+
+describe("Init Command Tests", () => {
+  const sandbox = sinon.createSandbox();
+  let registeredCommands: string[] = [];
+  let options: string[] = [];
+  let telemetryEvents: string[] = [];
+  let telemetryEventStatus: string | undefined = undefined;
+
+  before(() => {
+    sandbox.stub(HelpParamGenerator, "getYargsParamForHelp").returns({});
+    sandbox
+      .stub<any, any>(yargs, "command")
+      .callsFake((command: string, description: string, builder: any, handler: any) => {
+        registeredCommands.push(command);
+        builder(yargs);
+      });
+    sandbox.stub(yargs, "options").callsFake((ops: { [key: string]: Options }) => {
+      if (typeof ops === "string") {
+        options.push(ops);
+      } else {
+        options = options.concat(...Object.keys(ops));
+      }
+      return yargs;
+    });
+    sandbox.stub(yargs, "exit").callsFake((code: number, err: Error) => {
+      throw err;
+    });
+    sandbox.stub(FxCore.prototype, "phantomMigrationV3").callsFake((inputs) => {
+      if (inputs.projectPath?.includes("fake"))
+        return Promise.resolve(err(NonTeamsFxProjectFolder()));
+      return Promise.resolve(ok(Void));
+    });
+    sandbox
+      .stub(CliTelemetry, "sendTelemetryEvent")
+      .callsFake((eventName: string, options?: { [_: string]: string }) => {
+        telemetryEvents.push(eventName);
+        if (options && TelemetryProperty.Success in options) {
+          telemetryEventStatus = options[TelemetryProperty.Success];
+        }
+      });
+    sandbox
+      .stub(CliTelemetry, "sendTelemetryErrorEvent")
+      .callsFake((eventName: string, error: FxError) => {
+        telemetryEvents.push(eventName);
+        telemetryEventStatus = TelemetrySuccess.No;
+      });
+  });
+
+  after(() => {
+    sandbox.restore();
+  });
+
+  beforeEach(() => {
+    registeredCommands = [];
+    options = [];
+    telemetryEvents = [];
+    telemetryEventStatus = undefined;
+  });
+
+  it("Builder Check", () => {
+    const cmd = new Upgrade();
+    yargs.command(cmd.command, cmd.description, cmd.builder.bind(cmd), cmd.handler.bind(cmd));
+    expect(registeredCommands).deep.equals(["upgrade"]);
+  });
+
+  it("Command Running Check - init infra", async () => {
+    const cmd = new Upgrade();
+    const args = {
+      folder: TestFolder,
+    };
+    await cmd.handler(args);
+    expect(telemetryEvents).deep.equals([TelemetryEvent.UpgradeStart, TelemetryEvent.Upgrade]);
+    expect(telemetryEventStatus).equals(TelemetrySuccess.Yes);
+  });
+
+  it("Command Running Check - init infra - error", async () => {
+    const cmd = new Upgrade();
+    const args = {
+      folder: "fake",
+    };
+    await expect(cmd.handler(args)).rejected;
+  });
+});

--- a/packages/cli/tests/unit/cmds/upgrade.tests.ts
+++ b/packages/cli/tests/unit/cmds/upgrade.tests.ts
@@ -82,7 +82,7 @@ describe("Init Command Tests", () => {
     expect(registeredCommands).deep.equals(["upgrade"]);
   });
 
-  it("Command Running Check - init infra", async () => {
+  it("Command Running Check", async () => {
     const cmd = new Upgrade();
     const args = {
       folder: TestFolder,
@@ -92,7 +92,7 @@ describe("Init Command Tests", () => {
     expect(telemetryEventStatus).equals(TelemetrySuccess.Yes);
   });
 
-  it("Command Running Check - init infra - error", async () => {
+  it("Command Running Check - error", async () => {
     const cmd = new Upgrade();
     const args = {
       folder: "fake",


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/16625425
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/16625428

When `TEAMSFX_V3="true"`, `teamsfx -h` will show (`teamsfx upgrade` is added):
```bash
C:\Users\zhiyou\source\zhiyouTestTab>teamsfx -h
teamsfx <command>

Commands:
  teamsfx account <action>               Manage cloud service accounts. The supported cloud services
                                         are 'Azure' and 'Microsoft 365'.
  teamsfx new                            Create a new Teams application.
  teamsfx provision                      Provision the cloud resources in the current application.
  teamsfx deploy                         Deploy the current application.
  teamsfx package                        Build your Teams app into a package for publishing.
  teamsfx validate                       Validate the Teams app manifest.
  teamsfx publish                        Publish the app to Teams.
  teamsfx config <action>                Configure user settings.
  teamsfx preview                        Preview the current application.
  teamsfx env <action>                   Manage environments.
  teamsfx permission <action>            Check, grant and list user permission.
  teamsfx init <part>                    Initialize the project for using Teams Toolkit.
  teamsfx update <application-manifest>  Update the specific application manifest file.
  teamsfx upgrade                        Upgrade the project to the latest version of Teams Toolkit.

Options:
      --verbose      Print additional information.                        [boolean] [default: false]
      --debug        Print diagnostic information.                        [boolean] [default: false]
      --interactive  Run the command interactively.                                        [boolean]
  -h, --help         Show help                                                             [boolean]
  -v, --version      Show version number                                                   [boolean]

For more information about the Teams Toolkit - https://aka.ms/teamsfx-cli.
```

`teamsfx upgrade -h` will show: (adding the `--force` option to decide whether ask user to confirm again) 
```bash
C:\Users\zhiyou\source\zhiyouTestTab>teamsfx upgrade -h
teamsfx upgrade

Upgrade the project to the latest version of Teams Toolkit.

Options:
      --verbose  Print additional information.                            [boolean] [default: false]
      --debug    Print diagnostic information.                            [boolean] [default: false]
  -h, --help     Show help                                                                 [boolean]
      --force    Force to upgrade the project to the latest version of Teams Toolkit.      [boolean]
```

We will show an error if users run commands with `--interactive false` in a V2 project (this will let users not upgrade automatically in the CICD scenario):
```bash
C:\Users\zhiyou\source\zhiyouTestTab>teamsfx provision --interactive false
(×) [TeamsfxCLI.NotAllowedMigrationError]: Teams toolkit's pre-released version supports new project configuration and is incompatible with previous versions. Please try it by creating a new project or run "teamsfx upgrade" to upgrade your project first.
```

Users can run `teamsfx upgrade` to manually upgrade the project: (using `--force` will not ask users for confirmation)
```bash
C:\Users\zhiyou\source\zhiyouTestTab>teamsfx upgrade
? Please upgrade your project to stay compatible with the latest version, your current project contains configurations from an older Teams Toolkit.
The auto-upgrade process will generate backups in case an error occurs.: (Use arrow keys)
(*) Learn more
( ) Upgrade
( ) Cancel

C:\Users\zhiyou\source\zhiyouTestTab>teamsfx upgrade --force
Upgrade project successfully.

```