### PR TITLE
chore: init app studoi telemetry if creating app from TDP

### DIFF
--- a/packages/fx-core/src/component/developerPortalScaffoldUtils.ts
+++ b/packages/fx-core/src/component/developerPortalScaffoldUtils.ts
@@ -47,6 +47,7 @@ import {
   needTabAndBotCode,
   needTabCode,
 } from "./resource/appManifest/utils/utils";
+import { TelemetryUtils } from "./resource/appManifest/utils/telemetry";
 
 const appPackageFolderName = "appPackage";
 const colorFileName = "color.png";
@@ -94,6 +95,7 @@ async function updateManifest(
   appDefinition: AppDefinition,
   inputs: Inputs
 ): Promise<Result<undefined, FxError>> {
+  TelemetryUtils.init(ctx);
   const res = await appStudio.getAppPackage(
     appDefinition.teamsAppId!,
     ctx.tokenProvider!.m365TokenProvider,


### PR DESCRIPTION
work item: [Bug 17449612](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/17449612): Create project from TDP would fail in VS if using new prerelease of fxcore

need to init telemetry for appStudio API when calling for project scaffolding from TDP