### PR TITLE
chore: migrate with new action name

### DIFF
--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -1020,7 +1020,7 @@
   "driver.teamsApp.summary.validate": "Teams Toolkit has checked against all validation rules:\n\nSummary:\n%s failed, %s passed.\n%s\n%s\n\nA complete log of validations can be found in %s",
   "driver.teamsApp.validate.skip": "%s action is currently skipped, will be updated in the future version.",
   "driver.teamsApp.invalidParameter": "Following parameter is missing or invalid for %s action: %s.",
-  "driver.teamsApp.validate.invalidParameter": "Either %s or %s parameter should be provided for action %s",
+  "driver.teamsApp.validate.invalidParameter": "Parameter %s should be provided for action %s",
   "driver.teamsApp.validate.result": "Teams Toolkit has completed checking your app package against validation rules. %s failed, %s passed. Check [output window](%s) for details.",
   "driver.botFramework.error.invalidParameter": "Following parameter is missing or invalid for %s action: %s.",
   "driver.botFramework.error.unhandledError": "Unhandled error happened in %s action: %s",

--- a/packages/fx-core/templates/core/v3Migration/csharp.app.local.yml
+++ b/packages/fx-core/templates/core/v3Migration/csharp.app.local.yml
@@ -83,7 +83,7 @@ configureApp:
   # Output: following environment variable will be persisted in current environment's .env file.
   # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 {{/if}}
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value

--- a/packages/fx-core/templates/core/v3Migration/csharp.app.yml
+++ b/packages/fx-core/templates/core/v3Migration/csharp.app.yml
@@ -88,7 +88,7 @@ configureApp:
   # Output: following environment variable will be persisted in current environment's .env file.
   # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 {{/if}}
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value

--- a/packages/fx-core/templates/core/v3Migration/js.ts.app.local.yml
+++ b/packages/fx-core/templates/core/v3Migration/js.ts.app.local.yml
@@ -77,7 +77,7 @@ configureApp:
     # Output: following environment variable will be persisted in current environment's .env file.
     # TEAMS_APP_ID: the id of Teams app
   {{else}}
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
 

--- a/packages/fx-core/templates/core/v3Migration/js.ts.app.yml
+++ b/packages/fx-core/templates/core/v3Migration/js.ts.app.yml
@@ -171,7 +171,7 @@ configureApp:
   # Output: following environment variable will be persisted in current environment's .env file.
   # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 {{/if}}
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
@@ -186,7 +186,7 @@ configureApp:
     # TEAMS_APP_ID: the id of Teams app
 
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/packages/fx-core/templates/core/v3Migration/spfx.app.yml
+++ b/packages/fx-core/templates/core/v3Migration/spfx.app.yml
@@ -28,7 +28,7 @@ registerApp:
     # TEAMS_APP_ID: the id of Teams app
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
@@ -43,7 +43,7 @@ configureApp:
     # TEAMS_APP_ID: the id of Teams app
 
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/csharpFunctionBot/expectedResult/app.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/csharpFunctionBot/expectedResult/app.yml
@@ -41,7 +41,7 @@ registerApp:
     # TEAMS_APP_ID: the id of Teams app
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/csharpNonSsoTab/expectedResult/app.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/csharpNonSsoTab/expectedResult/app.yml
@@ -39,7 +39,7 @@ registerApp:
     # TEAMS_APP_ID: the id of Teams app
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/csharpSsoTab/expectedResult/app.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/csharpSsoTab/expectedResult/app.yml
@@ -56,7 +56,7 @@ configureApp:
       outputFilePath : ./build/aad.manifest.${{TEAMSFX_ENV}}.json
   # Output: following environment variable will be persisted in current environment's .env file.
   # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/csharpWebappBot/expectedResult/app.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/csharpWebappBot/expectedResult/app.yml
