### PR TITLE
chore: update dev-assist-dashboard id and time

### DIFF
--- a/packages/fx-core/src/common/samples-config-v3.json
+++ b/packages/fx-core/src/common/samples-config-v3.json
@@ -187,12 +187,12 @@
           "suggested": false
         },
         {
-            "id": "dev-assist-dashboard",
+            "id": "developer-assist-dashboard",
             "title": "Developer Assist Dashboard",
             "shortDescription": "A dashboard that integrates with Azure DevOps, Github issues and Planner tasks that accelerates developer productivity.",
             "fullDescription": "A dashboard that integrates with Azure DevOps, Github issues and Planner tasks that accelerates developer productivity.",
             "tags": ["Outlook", "Office", "TS"],
-            "time": "10min to run",
+            "time": "15min to run",
             "configuration": "Manual configurations required",
             "suggested": false
           }

--- a/packages/vscode-extension/src/controls/SampleGallery.tsx
+++ b/packages/vscode-extension/src/controls/SampleGallery.tsx
@@ -60,7 +60,7 @@ const imageMapping: { [p: string]: any } = {
   "deep-linking-hello-world-tab-without-sso-M365": DeepLinking,
   "team-central-dashboard": DashboardTab,
   "hello-world-teams-tab-and-outlook-add-in": TeamsTabAndOutlookAddin,
-  "dev-assist-dashboard": DevAssistDashboard,
+  "developer-assist-dashboard": DevAssistDashboard,
 };
 
 export default class SampleGallery extends React.Component<any, any> {


### PR DESCRIPTION
The sample id (dev-assist-dashboard) is initially set according to https://github.com/aycabas/dev-assist-dashboard. But when the PR is raised against Teamsfx-sample repo, the id is set as 'developer-assist-dashboard' (https://github.com/OfficeDev/TeamsFx-Samples/pull/715). So need to update it to avoid download error