### PR TITLE
fix: component property is redacted in action telemetry

### DIFF
--- a/packages/fx-core/src/component/driver/middleware/addStartAndEndTelemetry.ts
+++ b/packages/fx-core/src/component/driver/middleware/addStartAndEndTelemetry.ts
@@ -8,13 +8,15 @@ import { WrapDriverContext } from "../util/wrapUtil";
 import { ExecutionResult } from "../interface/stepDriver";
 
 // Based on fx-core's design that a component should always return FxError instead of throw exception, no error handling is added
+// Will remove `/` in the componentName to avoid the value being redacted.
 export function addStartAndEndTelemetry(eventName: string, componentName: string): Middleware {
   return async (ctx: HookContext, next: NextFunction) => {
     const driverContext = ctx.arguments[1] as WrapDriverContext;
     let telemetryReporter: TeamsFxTelemetryReporter | undefined = undefined;
     if (driverContext.telemetryReporter) {
+      const normalizedComponentName = componentName.replace(/\//g, ""); // Remove `/` in the componentName to avoid the value being redacted.
       telemetryReporter = new TeamsFxTelemetryReporter(driverContext.telemetryReporter, {
-        componentName,
+        componentName: normalizedComponentName,
       });
     }
     telemetryReporter?.sendStartEvent({ eventName });

--- a/packages/fx-core/tests/component/driver/aad/create.test.ts
+++ b/packages/fx-core/tests/component/driver/aad/create.test.ts
@@ -400,9 +400,9 @@ describe("aadAppCreate", async () => {
 
     expect(result.result.isOk()).to.be.true;
     expect(startTelemetry.eventName).to.equal("aadApp/create-start");
-    expect(startTelemetry.properties.component).to.equal("aadApp/create");
+    expect(startTelemetry.properties.component).to.equal("aadAppcreate");
     expect(endTelemetry.eventName).to.equal("aadApp/create");
-    expect(endTelemetry.properties.component).to.equal("aadApp/create");
+    expect(endTelemetry.properties.component).to.equal("aadAppcreate");
     expect(endTelemetry.properties.success).to.equal("yes");
   });
 
@@ -459,9 +459,9 @@ describe("aadAppCreate", async () => {
 
     expect(result.result.isOk()).to.be.false;
     expect(startTelemetry.eventName).to.equal("aadApp/create-start");
-    expect(startTelemetry.properties.component).to.equal("aadApp/create");
+    expect(startTelemetry.properties.component).to.equal("aadAppcreate");
     expect(endTelemetry.eventName).to.equal("aadApp/create");
-    expect(endTelemetry.properties.component).to.equal("aadApp/create");
+    expect(endTelemetry.properties.component).to.equal("aadAppcreate");
     expect(endTelemetry.properties.success).to.equal("no");
     expect(endTelemetry.properties["error-code"]).to.equal("aadApp/create.UnhandledError");
     expect(endTelemetry.properties["error-type"]).to.equal("user");


### PR DESCRIPTION
The string with `/` character will be treated as path and redacted by VSCode telemetry reporter. Remove the `/` character in component name to avoid the value being redacted.

E2E TEST: N/A. Covered by UT.