### PR TITLE
fix(localdebug): add label to the dev tunnel task in workflow bot

### DIFF
--- a/templates/scenarios/ts/workflow/.vscode/tasks.json
+++ b/templates/scenarios/ts/workflow/.vscode/tasks.json
@@ -36,6 +36,7 @@
         {
             // Start the local tunnel service to forward public URL to local port and inspect traffic.
             // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions.
+            "label": "Start local tunnel",
             "type": "teamsfx",
             "command": "debug-start-local-tunnel",
             "args": {


### PR DESCRIPTION
E2E TEST: https://github.com/devdiv-azure-service-dmitryr/TeamsFx-UI-Test/blob/ae8d6f145f7d4dc69f774eecd91eda021445c354/src/ui-test/localdebug/localdebug-workflow-bot-ts.test.ts#L38