### PR TITLE
chore: only update major version in template config

### DIFF
--- a/.github/scripts/fxcore-sync-up-version.js
+++ b/.github/scripts/fxcore-sync-up-version.js
@@ -33,7 +33,7 @@ if (!semver.prerelease(templateVersion)) {
     console.log(
       "================== template config version is not match with template latest release version, need bump up config version ^${templateVersion} =================="
     );
-    templateConfigFile.version = `^${result.major}.${result.minor}.0`;
+    templateConfigFile.version = `^${result.major}.0.0`;
     fse.writeFileSync(
       templateConfig,
       JSON.stringify(templateConfigFile, null, 4)


### PR DESCRIPTION
CD pipeline updated template config for each minor version, which is as design. 
The template config should be updated only when the major version upgrade.
https://github.com/OfficeDev/TeamsFx/commit/96b24bda20a4f78d87921b5d258205d4a25e5957