@@ -41,7 +41,7 @@ registerApp:
     # TEAMS_APP_ID: the id of Teams app
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/V3.5.0-V4.0.6-command/expected/app.local.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/V3.5.0-V4.0.6-command/expected/app.local.yml
@@ -25,7 +25,7 @@ provision:
         - name: msteams
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
 

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/V3.5.0-V4.0.6-notification-trigger/expected/app.local.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/V3.5.0-V4.0.6-notification-trigger/expected/app.local.yml
@@ -25,7 +25,7 @@ provision:
         - name: msteams
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
 

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/V3.5.0-V4.0.6-tab-bot-func/expected/app.local.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/V3.5.0-V4.0.6-tab-bot-func/expected/app.local.yml
@@ -51,7 +51,7 @@ configureApp:
   # Output: following environment variable will be persisted in current environment's .env file.
   # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
 

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/V3.5.0-V4.0.6-tab/expected/app.local.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/V3.5.0-V4.0.6-tab/expected/app.local.yml
@@ -34,7 +34,7 @@ configureApp:
   # Output: following environment variable will be persisted in current environment's .env file.
   # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
 

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/beforeV3.4.0-bot/expected/app.local.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/beforeV3.4.0-bot/expected/app.local.yml
@@ -44,7 +44,7 @@ configureApp:
   # Output: following environment variable will be persisted in current environment's .env file.
   # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
 

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/beforeV3.4.0-tab-bot-func/expected/app.local.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/beforeV3.4.0-tab-bot-func/expected/app.local.yml
@@ -51,7 +51,7 @@ configureApp:
   # Output: following environment variable will be persisted in current environment's .env file.
   # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
 

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/beforeV3.4.0-tab/expected/app.local.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/beforeV3.4.0-tab/expected/app.local.yml
@@ -34,7 +34,7 @@ configureApp:
   # Output: following environment variable will be persisted in current environment's .env file.
   # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
 

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-bot/expected/app.local.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-bot/expected/app.local.yml
@@ -26,7 +26,7 @@ provision:
         - name: m365extensions
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
 

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-notification/expected/app.local.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-notification/expected/app.local.yml
@@ -25,7 +25,7 @@ provision:
         - name: msteams
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
 

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-sso-bot/expected/app.local.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-sso-bot/expected/app.local.yml
@@ -44,7 +44,7 @@ configureApp:
   # Output: following environment variable will be persisted in current environment's .env file.
   # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
 

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-sso-tab/expected/app.local.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-sso-tab/expected/app.local.yml
@@ -34,7 +34,7 @@ configureApp:
   # Output: following environment variable will be persisted in current environment's .env file.
   # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
 

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-tab-bot-func/expected/app.local.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-tab-bot-func/expected/app.local.yml
@@ -51,7 +51,7 @@ configureApp:
   # Output: following environment variable will be persisted in current environment's .env file.
   # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
 

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-tab/expected/app.local.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-tab/expected/app.local.yml
@@ -15,7 +15,7 @@ configureApp:
         PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__ENDPOINT: https://localhost:53000
         PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH: /index.html#
 
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
 

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/jsFunctionBot/expectedResult/js.app.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/jsFunctionBot/expectedResult/js.app.yml
@@ -43,7 +43,7 @@ registerApp:
     # TEAMS_APP_ID: the id of Teams app
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
@@ -58,7 +58,7 @@ configureApp:
     # TEAMS_APP_ID: the id of Teams app
 
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/jsFunctionBot/expectedResult/ts.app.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/jsFunctionBot/expectedResult/ts.app.yml
@@ -47,7 +47,7 @@ registerApp:
     # TEAMS_APP_ID: the id of Teams app
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
@@ -62,7 +62,7 @@ configureApp:
     # TEAMS_APP_ID: the id of Teams app
 
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/jsNonSsoTab/expectedResult/js.app.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/jsNonSsoTab/expectedResult/js.app.yml
@@ -46,7 +46,7 @@ registerApp:
     # TEAMS_APP_ID: the id of Teams app
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
@@ -61,7 +61,7 @@ configureApp:
     # TEAMS_APP_ID: the id of Teams app
 
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/jsNonSsoTab/expectedResult/ts.app.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/jsNonSsoTab/expectedResult/ts.app.yml
@@ -46,7 +46,7 @@ registerApp:
     # TEAMS_APP_ID: the id of Teams app
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
@@ -61,7 +61,7 @@ configureApp:
     # TEAMS_APP_ID: the id of Teams app
 
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/jsSsoTab/expectedResult/js.app.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/jsSsoTab/expectedResult/js.app.yml
@@ -66,7 +66,7 @@ configureApp:
       outputFilePath : ./build/aad.manifest.${{TEAMSFX_ENV}}.json
   # Output: following environment variable will be persisted in current environment's .env file.
   # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
