### PR TITLE
chore: remove output comments in templates

### DIFF
--- a/templates/scenarios/common/office-addin/teamsapp.yml
+++ b/templates/scenarios/common/office-addin/teamsapp.yml
@@ -16,14 +16,12 @@ provision:
          parameters: ./infra/azure.parameters.json # Relative path to this file. Placeholders will be replaced with corresponding environment variable before ARM deployment.
          deploymentName: Create-resources-for-tab # Required when deploy ARM template
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: azureStorage/enableStaticWebsite
     with:
       storageResourceId: ${{ADDIN_AZURE_STORAGE_RESOURCE_ID}}
       indexPage: index.html
       errorPage: error.html
-    # Output: N/A
 
 # Triggered when 'teamsfx deploy' is executed
 deploy:

--- a/templates/scenarios/csharp/command-and-response/teamsapp.yml.tpl
+++ b/templates/scenarios/csharp/command-and-response/teamsapp.yml.tpl
@@ -29,7 +29,6 @@ provision:
         parameters: ./infra/azure.parameters.json
         deploymentName: Create-resources-for-bot
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/templates/scenarios/csharp/message-extension/teamsapp.yml.tpl
+++ b/templates/scenarios/csharp/message-extension/teamsapp.yml.tpl
@@ -29,7 +29,6 @@ provision:
          parameters: ./infra/azure.parameters.json # Relative path to this file. Placeholders will be replaced with corresponding environment variable before ARM deployment.
          deploymentName: Create-resources-for-tab # Required when deploy ARM template
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/templates/scenarios/csharp/non-sso-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/csharp/non-sso-tab/teamsapp.yml.tpl
@@ -22,7 +22,6 @@ provision:
          parameters: ./infra/azure.parameters.json # Relative path to this file. Placeholders will be replaced with corresponding environment variable before ARM deployment.
          deploymentName: Create-resources-for-tab # Required when deploy ARM template
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/templates/scenarios/csharp/notification-http-timer-trigger/teamsapp.yml.tpl
+++ b/templates/scenarios/csharp/notification-http-timer-trigger/teamsapp.yml.tpl
@@ -29,7 +29,6 @@ provision:
         parameters: ./infra/azure.parameters.json
         deploymentName: Create-resources-for-bot
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/templates/scenarios/csharp/notification-http-trigger/teamsapp.yml.tpl
+++ b/templates/scenarios/csharp/notification-http-trigger/teamsapp.yml.tpl
@@ -29,7 +29,6 @@ provision:
         parameters: ./infra/azure.parameters.json
         deploymentName: Create-resources-for-bot
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/templates/scenarios/csharp/notification-timer-trigger/teamsapp.yml.tpl
+++ b/templates/scenarios/csharp/notification-timer-trigger/teamsapp.yml.tpl
@@ -29,7 +29,6 @@ provision:
         parameters: ./infra/azure.parameters.json
         deploymentName: Create-resources-for-bot
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/templates/scenarios/csharp/notification-webapi/teamsapp.yml.tpl
+++ b/templates/scenarios/csharp/notification-webapi/teamsapp.yml.tpl
@@ -29,7 +29,6 @@ provision:
         parameters: ./infra/azure.parameters.json
         deploymentName: Create-resources-for-bot
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/templates/scenarios/csharp/sso-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/csharp/sso-tab/teamsapp.local.yml.tpl
@@ -46,8 +46,6 @@ provision:
     with:
       manifestPath: ./aad.manifest.json # Relative path to this file. Environment variables in manifest will be replaced before apply to AAD app
       outputFilePath : ./build/aad.manifest.${{TEAMSFX_ENV}}.json
-  # Output: following environment variable will be persisted in current environment's .env file.
-  # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
     with:

--- a/templates/scenarios/csharp/sso-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/csharp/sso-tab/teamsapp.yml.tpl
@@ -35,14 +35,11 @@ provision:
          parameters: ./infra/azure.parameters.json # Relative path to this file. Placeholders will be replaced with corresponding environment variable before ARM deployment.
          deploymentName: Create-resources-for-tab # Required when deploy ARM template
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:
       manifestPath: ./aad.manifest.json # Relative path to this file. Environment variables in manifest will be replaced before apply to AAD app
       outputFilePath : ./build/aad.manifest.${{TEAMSFX_ENV}}.json
