### PR TITLE
chore: dynamic output name for teams app id

### DIFF
--- a/packages/fx-core/src/component/resource/appManifest/utils/ManifestUtils.ts
+++ b/packages/fx-core/src/component/resource/appManifest/utils/ManifestUtils.ts
@@ -550,6 +550,10 @@ export class ManifestUtils {
       manifest.validDomains = [];
     }
 
+    // Corner Case: Avoid UnresolvedPlaceholderError for manifest.id
+    const teamsAppId = expandEnvironmentVariable(manifest.id);
+    manifest.id = "";
+
     const manifestTemplateString = JSON.stringify(manifest);
 
     // Add environment variable keys to telemetry
@@ -559,9 +563,7 @@ export class ManifestUtils {
 
     const resolvedManifestString = expandEnvironmentVariable(manifestTemplateString);
 
-    const tokens = getEnvironmentVariables(resolvedManifestString).filter(
-      (x) => x != "TEAMS_APP_ID"
-    );
+    const tokens = getEnvironmentVariables(resolvedManifestString);
     if (tokens.length > 0) {
       return err(
         new UnresolvedPlaceholderError("teamsApp", tokens.join(","), manifestTemplatePath)
@@ -570,8 +572,10 @@ export class ManifestUtils {
 
     manifest = JSON.parse(resolvedManifestString);
 
-    if (!isUUID(manifest.id)) {
+    if (!isUUID(teamsAppId)) {
       manifest.id = v4();
+    } else {
+      manifest.id = teamsAppId;
     }
 
     return ok(manifest);

--- a/packages/fx-core/tests/component/resource/appManifest/manifestUtils.test.ts
+++ b/packages/fx-core/tests/component/resource/appManifest/manifestUtils.test.ts
@@ -556,4 +556,12 @@ describe("getManifest V3", () => {
     const res = await manifestUtils.getManifestV3("", envInfo, false);
     chai.assert.isTrue(res.isErr() && res.error instanceof UnresolvedPlaceholderError);
   });
+
+  it("getManifestV3 teams app id resolved", async () => {
+    const manifest = new TeamsAppManifest();
+    manifest.id = uuid.v4();
+    sandbox.stub(manifestUtils, "_readAppManifest").resolves(ok(manifest));
+    const res = await manifestUtils.getManifestV3("", undefined, false);
+    chai.assert.isTrue(res.isOk());
+  });
 });


### PR DESCRIPTION
1) Escape unresolved placeholder check for manifest.id
2) Assign uuid if manifest.id is not valid