### PR TITLE
chore!: declare outputs for aadApp/create in templates

### DIFF
--- a/templates/scenarios/csharp/sso-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/csharp/sso-tab/teamsapp.local.yml.tpl
@@ -3,7 +3,7 @@
 version: 1.0.0
 
 provision:
-  - uses: aadApp/create # Creates a new AAD app to authenticate users if AAD_APP_CLIENT_ID environment variable is empty
+  - uses: aadApp/create # Creates a new AAD app to authenticate users if the environment variable that stores clientId is empty
     with:
       name: {{appName}}-aad # Note: when you run aadApp/update, the AAD app name will be updated based on the definition in manifest. If you don't want to change the name, make sure the name in AAD manifest is the same with the name defined here.
       generateClientSecret: true # If the value is false, the action will not generate client secret for you

--- a/templates/scenarios/csharp/sso-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/csharp/sso-tab/teamsapp.local.yml.tpl
@@ -3,7 +3,7 @@
 version: 1.0.0
 
 provision:
-  - uses: aadApp/create # Creates a new AAD app to authenticate users if the environment variable that stores clientId is empty
+  - uses: aadApp/create # Creates a new Azure Active Directory (AAD) app to authenticate users if the environment variable that stores clientId is empty
     with:
       name: {{appName}}-aad # Note: when you run aadApp/update, the AAD app name will be updated based on the definition in manifest. If you don't want to change the name, make sure the name in AAD manifest is the same with the name defined here.
       generateClientSecret: true # If the value is false, the action will not generate client secret for you

--- a/templates/scenarios/csharp/sso-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/csharp/sso-tab/teamsapp.local.yml.tpl
@@ -5,9 +5,9 @@ version: 1.0.0
 provision:
   - uses: aadApp/create # Creates a new AAD app to authenticate users if AAD_APP_CLIENT_ID environment variable is empty
     with:
-      name: {{appName}}-aad # Note: when you run aadApp/update, the AAD app name will be updated based on the definition of manifest. If you don't want to change the name, ensure the name in AAD manifest is same with the name defined here.
+      name: {{appName}}-aad # Note: when you run aadApp/update, the AAD app name will be updated based on the definition in manifest. If you don't want to change the name, make sure the name in AAD manifest is the same with the name defined here.
       generateClientSecret: true # If the value is false, the action will not generate client secret for you
-    writeToEnvironmentFile: # Writes the information of created resources to specified environment variable in the environment file
+    writeToEnvironmentFile: # Write the information of created resources into environment file for the specified environment variable(s).
       clientId: AAD_APP_CLIENT_ID
       clientSecret: SECRET_AAD_APP_CLIENT_SECRET # Environment variable that starts with `SECRET_` will be stored to the .env.{envName}.user environment file
       objectId: AAD_APP_OBJECT_ID

--- a/templates/scenarios/csharp/sso-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/csharp/sso-tab/teamsapp.local.yml.tpl
@@ -5,15 +5,15 @@ version: 1.0.0
 provision:
   - uses: aadApp/create # Creates a new AAD app to authenticate users if AAD_APP_CLIENT_ID environment variable is empty
     with:
-      name: {{appName}}-aad # Note: when you run configure/aadApp, the AAD app name will be updated based on the definition of manifest. If you don't want to change the name, ensure the name in AAD manifest is same with the name defined here.
+      name: {{appName}}-aad # Note: when you run aadApp/update, the AAD app name will be updated based on the definition of manifest. If you don't want to change the name, ensure the name in AAD manifest is same with the name defined here.
       generateClientSecret: true # If the value is false, the action will not generate client secret for you
-    # Output: following environment variable will be persisted in current environment's .env file.
-    # AAD_APP_CLIENT_ID: the client id of AAD app
-    # AAD_APP_CLIENT_SECRET: the client secret of AAD app
-    # AAD_APP_OBJECT_ID: the object id of AAD app
-    # AAD_APP_TENANT_ID: the tenant id of AAD app
-    # AAD_APP_OAUTH_AUTHORITY_HOST: the host of OAUTH authority of AAD app
-    # AAD_APP_OAUTH_AUTHORITY: the OAUTH authority of AAD app
+    writeToEnvironmentFile: # Writes the information of created resources to specified environment variable in the environment file
+      clientId: AAD_APP_CLIENT_ID
+      clientSecret: SECRET_AAD_APP_CLIENT_SECRET # Environment variable that starts with `SECRET_` will be stored to the .env.{envName}.user environment file
+      objectId: AAD_APP_OBJECT_ID
+      tenantId: AAD_APP_TENANT_ID
+      authority: AAD_APP_OAUTH_AUTHORITY
+      authorityHost: AAD_APP_OAUTH_AUTHORITY_HOST
 
   - uses: teamsApp/create # Creates a Teams app
     with:

--- a/templates/scenarios/csharp/sso-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/csharp/sso-tab/teamsapp.yml.tpl
@@ -8,15 +8,15 @@ environmentFolderPath: ./env
 provision:
   - uses: aadApp/create # Creates a new AAD app to authenticate users if AAD_APP_CLIENT_ID environment variable is empty
     with:
-      name: {{appName}}-aad # Note: when you run configure/aadApp, the AAD app name will be updated based on the definition of manifest. If you don't want to change the name, ensure the name in AAD manifest is same with the name defined here.
+      name: {{appName}}-aad # Note: when you run aadApp/update, the AAD app name will be updated based on the definition of manifest. If you don't want to change the name, ensure the name in AAD manifest is same with the name defined here.
       generateClientSecret: true # If the value is false, the action will not generate client secret for you
