### PR TITLE
chore: remove valid domains and fix 

### DIFF
--- a/packages/fx-core/src/component/developerPortalScaffoldUtils.ts
+++ b/packages/fx-core/src/component/developerPortalScaffoldUtils.ts
@@ -195,11 +195,9 @@ async function updateManifest(
     if (inputs[CoreQuestionNames.ReplaceBotIds].includes(answerToRepaceBotId)) {
       if (existingManifestTemplate.bots && existingManifestTemplate.bots.length > 0) {
         manifest.bots = existingManifestTemplate.bots;
-        manifest.validDomains = existingManifestTemplate.validDomains;
       } else {
         manifest.bots = BOTS_TPL_V3;
         manifest.bots[0].botId = "${{BOT_ID}}";
-        manifest.validDomains = existingManifestTemplate.validDomains;
       }
     }
 
@@ -209,11 +207,9 @@ async function updateManifest(
         existingManifestTemplate.composeExtensions.length > 0
       ) {
         manifest.composeExtensions = existingManifestTemplate.composeExtensions;
-        manifest.validDomains = existingManifestTemplate.validDomains;
       } else {
         manifest.composeExtensions = COMPOSE_EXTENSIONS_TPL_V3;
         manifest.composeExtensions[0].botId = "${{BOT_ID}}";
-        manifest.validDomains = existingManifestTemplate.validDomains;
       }
     }
   }

--- a/packages/fx-core/src/component/developerPortalScaffoldUtils.ts
+++ b/packages/fx-core/src/component/developerPortalScaffoldUtils.ts
@@ -190,6 +190,12 @@ async function updateManifest(
     );
   }
 
+  if (needUpdateStaticTabUrls) {
+    const validDomains = manifest.validDomains ?? [];
+    validDomains.push("${{TAB_DOMAIN}}");
+    manifest.validDomains = validDomains;
+  }
+
   // manifest: bot
   if (inputs[CoreQuestionNames.ReplaceBotIds]) {
     if (inputs[CoreQuestionNames.ReplaceBotIds].includes(answerToRepaceBotId)) {

--- a/packages/fx-core/src/component/developerPortalScaffoldUtils.ts
+++ b/packages/fx-core/src/component/developerPortalScaffoldUtils.ts
@@ -190,12 +190,6 @@ async function updateManifest(
     );
   }
 
-  if (needUpdateStaticTabUrls) {
-    const validDomains = manifest.validDomains ?? [];
-    validDomains.push("${{TAB_DOMAIN}}");
-    manifest.validDomains = validDomains;
-  }
-
   // manifest: bot
   if (inputs[CoreQuestionNames.ReplaceBotIds]) {
     if (inputs[CoreQuestionNames.ReplaceBotIds].includes(answerToRepaceBotId)) {

--- a/packages/fx-core/tests/component/developerPortalScaffoldUtils.test.ts
+++ b/packages/fx-core/tests/component/developerPortalScaffoldUtils.test.ts
@@ -338,7 +338,6 @@ describe("developPortalScaffoldUtils", () => {
       chai.assert.equal(updatedManifest.developer.privacyUrl, DEFAULT_DEVELOPER.privacyUrl);
       chai.assert.equal(updatedManifest.developer.termsOfUseUrl, DEFAULT_DEVELOPER.termsOfUseUrl);
       chai.assert.equal(updatedManifest.developer.websiteUrl, DEFAULT_DEVELOPER.websiteUrl);
-      chai.assert.isTrue(updatedManifest.validDomains?.includes("${{TAB_DOMAIN}}"));
       chai.assert.isTrue(writeSpy.calledThrice);
       chai.assert.isTrue(writeSpy.firstCall.firstArg.includes("TEAMS_APP_ID=mock-app-id"));
     });

--- a/packages/fx-core/tests/component/developerPortalScaffoldUtils.test.ts
+++ b/packages/fx-core/tests/component/developerPortalScaffoldUtils.test.ts
@@ -557,7 +557,6 @@ describe("developPortalScaffoldUtils", () => {
           name: "developer-name",
         },
         bots: [],
-        validDomains: ["valid-domain"],
       };
 
       let updateManifest = false;
@@ -615,7 +614,6 @@ describe("developPortalScaffoldUtils", () => {
       chai.assert.equal(updatedManifest.developer.privacyUrl, DEFAULT_DEVELOPER.privacyUrl);
       chai.assert.equal(updatedManifest.developer.termsOfUseUrl, DEFAULT_DEVELOPER.termsOfUseUrl);
       chai.assert.equal(updatedManifest.developer.websiteUrl, DEFAULT_DEVELOPER.websiteUrl);
-      chai.assert.isTrue(updatedManifest.validDomains?.includes("valid-domain"));
       chai.assert.isTrue(writeSpy.calledThrice);
       chai.assert.isTrue(writeSpy.firstCall.firstArg.includes("TEAMS_APP_ID=mock-app-id"));
     });
@@ -701,7 +699,6 @@ describe("developPortalScaffoldUtils", () => {
             ],
           },
         ],
-        validDomains: ["valid-domain"],
       };
 
       let updateManifest = false;
@@ -760,7 +757,6 @@ describe("developPortalScaffoldUtils", () => {
       chai.assert.equal(updatedManifest.developer.privacyUrl, DEFAULT_DEVELOPER.privacyUrl);
       chai.assert.equal(updatedManifest.developer.termsOfUseUrl, DEFAULT_DEVELOPER.termsOfUseUrl);
       chai.assert.equal(updatedManifest.developer.websiteUrl, DEFAULT_DEVELOPER.websiteUrl);
-      chai.assert.isTrue(updatedManifest.validDomains?.includes("valid-domain"));
       chai.assert.isTrue(writeSpy.calledThrice);
       chai.assert.isTrue(writeSpy.firstCall.firstArg.includes("TEAMS_APP_ID=mock-app-id"));
     });
@@ -848,7 +844,6 @@ describe("developPortalScaffoldUtils", () => {
             ],
           },
         ],
