### PR TITLE
chore: replace client id in codespaces

### DIFF
--- a/packages/vscode-extension/src/commonlib/m365CodeSpaceLogin.ts
+++ b/packages/vscode-extension/src/commonlib/m365CodeSpaceLogin.ts
@@ -19,7 +19,11 @@ import {
 import { getDefaultString } from "../utils/localizeUtils";
 import { UserCancelError } from "./codeFlowLogin";
 
-const CodeSpacesScopes = [
+// By using `VSCODE_CLIENT_ID:<aad-app-id>` in the `vscode.authentication` API,
+// we can override the scope with our own first-party AAD app.
+// Check https://www.eliostruyf.com/microsoft-authentication-provider-visual-studio-code/ for more details.
+// https://github.com/microsoft/vscode/blob/0f9d0328ebe1eccd28e4de11ece14f4b0db3e818/extensions/microsoft-authentication/src/AADHelper.ts#L603
+const TeamsFxAadScopes = [
   "VSCODE_CLIENT_ID:7ea7c24c-b1f6-4a20-9d11-9ae12e9e7ac0",
   "VSCODE_TENANT:common",
 ];
@@ -83,7 +87,7 @@ export class M365CodeSpaceLogin extends BasicLogin implements M365TokenProvider 
     scopes: Array<string>
   ): Promise<vscode.AuthenticationSession | undefined> {
     return vscode.authentication
-      .getSession("microsoft", CodeSpacesScopes.concat(scopes), { createIfNone: createIfNone })
+      .getSession("microsoft", TeamsFxAadScopes.concat(scopes), { createIfNone: createIfNone })
       .then((session: vscode.AuthenticationSession | undefined) => {
         return session;
       });

--- a/packages/vscode-extension/src/commonlib/m365CodeSpaceLogin.ts
+++ b/packages/vscode-extension/src/commonlib/m365CodeSpaceLogin.ts
@@ -19,6 +19,11 @@ import {
 import { getDefaultString } from "../utils/localizeUtils";
 import { UserCancelError } from "./codeFlowLogin";
 
+const CodeSpacesScopes = [
+  "VSCODE_CLIENT_ID:7ea7c24c-b1f6-4a20-9d11-9ae12e9e7ac0",
+  "VSCODE_TENANT:common",
+];
+
 // this login to work for code space only
 export class M365CodeSpaceLogin extends BasicLogin implements M365TokenProvider {
   private static instance: M365CodeSpaceLogin;
@@ -78,7 +83,7 @@ export class M365CodeSpaceLogin extends BasicLogin implements M365TokenProvider 
     scopes: Array<string>
   ): Promise<vscode.AuthenticationSession | undefined> {
     return vscode.authentication
-      .getSession("microsoft", scopes, { createIfNone: createIfNone })
+      .getSession("microsoft", CodeSpacesScopes.concat(scopes), { createIfNone: createIfNone })
       .then((session: vscode.AuthenticationSession | undefined) => {
         return session;
       });

--- a/packages/vscode-extension/src/commonlib/m365CodeSpaceLogin.ts
+++ b/packages/vscode-extension/src/commonlib/m365CodeSpaceLogin.ts
@@ -32,6 +32,15 @@ const TeamsFxAadScopes = [
 export class M365CodeSpaceLogin extends BasicLogin implements M365TokenProvider {
   private static instance: M365CodeSpaceLogin;
 
+  private constructor() {
+    super();
+    vscode.authentication.onDidChangeSessions(async (e) => {
+      if (e.provider.id === "microsoft") {
+        this.notifyStatus({ scopes: AppStudioScopes });
+      }
+    });
+  }
+
   /**
    * Gets instance
    * @returns instance

--- a/packages/vscode-extension/src/debug/prerequisitesHandler.ts
+++ b/packages/vscode-extension/src/debug/prerequisitesHandler.ts
@@ -63,7 +63,7 @@ import VsCodeLogInstance from "../commonlib/log";
 import { ExtensionSource, ExtensionErrors } from "../error";
 import { VS_CODE_UI } from "../extension";
 import * as globalVariables from "../globalVariables";
-import { tools, openAccountHelpHandler, detectVsCodeEnv, getM365LoginInstance } from "../handlers";
+import { tools, openAccountHelpHandler, getM365LoginInstance } from "../handlers";
 import { ExtTelemetry } from "../telemetry/extTelemetry";
 import {
   TelemetryDebugDevCertStatus,
@@ -702,7 +702,7 @@ async function ensureM365Account(
         if (tokenRes.isErr()) {
           return err(tokenRes.error);
         }
-        loginStatusRes = await m365Login.getStatus({ scopes: AppStudioScopes });
+        loginStatusRes = await getM365LoginInstance().getStatus({ scopes: AppStudioScopes });
         if (loginStatusRes.isErr()) {
           return err(loginStatusRes.error);
         }

--- a/packages/vscode-extension/src/debug/prerequisitesHandler.ts
+++ b/packages/vscode-extension/src/debug/prerequisitesHandler.ts
@@ -63,7 +63,7 @@ import VsCodeLogInstance from "../commonlib/log";
 import { ExtensionSource, ExtensionErrors } from "../error";
 import { VS_CODE_UI } from "../extension";
 import * as globalVariables from "../globalVariables";
-import { tools, openAccountHelpHandler, detectVsCodeEnv } from "../handlers";
+import { tools, openAccountHelpHandler, detectVsCodeEnv, getM365LoginInstance } from "../handlers";
 import { ExtTelemetry } from "../telemetry/extTelemetry";
 import {
   TelemetryDebugDevCertStatus,
@@ -91,7 +91,6 @@ import {
   prerequisiteCheckForGetStartedDisplayMessages,
   v3PrerequisiteCheckTaskDisplayMessages,
 } from "./constants";
-import M365TokenInstance from "../commonlib/m365Login";
 import { signedOut } from "../commonlib/common/constant";
 import { ProgressHandler } from "../progressHandler";
 import { ProgressHelper } from "./progressHelper";
@@ -100,7 +99,6 @@ import * as commonUtils from "./commonUtils";
 import { localTelemetryReporter } from "./localTelemetryReporter";
 import { Step } from "./commonUtils";
 import { PrerequisiteArgVxTestApp } from "./taskTerminal/prerequisiteTaskTerminal";
-import M365CodeSpaceTokenInstance from "../commonlib/m365CodeSpaceLogin";
 
 enum Checker {
   NpmInstall = "npm package installation",
@@ -686,12 +684,7 @@ async function ensureM365Account(
     async (
       ctx: TelemetryContext
     ): Promise<Result<{ token: string; tenantId?: string; loginHint?: string }, FxError>> => {
-      let m365Login: M365TokenProvider = M365TokenInstance;
-      const vscodeEnv = detectVsCodeEnv();
-      if (vscodeEnv === VsCodeEnv.codespaceBrowser || vscodeEnv === VsCodeEnv.codespaceVsCode) {
-        m365Login = M365CodeSpaceTokenInstance;
-      }
-      let loginStatusRes = await m365Login.getStatus({ scopes: AppStudioScopes });
+      let loginStatusRes = await getM365LoginInstance().getStatus({ scopes: AppStudioScopes });
       if (loginStatusRes.isErr()) {
         ctx.properties[TelemetryProperty.DebugM365AccountStatus] = "error";
         return err(loginStatusRes.error);

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -29,7 +29,6 @@ import {
 import commandController from "./commandController";
 import AzureAccountManager from "./commonlib/azureLogin";
 import VsCodeLogInstance from "./commonlib/log";
-import M365TokenInstance from "./commonlib/m365Login";
 import { openWelcomePageAfterExtensionInstallation } from "./controls/openWelcomePage";
 import { getLocalDebugSessionId, startLocalDebugSession } from "./debug/commonUtils";
 import { localSettingsJsonName } from "./debug/constants";
@@ -127,21 +126,25 @@ function activateTeamsFxRegistration(context: vscode.ExtensionContext) {
   TreeViewManagerInstance.registerTreeViews(context);
   accountTreeViewProviderInstance.subscribeToStatusChanges({
     azureAccountProvider: AzureAccountManager,
-    m365TokenProvider: M365TokenInstance,
+    m365TokenProvider: handlers.getM365LoginInstance(),
   });
   // Set region for M365 account every
-  M365TokenInstance.setStatusChangeMap(
-    "set-region",
-    { scopes: AuthSvcScopes },
-    async (status, token, accountInfo) => {
-      if (status === "SignedIn") {
-        const tokenRes = await M365TokenInstance.getAccessToken({ scopes: AuthSvcScopes });
-        if (tokenRes.isOk()) {
-          setRegion(tokenRes.value);
+  handlers
+    .getM365LoginInstance()
+    .setStatusChangeMap(
+      "set-region",
+      { scopes: AuthSvcScopes },
+      async (status, token, accountInfo) => {
+        if (status === "SignedIn") {
+          const tokenRes = await handlers
+            .getM365LoginInstance()
+            .getAccessToken({ scopes: AuthSvcScopes });
+          if (tokenRes.isOk()) {
+            setRegion(tokenRes.value);
+          }
         }
       }
-    }
-  );
+    );
 
   if (vscode.workspace.isTrusted) {
     registerCodelensAndHoverProviders(context);


### PR DESCRIPTION
Use our client id in Code Spaces login. Add notify logic for m365 code spaces login.

https://www.eliostruyf.com/microsoft-authentication-provider-visual-studio-code/
