### PR TITLE
chore: add launchHelper in core to get launch url

### DIFF
--- a/packages/fx-core/src/common/m365/constants.ts
+++ b/packages/fx-core/src/common/m365/constants.ts
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export enum Hub {
+  teams = "Teams",
+  outlook = "Outlook",
+  office = "the Microsoft 365 app",
+}

--- a/packages/fx-core/src/common/m365/launchHelper.ts
+++ b/packages/fx-core/src/common/m365/launchHelper.ts
@@ -1,0 +1,124 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import {
+  assembleError,
+  err,
+  FxError,
+  LogProvider,
+  M365TokenProvider,
+  ok,
+  Result,
+} from "@microsoft/teamsfx-api";
+
+import { CoreSource } from "../../core/error";
+import { AppStudioScopes } from "../tools";
+import { Hub } from "./constants";
+import { M365TitleNotAcquiredError } from "./errors";
+import { PackageService } from "./packageService";
+import { serviceEndpoint, serviceScope } from "./serviceConstant";
+
+export class LaunchHelper {
+  private readonly m365TokenProvider: M365TokenProvider;
+  private readonly logger?: LogProvider;
+
+  public constructor(m365TokenProvider: M365TokenProvider, logger?: LogProvider) {
+    this.m365TokenProvider = m365TokenProvider;
+    this.logger = logger;
+  }
+
+  public async getLaunchUrl(
+    hub: Hub,
+    teamsAppId: string,
+    capabilities: string[],
+    withLoginHint = true
+  ): Promise<Result<string, FxError>> {
+    const loginHint = withLoginHint
+      ? (await this.getUpnFromToken()) ?? "login_your_m365_account"
+      : undefined; // a workaround that user has the chance to login
+    let url: URL;
+    switch (hub) {
+      case Hub.teams: {
+        const baseUrl = `https://teams.microsoft.com/l/app/${teamsAppId}?installAppPackage=true&webjoin=true`;
+        url = new URL(baseUrl);
+        const tid = await this.getTidFromToken();
+        if (tid) {
+          url.searchParams.append("appTenantId", tid);
+        }
+        break;
+      }
+      case Hub.outlook: {
+        const result = await this.getM365AppId(teamsAppId);
+        if (result.isErr()) {
+          return err(result.error);
+        }
+        const baseUrl = capabilities.includes("staticTab")
+          ? `https://outlook.office.com/host/${result.value}`
+          : "https://outlook.office.com/mail";
+        url = new URL(baseUrl);
+        break;
+      }
+      case Hub.office:
+        {
+          const result = await this.getM365AppId(teamsAppId);
+          if (result.isErr()) {
+            return err(result.error);
+          }
+          const baseUrl = `https://www.office.com/m365apps/${result.value}?auth=2`;
+          url = new URL(baseUrl);
+        }
+        break;
+    }
+    if (loginHint) {
+      url.searchParams.append("login_hint", loginHint);
+    }
+    return ok(url.toString());
+  }
+
+  public async getM365AppId(teamsAppId: string): Promise<Result<string, FxError>> {
+    const sideloadingServiceEndpoint = process.env.SIDELOADING_SERVICE_ENDPOINT ?? serviceEndpoint;
+    const sideloadingServiceScope = process.env.SIDELOADING_SERVICE_SCOPE ?? serviceScope;
+    const packageService = new PackageService(sideloadingServiceEndpoint, this.logger);
+
+    const sideloadingTokenRes = await this.m365TokenProvider.getAccessToken({
+      scopes: [sideloadingServiceScope],
+    });
+    if (sideloadingTokenRes.isErr()) {
+      return err(sideloadingTokenRes.error);
+    }
+    const sideloadingToken = sideloadingTokenRes.value;
+
+    try {
+      const m365AppId = await packageService.retrieveAppId(sideloadingToken, teamsAppId);
+      if (!m365AppId) {
+        return err(new M365TitleNotAcquiredError(CoreSource));
+      }
+      return ok(m365AppId);
+    } catch (error) {
+      if ((error as FxError).innerError?.response.status === 404) {
+        return err(new M365TitleNotAcquiredError(CoreSource));
+      }
+      return err(assembleError(error));
+    }
+  }
+
+  private async getTidFromToken(): Promise<string | undefined> {
+    try {
+      const statusRes = await this.m365TokenProvider.getStatus({ scopes: AppStudioScopes });
+      const tokenObject = statusRes.isOk() ? statusRes.value.accountInfo : undefined;
+      return tokenObject?.tid as string;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private async getUpnFromToken(): Promise<string | undefined> {
+    try {
+      const statusRes = await this.m365TokenProvider.getStatus({ scopes: AppStudioScopes });
+      const tokenObject = statusRes.isOk() ? statusRes.value.accountInfo : undefined;
+      return tokenObject?.upn as string;
+    } catch {
+      return undefined;
+    }
+  }
+}

--- a/packages/fx-core/src/common/m365/launchHelper.ts
+++ b/packages/fx-core/src/common/m365/launchHelper.ts
@@ -34,8 +34,8 @@ export class LaunchHelper {
     withLoginHint = true
   ): Promise<Result<string, FxError>> {
     const loginHint = withLoginHint
-      ? (await this.getUpnFromToken()) ?? "login_your_m365_account"
-      : undefined; // a workaround that user has the chance to login
+      ? (await this.getUpnFromToken()) ?? "login_your_m365_account" // a workaround that user has the chance to login
+      : undefined;
     let url: URL;
     switch (hub) {
       case Hub.teams: {

--- a/packages/fx-core/tests/common/m365/launchHelper.test.ts
+++ b/packages/fx-core/tests/common/m365/launchHelper.test.ts
@@ -1,0 +1,169 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import "mocha";
+
+import * as chai from "chai";
+import sinon from "sinon";
+
+import { err, ok } from "@microsoft/teamsfx-api";
+
+import { Hub } from "../../../src/common/m365/constants";
+import { LaunchHelper } from "../../../src/common/m365/launchHelper";
+import { MockM365TokenProvider } from "../../core/utils";
+import { PackageService } from "../../../src/common/m365/packageService";
+
+describe("LaunchHelper", () => {
+  const m365TokenProvider = new MockM365TokenProvider();
+  const launchHelper = new LaunchHelper(m365TokenProvider);
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("getLaunchUrl", () => {
+    it("getLaunchUrl: Teams, signed in", async () => {
+      sinon.stub(m365TokenProvider, "getStatus").resolves(
+        ok({
+          status: "",
+          accountInfo: {
+            tid: "test-tid",
+            upn: "test-upn",
+          },
+        })
+      );
+      const result = await launchHelper.getLaunchUrl(Hub.teams, "test-id", ["staticTab"]);
+      chai.assert(result.isOk());
+      chai.assert.equal(
+        (result as any).value,
+        "https://teams.microsoft.com/l/app/test-id?installAppPackage=true&webjoin=true&appTenantId=test-tid&login_hint=test-upn"
+      );
+    });
+
+    it("Teams, signed out", async () => {
+      sinon.stub(m365TokenProvider, "getStatus").resolves(
+        ok({
+          status: "",
+        })
+      );
+      const result = await launchHelper.getLaunchUrl(Hub.teams, "test-id", ["staticTab"]);
+      chai.assert(result.isOk());
+      chai.assert.equal(
+        (result as any).value,
+        "https://teams.microsoft.com/l/app/test-id?installAppPackage=true&webjoin=true&login_hint=login_your_m365_account"
+      );
+    });
+
+    it("Outlook, staticTab, acquired, signed in", async () => {
+      sinon.stub(m365TokenProvider, "getStatus").resolves(
+        ok({
+          status: "",
+          accountInfo: {
+            tid: "test-tid",
+            upn: "test-upn",
+          },
+        })
+      );
+      sinon.stub(LaunchHelper.prototype, <any>"getM365AppId").resolves(ok("test-app-id"));
+      const result = await launchHelper.getLaunchUrl(Hub.outlook, "test-id", ["staticTab"]);
+      chai.assert(result.isOk());
+      chai.assert.equal(
+        (result as any).value,
+        "https://outlook.office.com/host/test-app-id?login_hint=test-upn"
+      );
+    });
+
+    it("Outlook, staticTab, unacquired, signed in", async () => {
+      sinon.stub(m365TokenProvider, "getStatus").resolves(
+        ok({
+          status: "",
+          accountInfo: {
+            tid: "test-tid",
+            upn: "test-upn",
+          },
+        })
+      );
+      sinon.stub(LaunchHelper.prototype, <any>"getM365AppId").resolves(err({ foo: "bar" }));
+      const result = await launchHelper.getLaunchUrl(Hub.outlook, "test-id", ["staticTab"]);
+      chai.assert(result.isErr());
+      chai.assert.deepEqual((result as any).error, { foo: "bar" });
+    });
+
+    it("Outlook, Bot, signed in", async () => {
+      sinon.stub(m365TokenProvider, "getStatus").resolves(
+        ok({
+          status: "",
+          accountInfo: {
+            tid: "test-tid",
+            upn: "test-upn",
+          },
+        })
+      );
+      sinon.stub(LaunchHelper.prototype, <any>"getM365AppId").resolves(ok("test-app-id"));
+      const result = await launchHelper.getLaunchUrl(Hub.outlook, "test-id", ["Bot"]);
+      chai.assert(result.isOk());
+      chai.assert.equal(
+        (result as any).value,
+        "https://outlook.office.com/mail?login_hint=test-upn"
+      );
+    });
+
+    it("Outlook, signed in", async () => {
+      sinon.stub(m365TokenProvider, "getStatus").resolves(
+        ok({
+          status: "",
+          accountInfo: {
+            tid: "test-tid",
+            upn: "test-upn",
+          },
+        })
+      );
+      sinon.stub(LaunchHelper.prototype, <any>"getM365AppId").resolves(ok("test-app-id"));
+      const result = await launchHelper.getLaunchUrl(Hub.office, "test-id", ["Bot"]);
+      chai.assert(result.isOk());
+      chai.assert.equal(
+        (result as any).value,
+        "https://www.office.com/m365apps/test-app-id?auth=2&login_hint=test-upn"
+      );
+    });
+  });
+
+  describe("getM365AppId", () => {
+    it("getAccessToken error", async () => {
+      sinon.stub(m365TokenProvider, "getAccessToken").resolves(err({ foo: "bar" } as any));
+      const result = await launchHelper.getM365AppId("test-id");
+      chai.assert(result.isErr());
+      chai.assert.deepEqual((result as any).error, { foo: "bar" });
+    });
+
+    it("retrieveAppId 404", async () => {
+      sinon.stub(m365TokenProvider, "getAccessToken").resolves(ok(""));
+      sinon.stub(PackageService.prototype, "retrieveAppId").throws({
+        innerError: {
+          response: {
+            status: 404,
+          },
+        },
+      });
+      const result = await launchHelper.getM365AppId("test-id");
+      chai.assert(result.isErr());
+      chai.assert.deepEqual((result as any).error.name, "M365TitleNotAcquiredError");
+    });
+
+    it("retrieveAppId undefined", async () => {
+      sinon.stub(m365TokenProvider, "getAccessToken").resolves(ok(""));
+      sinon.stub(PackageService.prototype, "retrieveAppId").resolves(undefined);
+      const result = await launchHelper.getM365AppId("test-id");
+      chai.assert(result.isErr());
+      chai.assert.deepEqual((result as any).error.name, "M365TitleNotAcquiredError");
+    });
+
+    it("happy path", async () => {
+      sinon.stub(m365TokenProvider, "getAccessToken").resolves(ok(""));
+      sinon.stub(PackageService.prototype, "retrieveAppId").resolves("test-app-id");
+      const result = await launchHelper.getM365AppId("test-id");
+      chai.assert(result.isOk());
+      chai.assert.deepEqual((result as any).value, "test-app-id");
+    });
+  });
+});


### PR DESCRIPTION
This utility can then be used in vsc and cli, which can reduce the redundant codes.