@@ -81,7 +81,7 @@ configureApp:
     # TEAMS_APP_ID: the id of Teams app
 
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/jsSsoTab/expectedResult/ts.app.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/jsSsoTab/expectedResult/ts.app.yml
@@ -66,7 +66,7 @@ configureApp:
       outputFilePath : ./build/aad.manifest.${{TEAMSFX_ENV}}.json
   # Output: following environment variable will be persisted in current environment's .env file.
   # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
@@ -81,7 +81,7 @@ configureApp:
     # TEAMS_APP_ID: the id of Teams app
 
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/jsTabWithApi/expectedResult/js.app.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/jsTabWithApi/expectedResult/js.app.yml
@@ -86,7 +86,7 @@ configureApp:
       outputFilePath : ./build/aad.manifest.${{TEAMSFX_ENV}}.json
   # Output: following environment variable will be persisted in current environment's .env file.
   # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
@@ -101,7 +101,7 @@ configureApp:
     # TEAMS_APP_ID: the id of Teams app
 
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/jsTabWithApi/expectedResult/ts.app.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/jsTabWithApi/expectedResult/ts.app.yml
@@ -90,7 +90,7 @@ configureApp:
       outputFilePath : ./build/aad.manifest.${{TEAMSFX_ENV}}.json
   # Output: following environment variable will be persisted in current environment's .env file.
   # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
@@ -105,7 +105,7 @@ configureApp:
     # TEAMS_APP_ID: the id of Teams app
 
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/jsWebappBot/expectedResult/js.app.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/jsWebappBot/expectedResult/js.app.yml
@@ -42,7 +42,7 @@ registerApp:
     # TEAMS_APP_ID: the id of Teams app
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
@@ -57,7 +57,7 @@ configureApp:
     # TEAMS_APP_ID: the id of Teams app
 
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/jsWebappBot/expectedResult/ts.app.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/jsWebappBot/expectedResult/ts.app.yml
@@ -46,7 +46,7 @@ registerApp:
     # TEAMS_APP_ID: the id of Teams app
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
@@ -61,7 +61,7 @@ configureApp:
     # TEAMS_APP_ID: the id of Teams app
 
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/jsWebappBotId/expectedResult/js.app.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/jsWebappBotId/expectedResult/js.app.yml
@@ -42,7 +42,7 @@ registerApp:
     # TEAMS_APP_ID: the id of Teams app
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
@@ -57,7 +57,7 @@ configureApp:
     # TEAMS_APP_ID: the id of Teams app
 
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/jsWebappBotId/expectedResult/ts.app.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/jsWebappBotId/expectedResult/ts.app.yml
@@ -46,7 +46,7 @@ registerApp:
     # TEAMS_APP_ID: the id of Teams app
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
@@ -61,7 +61,7 @@ configureApp:
     # TEAMS_APP_ID: the id of Teams app
 
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/spfxTab/expectedResult/app.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/spfxTab/expectedResult/app.yml
@@ -28,7 +28,7 @@ registerApp:
     # TEAMS_APP_ID: the id of Teams app
 
 configureApp:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
@@ -43,7 +43,7 @@ configureApp:
     # TEAMS_APP_ID: the id of Teams app
 
 publish:
-  - uses: teamsApp/validate
+  - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template
   - uses: teamsApp/zipAppPackage


### PR DESCRIPTION
For bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/16597713

teamsApp/validate has been renamed to teamsApp/validateManifest

Related PR: https://github.com/OfficeDev/TeamsFx/pull/8026