### PR TITLE
chore: update interface to define output names

### DIFF
--- a/packages/fx-core/src/component/driver/interface/stepDriver.ts
+++ b/packages/fx-core/src/component/driver/interface/stepDriver.ts
@@ -26,6 +26,11 @@ export interface StepDriver {
    * The summary is expected to contain human readable information that will be presented to users.
    * @param args Arguments from the `with` section in the yaml file.
    * @param ctx logger, telemetry, progress bar, etc.
+   * @param outputEnvVarNames the environment variable names for each output
    */
-  execute?(args: unknown, ctx: DriverContext): Promise<ExecutionResult>;
+  execute?(
+    args: unknown,
+    ctx: DriverContext,
+    outputEnvVarNames?: Map<string, string>
+  ): Promise<ExecutionResult>;
 }


### PR DESCRIPTION
Update action interface to accept output environment variable names.

Responsibility of YmlConfigManager:
1. Pass content of `writeToEnviornmentFile` to action
2. Write action's env output to environment file

Responsibility of Action:
1. Read required information based on `outputEnvVarNames`
2. Define action's env output based on `outputEnvVarNames`