### PR TITLE
feat: remove useless how-to guide for spfx

### DIFF
--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -3542,168 +3542,8 @@ export async function selectTutorialsHandler(args?: any[]): Promise<Result<unkno
   const config: SingleSelectConfig = {
     name: "tutorialName",
     title: localize("teamstoolkit.commandsTreeViewProvider.guideTitle"),
-    options: [
-      {
-        id: "cardActionResponse",
-        label: `${localize("teamstoolkit.guides.cardActionResponse.label")}`,
-        detail: localize("teamstoolkit.guides.cardActionResponse.detail"),
-        groupName: localize("teamstoolkit.guide.scenario"),
-        data: isV3Enabled()
-          ? "https://aka.ms/teamsfx-workflow-new"
-          : "https://aka.ms/teamsfx-card-action-response",
-        buttons: [
-          {
-            iconPath: "file-symlink-file",
-            tooltip: localize("teamstoolkit.guide.tooltip.github"),
-            command: "fx-extension.openTutorial",
-          },
-        ],
-      },
-      {
-        id: "sendNotification",
-        label: `${localize("teamstoolkit.guides.sendNotification.label")}`,
-        detail: localize("teamstoolkit.guides.sendNotification.detail"),
-        groupName: localize("teamstoolkit.guide.scenario"),
-        data: isV3Enabled()
-          ? "https://aka.ms/teamsfx-notification-new"
-          : "https://aka.ms/teamsfx-notification",
-        buttons: [
-          {
-            iconPath: "file-symlink-file",
-            tooltip: localize("teamstoolkit.guide.tooltip.github"),
-            command: "fx-extension.openTutorial",
-          },
-        ],
-      },
-      {
-        id: "commandAndResponse",
-        label: `${localize("teamstoolkit.guides.commandAndResponse.label")}`,
-        detail: localize("teamstoolkit.guides.commandAndResponse.detail"),
-        groupName: localize("teamstoolkit.guide.scenario"),
-        data: isV3Enabled()
-          ? "https://aka.ms/teamsfx-command-new"
-          : "https://aka.ms/teamsfx-command-response",
-        buttons: [
-          {
-            iconPath: "file-symlink-file",
-            tooltip: localize("teamstoolkit.guide.tooltip.github"),
-            command: "fx-extension.openTutorial",
-          },
-        ],
-      },
-      {
-        id: "dashboardApp",
-        label: `${localize("teamstoolkit.guides.dashboardApp.label")}`,
-        detail: localize("teamstoolkit.guides.dashboardApp.detail"),
-        groupName: localize("teamstoolkit.guide.scenario"),
-        data: isV3Enabled()
-          ? "https://aka.ms/teamsfx-dashboard-new"
-          : "https://aka.ms/teamsfx-dashboard-app",
-        buttons: [
-          {
-            iconPath: "file-symlink-file",
-            tooltip: localize("teamstoolkit.guide.tooltip.github"),
-            command: "fx-extension.openTutorial",
-          },
-        ],
-      },
-      ...(isV3Enabled()
-        ? [
-            {
-              id: "addTab",
-              label: `${localize("teamstoolkit.guides.addTab.label")}`,
-              detail: localize("teamstoolkit.guides.addTab.detail"),
-              groupName: localize("teamstoolkit.guide.capability"),
-              data: "https://aka.ms/teamsfx-add-tab",
-              buttons: [
-                {
-                  iconPath: "file-symlink-file",
-                  tooltip: localize("teamstoolkit.guide.tooltip.github"),
-                  command: "fx-extension.openTutorial",
-                },
-              ],
-            },
-            {
-              id: "addBot",
-              label: `${localize("teamstoolkit.guides.addBot.label")}`,
-              detail: localize("teamstoolkit.guides.addBot.detail"),
-              groupName: localize("teamstoolkit.guide.capability"),
-              data: "https://aka.ms/teamsfx-add-bot",
-              buttons: [
-                {
-                  iconPath: "file-symlink-file",
-                  tooltip: localize("teamstoolkit.guide.tooltip.github"),
-                  command: "fx-extension.openTutorial",
-                },
-              ],
-            },
-            {
-              id: "addME",
-              label: `${localize("teamstoolkit.guides.addME.label")}`,
-              detail: localize("teamstoolkit.guides.addME.detail"),
-              groupName: localize("teamstoolkit.guide.capability"),
-              data: "https://aka.ms/teamsfx-add-message-extension",
-              buttons: [
-                {
-                  iconPath: "file-symlink-file",
-                  tooltip: localize("teamstoolkit.guide.tooltip.github"),
-                  command: "fx-extension.openTutorial",
-                },
-              ],
-            },
-            ...(isOfficeAddinEnabled()
-              ? [
-                  {
-                    id: "addOutlookAddin",
-                    label: `${localize("teamstoolkit.guides.addOutlookAddin.label")}`,
-                    detail: localize("teamstoolkit.guides.addOutlookAddin.detail"),
-                    groupName: localize("teamstoolkit.guide.capability"),
-                    data: "https://aka.ms/teamsfx-add-outlook-add-in",
-                    buttons: [
-                      {
-                        iconPath: "file-symlink-file",
-                        tooltip: localize("teamstoolkit.guide.tooltip.github"),
-                        command: "fx-extension.openTutorial",
-                      },
-                    ],
-                  },
-                ]
-              : []),
-          ]
-        : []),
-      {
-        id: "addSso",
-        label: `${localize("teamstoolkit.guides.addSso.label")}`,
-        detail: localize("teamstoolkit.guides.addSso.detail"),
-        groupName: localize("teamstoolkit.guide.development"),
-        data: isV3Enabled()
-          ? "https://aka.ms/teamsfx-add-sso-new"
-          : "https://aka.ms/teamsfx-add-sso",
-        buttons: [
-          {
-            iconPath: "file-symlink-file",
-            tooltip: localize("teamstoolkit.guide.tooltip.github"),
-            command: "fx-extension.openTutorial",
-          },
-        ],
-      },
-      {
-        id: "connectApi",
-        label: `${localize("teamstoolkit.guides.connectApi.label")}`,
-        detail: localize("teamstoolkit.guides.connectApi.detail"),
-        groupName: localize("teamstoolkit.guide.development"),
-        data: isV3Enabled()
-          ? "https://aka.ms/teamsfx-add-api-connection-new"
-          : "https://aka.ms/teamsfx-add-api-connection",
-        buttons: [
-          {
-            iconPath: "file-symlink-file",
-            tooltip: localize("teamstoolkit.guide.tooltip.github"),
-            command: "fx-extension.openTutorial",
-          },
-        ],
-      },
-      ...(isV3Enabled()
+    options:
+      isV3Enabled() && globalVariables.isSPFxProject
         ? [
             {
               id: "cicdPipeline",
@@ -3719,68 +3559,246 @@ export async function selectTutorialsHandler(args?: any[]): Promise<Result<unkno
                 },
               ],
             },
-            {
-              id: "addAzureFunction",
-              label: localize("teamstoolkit.guides.addAzureFunction.label"),
-              detail: localize("teamstoolkit.guides.addAzureFunction.detail"),
-              groupName: localize("teamstoolkit.guide.cloudServiceIntegration"),
-              data: "https://aka.ms/teamsfx-add-azure-function",
-              buttons: [
-                {
-                  iconPath: "file-symlink-file",
-                  tooltip: localize("teamstoolkit.guide.tooltip.github"),
-                  command: "fx-extension.openTutorial",
-                },
-              ],
-            },
-            {
-              id: "addAzureSql",
-              label: localize("teamstoolkit.guides.addAzureSql.label"),
-              detail: localize("teamstoolkit.guides.addAzureSql.detail"),
-              groupName: localize("teamstoolkit.guide.cloudServiceIntegration"),
-              data: "https://aka.ms/teamsfx-add-azure-sql",
-              buttons: [
-                {
-                  iconPath: "file-symlink-file",
-                  tooltip: localize("teamstoolkit.guide.tooltip.github"),
-                  command: "fx-extension.openTutorial",
-                },
-              ],
-            },
-            {
-              id: "addAzureAPIM",
-              label: localize("teamstoolkit.guides.addAzureAPIM.label"),
-              detail: localize("teamstoolkit.guides.addAzureAPIM.detail"),
-              groupName: localize("teamstoolkit.guide.cloudServiceIntegration"),
-              data: "https://aka.ms/teamsfx-add-azure-apim",
-              buttons: [
-                {
-                  iconPath: "file-symlink-file",
-                  tooltip: localize("teamstoolkit.guide.tooltip.github"),
-                  command: "fx-extension.openTutorial",
-                },
-              ],
-            },
-            {
-              id: "addAzureKeyVault",
-              label: localize("teamstoolkit.guides.addAzureKeyVault.label"),
-              detail: localize("teamstoolkit.guides.addAzureKeyVault.detail"),
-              groupName: localize("teamstoolkit.guide.cloudServiceIntegration"),
-              data: "https://aka.ms/teamsfx-add-azure-keyvault",
-              buttons: [
-                {
-                  iconPath: "file-symlink-file",
-                  tooltip: localize("teamstoolkit.guide.tooltip.github"),
-                  command: "fx-extension.openTutorial",
-                },
-              ],
-            },
           ]
-        : []),
-    ],
+        : [
+            {
+              id: "cardActionResponse",
+              label: `${localize("teamstoolkit.guides.cardActionResponse.label")}`,
+              detail: localize("teamstoolkit.guides.cardActionResponse.detail"),
+              groupName: localize("teamstoolkit.guide.scenario"),
+              data: isV3Enabled()
+                ? "https://aka.ms/teamsfx-workflow-new"
+                : "https://aka.ms/teamsfx-card-action-response",
+              buttons: [
+                {
+                  iconPath: "file-symlink-file",
+                  tooltip: localize("teamstoolkit.guide.tooltip.github"),
+                  command: "fx-extension.openTutorial",
+                },
+              ],
+            },
+            {
+              id: "sendNotification",
+              label: `${localize("teamstoolkit.guides.sendNotification.label")}`,
+              detail: localize("teamstoolkit.guides.sendNotification.detail"),
+              groupName: localize("teamstoolkit.guide.scenario"),
+              data: isV3Enabled()
+                ? "https://aka.ms/teamsfx-notification-new"
+                : "https://aka.ms/teamsfx-notification",
+              buttons: [
+                {
+                  iconPath: "file-symlink-file",
+                  tooltip: localize("teamstoolkit.guide.tooltip.github"),
+                  command: "fx-extension.openTutorial",
+                },
+              ],
+            },
+            {
+              id: "commandAndResponse",
+              label: `${localize("teamstoolkit.guides.commandAndResponse.label")}`,
+              detail: localize("teamstoolkit.guides.commandAndResponse.detail"),
+              groupName: localize("teamstoolkit.guide.scenario"),
+              data: isV3Enabled()
+                ? "https://aka.ms/teamsfx-command-new"
+                : "https://aka.ms/teamsfx-command-response",
+              buttons: [
+                {
+                  iconPath: "file-symlink-file",
+                  tooltip: localize("teamstoolkit.guide.tooltip.github"),
+                  command: "fx-extension.openTutorial",
+                },
+              ],
+            },
+            {
+              id: "dashboardApp",
+              label: `${localize("teamstoolkit.guides.dashboardApp.label")}`,
+              detail: localize("teamstoolkit.guides.dashboardApp.detail"),
+              groupName: localize("teamstoolkit.guide.scenario"),
+              data: isV3Enabled()
+                ? "https://aka.ms/teamsfx-dashboard-new"
+                : "https://aka.ms/teamsfx-dashboard-app",
+              buttons: [
+                {
+                  iconPath: "file-symlink-file",
+                  tooltip: localize("teamstoolkit.guide.tooltip.github"),
+                  command: "fx-extension.openTutorial",
+                },
+              ],
+            },
+            ...(isV3Enabled()
+              ? [
+                  {
+                    id: "addTab",
+                    label: `${localize("teamstoolkit.guides.addTab.label")}`,
+                    detail: localize("teamstoolkit.guides.addTab.detail"),
+                    groupName: localize("teamstoolkit.guide.capability"),
+                    data: "https://aka.ms/teamsfx-add-tab",
+                    buttons: [
+                      {
+                        iconPath: "file-symlink-file",
+                        tooltip: localize("teamstoolkit.guide.tooltip.github"),
+                        command: "fx-extension.openTutorial",
+                      },
+                    ],
+                  },
+                  {
+                    id: "addBot",
+                    label: `${localize("teamstoolkit.guides.addBot.label")}`,
+                    detail: localize("teamstoolkit.guides.addBot.detail"),
+                    groupName: localize("teamstoolkit.guide.capability"),
+                    data: "https://aka.ms/teamsfx-add-bot",
+                    buttons: [
+                      {
+                        iconPath: "file-symlink-file",
+                        tooltip: localize("teamstoolkit.guide.tooltip.github"),
+                        command: "fx-extension.openTutorial",
+                      },
+                    ],
+                  },
+                  {
+                    id: "addME",
+                    label: `${localize("teamstoolkit.guides.addME.label")}`,
+                    detail: localize("teamstoolkit.guides.addME.detail"),
+                    groupName: localize("teamstoolkit.guide.capability"),
+                    data: "https://aka.ms/teamsfx-add-message-extension",
+                    buttons: [
+                      {
+                        iconPath: "file-symlink-file",
+                        tooltip: localize("teamstoolkit.guide.tooltip.github"),
+                        command: "fx-extension.openTutorial",
+                      },
+                    ],
+                  },
+                  ...(isOfficeAddinEnabled()
+                    ? [
+                        {
+                          id: "addOutlookAddin",
+                          label: `${localize("teamstoolkit.guides.addOutlookAddin.label")}`,
+                          detail: localize("teamstoolkit.guides.addOutlookAddin.detail"),
+                          groupName: localize("teamstoolkit.guide.capability"),
+                          data: "https://aka.ms/teamsfx-add-outlook-add-in",
+                          buttons: [
+                            {
+                              iconPath: "file-symlink-file",
+                              tooltip: localize("teamstoolkit.guide.tooltip.github"),
+                              command: "fx-extension.openTutorial",
+                            },
+                          ],
+                        },
+                      ]
+                    : []),
+                ]
+              : []),
+            {
+              id: "addSso",
+              label: `${localize("teamstoolkit.guides.addSso.label")}`,
+              detail: localize("teamstoolkit.guides.addSso.detail"),
+              groupName: localize("teamstoolkit.guide.development"),
+              data: isV3Enabled()
+                ? "https://aka.ms/teamsfx-add-sso-new"
+                : "https://aka.ms/teamsfx-add-sso",
+              buttons: [
+                {
+                  iconPath: "file-symlink-file",
+                  tooltip: localize("teamstoolkit.guide.tooltip.github"),
+                  command: "fx-extension.openTutorial",
+                },
+              ],
+            },
+            {
+              id: "connectApi",
+              label: `${localize("teamstoolkit.guides.connectApi.label")}`,
+              detail: localize("teamstoolkit.guides.connectApi.detail"),
+              groupName: localize("teamstoolkit.guide.development"),
+              data: isV3Enabled()
+                ? "https://aka.ms/teamsfx-add-api-connection-new"
+                : "https://aka.ms/teamsfx-add-api-connection",
+              buttons: [
+                {
+                  iconPath: "file-symlink-file",
+                  tooltip: localize("teamstoolkit.guide.tooltip.github"),
+                  command: "fx-extension.openTutorial",
+                },
+              ],
+            },
+            ...(isV3Enabled()
+              ? [
+                  {
+                    id: "cicdPipeline",
+                    label: `${localize("teamstoolkit.guides.cicdPipeline.label")}`,
+                    detail: localize("teamstoolkit.guides.cicdPipeline.detail"),
+                    groupName: localize("teamstoolkit.guide.development"),
+                    data: "https://aka.ms/teamsfx-add-cicd-new",
+                    buttons: [
+                      {
+                        iconPath: "file-symlink-file",
+                        tooltip: localize("teamstoolkit.guide.tooltip.github"),
+                        command: "fx-extension.openTutorial",
+                      },
+                    ],
+                  },
+                  {
+                    id: "addAzureFunction",
+                    label: localize("teamstoolkit.guides.addAzureFunction.label"),
+                    detail: localize("teamstoolkit.guides.addAzureFunction.detail"),
+                    groupName: localize("teamstoolkit.guide.cloudServiceIntegration"),
+                    data: "https://aka.ms/teamsfx-add-azure-function",
+                    buttons: [
+                      {
+                        iconPath: "file-symlink-file",
+                        tooltip: localize("teamstoolkit.guide.tooltip.github"),
+                        command: "fx-extension.openTutorial",
+                      },
+                    ],
+                  },
+                  {
+                    id: "addAzureSql",
+                    label: localize("teamstoolkit.guides.addAzureSql.label"),
+                    detail: localize("teamstoolkit.guides.addAzureSql.detail"),
+                    groupName: localize("teamstoolkit.guide.cloudServiceIntegration"),
+                    data: "https://aka.ms/teamsfx-add-azure-sql",
+                    buttons: [
+                      {
+                        iconPath: "file-symlink-file",
+                        tooltip: localize("teamstoolkit.guide.tooltip.github"),
+                        command: "fx-extension.openTutorial",
+                      },
+                    ],
+                  },
+                  {
+                    id: "addAzureAPIM",
+                    label: localize("teamstoolkit.guides.addAzureAPIM.label"),
+                    detail: localize("teamstoolkit.guides.addAzureAPIM.detail"),
+                    groupName: localize("teamstoolkit.guide.cloudServiceIntegration"),
+                    data: "https://aka.ms/teamsfx-add-azure-apim",
+                    buttons: [
+                      {
+                        iconPath: "file-symlink-file",
+                        tooltip: localize("teamstoolkit.guide.tooltip.github"),
+                        command: "fx-extension.openTutorial",
+                      },
+                    ],
+                  },
+                  {
+                    id: "addAzureKeyVault",
+                    label: localize("teamstoolkit.guides.addAzureKeyVault.label"),
+                    detail: localize("teamstoolkit.guides.addAzureKeyVault.detail"),
+                    groupName: localize("teamstoolkit.guide.cloudServiceIntegration"),
+                    data: "https://aka.ms/teamsfx-add-azure-keyvault",
+                    buttons: [
+                      {
+                        iconPath: "file-symlink-file",
+                        tooltip: localize("teamstoolkit.guide.tooltip.github"),
+                        command: "fx-extension.openTutorial",
+                      },
+                    ],
+                  },
+                ]
+              : []),
+          ],
     returnObject: true,
   };