-  # Output: following environment variable will be persisted in current environment's .env file.
-  # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/templates/scenarios/csharp/workflow/teamsapp.yml.tpl
+++ b/templates/scenarios/csharp/workflow/teamsapp.yml.tpl
@@ -29,7 +29,6 @@ provision:
         parameters: ./infra/azure.parameters.json
         deploymentName: Create-resources-for-bot
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/templates/scenarios/js/command-and-response/teamsapp.yml.tpl
+++ b/templates/scenarios/js/command-and-response/teamsapp.yml.tpl
@@ -29,7 +29,6 @@ provision:
         parameters: ./infra/azure.parameters.json
         deploymentName: Create-resources-for-bot
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/templates/scenarios/js/dashboard-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/js/dashboard-tab/teamsapp.yml.tpl
@@ -22,14 +22,12 @@ provision:
          parameters: ./infra/azure.parameters.json # Relative path to this file. Placeholders will be replaced with corresponding environment variable before ARM deployment.
          deploymentName: Create-resources-for-tab # Required when deploy ARM template
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: azureStorage/enableStaticWebsite
     with:
       storageResourceId: ${{TAB_AZURE_STORAGE_RESOURCE_ID}}
       indexPage: index.html
       errorPage: error.html
-    # Output: N/A
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/templates/scenarios/js/default-bot-message-extension/teamsapp.yml.tpl
+++ b/templates/scenarios/js/default-bot-message-extension/teamsapp.yml.tpl
@@ -29,7 +29,6 @@ provision:
         parameters: ./infra/azure.parameters.json
         deploymentName: Create-resources-for-bot
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/templates/scenarios/js/default-bot/teamsapp.yml.tpl
+++ b/templates/scenarios/js/default-bot/teamsapp.yml.tpl
@@ -29,7 +29,6 @@ provision:
         parameters: ./infra/azure.parameters.json
         deploymentName: Create-resources-for-bot
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/templates/scenarios/js/m365-message-extension/teamsapp.yml.tpl
+++ b/templates/scenarios/js/m365-message-extension/teamsapp.yml.tpl
@@ -29,7 +29,6 @@ provision:
         parameters: ./infra/azure.parameters.json
         deploymentName: Create-resources-for-bot
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/templates/scenarios/js/m365-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/js/m365-tab/teamsapp.local.yml.tpl
@@ -36,8 +36,6 @@ provision:
     with:
       manifestPath: ./aad.manifest.json # Relative path to this file. Environment variables in manifest will be replaced before apply to AAD app
       outputFilePath: ./build/aad.manifest.${{TEAMSFX_ENV}}.json
-  # Output: following environment variable will be persisted in current environment's .env file.
-  # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/templates/scenarios/js/m365-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/js/m365-tab/teamsapp.yml.tpl
@@ -35,21 +35,17 @@ provision:
          parameters: ./infra/azure.parameters.json # Relative path to this file. Placeholders will be replaced with corresponding environment variable before ARM deployment.
          deploymentName: Create-resources-for-tab # Required when deploy ARM template
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: azureStorage/enableStaticWebsite
     with:
       storageResourceId: ${{TAB_AZURE_STORAGE_RESOURCE_ID}}
       indexPage: index.html
       errorPage: error.html
-    # Output: N/A
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:
       manifestPath: ./aad.manifest.json # Relative path to this file. Environment variables in manifest will be replaced before apply to AAD app
       outputFilePath : ./build/aad.manifest.${{TEAMSFX_ENV}}.json
-  # Output: following environment variable will be persisted in current environment's .env file.
-  # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/templates/scenarios/js/message-extension/teamsapp.yml.tpl
+++ b/templates/scenarios/js/message-extension/teamsapp.yml.tpl
@@ -29,7 +29,6 @@ provision:
         parameters: ./infra/azure.parameters.json
         deploymentName: Create-resources-for-bot
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/templates/scenarios/js/non-sso-tab-default-bot/teamsapp.yml.tpl
+++ b/templates/scenarios/js/non-sso-tab-default-bot/teamsapp.yml.tpl
@@ -29,14 +29,12 @@ provision:
          parameters: ./infra/azure.parameters.json # Relative path to this file. Placeholders will be replaced with corresponding environment variable before ARM deployment.
          deploymentName: Create-resources # Required when deploy ARM template
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: azureStorage/enableStaticWebsite
     with:
       storageResourceId: ${{TAB_AZURE_STORAGE_RESOURCE_ID}}
       indexPage: index.html
       errorPage: error.html
