### PR TITLE
refactor: clean up default output logic in aadApp/create action

### DIFF
--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -840,6 +840,7 @@
   "error.BadComponent": "Component '%s' lacks of property: %s.",
   "error.InvalidFeature": "This feature is not applicable for your project.",
   "error.UpdateAadManifest.MissingEnvHint": "If you are developing with a new project created with Teams Toolkit, running provision or debug will register correct values for these environment variables.",
+  "driver.error.outputEnvironmentVariableUndefined": "The output environment variable name(s) are not defined.",
   "driver.aadApp.description.create": "Create an Azure Active Directory app to authenticate users",
   "driver.aadApp.description.update": "Apply Azure Active Directory app manifest to an existing app",
   "driver.aadApp.error.invalidParameter": "Following parameter is missing or invalid for %s action: %s.",

--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -840,7 +840,7 @@
   "error.BadComponent": "Component '%s' lacks of property: %s.",
   "error.InvalidFeature": "This feature is not applicable for your project.",
   "error.UpdateAadManifest.MissingEnvHint": "If you are developing with a new project created with Teams Toolkit, running provision or debug will register correct values for these environment variables.",
-  "driver.error.outputEnvironmentVariableUndefined": "The output environment variable name(s) are not defined.",
+  "error.driver.outputEnvironmentVariableUndefined": "The output environment variable name(s) are not defined.",
   "driver.aadApp.description.create": "Create an Azure Active Directory app to authenticate users",
   "driver.aadApp.description.update": "Apply Azure Active Directory app manifest to an existing app",
   "driver.aadApp.error.invalidParameter": "Following parameter is missing or invalid for %s action: %s.",

--- a/packages/fx-core/src/component/driver/aad/create.ts
+++ b/packages/fx-core/src/component/driver/aad/create.ts
@@ -7,7 +7,6 @@ import { Service } from "typedi";
 import { CreateAadAppArgs } from "./interface/createAadAppArgs";
 import { AadAppClient } from "./utility/aadAppClient";
 import { CreateAadAppOutput, OutputKeys } from "./interface/createAadAppOutput";