-  if (TreatmentVariableValue.inProductDoc) {
+  if (TreatmentVariableValue.inProductDoc && !globalVariables.isSPFxProject) {
     config.options.splice(0, 1, {
       id: "cardActionResponse",
       label: `${localize("teamstoolkit.guides.cardActionResponse.label")}`,

--- a/packages/vscode-extension/src/treeview/treeViewManager.ts
+++ b/packages/vscode-extension/src/treeview/treeViewManager.ts
@@ -178,6 +178,17 @@ class TreeViewManager {
         { name: "library", custom: false },
         TreeCategory.GettingStarted
       ),
+      ...(isV3Enabled() && isSPFxProject
+        ? [
+            new TreeViewCommand(
+              localize("teamstoolkit.commandsTreeViewProvider.addWebpartTitle"),
+              localize("teamstoolkit.commmands.addWebpart.description"),
+              "fx-extension.addWebpart",
+              "addWebpart",
+              { name: "teamsfx-add-feature", custom: false }
+            ),
+          ]
+        : []),
       new TreeViewCommand(
         localize("teamstoolkit.commandsTreeViewProvider.guideTitle"),
         localize("teamstoolkit.commandsTreeViewProvider.guideDescription"),
@@ -194,17 +205,7 @@ class TreeViewManager {
         { name: "debug-alt", custom: false }
       ),
       ...(isV3Enabled()
-        ? isSPFxProject
-          ? [
-              new TreeViewCommand(
-                localize("teamstoolkit.commandsTreeViewProvider.addWebpartTitle"),
-                localize("teamstoolkit.commmands.addWebpart.description"),
-                "fx-extension.addWebpart",
-                "addWebpart",
-                { name: "teamsfx-add-feature", custom: false }
-              ),
-            ]
-          : []
+        ? []
         : [
             new TreeViewCommand(
               localize("teamstoolkit.commandsTreeViewProvider.addFeatureTitle"),

--- a/packages/vscode-extension/test/extension/handlers.test.ts
+++ b/packages/vscode-extension/test/extension/handlers.test.ts
@@ -557,6 +557,7 @@ describe("handlers", () => {
       sinon.stub(ExtTelemetry, "sendTelemetryErrorEvent");
       sinon.stub(commonTools, "isV3Enabled").returns(true);
       sinon.stub(TreatmentVariableValue, "inProductDoc").value(true);
+      sinon.stub(globalVariables, "isSPFxProject").value(false);
       let tutorialOptions: OptionItem[] = [];
       sinon.stub(extension, "VS_CODE_UI").value({
         selectOption: (options: any) => {
@@ -571,6 +572,29 @@ describe("handlers", () => {
       chai.assert.equal(tutorialOptions.length, 15);
       chai.assert.isTrue(result.isOk());
       chai.assert.equal(tutorialOptions[1].data, "https://aka.ms/teamsfx-notification-new");
+    });
+
+    it("selectTutorialsHandler() for SPFx projects - v3", async () => {
+      sinon.stub(localizeUtils, "localize").returns("");
+      sinon.stub(ExtTelemetry, "sendTelemetryEvent");
+      sinon.stub(ExtTelemetry, "sendTelemetryErrorEvent");
+      sinon.stub(commonTools, "isV3Enabled").returns(true);
+      sinon.stub(TreatmentVariableValue, "inProductDoc").value(true);
+      sinon.stub(globalVariables, "isSPFxProject").value(true);
+      let tutorialOptions: OptionItem[] = [];
+      sinon.stub(extension, "VS_CODE_UI").value({
+        selectOption: (options: any) => {
+          tutorialOptions = options.options;
+          return Promise.resolve(ok({ type: "success", result: { id: "test", data: "data" } }));
+        },
+        openUrl: () => Promise.resolve(ok(true)),
+      });
+
+      const result = await handlers.selectTutorialsHandler();
+
+      chai.assert.equal(tutorialOptions.length, 1);
+      chai.assert.isTrue(result.isOk());
+      chai.assert.equal(tutorialOptions[0].data, "https://aka.ms/teamsfx-add-cicd-new");
     });
   });
 


### PR DESCRIPTION
1> Only keep CI/CD in 'view how-to guide ' for SPFx projects
2> Move 'Add web part' above 'view how-to guide' item

![image](https://user-images.githubusercontent.com/73154171/225800794-e40d7112-7ab9-4e65-b02d-f8e869fdcb89.png)
E2E TEST: NA