-        validDomains: ["valid-domain"],
       };
 
       let updateManifest = false;
@@ -908,7 +903,6 @@ describe("developPortalScaffoldUtils", () => {
       chai.assert.equal(updatedManifest.developer.privacyUrl, DEFAULT_DEVELOPER.privacyUrl);
       chai.assert.equal(updatedManifest.developer.termsOfUseUrl, DEFAULT_DEVELOPER.termsOfUseUrl);
       chai.assert.equal(updatedManifest.developer.websiteUrl, DEFAULT_DEVELOPER.websiteUrl);
-      chai.assert.isTrue(updatedManifest.validDomains?.includes("valid-domain"));
       chai.assert.isTrue(writeSpy.calledThrice);
       chai.assert.isTrue(writeSpy.firstCall.firstArg.includes("TEAMS_APP_ID=mock-app-id"));
     });
@@ -1042,6 +1036,7 @@ describe("developPortalScaffoldUtils", () => {
       chai.assert.isTrue(updateLanguage);
       const updatedManifest = JSON.parse(updatedManifestData) as TeamsAppManifest;
       chai.assert.equal(updatedManifest.id, "${{TEAMS_APP_ID}}");
+      chai.assert.isTrue(updatedManifest.validDomains?.includes("valid-domain"));
       chai.assert.deepEqual(updatedManifest.bots![0], existingManifest.bots![0]);
       chai.assert.equal(updatedManifest.developer.privacyUrl, DEFAULT_DEVELOPER.privacyUrl);
       chai.assert.equal(updatedManifest.developer.termsOfUseUrl, DEFAULT_DEVELOPER.termsOfUseUrl);
@@ -1050,7 +1045,6 @@ describe("developPortalScaffoldUtils", () => {
         updatedManifest.webApplicationInfo,
         existingManifest.webApplicationInfo
       );
-      chai.assert.isTrue(updatedManifest.validDomains?.includes("valid-domain"));
       chai.assert.isTrue(writeSpy.calledThrice);
       chai.assert.isTrue(writeSpy.firstCall.firstArg.includes("TEAMS_APP_ID=mock-app-id"));
     });

--- a/packages/fx-core/tests/component/developerPortalScaffoldUtils.test.ts
+++ b/packages/fx-core/tests/component/developerPortalScaffoldUtils.test.ts
@@ -541,7 +541,6 @@ describe("developPortalScaffoldUtils", () => {
             commands: [],
           },
         ],
-        validDomains: [],
       };
 
       const existingManifest: TeamsAppManifest = {
@@ -617,7 +616,7 @@ describe("developPortalScaffoldUtils", () => {
       chai.assert.equal(updatedManifest.developer.privacyUrl, DEFAULT_DEVELOPER.privacyUrl);
       chai.assert.equal(updatedManifest.developer.termsOfUseUrl, DEFAULT_DEVELOPER.termsOfUseUrl);
       chai.assert.equal(updatedManifest.developer.websiteUrl, DEFAULT_DEVELOPER.websiteUrl);
-      chai.assert.equal(updatedManifest.validDomains?.length, 0);
+      chai.assert.isUndefined(updatedManifest.validDomains);
       chai.assert.isTrue(writeSpy.calledThrice);
       chai.assert.isTrue(writeSpy.firstCall.firstArg.includes("TEAMS_APP_ID=mock-app-id"));
     });

--- a/packages/fx-core/tests/component/developerPortalScaffoldUtils.test.ts
+++ b/packages/fx-core/tests/component/developerPortalScaffoldUtils.test.ts
@@ -338,6 +338,7 @@ describe("developPortalScaffoldUtils", () => {
       chai.assert.equal(updatedManifest.developer.privacyUrl, DEFAULT_DEVELOPER.privacyUrl);
       chai.assert.equal(updatedManifest.developer.termsOfUseUrl, DEFAULT_DEVELOPER.termsOfUseUrl);
       chai.assert.equal(updatedManifest.developer.websiteUrl, DEFAULT_DEVELOPER.websiteUrl);
+      chai.assert.isTrue(updatedManifest.validDomains?.includes("${{TAB_DOMAIN}}"));
       chai.assert.isTrue(writeSpy.calledThrice);
       chai.assert.isTrue(writeSpy.firstCall.firstArg.includes("TEAMS_APP_ID=mock-app-id"));
     });
@@ -540,6 +541,7 @@ describe("developPortalScaffoldUtils", () => {
             commands: [],
           },
         ],
+        validDomains: [],
       };
 
       const existingManifest: TeamsAppManifest = {
@@ -557,6 +559,7 @@ describe("developPortalScaffoldUtils", () => {
           name: "developer-name",
         },
         bots: [],
+        validDomains: ["valid-domain"],
       };
 
       let updateManifest = false;
@@ -614,6 +617,7 @@ describe("developPortalScaffoldUtils", () => {
       chai.assert.equal(updatedManifest.developer.privacyUrl, DEFAULT_DEVELOPER.privacyUrl);
       chai.assert.equal(updatedManifest.developer.termsOfUseUrl, DEFAULT_DEVELOPER.termsOfUseUrl);
       chai.assert.equal(updatedManifest.developer.websiteUrl, DEFAULT_DEVELOPER.websiteUrl);
+      chai.assert.equal(updatedManifest.validDomains?.length, 0);
       chai.assert.isTrue(writeSpy.calledThrice);
       chai.assert.isTrue(writeSpy.firstCall.firstArg.includes("TEAMS_APP_ID=mock-app-id"));
     });
@@ -671,6 +675,7 @@ describe("developPortalScaffoldUtils", () => {
             commands: [],
           },
         ],
+        validDomains: [],
       };
 
       const existingManifest: TeamsAppManifest = {
@@ -699,6 +704,7 @@ describe("developPortalScaffoldUtils", () => {
             ],
           },
         ],
