### PR TITLE
chore: support outputEnvVarNames in prerequisite action

### DIFF
--- a/packages/fx-core/src/component/driver/prerequisite/installDriver.ts
+++ b/packages/fx-core/src/component/driver/prerequisite/installDriver.ts
@@ -30,15 +30,18 @@ import { DotnetInstallationUserError } from "./error/dotnetInstallationUserError
 import { FuncInstallationUserError } from "./error/funcInstallationUserError";
 import { InstallToolArgs } from "./interfaces/InstallToolArgs";
 import { InvalidActionInputError } from "../../../error/common";
+import { addStartAndEndTelemetry } from "../middleware/addStartAndEndTelemetry";
+import { hooks } from "@feathersjs/hooks/lib";
 
 const ACTION_NAME = "prerequisite/install";
-const outputName = Object.freeze({
-  SSL_CRT_FILE: "SSL_CRT_FILE",
-  SSL_KEY_FILE: "SSL_KEY_FILE",
-  FUNC_PATH: "FUNC_PATH",
-  DOTNET_PATH: "DOTNET_PATH",
-});
 const helpLink = "https://aka.ms/teamsfx-actions/prerequisite-install";
+
+const outputKeys = {
+  sslCertFile: "sslCertFile",
+  sslKeyFile: "sslKeyFile",
+  funcPath: "funcPath",
+  dotnetPath: "dotnetPath",
+};
 
 @Service(ACTION_NAME)
 export class ToolsInstallDriver implements StepDriver {
@@ -56,18 +59,30 @@ export class ToolsInstallDriver implements StepDriver {
     >;
   }
 
-  async execute(args: InstallToolArgs, context: DriverContext): Promise<ExecutionResult> {
+  @hooks([addStartAndEndTelemetry(ACTION_NAME, ACTION_NAME)])
+  async execute(
+    args: InstallToolArgs,
+    context: DriverContext,
+    outputEnvVarNames?: Map<string, string>
+  ): Promise<ExecutionResult> {
     const wrapContext = new WrapDriverContext(context, ACTION_NAME, ACTION_NAME);
 
     const impl = new ToolsInstallDriverImpl(wrapContext);
-    return (await wrapRun(wrapContext, () => impl.run(args), true)) as ExecutionResult;
+    return (await wrapRun(
+      wrapContext,
+      () => impl.run(args, outputEnvVarNames),
+      true
+    )) as ExecutionResult;
   }
 }
 
 export class ToolsInstallDriverImpl {
   constructor(private context: WrapDriverContext) {}
 
-  async run(args: InstallToolArgs): Promise<Map<string, string>> {
+  async run(
+    args: InstallToolArgs,
+    outputEnvVarNames?: Map<string, string>
+  ): Promise<Map<string, string>> {
     const res = new Map<string, string>();
     this.validateArgs(args);
 
@@ -76,33 +91,45 @@ export class ToolsInstallDriverImpl {
 
     if (args.devCert) {
       await progressBar?.next(ProgressMessages.devCert());
-      const localCertRes = await this.resolveLocalCertificate(args.devCert.trust);
+      const localCertRes = await this.resolveLocalCertificate(
+        args.devCert.trust,
+        outputEnvVarNames
+      );
       localCertRes.forEach((v, k) => res.set(k, v));
     }
 
     if (args.func) {
       await progressBar?.next(ProgressMessages.func());
-      const funcRes = await this.resolveFuncCoreTools();
+      const funcRes = await this.resolveFuncCoreTools(outputEnvVarNames);
       funcRes.forEach((v, k) => res.set(k, v));
     }
 
     if (args.dotnet) {
       await progressBar?.next(ProgressMessages.dotnet());
-      const dotnetRes = await this.resolveDotnet();
+      const dotnetRes = await this.resolveDotnet(outputEnvVarNames);
       dotnetRes.forEach((v, k) => res.set(k, v));
     }
 
     return res;
   }
 
-  async resolveLocalCertificate(trustDevCert: boolean): Promise<Map<string, string>> {
+  async resolveLocalCertificate(
+    trustDevCert: boolean,
+    outputEnvVarNames?: Map<string, string>
+  ): Promise<Map<string, string>> {
     const res = new Map<string, string>();
     // Do not print any log in LocalCertificateManager, use the error message returned instead.
     const certManager = new LocalCertificateManager(this.context.ui);
     const localCertResult = await certManager.setupCertificate(trustDevCert);
     if (trustDevCert) {
-      res.set(outputName.SSL_CRT_FILE, localCertResult.certPath);
-      res.set(outputName.SSL_KEY_FILE, localCertResult.keyPath);
+      let name = outputEnvVarNames?.get(outputKeys.sslCertFile);
+      if (name) {
+        res.set(name, localCertResult.certPath);
+      }
+      name = outputEnvVarNames?.get(outputKeys.sslKeyFile);
+      if (name) {
+        res.set(name, localCertResult.keyPath);
+      }
     }
 
     this.setDevCertTelemetry(trustDevCert, localCertResult);
@@ -119,7 +146,9 @@ export class ToolsInstallDriverImpl {
     return res;
   }
 
-  async resolveFuncCoreTools(): Promise<Map<string, string>> {
+  async resolveFuncCoreTools(
+    outputEnvVarNames?: Map<string, string>
+  ): Promise<Map<string, string>> {
     const res = new Map<string, string>();
     const depsManager = new DepsManager(new EmptyLogger(), new EmptyTelemetry());
     const funcStatus = await depsManager.ensureDependency(DepsType.FuncCoreTools, true);
@@ -137,12 +166,15 @@ export class ToolsInstallDriverImpl {
 
     if (funcStatus?.details?.binFolders !== undefined) {
       const funcBinFolder = funcStatus.details.binFolders.join(path.delimiter);
-      res.set(outputName.FUNC_PATH, funcBinFolder);
+      const name = outputEnvVarNames?.get(outputKeys.funcPath);
+      if (name) {
+        res.set(name, funcBinFolder);
+      }
     }
     return res;
   }
 
-  async resolveDotnet(): Promise<Map<string, string>> {
+  async resolveDotnet(outputEnvVarNames?: Map<string, string>): Promise<Map<string, string>> {
     const res = new Map<string, string>();
     const depsManager = new DepsManager(new EmptyLogger(), new EmptyTelemetry());
     const dotnetStatus = await depsManager.ensureDependency(DepsType.Dotnet, true);
@@ -161,7 +193,10 @@ export class ToolsInstallDriverImpl {
       const dotnetBinFolder = `${dotnetStatus.details.binFolders
         .map((f: string) => path.dirname(f))
         .join(path.delimiter)}`;
-      res.set(outputName.DOTNET_PATH, dotnetBinFolder);
+      const name = outputEnvVarNames?.get(outputKeys.dotnetPath);
+      if (name) {
+        res.set(name, dotnetBinFolder);
+      }
     }
     return res;
   }

--- a/packages/fx-core/tests/component/driver/tools/installDriver.test.ts
+++ b/packages/fx-core/tests/component/driver/tools/installDriver.test.ts
@@ -39,13 +39,7 @@ describe("Tools Install Driver test", () => {
       const res = await toolsInstallDriver.run({ devCert: { trust: true } }, mockedDriverContext);
       chai.assert.isTrue(res.isOk());
       if (res.isOk()) {
-        chai.assert.includeDeepMembers(
-          [
-            ["SSL_CRT_FILE", "testCertPath"],
-            ["SSL_KEY_FILE", "testKeyPath"],
-          ],
-          Array.from(res.value.entries())
-        );
+        chai.assert.isEmpty(res.value);
       }
     });
 
@@ -59,13 +53,7 @@ describe("Tools Install Driver test", () => {
       const res = await toolsInstallDriver.run({ devCert: { trust: true } }, mockedDriverContext);
       chai.assert.isTrue(res.isOk());
       if (res.isOk()) {
-        chai.assert.includeDeepMembers(
-          [
-            ["SSL_CRT_FILE", "testCertPath"],
-            ["SSL_KEY_FILE", "testKeyPath"],
-          ],
-          Array.from(res.value.entries())
-        );
+        chai.assert.isEmpty(res.value);
       }
     });
 
@@ -128,10 +116,7 @@ describe("Tools Install Driver test", () => {
       const res = await toolsInstallDriver.run({ func: true }, mockedDriverContext);
       chai.assert.isTrue(res.isOk());
       if (res.isOk()) {
-        chai.assert.includeDeepMembers(
-          [["FUNC_PATH", "~/.fx/bin/func/node_modules/.bin"]],
-          Array.from(res.value.entries())
-        );
+        chai.assert.isEmpty(res.value);
       }
     });
 
@@ -170,10 +155,7 @@ describe("Tools Install Driver test", () => {
       const res = await toolsInstallDriver.run({ func: true }, mockedDriverContext);
       chai.assert.isTrue(res.isOk());
       if (res.isOk()) {
-        chai.assert.includeDeepMembers(
-          [["FUNC_PATH", "~/.fx/bin/func/node_modules/.bin"]],
-          Array.from(res.value.entries())
-        );
+        chai.assert.isEmpty(res.value);
       }
     });
 
@@ -207,10 +189,7 @@ describe("Tools Install Driver test", () => {
       const res = await toolsInstallDriver.run({ dotnet: true }, mockedDriverContext);
       chai.assert.isTrue(res.isOk());
       if (res.isOk()) {
-        chai.assert.includeDeepMembers(
-          [["DOTNET_PATH", "~/.fx/dotnet"]],
-          Array.from(res.value.entries())
-        );
+        chai.assert.isEmpty(res.value);
       }
     });
 
@@ -230,7 +209,7 @@ describe("Tools Install Driver test", () => {
       const res = await toolsInstallDriver.run({ dotnet: true }, mockedDriverContext);
       chai.assert.isTrue(res.isOk());
       if (res.isOk()) {
-        chai.assert.includeDeepMembers([["DOTNET_PATH", ""]], Array.from(res.value.entries()));
+        chai.assert.isEmpty(res.value);
       }
     });
 
@@ -250,7 +229,7 @@ describe("Tools Install Driver test", () => {
       const res = await toolsInstallDriver.run({ dotnet: true }, mockedDriverContext);
       chai.assert.isTrue(res.isOk());
       if (res.isOk()) {
-        chai.assert.includeDeepMembers([["DOTNET_PATH", ""]], Array.from(res.value.entries()));
+        chai.assert.isEmpty(res.value);
       }
     });
 
@@ -293,20 +272,42 @@ describe("Tools Install Driver test", () => {
         isTrusted: true,
         alreadyTrusted: false,
       });
+      const outputEnvVarNames = new Map([
+        ["sslCertFile", "MY_SSL_CRT_FILE"],
+        ["sslKeyFile", "MY_SSL_KEY_FILE"],
+      ]);
       const res = await toolsInstallDriver.execute(
         { devCert: { trust: true } },
-        mockedDriverContext
+        mockedDriverContext,
+        outputEnvVarNames
       );
       chai.assert.isNotEmpty(res.summaries);
       chai.assert.isTrue(res.result.isOk());
       if (res.result.isOk()) {
-        chai.assert.includeDeepMembers(
-          [
-            ["SSL_CRT_FILE", "testCertPath"],
-            ["SSL_KEY_FILE", "testKeyPath"],
-          ],
-          Array.from(res.result.value.entries())
-        );
+        chai.assert.includeDeepMembers(Array.from(res.result.value.entries()), [
+          ["MY_SSL_CRT_FILE", "testCertPath"],
+          ["MY_SSL_KEY_FILE", "testKeyPath"],
+        ]);
+      }
+    });
+
+    it("Create and trust new local certificate: empty outputEnvVarNames", async () => {
+      sandbox.stub(LocalCertificateManager.prototype, "setupCertificate").resolves({
+        certPath: "testCertPath",
+        keyPath: "testKeyPath",
+        isTrusted: true,
+        alreadyTrusted: false,
+      });
+      const outputEnvVarNames = new Map();
+      const res = await toolsInstallDriver.execute(
+        { devCert: { trust: true } },
+        mockedDriverContext,
+        outputEnvVarNames
+      );
+      chai.assert.isNotEmpty(res.summaries);
+      chai.assert.isTrue(res.result.isOk());
+      if (res.result.isOk()) {
+        chai.assert.isEmpty(res.result.value);
       }
     });
 
@@ -317,20 +318,22 @@ describe("Tools Install Driver test", () => {
         isTrusted: true,
         alreadyTrusted: true,
       });
+      const outputEnvVarNames = new Map([
+        ["sslCertFile", "MY_SSL_CRT_FILE"],
+        ["sslKeyFile", "MY_SSL_KEY_FILE"],
+      ]);
       const res = await toolsInstallDriver.execute(
         { devCert: { trust: true } },
-        mockedDriverContext
+        mockedDriverContext,
+        outputEnvVarNames
       );
       chai.assert.isNotEmpty(res.summaries);
       chai.assert.isTrue(res.result.isOk());
       if (res.result.isOk()) {
-        chai.assert.includeDeepMembers(
-          [
-            ["SSL_CRT_FILE", "testCertPath"],
-            ["SSL_KEY_FILE", "testKeyPath"],
-          ],
-          Array.from(res.result.value.entries())
-        );
+        chai.assert.includeDeepMembers(Array.from(res.result.value.entries()), [
+          ["MY_SSL_CRT_FILE", "testCertPath"],
+          ["MY_SSL_KEY_FILE", "testKeyPath"],
+        ]);
       }
     });
 
@@ -341,9 +344,14 @@ describe("Tools Install Driver test", () => {
         isTrusted: undefined,
         alreadyTrusted: undefined,
       });
+      const outputEnvVarNames = new Map([
+        ["sslCertFile", "MY_SSL_CRT_FILE"],
+        ["sslKeyFile", "MY_SSL_KEY_FILE"],
+      ]);
       const res = await toolsInstallDriver.execute(
         { devCert: { trust: false } },
-        mockedDriverContext
+        mockedDriverContext,
+        outputEnvVarNames
       );
       chai.assert.isNotEmpty(res.summaries);
       chai.assert.isTrue(res.result.isOk());
@@ -363,18 +371,28 @@ describe("Tools Install Driver test", () => {
           name: "SetupCertificateError",
         }),
       });
+      const outputEnvVarNames = new Map([
+        ["sslCertFile", "MY_SSL_CRT_FILE"],
+        ["sslKeyFile", "MY_SSL_KEY_FILE"],
+      ]);
       const res = await toolsInstallDriver.execute(
         { devCert: { trust: true } },
-        mockedDriverContext
+        mockedDriverContext,
+        outputEnvVarNames
       );
       chai.assert.isEmpty(res.summaries);
       chai.assert.isTrue(res.result.isErr());
     });
 
     it("Invalid parameter", async () => {
+      const outputEnvVarNames = new Map([
+        ["sslCertFile", "MY_SSL_CRT_FILE"],
+        ["sslKeyFile", "MY_SSL_KEY_FILE"],
+      ]);
       const res = await toolsInstallDriver.execute(
         { devCert: { trust: "hello" } } as unknown as InstallToolArgs,
-        mockedDriverContext
+        mockedDriverContext,
+        outputEnvVarNames
       );
       chai.assert.isEmpty(res.summaries);
       chai.assert.isTrue(res.result.isErr());
@@ -399,14 +417,44 @@ describe("Tools Install Driver test", () => {
           binFolders: ["~/.fx/bin/func/node_modules/.bin"],
         },
       });
-      const res = await toolsInstallDriver.execute({ func: true }, mockedDriverContext);
+      const outputEnvVarNames = new Map([["funcPath", "MY_FUNC_PATH"]]);
+      const res = await toolsInstallDriver.execute(
+        { func: true },
+        mockedDriverContext,
+        outputEnvVarNames
+      );
       chai.assert.isNotEmpty(res.summaries);
       chai.assert.isTrue(res.result.isOk());
       if (res.result.isOk()) {
-        chai.assert.includeDeepMembers(
-          [["FUNC_PATH", "~/.fx/bin/func/node_modules/.bin"]],
-          Array.from(res.result.value.entries())
-        );
+        chai.assert.includeDeepMembers(Array.from(res.result.value.entries()), [
+          ["MY_FUNC_PATH", "~/.fx/bin/func/node_modules/.bin"],
+        ]);
+      }
+    });
+
+    it("Install func: empty outputEnvVarNames", async () => {
+      sandbox.stub(FuncToolChecker.prototype, "resolve").resolves({
+        name: "Azure Functions Core Tools",
+        type: DepsType.FuncCoreTools,
+        isInstalled: true,
+        command: "node ~/.fx/bin/func/node_modules/azure-functions-core-tools/lib/main.js",
+        details: {
+          isLinuxSupported: false,
+          supportedVersions: ["4"],
+          installVersion: "4",
+          binFolders: ["~/.fx/bin/func/node_modules/.bin"],
+        },
+      });
+      const outputEnvVarNames = new Map();
+      const res = await toolsInstallDriver.execute(
+        { func: true },
+        mockedDriverContext,
+        outputEnvVarNames
+      );
+      chai.assert.isNotEmpty(res.summaries);
+      chai.assert.isTrue(res.result.isOk());
+      if (res.result.isOk()) {
+        chai.assert.isEmpty(res.result.value);
       }
     });
 