-    # Output: following environment variable will be persisted in current environment's .env file.
-    # AAD_APP_CLIENT_ID: the client id of AAD app
-    # AAD_APP_CLIENT_SECRET: the client secret of AAD app
-    # AAD_APP_OBJECT_ID: the object id of AAD app
-    # AAD_APP_TENANT_ID: the tenant id of AAD app
-    # AAD_APP_OAUTH_AUTHORITY_HOST: the host of OAUTH authority of AAD app
-    # AAD_APP_OAUTH_AUTHORITY: the OAUTH authority of AAD app
+    writeToEnvironmentFile: # Writes the information of created resources to specified environment variable in the environment file
+      clientId: AAD_APP_CLIENT_ID
+      clientSecret: SECRET_AAD_APP_CLIENT_SECRET # Environment variable that starts with `SECRET_` will be stored to the .env.{envName}.user environment file
+      objectId: AAD_APP_OBJECT_ID
+      tenantId: AAD_APP_TENANT_ID
+      authority: AAD_APP_OAUTH_AUTHORITY
+      authorityHost: AAD_APP_OAUTH_AUTHORITY_HOST
 
   - uses: teamsApp/create # Creates a Teams app
     with:

--- a/templates/scenarios/csharp/sso-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/csharp/sso-tab/teamsapp.yml.tpl
@@ -6,7 +6,7 @@ environmentFolderPath: ./env
 
 # Triggered when 'teamsfx provision' is executed
 provision:
-  - uses: aadApp/create # Creates a new AAD app to authenticate users if the environment variable that stores clientId is empty
+  - uses: aadApp/create # Creates a new Azure Active Directory (AAD) app to authenticate users if the environment variable that stores clientId is empty
     with:
       name: {{appName}}-aad # Note: when you run aadApp/update, the AAD app name will be updated based on the definition in manifest. If you don't want to change the name, make sure the name in AAD manifest is the same with the name defined here.
       generateClientSecret: true # If the value is false, the action will not generate client secret for you

--- a/templates/scenarios/csharp/sso-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/csharp/sso-tab/teamsapp.yml.tpl
@@ -8,9 +8,9 @@ environmentFolderPath: ./env
 provision:
   - uses: aadApp/create # Creates a new AAD app to authenticate users if AAD_APP_CLIENT_ID environment variable is empty
     with:
-      name: {{appName}}-aad # Note: when you run aadApp/update, the AAD app name will be updated based on the definition of manifest. If you don't want to change the name, ensure the name in AAD manifest is same with the name defined here.
+      name: {{appName}}-aad # Note: when you run aadApp/update, the AAD app name will be updated based on the definition in manifest. If you don't want to change the name, make sure the name in AAD manifest is the same with the name defined here.
       generateClientSecret: true # If the value is false, the action will not generate client secret for you
-    writeToEnvironmentFile: # Writes the information of created resources to specified environment variable in the environment file
+    writeToEnvironmentFile: # Write the information of created resources into environment file for the specified environment variable(s).
       clientId: AAD_APP_CLIENT_ID
       clientSecret: SECRET_AAD_APP_CLIENT_SECRET # Environment variable that starts with `SECRET_` will be stored to the .env.{envName}.user environment file
       objectId: AAD_APP_OBJECT_ID

--- a/templates/scenarios/csharp/sso-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/csharp/sso-tab/teamsapp.yml.tpl
@@ -6,7 +6,7 @@ environmentFolderPath: ./env
 
 # Triggered when 'teamsfx provision' is executed
 provision:
-  - uses: aadApp/create # Creates a new AAD app to authenticate users if AAD_APP_CLIENT_ID environment variable is empty
+  - uses: aadApp/create # Creates a new AAD app to authenticate users if the environment variable that stores clientId is empty
     with:
       name: {{appName}}-aad # Note: when you run aadApp/update, the AAD app name will be updated based on the definition in manifest. If you don't want to change the name, make sure the name in AAD manifest is the same with the name defined here.
       generateClientSecret: true # If the value is false, the action will not generate client secret for you

--- a/templates/scenarios/js/m365-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/js/m365-tab/teamsapp.local.yml.tpl
@@ -3,7 +3,7 @@
 version: 1.0.0
 
 provision:
-  - uses: aadApp/create # Creates a new AAD app to authenticate users if AAD_APP_CLIENT_ID environment variable is empty
+  - uses: aadApp/create # Creates a new AAD app to authenticate users if the environment variable that stores clientId is empty
     with:
       name: {{appName}} # Note: when you run aadApp/update, the AAD app name will be updated based on the definition in manifest. If you don't want to change the name, make sure the name in AAD manifest is the same with the name defined here.
       generateClientSecret: true # If the value is false, the driver will not generate client secret for you

--- a/templates/scenarios/js/m365-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/js/m365-tab/teamsapp.local.yml.tpl
@@ -5,15 +5,15 @@ version: 1.0.0
 provision:
   - uses: aadApp/create # Creates a new AAD app to authenticate users if AAD_APP_CLIENT_ID environment variable is empty
     with:
-      name: {{appName}} # Note: when you run configure/aadApp, the AAD app name will be updated based on the definition of manifest. If you don't want to change the name, ensure the name in AAD manifest is same with the name defined here.
+      name: {{appName}} # Note: when you run aadApp/update, the AAD app name will be updated based on the definition of manifest. If you don't want to change the name, ensure the name in AAD manifest is same with the name defined here.
       generateClientSecret: true # If the value is false, the driver will not generate client secret for you
-    # Output: following environment variable will be persisted in current environment's .env file.
-    # AAD_APP_CLIENT_ID: the client id of AAD app
-    # AAD_APP_CLIENT_SECRET: the client secret of AAD app
-    # AAD_APP_OBJECT_ID: the object id of AAD app
-    # AAD_APP_TENANT_ID: the tenant id of AAD app
-    # AAD_APP_OAUTH_AUTHORITY_HOST: the host of OAUTH authority of AAD app
-    # AAD_APP_OAUTH_AUTHORITY: the OAUTH authority of AAD app
+    writeToEnvironmentFile: # Writes the information of created resources to specified environment variable in the environment file
+      clientId: AAD_APP_CLIENT_ID
+      clientSecret: SECRET_AAD_APP_CLIENT_SECRET # Environment variable that starts with `SECRET_` will be stored to the .env.{envName}.user environment file
+      objectId: AAD_APP_OBJECT_ID
+      tenantId: AAD_APP_TENANT_ID
+      authority: AAD_APP_OAUTH_AUTHORITY
+      authorityHost: AAD_APP_OAUTH_AUTHORITY_HOST
 
   - uses: teamsApp/create # Creates a Teams app
     with:

