### PR TITLE
test(e2e): add e2e test for debug

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,6 +41,8 @@
 /packages/cli/tests/e2e/scaffold @hund030 @eriolchan @IvanJobs
 /packages/cli/tests/e2e/multienv @a1exwang @dooriya @qinezh @xiaolang124 @kimizhu
 /packages/cli/tests/e2e/keyvault @adashen @formulahendry @xzf0587
+/packages/cli/tests/e2e/m365 @kimizhu @swatDong @kuojianlu
+/packages/cli/tests/e2e/debug @kimizhu @swatDong @kuojianlu
 /packages/cli/tests/unit/commonlib @kimizhu @swatDong @kuojianlu @a1exwang @qinezh @XiaofuHuang @xiaolang124 @dooriya
 /packages/cli/tests/unit/cmds/preview @swatDong @kuojianlu @qinezh @a1exwang
 /packages/cli/tests/unit/cmds/m365 @swatDong @kuojianlu @kimizhu

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -256,6 +256,10 @@ jobs:
         with:
           node-version: 16
 
+      - name: Setup Azure Functions Core Tools For Linux
+        run: |
+          sudo npm install --unsafe-perm -g azure-functions-core-tools@4
+
       - name: Setup legacy-peer-deps
         run: |
           npm config set legacy-peer-deps true
@@ -309,6 +313,8 @@ jobs:
           TEAMSFX_V3: "true"
           TEAMSFX_DEBUG_TEMPLATE: "true"
           NODE_ENV: "development"
+          SIDELOADING_SERVICE_ENDPOINT: ${{ secrets.SIDELOADING_SERVICE_ENDPOINT }}
+          SIDELOADING_SERVICE_SCOPE: ${{ secrets.SIDELOADING_SERVICE_SCOPE }}
         run: |
           file=`find . -wholename "${{ matrix.cases }}"`
           if [ -z "$file" ]; then

--- a/packages/cli/tests/e2e/debug/DebugNotificationHttpTrigger.tests.ts
+++ b/packages/cli/tests/e2e/debug/DebugNotificationHttpTrigger.tests.ts
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as chai from "chai";
+import { describe } from "mocha";
+import * as path from "path";
+
+import { it } from "@microsoft/extra-shot-mocha";
+import { isV3Enabled } from "@microsoft/teamsfx-core/build/common/tools";
+import { envUtil } from "@microsoft/teamsfx-core/build/component/utils/envUtil";
+import { setTools } from "@microsoft/teamsfx-core/build/core/globalVars";
+
+import { CliHelper } from "../../commonlib/cliHelper";
+import { Capability } from "../../commonlib/constants";
+import { cleanUpLocalProject, getTestFolder, getUniqueAppName } from "../commonUtils";
+import { deleteAadAppByClientId, deleteBot, deleteTeamsApp } from "./clean";
+
+describe("Debug V3 notification-http-trigger template", () => {
+  const testFolder = getTestFolder();
+  const appName = getUniqueAppName();
+  const projectPath = path.resolve(testFolder, appName);
+
+  setTools({} as any);
+
+  afterEach(async function () {
+    if (!isV3Enabled()) {
+      this.skip();
+    }
+
+    const envRes = await envUtil.readEnv(projectPath, "local", false);
+    chai.assert.isTrue(envRes.isOk());
+    if (envRes.isOk()) {
+      await deleteTeamsApp(envRes.value.TEAMS_APP_ID);
+      await deleteBot(envRes.value.BOT_ID);
+      await deleteAadAppByClientId(envRes.value.BOT_ID);
+    }
+    await cleanUpLocalProject(projectPath);
+  });
+
+  it("happy path: provision and deploy", { testPlanCaseId: 17449529 }, async function () {
+    if (!isV3Enabled()) {
+      this.skip();
+    }
+
+    await CliHelper.createProjectWithCapability(
+      appName,
+      testFolder,
+      Capability.Notification,
+      undefined,
+      "--bot-host-type-trigger http-functions"
+    );
+    console.log(`[Successfully] scaffold to ${projectPath}`);
+
+    await CliHelper.provisionProject(
+      projectPath,
+      "--env local",
+      Object.assign({}, process.env, {
+        BOT_DOMAIN: "test.ngrok.io",
+        BOT_ENDPOINT: "https://test.ngrok.io",
+      })
+    );
+    const envRes = await envUtil.readEnv(projectPath, "local", false);
+    chai.assert.isTrue(envRes.isOk());
+    if (envRes.isOk()) {
+      chai.assert.isTrue(
+        envRes.value.TEAMS_APP_ID !== undefined && envRes.value.TEAMS_APP_ID !== ""
+      );
+      chai.assert.isTrue(envRes.value.BOT_ID !== undefined && envRes.value.BOT_ID !== "");
+    }
+    console.log(`[Successfully] provision for ${projectPath}`);
+
+    await CliHelper.deployAll(projectPath, "--env local");
+    console.log(`[Successfully] deploy for ${projectPath}`);
+  });
+});

