### PR TITLE
fix(vsc): support activation from F5

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -52,6 +52,7 @@
     "onCommand:fx-extension.signinM365",
     "onCommand:fx-extension.validate-getStarted-prerequisites",
     "onCommand:workbench.action.tasks.runTask",
+    "onCommand:workbench.action.debug.start",
     "workspaceContains:**/.fx/*",
     "workspaceContains:teamsapp.yml",
     "onView:teamsfx-empty-project"


### PR DESCRIPTION
Related bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/17759185

E2E TEST: N/A