-    # Output: N/A
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/templates/scenarios/js/non-sso-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/js/non-sso-tab/teamsapp.yml.tpl
@@ -22,14 +22,12 @@ provision:
          parameters: ./infra/azure.parameters.json # Relative path to this file. Placeholders will be replaced with corresponding environment variable before ARM deployment.
          deploymentName: Create-resources-for-tab # Required when deploy ARM template
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: azureStorage/enableStaticWebsite
     with:
       storageResourceId: ${{TAB_AZURE_STORAGE_RESOURCE_ID}}
       indexPage: index.html
       errorPage: error.html
-    # Output: N/A
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/templates/scenarios/js/notification-http-timer-trigger/teamsapp.yml.tpl
+++ b/templates/scenarios/js/notification-http-timer-trigger/teamsapp.yml.tpl
@@ -29,7 +29,6 @@ provision:
         parameters: ./infra/azure.parameters.json
         deploymentName: Create-resources-for-bot
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
     with:

--- a/templates/scenarios/js/notification-http-trigger/teamsapp.yml.tpl
+++ b/templates/scenarios/js/notification-http-trigger/teamsapp.yml.tpl
@@ -29,7 +29,6 @@ provision:
         parameters: ./infra/azure.parameters.json
         deploymentName: Create-resources-for-bot
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
     with:

--- a/templates/scenarios/js/notification-restify/teamsapp.yml.tpl
+++ b/templates/scenarios/js/notification-restify/teamsapp.yml.tpl
@@ -29,7 +29,6 @@ provision:
         parameters: ./infra/azure.parameters.json
         deploymentName: Create-resources-for-bot
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/templates/scenarios/js/notification-timer-trigger/teamsapp.yml.tpl
+++ b/templates/scenarios/js/notification-timer-trigger/teamsapp.yml.tpl
@@ -29,7 +29,6 @@ provision:
         parameters: ./infra/azure.parameters.json
         deploymentName: Create-resources-for-bot
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
     with:

--- a/templates/scenarios/js/sso-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/js/sso-tab/teamsapp.local.yml.tpl
@@ -36,8 +36,6 @@ provision:
     with:
       manifestPath: ./aad.manifest.json # Relative path to this file. Environment variables in manifest will be replaced before apply to AAD app
       outputFilePath: ./build/aad.manifest.${{TEAMSFX_ENV}}.json
-  # Output: following environment variable will be persisted in current environment's .env file.
-  # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/templates/scenarios/js/sso-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/js/sso-tab/teamsapp.yml.tpl
@@ -35,21 +35,17 @@ provision:
          parameters: ./infra/azure.parameters.json # Relative path to this file. Placeholders will be replaced with corresponding environment variable before ARM deployment.
          deploymentName: Create-resources-for-tab # Required when deploy ARM template
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: azureStorage/enableStaticWebsite
     with:
       storageResourceId: ${{TAB_AZURE_STORAGE_RESOURCE_ID}}
       indexPage: index.html
       errorPage: error.html
-    # Output: N/A
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:
       manifestPath: ./aad.manifest.json # Relative path to this file. Environment variables in manifest will be replaced before apply to AAD app
       outputFilePath : ./build/aad.manifest.${{TEAMSFX_ENV}}.json
-  # Output: following environment variable will be persisted in current environment's .env file.
-  # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/templates/scenarios/js/workflow/teamsapp.yml.tpl
+++ b/templates/scenarios/js/workflow/teamsapp.yml.tpl
@@ -29,7 +29,6 @@ provision:
         parameters: ./infra/azure.parameters.json
         deploymentName: Create-resources-for-bot
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/templates/scenarios/ts/command-and-response/teamsapp.yml.tpl
+++ b/templates/scenarios/ts/command-and-response/teamsapp.yml.tpl
@@ -29,7 +29,6 @@ provision:
         parameters: ./infra/azure.parameters.json
         deploymentName: Create-resources-for-bot
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/templates/scenarios/ts/dashboard-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/ts/dashboard-tab/teamsapp.yml.tpl
@@ -22,14 +22,12 @@ provision:
          parameters: ./infra/azure.parameters.json # Relative path to this file. Placeholders will be replaced with corresponding environment variable before ARM deployment.
          deploymentName: Create-resources-for-tab # Required when deploy ARM template
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: azureStorage/enableStaticWebsite
     with:
       storageResourceId: ${{TAB_AZURE_STORAGE_RESOURCE_ID}}
       indexPage: index.html
       errorPage: error.html