+        validDomains: ["valid-domain"],
       };
 
       let updateManifest = false;
@@ -757,6 +763,7 @@ describe("developPortalScaffoldUtils", () => {
       chai.assert.equal(updatedManifest.developer.privacyUrl, DEFAULT_DEVELOPER.privacyUrl);
       chai.assert.equal(updatedManifest.developer.termsOfUseUrl, DEFAULT_DEVELOPER.termsOfUseUrl);
       chai.assert.equal(updatedManifest.developer.websiteUrl, DEFAULT_DEVELOPER.websiteUrl);
+      chai.assert.equal(updatedManifest.validDomains?.length, 0);
       chai.assert.isTrue(writeSpy.calledThrice);
       chai.assert.isTrue(writeSpy.firstCall.firstArg.includes("TEAMS_APP_ID=mock-app-id"));
     });
@@ -814,6 +821,7 @@ describe("developPortalScaffoldUtils", () => {
             commands: [],
           },
         ],
+        validDomains: [],
       };
 
       const existingManifest: TeamsAppManifest = {
@@ -844,6 +852,7 @@ describe("developPortalScaffoldUtils", () => {
             ],
           },
         ],
+        validDomains: ["valid-domain"],
       };
 
       let updateManifest = false;
@@ -903,6 +912,7 @@ describe("developPortalScaffoldUtils", () => {
       chai.assert.equal(updatedManifest.developer.privacyUrl, DEFAULT_DEVELOPER.privacyUrl);
       chai.assert.equal(updatedManifest.developer.termsOfUseUrl, DEFAULT_DEVELOPER.termsOfUseUrl);
       chai.assert.equal(updatedManifest.developer.websiteUrl, DEFAULT_DEVELOPER.websiteUrl);
+      chai.assert.equal(updatedManifest.validDomains?.length, 0);
       chai.assert.isTrue(writeSpy.calledThrice);
       chai.assert.isTrue(writeSpy.firstCall.firstArg.includes("TEAMS_APP_ID=mock-app-id"));
     });
