### PR TITLE
chore: update CD to release beta version from prerelease branch

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -64,11 +64,6 @@ jobs:
           sudo apt update
           sudo apt install wine64 -y
 
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 3.1.x
-
       - name: Setup npm registry
         run: |
           echo "${{ secrets.NPMRC }}" > ~/.npmrc
@@ -89,9 +84,14 @@ jobs:
           git config --global user.email 'yiz@microsoft.com'
 
       - name: release alpha npm packages to npmjs.org
-        if: ${{ github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/prerelease' }}
+        if: ${{ github.ref == 'refs/heads/dev' }}
         run: |
-          npx lerna version prerelease --preid=alpha.$(git rev-parse --short HEAD) --exact --no-push --allow-branch ${GITHUB_REF#refs/*/} --yes
+          npx lerna version prerelease --preid=alpha.$(git rev-parse --short HEAD) --exact --no-push --allow-branch dev --yes
+
+      - name: release beta packages to npmjs.org
+        if: ${{ github.ref == 'refs/heads/prerelease' }}
+        run: |
+          npx lerna version prerelease --preid=beta.$(date "+%Y%m%d%H") --exact --no-push --allow-branch prerelease --yes
 
       - name: version rc npm packages to npmjs.org
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.preid == 'rc' && github.ref == 'refs/heads/main' && github.event.inputs.skip-version-rc == 'no'}}
@@ -238,9 +238,16 @@ jobs:
           git commit -m "chore: update ai key"
 
       - name: publish alpha release to npm org
-        if: ${{ github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/prerelease' }}
+        if: ${{ github.ref == 'refs/heads/dev'}}
         run: |
-          npx lerna publish from-package --dist-tag=alpha --yes --allow-branch ${GITHUB_REF#refs/*/}
+          npx lerna publish from-package --dist-tag=alpha --yes --allow-branch dev
+        env:
+          TEMPLATE_PATH: ${{ runner.temp }}/teamsfx_templates_v3;${{ runner.temp }}/teamsfx_templates
+
+      - name: publish beta release to npm org
+        if: ${{ github.ref == refs/heads/prerelease }}
+        run: |
+          npx lerna publish from-package --dist-tag=beta --yes --allow-branch prerelease
         env:
           TEMPLATE_PATH: ${{ runner.temp }}/teamsfx_templates_v3;${{ runner.temp }}/teamsfx_templates
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -124,10 +124,6 @@ jobs:
               git push -d origin $(git tag --points-at HEAD | grep templates | grep rc)
           fi
 
-      - name: generate templates
-        run: |
-          .github/scripts/template-zip-autogen.sh ${{ runner.temp }}/teamsfx_templates
-
       - name: generate templates v3
         run: |
           .github/scripts/template-zip-autogen-v3.sh ${{ runner.temp }}/teamsfx_templates_v3

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -162,7 +162,7 @@ jobs:
           token: ${{ secrets.CD_PAT }}
           prerelease: true
           tag: "templates@0.0.0-rc"
-          artifacts: ${{ runner.temp }}/teamsfx_templates/*.zip, ${{ runner.temp }}/teamsfx_templates_v3/*.zip
+          artifacts: ${{ runner.temp }}/teamsfx_templates_v3/*.zip
           allowUpdates: true
           removeArtifacts: true
 
@@ -170,7 +170,7 @@ jobs:
         if: ${{ contains(steps.version-change.outputs.CHANGED, 'templates@') && github.event_name == 'workflow_dispatch' && github.event.inputs.preid == 'stable' }}
         uses: ncipollo/release-action@v1.10.0
         with:
-          artifacts: ${{ runner.temp }}/teamsfx_templates/*.zip, ${{ runner.temp }}/teamsfx_templates_v3/*.zip
+          artifacts: ${{ runner.temp }}/teamsfx_templates_v3/*.zip
           name: "Release for ${{ steps.version-change.outputs.TEMPLATE_VERSION }}"
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ steps.version-change.outputs.TEMPLATE_VERSION }}
@@ -238,28 +238,28 @@ jobs:
         run: |
           npx lerna publish from-package --dist-tag=alpha --yes --allow-branch dev
         env:
-          TEMPLATE_PATH: ${{ runner.temp }}/teamsfx_templates_v3;${{ runner.temp }}/teamsfx_templates
+          TEMPLATE_PATH: ${{ runner.temp }}/teamsfx_templates_v3
 
       - name: publish beta release to npm org
         if: ${{ github.ref == refs/heads/prerelease }}
         run: |
           npx lerna publish from-package --dist-tag=beta --yes --allow-branch prerelease
         env:
-          TEMPLATE_PATH: ${{ runner.temp }}/teamsfx_templates_v3;${{ runner.temp }}/teamsfx_templates
+          TEMPLATE_PATH: ${{ runner.temp }}/teamsfx_templates_v3
 
       - name: publish rc npm packages to npmjs.org
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.preid == 'rc' }}
         run: |
           npx lerna publish from-package --dist-tag=rc --yes
         env:
-          TEMPLATE_PATH: ${{ runner.temp }}/teamsfx_templates_v3;${{ runner.temp }}/teamsfx_templates
+          TEMPLATE_PATH: ${{ runner.temp }}/teamsfx_templates_v3
 
       - name: publish stable npm packages to npmjs.org
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.preid == 'stable' }}
         run: |
           npx lerna publish from-package --yes
         env:
-          TEMPLATE_PATH: ${{ runner.temp }}/teamsfx_templates_v3;${{ runner.temp }}/teamsfx_templates
+          TEMPLATE_PATH: ${{ runner.temp }}/teamsfx_templates_v3
 
       - name: pack server bits
         if: ${{ contains(steps.version-change.outputs.CHANGED, '@microsoft/teamsfx-server') }}


### PR DESCRIPTION
currently the following packages update the version to latest alpha.
cli 2.0.0-alpha
fx-core 2.0.0-alpha
vscode-extension 4.99.0-alpha
server 2.0.0-alpha

from now on, prerelease branch only release production with preid as beta