### PR TITLE
chore(cli+core): check non-interactive in the migration v3 middleware

### DIFF
--- a/packages/cli/src/userInteraction.ts
+++ b/packages/cli/src/userInteraction.ts
@@ -519,9 +519,9 @@ export class CLIUserInteraction implements UserInteraction {
     modal: boolean,
     ...items: string[]
   ): Promise<Result<string | undefined, FxError>> {
-    if (!this.interactive && items.includes("Upgrade")) {
-      throw new NotAllowedMigrationError();
-    }
+    // if (!this.interactive && items.includes("Upgrade")) {
+    //   throw new NotAllowedMigrationError();
+    // }
     let plainText: string;
     if (message instanceof Array) {
       plainText = message.map((x) => x.content).join("");

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -509,6 +509,7 @@ export function getSystemInputs(projectPath?: string, env?: string): Inputs {
     projectPath: projectPath,
     correlationId: uuid.v4(),
     env: env,
+    nonInteractive: !CLIUIInstance.interactive,
   };
   return systemInputs;
 }

--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -114,6 +114,7 @@
   "core.migrationV3.manifestNotExist": "templates/appPackage/manifest.template.json does not exist. You may be trying to upgrade a project created by Teams Toolkit <= v3.8.0. Please install Teams Toolkit v4.x and run upgrade first.",
   "core.migrationV3.CreateNewProject": "Teams Toolkit (pre-release) does not support migrating projects from previous versions. Project migration will be added in an upcoming release.",
   "core.migrationV3.abandonedProject": "This project is only for previewing and will not be supported by Teams Toolkit. Please try Teams Toolkit by creating a new project",
+  "core.migrationV3.notAllowedMigration": "Teams Toolkit's Pre-Release version supports new project configuration and is incompatible with previous versions. Try it by creating a new project or run \"teamsfx upgrade\" to upgrade your project first.",
   "core.migrationToArmAndMultiEnv.SuccessMessage": "Upgrade succeeded.",
   "core.migrationToArmAndMultiEnv.ErrorMessage": "Upgrade Failed. Check the error message in [output channel](command:fx-extension.showOutputChannel) to troubleshoot and fix. To upgrade manually, click Learn More for the FAQ.",
   "core.migrationToArmAndMultiEnv.PreCheckErrorMessage": "Upgrade Failed. '%s' doesn't exist or is not in JSON format. Please fix it and try again by running command (Teams: Upgrade project).\nTo upgrade manually, click Learn More for the FAQ.",

--- a/packages/fx-core/src/core/error.ts
+++ b/packages/fx-core/src/core/error.ts
@@ -447,3 +447,14 @@ export class VideoFilterAppRemoteNotSupportedError extends UserError {
     });
   }
 }
+
+export class NotAllowedMigrationError extends UserError {
+  constructor() {
+    super({
+      source: CoreSource,
+      name: NotAllowedMigrationError.name,
+      message: getLocalizedString("core.migrationV3.notAllowedMigration"),
+      displayMessage: getLocalizedString("core.migrationV3.notAllowedMigration"),
+    });
+  }
+}

--- a/packages/fx-core/src/core/middleware/projectMigratorV3.ts
+++ b/packages/fx-core/src/core/middleware/projectMigratorV3.ts
@@ -16,6 +16,7 @@ import {
   Platform,
   AzureSolutionSettings,
   ProjectSettingsV3,
+  Inputs,
 } from "@microsoft/teamsfx-api";
 import { Middleware, NextFunction } from "@feathersjs/hooks/lib";
 import { CoreHookContext } from "../types";
@@ -36,6 +37,7 @@ import {
   MigrationError,
   AbandonedProjectError,
   ToolkitNotSupportError,
+  NotAllowedMigrationError,
 } from "../error";
 import { AppYmlGenerator } from "./utils/appYmlGenerator";
 import * as fs from "fs-extra";
@@ -181,6 +183,12 @@ export const ProjectMigratorMWV3: Middleware = async (ctx: CoreHookContext, next
       );
       ctx.result = err(ToolkitNotSupportError());
       return false;
+    }
+
+    const inputs = ctx.arguments[ctx.arguments.length - 1] as Inputs;
+    if (inputs.nonInteractive) {
+      ctx.result = err(new NotAllowedMigrationError());
+      return;
     }
 
     const isRunMigration = await showNotification(ctx, versionForMigration);


### PR DESCRIPTION
Move an upgrade string to core resource file and check non-interactive in core. Related PR: https://github.com/OfficeDev/TeamsFx/pull/7829
https://dev.azure.com/msazure/Microsoft%20Teams%20Extensibility/_workitems/edit/17332172
