### PR TITLE
chore(localdebug): rename output to writeToEnvironmentFile in ngrok task

### DIFF
--- a/packages/fx-core/src/common/local/constants.ts
+++ b/packages/fx-core/src/common/local/constants.ts
@@ -153,7 +153,7 @@ export const TaskDefaultValue = Object.freeze({
   startLocalTunnel: {
     ngrokArgs: "http 3978 --log=stdout --log-format=logfmt",
     ngrokPath: "ngrok",
-    output: {
+    writeToEnvironmentFile: {
       endpoint: "BOT_ENDPOINT",
       domain: "BOT_DOMAIN",
     },

--- a/packages/fx-core/src/core/middleware/utils/debug/taskMigrator.ts
+++ b/packages/fx-core/src/core/middleware/utils/debug/taskMigrator.ts
@@ -99,7 +99,7 @@ export async function migrateTransparentLocalTunnel(context: DebugMigrationConte
       `;
       task["args"]["type"] = TunnelType.ngrok;
       task["args"]["env"] = "local";
-      task["args"]["output"] = assign(parse(comment), {
+      task["args"]["writeToEnvironmentFile"] = assign(parse(comment), {
         endpoint: context.placeholderMapping.botEndpoint,
         domain: context.placeholderMapping.botDomain,
       });
@@ -908,7 +908,7 @@ function generateLocalTunnelTask(context: DebugMigrationContext, task?: CommentO
       type: TunnelType.ngrok,
       ngrokArgs: TaskDefaultValue.startLocalTunnel.ngrokArgs,
       env: "local",
-      output: assign(parse(placeholderComment), {
+      writeToEnvironmentFile: assign(parse(placeholderComment), {
         endpoint: context.placeholderMapping.botEndpoint,
         domain: context.placeholderMapping.botDomain,
       }),

--- a/packages/fx-core/tests/core/middleware/debug/taskMigrator.test.ts
+++ b/packages/fx-core/tests/core/middleware/debug/taskMigrator.test.ts
@@ -627,7 +627,7 @@ describe("debugMigration", () => {
               "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
               "type": "ngrok",
               "env": "local",
-              "output": {
+              "writeToEnvironmentFile": {
                 // Keep consistency with upgraded configuration.
                 "endpoint": "PROVISIONOUTPUT__AZUREWEBAPPBOTOUTPUT__SITEENDPOINT",
                 "domain": "PROVISIONOUTPUT__AZUREWEBAPPBOTOUTPUT__DOMAIN"
@@ -684,7 +684,7 @@ describe("debugMigration", () => {
               "ngrokPath": "ngrok",
               "type": "ngrok",
               "env": "local",
-              "output": {
+              "writeToEnvironmentFile": {
                 // Keep consistency with upgraded configuration.
                 "endpoint": "PROVISIONOUTPUT__AZUREWEBAPPBOTOUTPUT__SITEENDPOINT",
                 "domain": "PROVISIONOUTPUT__AZUREWEBAPPBOTOUTPUT__DOMAIN"
@@ -1554,7 +1554,7 @@ describe("debugMigration", () => {
               "type": "ngrok",
               "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
               "env": "local",
-              "output": {
+              "writeToEnvironmentFile": {
                   // Keep consistency with upgraded configuration.
                   "endpoint": "PROVISIONOUTPUT__AZUREWEBAPPBOTOUTPUT__SITEENDPOINT",
                   "domain": "PROVISIONOUTPUT__AZUREWEBAPPBOTOUTPUT__DOMAIN"
@@ -1611,7 +1611,7 @@ describe("debugMigration", () => {
               "type": "ngrok",
               "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
               "env": "local",
-              "output": {
+              "writeToEnvironmentFile": {
                   // Keep consistency with upgraded configuration.
                   "endpoint": "PROVISIONOUTPUT__AZUREWEBAPPBOTOUTPUT__SITEENDPOINT",
                   "domain": "PROVISIONOUTPUT__AZUREWEBAPPBOTOUTPUT__DOMAIN"
@@ -1673,7 +1673,7 @@ describe("debugMigration", () => {
               "type": "ngrok",
               "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
               "env": "local",
-              "output": {
+              "writeToEnvironmentFile": {
                   // Keep consistency with upgraded configuration.
                   "endpoint": "PROVISIONOUTPUT__AZUREWEBAPPBOTOUTPUT__SITEENDPOINT",
                   "domain": "PROVISIONOUTPUT__AZUREWEBAPPBOTOUTPUT__DOMAIN"

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/V3.5.0-V4.0.6-command/expected/tasks.json
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/V3.5.0-V4.0.6-command/expected/tasks.json
@@ -52,7 +52,7 @@
                 "type": "ngrok",
                 "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
                 "env": "local",
-                "output": {
+                "writeToEnvironmentFile": {
                     // Keep consistency with upgraded configuration.
                     "endpoint": "PROVISIONOUTPUT__AZUREWEBAPPBOTOUTPUT__SITEENDPOINT",
                     "domain": "PROVISIONOUTPUT__AZUREWEBAPPBOTOUTPUT__DOMAIN"

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/V3.5.0-V4.0.6-notification-trigger/expected/tasks.json
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/V3.5.0-V4.0.6-notification-trigger/expected/tasks.json
@@ -52,7 +52,7 @@
                 "type": "ngrok",
                 "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
                 "env": "local",
-                "output": {
+                "writeToEnvironmentFile": {
                     // Keep consistency with upgraded configuration.
                     "endpoint": "PROVISIONOUTPUT__AZUREFUNCTIONBOTOUTPUT__SITEENDPOINT",
                     "domain": "PROVISIONOUTPUT__AZUREFUNCTIONBOTOUTPUT__DOMAIN"

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/V3.5.0-V4.0.6-tab-bot-func/expected/tasks.json
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/V3.5.0-V4.0.6-tab-bot-func/expected/tasks.json
@@ -55,7 +55,7 @@
                 "type": "ngrok",
                 "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
                 "env": "local",
-                "output": {
+                "writeToEnvironmentFile": {
                     // Keep consistency with upgraded configuration.
                     "endpoint": "PROVISIONOUTPUT__AZUREWEBAPPBOTOUTPUT__SITEENDPOINT",
                     "domain": "PROVISIONOUTPUT__AZUREWEBAPPBOTOUTPUT__DOMAIN"

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/beforeV3.4.0-bot/expected/tasks.json
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/beforeV3.4.0-bot/expected/tasks.json
@@ -46,7 +46,7 @@
                 "type": "ngrok",
                 "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
                 "env": "local",
-                "output": {
+                "writeToEnvironmentFile": {
                     // Keep consistency with upgraded configuration.
                     "endpoint": "PROVISIONOUTPUT__BOTOUTPUT__SITEENDPOINT",
                     "domain": "PROVISIONOUTPUT__BOTOUTPUT__DOMAIN"

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/beforeV3.4.0-tab-bot-func/expected/tasks.json
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/beforeV3.4.0-tab-bot-func/expected/tasks.json
@@ -49,7 +49,7 @@
                 "type": "ngrok",
                 "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
                 "env": "local",
-                "output": {
+                "writeToEnvironmentFile": {
                     // Keep consistency with upgraded configuration.
                     "endpoint": "PROVISIONOUTPUT__BOTOUTPUT__SITEENDPOINT",
                     "domain": "PROVISIONOUTPUT__BOTOUTPUT__DOMAIN"

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-bot/expected/tasks.json
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-bot/expected/tasks.json
@@ -43,7 +43,7 @@
                 "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
                 "type": "ngrok",
                 "env": "local",
-                "output": {
+                "writeToEnvironmentFile": {
                     // Keep consistency with upgraded configuration.
                     "endpoint": "PROVISIONOUTPUT__WEBAPPOUTPUT__SITEENDPOINT",
                     "domain": "PROVISIONOUTPUT__WEBAPPOUTPUT__DOMAIN"

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-m365-me/expected/tasks.json
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-m365-me/expected/tasks.json
@@ -57,7 +57,7 @@
                 "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
                 "type": "ngrok",
                 "env": "local",
-                "output": {
+                "writeToEnvironmentFile": {
                     // Keep consistency with upgraded configuration.
                     "endpoint": "PROVISIONOUTPUT__WEBAPPOUTPUT__SITEENDPOINT",
                     "domain": "PROVISIONOUTPUT__WEBAPPOUTPUT__DOMAIN"

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-notification/expected/tasks.json
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-notification/expected/tasks.json
@@ -43,7 +43,7 @@
                 "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
                 "type": "ngrok",
                 "env": "local",
-                "output": {
+                "writeToEnvironmentFile": {
                     // Keep consistency with upgraded configuration.
                     "endpoint": "PROVISIONOUTPUT__AZUREFUNCTIONBOTOUTPUT__SITEENDPOINT",
                     "domain": "PROVISIONOUTPUT__AZUREFUNCTIONBOTOUTPUT__DOMAIN"

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-sso-bot/expected/tasks.json
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-sso-bot/expected/tasks.json
@@ -43,7 +43,7 @@
                 "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
                 "type": "ngrok",
                 "env": "local",
-                "output": {
+                "writeToEnvironmentFile": {
                     // Keep consistency with upgraded configuration.
                     "endpoint": "PROVISIONOUTPUT__AZUREWEBAPPBOTOUTPUT__SITEENDPOINT",
                     "domain": "PROVISIONOUTPUT__AZUREWEBAPPBOTOUTPUT__DOMAIN"

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-tab-bot-func/expected/tasks.json
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-tab-bot-func/expected/tasks.json
@@ -46,7 +46,7 @@
                 "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
                 "type": "ngrok",
                 "env": "local",
-                "output": {
+                "writeToEnvironmentFile": {
                     // Keep consistency with upgraded configuration.
                     "endpoint": "PROVISIONOUTPUT__AZUREFUNCTIONBOTOUTPUT__SITEENDPOINT",
                     "domain": "PROVISIONOUTPUT__AZUREFUNCTIONBOTOUTPUT__DOMAIN"

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -955,7 +955,7 @@
                       {}
                     ]
                   },
-                  "output": {
+                  "writeToEnvironmentFile": {
                     "type": "object",
                     "description": "%teamstoolkit.taskDefinitions.args.output.title%",
                     "properties": {

--- a/packages/vscode-extension/src/debug/taskTerminal/devTunnelTaskTerminal.ts
+++ b/packages/vscode-extension/src/debug/taskTerminal/devTunnelTaskTerminal.ts
@@ -328,10 +328,10 @@ export class DevTunnelTaskTerminal extends BaseTunnelTaskTerminal {
             access: maskValue(port.access, Object.values(Access)),
             writeToEnvironmentFile: {
               endpoint: maskValue(port.writeToEnvironmentFile?.endpoint, [
-                TaskDefaultValue.startLocalTunnel.output.endpoint,
+                TaskDefaultValue.startLocalTunnel.writeToEnvironmentFile.endpoint,
               ]),
               domain: maskValue(port.writeToEnvironmentFile?.domain, [
-                TaskDefaultValue.startLocalTunnel.output.domain,
+                TaskDefaultValue.startLocalTunnel.writeToEnvironmentFile.domain,
               ]),
             },
           };

--- a/packages/vscode-extension/src/debug/taskTerminal/ngrokTunnelTaskTerminal.ts
+++ b/packages/vscode-extension/src/debug/taskTerminal/ngrokTunnelTaskTerminal.ts
@@ -57,7 +57,7 @@ export interface INgrokTunnelArgs extends IBaseTunnelArgs {
   ngrokArgs: string[];
   ngrokPath?: string;
   tunnelInspection?: string;
-  output?: {
+  writeToEnvironmentFile?: {
     endpoint?: string;
     domain?: string;
   };
@@ -118,12 +118,18 @@ export class NgrokTunnelTaskTerminal extends BaseTunnelTaskTerminal {
 
     args.ngrokArgs = !Array.isArray(args.ngrokArgs) ? [args.ngrokArgs] : args.ngrokArgs;
 
-    if (typeof args.output?.domain !== "undefined" && typeof args.output?.domain !== "string") {
-      throw BaseTaskTerminal.taskDefinitionError("args.output.domain");
+    if (
+      typeof args.writeToEnvironmentFile?.domain !== "undefined" &&
+      typeof args.writeToEnvironmentFile?.domain !== "string"
+    ) {
+      throw BaseTaskTerminal.taskDefinitionError("args.writeToEnvironmentFile.domain");
     }
 
-    if (typeof args.output?.endpoint !== "undefined" && typeof args.output?.endpoint !== "string") {
-      throw BaseTaskTerminal.taskDefinitionError("args.output.endpoint");
+    if (
+      typeof args.writeToEnvironmentFile?.endpoint !== "undefined" &&
+      typeof args.writeToEnvironmentFile?.endpoint !== "string"
+    ) {
+      throw BaseTaskTerminal.taskDefinitionError("args.writeToEnvironmentFile.endpoint");
     }
   }
 
@@ -279,11 +285,11 @@ export class NgrokTunnelTaskTerminal extends BaseTunnelTaskTerminal {
     try {
       const url = new URL(endpoint);
       const envVars: { [key: string]: string } = {};
-      if (this.args?.output?.endpoint) {
-        envVars[this.args.output.endpoint] = url.origin;
+      if (this.args?.writeToEnvironmentFile?.endpoint) {
+        envVars[this.args.writeToEnvironmentFile.endpoint] = url.origin;
       }
-      if (this.args?.output?.domain) {
-        envVars[this.args.output.domain] = url.hostname;
+      if (this.args?.writeToEnvironmentFile?.domain) {
+        envVars[this.args.writeToEnvironmentFile.domain] = url.hostname;
       }
       return this.savePropertiesToEnv(this.args.env, envVars);
     } catch (error: any) {
@@ -326,12 +332,12 @@ export class NgrokTunnelTaskTerminal extends BaseTunnelTaskTerminal {
         ngrokPath: maskValue(this.args.ngrokPath, [TaskDefaultValue.startLocalTunnel.ngrokPath]),
         tunnelInspection: maskValue(this.args.tunnelInspection),
         env: maskValue(this.args.env, [TaskDefaultValue.env]),
-        output: {
-          endpoint: maskValue(this.args.output?.endpoint, [
-            TaskDefaultValue.startLocalTunnel.output.endpoint,
+        writeToEnvironmentFile: {
+          endpoint: maskValue(this.args.writeToEnvironmentFile?.endpoint, [
+            TaskDefaultValue.startLocalTunnel.writeToEnvironmentFile.endpoint,
           ]),
-          domain: maskValue(this.args.output?.domain, [
-            TaskDefaultValue.startLocalTunnel.output.domain,
+          domain: maskValue(this.args.writeToEnvironmentFile?.domain, [
+            TaskDefaultValue.startLocalTunnel.writeToEnvironmentFile.domain,
           ]),
         },
       }),


### PR DESCRIPTION
sample:
```
      {
            "label": "Start local tunnel",
            "type": "teamsfx",
            "command": "debug-start-local-tunnel",
            "args": {
                "ngrokArgs": "http 3978 --log=stdout --log-format=logfmt",
                "type": "ngrok",
                "env": "local",
                "writeToEnvironmentFile": {
                    // Keep consistency with upgraded configuration.
                    "endpoint": "PROVISIONOUTPUT__AZUREWEBAPPBOTOUTPUT__SITEENDPOINT",
                    "domain": "PROVISIONOUTPUT__AZUREWEBAPPBOTOUTPUT__DOMAIN"
                  }
              },
              "isBackground": true,
              "problemMatcher": "$teamsfx-local-tunnel-watch"
        }
```