@@ -424,7 +472,12 @@ describe("Tools Install Driver test", () => {
         },
         error: new DepsCheckerError("test message", "test link"),
       });
-      const res = await toolsInstallDriver.execute({ func: true }, mockedDriverContext);
+      const outputEnvVarNames = new Map([["funcPath", "MY_FUNC_PATH"]]);
+      const res = await toolsInstallDriver.execute(
+        { func: true },
+        mockedDriverContext,
+        outputEnvVarNames
+      );
       chai.assert.isEmpty(res.summaries);
       chai.assert.isTrue(res.result.isErr());
     });
@@ -443,21 +496,27 @@ describe("Tools Install Driver test", () => {
         },
         error: new DepsCheckerError("warning message", "test link"),
       });
-      const res = await toolsInstallDriver.execute({ func: true }, mockedDriverContext);
+      const outputEnvVarNames = new Map([["funcPath", "MY_FUNC_PATH"]]);
+      const res = await toolsInstallDriver.execute(
+        { func: true },
+        mockedDriverContext,
+        outputEnvVarNames
+      );
       chai.assert.isNotEmpty(res.summaries);
       chai.assert.isTrue(res.result.isOk());
       if (res.result.isOk()) {
-        chai.assert.includeDeepMembers(
-          [["FUNC_PATH", "~/.fx/bin/func/node_modules/.bin"]],
-          Array.from(res.result.value.entries())
-        );
+        chai.assert.includeDeepMembers(Array.from(res.result.value.entries()), [
+          ["MY_FUNC_PATH", "~/.fx/bin/func/node_modules/.bin"],
+        ]);
       }
     });
 
     it("Invalid parameter", async () => {
+      const outputEnvVarNames = new Map([["funcPath", "MY_FUNC_PATH"]]);
       const res = await toolsInstallDriver.execute(
         { func: { version: "hello" } } as unknown as InstallToolArgs,
-        mockedDriverContext
+        mockedDriverContext,
+        outputEnvVarNames
       );
       chai.assert.isEmpty(res.summaries);
       chai.assert.isTrue(res.result.isErr());
@@ -482,14 +541,44 @@ describe("Tools Install Driver test", () => {
           binFolders: ["~/.fx/dotnet/dotnet.exe"],
         },
       });
-      const res = await toolsInstallDriver.execute({ dotnet: true }, mockedDriverContext);
+      const outputEnvVarNames = new Map([["dotnetPath", "MY_DOTNET_PATH"]]);
+      const res = await toolsInstallDriver.execute(
+        { dotnet: true },
+        mockedDriverContext,
+        outputEnvVarNames
+      );
       chai.assert.isNotEmpty(res.summaries);
       chai.assert.isTrue(res.result.isOk());
       if (res.result.isOk()) {
-        chai.assert.includeDeepMembers(
-          [["DOTNET_PATH", "~/.fx/dotnet"]],
-          Array.from(res.result.value.entries())
-        );
+        chai.assert.includeDeepMembers(Array.from(res.result.value.entries()), [
+          ["MY_DOTNET_PATH", "~/.fx/dotnet"],
+        ]);
+      }
+    });
+
+    it("Install dotnet: empty outputEnvVarNames", async () => {
+      sandbox.stub(DotnetChecker.prototype, "resolve").resolves({
+        name: ".NET Core SDK",
+        type: DepsType.Dotnet,
+        isInstalled: true,
+        command: "~/.fx/dotnet/dotnet.exe",
+        details: {
+          isLinuxSupported: false,
+          installVersion: "3.1",
+          supportedVersions: ["3.1", "5.0", "6.0"],
+          binFolders: ["~/.fx/dotnet/dotnet.exe"],
+        },
+      });
+      const outputEnvVarNames = new Map();
+      const res = await toolsInstallDriver.execute(
+        { dotnet: true },
+        mockedDriverContext,
+        outputEnvVarNames
+      );
+      chai.assert.isNotEmpty(res.summaries);
+      chai.assert.isTrue(res.result.isOk());
+      if (res.result.isOk()) {
+        chai.assert.isEmpty(res.result.value);
       }
     });
 