--- a/packages/cli/tests/e2e/debug/DebugSsoTab.tests.ts
+++ b/packages/cli/tests/e2e/debug/DebugSsoTab.tests.ts
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as chai from "chai";
+import { describe } from "mocha";
+import * as path from "path";
+
+import { it } from "@microsoft/extra-shot-mocha";
+import { isV3Enabled } from "@microsoft/teamsfx-core/build/common/tools";
+import { envUtil } from "@microsoft/teamsfx-core/build/component/utils/envUtil";
+import { setTools } from "@microsoft/teamsfx-core/build/core/globalVars";
+
+import { CliHelper } from "../../commonlib/cliHelper";
+import { Capability } from "../../commonlib/constants";
+import { cleanUpLocalProject, getTestFolder, getUniqueAppName } from "../commonUtils";
+import { deleteAadAppByObjectId, deleteTeamsApp } from "./clean";
+
+describe("Debug V3 sso-tab template", () => {
+  const testFolder = getTestFolder();
+  const appName = getUniqueAppName();
+  const projectPath = path.resolve(testFolder, appName);
+
+  setTools({} as any);
+
+  afterEach(async function () {
+    if (!isV3Enabled()) {
+      this.skip();
+    }
+
+    const envRes = await envUtil.readEnv(projectPath, "local", false);
+    chai.assert.isTrue(envRes.isOk());
+    if (envRes.isOk()) {
+      await deleteTeamsApp(envRes.value.TEAMS_APP_ID);
+      await deleteAadAppByObjectId(envRes.value.AAD_APP_OBJECT_ID);
+    }
+    await cleanUpLocalProject(projectPath);
+  });
+
+  it("happy path: provision and deploy", { testPlanCaseId: 17449525 }, async function () {
+    if (!isV3Enabled()) {
+      this.skip();
+    }
+
+    await CliHelper.createProjectWithCapability(appName, testFolder, Capability.Tab);
+    console.log(`[Successfully] scaffold to ${projectPath}`);
+
+    await CliHelper.provisionProject(projectPath, "--env local");
+    const envRes = await envUtil.readEnv(projectPath, "local", false);
+    chai.assert.isTrue(envRes.isOk());
+    if (envRes.isOk()) {
+      chai.assert.isTrue(
+        envRes.value.TEAMS_APP_ID !== undefined && envRes.value.TEAMS_APP_ID !== ""
+      );
+      chai.assert.isTrue(
+        envRes.value.AAD_APP_OBJECT_ID !== undefined && envRes.value.AAD_APP_OBJECT_ID !== ""
+      );
+    }
+    console.log(`[Successfully] provision for ${projectPath}`);
+
+    await CliHelper.deployAll(projectPath, "--env local");
+    console.log(`[Successfully] deploy for ${projectPath}`);
+  });
+});

