### PR TITLE
chore: use set-teamsfx-env instead of set-output

### DIFF
--- a/packages/fx-core/templates/core/v3Migration/csharp.app.local.yml
+++ b/packages/fx-core/templates/core/v3Migration/csharp.app.local.yml
@@ -55,15 +55,15 @@ configureApp:
   - uses: script # Set env for local launch
     name: Set {{placeholderMappings.tabDomain}} for local launch
     with:
-      run: echo "::set-output {{placeholderMappings.tabDomain}}=localhost:44302"
+      run: echo "set-teamsfx-env {{placeholderMappings.tabDomain}}=localhost:44302"
   - uses: script # Set env for local launch
     name: Set {{placeholderMappings.tabEndpoint}} for local launch
     with:
-      run: echo "::set-output {{placeholderMappings.tabEndpoint}}=https://localhost:44302"
+      run: echo "set-teamsfx-env {{placeholderMappings.tabEndpoint}}=https://localhost:44302"
   - uses: script # Set env for local launch
     name: Set {{placeholderMappings.tabIndexPath}} for local launch
     with:
-      run: echo "::set-output {{placeholderMappings.tabIndexPath}}=#"
+      run: echo "set-teamsfx-env {{placeholderMappings.tabIndexPath}}=#"
   {{#if activePlugins.fx-resource-aad-app-for-teams}}
   - uses: file/createOrUpdateJsonFile
     with:
@@ -80,7 +80,7 @@ configureApp:
   - uses: script # Set env for local launch
     name: Set {{placeholderMappings.botDomain}} for local launch
     with:
-      run: echo "::set-output {{placeholderMappings.botDomain}}=$\{{BOT_DOMAIN}}"
+      run: echo "set-teamsfx-env {{placeholderMappings.botDomain}}=$\{{BOT_DOMAIN}}"
 {{/if}}
 {{#if activePlugins.fx-resource-aad-app-for-teams}}
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.

--- a/packages/fx-core/templates/core/v3Migration/csharp.app.yml
+++ b/packages/fx-core/templates/core/v3Migration/csharp.app.yml
@@ -44,7 +44,7 @@ provision:
 {{#if activePlugins.fx-resource-frontend-hosting}}
   - uses: script # Add additional item to .env file
     with:
-      run: echo "::set-output {{placeholderMappings.[state.fx-resource-frontend-hosting.indexPath]}}=/" # Used in appPackage/manifest.json file.
+      run: echo "set-teamsfx-env {{placeholderMappings.[state.fx-resource-frontend-hosting.indexPath]}}=/" # Used in appPackage/manifest.json file.
 {{/if}}
 {{#if activePlugins.fx-resource-aad-app-for-teams}}
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.

--- a/packages/fx-core/templates/core/v3Migration/js.ts.app.local.yml
+++ b/packages/fx-core/templates/core/v3Migration/js.ts.app.local.yml
@@ -53,15 +53,15 @@ provision:
   - uses: script # Set env for local launch
     name: Set {{../../../placeholderMappings.tabDomain}} for local launch
     with:
-      run: echo "::set-output {{../../../placeholderMappings.tabDomain}}={{domain}}"
+      run: echo "set-teamsfx-env {{../../../placeholderMappings.tabDomain}}={{domain}}"
   - uses: script # Set env for local launch
     name: Set {{../../../placeholderMappings.tabEndpoint}} for local launch
     with:
-      run: echo "::set-output {{../../../placeholderMappings.tabEndpoint}}={{endpoint}}"
+      run: echo "set-teamsfx-env {{../../../placeholderMappings.tabEndpoint}}={{endpoint}}"
   - uses: script # Set env for local launch
     name: Set {{../../../placeholderMappings.tabIndexPath}} for local launch
     with:
-      run: echo "::set-output {{../../../placeholderMappings.tabIndexPath}}=/index.html#"
+      run: echo "set-teamsfx-env {{../../../placeholderMappings.tabIndexPath}}=/index.html#"
 
   {{/tab}}
   {{#if aad}}

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/csharpNonSsoTab/expectedResult/app.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/csharpNonSsoTab/expectedResult/app.yml
@@ -21,7 +21,7 @@ provision:
       bicepCliVersion: v0.4.613 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
   - uses: script # Add additional item to .env file
     with:
-      run: echo "::set-output PROVISIONOUTPUT__AZUREWEBAPPTABOUTPUT__INDEXPATH=/" # Used in appPackage/manifest.json file.
+      run: echo "set-teamsfx-env PROVISIONOUTPUT__AZUREWEBAPPTABOUTPUT__INDEXPATH=/" # Used in appPackage/manifest.json file.
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/csharpSsoTab/expectedResult/app.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/csharpSsoTab/expectedResult/app.yml
@@ -33,7 +33,7 @@ provision:
       bicepCliVersion: v0.4.613 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
   - uses: script # Add additional item to .env file
     with:
-      run: echo "::set-output PROVISIONOUTPUT__AZUREWEBAPPTABOUTPUT__INDEXPATH=/" # Used in appPackage/manifest.json file.
+      run: echo "set-teamsfx-env PROVISIONOUTPUT__AZUREWEBAPPTABOUTPUT__INDEXPATH=/" # Used in appPackage/manifest.json file.
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:
       manifestPath: ./aad.manifest.json # Relative path to this file. Environment variables in manifest will be replaced before apply to AAD app

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/V3.5.0-V4.0.6-tab-bot-func/expected/app.local.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/V3.5.0-V4.0.6-tab-bot-func/expected/app.local.yml
@@ -39,15 +39,15 @@ provision:
   - uses: script # Set env for local launch
     name: Set PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__DOMAIN for local launch
     with:
-      run: echo "::set-output PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__DOMAIN=localhost:53000"
+      run: echo "set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__DOMAIN=localhost:53000"
   - uses: script # Set env for local launch
     name: Set PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__ENDPOINT for local launch
     with:
-      run: echo "::set-output PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__ENDPOINT=https://localhost:53000"
+      run: echo "set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__ENDPOINT=https://localhost:53000"
   - uses: script # Set env for local launch
     name: Set PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH for local launch
     with:
-      run: echo "::set-output PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH=/index.html#"
+      run: echo "set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH=/index.html#"
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/V3.5.0-V4.0.6-tab/expected/app.local.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/V3.5.0-V4.0.6-tab/expected/app.local.yml
@@ -23,15 +23,15 @@ provision:
   - uses: script # Set env for local launch
     name: Set PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__DOMAIN for local launch
     with:
-      run: echo "::set-output PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__DOMAIN=localhost:53000"
+      run: echo "set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__DOMAIN=localhost:53000"
   - uses: script # Set env for local launch
     name: Set PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__ENDPOINT for local launch
     with:
-      run: echo "::set-output PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__ENDPOINT=https://localhost:53000"
+      run: echo "set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__ENDPOINT=https://localhost:53000"
   - uses: script # Set env for local launch
     name: Set PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH for local launch
     with:
-      run: echo "::set-output PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH=/index.html#"
+      run: echo "set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH=/index.html#"
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/beforeV3.4.0-tab-bot-func/expected/app.local.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/beforeV3.4.0-tab-bot-func/expected/app.local.yml
@@ -39,15 +39,15 @@ provision:
   - uses: script # Set env for local launch
     name: Set PROVISIONOUTPUT__FRONTENDHOSTINGOUTPUT__DOMAIN for local launch
     with:
-      run: echo "::set-output PROVISIONOUTPUT__FRONTENDHOSTINGOUTPUT__DOMAIN=localhost:53000"
+      run: echo "set-teamsfx-env PROVISIONOUTPUT__FRONTENDHOSTINGOUTPUT__DOMAIN=localhost:53000"
   - uses: script # Set env for local launch
     name: Set PROVISIONOUTPUT__FRONTENDHOSTINGOUTPUT__ENDPOINT for local launch
     with:
-      run: echo "::set-output PROVISIONOUTPUT__FRONTENDHOSTINGOUTPUT__ENDPOINT=https://localhost:53000"
+      run: echo "set-teamsfx-env PROVISIONOUTPUT__FRONTENDHOSTINGOUTPUT__ENDPOINT=https://localhost:53000"
   - uses: script # Set env for local launch
     name: Set PROVISIONOUTPUT__FRONTENDHOSTINGOUTPUT__INDEXPATH for local launch
     with:
-      run: echo "::set-output PROVISIONOUTPUT__FRONTENDHOSTINGOUTPUT__INDEXPATH=/index.html#"
+      run: echo "set-teamsfx-env PROVISIONOUTPUT__FRONTENDHOSTINGOUTPUT__INDEXPATH=/index.html#"
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/beforeV3.4.0-tab/expected/app.local.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/beforeV3.4.0-tab/expected/app.local.yml
@@ -23,15 +23,15 @@ provision:
   - uses: script # Set env for local launch
     name: Set PROVISIONOUTPUT__FRONTENDHOSTINGOUTPUT__DOMAIN for local launch
     with:
-      run: echo "::set-output PROVISIONOUTPUT__FRONTENDHOSTINGOUTPUT__DOMAIN=localhost:53000"
+      run: echo "set-teamsfx-env PROVISIONOUTPUT__FRONTENDHOSTINGOUTPUT__DOMAIN=localhost:53000"
   - uses: script # Set env for local launch
     name: Set PROVISIONOUTPUT__FRONTENDHOSTINGOUTPUT__ENDPOINT for local launch
     with:
-      run: echo "::set-output PROVISIONOUTPUT__FRONTENDHOSTINGOUTPUT__ENDPOINT=https://localhost:53000"
+      run: echo "set-teamsfx-env PROVISIONOUTPUT__FRONTENDHOSTINGOUTPUT__ENDPOINT=https://localhost:53000"
   - uses: script # Set env for local launch
     name: Set PROVISIONOUTPUT__FRONTENDHOSTINGOUTPUT__INDEXPATH for local launch
     with:
-      run: echo "::set-output PROVISIONOUTPUT__FRONTENDHOSTINGOUTPUT__INDEXPATH=/index.html#"
+      run: echo "set-teamsfx-env PROVISIONOUTPUT__FRONTENDHOSTINGOUTPUT__INDEXPATH=/index.html#"
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-m365-tab/expected/app.local.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-m365-tab/expected/app.local.yml
@@ -23,15 +23,15 @@ provision:
   - uses: script # Set env for local launch
     name: Set PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__DOMAIN for local launch
     with:
-      run: echo "::set-output PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__DOMAIN=localhost:53000"
+      run: echo "set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__DOMAIN=localhost:53000"
   - uses: script # Set env for local launch
     name: Set PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__ENDPOINT for local launch
     with:
-      run: echo "::set-output PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__ENDPOINT=https://localhost:53000"
+      run: echo "set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__ENDPOINT=https://localhost:53000"
   - uses: script # Set env for local launch
     name: Set PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH for local launch
     with:
-      run: echo "::set-output PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH=/index.html#"
+      run: echo "set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH=/index.html#"
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-sso-tab/expected/app.local.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-sso-tab/expected/app.local.yml
@@ -23,15 +23,15 @@ provision:
   - uses: script # Set env for local launch
     name: Set PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__DOMAIN for local launch
     with:
-      run: echo "::set-output PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__DOMAIN=localhost:53000"
+      run: echo "set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__DOMAIN=localhost:53000"
   - uses: script # Set env for local launch
     name: Set PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__ENDPOINT for local launch
     with:
-      run: echo "::set-output PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__ENDPOINT=https://localhost:53000"
+      run: echo "set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__ENDPOINT=https://localhost:53000"
   - uses: script # Set env for local launch
     name: Set PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH for local launch
     with:
-      run: echo "::set-output PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH=/index.html#"
+      run: echo "set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH=/index.html#"
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-tab-bot-func/expected/app.local.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-tab-bot-func/expected/app.local.yml
@@ -39,15 +39,15 @@ provision:
   - uses: script # Set env for local launch
     name: Set PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__DOMAIN for local launch
     with:
-      run: echo "::set-output PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__DOMAIN=localhost:53000"
+      run: echo "set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__DOMAIN=localhost:53000"
   - uses: script # Set env for local launch
     name: Set PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__ENDPOINT for local launch
     with:
-      run: echo "::set-output PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__ENDPOINT=https://localhost:53000"
+      run: echo "set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__ENDPOINT=https://localhost:53000"
   - uses: script # Set env for local launch
     name: Set PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH for local launch
     with:
-      run: echo "::set-output PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH=/index.html#"
+      run: echo "set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH=/index.html#"
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-tab/expected/app.local.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-tab/expected/app.local.yml
@@ -10,15 +10,15 @@ provision:
   - uses: script # Set env for local launch
     name: Set PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__DOMAIN for local launch
     with:
-      run: echo "::set-output PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__DOMAIN=localhost:53000"
+      run: echo "set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__DOMAIN=localhost:53000"
   - uses: script # Set env for local launch
     name: Set PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__ENDPOINT for local launch
     with:
-      run: echo "::set-output PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__ENDPOINT=https://localhost:53000"
+      run: echo "set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__ENDPOINT=https://localhost:53000"
   - uses: script # Set env for local launch
     name: Set PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH for local launch
     with:
-      run: echo "::set-output PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH=/index.html#"
+      run: echo "set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH=/index.html#"
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/templates/scenarios/csharp/non-sso-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/csharp/non-sso-tab/teamsapp.local.yml.tpl
@@ -7,11 +7,11 @@ provision:
   - uses: script # Set TAB_DOMAIN for local launch
     name: Set TAB_DOMAIN for local launch
     with:
-      run: echo "::set-output TAB_DOMAIN=localhost:44302"
+      run: echo "set-teamsfx-env TAB_DOMAIN=localhost:44302"
   - uses: script # Set TAB_ENDPOINT for local launch
     name: Set TAB_ENDPOINT for local launch
     with:
-      run: echo "::set-output TAB_ENDPOINT=https://localhost:44302"
+      run: echo "set-teamsfx-env TAB_ENDPOINT=https://localhost:44302"
 
   - uses: teamsApp/create # Creates a Teams app
     with:

--- a/templates/scenarios/csharp/sso-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/csharp/sso-tab/teamsapp.local.yml.tpl
@@ -25,11 +25,11 @@ provision:
   - uses: script # Set TAB_DOMAIN for local launch
     name: Set TAB_DOMAIN for local launch
     with:
-      run: echo "::set-output TAB_DOMAIN=localhost:44302"
+      run: echo "set-teamsfx-env TAB_DOMAIN=localhost:44302"
   - uses: script # Set TAB_ENDPOINT for local launch
     name: Set TAB_ENDPOINT for local launch
     with:
-      run: echo "::set-output TAB_ENDPOINT=https://localhost:44302"
+      run: echo "set-teamsfx-env TAB_ENDPOINT=https://localhost:44302"
 
   - uses: file/createOrUpdateJsonFile # Generate runtime appsettings to JSON file
     with:

--- a/templates/scenarios/js/dashboard-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/js/dashboard-tab/teamsapp.local.yml.tpl
@@ -12,11 +12,11 @@ provision:
   - uses: script # Set TAB_DOMAIN for local launch
     name: Set TAB_DOMAIN for local launch
     with:
-      run: echo "::set-output TAB_DOMAIN=localhost:53000"
+      run: echo "set-teamsfx-env TAB_DOMAIN=localhost:53000"
   - uses: script # Set TAB_ENDPOINT for local launch
     name: Set TAB_ENDPOINT for local launch
     with:
-      run: echo "::set-output TAB_ENDPOINT=https://localhost:53000"
+      run: echo "set-teamsfx-env TAB_ENDPOINT=https://localhost:53000"
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template

--- a/templates/scenarios/js/m365-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/js/m365-tab/teamsapp.local.yml.tpl
@@ -25,11 +25,11 @@ provision:
   - uses: script # Set TAB_DOMAIN for local launch
     name: Set TAB_DOMAIN for local launch
     with:
-      run: echo "::set-output TAB_DOMAIN=localhost:53000"
+      run: echo "set-teamsfx-env TAB_DOMAIN=localhost:53000"
   - uses: script # Set TAB_ENDPOINT for local launch
     name: Set TAB_ENDPOINT for local launch
     with:
-      run: echo "::set-output TAB_ENDPOINT=https://localhost:53000"
+      run: echo "set-teamsfx-env TAB_ENDPOINT=https://localhost:53000"
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:

--- a/templates/scenarios/js/non-sso-tab-default-bot/teamsapp.local.yml.tpl
+++ b/templates/scenarios/js/non-sso-tab-default-bot/teamsapp.local.yml.tpl
@@ -28,11 +28,11 @@ provision:
   - uses: script # Set TAB_DOMAIN for local launch
     name: Set TAB_DOMAIN for local launch
     with:
-      run: echo "::set-output TAB_DOMAIN=localhost:53000"
+      run: echo "set-teamsfx-env TAB_DOMAIN=localhost:53000"
   - uses: script # Set TAB_ENDPOINT for local launch
     name: Set TAB_ENDPOINT for local launch
     with:
-      run: echo "::set-output TAB_ENDPOINT=https://localhost:53000"
+      run: echo "set-teamsfx-env TAB_ENDPOINT=https://localhost:53000"
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template

--- a/templates/scenarios/js/non-sso-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/js/non-sso-tab/teamsapp.local.yml.tpl
@@ -12,11 +12,11 @@ provision:
   - uses: script # Set TAB_DOMAIN for local launch
     name: Set TAB_DOMAIN for local launch
     with:
-      run: echo "::set-output TAB_DOMAIN=localhost:53000"
+      run: echo "set-teamsfx-env TAB_DOMAIN=localhost:53000"
   - uses: script # Set TAB_ENDPOINT for local launch
     name: Set TAB_ENDPOINT for local launch
     with:
-      run: echo "::set-output TAB_ENDPOINT=https://localhost:53000"
+      run: echo "set-teamsfx-env TAB_ENDPOINT=https://localhost:53000"
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template

--- a/templates/scenarios/js/sso-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/js/sso-tab/teamsapp.local.yml.tpl
@@ -25,11 +25,11 @@ provision:
   - uses: script # Set TAB_DOMAIN for local launch
     name: Set TAB_DOMAIN for local launch
     with:
-      run: echo "::set-output TAB_DOMAIN=localhost:53000"
+      run: echo "set-teamsfx-env TAB_DOMAIN=localhost:53000"
   - uses: script # Set TAB_ENDPOINT for local launch
     name: Set TAB_ENDPOINT for local launch
     with:
-      run: echo "::set-output TAB_ENDPOINT=https://localhost:53000"
+      run: echo "set-teamsfx-env TAB_ENDPOINT=https://localhost:53000"
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:

--- a/templates/scenarios/ts/dashboard-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/ts/dashboard-tab/teamsapp.local.yml.tpl
@@ -12,11 +12,11 @@ provision:
   - uses: script # Set TAB_DOMAIN for local launch
     name: Set TAB_DOMAIN for local launch
     with:
-      run: echo "::set-output TAB_DOMAIN=localhost:53000"
+      run: echo "set-teamsfx-env TAB_DOMAIN=localhost:53000"
   - uses: script # Set TAB_ENDPOINT for local launch
     name: Set TAB_ENDPOINT for local launch
     with:
-      run: echo "::set-output TAB_ENDPOINT=https://localhost:53000"
+      run: echo "set-teamsfx-env TAB_ENDPOINT=https://localhost:53000"
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template

--- a/templates/scenarios/ts/m365-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/ts/m365-tab/teamsapp.local.yml.tpl
@@ -25,11 +25,11 @@ provision:
   - uses: script # Set TAB_DOMAIN for local launch
     name: Set TAB_DOMAIN for local launch
     with:
-      run: echo "::set-output TAB_DOMAIN=localhost:53000"
+      run: echo "set-teamsfx-env TAB_DOMAIN=localhost:53000"
   - uses: script # Set TAB_ENDPOINT for local launch
     name: Set TAB_ENDPOINT for local launch
     with:
-      run: echo "::set-output TAB_ENDPOINT=https://localhost:53000"
+      run: echo "set-teamsfx-env TAB_ENDPOINT=https://localhost:53000"
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:

--- a/templates/scenarios/ts/non-sso-tab-default-bot/teamsapp.local.yml.tpl
+++ b/templates/scenarios/ts/non-sso-tab-default-bot/teamsapp.local.yml.tpl
@@ -28,11 +28,11 @@ provision:
   - uses: script # Set TAB_DOMAIN for local launch
     name: Set TAB_DOMAIN for local launch
     with:
-      run: echo "::set-output TAB_DOMAIN=localhost:53000"
+      run: echo "set-teamsfx-env TAB_DOMAIN=localhost:53000"
   - uses: script # Set TAB_ENDPOINT for local launch
     name: Set TAB_ENDPOINT for local launch
     with:
-      run: echo "::set-output TAB_ENDPOINT=https://localhost:53000"
+      run: echo "set-teamsfx-env TAB_ENDPOINT=https://localhost:53000"
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template

--- a/templates/scenarios/ts/non-sso-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/ts/non-sso-tab/teamsapp.local.yml.tpl
@@ -11,11 +11,11 @@ provision:
   - uses: script # Set TAB_DOMAIN for local launch
     name: Set TAB_DOMAIN for local launch
     with:
-      run: echo "::set-output TAB_DOMAIN=localhost:53000"
+      run: echo "set-teamsfx-env TAB_DOMAIN=localhost:53000"
   - uses: script # Set TAB_ENDPOINT for local launch
     name: Set TAB_ENDPOINT for local launch
     with:
-      run: echo "::set-output TAB_ENDPOINT=https://localhost:53000"
+      run: echo "set-teamsfx-env TAB_ENDPOINT=https://localhost:53000"
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template

--- a/templates/scenarios/ts/sso-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/ts/sso-tab/teamsapp.local.yml.tpl
@@ -25,11 +25,11 @@ provision:
   - uses: script # Set TAB_DOMAIN for local launch
     name: Set TAB_DOMAIN for local launch
     with:
-      run: echo "::set-output TAB_DOMAIN=localhost:53000"
+      run: echo "set-teamsfx-env TAB_DOMAIN=localhost:53000"
   - uses: script # Set TAB_ENDPOINT for local launch
     name: Set TAB_ENDPOINT for local launch
     with:
-      run: echo "::set-output TAB_ENDPOINT=https://localhost:53000"
+      run: echo "set-teamsfx-env TAB_ENDPOINT=https://localhost:53000"
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:


### PR DESCRIPTION
Align with #8111 and [script wiki](https://github.com/OfficeDev/TeamsFx/wiki/Available-actions-in-Teams-Toolkit#script), use `set-teamsfx-env` instead of `::set-output`