--- a/templates/scenarios/js/m365-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/js/m365-tab/teamsapp.local.yml.tpl
@@ -5,9 +5,9 @@ version: 1.0.0
 provision:
   - uses: aadApp/create # Creates a new AAD app to authenticate users if AAD_APP_CLIENT_ID environment variable is empty
     with:
-      name: {{appName}} # Note: when you run aadApp/update, the AAD app name will be updated based on the definition of manifest. If you don't want to change the name, ensure the name in AAD manifest is same with the name defined here.
+      name: {{appName}} # Note: when you run aadApp/update, the AAD app name will be updated based on the definition in manifest. If you don't want to change the name, make sure the name in AAD manifest is the same with the name defined here.
       generateClientSecret: true # If the value is false, the driver will not generate client secret for you
-    writeToEnvironmentFile: # Writes the information of created resources to specified environment variable in the environment file
+    writeToEnvironmentFile: # Write the information of created resources into environment file for the specified environment variable(s).
       clientId: AAD_APP_CLIENT_ID
       clientSecret: SECRET_AAD_APP_CLIENT_SECRET # Environment variable that starts with `SECRET_` will be stored to the .env.{envName}.user environment file
       objectId: AAD_APP_OBJECT_ID

--- a/templates/scenarios/js/m365-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/js/m365-tab/teamsapp.local.yml.tpl
@@ -3,7 +3,7 @@
 version: 1.0.0
 
 provision:
-  - uses: aadApp/create # Creates a new AAD app to authenticate users if the environment variable that stores clientId is empty
+  - uses: aadApp/create # Creates a new Azure Active Directory (AAD) app to authenticate users if the environment variable that stores clientId is empty
     with:
       name: {{appName}} # Note: when you run aadApp/update, the AAD app name will be updated based on the definition in manifest. If you don't want to change the name, make sure the name in AAD manifest is the same with the name defined here.
       generateClientSecret: true # If the value is false, the driver will not generate client secret for you

--- a/templates/scenarios/js/m365-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/js/m365-tab/teamsapp.yml.tpl
@@ -8,15 +8,15 @@ environmentFolderPath: ./env
 provision:
   - uses: aadApp/create # Creates a new AAD app to authenticate users if AAD_APP_CLIENT_ID environment variable is empty
     with:
-      name: {{appName}} # Note: when you run configure/aadApp, the AAD app name will be updated based on the definition of manifest. If you don't want to change the name, ensure the name in AAD manifest is same with the name defined here.
+      name: {{appName}} # Note: when you run aadApp/update, the AAD app name will be updated based on the definition of manifest. If you don't want to change the name, ensure the name in AAD manifest is same with the name defined here.
       generateClientSecret: true # If the value is false, the action will not generate client secret for you
-    # Output: following environment variable will be persisted in current environment's .env file.
-    # AAD_APP_CLIENT_ID: the client id of AAD app
-    # AAD_APP_CLIENT_SECRET: the client secret of AAD app
-    # AAD_APP_OBJECT_ID: the object id of AAD app
-    # AAD_APP_TENANT_ID: the tenant id of AAD app
-    # AAD_APP_OAUTH_AUTHORITY_HOST: the host of OAUTH authority of AAD app
-    # AAD_APP_OAUTH_AUTHORITY: the OAUTH authority of AAD app
+    writeToEnvironmentFile: # Writes the information of created resources to specified environment variable in the environment file
+      clientId: AAD_APP_CLIENT_ID
+      clientSecret: SECRET_AAD_APP_CLIENT_SECRET # Environment variable that starts with `SECRET_` will be stored to the .env.{envName}.user environment file
+      objectId: AAD_APP_OBJECT_ID
+      tenantId: AAD_APP_TENANT_ID
+      authority: AAD_APP_OAUTH_AUTHORITY
+      authorityHost: AAD_APP_OAUTH_AUTHORITY_HOST
 
   - uses: teamsApp/create # Creates a Teams app
     with:

--- a/templates/scenarios/js/m365-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/js/m365-tab/teamsapp.yml.tpl
@@ -8,9 +8,9 @@ environmentFolderPath: ./env
 provision:
   - uses: aadApp/create # Creates a new AAD app to authenticate users if AAD_APP_CLIENT_ID environment variable is empty
     with:
-      name: {{appName}} # Note: when you run aadApp/update, the AAD app name will be updated based on the definition of manifest. If you don't want to change the name, ensure the name in AAD manifest is same with the name defined here.
+      name: {{appName}} # Note: when you run aadApp/update, the AAD app name will be updated based on the definition in manifest. If you don't want to change the name, make sure the name in AAD manifest is the same with the name defined here.
       generateClientSecret: true # If the value is false, the action will not generate client secret for you
-    writeToEnvironmentFile: # Writes the information of created resources to specified environment variable in the environment file
+    writeToEnvironmentFile: # Write the information of created resources into environment file for the specified environment variable(s).
       clientId: AAD_APP_CLIENT_ID
       clientSecret: SECRET_AAD_APP_CLIENT_SECRET # Environment variable that starts with `SECRET_` will be stored to the .env.{envName}.user environment file
       objectId: AAD_APP_OBJECT_ID

--- a/templates/scenarios/js/m365-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/js/m365-tab/teamsapp.yml.tpl
@@ -6,7 +6,7 @@ environmentFolderPath: ./env
 
 # Triggered when 'teamsfx provision' is executed
 provision:
-  - uses: aadApp/create # Creates a new AAD app to authenticate users if the environment variable that stores clientId is empty
+  - uses: aadApp/create # Creates a new Azure Active Directory (AAD) app to authenticate users if the environment variable that stores clientId is empty
     with:
       name: {{appName}} # Note: when you run aadApp/update, the AAD app name will be updated based on the definition in manifest. If you don't want to change the name, make sure the name in AAD manifest is the same with the name defined here.
       generateClientSecret: true # If the value is false, the action will not generate client secret for you

--- a/templates/scenarios/js/m365-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/js/m365-tab/teamsapp.yml.tpl
@@ -6,7 +6,7 @@ environmentFolderPath: ./env
 
 # Triggered when 'teamsfx provision' is executed
 provision:
-  - uses: aadApp/create # Creates a new AAD app to authenticate users if AAD_APP_CLIENT_ID environment variable is empty
+  - uses: aadApp/create # Creates a new AAD app to authenticate users if the environment variable that stores clientId is empty
     with:
       name: {{appName}} # Note: when you run aadApp/update, the AAD app name will be updated based on the definition in manifest. If you don't want to change the name, make sure the name in AAD manifest is the same with the name defined here.
       generateClientSecret: true # If the value is false, the action will not generate client secret for you

--- a/templates/scenarios/js/sso-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/js/sso-tab/teamsapp.local.yml.tpl
@@ -3,7 +3,7 @@
 version: 1.0.0
 
 provision:
-  - uses: aadApp/create # Creates a new AAD app to authenticate users if AAD_APP_CLIENT_ID environment variable is empty
+  - uses: aadApp/create # Creates a new AAD app to authenticate users if the environment variable that stores clientId is empty
     with:
       name: {{appName}}-aad # Note: when you run aadApp/update, the AAD app name will be updated based on the definition in manifest. If you don't want to change the name, make sure the name in AAD manifest is the same with the name defined here.
       generateClientSecret: true # If the value is false, the action will not generate client secret for you

--- a/templates/scenarios/js/sso-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/js/sso-tab/teamsapp.local.yml.tpl
@@ -3,7 +3,7 @@
 version: 1.0.0
 
 provision:
-  - uses: aadApp/create # Creates a new AAD app to authenticate users if the environment variable that stores clientId is empty
+  - uses: aadApp/create # Creates a new Azure Active Directory (AAD) app to authenticate users if the environment variable that stores clientId is empty
     with:
       name: {{appName}}-aad # Note: when you run aadApp/update, the AAD app name will be updated based on the definition in manifest. If you don't want to change the name, make sure the name in AAD manifest is the same with the name defined here.
       generateClientSecret: true # If the value is false, the action will not generate client secret for you

--- a/templates/scenarios/js/sso-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/js/sso-tab/teamsapp.local.yml.tpl
@@ -5,9 +5,9 @@ version: 1.0.0
 provision:
   - uses: aadApp/create # Creates a new AAD app to authenticate users if AAD_APP_CLIENT_ID environment variable is empty
     with:
-      name: {{appName}}-aad # Note: when you run aadApp/update, the AAD app name will be updated based on the definition of manifest. If you don't want to change the name, ensure the name in AAD manifest is same with the name defined here.
+      name: {{appName}}-aad # Note: when you run aadApp/update, the AAD app name will be updated based on the definition in manifest. If you don't want to change the name, make sure the name in AAD manifest is the same with the name defined here.
       generateClientSecret: true # If the value is false, the action will not generate client secret for you
-    writeToEnvironmentFile: # Writes the information of created resources to specified environment variable in the environment file
+    writeToEnvironmentFile: # Write the information of created resources into environment file for the specified environment variable(s).
       clientId: AAD_APP_CLIENT_ID
       clientSecret: SECRET_AAD_APP_CLIENT_SECRET # Environment variable that starts with `SECRET_` will be stored to the .env.{envName}.user environment file
       objectId: AAD_APP_OBJECT_ID

--- a/templates/scenarios/js/sso-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/js/sso-tab/teamsapp.local.yml.tpl
@@ -5,15 +5,15 @@ version: 1.0.0
 provision:
   - uses: aadApp/create # Creates a new AAD app to authenticate users if AAD_APP_CLIENT_ID environment variable is empty
     with:
-      name: {{appName}}-aad # Note: when you run configure/aadApp, the AAD app name will be updated based on the definition of manifest. If you don't want to change the name, ensure the name in AAD manifest is same with the name defined here.
+      name: {{appName}}-aad # Note: when you run aadApp/update, the AAD app name will be updated based on the definition of manifest. If you don't want to change the name, ensure the name in AAD manifest is same with the name defined here.
       generateClientSecret: true # If the value is false, the action will not generate client secret for you
-    # Output: following environment variable will be persisted in current environment's .env file.
-    # AAD_APP_CLIENT_ID: the client id of AAD app
-    # AAD_APP_CLIENT_SECRET: the client secret of AAD app
-    # AAD_APP_OBJECT_ID: the object id of AAD app
-    # AAD_APP_TENANT_ID: the tenant id of AAD app
-    # AAD_APP_OAUTH_AUTHORITY_HOST: the host of OAUTH authority of AAD app
-    # AAD_APP_OAUTH_AUTHORITY: the OAUTH authority of AAD app
+    writeToEnvironmentFile: # Writes the information of created resources to specified environment variable in the environment file
+      clientId: AAD_APP_CLIENT_ID
+      clientSecret: SECRET_AAD_APP_CLIENT_SECRET # Environment variable that starts with `SECRET_` will be stored to the .env.{envName}.user environment file
+      objectId: AAD_APP_OBJECT_ID
+      tenantId: AAD_APP_TENANT_ID
+      authority: AAD_APP_OAUTH_AUTHORITY
+      authorityHost: AAD_APP_OAUTH_AUTHORITY_HOST
 
   - uses: teamsApp/create # Creates a Teams app
     with:

--- a/templates/scenarios/js/sso-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/js/sso-tab/teamsapp.yml.tpl
@@ -8,15 +8,15 @@ environmentFolderPath: ./env
 provision:
   - uses: aadApp/create # Creates a new AAD app to authenticate users if AAD_APP_CLIENT_ID environment variable is empty
     with:
-      name: {{appName}}-aad # Note: when you run configure/aadApp, the AAD app name will be updated based on the definition of manifest. If you don't want to change the name, ensure the name in AAD manifest is same with the name defined here.
+      name: {{appName}}-aad # Note: when you run aadApp/update, the AAD app name will be updated based on the definition of manifest. If you don't want to change the name, ensure the name in AAD manifest is same with the name defined here.
       generateClientSecret: true # If the value is false, the action will not generate client secret for you
-    # Output: following environment variable will be persisted in current environment's .env file.
-    # AAD_APP_CLIENT_ID: the client id of AAD app
-    # AAD_APP_CLIENT_SECRET: the client secret of AAD app
-    # AAD_APP_OBJECT_ID: the object id of AAD app
-    # AAD_APP_TENANT_ID: the tenant id of AAD app
-    # AAD_APP_OAUTH_AUTHORITY_HOST: the host of OAUTH authority of AAD app
-    # AAD_APP_OAUTH_AUTHORITY: the OAUTH authority of AAD app
+    writeToEnvironmentFile: # Writes the information of created resources to specified environment variable in the environment file
+      clientId: AAD_APP_CLIENT_ID
+      clientSecret: SECRET_AAD_APP_CLIENT_SECRET # Environment variable that starts with `SECRET_` will be stored to the .env.{envName}.user environment file
+      objectId: AAD_APP_OBJECT_ID
+      tenantId: AAD_APP_TENANT_ID
+      authority: AAD_APP_OAUTH_AUTHORITY
+      authorityHost: AAD_APP_OAUTH_AUTHORITY_HOST
 
   - uses: teamsApp/create # Creates a Teams app
     with:

--- a/templates/scenarios/js/sso-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/js/sso-tab/teamsapp.yml.tpl
@@ -6,7 +6,7 @@ environmentFolderPath: ./env
 
 # Triggered when 'teamsfx provision' is executed
 provision:
-  - uses: aadApp/create # Creates a new AAD app to authenticate users if the environment variable that stores clientId is empty
+  - uses: aadApp/create # Creates a new Azure Active Directory (AAD) app to authenticate users if the environment variable that stores clientId is empty
     with:
       name: {{appName}}-aad # Note: when you run aadApp/update, the AAD app name will be updated based on the definition in manifest. If you don't want to change the name, make sure the name in AAD manifest is the same with the name defined here.
       generateClientSecret: true # If the value is false, the action will not generate client secret for you

--- a/templates/scenarios/js/sso-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/js/sso-tab/teamsapp.yml.tpl
@@ -8,9 +8,9 @@ environmentFolderPath: ./env
 provision:
   - uses: aadApp/create # Creates a new AAD app to authenticate users if AAD_APP_CLIENT_ID environment variable is empty
     with:
-      name: {{appName}}-aad # Note: when you run aadApp/update, the AAD app name will be updated based on the definition of manifest. If you don't want to change the name, ensure the name in AAD manifest is same with the name defined here.
+      name: {{appName}}-aad # Note: when you run aadApp/update, the AAD app name will be updated based on the definition in manifest. If you don't want to change the name, make sure the name in AAD manifest is the same with the name defined here.
       generateClientSecret: true # If the value is false, the action will not generate client secret for you
-    writeToEnvironmentFile: # Writes the information of created resources to specified environment variable in the environment file
+    writeToEnvironmentFile: # Write the information of created resources into environment file for the specified environment variable(s).
       clientId: AAD_APP_CLIENT_ID
       clientSecret: SECRET_AAD_APP_CLIENT_SECRET # Environment variable that starts with `SECRET_` will be stored to the .env.{envName}.user environment file
       objectId: AAD_APP_OBJECT_ID

--- a/templates/scenarios/js/sso-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/js/sso-tab/teamsapp.yml.tpl
@@ -6,7 +6,7 @@ environmentFolderPath: ./env
 
 # Triggered when 'teamsfx provision' is executed
 provision:
-  - uses: aadApp/create # Creates a new AAD app to authenticate users if AAD_APP_CLIENT_ID environment variable is empty
+  - uses: aadApp/create # Creates a new AAD app to authenticate users if the environment variable that stores clientId is empty
     with:
       name: {{appName}}-aad # Note: when you run aadApp/update, the AAD app name will be updated based on the definition in manifest. If you don't want to change the name, make sure the name in AAD manifest is the same with the name defined here.
       generateClientSecret: true # If the value is false, the action will not generate client secret for you

--- a/templates/scenarios/ts/m365-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/ts/m365-tab/teamsapp.local.yml.tpl
@@ -3,7 +3,7 @@
 version: 1.0.0
 
 provision:
-  - uses: aadApp/create # Creates a new AAD app to authenticate users if AAD_APP_CLIENT_ID environment variable is empty
+  - uses: aadApp/create # Creates a new AAD app to authenticate users if the environment variable that stores clientId is empty
     with:
       name: {{appName}} # Note: when you run aadApp/update, the AAD app name will be updated based on the definition in manifest. If you don't want to change the name, make sure the name in AAD manifest is the same with the name defined here.
       generateClientSecret: true # If the value is false, the driver will not generate client secret for you

--- a/templates/scenarios/ts/m365-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/ts/m365-tab/teamsapp.local.yml.tpl
@@ -5,15 +5,15 @@ version: 1.0.0
 provision:
   - uses: aadApp/create # Creates a new AAD app to authenticate users if AAD_APP_CLIENT_ID environment variable is empty
     with:
-      name: {{appName}} # Note: when you run configure/aadApp, the AAD app name will be updated based on the definition of manifest. If you don't want to change the name, ensure the name in AAD manifest is same with the name defined here.
+      name: {{appName}} # Note: when you run aadApp/update, the AAD app name will be updated based on the definition of manifest. If you don't want to change the name, ensure the name in AAD manifest is same with the name defined here.
       generateClientSecret: true # If the value is false, the driver will not generate client secret for you