--- a/packages/cli/tests/e2e/debug/clean.ts
+++ b/packages/cli/tests/e2e/debug/clean.ts
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import m365Provider from "../../../src/commonlib/m365LoginUserPassword";
+import { AppStudioScopes } from "@microsoft/teamsfx-core/build/common/tools";
+import axios, { AxiosInstance } from "axios";
+
+async function createRequester(): Promise<AxiosInstance> {
+  const appStudioTokenRes = await m365Provider.getAccessToken({ scopes: AppStudioScopes });
+  const appStudioToken = appStudioTokenRes.isOk() ? appStudioTokenRes.value : undefined;
+  const requester = axios.create({
+    baseURL: "https://dev.teams.microsoft.com",
+  });
+  requester.defaults.headers.common["Authorization"] = `Bearer ${appStudioToken}`;
+  return requester;
+}
+
+export async function deleteAadAppByObjectId(objectId: string) {
+  const requester = await createRequester();
+  for (let retries = 3; retries > 0; --retries) {
+    try {
+      const response = await requester.delete(`api/aadapp/v2/${objectId}`);
+      if (response.status >= 200 && response.status < 300) {
+        console.log("Successfully deleted AAD app");
+        return;
+      }
+    } catch (e) {
+      console.log(`Failed to delete AAD app, error: ${e}`);
+    }
+  }
+}
+
+export async function deleteAadAppByClientId(clientId: string) {
+  const requester = await createRequester();
+  let objectId: string | undefined = undefined;
+  for (let retries = 3; retries > 0; --retries) {
+    try {
+      const response = await requester.get(`api/aadapp/${clientId}`);
+      if (response.status >= 200 && response.status < 300) {
+        console.log("Successfully got AAD app");
+        objectId = response.data.id;
+        break;
+      }
+    } catch (e) {
+      console.log(`Failed to get AAD app, error: ${e}`);
+    }
+  }
+  if (objectId) {
+    await deleteAadAppByObjectId(objectId);
+  }
+}
+
+export async function deleteBot(botId: string) {
+  const requester = await createRequester();
+  for (let retries = 3; retries > 0; --retries) {
+    try {
+      const response = await requester.delete(`/api/botframework/${botId}`);
+      if (response.status >= 200 && response.status < 300) {
+        console.log("Successfully deleted bot");
+        return;
+      }
+    } catch (e) {
+      console.log(`Failed to delete bot, error: ${e}`);
+    }
+  }
+}
+
+export async function deleteTeamsApp(teamsAppId: string) {
+  const requester = await createRequester();
+  for (let retries = 3; retries > 0; --retries) {
+    try {
+      const response = await requester.delete(`/api/appdefinitions/${teamsAppId}`);
+      if (response.status >= 200 && response.status < 300) {
+        console.log("Successfully deleted Teams app");
+        return;
+      }
+    } catch (e) {
+      console.log(`Failed to delete Teams app, error: ${e}`);
+    }
+  }
+}

--- a/packages/cli/tests/e2e/m365/DebugM365MessageExtension.tests.ts
+++ b/packages/cli/tests/e2e/m365/DebugM365MessageExtension.tests.ts
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as chai from "chai";
+import { describe } from "mocha";
+import * as path from "path";
+
+import { it } from "@microsoft/extra-shot-mocha";
+import { isV3Enabled } from "@microsoft/teamsfx-core/build/common/tools";
+import { envUtil } from "@microsoft/teamsfx-core/build/component/utils/envUtil";
+import { setTools } from "@microsoft/teamsfx-core/build/core/globalVars";
+
+import { CliHelper } from "../../commonlib/cliHelper";
+import { Capability } from "../../commonlib/constants";
+import { cleanUpLocalProject, getTestFolder, getUniqueAppName } from "../commonUtils";
+import { deleteAadAppByClientId, deleteBot, deleteTeamsApp } from "../debug/clean";
+
+describe("Debug V3 m365-message-extension template", () => {
+  const testFolder = getTestFolder();
+  const appName = getUniqueAppName();
+  const projectPath = path.resolve(testFolder, appName);
+
+  setTools({} as any);
+
+  afterEach(async function () {
+    if (!isV3Enabled()) {
+      this.skip();
+    }
+
+    const envRes = await envUtil.readEnv(projectPath, "local", false);
+    chai.assert.isTrue(envRes.isOk());
+    if (envRes.isOk()) {
+      await deleteTeamsApp(envRes.value.TEAMS_APP_ID);
+      await deleteBot(envRes.value.BOT_ID);
+      await deleteAadAppByClientId(envRes.value.BOT_ID);
+    }
+    await cleanUpLocalProject(projectPath);
+  });
+
+  it("happy path: provision and deploy", { testPlanCaseId: 17449538 }, async function () {
+    if (!isV3Enabled()) {
+      this.skip();
+    }
+
+    await CliHelper.createProjectWithCapability(appName, testFolder, Capability.M365SearchApp);
+    console.log(`[Successfully] scaffold to ${projectPath}`);
+
+    await CliHelper.provisionProject(
+      projectPath,
+      "--env local",
+      Object.assign({}, process.env, {
+        BOT_DOMAIN: "test.ngrok.io",
+        BOT_ENDPOINT: "https://test.ngrok.io",
+      })
+    );
+    const envRes = await envUtil.readEnv(projectPath, "local", false);
+    chai.assert.isTrue(envRes.isOk());
+    if (envRes.isOk()) {
+      chai.assert.isTrue(
+        envRes.value.TEAMS_APP_ID !== undefined && envRes.value.TEAMS_APP_ID !== ""
+      );
+      chai.assert.isTrue(envRes.value.BOT_ID !== undefined && envRes.value.BOT_ID !== "");
+    }
+    console.log(`[Successfully] provision for ${projectPath}`);
+
+    await CliHelper.deployAll(projectPath, "--env local");
+    console.log(`[Successfully] deploy for ${projectPath}`);
+  });
+});