-import { ProgressBarSetting } from "./interface/progressBarSetting";
 import {
   FxError,
   M365TokenProvider,
@@ -30,20 +29,12 @@ import { InvalidActionInputError } from "../../../error/common";
 import { loadStateFromEnv, mapStateToEnv } from "../util/utils";
 import { SignInAudience } from "./interface/signInAudience";
 import { updateProgress } from "../middleware/updateProgress";
+import { OutputEnvironmentVariableUndefinedError } from "../error/outputEnvironmentVariableUndefinedError";
 
 const actionName = "aadApp/create"; // DO NOT MODIFY the name
 const helpLink = "https://aka.ms/teamsfx-actions/aadapp-create";
 const driverConstants = {
   generateSecretErrorMessageKey: "driver.aadApp.error.generateSecretFailed",
-};
-
-const defaultOutputEnvVarNames = {
-  clientId: "AAD_APP_CLIENT_ID",
-  objectId: "AAD_APP_OBJECT_ID",
-  tenantId: "AAD_APP_TENANT_ID",
-  authorityHost: "AAD_APP_OAUTH_AUTHORITY_HOST",
-  authority: "AAD_APP_OAUTH_AUTHORITY",
-  clientSecret: "SECRET_AAD_APP_CLIENT_SECRET",
 };
 
 @Service(actionName) // DO NOT MODIFY the service name
@@ -73,10 +64,10 @@ export class CreateAadAppDriver implements StepDriver {
       context.logProvider?.info(getLocalizedString(logMessageKeys.startExecuteDriver, actionName));
 
       this.validateArgs(args);
-      // TODO: Remove this logic when config manager forces schema validation
       if (!outputEnvVarNames) {
-        outputEnvVarNames = new Map(Object.entries(defaultOutputEnvVarNames));
+        throw new OutputEnvironmentVariableUndefinedError(actionName);
       }
+
       const aadAppClient = new AadAppClient(context.m365TokenProvider);
       const aadAppState: CreateAadAppOutput = loadStateFromEnv(outputEnvVarNames);
       if (!aadAppState.clientId) {

--- a/packages/fx-core/src/component/driver/error/outputEnvironmentVariableUndefinedError.ts
+++ b/packages/fx-core/src/component/driver/error/outputEnvironmentVariableUndefinedError.ts
@@ -5,7 +5,7 @@ import { SystemError } from "@microsoft/teamsfx-api";
 import { getDefaultString, getLocalizedString } from "../../../common/localizeUtils";
 
 const errorCode = "OutputEnvironmentVariableUndefined";
-const messageKey = "driver.error.outputEnvironmentVariableUndefined"; // The output environment variable name(s) are not defined.
+const messageKey = "error.driver.outputEnvironmentVariableUndefined"; // The output environment variable name(s) are not defined.
 
 // This error should only be thrown when an internal logic calls the action directly. If users defines wrong output env vars in the yml file, the schema validation is expected to find the error and instruct users to fix them.
 export class OutputEnvironmentVariableUndefinedError extends SystemError {

--- a/packages/fx-core/src/component/driver/error/outputEnvironmentVariableUndefinedError.ts
+++ b/packages/fx-core/src/component/driver/error/outputEnvironmentVariableUndefinedError.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { SystemError } from "@microsoft/teamsfx-api";
+import { getDefaultString, getLocalizedString } from "../../../common/localizeUtils";
+
+const errorCode = "OutputEnvironmentVariableUndefined";
+const messageKey = "driver.error.outputEnvironmentVariableUndefined"; // The output environment variable name(s) are not defined.
+
+// This error should only be thrown when an internal logic calls the action directly. If users defines wrong output env vars in the yml file, the schema validation is expected to find the error and instruct users to fix them.
+export class OutputEnvironmentVariableUndefinedError extends SystemError {
+  constructor(actionName: string) {
+    super({
+      source: actionName,
+      name: errorCode,
+      message: getDefaultString(messageKey),
+      displayMessage: getLocalizedString(messageKey),
+    });
+  }
+}

--- a/packages/fx-core/tests/component/driver/aad/create.test.ts
+++ b/packages/fx-core/tests/component/driver/aad/create.test.ts
@@ -21,18 +21,21 @@ import {
 import { MissingEnvUserError } from "../../../../src/component/driver/aad/error/missingEnvError";
 import { InvalidActionInputError } from "../../../../src/error/common";
 import { UserError } from "@microsoft/teamsfx-api";
+import { OutputEnvironmentVariableUndefinedError } from "../../../../src/component/driver/error/outputEnvironmentVariableUndefinedError";
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;
 
 const outputKeys = {
-  AAD_APP_CLIENT_ID: "AAD_APP_CLIENT_ID",
-  AAD_APP_OBJECT_ID: "AAD_APP_OBJECT_ID",
-  AAD_APP_TENANT_ID: "AAD_APP_TENANT_ID",
-  AAD_APP_OAUTH_AUTHORITY_HOST: "AAD_APP_OAUTH_AUTHORITY_HOST",
-  AAD_APP_OAUTH_AUTHORITY: "AAD_APP_OAUTH_AUTHORITY",
-  SECRET_AAD_APP_CLIENT_SECRET: "SECRET_AAD_APP_CLIENT_SECRET",
+  clientId: "AAD_APP_CLIENT_ID",
+  objectId: "AAD_APP_OBJECT_ID",
+  tenantId: "AAD_APP_TENANT_ID",
+  authorityHost: "AAD_APP_OAUTH_AUTHORITY_HOST",
+  authority: "AAD_APP_OAUTH_AUTHORITY",
+  clientSecret: "SECRET_AAD_APP_CLIENT_SECRET",
 };
+
+const outputEnvVarNames = new Map<string, string>(Object.entries(outputKeys));
 
 describe("aadAppCreate", async () => {
   const expectedObjectId = "00000000-0000-0000-0000-000000000000";
@@ -59,19 +62,19 @@ describe("aadAppCreate", async () => {
     let args: any = {
       name: "test",
     };
-    let result = await createAadAppDriver.execute(args, mockedDriverContext);
+    let result = await createAadAppDriver.execute(args, mockedDriverContext, outputEnvVarNames);
     expect(result.result.isErr()).to.be.true;
     expect(result.result._unsafeUnwrapErr()).is.instanceOf(InvalidActionInputError);
 
     args = {
       generateClientSecret: true,
     };
-    result = await createAadAppDriver.execute(args, mockedDriverContext);
+    result = await createAadAppDriver.execute(args, mockedDriverContext, outputEnvVarNames);
     expect(result.result.isErr()).to.be.true;
     expect(result.result._unsafeUnwrapErr()).is.instanceOf(InvalidActionInputError);
 
     args = {};
-    result = await createAadAppDriver.execute(args, mockedDriverContext);
+    result = await createAadAppDriver.execute(args, mockedDriverContext, outputEnvVarNames);
     expect(result.result.isErr()).to.be.true;
     expect(result.result._unsafeUnwrapErr()).is.instanceOf(InvalidActionInputError);
   });
@@ -81,7 +84,7 @@ describe("aadAppCreate", async () => {
       name: "test",
       generateClientSecret: "no",
     };
-    let result = await createAadAppDriver.execute(args, mockedDriverContext);
+    let result = await createAadAppDriver.execute(args, mockedDriverContext, outputEnvVarNames);
     expect(result.result.isErr()).to.be.true;
     expect(result.result._unsafeUnwrapErr()).is.instanceOf(InvalidActionInputError);
 
@@ -89,7 +92,7 @@ describe("aadAppCreate", async () => {
       name: "",
       generateClientSecret: true,
     };
-    result = await createAadAppDriver.execute(args, mockedDriverContext);
+    result = await createAadAppDriver.execute(args, mockedDriverContext, outputEnvVarNames);
     expect(result.result.isErr()).to.be.true;
     expect(result.result._unsafeUnwrapErr()).is.instanceOf(InvalidActionInputError);
 
@@ -97,9 +100,20 @@ describe("aadAppCreate", async () => {
       name: "",
       generateClientSecret: "no",
     };
-    result = await createAadAppDriver.execute(args, mockedDriverContext);
+    result = await createAadAppDriver.execute(args, mockedDriverContext, outputEnvVarNames);
     expect(result.result.isErr()).to.be.true;
     expect(result.result._unsafeUnwrapErr()).is.instanceOf(InvalidActionInputError);
+  });
+
+  it("should throw error if outputEnvVarNames is undefined", async () => {
+    const args: any = {
+      name: "test",
+      generateClientSecret: true,
+    };
+
+    const result = await createAadAppDriver.execute(args, mockedDriverContext);
+    expect(result.result.isErr()).to.be.true;
+    expect(result.result._unsafeUnwrapErr()).is.instanceOf(OutputEnvironmentVariableUndefinedError);
   });
 
   it("should create new AAD app and client secret with empty .env", async () => {
@@ -116,25 +130,19 @@ describe("aadAppCreate", async () => {
       generateClientSecret: true,
     };
 
-    const result = await createAadAppDriver.execute(args, mockedDriverContext);
+    const result = await createAadAppDriver.execute(args, mockedDriverContext, outputEnvVarNames);
 
     expect(result.result.isOk()).to.be.true;
-    expect(result.result._unsafeUnwrap().get(outputKeys.AAD_APP_CLIENT_ID)).to.equal(
-      expectedClientId
-    );
-    expect(result.result._unsafeUnwrap().get(outputKeys.AAD_APP_OBJECT_ID)).to.equal(
-      expectedObjectId
-    );
-    expect(result.result._unsafeUnwrap().get(outputKeys.AAD_APP_TENANT_ID)).to.equal("tenantId");
-    expect(result.result._unsafeUnwrap().get(outputKeys.AAD_APP_OAUTH_AUTHORITY)).to.equal(
+    expect(result.result._unsafeUnwrap().get(outputKeys.clientId)).to.equal(expectedClientId);
+    expect(result.result._unsafeUnwrap().get(outputKeys.objectId)).to.equal(expectedObjectId);
+    expect(result.result._unsafeUnwrap().get(outputKeys.tenantId)).to.equal("tenantId");
+    expect(result.result._unsafeUnwrap().get(outputKeys.authority)).to.equal(
       "https://login.microsoftonline.com/tenantId"
     );
-    expect(result.result._unsafeUnwrap().get(outputKeys.AAD_APP_OAUTH_AUTHORITY_HOST)).to.equal(
+    expect(result.result._unsafeUnwrap().get(outputKeys.authorityHost)).to.equal(
       "https://login.microsoftonline.com"
     );
-    expect(result.result._unsafeUnwrap().get(outputKeys.SECRET_AAD_APP_CLIENT_SECRET)).to.equal(
-      expectedSecretText
-    );
+    expect(result.result._unsafeUnwrap().get(outputKeys.clientSecret)).to.equal(expectedSecretText);
     expect(result.result._unsafeUnwrap().size).to.equal(6);
     expect(result.summaries.length).to.equal(2);
     expect(result.summaries).includes(
@@ -197,8 +205,8 @@ describe("aadAppCreate", async () => {
     sinon.stub(AadAppClient.prototype, "generateClientSecret").resolves(expectedSecretText);
 
     envRestore = mockedEnv({
-      [outputKeys.AAD_APP_CLIENT_ID]: "existing value",
-      [outputKeys.AAD_APP_OBJECT_ID]: "existing value",
+      [outputKeys.clientId]: "existing value",
+      [outputKeys.objectId]: "existing value",
     });
 
     const args = {
@@ -206,11 +214,9 @@ describe("aadAppCreate", async () => {
       generateClientSecret: true,
     };
 
-    const result = await createAadAppDriver.execute(args, mockedDriverContext);
+    const result = await createAadAppDriver.execute(args, mockedDriverContext, outputEnvVarNames);
     expect(result.result.isOk()).to.be.true;
-    expect(result.result._unsafeUnwrap().get(outputKeys.SECRET_AAD_APP_CLIENT_SECRET)).to.equal(
-      expectedSecretText
-    );
+    expect(result.result._unsafeUnwrap().get(outputKeys.clientSecret)).to.equal(expectedSecretText);
     expect(result.result._unsafeUnwrap().size).to.equal(1); // 1 new env and 2 existing env
     expect(result.summaries.length).to.equal(1);
     expect(result.summaries).includes(
@@ -225,9 +231,9 @@ describe("aadAppCreate", async () => {
       .rejects("generateClientSecret should not be called");
 
     envRestore = mockedEnv({
-      [outputKeys.AAD_APP_CLIENT_ID]: "existing value",
-      [outputKeys.AAD_APP_OBJECT_ID]: "existing value",
-      [outputKeys.SECRET_AAD_APP_CLIENT_SECRET]: "existing value",
+      [outputKeys.clientId]: "existing value",
+      [outputKeys.objectId]: "existing value",
+      [outputKeys.clientSecret]: "existing value",
     });
 
     const args = {
@@ -235,7 +241,7 @@ describe("aadAppCreate", async () => {
       generateClientSecret: true,
     };
 
-    const result = await createAadAppDriver.execute(args, mockedDriverContext);
+    const result = await createAadAppDriver.execute(args, mockedDriverContext, outputEnvVarNames);
     expect(result.result.isOk()).to.be.true;
     expect(result.result._unsafeUnwrap().size).to.equal(0);
     expect(result.summaries.length).to.equal(0); // no summary when action does nothing
@@ -257,23 +263,18 @@ describe("aadAppCreate", async () => {
       generateClientSecret: false,
     };
 
-    const result = await createAadAppDriver.execute(args, mockedDriverContext);
+    const result = await createAadAppDriver.execute(args, mockedDriverContext, outputEnvVarNames);
     expect(result.result.isOk()).to.be.true;
-    expect(result.result._unsafeUnwrap().get(outputKeys.AAD_APP_CLIENT_ID)).to.equal(
-      expectedClientId
-    );
-    expect(result.result._unsafeUnwrap().get(outputKeys.AAD_APP_OBJECT_ID)).to.equal(
-      expectedObjectId
-    );
-    expect(result.result._unsafeUnwrap().get(outputKeys.AAD_APP_TENANT_ID)).to.equal("tenantId");
-    expect(result.result._unsafeUnwrap().get(outputKeys.AAD_APP_OAUTH_AUTHORITY)).to.equal(
+    expect(result.result._unsafeUnwrap().get(outputKeys.clientId)).to.equal(expectedClientId);
+    expect(result.result._unsafeUnwrap().get(outputKeys.objectId)).to.equal(expectedObjectId);
+    expect(result.result._unsafeUnwrap().get(outputKeys.tenantId)).to.equal("tenantId");
+    expect(result.result._unsafeUnwrap().get(outputKeys.authority)).to.equal(
       "https://login.microsoftonline.com/tenantId"
     );
-    expect(result.result._unsafeUnwrap().get(outputKeys.AAD_APP_OAUTH_AUTHORITY_HOST)).to.equal(
+    expect(result.result._unsafeUnwrap().get(outputKeys.authorityHost)).to.equal(
       "https://login.microsoftonline.com"
     );
-    expect(result.result._unsafeUnwrap().get(outputKeys.SECRET_AAD_APP_CLIENT_SECRET)).to.be
-      .undefined;
+    expect(result.result._unsafeUnwrap().get(outputKeys.clientSecret)).to.be.undefined;
     expect(result.result._unsafeUnwrap().size).to.equal(5);
     expect(result.summaries.length).to.equal(1);
     expect(result.summaries).includes(
@@ -283,7 +284,7 @@ describe("aadAppCreate", async () => {
 
   it("should throw error when generate client secret if AAD_APP_OBJECT_ID is missing", async () => {
     envRestore = mockedEnv({
-      [outputKeys.AAD_APP_CLIENT_ID]: "existing value",
+      [outputKeys.clientId]: "existing value",
     });
 
     const args: any = {
@@ -291,7 +292,7 @@ describe("aadAppCreate", async () => {
       generateClientSecret: true,
     };
 
-    const result = await createAadAppDriver.execute(args, mockedDriverContext);
+    const result = await createAadAppDriver.execute(args, mockedDriverContext, outputEnvVarNames);
     expect(result.result.isErr()).to.be.true;
     expect(result.result._unsafeUnwrapErr())
       .is.instanceOf(MissingEnvUserError)
@@ -321,7 +322,7 @@ describe("aadAppCreate", async () => {
       generateClientSecret: false,
     };
 
-    const result = await createAadAppDriver.execute(args, mockedDriverContext);
+    const result = await createAadAppDriver.execute(args, mockedDriverContext, outputEnvVarNames);
     expect(result.result.isErr()).to.be.true;
     expect(result.result._unsafeUnwrapErr())
       .is.instanceOf(UnhandledUserError)
@@ -348,7 +349,7 @@ describe("aadAppCreate", async () => {
       generateClientSecret: false,
     };
 
-    const result = await createAadAppDriver.execute(args, mockedDriverContext);
+    const result = await createAadAppDriver.execute(args, mockedDriverContext, outputEnvVarNames);
     expect(result.result.isErr()).to.be.true;
     expect(result.result._unsafeUnwrapErr())
       .is.instanceOf(UnhandledSystemError)
@@ -396,7 +397,7 @@ describe("aadAppCreate", async () => {
       telemetryReporter: mockedTelemetryReporter,
     };
 
-    const result = await createAadAppDriver.execute(args, driverContext);
+    const result = await createAadAppDriver.execute(args, driverContext, outputEnvVarNames);
 
     expect(result.result.isOk()).to.be.true;
     expect(startTelemetry.eventName).to.equal("aadApp/create-start");
@@ -455,7 +456,7 @@ describe("aadAppCreate", async () => {
       telemetryReporter: mockedTelemetryReporter,
     };
 
-    const result = await createAadAppDriver.execute(args, driverContext);
+    const result = await createAadAppDriver.execute(args, driverContext, outputEnvVarNames);
 
     expect(result.result.isOk()).to.be.false;
     expect(startTelemetry.eventName).to.equal("aadApp/create-start");
@@ -490,25 +491,19 @@ describe("aadAppCreate", async () => {
       signInAudience: "AzureADMultipleOrgs",
     };
 
-    const result = await createAadAppDriver.execute(args, mockedDriverContext);
+    const result = await createAadAppDriver.execute(args, mockedDriverContext, outputEnvVarNames);
 
     expect(result.result.isOk()).to.be.true;
-    expect(result.result._unsafeUnwrap().get(outputKeys.AAD_APP_CLIENT_ID)).to.equal(
-      expectedClientId
-    );
-    expect(result.result._unsafeUnwrap().get(outputKeys.AAD_APP_OBJECT_ID)).to.equal(
-      expectedObjectId
-    );
-    expect(result.result._unsafeUnwrap().get(outputKeys.AAD_APP_TENANT_ID)).to.equal("tenantId");
-    expect(result.result._unsafeUnwrap().get(outputKeys.AAD_APP_OAUTH_AUTHORITY)).to.equal(
+    expect(result.result._unsafeUnwrap().get(outputKeys.clientId)).to.equal(expectedClientId);
+    expect(result.result._unsafeUnwrap().get(outputKeys.objectId)).to.equal(expectedObjectId);
+    expect(result.result._unsafeUnwrap().get(outputKeys.tenantId)).to.equal("tenantId");
+    expect(result.result._unsafeUnwrap().get(outputKeys.authority)).to.equal(
       "https://login.microsoftonline.com/tenantId"
     );
-    expect(result.result._unsafeUnwrap().get(outputKeys.AAD_APP_OAUTH_AUTHORITY_HOST)).to.equal(
+    expect(result.result._unsafeUnwrap().get(outputKeys.authorityHost)).to.equal(
       "https://login.microsoftonline.com"
     );
-    expect(result.result._unsafeUnwrap().get(outputKeys.SECRET_AAD_APP_CLIENT_SECRET)).to.equal(
-      expectedSecretText
-    );
+    expect(result.result._unsafeUnwrap().get(outputKeys.clientSecret)).to.equal(expectedSecretText);
     expect(result.result._unsafeUnwrap().size).to.equal(6);
     expect(result.summaries.length).to.equal(2);
     expect(result.summaries).includes(
@@ -526,7 +521,7 @@ describe("aadAppCreate", async () => {
       signInAudience: "WrongAudience",
     };
 
-    const result = await createAadAppDriver.execute(args, mockedDriverContext);
+    const result = await createAadAppDriver.execute(args, mockedDriverContext, outputEnvVarNames);
 
     expect(result.result.isErr()).to.be.true;
     expect(result.result._unsafeUnwrapErr())


### PR DESCRIPTION
Previously we kept the default output logic to avoid breaking existing templates immediately. Now all the templates/samples should have `writeToEnvironmentFile` and the schema validation is also enabled to ensure `writeToEnvironmentFile` is provided. So removing the backward compatibility logic.

E2E TEST: N/A. Covered by UT.