### PR TITLE
chore: add metadata events at the start of debug

### DIFF
--- a/packages/vscode-extension/src/debug/localTelemetryReporter.ts
+++ b/packages/vscode-extension/src/debug/localTelemetryReporter.ts
@@ -3,7 +3,7 @@
 
 import { performance } from "perf_hooks";
 
-import { FxError } from "@microsoft/teamsfx-api";
+import { FxError, TeamsAppManifest } from "@microsoft/teamsfx-api";
 import {
   LocalEnvManager,
   LocalTelemetryReporter,
@@ -11,6 +11,8 @@ import {
   TaskLabel,
   TaskOverallLabel,
 } from "@microsoft/teamsfx-core/build/common/local";
+import { metadataUtil } from "@microsoft/teamsfx-core/build/component/utils/metadataUtil";
+import { pathUtils } from "@microsoft/teamsfx-core/build/component/utils/pathUtils";
 
 import * as globalVariables from "../globalVariables";
 import { ExtTelemetry } from "../telemetry/extTelemetry";
@@ -22,6 +24,16 @@ import {
 } from "../telemetry/extTelemetryEvents";
 import { getLocalDebugSession, getProjectComponents } from "./commonUtils";
 import { TeamsfxTaskProvider } from "./teamsfxTaskProvider";
+import { actionName as createAppPackageActionName } from "@microsoft/teamsfx-core/build/component/driver/teamsApp/createAppPackage";
+import { actionName as updateAppPackageActionName } from "@microsoft/teamsfx-core/build/component/driver/teamsApp/configure";
+import * as fs from "fs-extra";
+import * as path from "path";
+import { CreateAppPackageArgs } from "@microsoft/teamsfx-core/build/component/driver/teamsApp/interfaces/CreateAppPackageArgs";
+import { ConfigureTeamsAppArgs } from "@microsoft/teamsfx-core/build/component/driver/teamsApp/interfaces/ConfigureTeamsAppArgs";
+import { ProjectModel } from "@microsoft/teamsfx-core/build/component/configManager/interface";
+import { Constants as ManifestConstants } from "@microsoft/teamsfx-core/build/component/resource/appManifest/constants";
+import AdmZip = require("adm-zip");
+import { environmentManager } from "@microsoft/teamsfx-core";
 
 function saveEventTime(eventName: string, time: number) {
   const session = getLocalDebugSession();
@@ -52,6 +64,18 @@ export const localTelemetryReporter = new LocalTelemetryReporter(
   saveEventTime
 );
 
+export async function sendDebugInitialEvents(
+  projectPath: string | undefined,
+  debugAllStartAdditionalProperties: {
+    [key: string]: string;
+  }
+): Promise<void> {
+  sendDebugAllStartEvent(debugAllStartAdditionalProperties);
+  if (projectPath) {
+    sendDebugMetadataEvent(projectPath);
+  }
+}
+
 export async function sendDebugAllStartEvent(additionalProperties: {
   [key: string]: string;
 }): Promise<void> {
@@ -65,6 +89,146 @@ export async function sendDebugAllStartEvent(additionalProperties: {
     session.properties
   );
   localTelemetryReporter.sendTelemetryEvent(TelemetryEvent.DebugAllStart, properties);
+}
+
+async function readManifestFromAppPackage(
+  appPackagePath: string
+): Promise<TeamsAppManifest | undefined> {
+  const appPackageBuffer = await fs.readFile(appPackagePath);
+  const admzip = new AdmZip(appPackageBuffer);
+  const zipEntries = admzip.getEntries();
+  const manifestFile = zipEntries.find((x) => x.entryName === ManifestConstants.MANIFEST_FILE);
+  if (manifestFile) {
+    const manifestString = manifestFile.getData().toString("utf-8");
+    return JSON.parse(manifestString);
+  } else {
+    return undefined;
+  }
+}
+
+async function readManifest(projectPath: string, manifestPath: string): Promise<TeamsAppManifest> {
+  if (!path.isAbsolute(manifestPath)) {
+    manifestPath = path.join(projectPath, manifestPath);
+  }
+  return await fs.readJson(manifestPath, { encoding: "utf-8" });
+}
+
+const defaultManifestPathsV3 = ["appPackage/manifest.json"];
+
+export const ManifestSources = Object.freeze({
+  PublishAppPackageManifestPath: "PublishAppPackageManifestPath",
+  PublishAppPackageAppPackagePath: "PublishAppPackageAppPackagePath",
+  DefaultManifestPath: "DefaultManifestPath",
+  DefaultAppPackagePath: "DefaultAppPackagePath",
+});
+export type ManifestSource = typeof ManifestSources[keyof typeof ManifestSources];
+
+// Find manifest by search in the yaml file with best effort.
+async function tryGetManifestFromYml(
+  projectPath: string,
+  yml: ProjectModel
+): Promise<{ source: ManifestSource; manifest: TeamsAppManifest } | undefined> {
+  const configureTeamsApp = yml.provision?.driverDefs?.find(
+    (item) => item.uses === updateAppPackageActionName
+  );
+  const configureTeamsAppArgs = configureTeamsApp?.with as
+    | Partial<ConfigureTeamsAppArgs>
+    | undefined;
+  const configureTeamsAppPath = configureTeamsAppArgs?.appPackagePath;
+
+  if (configureTeamsAppPath) {
+    // Case 1: Happy path
+    // Start from "teamsApp/update".appPackagePath
+    // => "teamsApp/zipAppPackage".outputZipPath
+    // => "teamsApp/zipAppPackage".manifestPath
+    try {
+      let manifestPath: string | undefined;
+      yml.provision?.driverDefs?.forEach((item) => {
+        if (item.uses !== createAppPackageActionName) {
+          return;
+        }
+        const createAppPackageArgs = item.with as Partial<CreateAppPackageArgs> | undefined;
+        if (!createAppPackageArgs?.outputZipPath) {
+          return;
+        }
+
+        if (createAppPackageArgs.outputZipPath === createAppPackageActionName) {
+          manifestPath = createAppPackageArgs.manifestPath;
+        }
+      });
+      if (manifestPath) {
+        return {
+          source: ManifestSources.PublishAppPackageManifestPath,
+          manifest: await readManifest(projectPath, manifestPath),
+        };
+      }
+    } catch (e) {
+      // fall through next case
+    }
+
+    // Case 2: Assume user uploads app package manually
+    // Start from "teamsApp/zipAppPackage".appPackagePath
+    // => Unzip appPackage (in memory) to get manifest
+    try {
+      const manifest = await readManifestFromAppPackage(configureTeamsAppPath);
+      if (manifest) {
+        return {
+          source: ManifestSources.PublishAppPackageAppPackagePath,
+          manifest,
+        };
+      }
+    } catch (e) {
+      // fall through next case
+    }
+  }
+
+  // Case 3: Assume user zips & uploads app package manually
+  // Try default location of manifest: appPackage/manifest.json
+  try {
+    for (const defaultPath of defaultManifestPathsV3) {
+      const manifest = await readManifest(projectPath, defaultPath);
+      if (manifest) {
+        return {
+          source: ManifestSources.DefaultManifestPath,
+          manifest,
+        };
+      }
+    }
+  } catch (e) {
+    // fall through next case
+  }
+
+  return undefined;
+}
+
+export async function sendDebugMetadataEvent(projectPath: string) {
+  // send metadata events before debug
+  // - yaml file
+  // - manifest template => determine project capabilities (tab, bot, me, spfx)
+  // - tasks.json (TODO) => determine project scenario (restify-notification/func-notification, sso/non-sso tab)
+
+  try {
+    const localEnv = environmentManager.getLocalEnvName();
+    const yamlFilePath = pathUtils.getYmlFilePath(projectPath, localEnv);
+
+    // send yaml metadata
+    const yamlResult = await metadataUtil.parse(yamlFilePath, localEnv);
+    if (yamlResult.isErr()) {
+      return;
+    }
+
+    const manifestData = await tryGetManifestFromYml(projectPath, yamlResult.value);
+    if (manifestData === undefined) {
+      return;
+    }
+
+    // TODO: add source to properties of metadataUtil.parseManifest (currently not exposed)
+    const { source, manifest } = manifestData;
+    // send manifest metadata
+    metadataUtil.parseManifest(manifest);
+  } catch (e) {
+    // ignore telemetry errors
+  }
 }
 
 export async function sendDebugAllEvent(

--- a/packages/vscode-extension/src/debug/localTelemetryReporter.ts
+++ b/packages/vscode-extension/src/debug/localTelemetryReporter.ts
@@ -116,10 +116,9 @@ async function readManifest(projectPath: string, manifestPath: string): Promise<
 const defaultManifestPathsV3 = ["appPackage/manifest.json"];
 
 export const ManifestSources = Object.freeze({
-  PublishAppPackageManifestPath: "PublishAppPackageManifestPath",
-  PublishAppPackageAppPackagePath: "PublishAppPackageAppPackagePath",
+  ConfigureAppPackageManifestPath: "ConfigureAppPackageManifestPath",
+  ConfigureAppPackageAppPackagePath: "ConfigureAppPackageAppPackagePath",
   DefaultManifestPath: "DefaultManifestPath",
-  DefaultAppPackagePath: "DefaultAppPackagePath",
 });
 export type ManifestSource = typeof ManifestSources[keyof typeof ManifestSources];
 
@@ -158,7 +157,7 @@ async function tryGetManifestFromYml(
       });
       if (manifestPath) {
         return {
-          source: ManifestSources.PublishAppPackageManifestPath,
+          source: ManifestSources.ConfigureAppPackageManifestPath,
           manifest: await readManifest(projectPath, manifestPath),
         };
       }
@@ -173,7 +172,7 @@ async function tryGetManifestFromYml(
       const manifest = await readManifestFromAppPackage(configureTeamsAppPath);
       if (manifest) {
         return {
-          source: ManifestSources.PublishAppPackageAppPackagePath,
+          source: ManifestSources.ConfigureAppPackageAppPackagePath,
           manifest,
         };
       }

--- a/packages/vscode-extension/src/debug/taskTerminal/prerequisiteTaskTerminal.ts
+++ b/packages/vscode-extension/src/debug/taskTerminal/prerequisiteTaskTerminal.ts
@@ -18,7 +18,7 @@ import {
 import {
   localTelemetryReporter,
   maskArrayValue,
-  sendDebugAllStartEvent,
+  sendDebugInitialEvents,
 } from "../localTelemetryReporter";
 import { checkAndInstallForTask } from "../prerequisitesHandler";
 import { BaseTaskTerminal } from "./baseTaskTerminal";
@@ -71,7 +71,8 @@ export class PrerequisiteTaskTerminal extends BaseTaskTerminal {
       if (commonUtils.checkAndSkipDebugging()) {
         throw new Error(DebugSessionExists);
       }
-      await sendDebugAllStartEvent(additionalProperties);
+      const projectPath = vscode.workspace.workspaceFolders?.[0]?.uri?.fsPath;
+      await sendDebugInitialEvents(projectPath, additionalProperties);
       return await localTelemetryReporter.runWithTelemetryProperties(
         TelemetryEvent.DebugCheckPrerequisitesTask,
         telemetryProperties,

--- a/packages/vscode-extension/test/localdebug/localTelemetryReporter.test.ts
+++ b/packages/vscode-extension/test/localdebug/localTelemetryReporter.test.ts
@@ -1,12 +1,31 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+import { ContextV3, TeamsAppManifest, Tools } from "@microsoft/teamsfx-api";
+import { FxCore } from "@microsoft/teamsfx-core";
 import { LocalEnvManager, TaskOverallLabel } from "@microsoft/teamsfx-core/build/common/local";
+import { pathUtils, PathUtils } from "@microsoft/teamsfx-core/build/component/utils/pathUtils";
+import { TelemetryEvent } from "@microsoft/teamsfx-core/build/common/telemetry";
+import { Generator } from "@microsoft/teamsfx-core/build/component/generator/generator";
+import { FeatureFlagName } from "@microsoft/teamsfx-core/build/common/constants";
 import * as chai from "chai";
 import * as path from "path";
 import * as sinon from "sinon";
 import * as vscode from "vscode";
-import { getTaskInfo, maskArrayValue, maskValue } from "../../src/debug/localTelemetryReporter";
+import {
+  getTaskInfo,
+  maskArrayValue,
+  maskValue,
+  sendDebugMetadataEvent,
+} from "../../src/debug/localTelemetryReporter";
 import * as globalVariables from "../../src/globalVariables";
+import { MockLogProvier, MockTelemetryReporter, MockUserInteraction } from "./testUtils";
+import * as fs from "fs-extra";
+import * as chaiAsPromised from "chai-as-promised";
+import * as tmp from "tmp";
+import { actionName as createAppPackageActionName } from "@microsoft/teamsfx-core/build/component/driver/teamsApp/createAppPackage";
+import { actionName as configureAppPackageActionName } from "@microsoft/teamsfx-core/build/component/driver/teamsApp/configure";
+import { metadataUtil } from "@microsoft/teamsfx-core/build/component/utils/metadataUtil";
+chai.use(chaiAsPromised);
 
 describe("LocalTelemetryReporter", () => {
   describe("maskValue()", () => {
@@ -328,6 +347,154 @@ describe("LocalTelemetryReporter", () => {
           },
         ]
       );
+    });
+  });
+});
+
+describe("sendDebugMetadataEvent()", () => {
+  let mockReporter: MockTelemetryReporter;
+  let sandbox: sinon.SinonSandbox;
+  let mockCtx: ContextV3;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    const ui = new MockUserInteraction();
+    mockReporter = new MockTelemetryReporter();
+    const mockTools = { telemetryReporter: mockReporter, ui } as any as Tools;
+    // call setTools in constructor
+    new FxCore(mockTools);
+
+    mockCtx = {
+      logProvider: new MockLogProvier(),
+      templateVariables: Generator.getDefaultVariables("test-mock-app"),
+    } as ContextV3;
+    // force generating template files from source code rather than GitHub
+    sandbox.stub(process, "env").value({
+      [FeatureFlagName.DebugTemplate]: "true",
+      NODE_ENV: "development",
+    });
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("Notification bot happy path", async () => {
+    let projectPath: string;
+    {
+      const tmpobj = tmp.dirSync({ unsafeCleanup: true });
+      projectPath = tmpobj.name;
+      after(() => {
+        tmpobj.removeCallback();
+      });
+      const result = await Generator.generateTemplate(
+        mockCtx,
+        tmpobj.name,
+        "notification-restify",
+        "js"
+      );
+      chai.assert.isTrue(result.isOk());
+    }
+
+    // prevent being affected by events sent from previous actions
+    mockReporter.resetEvents();
+    await sendDebugMetadataEvent(projectPath);
+
+    // Assert
+    chai.assert.equal(mockReporter.events.length, 2);
+    // yaml metadata event
+    chai.assert.equal(mockReporter.events[0].eventName, TelemetryEvent.MetaData);
+    chai.assert.equal(mockReporter.events[0].properties?.["yml-name"], "teamsapplocalyml");
+
+    const actionList = mockReporter.events[0].properties?.["provision.actions"]?.split(",");
+    chai.assert.isNotEmpty(actionList);
+    chai.assert.include(actionList!, configureAppPackageActionName.replace(/\//g, ""));
+    chai.assert.include(actionList!, createAppPackageActionName.replace(/\//g, ""));
+
+    // manifest metdata event
+    chai.assert.equal(mockReporter.events[1].eventName, TelemetryEvent.MetaData);
+    chai.assert.isNotEmpty(mockReporter.events[1].properties?.["manifest.id"]);
+    chai.assert.isNotEmpty(mockReporter.events[1].properties?.["manifest.bots"]);
+  });
+
+  it("SSO tab happy path", async () => {
+    let projectPath: string;
+    {
+      const tmpobj = tmp.dirSync({ unsafeCleanup: true });
+      projectPath = tmpobj.name;
+      after(() => {
+        tmpobj.removeCallback();
+      });
+      const result = await Generator.generateTemplate(mockCtx, tmpobj.name, "sso-tab", "js");
+      chai.assert.isTrue(result.isOk());
+    }
+
+    // prevent being affected by events sent from previous actions
+    mockReporter.resetEvents();
+    await sendDebugMetadataEvent(projectPath);
+
+    // Assert
+    chai.assert.equal(mockReporter.events.length, 2);
+    // yaml metadata event
+    chai.assert.equal(mockReporter.events[0].eventName, TelemetryEvent.MetaData);
+    chai.assert.equal(mockReporter.events[0].properties?.["yml-name"], "teamsapplocalyml");
+
+    const actionList = mockReporter.events[0].properties?.["provision.actions"]?.split(",");
+    chai.assert.isNotEmpty(actionList);
+    chai.assert.include(actionList!, configureAppPackageActionName.replace(/\//g, ""));
+    chai.assert.include(actionList!, createAppPackageActionName.replace(/\//g, ""));
+
+    // manifest metdata event
+    chai.assert.equal(mockReporter.events[1].eventName, TelemetryEvent.MetaData);
+    chai.assert.isNotEmpty(mockReporter.events[1].properties?.["manifest.id"]);
+    chai.assert.isNotEmpty(mockReporter.events[1].properties?.["manifest.staticTabs.contentUrl"]);
+    chai.assert.isNotEmpty(
+      mockReporter.events[1].properties?.["manifest.configurableTabs.configurationUrl"]
+    );
+    chai.assert.isNotEmpty(mockReporter.events[1].properties?.["manifest.webApplicationInfo.id"]);
+  });
+
+  describe("Telemetry failure should not block execution", () => {
+    let projectPath: string;
+    beforeEach(async () => {
+      {
+        const tmpobj = tmp.dirSync({ unsafeCleanup: true });
+        projectPath = tmpobj.name;
+        after(() => {
+          tmpobj.removeCallback();
+        });
+        const result = await Generator.generateTemplate(
+          mockCtx,
+          tmpobj.name,
+          "notification-restify",
+          "js"
+        );
+        chai.assert.isTrue(result.isOk());
+      }
+    });
+
+    it("Should not throw error on failure: pathUtils.getYmlFilePath()", async () => {
+      const stub = sandbox.stub(pathUtils, "getYmlFilePath").throws(new Error("Mock error"));
+      after(() => stub.reset());
+      await sendDebugMetadataEvent(projectPath);
+    });
+
+    it("Should not throw error on failure: metadataUtil.parse()", async () => {
+      const stub = sandbox.stub(metadataUtil, "parse").throws(new Error("Mock error"));
+      after(() => stub.reset());
+      await sendDebugMetadataEvent(projectPath);
+    });
+
+    it("Should not throw error on failure: metadataUtil.parseManifest()", async () => {
+      const stub = sandbox.stub(metadataUtil, "parseManifest").throws(new Error("Mock error"));
+      after(() => stub.reset());
+      await sendDebugMetadataEvent(projectPath);
+    });
+
+    it("Should not throw error on failure: fs.readJson()", async () => {
+      const stub = sandbox.stub(fs, "readJson").throws(new Error("Mock error"));
+      after(() => stub.reset());
+      await sendDebugMetadataEvent(projectPath);
     });
   });
 });

--- a/packages/vscode-extension/test/localdebug/testUtils.ts
+++ b/packages/vscode-extension/test/localdebug/testUtils.ts
@@ -1,0 +1,174 @@
+import {
+  Colors,
+  FxError,
+  InputTextConfig,
+  InputTextResult,
+  IProgressHandler,
+  LogLevel,
+  LogProvider,
+  MultiSelectConfig,
+  MultiSelectResult,
+  ok,
+  Result,
+  RunnableTask,
+  SelectFileConfig,
+  SelectFileResult,
+  SelectFilesConfig,
+  SelectFilesResult,
+  SelectFolderConfig,
+  SelectFolderResult,
+  SingleSelectConfig,
+  SingleSelectResult,
+  TaskConfig,
+  TelemetryReporter,
+  UserInteraction,
+} from "@microsoft/teamsfx-api";
+
+export const EventTypes = Object.freeze({
+  TelemetryEvent: "TelemetryEvent",
+  TelemetryErrorEvent: "TelemetryErrorEvent",
+});
+export type EventType = typeof EventTypes[keyof typeof EventTypes];
+
+export interface TelemetryEventParams {
+  type: EventType;
+  eventName: string;
+  properties?: { [key: string]: string };
+  measurements?: { [key: string]: number };
+}
+
+export class MockUserInteraction implements UserInteraction {
+  selectOption(config: SingleSelectConfig): Promise<Result<SingleSelectResult, FxError>> {
+    throw new Error(`Method selectOption not implemented: ${JSON.stringify(config)}`);
+  }
+
+  selectOptions(config: MultiSelectConfig): Promise<Result<MultiSelectResult, FxError>> {
+    throw new Error(`Method selectOptions not implemented: ${JSON.stringify(config)}`);
+  }
+
+  inputText(config: InputTextConfig): Promise<Result<InputTextResult, FxError>> {
+    throw new Error(`Method inputText not implemented: ${JSON.stringify(config)}`);
+  }
+
+  selectFile(config: SelectFileConfig): Promise<Result<SelectFileResult, FxError>> {
+    throw new Error(`Method selectFile not implemented: ${JSON.stringify(config)}`);
+  }
+
+  selectFiles(config: SelectFilesConfig): Promise<Result<SelectFilesResult, FxError>> {
+    throw new Error(`Method selectFiles not implemented: ${JSON.stringify(config)}`);
+  }
+
+  selectFolder(config: SelectFolderConfig): Promise<Result<SelectFolderResult, FxError>> {
+    throw new Error(`Method selectFolder not implemented: ${JSON.stringify(config)}`);
+  }
+
+  openUrl(link: string): Promise<Result<boolean, FxError>> {
+    throw new Error(`Method openUrl not implemented: ${link}`);
+  }
+
+  async showMessage(
+    level: "info" | "warn" | "error",
+    message: string,
+    modal: boolean,
+    ...items: string[]
+  ): Promise<Result<string | undefined, FxError>>;
+
+  async showMessage(
+    level: "info" | "warn" | "error",
+    message: Array<{ content: string; color: Colors }>,
+    modal: boolean,
+    ...items: string[]
+  ): Promise<Result<string | undefined, FxError>>;
+
+  async showMessage(
+    level: "info" | "warn" | "error",
+    message: string | Array<{ content: string; color: Colors }>,
+    modal: boolean,
+    ...items: string[]
+  ): Promise<Result<string | undefined, FxError>> {
+    return ok("");
+  }
+
+  createProgressBar(title: string, totalSteps: number): IProgressHandler {
+    const handler: IProgressHandler = {
+      start: async (detail?: string): Promise<void> => {},
+      next: async (detail?: string): Promise<void> => {},
+      end: async (): Promise<void> => {},
+    };
+    return handler;
+  }
+
+  async runWithProgress<T>(
+    task: RunnableTask<T>,
+    config: TaskConfig,
+    ...args: any
+  ): Promise<Result<T, FxError>> {
+    return task.run(args);
+  }
+  async runCommand(args: {
+    cmd: string;
+    workingDirectory?: string;
+    shell?: string;
+    timeout?: number;
+    env?: { [k: string]: string };
+  }): Promise<Result<string, FxError>> {
+    throw new Error(`Method openUrl not implemented: runCommand`);
+  }
+}
+
+export class MockTelemetryReporter implements TelemetryReporter {
+  events: TelemetryEventParams[] = [];
+
+  sendTelemetryErrorEvent(
+    eventName: string,
+    properties?: { [key: string]: string },
+    measurements?: { [key: string]: number },
+    errorProps?: string[]
+  ): void {
+    this.events.push({ type: EventTypes.TelemetryErrorEvent, eventName, properties, measurements });
+  }
+
+  sendTelemetryEvent(
+    eventName: string,
+    properties?: { [key: string]: string },
+    measurements?: { [key: string]: number }
+  ): void {
+    this.events.push({ type: EventTypes.TelemetryEvent, eventName, properties, measurements });
+  }
+
+  sendTelemetryException(
+    error: Error,
+    properties?: { [key: string]: string },
+    measurements?: { [key: string]: number }
+  ): void {
+    throw new Error("Not implemented");
+  }
+
+  resetEvents() {
+    this.events = [];
+  }
+}
+
+export class MockLogProvier implements LogProvider {
+  async log(logLevel: LogLevel, message: string): Promise<boolean> {
+    return true;
+  }
+  async trace(message: string): Promise<boolean> {
+    return true;
+  }
+  async debug(message: string): Promise<boolean> {
+    return true;
+  }
+  async info(message: string | Array<{ content: string; color: Colors }>): Promise<boolean> {
+    return true;
+  }
+  async warning(message: string): Promise<boolean> {
+    return true;
+  }
+  async error(message: string): Promise<boolean> {
+    return true;
+  }
+  async fatal(message: string): Promise<boolean> {
+    return true;
+  }
+}


### PR DESCRIPTION
Send manifest/yml metadata events at the first of local debug in case of preqrequisites check failure.

To determine project type/capabilities for V5 local debug:
  - For happy path: use metadata events in the actual action
  - For users blocked by prerequisites check: use this metadata events to determine project type 

tasks.json metadata event will be added in another PR.

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/17518368/