@@ -1036,7 +1046,6 @@ describe("developPortalScaffoldUtils", () => {
       chai.assert.isTrue(updateLanguage);
       const updatedManifest = JSON.parse(updatedManifestData) as TeamsAppManifest;
       chai.assert.equal(updatedManifest.id, "${{TEAMS_APP_ID}}");
-      chai.assert.isTrue(updatedManifest.validDomains?.includes("valid-domain"));
       chai.assert.deepEqual(updatedManifest.bots![0], existingManifest.bots![0]);
       chai.assert.equal(updatedManifest.developer.privacyUrl, DEFAULT_DEVELOPER.privacyUrl);
       chai.assert.equal(updatedManifest.developer.termsOfUseUrl, DEFAULT_DEVELOPER.termsOfUseUrl);
@@ -1045,6 +1054,7 @@ describe("developPortalScaffoldUtils", () => {
         updatedManifest.webApplicationInfo,
         existingManifest.webApplicationInfo
       );
+      chai.assert.isTrue(updatedManifest.validDomains?.includes("valid-domain"));
       chai.assert.isTrue(writeSpy.calledThrice);
       chai.assert.isTrue(writeSpy.firstCall.firstArg.includes("TEAMS_APP_ID=mock-app-id"));
     });

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -172,6 +172,7 @@ import * as commonTools from "@microsoft/teamsfx-core/build/common/tools";
 import { ConvertTokenToJson } from "./commonlib/codeFlowLogin";
 import { TreatmentVariableValue } from "./exp/treatmentVariables";
 import { AppStudioClient } from "@microsoft/teamsfx-core/build/component/resource/appManifest/appStudioClient";
+import { TelemetryUtils as AppManifestUtils } from "@microsoft/teamsfx-core/build/component/resource/appManifest/utils/telemetry";
 import commandController from "./commandController";
 import M365CodeSpaceTokenInstance from "./commonlib/m365CodeSpaceLogin";
 import { ExtensionSurvey } from "./utils/survey";
@@ -4018,6 +4019,7 @@ export async function scaffoldFromDeveloperPortalHandler(
 
   let appDefinition;
   try {
+    AppManifestUtils.init({ telemetryReporter: tools.telemetryReporter } as any); // need to initiate temeletry so that telemetry set up in appManifest component can work.
     appDefinition = await AppStudioClient.getApp(appId, token, VsCodeLogInstance);
   } catch (error: any) {
     ExtTelemetry.sendTelemetryErrorEvent(

--- a/templates/scenarios/js/non-sso-tab-default-bot/appPackage/manifest.json.tpl
+++ b/templates/scenarios/js/non-sso-tab-default-bot/appPackage/manifest.json.tpl
@@ -79,9 +79,5 @@
     "permissions": [
         "identity",
         "messageTeamMembers"
-    ],
-    "validDomains": [
-        "${{TAB_DOMAIN}}",
-        "${{BOT_DOMAIN}}"
     ]
 }

--- a/templates/scenarios/js/non-sso-tab-default-bot/appPackage/manifest.json.tpl
+++ b/templates/scenarios/js/non-sso-tab-default-bot/appPackage/manifest.json.tpl
@@ -79,5 +79,8 @@
     "permissions": [
         "identity",
         "messageTeamMembers"
+    ],
+    "validDomains": [
+        "${{TAB_DOMAIN}}"
     ]
 }

--- a/templates/scenarios/ts/non-sso-tab-default-bot/appPackage/manifest.json.tpl
+++ b/templates/scenarios/ts/non-sso-tab-default-bot/appPackage/manifest.json.tpl
@@ -79,9 +79,5 @@
     "permissions": [
         "identity",
         "messageTeamMembers"
-    ],
-    "validDomains": [
-        "${{TAB_DOMAIN}}",
-        "${{BOT_DOMAIN}}"
     ]
 }

--- a/templates/scenarios/ts/non-sso-tab-default-bot/appPackage/manifest.json.tpl
+++ b/templates/scenarios/ts/non-sso-tab-default-bot/appPackage/manifest.json.tpl
@@ -79,5 +79,8 @@
     "permissions": [
         "identity",
         "messageTeamMembers"
+    ],
+    "validDomains": [
+        "${{TAB_DOMAIN}}"
     ]
 }


### PR DESCRIPTION
- remove valid domains if the template
-  also remove it when creating projects from TDP
- noticed an issue as we add telemetry for GET api, so run .init before calling the GET api if the request is from TDP