-    # Output: following environment variable will be persisted in current environment's .env file.
-    # AAD_APP_CLIENT_ID: the client id of AAD app
-    # AAD_APP_CLIENT_SECRET: the client secret of AAD app
-    # AAD_APP_OBJECT_ID: the object id of AAD app
-    # AAD_APP_TENANT_ID: the tenant id of AAD app
-    # AAD_APP_OAUTH_AUTHORITY_HOST: the host of OAUTH authority of AAD app
-    # AAD_APP_OAUTH_AUTHORITY: the OAUTH authority of AAD app
+    writeToEnvironmentFile: # Writes the information of created resources to specified environment variable in the environment file
+      clientId: AAD_APP_CLIENT_ID
+      clientSecret: SECRET_AAD_APP_CLIENT_SECRET # Environment variable that starts with `SECRET_` will be stored to the .env.{envName}.user environment file
+      objectId: AAD_APP_OBJECT_ID
+      tenantId: AAD_APP_TENANT_ID
+      authority: AAD_APP_OAUTH_AUTHORITY
+      authorityHost: AAD_APP_OAUTH_AUTHORITY_HOST
 
   - uses: teamsApp/create # Creates a Teams app
     with:

--- a/templates/scenarios/ts/m365-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/ts/m365-tab/teamsapp.local.yml.tpl
@@ -5,9 +5,9 @@ version: 1.0.0
 provision:
   - uses: aadApp/create # Creates a new AAD app to authenticate users if AAD_APP_CLIENT_ID environment variable is empty
     with:
-      name: {{appName}} # Note: when you run aadApp/update, the AAD app name will be updated based on the definition of manifest. If you don't want to change the name, ensure the name in AAD manifest is same with the name defined here.
+      name: {{appName}} # Note: when you run aadApp/update, the AAD app name will be updated based on the definition in manifest. If you don't want to change the name, make sure the name in AAD manifest is the same with the name defined here.
       generateClientSecret: true # If the value is false, the driver will not generate client secret for you
-    writeToEnvironmentFile: # Writes the information of created resources to specified environment variable in the environment file
+    writeToEnvironmentFile: # Write the information of created resources into environment file for the specified environment variable(s).
       clientId: AAD_APP_CLIENT_ID
       clientSecret: SECRET_AAD_APP_CLIENT_SECRET # Environment variable that starts with `SECRET_` will be stored to the .env.{envName}.user environment file
       objectId: AAD_APP_OBJECT_ID

--- a/templates/scenarios/ts/m365-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/ts/m365-tab/teamsapp.local.yml.tpl
@@ -3,7 +3,7 @@
 version: 1.0.0
 
 provision:
-  - uses: aadApp/create # Creates a new AAD app to authenticate users if the environment variable that stores clientId is empty
+  - uses: aadApp/create # Creates a new Azure Active Directory (AAD) app to authenticate users if the environment variable that stores clientId is empty
     with:
       name: {{appName}} # Note: when you run aadApp/update, the AAD app name will be updated based on the definition in manifest. If you don't want to change the name, make sure the name in AAD manifest is the same with the name defined here.
       generateClientSecret: true # If the value is false, the driver will not generate client secret for you

--- a/templates/scenarios/ts/m365-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/ts/m365-tab/teamsapp.yml.tpl
@@ -8,15 +8,15 @@ environmentFolderPath: ./env
 provision:
   - uses: aadApp/create # Creates a new AAD app to authenticate users if AAD_APP_CLIENT_ID environment variable is empty
     with:
-      name: {{appName}} # Note: when you run configure/aadApp, the AAD app name will be updated based on the definition of manifest. If you don't want to change the name, ensure the name in AAD manifest is same with the name defined here.
+      name: {{appName}} # Note: when you run aadApp/update, the AAD app name will be updated based on the definition of manifest. If you don't want to change the name, ensure the name in AAD manifest is same with the name defined here.
       generateClientSecret: true # If the value is false, the action will not generate client secret for you
-    # Output: following environment variable will be persisted in current environment's .env file.
-    # AAD_APP_CLIENT_ID: the client id of AAD app
-    # AAD_APP_CLIENT_SECRET: the client secret of AAD app
-    # AAD_APP_OBJECT_ID: the object id of AAD app
-    # AAD_APP_TENANT_ID: the tenant id of AAD app
-    # AAD_APP_OAUTH_AUTHORITY_HOST: the host of OAUTH authority of AAD app
-    # AAD_APP_OAUTH_AUTHORITY: the OAUTH authority of AAD app
+    writeToEnvironmentFile: # Writes the information of created resources to specified environment variable in the environment file
+      clientId: AAD_APP_CLIENT_ID
+      clientSecret: SECRET_AAD_APP_CLIENT_SECRET # Environment variable that starts with `SECRET_` will be stored to the .env.{envName}.user environment file
+      objectId: AAD_APP_OBJECT_ID
+      tenantId: AAD_APP_TENANT_ID
+      authority: AAD_APP_OAUTH_AUTHORITY
+      authorityHost: AAD_APP_OAUTH_AUTHORITY_HOST
 
   - uses: teamsApp/create # Creates a Teams app
     with:

--- a/templates/scenarios/ts/m365-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/ts/m365-tab/teamsapp.yml.tpl
@@ -8,9 +8,9 @@ environmentFolderPath: ./env
 provision:
   - uses: aadApp/create # Creates a new AAD app to authenticate users if AAD_APP_CLIENT_ID environment variable is empty
     with:
-      name: {{appName}} # Note: when you run aadApp/update, the AAD app name will be updated based on the definition of manifest. If you don't want to change the name, ensure the name in AAD manifest is same with the name defined here.
+      name: {{appName}} # Note: when you run aadApp/update, the AAD app name will be updated based on the definition in manifest. If you don't want to change the name, make sure the name in AAD manifest is the same with the name defined here.
       generateClientSecret: true # If the value is false, the action will not generate client secret for you
