### PR TITLE
fix: new bot service if switching tenant for notification bot (func) (v2)

### DIFF
--- a/packages/fx-core/src/component/provisionUtils.ts
+++ b/packages/fx-core/src/component/provisionUtils.ts
@@ -1134,7 +1134,9 @@ export function hasBotServiceCreated(envInfo: v3.EnvInfoV3): boolean {
     (!!envInfo.state[BuiltInFeaturePluginNames.bot] &&
       !!envInfo.state[BuiltInFeaturePluginNames.bot]["resourceId"]) ||
     (!!envInfo.state[ComponentNames.TeamsBot] &&
-      !!envInfo.state[ComponentNames.TeamsBot]["resourceId"])
+      !!envInfo.state[ComponentNames.TeamsBot]["resourceId"]) ||
+    (!!envInfo.state[ComponentNames.TeamsBot] &&
+      !!envInfo.state[ComponentNames.TeamsBot]["functionAppResourceId"])
   );
 }
 


### PR DESCRIPTION
bug: [Bug 17709375](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/17709375): [VS][V2]Switching tenant account does not work for notification bot with azure function
- E2E TEST: N/A
