### PR TITLE
chore: adjust duration

### DIFF
--- a/packages/fx-core/src/component/driver/botAadApp/create.ts
+++ b/packages/fx-core/src/component/driver/botAadApp/create.ts
@@ -7,7 +7,7 @@ import { Service } from "typedi";
 import { CreateBotAadAppArgs } from "./interface/createBotAadAppArgs";
 import { CreateBotAadAppOutput } from "./interface/createBotAadAppOutput";
 import { FxError, Result, SystemError, UserError } from "@microsoft/teamsfx-api";
-import Timer from "@dbpiper/timer";
+import { performance } from "perf_hooks";
 import { InvalidParameterUserError } from "./error/invalidParameterUserError";
 import { UnhandledSystemError, UnhandledUserError } from "./error/unhandledError";
 import axios from "axios";
@@ -85,8 +85,7 @@ export class CreateBotAadAppDriver implements StepDriver {
       const botRegistration: BotRegistration = new RemoteBotRegistration();
 
       await progressHandler?.next(getLocalizedString(progressBarKeys.creatingBotAadApp));
-      const timer = new Timer();
-      timer.start();
+      const startTime = performance.now();
       const createRes = await botRegistration.createBotRegistration(
         context.m365TokenProvider,
         args.name,
@@ -94,7 +93,7 @@ export class CreateBotAadAppDriver implements StepDriver {
         botConfig,
         context.logProvider
       );
-      const timeResult = timer.stop();
+      const durationMilliSeconds = performance.now() - startTime;
       if (createRes.isErr()) {
         throw createRes.error;
       }
@@ -116,7 +115,7 @@ export class CreateBotAadAppDriver implements StepDriver {
       );
       context.telemetryReporter.sendTelemetryEvent(successRegisterBotAad, {
         [propertyKeys.reusingExistingBotAad]: isReusingExisting.toString(),
-        [propertyKeys.registerBotAadTime]: timeResult.milliseconds.toString(),
+        [propertyKeys.registerBotAadTime]: durationMilliSeconds.toString(),
       });
       return {
         output: new Map([


### PR DESCRIPTION
`timeResult.milliseconds` is not what we expected.
It's just part of the overall duration and the right number should be:
`... + 1000 * timeResult.seconds + timeResult.milliseconds`.
So change to use `perf_hooks` which has a more natural APIs.

To fix https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/17519958.

@microsoft/adaptivecards-tools	v1.4.0-rc.0
@microsoft/teamsfx-api	v0.22.2-rc.0
@microsoft/teamsfx-cli	v1.2.5-rc.0
@microsoft/teamsfx-core	v1.24.0-rc.0
@microsoft/teams-manifest	v0.0.10-rc.0
@microsoft/metrics-ts	v0.0.4-rc.0
@microsoft/teamsfx	v2.3.0-rc.0
@microsoft/teamsfx-react	v3.0.0-rc.0
ms-teams-vscode-extension	v4.3.0-rc.0

CLI BREAKING CHANGE:
  

Extension-toolkit BREAKING CHANGE:
 

CLI feat commits:
 feat(vsc): account help itp (#6808) a64e8650d
feat: upgrade SPFx version to 1.16 2d4cb7812
feat(video-filter): add VxTestAppChecker boilerplate code (#6757) 8e5aa6cb8
feat(sdk-react): update to sdk 2.0 and merge useTeams (#6362) 6dcf1320c
feat: up ff8539a61
feat: up 9716235ec
feat(cli): support new/add capability for workflow bot (#6008) 46663f250
feat: up (#5697) c00520609
feat: up (#5677) f4b2f935a
feat: prompt user to upgrade spfx project or toolkit to match spfx ve… (#5642) 0f8ca327c 

Extension-toolkit feat commits:
 feat: onboard dev-assist-dashboard sample cf8be4865
feat: add debug task to launch Teams web client for codespaces (#7938) e754914ab
feat: validate against app package (#7753) 0b99cd614
feat(localdebug): init basis tunnel service task (#7899) c3e56206c
feat: new feedback survey and add feedback section in treeview (#7663) 31f71e5fa
feat(vsc): support V3 migration (#7419) f7a8ef9d3
feat: localization part 1 (#7391) a893cc649
feat(vsc): account help itp (#6808) a64e8650d
feat(vsc): support openFile API (#7149) ee1653316
feat(vsc): codelens crypto support for v3 (#7106) c6814c6c4
feat: upgrade SPFx version to 1.16 2d4cb7812
feat: add tutorial entry for dashboard scenario 0ef5a5316
feat: remove spfx version select configuration and related code logic 8c266f8ad
feat(vsc): change "Tutorials" to "How-to guides" (#6965) d61be28f3
feat(sample): add sample app for video filter (#6924) c77eb6917
feat: onboard deeplinking sample app 9f852e948
feat(vsc): v3 add "Add Environment" command in development view (#6820) 1ad44e96d
feat(video-filter): add installOptions for dependency checker (#6773) 5059aa34b
feat(video-filter): add VxTestAppChecker boilerplate code (#6757) 8e5aa6cb8
feat(vsc): remove subscription node and adapt to new API in v3 (#6755) c79be147e
feat: up (#6741) 663a58586
feat(vsc): add in-product guide (#6703) 5b8e93cb3
feat(templates): update templates to use SDK v2 (#6404) a0b5241bc
feat: update sdk to use teamsjs v2 (#6195) 7e5ed2148
feat(vsc): add support for untrusted workspace (#6279) 540807041
feat(vsc): add tutorial for card action response (#6261) 242e92b52
feat: support both spfx 1.15 and 1.16 beta  (#6150) 0d532389e
feat: onboard stock update sample app (#5856) 494f4b6f3
feat(vsc): add preview command in treeview to run F5 directly in A/B test (#5878) d9048ba59
feat(vsc): open created project in new window by default (#5870) 83d3dc316
feat: notification when switch account for local debug in vs code (#5781) cfe223dbc
feat: prompt user to upgrade spfx project or toolkit to match spfx ve… (#5642) 0f8ca327c
feat: enable switch tenant for local debug (#5637) ae549cb45