-    writeToEnvironmentFile: # Writes the information of created resources to specified environment variable in the environment file
+    writeToEnvironmentFile: # Write the information of created resources into environment file for the specified environment variable(s).
       clientId: AAD_APP_CLIENT_ID
       clientSecret: SECRET_AAD_APP_CLIENT_SECRET # Environment variable that starts with `SECRET_` will be stored to the .env.{envName}.user environment file
       objectId: AAD_APP_OBJECT_ID

--- a/templates/scenarios/ts/m365-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/ts/m365-tab/teamsapp.yml.tpl
@@ -6,7 +6,7 @@ environmentFolderPath: ./env
 
 # Triggered when 'teamsfx provision' is executed
 provision:
-  - uses: aadApp/create # Creates a new AAD app to authenticate users if the environment variable that stores clientId is empty
+  - uses: aadApp/create # Creates a new Azure Active Directory (AAD) app to authenticate users if the environment variable that stores clientId is empty
     with:
       name: {{appName}} # Note: when you run aadApp/update, the AAD app name will be updated based on the definition in manifest. If you don't want to change the name, make sure the name in AAD manifest is the same with the name defined here.
       generateClientSecret: true # If the value is false, the action will not generate client secret for you

--- a/templates/scenarios/ts/m365-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/ts/m365-tab/teamsapp.yml.tpl
@@ -6,7 +6,7 @@ environmentFolderPath: ./env
 
 # Triggered when 'teamsfx provision' is executed
 provision:
-  - uses: aadApp/create # Creates a new AAD app to authenticate users if AAD_APP_CLIENT_ID environment variable is empty
+  - uses: aadApp/create # Creates a new AAD app to authenticate users if the environment variable that stores clientId is empty
     with:
       name: {{appName}} # Note: when you run aadApp/update, the AAD app name will be updated based on the definition in manifest. If you don't want to change the name, make sure the name in AAD manifest is the same with the name defined here.
       generateClientSecret: true # If the value is false, the action will not generate client secret for you

--- a/templates/scenarios/ts/sso-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/ts/sso-tab/teamsapp.local.yml.tpl
@@ -3,7 +3,7 @@
 version: 1.0.0
 
 provision:
-  - uses: aadApp/create # Creates a new AAD app to authenticate users if AAD_APP_CLIENT_ID environment variable is empty
+  - uses: aadApp/create # Creates a new AAD app to authenticate users if the environment variable that stores clientId is empty
     with:
       name: {{appName}}-aad # Note: when you run aadApp/update, the AAD app name will be updated based on the definition in manifest. If you don't want to change the name, make sure the name in AAD manifest is the same with the name defined here.
       generateClientSecret: true # If the value is false, the action will not generate client secret for you

--- a/templates/scenarios/ts/sso-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/ts/sso-tab/teamsapp.local.yml.tpl
@@ -3,7 +3,7 @@
 version: 1.0.0
 
 provision:
-  - uses: aadApp/create # Creates a new AAD app to authenticate users if the environment variable that stores clientId is empty
+  - uses: aadApp/create # Creates a new Azure Active Directory (AAD) app to authenticate users if the environment variable that stores clientId is empty
     with:
       name: {{appName}}-aad # Note: when you run aadApp/update, the AAD app name will be updated based on the definition in manifest. If you don't want to change the name, make sure the name in AAD manifest is the same with the name defined here.
       generateClientSecret: true # If the value is false, the action will not generate client secret for you

--- a/templates/scenarios/ts/sso-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/ts/sso-tab/teamsapp.local.yml.tpl
@@ -5,9 +5,9 @@ version: 1.0.0
 provision:
   - uses: aadApp/create # Creates a new AAD app to authenticate users if AAD_APP_CLIENT_ID environment variable is empty
     with:
-      name: {{appName}}-aad # Note: when you run aadApp/update, the AAD app name will be updated based on the definition of manifest. If you don't want to change the name, ensure the name in AAD manifest is same with the name defined here.
+      name: {{appName}}-aad # Note: when you run aadApp/update, the AAD app name will be updated based on the definition in manifest. If you don't want to change the name, make sure the name in AAD manifest is the same with the name defined here.
       generateClientSecret: true # If the value is false, the action will not generate client secret for you
-    writeToEnvironmentFile: # Writes the information of created resources to specified environment variable in the environment file
+    writeToEnvironmentFile: # Write the information of created resources into environment file for the specified environment variable(s).
       clientId: AAD_APP_CLIENT_ID
       clientSecret: SECRET_AAD_APP_CLIENT_SECRET # Environment variable that starts with `SECRET_` will be stored to the .env.{envName}.user environment file
       objectId: AAD_APP_OBJECT_ID

--- a/templates/scenarios/ts/sso-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/ts/sso-tab/teamsapp.local.yml.tpl
@@ -5,15 +5,15 @@ version: 1.0.0
 provision:
   - uses: aadApp/create # Creates a new AAD app to authenticate users if AAD_APP_CLIENT_ID environment variable is empty
     with:
-      name: {{appName}}-aad # Note: when you run configure/aadApp, the AAD app name will be updated based on the definition of manifest. If you don't want to change the name, ensure the name in AAD manifest is same with the name defined here.
+      name: {{appName}}-aad # Note: when you run aadApp/update, the AAD app name will be updated based on the definition of manifest. If you don't want to change the name, ensure the name in AAD manifest is same with the name defined here.
       generateClientSecret: true # If the value is false, the action will not generate client secret for you
