### PR TITLE
chore: avoid bot from debug wordings

### DIFF
--- a/templates/scenarios/common/init-debug-vsc-bot/{%dotVscodeFolderName%}/launch.json
+++ b/templates/scenarios/common/init-debug-vsc-bot/{%dotVscodeFolderName%}/launch.json
@@ -24,12 +24,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Edge)",
+            "name": "Launch App (Edge)",
             "type": "pwa-msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -38,12 +38,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Chrome)",
+            "name": "Launch App (Chrome)",
             "type": "pwa-chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -52,7 +52,7 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Attach to Bot",
+            "name": "Attach to Local Service",
             "type": "pwa-node",
             "request": "attach",
             "port": 9239,
@@ -68,8 +68,8 @@
         {
             "name": "Debug (Edge)",
             "configurations": [
-                "Launch Bot (Edge)",
-                "Attach to Bot"
+                "Launch App (Edge)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
@@ -81,8 +81,8 @@
         {
             "name": "Debug (Chrome)",
             "configurations": [
-                "Launch Bot (Chrome)",
-                "Attach to Bot"
+                "Launch App (Chrome)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {

--- a/templates/scenarios/common/init-debug-vsc-bot/{%dotVscodeFolderName%}/tasks.json
+++ b/templates/scenarios/common/init-debug-vsc-bot/{%dotVscodeFolderName%}/tasks.json
@@ -27,8 +27,8 @@
                     "portOccupancy" // Validate available ports to ensure those debug ones are not occupied.
                 ],
                 "portOccupancy": [
-                    3978, // bot service port
-                    9239 // bot inspector port for Node.js debugger
+                    3978, // app service port
+                    9239 // app inspector port for Node.js debugger
                 ]
             }
         },
@@ -76,12 +76,6 @@
         },
         {
             "label": "Start application",
-            "dependsOn": [
-                "Start bot"
-            ]
-        },
-        {
-            "label": "Start bot",
             "type": "shell",
             // load teamsfx runtime settings and execute `npm run start`
             "command": "npx env-cmd --silent -f .localSettings npm run start",

--- a/templates/scenarios/js/command-and-response/.vscode/launch.json
+++ b/templates/scenarios/js/command-and-response/.vscode/launch.json
@@ -24,12 +24,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Edge)",
+            "name": "Launch App (Edge)",
             "type": "pwa-msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -38,12 +38,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Chrome)",
+            "name": "Launch App (Chrome)",
             "type": "pwa-chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -52,7 +52,7 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Attach to Bot",
+            "name": "Attach to Local Service",
             "type": "pwa-node",
             "request": "attach",
             "port": 9239,
@@ -68,8 +68,8 @@
         {
             "name": "Debug (Edge)",
             "configurations": [
-                "Launch Bot (Edge)",
-                "Attach to Bot"
+                "Launch App (Edge)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
@@ -81,8 +81,8 @@
         {
             "name": "Debug (Chrome)",
             "configurations": [
-                "Launch Bot (Chrome)",
-                "Attach to Bot"
+                "Launch App (Chrome)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {

--- a/templates/scenarios/js/command-and-response/.vscode/tasks.json
+++ b/templates/scenarios/js/command-and-response/.vscode/tasks.json
@@ -28,8 +28,8 @@
                     "portOccupancy" // Validate available ports to ensure those debug ones are not occupied.
                 ],
                 "portOccupancy": [
-                    3978, // bot service port
-                    9239 // bot inspector port for Node.js debugger
+                    3978, // app service port
+                    9239 // app inspector port for Node.js debugger
                 ]
             }
         },
@@ -77,12 +77,6 @@
         },
         {
             "label": "Start application",
-            "dependsOn": [
-                "Start bot"
-            ]
-        },
-        {
-            "label": "Start bot",
             "type": "shell",
             "command": "npm run dev:teamsfx",
             "isBackground": true,

--- a/templates/scenarios/js/default-bot-message-extension/.vscode/launch.json
+++ b/templates/scenarios/js/default-bot-message-extension/.vscode/launch.json
@@ -24,12 +24,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Edge)",
+            "name": "Launch App (Edge)",
             "type": "pwa-msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -38,12 +38,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Chrome)",
+            "name": "Launch App (Chrome)",
             "type": "pwa-chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -52,7 +52,7 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Attach to Bot",
+            "name": "Attach to Local Service",
             "type": "pwa-node",
             "request": "attach",
             "port": 9239,
@@ -68,8 +68,8 @@
         {
             "name": "Debug (Edge)",
             "configurations": [
-                "Launch Bot (Edge)",
-                "Attach to Bot"
+                "Launch App (Edge)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
@@ -81,8 +81,8 @@
         {
             "name": "Debug (Chrome)",
             "configurations": [
-                "Launch Bot (Chrome)",
-                "Attach to Bot"
+                "Launch App (Chrome)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {

--- a/templates/scenarios/js/default-bot-message-extension/.vscode/tasks.json
+++ b/templates/scenarios/js/default-bot-message-extension/.vscode/tasks.json
@@ -28,8 +28,8 @@
                     "portOccupancy" // Validate available ports to ensure those debug ones are not occupied.
                 ],
                 "portOccupancy": [
-                    3978, // bot service port
-                    9239 // bot inspector port for Node.js debugger
+                    3978, // app service port
+                    9239 // app inspector port for Node.js debugger
                 ]
             }
         },
@@ -77,12 +77,6 @@
         },
         {
             "label": "Start application",
-            "dependsOn": [
-                "Start bot"
-            ]
-        },
-        {
-            "label": "Start bot",
             "type": "shell",
             "command": "npm run dev:teamsfx",
             "isBackground": true,

--- a/templates/scenarios/js/default-bot/.vscode/launch.json
+++ b/templates/scenarios/js/default-bot/.vscode/launch.json
@@ -24,12 +24,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Edge)",
+            "name": "Launch App (Edge)",
             "type": "pwa-msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -38,12 +38,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Chrome)",
+            "name": "Launch App (Chrome)",
             "type": "pwa-chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -52,7 +52,7 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Attach to Bot",
+            "name": "Attach to Local Service",
             "type": "pwa-node",
             "request": "attach",
             "port": 9239,
