### PR TITLE
fix(v2): use 127.0.0.1 instead of localhost for node 18 to get ngrok url

### DIFF
--- a/packages/fx-core/src/component/debug/util/ngrok.ts
+++ b/packages/fx-core/src/component/debug/util/ngrok.ts
@@ -28,7 +28,7 @@ export async function getNgrokHttpUrl(addr: string | number): Promise<string | u
     let numRetries = 5;
     while (numRetries > 0) {
       try {
-        const resp = await axios.get(`http://localhost:${ngrokWebInterfacePort}/api/tunnels`);
+        const resp = await axios.get(`http://127.0.0.1:${ngrokWebInterfacePort}/api/tunnels`);
         if (resp && resp.data) {
           const tunnels = (<NgrokApiTunnelsResponse>resp.data).tunnels;
           // tunnels will be empty if tunnel connection is not completed
@@ -47,6 +47,7 @@ export async function getNgrokHttpUrl(addr: string | number): Promise<string | u
         }
       } catch (err) {
         // ECONNREFUSED if ngrok is not started
+        console.log(err);
       }
       await delay(2000);
       --numRetries;

--- a/packages/fx-core/src/component/debug/util/ngrok.ts
+++ b/packages/fx-core/src/component/debug/util/ngrok.ts
@@ -47,7 +47,6 @@ export async function getNgrokHttpUrl(addr: string | number): Promise<string | u
         }
       } catch (err) {
         // ECONNREFUSED if ngrok is not started
-        console.log(err);
       }
       await delay(2000);
       --numRetries;


### PR DESCRIPTION
detail: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/17665830

Node.js switched the lookup order of DNS resolution from v17. Explicitly using IPv4 127.0.0.1 instead of localhost. 
(https://github.com/axios/axios/issues/3821)

E2E TEST: https://github.com/devdiv-azure-service-dmitryr/TeamsFx-UI-Test/blob/20a9d90ec46f128857e0fb023f71f0e45edced6d/src/ui-test/localdebug/localdebug-bot.test.ts#L29