### PR TITLE
chore: turn on V5 feature flag by default

### DIFF
--- a/packages/fx-core/src/common/tools.ts
+++ b/packages/fx-core/src/common/tools.ts
@@ -413,7 +413,7 @@ export function isApiConnectEnabled(): boolean {
 }
 
 export function isV3Enabled(): boolean {
-  return process.env.TEAMSFX_V3 ? process.env.TEAMSFX_V3 === "true" : false;
+  return process.env.TEAMSFX_V3 ? process.env.TEAMSFX_V3 === "true" : true;
 }
 
 export function isVideoFilterEnabled(): boolean {

--- a/packages/fx-core/tests/common/tools.test.ts
+++ b/packages/fx-core/tests/common/tools.test.ts
@@ -565,4 +565,26 @@ projectId: 00000000-0000-0000-0000-000000000000`;
       const res = await getSPFxToken(mockTools.tokenProvider.m365TokenProvider);
     });
   });
+  describe("feature flag check", () => {
+    const sandbox = sinon.createSandbox();
+    let mockedEnvRestore: RestoreFn;
+    afterEach(() => {
+      mockedEnvRestore();
+    });
+    it("should return true if no v5 set", () => {
+      mockedEnvRestore = mockedEnv({}, { clear: true });
+      const res = isV3Enabled();
+      chai.expect(res).true;
+    });
+    it("should return true if v5 set", () => {
+      mockedEnvRestore = mockedEnv({ TEAMSFX_V3: "true" }, { clear: true });
+      const res = isV3Enabled();
+      chai.expect(res).true;
+    });
+    it("should return false is v5 set false", () => {
+      mockedEnvRestore = mockedEnv({ TEAMSFX_V3: "false" }, { clear: true });
+      const res = isV3Enabled();
+      chai.expect(res).false;
+    });
+  });
 });

--- a/packages/fx-core/tests/common/tools.test.ts
+++ b/packages/fx-core/tests/common/tools.test.ts
@@ -21,7 +21,6 @@ import {
   getSPFxToken,
   isV3Enabled,
   isApiConnectEnabled,
-  isValidationEnabled,
 } from "../../src/common/tools";
 import * as telemetry from "../../src/common/telemetry";
 import {
@@ -566,7 +565,6 @@ projectId: 00000000-0000-0000-0000-000000000000`;
     });
   });
   describe("feature flag check", () => {
-    const sandbox = sinon.createSandbox();
     let mockedEnvRestore: RestoreFn;
     afterEach(() => {
       mockedEnvRestore();
@@ -585,6 +583,16 @@ projectId: 00000000-0000-0000-0000-000000000000`;
       mockedEnvRestore = mockedEnv({ TEAMSFX_V3: "false" }, { clear: true });
       const res = isV3Enabled();
       chai.expect(res).false;
+    });
+    it("should return false if no TEAMSFX_API_CONNECT_ENABLE set", () => {
+      mockedEnvRestore = mockedEnv({}, { clear: true });
+      const res = isApiConnectEnabled();
+      chai.expect(res).false;
+    });
+    it("should return true if TEAMSFX_API_CONNECT_ENABLE set", () => {
+      mockedEnvRestore = mockedEnv({ TEAMSFX_API_CONNECT_ENABLE: "true" }, { clear: true });
+      const res = isApiConnectEnabled();
+      chai.expect(res).true;
     });
   });
 });


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_sprints/taskboard/AuthAndData/Microsoft%20Teams%20Extensibility/CY23-3.1?workitem=17451165