### PR TITLE
fix(localdebug): remove template arg in lifecycle task

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -1071,10 +1071,6 @@
                       },
                       {}
                     ]
-                  },
-                  "template": {
-                    "type": "string",
-                    "description": "%teamstoolkit.taskDefinitions.args.template.title%"
                   }
                 },
                 "additionalProperties": false

--- a/packages/vscode-extension/package.nls.json
+++ b/packages/vscode-extension/package.nls.json
@@ -413,7 +413,6 @@
     "teamstoolkit.taskDefinitions.args.ports.portNumber.title": "Local server port number.",
     "teamstoolkit.taskDefinitions.args.ports.protocol.title": "Protocol for the port.",
     "teamstoolkit.taskDefinitions.args.ports.access.title": "Access control for the tunnel.",
-    "teamstoolkit.taskDefinitions.args.template.title": "The path to yml template.",
     "teamstoolkit.manageCollaborator.grantPermission.label": "Add App Owners",
     "teamstoolkit.manageCollaborator.grantPermission.description": "Add owners to your Teams app and Azure Active Director app registrations so they can make changes",
     "teamstoolkit.manageCollaborator.listCollaborator.label": "List App Owners",


### PR DESCRIPTION
Now the `template` cannot be specified in lifecycle task. Remove it from the task definitations.

The following is the current lifecycle task.
```
        {
            // Create the debug resources.
            // See https://aka.ms/teamsfx-tasks/provision to know the details and how to customize the args.
            "label": "Provision",
            "type": "teamsfx",
            "command": "provision",
            "args": {
                "env": "local"
            }
        },
        {
            // Build project.
            // See https://aka.ms/teamsfx-tasks/deploy to know the details and how to customize the args.
            "label": "Deploy",
            "type": "teamsfx",
            "command": "deploy",
            "args": {
                "env": "local"
            }
        },
```
detail: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/17920619/
E2E TEST: none