-    # Output: N/A
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/templates/scenarios/ts/default-bot-message-extension/teamsapp.yml.tpl
+++ b/templates/scenarios/ts/default-bot-message-extension/teamsapp.yml.tpl
@@ -29,7 +29,6 @@ provision:
         parameters: ./infra/azure.parameters.json
         deploymentName: Create-resources-for-bot
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/templates/scenarios/ts/default-bot/teamsapp.yml.tpl
+++ b/templates/scenarios/ts/default-bot/teamsapp.yml.tpl
@@ -29,7 +29,6 @@ provision:
         parameters: ./infra/azure.parameters.json
         deploymentName: Create-resources-for-bot
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/templates/scenarios/ts/m365-message-extension/teamsapp.yml.tpl
+++ b/templates/scenarios/ts/m365-message-extension/teamsapp.yml.tpl
@@ -29,7 +29,6 @@ provision:
         parameters: ./infra/azure.parameters.json
         deploymentName: Create-resources-for-bot
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/templates/scenarios/ts/m365-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/ts/m365-tab/teamsapp.local.yml.tpl
@@ -36,8 +36,6 @@ provision:
     with:
       manifestPath: ./aad.manifest.json # Relative path to this file. Environment variables in manifest will be replaced before apply to AAD app
       outputFilePath: ./build/aad.manifest.${{TEAMSFX_ENV}}.json
-  # Output: following environment variable will be persisted in current environment's .env file.
-  # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/templates/scenarios/ts/m365-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/ts/m365-tab/teamsapp.yml.tpl
@@ -35,21 +35,17 @@ provision:
          parameters: ./infra/azure.parameters.json # Relative path to this file. Placeholders will be replaced with corresponding environment variable before ARM deployment.
          deploymentName: Create-resources-for-tab # Required when deploy ARM template
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: azureStorage/enableStaticWebsite
     with:
       storageResourceId: ${{TAB_AZURE_STORAGE_RESOURCE_ID}}
       indexPage: index.html
       errorPage: error.html
-    # Output: N/A
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:
       manifestPath: ./aad.manifest.json # Relative path to this file. Environment variables in manifest will be replaced before apply to AAD app
       outputFilePath : ./build/aad.manifest.${{TEAMSFX_ENV}}.json
-  # Output: following environment variable will be persisted in current environment's .env file.
-  # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/templates/scenarios/ts/message-extension/teamsapp.yml.tpl
+++ b/templates/scenarios/ts/message-extension/teamsapp.yml.tpl
@@ -29,7 +29,6 @@ provision:
         parameters: ./infra/azure.parameters.json
         deploymentName: Create-resources-for-bot
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/templates/scenarios/ts/non-sso-tab-default-bot/teamsapp.yml.tpl
+++ b/templates/scenarios/ts/non-sso-tab-default-bot/teamsapp.yml.tpl
@@ -29,14 +29,12 @@ provision:
          parameters: ./infra/azure.parameters.json # Relative path to this file. Placeholders will be replaced with corresponding environment variable before ARM deployment.
          deploymentName: Create-resources # Required when deploy ARM template
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: azureStorage/enableStaticWebsite
     with:
       storageResourceId: ${{TAB_AZURE_STORAGE_RESOURCE_ID}}
       indexPage: index.html
       errorPage: error.html
-    # Output: N/A
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/templates/scenarios/ts/non-sso-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/ts/non-sso-tab/teamsapp.yml.tpl
@@ -22,14 +22,12 @@ provision:
          parameters: ./infra/azure.parameters.json # Relative path to this file. Placeholders will be replaced with corresponding environment variable before ARM deployment.
          deploymentName: Create-resources-for-tab # Required when deploy ARM template
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: azureStorage/enableStaticWebsite
     with:
       storageResourceId: ${{TAB_AZURE_STORAGE_RESOURCE_ID}}
       indexPage: index.html
       errorPage: error.html
