### PR TITLE
chore: update node space size while pack visx on CD pipeline

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -309,6 +309,8 @@ jobs:
 
       - name: pack vsix
         if: ${{ contains(steps.version-change.outputs.CHANGED, 'ms-teams-vscode-extension@') && github.ref != 'refs/heads/prerelease' }}
+        env:
+          NODE_OPTIONS: "--max_old_space_size=4096"
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 10
@@ -372,6 +374,7 @@ jobs:
         if: ${{ contains(steps.version-change.outputs.CHANGED, 'ms-teams-vscode-extension@') && github.ref == 'refs/heads/prerelease' }}
         env:
           RELEASE: preview
+          NODE_OPTIONS: "--max_old_space_size=4096"
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 10


### PR DESCRIPTION
https://github.com/OfficeDev/TeamsFx/actions/runs/4309172174/jobs/7516246063 
FATAL ERROR: MarkCompactCollector: young object promotion failed Allocation failed - JavaScript heap out of memory

