### PR TITLE
chore: add v3 templates code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -115,6 +115,29 @@
 /packages/fx-core/src/common/template-utils @hund030 @IvanJobs @eriolchan
 /packages/fx-core/tests/common/templateFetch.test.ts @hund030 @IvanJobs @eriolchan
 
+/templates/scenarios/js/command-and-response @kimizhu @dooriya @swatDong
+/templates/scenarios/js/notification-http-timer-trigger @kimizhu @dooriya @swatDong
+/templates/scenarios/js/notification-http-trigger @kimizhu @dooriya @swatDong
+/templates/scenarios/js/notification-restify @kimizhu @dooriya @swatDong
+/templates/scenarios/js/notification-timer-trigger @kimizhu @dooriya @swatDong
+/templates/scenarios/js/workflow @kimizhu @dooriya @swatDong
+/templates/scenarios/js/m365-message-extension @kimizhu @swatDong @kuojianlu
+/templates/scenarios/js/m365-tab @kimizhu @swatDong @kuojianlu
+/templates/scenarios/ts/command-and-response @kimizhu @dooriya @swatDong
+/templates/scenarios/ts/notification-http-timer-trigger @kimizhu @dooriya @swatDong
+/templates/scenarios/ts/notification-http-trigger @kimizhu @dooriya @swatDong
+/templates/scenarios/ts/notification-restify @kimizhu @dooriya @swatDong
+/templates/scenarios/ts/notification-timer-trigger @kimizhu @dooriya @swatDong
+/templates/scenarios/ts/workflow @kimizhu @dooriya @swatDong
+/templates/scenarios/ts/m365-message-extension @kimizhu @swatDong @kuojianlu
+/templates/scenarios/ts/m365-tab @kimizhu @swatDong @kuojianlu
+/templates/scenarios/csharp/command-and-response @kimizhu @dooriya @swatDong
+/templates/scenarios/csharp/notification-http-timer-trigger @kimizhu @dooriya @swatDong
+/templates/scenarios/csharp/notification-http-trigger @kimizhu @dooriya @swatDong
+/templates/scenarios/csharp/notification-webapi @kimizhu @dooriya @swatDong
+/templates/scenarios/csharp/notification-timer-trigger @kimizhu @dooriya @swatDong
+/templates/scenarios/csharp/workflow @kimizhu @dooriya @swatDong
+
 /packages/fx-core/src/plugins/resource/identity @xzf0587 @adashen @blackchoey
 /packages/fx-core/tests/plugins/resource/identity @xzf0587 @adashen @blackchoey
 


### PR DESCRIPTION
- add code owners for command, notification, workflow bot, and m365 v3 templates