### PR TITLE
chore: update file action schema

### DIFF
--- a/packages/fx-core/resource/yaml.schema.json
+++ b/packages/fx-core/resource/yaml.schema.json
@@ -1071,7 +1071,19 @@
             "envs": {
               "type": "object",
               "description": "the environment variable(s) to be generated",
-              "additionalProperties": { "type": [ "boolean", "number", "string" ] }
+              "additionalProperties": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              }
             },
             "target": {
               "type": "string",


### PR DESCRIPTION
E2E TEST: https://github.com/OfficeDev/TeamsFx/actions/runs/4605579044

To fix following warning:
strict mode: use allowUnionTypes to allow union type keyword at "#/definitions/fileCreateOrUpdateEnvironmentFile/properties/with/properties/envs/additionalProperties" (strictTypes)