### PR TITLE
chore: sync up fallback template after new template released

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -127,6 +127,11 @@ jobs:
       - name: generate templates v3
         run: |
           .github/scripts/template-zip-autogen-v3.sh ${{ runner.temp }}/teamsfx_templates_v3
+          cd ./packages/fx-core
+          rm -rf ./templates/fallback
+          node ./scripts/download-templates-zip.js
+        env:
+          TEMPLATE_PATH: ${{ runner.temp }}/teamsfx_templates_v3
 
       - name: update templates prerelease tag
         uses: richardsimko/update-tag@v1
@@ -190,14 +195,6 @@ jobs:
           token: ${{ secrets.github_token }}
           tag: "template-tag-list"
           allowUpdates: true
-
-      - name: sync up fx-core fallback templates
-        run: |
-          rm -rf ./templates/fallback
-          node ./scripts/download-templates-zip.js
-        working-directory: ./packages/fx-core
-        env:
-          TEMPLATE_PATH: ${{ runner.temp }}/teamsfx_templates_v3
 
       - name: download simpleauth to fx-core
         uses: nick-invision/retry@v2

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -126,7 +126,7 @@ jobs:
 
       - name: generate templates v3
         run: |
-          .github/scripts/template-zip-autogen-v3.sh ${{ runner.temp }}/teamsfx_templates_v3
+          .github/scripts/template-zip-autogen-v3.sh $TEMPLATE_PATH
           cd ./packages/fx-core
           rm -rf ./templates/fallback
           node ./scripts/download-templates-zip.js

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -191,6 +191,14 @@ jobs:
           tag: "template-tag-list"
           allowUpdates: true
 
+      - name: sync up fx-core fallback templates
+        run: |
+          rm -r ./templates/fallback
+          node ./scripts/download-templates-zip.js $(git tag -l templates*)
+        working-directory: ./packages/fx-core
+        env:
+          TEMPLATE_PATH: ${{ runner.temp }}/teamsfx_templates_v3
+
       - name: download simpleauth to fx-core
         uses: nick-invision/retry@v2
         with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -193,8 +193,8 @@ jobs:
 
       - name: sync up fx-core fallback templates
         run: |
-          rm -r ./templates/fallback
-          node ./scripts/download-templates-zip.js $(git tag -l templates*)
+          rm -rf ./templates/fallback
+          node ./scripts/download-templates-zip.js
         working-directory: ./packages/fx-core
         env:
           TEMPLATE_PATH: ${{ runner.temp }}/teamsfx_templates_v3


### PR DESCRIPTION
VSC extension copies local templates when webpack. So, we should make sure the local templates are up to date.
TEST: https://github.com/hund030/TeamsFx/actions/runs/4625258194/jobs/8180845521