@@ -506,14 +595,18 @@ describe("Tools Install Driver test", () => {
           binFolders: [],
         },
       });
-      const res = await toolsInstallDriver.execute({ dotnet: true }, mockedDriverContext);
+      const outputEnvVarNames = new Map([["dotnetPath", "MY_DOTNET_PATH"]]);
+      const res = await toolsInstallDriver.execute(
+        { dotnet: true },
+        mockedDriverContext,
+        outputEnvVarNames
+      );
       chai.assert.isNotEmpty(res.summaries);
       chai.assert.isTrue(res.result.isOk());
       if (res.result.isOk()) {
-        chai.assert.includeDeepMembers(
-          [["DOTNET_PATH", ""]],
-          Array.from(res.result.value.entries())
-        );
+        chai.assert.includeDeepMembers(Array.from(res.result.value.entries()), [
+          ["MY_DOTNET_PATH", ""],
+        ]);
       }
     });
 
@@ -530,14 +623,16 @@ describe("Tools Install Driver test", () => {
           binFolders: undefined,
         },
       });
-      const res = await toolsInstallDriver.execute({ dotnet: true }, mockedDriverContext);
+      const outputEnvVarNames = new Map([["dotnetPath", "MY_DOTNET_PATH"]]);
+      const res = await toolsInstallDriver.execute(
+        { dotnet: true },
+        mockedDriverContext,
+        outputEnvVarNames
+      );
       chai.assert.isNotEmpty(res.summaries);
       chai.assert.isTrue(res.result.isOk());
       if (res.result.isOk()) {
-        chai.assert.includeDeepMembers(
-          [["DOTNET_PATH", ""]],
-          Array.from(res.result.value.entries())
-        );
+        chai.assert.isEmpty(res.result.value);
       }
     });
 
@@ -555,15 +650,22 @@ describe("Tools Install Driver test", () => {
         },
         error: new DepsCheckerError("test message", "test link"),
       });
-      const res = await toolsInstallDriver.execute({ dotnet: true }, mockedDriverContext);
+      const outputEnvVarNames = new Map([["dotnetPath", "MY_DOTNET_PATH"]]);
+      const res = await toolsInstallDriver.execute(
+        { dotnet: true },
+        mockedDriverContext,
+        outputEnvVarNames
+      );
       chai.assert.isEmpty(res.summaries);
       chai.assert.isTrue(res.result.isErr());
     });
 
     it("Invalid parameter", async () => {
+      const outputEnvVarNames = new Map([["dotnetPath", "MY_DOTNET_PATH"]]);
       const res = await toolsInstallDriver.execute(
         { dotnet: { version: "hello" } } as unknown as InstallToolArgs,
-        mockedDriverContext
+        mockedDriverContext,
+        outputEnvVarNames
       );
       chai.assert.isTrue(res.result.isErr());
       chai.assert.isEmpty(res.summaries);


### PR DESCRIPTION
sslCertFile, sslKeyFile, funcPath, dotnetPath are all optional