### PR TITLE
chore: fix telemetry in VSC

### DIFF
--- a/packages/fx-core/src/component/coordinator/index.ts
+++ b/packages/fx-core/src/component/coordinator/index.ts
@@ -237,7 +237,7 @@ export class Coordinator {
 
       merge(actionContext?.telemetryProps, {
         [TelemetryProperty.Capabilities]: feature,
-        [TelemetryProperty.IsFromTdp]: !!inputs.teamsAppFromTdp,
+        [TelemetryProperty.IsFromTdp]: !!inputs.teamsAppFromTdp.toString(),
       });
 
       if (feature === TabSPFxNewUIItem().id) {

--- a/packages/fx-core/src/component/coordinator/index.ts
+++ b/packages/fx-core/src/component/coordinator/index.ts
@@ -237,7 +237,7 @@ export class Coordinator {
 
       merge(actionContext?.telemetryProps, {
         [TelemetryProperty.Capabilities]: feature,
-        [TelemetryProperty.IsFromTdp]: !!inputs.teamsAppFromTdp.toString(),
+        [TelemetryProperty.IsFromTdp]: (!!inputs.teamsAppFromTdp).toString(),
       });
 
       if (feature === TabSPFxNewUIItem().id) {


### PR DESCRIPTION
- this property was missing in VSC telemetry and looks like it need to be a string. 