### PR TITLE
chore: add metadata source to localdebug telemetry

### DIFF
--- a/packages/fx-core/src/component/utils/metadataUtil.ts
+++ b/packages/fx-core/src/component/utils/metadataUtil.ts
@@ -7,9 +7,13 @@ import { yamlParser } from "../configManager/parser";
 import { createHash } from "crypto";
 
 export class MetadataUtil {
-  async parse(path: string, env: string | undefined): Promise<Result<ProjectModel, FxError>> {
+  async parse(
+    path: string,
+    env: string | undefined,
+    additionalProperties?: { [key: string]: string }
+  ): Promise<Result<ProjectModel, FxError>> {
     const res = await yamlParser.parse(path);
-    const props: { [key: string]: string } = {};
+    let props: { [key: string]: string } = {};
     props[TelemetryProperty.YmlName] = (
       env === "local" ? MetadataV3.localConfigFile : MetadataV3.configFile
     )
@@ -25,14 +29,20 @@ export class MetadataUtil {
         props[name + ".actions"] = str ?? "";
       }
 
+      if (additionalProperties) {
+        props = { ...props, ...additionalProperties };
+      }
       TOOLS.telemetryReporter?.sendTelemetryEvent(TelemetryEvent.MetaData, props);
     }
 
     return res;
   }
 
-  parseManifest(manifest: TeamsAppManifest): void {
-    const props: { [key: string]: string } = {};
+  parseManifest(
+    manifest: TeamsAppManifest,
+    additionalProperties?: { [key: string]: string }
+  ): void {
+    let props: { [key: string]: string } = {};
     const prefix = "manifest.";
     props[prefix + "id"] = manifest.id ?? "";
     props[prefix + "version"] = manifest.version ?? "";
@@ -55,6 +65,10 @@ export class MetadataUtil {
         )
         .toString() ?? "";
     props[prefix + "webApplicationInfo.id"] = manifest.webApplicationInfo?.id ?? "";
+
+    if (additionalProperties) {
+      props = { ...props, ...additionalProperties };
+    }
 
     TOOLS.telemetryReporter?.sendTelemetryEvent(TelemetryEvent.MetaData, props);
   }

--- a/packages/vscode-extension/src/debug/localTelemetryReporter.ts
+++ b/packages/vscode-extension/src/debug/localTelemetryReporter.ts
@@ -133,9 +133,9 @@ async function tryGetManifestFromYml(
   const configureTeamsAppArgs = configureTeamsApp?.with as
     | Partial<ConfigureTeamsAppArgs>
     | undefined;
-  const configureTeamsAppPath = configureTeamsAppArgs?.appPackagePath;
+  const configureTeamsAppAppPackagePath = configureTeamsAppArgs?.appPackagePath;
 
-  if (configureTeamsAppPath) {
+  if (configureTeamsAppAppPackagePath) {
     // Case 1: Happy path
     // Start from "teamsApp/update".appPackagePath
     // => "teamsApp/zipAppPackage".outputZipPath
@@ -151,7 +151,7 @@ async function tryGetManifestFromYml(
           return;
         }
 
-        if (createAppPackageArgs.outputZipPath === createAppPackageActionName) {
+        if (createAppPackageArgs.outputZipPath === configureTeamsAppAppPackagePath) {
           manifestPath = createAppPackageArgs.manifestPath;
         }
       });
@@ -169,7 +169,7 @@ async function tryGetManifestFromYml(
     // Start from "teamsApp/zipAppPackage".appPackagePath
     // => Unzip appPackage (in memory) to get manifest
     try {
-      const manifest = await readManifestFromAppPackage(configureTeamsAppPath);
+      const manifest = await readManifestFromAppPackage(configureTeamsAppAppPackagePath);
       if (manifest) {
         return {
           source: ManifestSources.ConfigureAppPackageAppPackagePath,
@@ -224,7 +224,7 @@ export async function sendDebugMetadataEvent(projectPath: string) {
     // TODO: add source to properties of metadataUtil.parseManifest (currently not exposed)
     const { source, manifest } = manifestData;
     // send manifest metadata
-    metadataUtil.parseManifest(manifest);
+    metadataUtil.parseManifest(manifest, { [TelemetryProperty.DebugMetadataSource]: source });
   } catch (e) {
     // ignore telemetry errors
   }

--- a/packages/vscode-extension/src/debug/localTelemetryReporter.ts
+++ b/packages/vscode-extension/src/debug/localTelemetryReporter.ts
@@ -221,7 +221,6 @@ export async function sendDebugMetadataEvent(projectPath: string) {
       return;
     }
 
-    // TODO: add source to properties of metadataUtil.parseManifest (currently not exposed)
     const { source, manifest } = manifestData;
     // send manifest metadata
     metadataUtil.parseManifest(manifest, { [TelemetryProperty.DebugMetadataSource]: source });

--- a/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
@@ -292,6 +292,7 @@ export enum TelemetryProperty {
   DebugPrelaunchTaskInfo = "debug-prelaunch-task-info",
   DebugNgrokLog = "debug-ngrok-log",
   DebugConfigName = "debug-config-name",
+  DebugMetadataSource = "debug-metadata-source",
   Internal = "internal",
   InternalAlias = "internal-alias",
   OSArch = "os-arch",


### PR DESCRIPTION
Add `debug-metadata-source` property to distinguish different cases in local debug.
- `undefined` => metadata is from running the actual actions. This is for happy path.
- others => read metadata before local debug. This is for cases when prerequisites-check fails and the previous case isn't executed to determine project type.


https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/17518368/