-    # Output: following environment variable will be persisted in current environment's .env file.
-    # AAD_APP_CLIENT_ID: the client id of AAD app
-    # AAD_APP_CLIENT_SECRET: the client secret of AAD app
-    # AAD_APP_OBJECT_ID: the object id of AAD app
-    # AAD_APP_TENANT_ID: the tenant id of AAD app
-    # AAD_APP_OAUTH_AUTHORITY_HOST: the host of OAUTH authority of AAD app
-    # AAD_APP_OAUTH_AUTHORITY: the OAUTH authority of AAD app
+    writeToEnvironmentFile: # Writes the information of created resources to specified environment variable in the environment file
+      clientId: AAD_APP_CLIENT_ID
+      clientSecret: SECRET_AAD_APP_CLIENT_SECRET # Environment variable that starts with `SECRET_` will be stored to the .env.{envName}.user environment file
+      objectId: AAD_APP_OBJECT_ID
+      tenantId: AAD_APP_TENANT_ID
+      authority: AAD_APP_OAUTH_AUTHORITY
+      authorityHost: AAD_APP_OAUTH_AUTHORITY_HOST
 
   - uses: teamsApp/create # Creates a Teams app
     with:

--- a/templates/scenarios/ts/sso-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/ts/sso-tab/teamsapp.yml.tpl
@@ -8,15 +8,15 @@ environmentFolderPath: ./env
 provision:
   - uses: aadApp/create # Creates a new AAD app to authenticate users if AAD_APP_CLIENT_ID environment variable is empty
     with:
-      name: {{appName}}-aad # Note: when you run configure/aadApp, the AAD app name will be updated based on the definition of manifest. If you don't want to change the name, ensure the name in AAD manifest is same with the name defined here.
+      name: {{appName}}-aad # Note: when you run aadApp/update, the AAD app name will be updated based on the definition of manifest. If you don't want to change the name, ensure the name in AAD manifest is same with the name defined here.
       generateClientSecret: true # If the value is false, the action will not generate client secret for you
-    # Output: following environment variable will be persisted in current environment's .env file.
-    # AAD_APP_CLIENT_ID: the client id of AAD app
-    # AAD_APP_CLIENT_SECRET: the client secret of AAD app
-    # AAD_APP_OBJECT_ID: the object id of AAD app
-    # AAD_APP_TENANT_ID: the tenant id of AAD app
-    # AAD_APP_OAUTH_AUTHORITY_HOST: the host of OAUTH authority of AAD app
-    # AAD_APP_OAUTH_AUTHORITY: the OAUTH authority of AAD app
+    writeToEnvironmentFile: # Writes the information of created resources to specified environment variable in the environment file
+      clientId: AAD_APP_CLIENT_ID
+      clientSecret: SECRET_AAD_APP_CLIENT_SECRET # Environment variable that starts with `SECRET_` will be stored to the .env.{envName}.user environment file
+      objectId: AAD_APP_OBJECT_ID
+      tenantId: AAD_APP_TENANT_ID
+      authority: AAD_APP_OAUTH_AUTHORITY
+      authorityHost: AAD_APP_OAUTH_AUTHORITY_HOST
 
   - uses: teamsApp/create # Creates a Teams app
     with:

--- a/templates/scenarios/ts/sso-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/ts/sso-tab/teamsapp.yml.tpl
@@ -6,7 +6,7 @@ environmentFolderPath: ./env
 
 # Triggered when 'teamsfx provision' is executed
 provision:
-  - uses: aadApp/create # Creates a new AAD app to authenticate users if the environment variable that stores clientId is empty
+  - uses: aadApp/create # Creates a new Azure Active Directory (AAD) app to authenticate users if the environment variable that stores clientId is empty
     with:
       name: {{appName}}-aad # Note: when you run aadApp/update, the AAD app name will be updated based on the definition in manifest. If you don't want to change the name, make sure the name in AAD manifest is the same with the name defined here.
       generateClientSecret: true # If the value is false, the action will not generate client secret for you

--- a/templates/scenarios/ts/sso-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/ts/sso-tab/teamsapp.yml.tpl
@@ -8,9 +8,9 @@ environmentFolderPath: ./env
 provision:
   - uses: aadApp/create # Creates a new AAD app to authenticate users if AAD_APP_CLIENT_ID environment variable is empty
     with:
-      name: {{appName}}-aad # Note: when you run aadApp/update, the AAD app name will be updated based on the definition of manifest. If you don't want to change the name, ensure the name in AAD manifest is same with the name defined here.
+      name: {{appName}}-aad # Note: when you run aadApp/update, the AAD app name will be updated based on the definition in manifest. If you don't want to change the name, make sure the name in AAD manifest is the same with the name defined here.
       generateClientSecret: true # If the value is false, the action will not generate client secret for you
-    writeToEnvironmentFile: # Writes the information of created resources to specified environment variable in the environment file
+    writeToEnvironmentFile: # Write the information of created resources into environment file for the specified environment variable(s).
       clientId: AAD_APP_CLIENT_ID
       clientSecret: SECRET_AAD_APP_CLIENT_SECRET # Environment variable that starts with `SECRET_` will be stored to the .env.{envName}.user environment file
       objectId: AAD_APP_OBJECT_ID

--- a/templates/scenarios/ts/sso-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/ts/sso-tab/teamsapp.yml.tpl
@@ -6,7 +6,7 @@ environmentFolderPath: ./env
 
 # Triggered when 'teamsfx provision' is executed
 provision:
-  - uses: aadApp/create # Creates a new AAD app to authenticate users if AAD_APP_CLIENT_ID environment variable is empty
+  - uses: aadApp/create # Creates a new AAD app to authenticate users if the environment variable that stores clientId is empty
     with:
       name: {{appName}}-aad # Note: when you run aadApp/update, the AAD app name will be updated based on the definition in manifest. If you don't want to change the name, make sure the name in AAD manifest is the same with the name defined here.
       generateClientSecret: true # If the value is false, the action will not generate client secret for you


### PR DESCRIPTION
1. declare outputs for aadApp/create in templates
2. mark it as breaking change to bump the major version of our templates

BREAKING CHANGE: the `writeToEnvironmentFile` property will be required in the future, and there will also be other breaking changes recently. So mark this PR as breaking change to bump the major version of our templates.