-    # Output: N/A
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/templates/scenarios/ts/notification-http-timer-trigger/teamsapp.yml.tpl
+++ b/templates/scenarios/ts/notification-http-timer-trigger/teamsapp.yml.tpl
@@ -29,7 +29,6 @@ provision:
         parameters: ./infra/azure.parameters.json
         deploymentName: Create-resources-for-bot
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
     with:

--- a/templates/scenarios/ts/notification-http-trigger/teamsapp.yml.tpl
+++ b/templates/scenarios/ts/notification-http-trigger/teamsapp.yml.tpl
@@ -29,7 +29,6 @@ provision:
         parameters: ./infra/azure.parameters.json
         deploymentName: Create-resources-for-bot
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
     with:

--- a/templates/scenarios/ts/notification-restify/teamsapp.yml.tpl
+++ b/templates/scenarios/ts/notification-restify/teamsapp.yml.tpl
@@ -29,7 +29,6 @@ provision:
         parameters: ./infra/azure.parameters.json
         deploymentName: Create-resources-for-bot
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/templates/scenarios/ts/notification-timer-trigger/teamsapp.yml.tpl
+++ b/templates/scenarios/ts/notification-timer-trigger/teamsapp.yml.tpl
@@ -29,7 +29,6 @@ provision:
         parameters: ./infra/azure.parameters.json
         deploymentName: Create-resources-for-bot
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: teamsApp/zipAppPackage # Build Teams app package with latest env value
     with:

--- a/templates/scenarios/ts/office-addin/teamsapp.yml
+++ b/templates/scenarios/ts/office-addin/teamsapp.yml
@@ -16,14 +16,12 @@ provision:
          parameters: ./infra/azure.parameters.json # Relative path to this file. Placeholders will be replaced with corresponding environment variable before ARM deployment.
          deploymentName: Create-resources-for-tab # Required when deploy ARM template
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: azureStorage/enableStaticWebsite
     with:
       storageResourceId: ${{ADDIN_AZURE_STORAGE_RESOURCE_ID}}
       indexPage: index.html
       errorPage: error.html
-    # Output: N/A
 
 # Triggered when 'teamsfx deploy' is executed
 deploy:

--- a/templates/scenarios/ts/sso-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/ts/sso-tab/teamsapp.local.yml.tpl
@@ -36,8 +36,6 @@ provision:
     with:
       manifestPath: ./aad.manifest.json # Relative path to this file. Environment variables in manifest will be replaced before apply to AAD app
       outputFilePath: ./build/aad.manifest.${{TEAMSFX_ENV}}.json
-  # Output: following environment variable will be persisted in current environment's .env file.
-  # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/templates/scenarios/ts/sso-tab/teamsapp.yml.tpl
+++ b/templates/scenarios/ts/sso-tab/teamsapp.yml.tpl
@@ -35,21 +35,17 @@ provision:
          parameters: ./infra/azure.parameters.json # Relative path to this file. Placeholders will be replaced with corresponding environment variable before ARM deployment.
          deploymentName: Create-resources-for-tab # Required when deploy ARM template
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: azureStorage/enableStaticWebsite
     with:
       storageResourceId: ${{TAB_AZURE_STORAGE_RESOURCE_ID}}
       indexPage: index.html
       errorPage: error.html
-    # Output: N/A
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:
       manifestPath: ./aad.manifest.json # Relative path to this file. Environment variables in manifest will be replaced before apply to AAD app
       outputFilePath : ./build/aad.manifest.${{TEAMSFX_ENV}}.json
-  # Output: following environment variable will be persisted in current environment's .env file.
-  # AAD_APP_ACCESS_AS_USER_PERMISSION_ID: the id of access_as_user permission which is used to enable SSO
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/templates/scenarios/ts/workflow/teamsapp.yml.tpl
+++ b/templates/scenarios/ts/workflow/teamsapp.yml.tpl
@@ -29,7 +29,6 @@ provision:
         parameters: ./infra/azure.parameters.json
         deploymentName: Create-resources-for-bot
       bicepCliVersion: v0.9.1 # Teams Toolkit will download this bicep CLI version from github for you, will use bicep CLI in PATH if you remove this config.
-    # Output: every bicep output will be persisted in current environment's .env file with certain naming conversion. Refer https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming conversion rule.
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:


### PR DESCRIPTION
Since we have `writeToEnvironmentFile` field, remove the remaining output comments as they're explained in action's wiki page.