--- a/packages/cli/tests/e2e/m365/DebugM365Tab.tests.ts
+++ b/packages/cli/tests/e2e/m365/DebugM365Tab.tests.ts
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as chai from "chai";
+import { describe } from "mocha";
+import * as path from "path";
+
+import { it } from "@microsoft/extra-shot-mocha";
+import { isV3Enabled } from "@microsoft/teamsfx-core/build/common/tools";
+import { envUtil } from "@microsoft/teamsfx-core/build/component/utils/envUtil";
+import { setTools } from "@microsoft/teamsfx-core/build/core/globalVars";
+
+import { CliHelper } from "../../commonlib/cliHelper";
+import { Capability } from "../../commonlib/constants";
+import { cleanUpLocalProject, getTestFolder, getUniqueAppName } from "../commonUtils";
+import { deleteAadAppByObjectId, deleteTeamsApp } from "../debug/clean";
+
+describe("Debug V3 m365-tab template", () => {
+  const testFolder = getTestFolder();
+  const appName = getUniqueAppName();
+  const projectPath = path.resolve(testFolder, appName);
+
+  setTools({} as any);
+
+  afterEach(async function () {
+    if (!isV3Enabled()) {
+      this.skip();
+    }
+
+    const envRes = await envUtil.readEnv(projectPath, "local", false);
+    chai.assert.isTrue(envRes.isOk());
+    if (envRes.isOk()) {
+      await deleteTeamsApp(envRes.value.TEAMS_APP_ID);
+      await deleteAadAppByObjectId(envRes.value.AAD_APP_OBJECT_ID);
+    }
+    await cleanUpLocalProject(projectPath);
+  });
+
+  it("happy path: provision and deploy", { testPlanCaseId: 17449535 }, async function () {
+    if (!isV3Enabled()) {
+      this.skip();
+    }
+
+    await CliHelper.createProjectWithCapability(appName, testFolder, Capability.M365SsoLaunchPage);
+    console.log(`[Successfully] scaffold to ${projectPath}`);
+
+    await CliHelper.provisionProject(projectPath, "--env local");
+    const envRes = await envUtil.readEnv(projectPath, "local", false);
+    chai.assert.isTrue(envRes.isOk());
+    if (envRes.isOk()) {
+      chai.assert.isTrue(
+        envRes.value.TEAMS_APP_ID !== undefined && envRes.value.TEAMS_APP_ID !== ""
+      );
+      chai.assert.isTrue(
+        envRes.value.AAD_APP_OBJECT_ID !== undefined && envRes.value.AAD_APP_OBJECT_ID !== ""
+      );
+    }
+    console.log(`[Successfully] provision for ${projectPath}`);
+
+    await CliHelper.deployAll(projectPath, "--env local");
+    console.log(`[Successfully] deploy for ${projectPath}`);
+  });
+});


### PR DESCRIPTION
- add e2e test for sso-tab, notification-http-trigger debug
- add e2e test for m365-tab m365-message-extension debug
- update code owners
- add azure functions installation in e2e-test.yml
- add env for sideloading service in e2e-test.yml