### PR TITLE
chore: be compatible with draft-04 and draft-07

### DIFF
--- a/packages/manifest/package-lock.json
+++ b/packages/manifest/package-lock.json
@@ -841,6 +841,14 @@
             "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
             "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw=="
         },
+        "ajv-formats": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+			"integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+			"requires": {
+				"ajv": "^8.0.0"
+			}
+		},
         "ansi-colors": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",

--- a/packages/manifest/package.json
+++ b/packages/manifest/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "ajv": "^8.5.0",
     "ajv-draft-04": "^1.0.0",
+    "ajv-formats": "2.1.1",
     "axios": "^0.21.2",
     "fs-extra": "^9.1.0"
   },

--- a/packages/manifest/src/index.ts
+++ b/packages/manifest/src/index.ts
@@ -3,8 +3,9 @@
 
 import { TeamsAppManifest } from "./manifest";
 import fs from "fs-extra";
-import Ajv from "ajv-draft-04";
-import { JSONSchemaType } from "ajv";
+import AjvDraft04 from "ajv-draft-04";
+import Ajv, { JSONSchemaType } from "ajv";
+import addFormats from "ajv-formats";
 import axios, { AxiosResponse } from "axios";
 import { DevPreviewSchema } from "./devPreviewManifest";
 
@@ -54,7 +55,14 @@ export class ManifestUtil {
     manifest: T,
     schema: JSONSchemaType<T>
   ): Promise<string[]> {
-    const ajv = new Ajv({ formats: { uri: true } });
+    let ajv;
+    const draft07MetaSchema = require("ajv/dist/refs/json-schema-draft-07.json");
+    if (schema.$schema === draft07MetaSchema.$schema) {
+      ajv = new Ajv();
+      addFormats(ajv);
+    } else {
+      ajv = new AjvDraft04({ formats: { uri: true } });
+    }
     const validate = ajv.compile(schema);
     const valid = validate(manifest);
     if (!valid && validate.errors) {


### PR DESCRIPTION
For P0 bug: 
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/17900028

Office add-in manifest schema uses draft-07 schema. Need 2 ajv instances
![image](https://user-images.githubusercontent.com/71362691/231042204-6f963344-17d2-4d5f-a347-39976e65d96c.png)
