### PR TITLE
chore(template): change ngrok to basis in V5 templates

### DIFF
--- a/templates/scenarios/common/init-debug-vsc-bot/{%dotVscodeFolderName%}/tasks.json
+++ b/templates/scenarios/common/init-debug-vsc-bot/{%dotVscodeFolderName%}/tasks.json
@@ -33,22 +33,22 @@
             }
         },
         {
-            // Start the local tunnel service to forward public ngrok URL to local port and inspect traffic.
-            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions,
-            // as well as samples to:
-            //   - use your own ngrok command / configuration / binary
-            //   - use your own tunnel solution
-            //   - provide alternatives if ngrok does not work on your dev machine
+            // Start the local tunnel service to forward public URL to local port and inspect traffic.
+            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions.
             "label": "Start local tunnel",
             "type": "teamsfx",
             "command": "debug-start-local-tunnel",
             "args": {
-                "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
+                "type": "dev-tunnel",
+                "port": 3978,
+                "protocol": "http",
+                "access": "public",
                 "env": "local",
                 "output": {
                     // output to .env.local
                     "endpoint": "BOT_ENDPOINT", // output tunnel endpoint as BOT_ENDPOINT
-                    "domain": "BOT_DOMAIN" // output tunnel domain as BOT_DOMAIN
+                    "domain": "BOT_DOMAIN", // output tunnel domain as BOT_DOMAIN
+                    "id": "DEV_TUNNEL_ID" // output dev tunnel id as DEV_TUNNEL_ID
                 }
             },
             "isBackground": true,

--- a/templates/scenarios/js/command-and-response/.vscode/tasks.json
+++ b/templates/scenarios/js/command-and-response/.vscode/tasks.json
@@ -34,22 +34,22 @@
             }
         },
         {
-            // Start the local tunnel service to forward public ngrok URL to local port and inspect traffic.
-            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions,
-            // as well as samples to:
-            //   - use your own ngrok command / configuration / binary
-            //   - use your own tunnel solution
-            //   - provide alternatives if ngrok does not work on your dev machine
+            // Start the local tunnel service to forward public URL to local port and inspect traffic.
+            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions.
             "label": "Start local tunnel",
             "type": "teamsfx",
             "command": "debug-start-local-tunnel",
             "args": {
-                "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
+                "type": "dev-tunnel",
+                "port": 3978,
+                "protocol": "http",
+                "access": "public",
                 "env": "local",
                 "output": {
                     // output to .env.local
                     "endpoint": "BOT_ENDPOINT", // output tunnel endpoint as BOT_ENDPOINT
-                    "domain": "BOT_DOMAIN" // output tunnel domain as BOT_DOMAIN
+                    "domain": "BOT_DOMAIN", // output tunnel domain as BOT_DOMAIN
+                    "id": "DEV_TUNNEL_ID" // output dev tunnel id as DEV_TUNNEL_ID
                 }
             },
             "isBackground": true,

--- a/templates/scenarios/js/default-bot-message-extension/.vscode/tasks.json
+++ b/templates/scenarios/js/default-bot-message-extension/.vscode/tasks.json
@@ -34,22 +34,22 @@
             }
         },
         {
-            // Start the local tunnel service to forward public ngrok URL to local port and inspect traffic.
-            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions,
-            // as well as samples to:
-            //   - use your own ngrok command / configuration / binary
-            //   - use your own tunnel solution
-            //   - provide alternatives if ngrok does not work on your dev machine
+            // Start the local tunnel service to forward public URL to local port and inspect traffic.
+            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions.
             "label": "Start local tunnel",
             "type": "teamsfx",
             "command": "debug-start-local-tunnel",
             "args": {
-                "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
+                "type": "dev-tunnel",
+                "port": 3978,
+                "protocol": "http",
+                "access": "public",
                 "env": "local",
                 "output": {
                     // output to .env.local
                     "endpoint": "BOT_ENDPOINT", // output tunnel endpoint as BOT_ENDPOINT
-                    "domain": "BOT_DOMAIN" // output tunnel domain as BOT_DOMAIN
+                    "domain": "BOT_DOMAIN", // output tunnel domain as BOT_DOMAIN
+                    "id": "DEV_TUNNEL_ID" // output dev tunnel id as DEV_TUNNEL_ID
                 }
             },
             "isBackground": true,

--- a/templates/scenarios/js/default-bot/.vscode/tasks.json
+++ b/templates/scenarios/js/default-bot/.vscode/tasks.json
@@ -34,22 +34,22 @@
             }
         },
         {
-            // Start the local tunnel service to forward public ngrok URL to local port and inspect traffic.
-            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions,
-            // as well as samples to:
-            //   - use your own ngrok command / configuration / binary
-            //   - use your own tunnel solution
-            //   - provide alternatives if ngrok does not work on your dev machine
+            // Start the local tunnel service to forward public URL to local port and inspect traffic.
+            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions.
             "label": "Start local tunnel",
             "type": "teamsfx",
             "command": "debug-start-local-tunnel",
             "args": {
-                "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
+                "type": "dev-tunnel",
+                "port": 3978,
+                "protocol": "http",
+                "access": "public",
                 "env": "local",
                 "output": {
                     // output to .env.local
                     "endpoint": "BOT_ENDPOINT", // output tunnel endpoint as BOT_ENDPOINT
-                    "domain": "BOT_DOMAIN" // output tunnel domain as BOT_DOMAIN
+                    "domain": "BOT_DOMAIN", // output tunnel domain as BOT_DOMAIN
+                    "id": "DEV_TUNNEL_ID" // output dev tunnel id as DEV_TUNNEL_ID
                 }
             },
             "isBackground": true,

--- a/templates/scenarios/js/m365-message-extension/.vscode/tasks.json
+++ b/templates/scenarios/js/m365-message-extension/.vscode/tasks.json
@@ -34,22 +34,22 @@
             }
         },
         {
-            // Start the local tunnel service to forward public ngrok URL to local port and inspect traffic.
-            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions,
-            // as well as samples to:
-            //   - use your own ngrok command / configuration / binary
-            //   - use your own tunnel solution
-            //   - provide alternatives if ngrok does not work on your dev machine
+            // Start the local tunnel service to forward public URL to local port and inspect traffic.
+            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions.
             "label": "Start local tunnel",
             "type": "teamsfx",
             "command": "debug-start-local-tunnel",
             "args": {
-                "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
+                "type": "dev-tunnel",
+                "port": 3978,
+                "protocol": "http",
+                "access": "public",
                 "env": "local",
                 "output": {
                     // output to .env.local
                     "endpoint": "BOT_ENDPOINT", // output tunnel endpoint as BOT_ENDPOINT
-                    "domain": "BOT_DOMAIN" // output tunnel domain as BOT_DOMAIN
+                    "domain": "BOT_DOMAIN", // output tunnel domain as BOT_DOMAIN
+                    "id": "DEV_TUNNEL_ID" // output dev tunnel id as DEV_TUNNEL_ID
                 }
             },
             "isBackground": true,

--- a/templates/scenarios/js/message-extension/.vscode/tasks.json
+++ b/templates/scenarios/js/message-extension/.vscode/tasks.json
@@ -34,22 +34,22 @@
             }
         },
         {
-            // Start the local tunnel service to forward public ngrok URL to local port and inspect traffic.
-            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions,
-            // as well as samples to:
-            //   - use your own ngrok command / configuration / binary
-            //   - use your own tunnel solution
-            //   - provide alternatives if ngrok does not work on your dev machine
+            // Start the local tunnel service to forward public URL to local port and inspect traffic.
+            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions.
             "label": "Start local tunnel",
             "type": "teamsfx",
             "command": "debug-start-local-tunnel",
             "args": {
-                "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
+                "type": "dev-tunnel",
+                "port": 3978,
+                "protocol": "http",
+                "access": "public",
                 "env": "local",
                 "output": {
                     // output to .env.local
                     "endpoint": "BOT_ENDPOINT", // output tunnel endpoint as BOT_ENDPOINT
-                    "domain": "BOT_DOMAIN" // output tunnel domain as BOT_DOMAIN
+                    "domain": "BOT_DOMAIN", // output tunnel domain as BOT_DOMAIN
+                    "id": "DEV_TUNNEL_ID" // output dev tunnel id as DEV_TUNNEL_ID
                 }
             },
             "isBackground": true,

--- a/templates/scenarios/js/non-sso-tab-default-bot/.vscode/tasks.json
+++ b/templates/scenarios/js/non-sso-tab-default-bot/.vscode/tasks.json
@@ -35,22 +35,22 @@
             }
         },
         {
-            // Start the local tunnel service to forward public ngrok URL to local port and inspect traffic.
-            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions,
-            // as well as samples to:
-            //   - use your own ngrok command / configuration / binary
-            //   - use your own tunnel solution
-            //   - provide alternatives if ngrok does not work on your dev machine
+            // Start the local tunnel service to forward public URL to local port and inspect traffic.
+            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions.
             "label": "Start local tunnel",
             "type": "teamsfx",
             "command": "debug-start-local-tunnel",
             "args": {
-                "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
+                "type": "dev-tunnel",
+                "port": 3978,
+                "protocol": "http",
+                "access": "public",
                 "env": "local",
                 "output": {
                     // output to .env.local
                     "endpoint": "BOT_ENDPOINT", // output tunnel endpoint as BOT_ENDPOINT
-                    "domain": "BOT_DOMAIN" // output tunnel domain as BOT_DOMAIN
+                    "domain": "BOT_DOMAIN", // output tunnel domain as BOT_DOMAIN
+                    "id": "DEV_TUNNEL_ID" // output dev tunnel id as DEV_TUNNEL_ID
                 }
             },
             "isBackground": true,

--- a/templates/scenarios/js/notification-http-timer-trigger/.vscode/tasks.json
+++ b/templates/scenarios/js/notification-http-timer-trigger/.vscode/tasks.json
@@ -34,22 +34,22 @@
             }
         },
         {
-            // Start the local tunnel service to forward public ngrok URL to local port and inspect traffic.
-            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions,
-            // as well as samples to:
-            //   - use your own ngrok command / configuration / binary
-            //   - use your own tunnel solution
-            //   - provide alternatives if ngrok does not work on your dev machine
+            // Start the local tunnel service to forward public URL to local port and inspect traffic.
+            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions.
             "label": "Start local tunnel",
             "type": "teamsfx",
             "command": "debug-start-local-tunnel",
             "args": {
-                "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
+                "type": "dev-tunnel",
+                "port": 3978,
+                "protocol": "http",
+                "access": "public",
                 "env": "local",
                 "output": {
                     // output to .env.local
                     "endpoint": "BOT_ENDPOINT", // output tunnel endpoint as BOT_ENDPOINT
-                    "domain": "BOT_DOMAIN" // output tunnel domain as BOT_DOMAIN
+                    "domain": "BOT_DOMAIN", // output tunnel domain as BOT_DOMAIN
+                    "id": "DEV_TUNNEL_ID" // output dev tunnel id as DEV_TUNNEL_ID
                 }
             },
             "isBackground": true,

--- a/templates/scenarios/js/notification-http-trigger/.vscode/tasks.json
+++ b/templates/scenarios/js/notification-http-trigger/.vscode/tasks.json
@@ -34,22 +34,22 @@
             }
         },
         {
-            // Start the local tunnel service to forward public ngrok URL to local port and inspect traffic.
-            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions,
-            // as well as samples to:
-            //   - use your own ngrok command / configuration / binary
-            //   - use your own tunnel solution
-            //   - provide alternatives if ngrok does not work on your dev machine
+            // Start the local tunnel service to forward public URL to local port and inspect traffic.
+            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions.
             "label": "Start local tunnel",
             "type": "teamsfx",
             "command": "debug-start-local-tunnel",
             "args": {
-                "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
+                "type": "dev-tunnel",
+                "port": 3978,
+                "protocol": "http",
+                "access": "public",
                 "env": "local",
                 "output": {
                     // output to .env.local
                     "endpoint": "BOT_ENDPOINT", // output tunnel endpoint as BOT_ENDPOINT
-                    "domain": "BOT_DOMAIN" // output tunnel domain as BOT_DOMAIN
+                    "domain": "BOT_DOMAIN", // output tunnel domain as BOT_DOMAIN
+                    "id": "DEV_TUNNEL_ID" // output dev tunnel id as DEV_TUNNEL_ID
                 }
             },
             "isBackground": true,

--- a/templates/scenarios/js/notification-restify/.vscode/tasks.json
+++ b/templates/scenarios/js/notification-restify/.vscode/tasks.json
@@ -34,22 +34,22 @@
             }
         },
         {
-            // Start the local tunnel service to forward public ngrok URL to local port and inspect traffic.
-            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions,
-            // as well as samples to:
-            //   - use your own ngrok command / configuration / binary
-            //   - use your own tunnel solution
-            //   - provide alternatives if ngrok does not work on your dev machine
+            // Start the local tunnel service to forward public URL to local port and inspect traffic.
+            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions.
             "label": "Start local tunnel",
             "type": "teamsfx",
             "command": "debug-start-local-tunnel",
             "args": {
-                "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
+                "type": "dev-tunnel",
+                "port": 3978,
+                "protocol": "http",
+                "access": "public",
                 "env": "local",
                 "output": {
                     // output to .env.local
                     "endpoint": "BOT_ENDPOINT", // output tunnel endpoint as BOT_ENDPOINT
-                    "domain": "BOT_DOMAIN" // output tunnel domain as BOT_DOMAIN
+                    "domain": "BOT_DOMAIN", // output tunnel domain as BOT_DOMAIN
+                    "id": "DEV_TUNNEL_ID" // output dev tunnel id as DEV_TUNNEL_ID
                 }
             },
             "isBackground": true,

--- a/templates/scenarios/js/notification-timer-trigger/.vscode/tasks.json
+++ b/templates/scenarios/js/notification-timer-trigger/.vscode/tasks.json
@@ -34,22 +34,22 @@
             }
         },
         {
-            // Start the local tunnel service to forward public ngrok URL to local port and inspect traffic.
-            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions,
-            // as well as samples to:
-            //   - use your own ngrok command / configuration / binary
-            //   - use your own tunnel solution
-            //   - provide alternatives if ngrok does not work on your dev machine
+            // Start the local tunnel service to forward public URL to local port and inspect traffic.
+            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions.
             "label": "Start local tunnel",
             "type": "teamsfx",
             "command": "debug-start-local-tunnel",
             "args": {
-                "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
+                "type": "dev-tunnel",
+                "port": 3978,
+                "protocol": "http",
+                "access": "public",
                 "env": "local",
                 "output": {
                     // output to .env.local
                     "endpoint": "BOT_ENDPOINT", // output tunnel endpoint as BOT_ENDPOINT
-                    "domain": "BOT_DOMAIN" // output tunnel domain as BOT_DOMAIN
+                    "domain": "BOT_DOMAIN", // output tunnel domain as BOT_DOMAIN
+                    "id": "DEV_TUNNEL_ID" // output dev tunnel id as DEV_TUNNEL_ID
                 }
             },
             "isBackground": true,

--- a/templates/scenarios/js/workflow/.vscode/tasks.json
+++ b/templates/scenarios/js/workflow/.vscode/tasks.json
@@ -34,22 +34,22 @@
             }
         },
         {
-            // Start the local tunnel service to forward public ngrok URL to local port and inspect traffic.
-            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions,
-            // as well as samples to:
-            //   - use your own ngrok command / configuration / binary
-            //   - use your own tunnel solution
-            //   - provide alternatives if ngrok does not work on your dev machine
+            // Start the local tunnel service to forward public URL to local port and inspect traffic.
+            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions.
             "label": "Start local tunnel",
             "type": "teamsfx",
             "command": "debug-start-local-tunnel",
             "args": {
-                "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
+                "type": "dev-tunnel",
+                "port": 3978,
+                "protocol": "http",
+                "access": "public",
                 "env": "local",
                 "output": {
                     // output to .env.local
                     "endpoint": "BOT_ENDPOINT", // output tunnel endpoint as BOT_ENDPOINT
-                    "domain": "BOT_DOMAIN" // output tunnel domain as BOT_DOMAIN
+                    "domain": "BOT_DOMAIN", // output tunnel domain as BOT_DOMAIN
+                    "id": "DEV_TUNNEL_ID" // output dev tunnel id as DEV_TUNNEL_ID
                 }
             },
             "isBackground": true,

--- a/templates/scenarios/ts/command-and-response/.vscode/tasks.json
+++ b/templates/scenarios/ts/command-and-response/.vscode/tasks.json
@@ -34,22 +34,22 @@
             }
         },
         {
-            // Start the local tunnel service to forward public ngrok URL to local port and inspect traffic.
-            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions,
-            // as well as samples to:
-            //   - use your own ngrok command / configuration / binary
-            //   - use your own tunnel solution
-            //   - provide alternatives if ngrok does not work on your dev machine
+            // Start the local tunnel service to forward public URL to local port and inspect traffic.
+            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions.
             "label": "Start local tunnel",
             "type": "teamsfx",
             "command": "debug-start-local-tunnel",
             "args": {
-                "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
+                "type": "dev-tunnel",
+                "port": 3978,
+                "protocol": "http",
+                "access": "public",
                 "env": "local",
                 "output": {
                     // output to .env.local
                     "endpoint": "BOT_ENDPOINT", // output tunnel endpoint as BOT_ENDPOINT
-                    "domain": "BOT_DOMAIN" // output tunnel domain as BOT_DOMAIN
+                    "domain": "BOT_DOMAIN", // output tunnel domain as BOT_DOMAIN
+                    "id": "DEV_TUNNEL_ID" // output dev tunnel id as DEV_TUNNEL_ID
                 }
             },
             "isBackground": true,

--- a/templates/scenarios/ts/default-bot-message-extension/.vscode/tasks.json
+++ b/templates/scenarios/ts/default-bot-message-extension/.vscode/tasks.json
@@ -34,22 +34,22 @@
             }
         },
         {
-            // Start the local tunnel service to forward public ngrok URL to local port and inspect traffic.
-            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions,
-            // as well as samples to:
-            //   - use your own ngrok command / configuration / binary
-            //   - use your own tunnel solution
-            //   - provide alternatives if ngrok does not work on your dev machine
+            // Start the local tunnel service to forward public URL to local port and inspect traffic.
+            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions.
             "label": "Start local tunnel",
             "type": "teamsfx",
             "command": "debug-start-local-tunnel",
             "args": {
-                "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
+                "type": "dev-tunnel",
+                "port": 3978,
+                "protocol": "http",
+                "access": "public",
                 "env": "local",
                 "output": {
                     // output to .env.local
                     "endpoint": "BOT_ENDPOINT", // output tunnel endpoint as BOT_ENDPOINT
-                    "domain": "BOT_DOMAIN" // output tunnel domain as BOT_DOMAIN
+                    "domain": "BOT_DOMAIN", // output tunnel domain as BOT_DOMAIN
+                    "id": "DEV_TUNNEL_ID" // output dev tunnel id as DEV_TUNNEL_ID
                 }
             },
             "isBackground": true,

--- a/templates/scenarios/ts/default-bot/.vscode/tasks.json
+++ b/templates/scenarios/ts/default-bot/.vscode/tasks.json
@@ -34,22 +34,22 @@
             }
         },
         {
-            // Start the local tunnel service to forward public ngrok URL to local port and inspect traffic.
-            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions,
-            // as well as samples to:
-            //   - use your own ngrok command / configuration / binary
-            //   - use your own tunnel solution
-            //   - provide alternatives if ngrok does not work on your dev machine
+            // Start the local tunnel service to forward public URL to local port and inspect traffic.
+            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions.
             "label": "Start local tunnel",
             "type": "teamsfx",
             "command": "debug-start-local-tunnel",
             "args": {
-                "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
+                "type": "dev-tunnel",
+                "port": 3978,
+                "protocol": "http",
+                "access": "public",
                 "env": "local",
                 "output": {
                     // output to .env.local
                     "endpoint": "BOT_ENDPOINT", // output tunnel endpoint as BOT_ENDPOINT
-                    "domain": "BOT_DOMAIN" // output tunnel domain as BOT_DOMAIN
+                    "domain": "BOT_DOMAIN", // output tunnel domain as BOT_DOMAIN
+                    "id": "DEV_TUNNEL_ID" // output dev tunnel id as DEV_TUNNEL_ID
                 }
             },
             "isBackground": true,

--- a/templates/scenarios/ts/m365-message-extension/.vscode/tasks.json
+++ b/templates/scenarios/ts/m365-message-extension/.vscode/tasks.json
@@ -34,22 +34,22 @@
             }
         },
         {
-            // Start the local tunnel service to forward public ngrok URL to local port and inspect traffic.
-            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions,
-            // as well as samples to:
-            //   - use your own ngrok command / configuration / binary
-            //   - use your own tunnel solution
-            //   - provide alternatives if ngrok does not work on your dev machine
+            // Start the local tunnel service to forward public URL to local port and inspect traffic.
+            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions.
             "label": "Start local tunnel",
             "type": "teamsfx",
             "command": "debug-start-local-tunnel",
             "args": {
-                "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
+                "type": "dev-tunnel",
+                "port": 3978,
+                "protocol": "http",
+                "access": "public",
                 "env": "local",
                 "output": {
                     // output to .env.local
                     "endpoint": "BOT_ENDPOINT", // output tunnel endpoint as BOT_ENDPOINT
-                    "domain": "BOT_DOMAIN" // output tunnel domain as BOT_DOMAIN
+                    "domain": "BOT_DOMAIN", // output tunnel domain as BOT_DOMAIN
+                    "id": "DEV_TUNNEL_ID" // output dev tunnel id as DEV_TUNNEL_ID
                 }
             },
             "isBackground": true,

--- a/templates/scenarios/ts/message-extension/.vscode/tasks.json
+++ b/templates/scenarios/ts/message-extension/.vscode/tasks.json
@@ -34,22 +34,22 @@
             }
         },
         {
-            // Start the local tunnel service to forward public ngrok URL to local port and inspect traffic.
-            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions,
-            // as well as samples to:
-            //   - use your own ngrok command / configuration / binary
-            //   - use your own tunnel solution
-            //   - provide alternatives if ngrok does not work on your dev machine
+            // Start the local tunnel service to forward public URL to local port and inspect traffic.
+            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions.
             "label": "Start local tunnel",
             "type": "teamsfx",
             "command": "debug-start-local-tunnel",
             "args": {
-                "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
+                "type": "dev-tunnel",
+                "port": 3978,
+                "protocol": "http",
+                "access": "public",
                 "env": "local",
                 "output": {
                     // output to .env.local
                     "endpoint": "BOT_ENDPOINT", // output tunnel endpoint as BOT_ENDPOINT
-                    "domain": "BOT_DOMAIN" // output tunnel domain as BOT_DOMAIN
+                    "domain": "BOT_DOMAIN", // output tunnel domain as BOT_DOMAIN
+                    "id": "DEV_TUNNEL_ID" // output dev tunnel id as DEV_TUNNEL_ID
                 }
             },
             "isBackground": true,

--- a/templates/scenarios/ts/non-sso-tab-default-bot/.vscode/tasks.json
+++ b/templates/scenarios/ts/non-sso-tab-default-bot/.vscode/tasks.json
@@ -35,22 +35,22 @@
             }
         },
         {
-            // Start the local tunnel service to forward public ngrok URL to local port and inspect traffic.
-            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions,
-            // as well as samples to:
-            //   - use your own ngrok command / configuration / binary
-            //   - use your own tunnel solution
-            //   - provide alternatives if ngrok does not work on your dev machine
+            // Start the local tunnel service to forward public URL to local port and inspect traffic.
+            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions
             "label": "Start local tunnel",
             "type": "teamsfx",
             "command": "debug-start-local-tunnel",
             "args": {
-                "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
+                "type": "dev-tunnel",
+                "port": 3978,
+                "protocol": "http",
+                "access": "public",
                 "env": "local",
                 "output": {
                     // output to .env.local
                     "endpoint": "BOT_ENDPOINT", // output tunnel endpoint as BOT_ENDPOINT
-                    "domain": "BOT_DOMAIN" // output tunnel domain as BOT_DOMAIN
+                    "domain": "BOT_DOMAIN", // output tunnel domain as BOT_DOMAIN
+                    "id": "DEV_TUNNEL_ID" // output dev tunnel id as DEV_TUNNEL_ID
                 }
             },
             "isBackground": true,

--- a/templates/scenarios/ts/notification-http-timer-trigger/.vscode/tasks.json
+++ b/templates/scenarios/ts/notification-http-timer-trigger/.vscode/tasks.json
@@ -34,22 +34,22 @@
             }
         },
         {
-            // Start the local tunnel service to forward public ngrok URL to local port and inspect traffic.
-            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions,
-            // as well as samples to:
-            //   - use your own ngrok command / configuration / binary
-            //   - use your own tunnel solution
-            //   - provide alternatives if ngrok does not work on your dev machine
+            // Start the local tunnel service to forward public URL to local port and inspect traffic.
+            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions.
             "label": "Start local tunnel",
             "type": "teamsfx",
             "command": "debug-start-local-tunnel",
             "args": {
-                "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
+                "type": "dev-tunnel",
+                "port": 3978,
+                "protocol": "http",
+                "access": "public",
                 "env": "local",
                 "output": {
                     // output to .env.local
                     "endpoint": "BOT_ENDPOINT", // output tunnel endpoint as BOT_ENDPOINT
-                    "domain": "BOT_DOMAIN" // output tunnel domain as BOT_DOMAIN
+                    "domain": "BOT_DOMAIN", // output tunnel domain as BOT_DOMAIN
+                    "id": "DEV_TUNNEL_ID" // output dev tunnel id as DEV_TUNNEL_ID
                 }
             },
             "isBackground": true,

--- a/templates/scenarios/ts/notification-http-trigger/.vscode/tasks.json
+++ b/templates/scenarios/ts/notification-http-trigger/.vscode/tasks.json
@@ -34,22 +34,22 @@
             }
         },
         {
-            // Start the local tunnel service to forward public ngrok URL to local port and inspect traffic.
-            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions,
-            // as well as samples to:
-            //   - use your own ngrok command / configuration / binary
-            //   - use your own tunnel solution
-            //   - provide alternatives if ngrok does not work on your dev machine
+            // Start the local tunnel service to forward public URL to local port and inspect traffic.
+            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions.
             "label": "Start local tunnel",
             "type": "teamsfx",
             "command": "debug-start-local-tunnel",
             "args": {
-                "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
+                "type": "dev-tunnel",
+                "port": 3978,
+                "protocol": "http",
+                "access": "public",
                 "env": "local",
                 "output": {
                     // output to .env.local
                     "endpoint": "BOT_ENDPOINT", // output tunnel endpoint as BOT_ENDPOINT
-                    "domain": "BOT_DOMAIN" // output tunnel domain as BOT_DOMAIN
+                    "domain": "BOT_DOMAIN", // output tunnel domain as BOT_DOMAIN
+                    "id": "DEV_TUNNEL_ID" // output dev tunnel id as DEV_TUNNEL_ID
                 }
             },
             "isBackground": true,

--- a/templates/scenarios/ts/notification-restify/.vscode/tasks.json
+++ b/templates/scenarios/ts/notification-restify/.vscode/tasks.json
@@ -34,22 +34,22 @@
             }
         },
         {
-            // Start the local tunnel service to forward public ngrok URL to local port and inspect traffic.
-            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions,
-            // as well as samples to:
-            //   - use your own ngrok command / configuration / binary
-            //   - use your own tunnel solution
-            //   - provide alternatives if ngrok does not work on your dev machine
+            // Start the local tunnel service to forward public URL to local port and inspect traffic.
+            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions.
             "label": "Start local tunnel",
             "type": "teamsfx",
             "command": "debug-start-local-tunnel",
             "args": {
-                "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
+                "type": "dev-tunnel",
+                "port": 3978,
+                "protocol": "http",
+                "access": "public",
                 "env": "local",
                 "output": {
                     // output to .env.local
                     "endpoint": "BOT_ENDPOINT", // output tunnel endpoint as BOT_ENDPOINT
-                    "domain": "BOT_DOMAIN" // output tunnel domain as BOT_DOMAIN
+                    "domain": "BOT_DOMAIN", // output tunnel domain as BOT_DOMAIN
+                    "id": "DEV_TUNNEL_ID" // output dev tunnel id as DEV_TUNNEL_ID
                 }
             },
             "isBackground": true,

--- a/templates/scenarios/ts/notification-timer-trigger/.vscode/tasks.json
+++ b/templates/scenarios/ts/notification-timer-trigger/.vscode/tasks.json
@@ -34,22 +34,22 @@
             }
         },
         {
-            // Start the local tunnel service to forward public ngrok URL to local port and inspect traffic.
-            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions,
-            // as well as samples to:
-            //   - use your own ngrok command / configuration / binary
-            //   - use your own tunnel solution
-            //   - provide alternatives if ngrok does not work on your dev machine
+            // Start the local tunnel service to forward public URL to local port and inspect traffic.
+            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions.
             "label": "Start local tunnel",
             "type": "teamsfx",
             "command": "debug-start-local-tunnel",
             "args": {
-                "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
+                "type": "dev-tunnel",
+                "port": 3978,
+                "protocol": "http",
+                "access": "public",
                 "env": "local",
                 "output": {
                     // output to .env.local
                     "endpoint": "BOT_ENDPOINT", // output tunnel endpoint as BOT_ENDPOINT
-                    "domain": "BOT_DOMAIN" // output tunnel domain as BOT_DOMAIN
+                    "domain": "BOT_DOMAIN", // output tunnel domain as BOT_DOMAIN
+                    "id": "DEV_TUNNEL_ID" // output dev tunnel id as DEV_TUNNEL_ID
                 }
             },
             "isBackground": true,

--- a/templates/scenarios/ts/workflow/.vscode/tasks.json
+++ b/templates/scenarios/ts/workflow/.vscode/tasks.json
@@ -34,22 +34,21 @@
             }
         },
         {
-            // Start the local tunnel service to forward public ngrok URL to local port and inspect traffic.
-            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions,
-            // as well as samples to:
-            //   - use your own ngrok command / configuration / binary
-            //   - use your own tunnel solution
-            //   - provide alternatives if ngrok does not work on your dev machine
-            "label": "Start local tunnel",
+            // Start the local tunnel service to forward public URL to local port and inspect traffic.
+            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions.
             "type": "teamsfx",
             "command": "debug-start-local-tunnel",
             "args": {
-                "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
+                "type": "dev-tunnel",
+                "port": 3978,
+                "protocol": "http",
+                "access": "public",
                 "env": "local",
                 "output": {
                     // output to .env.local
                     "endpoint": "BOT_ENDPOINT", // output tunnel endpoint as BOT_ENDPOINT
-                    "domain": "BOT_DOMAIN" // output tunnel domain as BOT_DOMAIN
+                    "domain": "BOT_DOMAIN", // output tunnel domain as BOT_DOMAIN
+                    "id": "DEV_TUNNEL_ID" // output dev tunnel id as DEV_TUNNEL_ID
                 }
             },
             "isBackground": true,


### PR DESCRIPTION
Detail: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/17382761/

PS: The projects migrated from V4 will still use ngrok.