### PR TITLE
chore: sync up templates version support beta with carot

### DIFF
--- a/.github/scripts/sync-version.js
+++ b/.github/scripts/sync-version.js
@@ -45,7 +45,7 @@ function updateFileDeps(file, deps) {
                 continue;
             }
             fileChange = true;
-            if(semver.prerelease(value) && (semver.prerelease(value)[0] === "alpha" || semver.prerelease(value)[0] === "beta")){
+            if(semver.prerelease(value) && semver.prerelease(value)[0] === "alpha"){
                 dep_[key] = value;
             } else {
                 dep_[key] = `^${value}`;


### PR DESCRIPTION
beta release will change version to "3.0.0-beta.timestamp.0" so the carot can cover this case