@@ -68,8 +68,8 @@
         {
             "name": "Debug (Edge)",
             "configurations": [
-                "Launch Bot (Edge)",
-                "Attach to Bot"
+                "Launch App (Edge)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
@@ -81,8 +81,8 @@
         {
             "name": "Debug (Chrome)",
             "configurations": [
-                "Launch Bot (Chrome)",
-                "Attach to Bot"
+                "Launch App (Chrome)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {

--- a/templates/scenarios/js/default-bot/.vscode/tasks.json
+++ b/templates/scenarios/js/default-bot/.vscode/tasks.json
@@ -28,8 +28,8 @@
                     "portOccupancy" // Validate available ports to ensure those debug ones are not occupied.
                 ],
                 "portOccupancy": [
-                    3978, // bot service port
-                    9239 // bot inspector port for Node.js debugger
+                    3978, // app service port
+                    9239 // app inspector port for Node.js debugger
                 ]
             }
         },
@@ -77,12 +77,6 @@
         },
         {
             "label": "Start application",
-            "dependsOn": [
-                "Start bot"
-            ]
-        },
-        {
-            "label": "Start bot",
             "type": "shell",
             "command": "npm run dev:teamsfx",
             "isBackground": true,

--- a/templates/scenarios/js/m365-message-extension/.vscode/launch.json
+++ b/templates/scenarios/js/m365-message-extension/.vscode/launch.json
@@ -46,12 +46,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot in Teams (Edge)",
+            "name": "Launch App in Teams (Edge)",
             "type": "pwa-msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -60,12 +60,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot in Teams (Chrome)",
+            "name": "Launch App in Teams (Chrome)",
             "type": "pwa-chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -74,12 +74,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot in Outlook (Edge)",
+            "name": "Launch App in Outlook (Edge)",
             "type": "pwa-msedge",
             "request": "launch",
             "url": "https://outlook.office.com/mail?${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -88,12 +88,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot in Outlook (Chrome)",
+            "name": "Launch App in Outlook (Chrome)",
             "type": "pwa-chrome",
             "request": "launch",
             "url": "https://outlook.office.com/mail?${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -102,7 +102,7 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Attach to Bot",
+            "name": "Attach to Local Service",
             "type": "pwa-node",
             "request": "attach",
             "port": 9239,
@@ -118,8 +118,8 @@
         {
             "name": "Debug in Teams (Edge)",
             "configurations": [
-                "Launch Bot in Teams (Edge)",
-                "Attach to Bot"
+                "Launch App in Teams (Edge)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
@@ -131,8 +131,8 @@
         {
             "name": "Debug in Teams (Chrome)",
             "configurations": [
-                "Launch Bot in Teams (Chrome)",
-                "Attach to Bot"
+                "Launch App in Teams (Chrome)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
@@ -144,8 +144,8 @@
         {
             "name": "Debug in Outlook (Edge)",
             "configurations": [
-                "Launch Bot in Outlook (Edge)",
-                "Attach to Bot"
+                "Launch App in Outlook (Edge)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
@@ -157,8 +157,8 @@
         {
             "name": "Debug in Outlook (Chrome)",
             "configurations": [
-                "Launch Bot in Outlook (Chrome)",
-                "Attach to Bot"
+                "Launch App in Outlook (Chrome)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {

--- a/templates/scenarios/js/m365-message-extension/.vscode/tasks.json
+++ b/templates/scenarios/js/m365-message-extension/.vscode/tasks.json
@@ -28,8 +28,8 @@
                     "portOccupancy" // Validate available ports to ensure those debug ones are not occupied.
                 ],
                 "portOccupancy": [
-                    3978, // bot service port
-                    9239 // bot inspector port for Node.js debugger
+                    3978, // app service port
+                    9239 // app inspector port for Node.js debugger
                 ]
             }
         },
@@ -77,12 +77,6 @@
         },
         {
             "label": "Start application",
-            "dependsOn": [
-                "Start bot"
-            ]
-        },
-        {
-            "label": "Start bot",
             "type": "shell",
             "command": "npm run dev:teamsfx",
             "isBackground": true,

--- a/templates/scenarios/js/message-extension/.vscode/launch.json
+++ b/templates/scenarios/js/message-extension/.vscode/launch.json
@@ -24,12 +24,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Edge)",
+            "name": "Launch App (Edge)",
             "type": "pwa-msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -38,12 +38,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Chrome)",
+            "name": "Launch App (Chrome)",
             "type": "pwa-chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -52,7 +52,7 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Attach to Bot",
+            "name": "Attach to Local Service",
             "type": "pwa-node",
             "request": "attach",
             "port": 9239,
@@ -68,8 +68,8 @@
         {
             "name": "Debug (Edge)",
             "configurations": [
-                "Launch Bot (Edge)",
-                "Attach to Bot"
+                "Launch App (Edge)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
@@ -81,8 +81,8 @@
         {
             "name": "Debug (Chrome)",
             "configurations": [
-                "Launch Bot (Chrome)",
-                "Attach to Bot"
+                "Launch App (Chrome)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {

--- a/templates/scenarios/js/message-extension/.vscode/tasks.json
+++ b/templates/scenarios/js/message-extension/.vscode/tasks.json
@@ -28,8 +28,8 @@
                     "portOccupancy" // Validate available ports to ensure those debug ones are not occupied.
                 ],
                 "portOccupancy": [
-                    3978, // bot service port
-                    9239 // bot inspector port for Node.js debugger
+                    3978, // app service port
+                    9239 // app inspector port for Node.js debugger
                 ]
             }
         },
@@ -77,12 +77,6 @@
         },
         {
             "label": "Start application",
-            "dependsOn": [
-                "Start bot"
-            ]
-        },
-        {
-            "label": "Start bot",
             "type": "shell",
             "command": "npm run dev:teamsfx",
             "isBackground": true,

--- a/templates/scenarios/js/non-sso-tab-default-bot/.vscode/launch.json
+++ b/templates/scenarios/js/non-sso-tab-default-bot/.vscode/launch.json
@@ -29,7 +29,7 @@
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -43,7 +43,7 @@
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -52,7 +52,7 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Attach to Bot",
+            "name": "Attach to Local Service",
             "type": "pwa-node",
             "request": "attach",
             "port": 9239,
@@ -69,7 +69,7 @@
             "name": "Debug (Edge)",
             "configurations": [
                 "Attach to Frontend (Edge)",
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
@@ -82,7 +82,7 @@
             "name": "Debug (Chrome)",
             "configurations": [
                 "Attach to Frontend (Chrome)",
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {

--- a/templates/scenarios/js/notification-http-timer-trigger/.vscode/launch.json
+++ b/templates/scenarios/js/notification-http-timer-trigger/.vscode/launch.json
@@ -24,12 +24,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Edge)",
+            "name": "Launch App (Edge)",
             "type": "pwa-msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -38,12 +38,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Chrome)",
+            "name": "Launch App (Chrome)",
             "type": "pwa-chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -52,7 +52,7 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Attach to Bot",
+            "name": "Attach to Local Service",
             "type": "pwa-node",
             "request": "attach",
             "port": 9239,
@@ -68,8 +68,8 @@
         {
             "name": "Debug (Edge)",
             "configurations": [
-                "Launch Bot (Edge)",
-                "Attach to Bot"
+                "Launch App (Edge)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
@@ -81,8 +81,8 @@
         {
             "name": "Debug (Chrome)",
             "configurations": [
-                "Launch Bot (Chrome)",
-                "Attach to Bot"
+                "Launch App (Chrome)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {

--- a/templates/scenarios/js/notification-http-timer-trigger/.vscode/tasks.json
+++ b/templates/scenarios/js/notification-http-timer-trigger/.vscode/tasks.json
@@ -28,8 +28,8 @@
                     "portOccupancy" // Validate available ports to ensure those debug ones are not occupied.
                 ],
                 "portOccupancy": [
-                    3978, // bot service port
-                    9239 // bot inspector port for Node.js debugger
+                    3978, // app service port
+                    9239 // app inspector port for Node.js debugger
                 ]
             }
         },
@@ -77,12 +77,6 @@
         },
         {
             "label": "Start application",
-            "dependsOn": [
-                "Start bot"
-            ]
-        },
-        {
-            "label": "Start bot",
             "type": "shell",
             "command": "npm run dev:teamsfx",
             "isBackground": true,

--- a/templates/scenarios/js/notification-http-timer-trigger/src/httpTrigger.js
+++ b/templates/scenarios/js/notification-http-timer-trigger/src/httpTrigger.js
@@ -1,10 +1,10 @@
 const notificationTemplate = require("./adaptiveCards/notification-default.json");
 const { AdaptiveCards } = require("@microsoft/adaptivecards-tools");
-const { bot } = require("./internal/initialize");
+const { notificationApp } = require("./internal/initialize");
 
 // HTTP trigger to send notification. You need to add authentication / authorization for this API. Refer https://aka.ms/teamsfx-notification for more details.
 module.exports = async function (context, req) {
-  for (const target of await bot.notification.installations()) {
+  for (const target of await notificationApp.notification.installations()) {
     await target.sendAdaptiveCard(
       AdaptiveCards.declare(notificationTemplate).render({
         title: "New Event Occurred!",
@@ -53,14 +53,14 @@ module.exports = async function (context, req) {
   **/
 
   /** You can also find someone and notify the individual person
-  const member = await bot.notification.findMember(
+  const member = await notificationApp.notification.findMember(
     async (m) => m.account.email === "someone@contoso.com"
   );
   await member?.sendAdaptiveCard(...);
   **/
 
   /** Or find multiple people and notify them
-  const members = await bot.notification.findAllMembers(
+  const members = await notificationApp.notification.findAllMembers(
     async (m) => m.account.email?.startsWith("test")
   );
   for (const member of members) {

--- a/templates/scenarios/js/notification-http-timer-trigger/src/internal/initialize.js
+++ b/templates/scenarios/js/notification-http-timer-trigger/src/internal/initialize.js
@@ -3,7 +3,7 @@ const ConversationBot = BotBuilderCloudAdapter.ConversationBot;
 const config = require("./config");
 
 // Create bot.
-const bot = new ConversationBot({
+const notificationApp = new ConversationBot({
   // The bot id and password to create CloudAdapter.
   // See https://aka.ms/about-bot-adapter to learn more about adapters.
   adapterConfig: {
@@ -18,5 +18,5 @@ const bot = new ConversationBot({
 });
 
 module.exports = {
-  bot,
+  notificationApp,
 };

--- a/templates/scenarios/js/notification-http-timer-trigger/src/internal/messageHandler.js
+++ b/templates/scenarios/js/notification-http-timer-trigger/src/internal/messageHandler.js
@@ -1,11 +1,11 @@
 const { TeamsBot } = require("../teamsBot");
-const { bot } = require("./initialize");
+const { notificationApp } = require("./initialize");
 const { ResponseWrapper } = require("./responseWrapper");
 
 module.exports = async function (context, req) {
   const res = new ResponseWrapper(context.res);
   const teamsBot = new TeamsBot();
-  await bot.requestHandler(req, res, async (context) => {
+  await notificationApp.requestHandler(req, res, async (context) => {
     await teamsBot.run(context);
   });
   return res.body;

--- a/templates/scenarios/js/notification-http-timer-trigger/src/timerTrigger.js
+++ b/templates/scenarios/js/notification-http-timer-trigger/src/timerTrigger.js
@@ -1,11 +1,11 @@
 const notificationTemplate = require("./adaptiveCards/notification-default.json");
 const { AdaptiveCards } = require("@microsoft/adaptivecards-tools");
-const { bot } = require("./internal/initialize");
+const { notificationApp } = require("./internal/initialize");
 
 // Time trigger to send notification. You can change the schedule in ../timerNotifyTrigger/function.json
 module.exports = async function (context, myTimer) {
   const timeStamp = new Date().toISOString();
-  for (const target of await bot.notification.installations()) {
+  for (const target of await notificationApp.notification.installations()) {
     await target.sendAdaptiveCard(
       AdaptiveCards.declare(notificationTemplate).render({
         title: "New Event Occurred!",
@@ -54,14 +54,14 @@ module.exports = async function (context, myTimer) {
   **/
 
   /** You can also find someone and notify the individual person
-  const member = await bot.notification.findMember(
+  const member = await notificationApp.notification.findMember(
     async (m) => m.account.email === "someone@contoso.com"
   );
   await member?.sendAdaptiveCard(...);
   **/
 
   /** Or find multiple people and notify them
-  const members = await bot.notification.findAllMembers(
+  const members = await notificationApp.notification.findAllMembers(
     async (m) => m.account.email?.startsWith("test")
   );
   for (const member of members) {

--- a/templates/scenarios/js/notification-http-trigger/.vscode/launch.json
+++ b/templates/scenarios/js/notification-http-trigger/.vscode/launch.json
@@ -24,12 +24,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Edge)",
+            "name": "Launch App (Edge)",
             "type": "pwa-msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -38,12 +38,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Chrome)",
+            "name": "Launch App (Chrome)",
             "type": "pwa-chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -52,7 +52,7 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Attach to Bot",
+            "name": "Attach to Local Service",
             "type": "pwa-node",
             "request": "attach",
             "port": 9239,
@@ -68,8 +68,8 @@
         {
             "name": "Debug (Edge)",
             "configurations": [
-                "Launch Bot (Edge)",
-                "Attach to Bot"
+                "Launch App (Edge)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
@@ -81,8 +81,8 @@
         {
             "name": "Debug (Chrome)",
             "configurations": [
-                "Launch Bot (Chrome)",
-                "Attach to Bot"
+                "Launch App (Chrome)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {

--- a/templates/scenarios/js/notification-http-trigger/.vscode/tasks.json
+++ b/templates/scenarios/js/notification-http-trigger/.vscode/tasks.json
@@ -28,8 +28,8 @@
                     "portOccupancy" // Validate available ports to ensure those debug ones are not occupied.
                 ],
                 "portOccupancy": [
-                    3978, // bot service port
-                    9239 // bot inspector port for Node.js debugger
+                    3978, // app service port
+                    9239 // app inspector port for Node.js debugger
                 ]
             }
         },
@@ -77,12 +77,6 @@
         },
         {
             "label": "Start application",
-            "dependsOn": [
-                "Start bot"
-            ]
-        },
-        {
-            "label": "Start bot",
             "type": "shell",
             "command": "npm run dev:teamsfx",
             "isBackground": true,

--- a/templates/scenarios/js/notification-http-trigger/src/httpTrigger.js
+++ b/templates/scenarios/js/notification-http-trigger/src/httpTrigger.js
@@ -1,10 +1,10 @@
 const notificationTemplate = require("./adaptiveCards/notification-default.json");
 const { AdaptiveCards } = require("@microsoft/adaptivecards-tools");
-const { bot } = require("./internal/initialize");
+const { notificationApp } = require("./internal/initialize");
 
 // HTTP trigger to send notification. You need to add authentication / authorization for this API. Refer https://aka.ms/teamsfx-notification for more details.
 module.exports = async function (context, req) {
-  for (const target of await bot.notification.installations()) {
+  for (const target of await notificationApp.notification.installations()) {
     await target.sendAdaptiveCard(
       AdaptiveCards.declare(notificationTemplate).render({
         title: "New Event Occurred!",
@@ -53,14 +53,14 @@ module.exports = async function (context, req) {
   **/
 
   /** You can also find someone and notify the individual person
-  const member = await bot.notification.findMember(
+  const member = await notificationApp.notification.findMember(
     async (m) => m.account.email === "someone@contoso.com"
   );
   await member?.sendAdaptiveCard(...);
   **/
 
   /** Or find multiple people and notify them
-  const members = await bot.notification.findAllMembers(
+  const members = await notificationApp.notification.findAllMembers(
     async (m) => m.account.email?.startsWith("test")
   );
   for (const member of members) {

--- a/templates/scenarios/js/notification-http-trigger/src/internal/initialize.js
+++ b/templates/scenarios/js/notification-http-trigger/src/internal/initialize.js
@@ -3,7 +3,7 @@ const ConversationBot = BotBuilderCloudAdapter.ConversationBot;
 const config = require("./config");
 
 // Create bot.
-const bot = new ConversationBot({
+const notificationApp = new ConversationBot({
   // The bot id and password to create CloudAdapter.
   // See https://aka.ms/about-bot-adapter to learn more about adapters.
   adapterConfig: {
@@ -18,5 +18,5 @@ const bot = new ConversationBot({
 });
 
 module.exports = {
-  bot,
+  notificationApp,
 };

--- a/templates/scenarios/js/notification-http-trigger/src/internal/messageHandler.js
+++ b/templates/scenarios/js/notification-http-trigger/src/internal/messageHandler.js
@@ -1,11 +1,11 @@
 const { TeamsBot } = require("../teamsBot");
-const { bot } = require("./initialize");
+const { notificationApp } = require("./initialize");
 const { ResponseWrapper } = require("./responseWrapper");
 
 module.exports = async function (context, req) {
   const res = new ResponseWrapper(context.res);
   const teamsBot = new TeamsBot();
-  await bot.requestHandler(req, res, async (context) => {
+  await notificationApp.requestHandler(req, res, async (context) => {
     await teamsBot.run(context);
   });
   return res.body;

--- a/templates/scenarios/js/notification-restify/.vscode/launch.json
+++ b/templates/scenarios/js/notification-restify/.vscode/launch.json
@@ -24,12 +24,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Edge)",
+            "name": "Launch App (Edge)",
             "type": "pwa-msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -38,12 +38,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Chrome)",
+            "name": "Launch App (Chrome)",
             "type": "pwa-chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -52,7 +52,7 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Attach to Bot",
+            "name": "Attach to Local Service",
             "type": "pwa-node",
             "request": "attach",
             "port": 9239,
@@ -68,8 +68,8 @@
         {
             "name": "Debug (Edge)",
             "configurations": [
-                "Launch Bot (Edge)",
-                "Attach to Bot"
+                "Launch App (Edge)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
@@ -81,8 +81,8 @@
         {
             "name": "Debug (Chrome)",
             "configurations": [
-                "Launch Bot (Chrome)",
-                "Attach to Bot"
+                "Launch App (Chrome)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {

--- a/templates/scenarios/js/notification-restify/.vscode/tasks.json
+++ b/templates/scenarios/js/notification-restify/.vscode/tasks.json
@@ -28,8 +28,8 @@
                     "portOccupancy" // Validate available ports to ensure those debug ones are not occupied.
                 ],
                 "portOccupancy": [
-                    3978, // bot service port
-                    9239 // bot inspector port for Node.js debugger
+                    3978, // app service port
+                    9239 // app inspector port for Node.js debugger
                 ]
             }
         },
@@ -77,12 +77,6 @@
         },
         {
             "label": "Start application",
-            "dependsOn": [
-                "Start bot"
-            ]
-        },
-        {
-            "label": "Start bot",
             "type": "shell",
             "command": "npm run dev:teamsfx",
             "isBackground": true,

--- a/templates/scenarios/js/notification-timer-trigger/.vscode/launch.json
+++ b/templates/scenarios/js/notification-timer-trigger/.vscode/launch.json
@@ -24,12 +24,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Edge)",
+            "name": "Launch App (Edge)",
             "type": "pwa-msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -38,12 +38,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Chrome)",
+            "name": "Launch App (Chrome)",
             "type": "pwa-chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -52,7 +52,7 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Attach to Bot",
+            "name": "Attach to Local Service",
             "type": "pwa-node",
             "request": "attach",
             "port": 9239,
@@ -68,8 +68,8 @@
         {
             "name": "Debug (Edge)",
             "configurations": [
-                "Launch Bot (Edge)",
-                "Attach to Bot"
+                "Launch App (Edge)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
@@ -81,8 +81,8 @@
         {
             "name": "Debug (Chrome)",
             "configurations": [
-                "Launch Bot (Chrome)",
-                "Attach to Bot"
+                "Launch App (Chrome)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {

--- a/templates/scenarios/js/notification-timer-trigger/.vscode/tasks.json
+++ b/templates/scenarios/js/notification-timer-trigger/.vscode/tasks.json
@@ -28,8 +28,8 @@
                     "portOccupancy" // Validate available ports to ensure those debug ones are not occupied.
                 ],
                 "portOccupancy": [
-                    3978, // bot service port
-                    9239 // bot inspector port for Node.js debugger
+                    3978, // app service port
+                    9239 // app inspector port for Node.js debugger
                 ]
             }
         },
@@ -77,12 +77,6 @@
         },
         {
             "label": "Start application",
-            "dependsOn": [
-                "Start bot"
-            ]
-        },
-        {
-            "label": "Start bot",
             "type": "shell",
             "command": "npm run dev:teamsfx",
             "isBackground": true,

--- a/templates/scenarios/js/notification-timer-trigger/src/internal/initialize.js
+++ b/templates/scenarios/js/notification-timer-trigger/src/internal/initialize.js
@@ -3,7 +3,7 @@ const ConversationBot = BotBuilderCloudAdapter.ConversationBot;
 const config = require("./config");
 
 // Create bot.
-const bot = new ConversationBot({
+const notificationApp = new ConversationBot({
   // The bot id and password to create CloudAdapter.
   // See https://aka.ms/about-bot-adapter to learn more about adapters.
   adapterConfig: {
@@ -18,5 +18,5 @@ const bot = new ConversationBot({
 });
 
 module.exports = {
-  bot,
+  notificationApp,
 };

--- a/templates/scenarios/js/notification-timer-trigger/src/internal/messageHandler.js
+++ b/templates/scenarios/js/notification-timer-trigger/src/internal/messageHandler.js
@@ -1,11 +1,11 @@
 const { TeamsBot } = require("../teamsBot");
-const { bot } = require("./initialize");
+const { notificationApp } = require("./initialize");
 const { ResponseWrapper } = require("./responseWrapper");
 
 module.exports = async function (context, req) {
   const res = new ResponseWrapper(context.res);
   const teamsBot = new TeamsBot();
-  await bot.requestHandler(req, res, async (context) => {
+  await notificationApp.requestHandler(req, res, async (context) => {
     await teamsBot.run(context);
   });
   return res.body;

--- a/templates/scenarios/js/notification-timer-trigger/src/timerTrigger.js
+++ b/templates/scenarios/js/notification-timer-trigger/src/timerTrigger.js
@@ -1,11 +1,11 @@
 const notificationTemplate = require("./adaptiveCards/notification-default.json");
 const { AdaptiveCards } = require("@microsoft/adaptivecards-tools");
-const { bot } = require("./internal/initialize");
+const { notificationApp } = require("./internal/initialize");
 
 // Time trigger to send notification. You can change the schedule in ../timerNotifyTrigger/function.json
 module.exports = async function (context, myTimer) {
   const timeStamp = new Date().toISOString();
-  for (const target of await bot.notification.installations()) {
+  for (const target of await notificationApp.notification.installations()) {
     await target.sendAdaptiveCard(
       AdaptiveCards.declare(notificationTemplate).render({
         title: "New Event Occurred!",
@@ -54,14 +54,14 @@ module.exports = async function (context, myTimer) {
   **/
 
   /** You can also find someone and notify the individual person
-  const member = await bot.notification.findMember(
+  const member = await notificationApp.notification.findMember(
     async (m) => m.account.email === "someone@contoso.com"
   );
   await member?.sendAdaptiveCard(...);
   **/
 
   /** Or find multiple people and notify them
-  const members = await bot.notification.findAllMembers(
+  const members = await notificationApp.notification.findAllMembers(
     async (m) => m.account.email?.startsWith("test")
   );
   for (const member of members) {

--- a/templates/scenarios/js/workflow/.vscode/launch.json
+++ b/templates/scenarios/js/workflow/.vscode/launch.json
@@ -24,12 +24,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Edge)",
+            "name": "Launch App (Edge)",
             "type": "pwa-msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -38,12 +38,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Chrome)",
+            "name": "Launch App (Chrome)",
             "type": "pwa-chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -52,7 +52,7 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Attach to Bot",
+            "name": "Attach to Local Service",
             "type": "pwa-node",
             "request": "attach",
             "port": 9239,
@@ -68,8 +68,8 @@
         {
             "name": "Debug (Edge)",
             "configurations": [
-                "Launch Bot (Edge)",
-                "Attach to Bot"
+                "Launch App (Edge)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
@@ -81,8 +81,8 @@
         {
             "name": "Debug (Chrome)",
             "configurations": [
-                "Launch Bot (Chrome)",
-                "Attach to Bot"
+                "Launch App (Chrome)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {

--- a/templates/scenarios/js/workflow/.vscode/tasks.json
+++ b/templates/scenarios/js/workflow/.vscode/tasks.json
@@ -28,8 +28,8 @@
                     "portOccupancy" // Validate available ports to ensure those debug ones are not occupied.
                 ],
                 "portOccupancy": [
-                    3978, // bot service port
-                    9239 // bot inspector port for Node.js debugger
+                    3978, // app service port
+                    9239 // app inspector port for Node.js debugger
                 ]
             }
         },
@@ -77,12 +77,6 @@
         },
         {
             "label": "Start application",
-            "dependsOn": [
-                "Start bot"
-            ]
-        },
-        {
-            "label": "Start bot",
             "type": "shell",
             "command": "npm run dev:teamsfx",
             "isBackground": true,

--- a/templates/scenarios/ts/command-and-response/.vscode/launch.json
+++ b/templates/scenarios/ts/command-and-response/.vscode/launch.json
@@ -24,12 +24,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Edge)",
+            "name": "Launch App (Edge)",
             "type": "pwa-msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -38,12 +38,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Chrome)",
+            "name": "Launch App (Chrome)",
             "type": "pwa-chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -52,7 +52,7 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Attach to Bot",
+            "name": "Attach to Local Service",
             "type": "pwa-node",
             "request": "attach",
             "port": 9239,
@@ -68,8 +68,8 @@
         {
             "name": "Debug (Edge)",
             "configurations": [
-                "Launch Bot (Edge)",
-                "Attach to Bot"
+                "Launch App (Edge)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
@@ -81,8 +81,8 @@
         {
             "name": "Debug (Chrome)",
             "configurations": [
-                "Launch Bot (Chrome)",
-                "Attach to Bot"
+                "Launch App (Chrome)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {

--- a/templates/scenarios/ts/command-and-response/.vscode/tasks.json
+++ b/templates/scenarios/ts/command-and-response/.vscode/tasks.json
@@ -28,8 +28,8 @@
                     "portOccupancy" // Validate available ports to ensure those debug ones are not occupied.
                 ],
                 "portOccupancy": [
-                    3978, // bot service port
-                    9239 // bot inspector port for Node.js debugger
+                    3978, // app service port
+                    9239 // app inspector port for Node.js debugger
                 ]
             }
         },
@@ -77,12 +77,6 @@
         },
         {
             "label": "Start application",
-            "dependsOn": [
-                "Start bot"
-            ]
-        },
-        {
-            "label": "Start bot",
             "type": "shell",
             "command": "npm run dev:teamsfx",
             "isBackground": true,

--- a/templates/scenarios/ts/default-bot-message-extension/.vscode/launch.json
+++ b/templates/scenarios/ts/default-bot-message-extension/.vscode/launch.json
@@ -24,12 +24,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Edge)",
+            "name": "Launch App (Edge)",
             "type": "pwa-msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -38,12 +38,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Chrome)",
+            "name": "Launch App (Chrome)",
             "type": "pwa-chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -52,7 +52,7 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Attach to Bot",
+            "name": "Attach to Local Service",
             "type": "pwa-node",
             "request": "attach",
             "port": 9239,
@@ -68,8 +68,8 @@
         {
             "name": "Debug (Edge)",
             "configurations": [
-                "Launch Bot (Edge)",
-                "Attach to Bot"
+                "Launch App (Edge)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
@@ -81,8 +81,8 @@
         {
             "name": "Debug (Chrome)",
             "configurations": [
-                "Launch Bot (Chrome)",
-                "Attach to Bot"
+                "Launch App (Chrome)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {

--- a/templates/scenarios/ts/default-bot-message-extension/.vscode/tasks.json
+++ b/templates/scenarios/ts/default-bot-message-extension/.vscode/tasks.json
@@ -28,8 +28,8 @@
                     "portOccupancy" // Validate available ports to ensure those debug ones are not occupied.
                 ],
                 "portOccupancy": [
-                    3978, // bot service port
-                    9239 // bot inspector port for Node.js debugger
+                    3978, // app service port
+                    9239 // app inspector port for Node.js debugger
                 ]
             }
         },
@@ -77,12 +77,6 @@
         },
         {
             "label": "Start application",
-            "dependsOn": [
-                "Start bot"
-            ]
-        },
-        {
-            "label": "Start bot",
             "type": "shell",
             "command": "npm run dev:teamsfx",
             "isBackground": true,

--- a/templates/scenarios/ts/default-bot/.vscode/launch.json
+++ b/templates/scenarios/ts/default-bot/.vscode/launch.json
@@ -24,12 +24,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Edge)",
+            "name": "Launch App (Edge)",
             "type": "pwa-msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -38,12 +38,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Chrome)",
+            "name": "Launch App (Chrome)",
             "type": "pwa-chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -52,7 +52,7 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Attach to Bot",
+            "name": "Attach to Local Service",
             "type": "pwa-node",
             "request": "attach",
             "port": 9239,
@@ -68,8 +68,8 @@
         {
             "name": "Debug (Edge)",
             "configurations": [
-                "Launch Bot (Edge)",
-                "Attach to Bot"
+                "Launch App (Edge)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
@@ -81,8 +81,8 @@
         {
             "name": "Debug (Chrome)",
             "configurations": [
-                "Launch Bot (Chrome)",
-                "Attach to Bot"
+                "Launch App (Chrome)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {

--- a/templates/scenarios/ts/default-bot/.vscode/tasks.json
+++ b/templates/scenarios/ts/default-bot/.vscode/tasks.json
@@ -28,8 +28,8 @@
                     "portOccupancy" // Validate available ports to ensure those debug ones are not occupied.
                 ],
                 "portOccupancy": [
-                    3978, // bot service port
-                    9239 // bot inspector port for Node.js debugger
+                    3978, // app service port
+                    9239 // app inspector port for Node.js debugger
                 ]
             }
         },
@@ -77,12 +77,6 @@
         },
         {
             "label": "Start application",
-            "dependsOn": [
-                "Start bot"
-            ]
-        },
-        {
-            "label": "Start bot",
             "type": "shell",
             "command": "npm run dev:teamsfx",
             "isBackground": true,

--- a/templates/scenarios/ts/m365-message-extension/.vscode/launch.json
+++ b/templates/scenarios/ts/m365-message-extension/.vscode/launch.json
@@ -46,12 +46,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot in Teams (Edge)",
+            "name": "Launch App in Teams (Edge)",
             "type": "pwa-msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -60,12 +60,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot in Teams (Chrome)",
+            "name": "Launch App in Teams (Chrome)",
             "type": "pwa-chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -74,12 +74,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot in Outlook (Edge)",
+            "name": "Launch App in Outlook (Edge)",
             "type": "pwa-msedge",
             "request": "launch",
             "url": "https://outlook.office.com/mail?${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -88,12 +88,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot in Outlook (Chrome)",
+            "name": "Launch App in Outlook (Chrome)",
             "type": "pwa-chrome",
             "request": "launch",
             "url": "https://outlook.office.com/mail?${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -102,7 +102,7 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Attach to Bot",
+            "name": "Attach to Local Service",
             "type": "pwa-node",
             "request": "attach",
             "port": 9239,
@@ -118,8 +118,8 @@
         {
             "name": "Debug in Teams (Edge)",
             "configurations": [
-                "Launch Bot in Teams (Edge)",
-                "Attach to Bot"
+                "Launch App in Teams (Edge)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
@@ -131,8 +131,8 @@
         {
             "name": "Debug in Teams (Chrome)",
             "configurations": [
-                "Launch Bot in Teams (Chrome)",
-                "Attach to Bot"
+                "Launch App in Teams (Chrome)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
@@ -144,8 +144,8 @@
         {
             "name": "Debug in Outlook (Edge)",
             "configurations": [
-                "Launch Bot in Outlook (Edge)",
-                "Attach to Bot"
+                "Launch App in Outlook (Edge)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
@@ -157,8 +157,8 @@
         {
             "name": "Debug in Outlook (Chrome)",
             "configurations": [
-                "Launch Bot in Outlook (Chrome)",
-                "Attach to Bot"
+                "Launch App in Outlook (Chrome)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {

--- a/templates/scenarios/ts/m365-message-extension/.vscode/tasks.json
+++ b/templates/scenarios/ts/m365-message-extension/.vscode/tasks.json
@@ -28,8 +28,8 @@
                     "portOccupancy" // Validate available ports to ensure those debug ones are not occupied.
                 ],
                 "portOccupancy": [
-                    3978, // bot service port
-                    9239 // bot inspector port for Node.js debugger
+                    3978, // app service port
+                    9239 // app inspector port for Node.js debugger
                 ]
             }
         },
@@ -77,12 +77,6 @@
         },
         {
             "label": "Start application",
-            "dependsOn": [
-                "Start bot"
-            ]
-        },
-        {
-            "label": "Start bot",
             "type": "shell",
             "command": "npm run dev:teamsfx",
             "isBackground": true,

--- a/templates/scenarios/ts/message-extension/.vscode/launch.json
+++ b/templates/scenarios/ts/message-extension/.vscode/launch.json
@@ -24,12 +24,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Edge)",
+            "name": "Launch App (Edge)",
             "type": "pwa-msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -38,12 +38,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Chrome)",
+            "name": "Launch App (Chrome)",
             "type": "pwa-chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -52,7 +52,7 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Attach to Bot",
+            "name": "Attach to Local Service",
             "type": "pwa-node",
             "request": "attach",
             "port": 9239,
@@ -68,8 +68,8 @@
         {
             "name": "Debug (Edge)",
             "configurations": [
-                "Launch Bot (Edge)",
-                "Attach to Bot"
+                "Launch App (Edge)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
@@ -81,8 +81,8 @@
         {
             "name": "Debug (Chrome)",
             "configurations": [
-                "Launch Bot (Chrome)",
-                "Attach to Bot"
+                "Launch App (Chrome)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {

--- a/templates/scenarios/ts/message-extension/.vscode/tasks.json
+++ b/templates/scenarios/ts/message-extension/.vscode/tasks.json
@@ -28,8 +28,8 @@
                     "portOccupancy" // Validate available ports to ensure those debug ones are not occupied.
                 ],
                 "portOccupancy": [
-                    3978, // bot service port
-                    9239 // bot inspector port for Node.js debugger
+                    3978, // app service port
+                    9239 // app inspector port for Node.js debugger
                 ]
             }
         },
@@ -77,12 +77,6 @@
         },
         {
             "label": "Start application",
-            "dependsOn": [
-                "Start bot"
-            ]
-        },
-        {
-            "label": "Start bot",
             "type": "shell",
             "command": "npm run dev:teamsfx",
             "isBackground": true,

--- a/templates/scenarios/ts/non-sso-tab-default-bot/.vscode/launch.json
+++ b/templates/scenarios/ts/non-sso-tab-default-bot/.vscode/launch.json
@@ -29,7 +29,7 @@
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -43,7 +43,7 @@
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -52,7 +52,7 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Attach to Bot",
+            "name": "Attach to Local Service",
             "type": "pwa-node",
             "request": "attach",
             "port": 9239,
@@ -69,7 +69,7 @@
             "name": "Debug (Edge)",
             "configurations": [
                 "Attach to Frontend (Edge)",
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
@@ -82,7 +82,7 @@
             "name": "Debug (Chrome)",
             "configurations": [
                 "Attach to Frontend (Chrome)",
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {

--- a/templates/scenarios/ts/notification-http-timer-trigger/.vscode/launch.json
+++ b/templates/scenarios/ts/notification-http-timer-trigger/.vscode/launch.json
@@ -24,12 +24,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Edge)",
+            "name": "Launch App (Edge)",
             "type": "pwa-msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -38,12 +38,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Chrome)",
+            "name": "Launch App (Chrome)",
             "type": "pwa-chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -52,7 +52,7 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Attach to Bot",
+            "name": "Attach to Local Service",
             "type": "pwa-node",
             "request": "attach",
             "port": 9239,
@@ -68,8 +68,8 @@
         {
             "name": "Debug (Edge)",
             "configurations": [
-                "Launch Bot (Edge)",
-                "Attach to Bot"
+                "Launch App (Edge)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
@@ -81,8 +81,8 @@
         {
             "name": "Debug (Chrome)",
             "configurations": [
-                "Launch Bot (Chrome)",
-                "Attach to Bot"
+                "Launch App (Chrome)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {

--- a/templates/scenarios/ts/notification-http-timer-trigger/.vscode/tasks.json
+++ b/templates/scenarios/ts/notification-http-timer-trigger/.vscode/tasks.json
@@ -28,8 +28,8 @@
                     "portOccupancy" // Validate available ports to ensure those debug ones are not occupied.
                 ],
                 "portOccupancy": [
-                    3978, // bot service port
-                    9239 // bot inspector port for Node.js debugger
+                    3978, // app service port
+                    9239 // app inspector port for Node.js debugger
                 ]
             }
         },
@@ -77,12 +77,6 @@
         },
         {
             "label": "Start application",
-            "dependsOn": [
-                "Start bot"
-            ]
-        },
-        {
-            "label": "Start bot",
             "type": "shell",
             "command": "npm run dev:teamsfx",
             "isBackground": true,
@@ -107,7 +101,7 @@
             },
             "dependsOn": [
                 "Start Azurite emulator",
-                "Watch bot"
+                "Compile typescript"
             ]
         },
         {
@@ -138,7 +132,7 @@
             }
         },
         {
-            "label": "Watch bot",
+            "label": "Compile typescript",
             "type": "shell",
             "command": "npm run watch:teamsfx",
             "isBackground": true,

--- a/templates/scenarios/ts/notification-http-timer-trigger/src/httpTrigger.ts
+++ b/templates/scenarios/ts/notification-http-timer-trigger/src/httpTrigger.ts
@@ -2,7 +2,7 @@ import { AzureFunction, Context, HttpRequest } from "@azure/functions";
 import { AdaptiveCards } from "@microsoft/adaptivecards-tools";
 import notificationTemplate from "./adaptiveCards/notification-default.json";
 import { CardData } from "./cardModels";
-import { bot } from "./internal/initialize";
+import { notificationApp } from "./internal/initialize";
 
 // An Azure Function HTTP trigger.
 //
@@ -21,7 +21,7 @@ const httpTrigger: AzureFunction = async function (
 ): Promise<void> {
   // By default this function will iterate all the installation points and send an Adaptive Card
   // to every installation.
-  for (const target of await bot.notification.installations()) {
+  for (const target of await notificationApp.notification.installations()) {
     await target.sendAdaptiveCard(
       AdaptiveCards.declare<CardData>(notificationTemplate).render({
         title: "New Event Occurred!",
@@ -78,14 +78,14 @@ const httpTrigger: AzureFunction = async function (
   }
 
   /** You can also find someone and notify the individual person
-  const member = await bot.notification.findMember(
+  const member = await notificationApp.notification.findMember(
     async (m) => m.account.email === "someone@contoso.com"
   );
   await member?.sendAdaptiveCard(...);
   **/
 
   /** Or find multiple people and notify them
-  const members = await bot.notification.findAllMembers(
+  const members = await notificationApp.notification.findAllMembers(
     async (m) => m.account.email?.startsWith("test")
   );
   for (const member of members) {

--- a/templates/scenarios/ts/notification-http-timer-trigger/src/internal/initialize.ts
+++ b/templates/scenarios/ts/notification-http-timer-trigger/src/internal/initialize.ts
@@ -3,7 +3,7 @@ import ConversationBot = BotBuilderCloudAdapter.ConversationBot;
 import config from "./config";
 
 // Create bot.
-export const bot = new ConversationBot({
+export const notificationApp = new ConversationBot({
   // The bot id and password to create CloudAdapter.
   // See https://aka.ms/about-bot-adapter to learn more about adapters.
   adapterConfig: {

--- a/templates/scenarios/ts/notification-http-timer-trigger/src/internal/messageHandler.ts
+++ b/templates/scenarios/ts/notification-http-timer-trigger/src/internal/messageHandler.ts
@@ -1,6 +1,6 @@
 import { AzureFunction, Context, HttpRequest } from "@azure/functions";
 import { TeamsBot } from "../teamsBot";
-import { bot } from "./initialize";
+import { notificationApp } from "./initialize";
 import { ResponseWrapper } from "./responseWrapper";
 
 const httpTrigger: AzureFunction = async function (
@@ -9,7 +9,7 @@ const httpTrigger: AzureFunction = async function (
 ): Promise<any> {
   const res = new ResponseWrapper(context.res);
   const teamsBot = new TeamsBot();
-  await bot.requestHandler(req, res, async (context) => {
+  await notificationApp.requestHandler(req, res, async (context) => {
     await teamsBot.run(context);
   });
   return res.body;

--- a/templates/scenarios/ts/notification-http-timer-trigger/src/timerTrigger.ts
+++ b/templates/scenarios/ts/notification-http-timer-trigger/src/timerTrigger.ts
@@ -2,7 +2,7 @@ import { AzureFunction, Context } from "@azure/functions";
 import { AdaptiveCards } from "@microsoft/adaptivecards-tools";
 import notificationTemplate from "./adaptiveCards/notification-default.json";
 import { CardData } from "./cardModels";
-import { bot } from "./internal/initialize";
+import { notificationApp } from "./internal/initialize";
 
 // An Azure Function timer trigger.
 //
@@ -16,7 +16,7 @@ const timerTrigger: AzureFunction = async function (context: Context, myTimer: a
 
   // By default this function will iterate all the installation points and send an Adaptive Card
   // to every installation.
-  for (const target of await bot.notification.installations()) {
+  for (const target of await notificationApp.notification.installations()) {
     await target.sendAdaptiveCard(
       AdaptiveCards.declare<CardData>(notificationTemplate).render({
         title: "New Event Occurred!",
@@ -73,14 +73,14 @@ const timerTrigger: AzureFunction = async function (context: Context, myTimer: a
   }
 
   /** You can also find someone and notify the individual person
-  const member = await bot.notification.findMember(
+  const member = await notificationApp.notification.findMember(
     async (m) => m.account.email === "someone@contoso.com"
   );
   await member?.sendAdaptiveCard(...);
   **/
 
   /** Or find multiple people and notify them
-  const members = await bot.notification.findAllMembers(
+  const members = await notificationApp.notification.findAllMembers(
     async (m) => m.account.email?.startsWith("test")
   );
   for (const member of members) {

--- a/templates/scenarios/ts/notification-http-trigger/.vscode/launch.json
+++ b/templates/scenarios/ts/notification-http-trigger/.vscode/launch.json
@@ -24,12 +24,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Edge)",
+            "name": "Launch App (Edge)",
             "type": "pwa-msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -38,12 +38,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Chrome)",
+            "name": "Launch App (Chrome)",
             "type": "pwa-chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -52,7 +52,7 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Attach to Bot",
+            "name": "Attach to Local Service",
             "type": "pwa-node",
             "request": "attach",
             "port": 9239,
@@ -68,8 +68,8 @@
         {
             "name": "Debug (Edge)",
             "configurations": [
-                "Launch Bot (Edge)",
-                "Attach to Bot"
+                "Launch App (Edge)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
@@ -81,8 +81,8 @@
         {
             "name": "Debug (Chrome)",
             "configurations": [
-                "Launch Bot (Chrome)",
-                "Attach to Bot"
+                "Launch App (Chrome)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {

--- a/templates/scenarios/ts/notification-http-trigger/.vscode/tasks.json
+++ b/templates/scenarios/ts/notification-http-trigger/.vscode/tasks.json
@@ -28,8 +28,8 @@
                     "portOccupancy" // Validate available ports to ensure those debug ones are not occupied.
                 ],
                 "portOccupancy": [
-                    3978, // bot service port
-                    9239 // bot inspector port for Node.js debugger
+                    3978, // app service port
+                    9239 // app inspector port for Node.js debugger
                 ]
             }
         },
@@ -77,12 +77,6 @@
         },
         {
             "label": "Start application",
-            "dependsOn": [
-                "Start bot"
-            ]
-        },
-        {
-            "label": "Start bot",
             "type": "shell",
             "command": "npm run dev:teamsfx",
             "isBackground": true,
@@ -107,7 +101,7 @@
             },
             "dependsOn": [
                 "Start Azurite emulator",
-                "Watch bot"
+                "Compile typescript"
             ]
         },
         {
@@ -138,7 +132,7 @@
             }
         },
         {
-            "label": "Watch bot",
+            "label": "Compile typescript",
             "type": "shell",
             "command": "npm run watch:teamsfx",
             "isBackground": true,

--- a/templates/scenarios/ts/notification-http-trigger/src/httpTrigger.ts
+++ b/templates/scenarios/ts/notification-http-trigger/src/httpTrigger.ts
@@ -2,7 +2,7 @@ import { AzureFunction, Context, HttpRequest } from "@azure/functions";
 import { AdaptiveCards } from "@microsoft/adaptivecards-tools";
 import notificationTemplate from "./adaptiveCards/notification-default.json";
 import { CardData } from "./cardModels";
-import { bot } from "./internal/initialize";
+import { notificationApp } from "./internal/initialize";
 
 // An Azure Function HTTP trigger.
 //
@@ -21,7 +21,7 @@ const httpTrigger: AzureFunction = async function (
 ): Promise<void> {
   // By default this function will iterate all the installation points and send an Adaptive Card
   // to every installation.
-  for (const target of await bot.notification.installations()) {
+  for (const target of await notificationApp.notification.installations()) {
     await target.sendAdaptiveCard(
       AdaptiveCards.declare<CardData>(notificationTemplate).render({
         title: "New Event Occurred!",
@@ -78,14 +78,14 @@ const httpTrigger: AzureFunction = async function (
   }
 
   /** You can also find someone and notify the individual person
-  const member = await bot.notification.findMember(
+  const member = await notificationApp.notification.findMember(
     async (m) => m.account.email === "someone@contoso.com"
   );
   await member?.sendAdaptiveCard(...);
   **/
 
   /** Or find multiple people and notify them
-  const members = await bot.notification.findAllMembers(
+  const members = await notificationApp.notification.findAllMembers(
     async (m) => m.account.email?.startsWith("test")
   );
   for (const member of members) {

--- a/templates/scenarios/ts/notification-http-trigger/src/internal/initialize.ts
+++ b/templates/scenarios/ts/notification-http-trigger/src/internal/initialize.ts
@@ -3,7 +3,7 @@ import ConversationBot = BotBuilderCloudAdapter.ConversationBot;
 import config from "./config";
 
 // Create bot.
-export const bot = new ConversationBot({
+export const notificationApp = new ConversationBot({
   // The bot id and password to create CloudAdapter.
   // See https://aka.ms/about-bot-adapter to learn more about adapters.
   adapterConfig: {

--- a/templates/scenarios/ts/notification-http-trigger/src/internal/messageHandler.ts
+++ b/templates/scenarios/ts/notification-http-trigger/src/internal/messageHandler.ts
@@ -1,6 +1,6 @@
 import { AzureFunction, Context, HttpRequest } from "@azure/functions";
 import { TeamsBot } from "../teamsBot";
-import { bot } from "./initialize";
+import { notificationApp } from "./initialize";
 import { ResponseWrapper } from "./responseWrapper";
 
 const httpTrigger: AzureFunction = async function (
@@ -9,7 +9,7 @@ const httpTrigger: AzureFunction = async function (
 ): Promise<any> {
   const res = new ResponseWrapper(context.res);
   const teamsBot = new TeamsBot();
-  await bot.requestHandler(req, res, async (context) => {
+  await notificationApp.requestHandler(req, res, async (context) => {
     await teamsBot.run(context);
   });
   return res.body;

--- a/templates/scenarios/ts/notification-restify/.vscode/launch.json
+++ b/templates/scenarios/ts/notification-restify/.vscode/launch.json
@@ -24,12 +24,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Edge)",
+            "name": "Launch App (Edge)",
             "type": "pwa-msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -38,12 +38,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Chrome)",
+            "name": "Launch App (Chrome)",
             "type": "pwa-chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -52,7 +52,7 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Attach to Bot",
+            "name": "Attach to Local Service",
             "type": "pwa-node",
             "request": "attach",
             "port": 9239,
@@ -68,8 +68,8 @@
         {
             "name": "Debug (Edge)",
             "configurations": [
-                "Launch Bot (Edge)",
-                "Attach to Bot"
+                "Launch App (Edge)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
@@ -81,8 +81,8 @@
         {
             "name": "Debug (Chrome)",
             "configurations": [
-                "Launch Bot (Chrome)",
-                "Attach to Bot"
+                "Launch App (Chrome)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {

--- a/templates/scenarios/ts/notification-restify/.vscode/tasks.json
+++ b/templates/scenarios/ts/notification-restify/.vscode/tasks.json
@@ -28,8 +28,8 @@
                     "portOccupancy" // Validate available ports to ensure those debug ones are not occupied.
                 ],
                 "portOccupancy": [
-                    3978, // bot service port
-                    9239 // bot inspector port for Node.js debugger
+                    3978, // app service port
+                    9239 // app inspector port for Node.js debugger
                 ]
             }
         },
@@ -77,12 +77,6 @@
         },
         {
             "label": "Start application",
-            "dependsOn": [
-                "Start bot"
-            ]
-        },
-        {
-            "label": "Start bot",
             "type": "shell",
             "command": "npm run dev:teamsfx",
             "isBackground": true,

--- a/templates/scenarios/ts/notification-timer-trigger/.vscode/launch.json
+++ b/templates/scenarios/ts/notification-timer-trigger/.vscode/launch.json
@@ -24,12 +24,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Edge)",
+            "name": "Launch App (Edge)",
             "type": "pwa-msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -38,12 +38,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Chrome)",
+            "name": "Launch App (Chrome)",
             "type": "pwa-chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -52,7 +52,7 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Attach to Bot",
+            "name": "Attach to Local Service",
             "type": "pwa-node",
             "request": "attach",
             "port": 9239,
@@ -68,8 +68,8 @@
         {
             "name": "Debug (Edge)",
             "configurations": [
-                "Launch Bot (Edge)",
-                "Attach to Bot"
+                "Launch App (Edge)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
@@ -81,8 +81,8 @@
         {
             "name": "Debug (Chrome)",
             "configurations": [
-                "Launch Bot (Chrome)",
-                "Attach to Bot"
+                "Launch App (Chrome)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {

--- a/templates/scenarios/ts/notification-timer-trigger/.vscode/tasks.json
+++ b/templates/scenarios/ts/notification-timer-trigger/.vscode/tasks.json
@@ -28,8 +28,8 @@
                     "portOccupancy" // Validate available ports to ensure those debug ones are not occupied.
                 ],
                 "portOccupancy": [
-                    3978, // bot service port
-                    9239 // bot inspector port for Node.js debugger
+                    3978, // app service port
+                    9239 // app inspector port for Node.js debugger
                 ]
             }
         },
@@ -77,12 +77,6 @@
         },
         {
             "label": "Start application",
-            "dependsOn": [
-                "Start bot"
-            ]
-        },
-        {
-            "label": "Start bot",
             "type": "shell",
             "command": "npm run dev:teamsfx",
             "isBackground": true,
@@ -107,7 +101,7 @@
             },
             "dependsOn": [
                 "Start Azurite emulator",
-                "Watch bot"
+                "Compile typescript"
             ]
         },
         {
@@ -138,7 +132,7 @@
             }
         },
         {
-            "label": "Watch bot",
+            "label": "Compile typescript",
             "type": "shell",
             "command": "npm run watch:teamsfx",
             "isBackground": true,

--- a/templates/scenarios/ts/notification-timer-trigger/src/internal/initialize.ts
+++ b/templates/scenarios/ts/notification-timer-trigger/src/internal/initialize.ts
@@ -3,7 +3,7 @@ import ConversationBot = BotBuilderCloudAdapter.ConversationBot;
 import config from "./config";
 
 // Create bot.
-export const bot = new ConversationBot({
+export const notificationApp = new ConversationBot({
   // The bot id and password to create CloudAdapter.
   // See https://aka.ms/about-bot-adapter to learn more about adapters.
   adapterConfig: {

--- a/templates/scenarios/ts/notification-timer-trigger/src/internal/messageHandler.ts
+++ b/templates/scenarios/ts/notification-timer-trigger/src/internal/messageHandler.ts
@@ -1,6 +1,6 @@
 import { AzureFunction, Context, HttpRequest } from "@azure/functions";
 import { TeamsBot } from "../teamsBot";
-import { bot } from "./initialize";
+import { notificationApp } from "./initialize";
 import { ResponseWrapper } from "./responseWrapper";
 
 const httpTrigger: AzureFunction = async function (
@@ -9,7 +9,7 @@ const httpTrigger: AzureFunction = async function (
 ): Promise<any> {
   const res = new ResponseWrapper(context.res);
   const teamsBot = new TeamsBot();
-  await bot.requestHandler(req, res, async (context) => {
+  await notificationApp.requestHandler(req, res, async (context) => {
     await teamsBot.run(context);
   });
   return res.body;

--- a/templates/scenarios/ts/notification-timer-trigger/src/timerTrigger.ts
+++ b/templates/scenarios/ts/notification-timer-trigger/src/timerTrigger.ts
@@ -2,7 +2,7 @@ import { AzureFunction, Context } from "@azure/functions";
 import { AdaptiveCards } from "@microsoft/adaptivecards-tools";
 import notificationTemplate from "./adaptiveCards/notification-default.json";
 import { CardData } from "./cardModels";
-import { bot } from "./internal/initialize";
+import { notificationApp } from "./internal/initialize";
 
 // An Azure Function timer trigger.
 //
@@ -16,7 +16,7 @@ const timerTrigger: AzureFunction = async function (context: Context, myTimer: a
 
   // By default this function will iterate all the installation points and send an Adaptive Card
   // to every installation.
-  for (const target of await bot.notification.installations()) {
+  for (const target of await notificationApp.notification.installations()) {
     await target.sendAdaptiveCard(
       AdaptiveCards.declare<CardData>(notificationTemplate).render({
         title: "New Event Occurred!",
@@ -73,14 +73,14 @@ const timerTrigger: AzureFunction = async function (context: Context, myTimer: a
   }
 
   /** You can also find someone and notify the individual person
-  const member = await bot.notification.findMember(
+  const member = await notificationApp.notification.findMember(
     async (m) => m.account.email === "someone@contoso.com"
   );
   await member?.sendAdaptiveCard(...);
   **/
 
   /** Or find multiple people and notify them
-  const members = await bot.notification.findAllMembers(
+  const members = await notificationApp.notification.findAllMembers(
     async (m) => m.account.email?.startsWith("test")
   );
   for (const member of members) {

--- a/templates/scenarios/ts/workflow/.vscode/launch.json
+++ b/templates/scenarios/ts/workflow/.vscode/launch.json
@@ -24,12 +24,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Edge)",
+            "name": "Launch App (Edge)",
             "type": "pwa-msedge",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -38,12 +38,12 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Launch Bot (Chrome)",
+            "name": "Launch App (Chrome)",
             "type": "pwa-chrome",
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${local:teamsAppId}?installAppPackage=true&webjoin=true&${account-hint}",
             "cascadeTerminateToConfigurations": [
-                "Attach to Bot"
+                "Attach to Local Service"
             ],
             "presentation": {
                 "group": "all",
@@ -52,7 +52,7 @@
             "internalConsoleOptions": "neverOpen"
         },
         {
-            "name": "Attach to Bot",
+            "name": "Attach to Local Service",
             "type": "pwa-node",
             "request": "attach",
             "port": 9239,
@@ -68,8 +68,8 @@
         {
             "name": "Debug (Edge)",
             "configurations": [
-                "Launch Bot (Edge)",
-                "Attach to Bot"
+                "Launch App (Edge)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
@@ -81,8 +81,8 @@
         {
             "name": "Debug (Chrome)",
             "configurations": [
-                "Launch Bot (Chrome)",
-                "Attach to Bot"
+                "Launch App (Chrome)",
+                "Attach to Local Service"
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {

--- a/templates/scenarios/ts/workflow/.vscode/tasks.json
+++ b/templates/scenarios/ts/workflow/.vscode/tasks.json
@@ -28,8 +28,8 @@
                     "portOccupancy" // Validate available ports to ensure those debug ones are not occupied.
                 ],
                 "portOccupancy": [
-                    3978, // bot service port
-                    9239 // bot inspector port for Node.js debugger
+                    3978, // app service port
+                    9239 // app inspector port for Node.js debugger
                 ]
             }
         },
@@ -77,12 +77,6 @@
         },
         {
             "label": "Start application",
-            "dependsOn": [
-                "Start bot"
-            ]
-        },
-        {
-            "label": "Start bot",
             "type": "shell",
             "command": "npm run dev:teamsfx",
             "isBackground": true,


### PR DESCRIPTION
workitem: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/17397031/

- Avoid using `bot` to describe the local service since it's just a web service, not limited to bot
- Using `notificationApp` instead of `bot` in source code, to align with other scenarios

This PR applies to v5 templates. Sample change will be in another PR.