### PR TITLE
chore: remove conventional-commit for cd

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -96,17 +96,17 @@ jobs:
       - name: version rc npm packages to npmjs.org
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.preid == 'rc' && github.ref == 'refs/heads/main' && github.event.inputs.skip-version-rc == 'no'}}
         run: |
-          npx lerna version --conventional-commits --conventional-prerelease --preid=rc --no-changelog --yes
+          npx lerna version prerelease --conventional-prerelease --preid=rc --no-changelog --yes
 
       - name: version rc npm packages to npmjs.org on hotfix
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.preid == 'rc' && startsWith(github.ref, 'refs/heads/hotfix/') && github.event.inputs.skip-version-rc == 'no'}}
         run: |
-          npx lerna version --conventional-commits --conventional-prerelease --preid=rc-hotfix --no-changelog --allow-branch ${GITHUB_REF#refs/*/} --yes
+          npx lerna version prerelease --conventional-prerelease --preid=rc-hotfix --no-changelog --allow-branch ${GITHUB_REF#refs/*/} --yes
 
       - name: version stable npm packages to npmjs.org
         if: ${{ github.event_name == 'workflow_dispatch' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/hotfix/')) && github.event.inputs.preid == 'stable' }}
         run: |
-          npx lerna version --conventional-commits --conventional-graduate --no-changelog --allow-branch ${GITHUB_REF#refs/*/} --yes
+          npx lerna version --conventional-graduate --no-changelog --allow-branch ${GITHUB_REF#refs/*/} --yes
 
       - name: version change
         id: version-change


### PR DESCRIPTION
Currently the conventional-commits not suit for the repo.
because the VS release need hold the branches for hotfix, and later the vsc ttk will release the v5.0.0, later 5.even.* is stable and 5.odd.* is prerelease.
After change, the version going to bump up is patch by default, but developers can also custom the version by modify the verison in package.json such as 5.0.0-rc