### PR TITLE
chore(vsc): align the preview command UX with local debug

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -386,10 +386,6 @@
           "when": "false"
         },
         {
-          "command": "fx-extension.debug",
-          "when": "false"
-        },
-        {
           "command": "fx-extension.updateAadAppManifestFromCtxMenu",
           "when": "false"
         },
@@ -593,12 +589,6 @@
         "enablement": "fx-extension.initialized"
       },
       {
-        "command": "fx-extension.debug",
-        "title": "%teamstoolkit.commands.debug.title%",
-        "enablement": "!fx-extension.commandLocked",
-        "category": "Teams"
-      },
-      {
         "command": "fx-extension.deploy",
         "title": "%teamstoolkit.commands.deploy.title%",
         "enablement": "fx-extension.isTeamsFx && isWorkspaceTrusted && !fx-extension.commandLocked",
@@ -707,7 +697,9 @@
       },
       {
         "command": "fx-extension.localdebug",
-        "title": "%teamstoolkit.commands.localDebug.title%"
+        "title": "%teamstoolkit.commands.localDebug.title%",
+        "enablement": "!fx-extension.commandLocked",
+        "category": "Teams"
       },
       {
         "command": "fx-extension.localdebugWithIcon",

--- a/packages/vscode-extension/src/commandController.ts
+++ b/packages/vscode-extension/src/commandController.ts
@@ -40,7 +40,6 @@ class CommandController {
       "fx-extension.addFeature",
       "fx-extension.build",
       "fx-extension.create",
-      "fx-extension.debug",
       "fx-extension.deploy",
       "fx-extension.manageCollaborator",
       "fx-extension.openFromTdp",

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -353,9 +353,6 @@ function registerTreeViewCommandsInDevelopment(context: vscode.ExtensionContext)
     "initProject"
   );
 
-  // User can click to debug directly, same as pressing "F5".
-  registerInCommandController(context, "fx-extension.debug", handlers.debugHandler);
-
   if (!isV3Enabled()) {
     // Add features
     registerInCommandController(

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -589,13 +589,6 @@ export async function createProjectFromWalkthroughHandler(
   return result;
 }
 
-export async function debugHandler(args?: any[]): Promise<Result<null, FxError>> {
-  ExtTelemetry.sendTelemetryEvent(TelemetryEvent.TreeViewLocalDebug, getTriggerFromProperty(args));
-  await vscode.commands.executeCommand("workbench.action.debug.start");
-
-  return ok(null);
-}
-
 export async function selectAndDebugHandler(args?: any[]): Promise<Result<null, FxError>> {
   ExtTelemetry.sendTelemetryEvent(TelemetryEvent.RunIconDebugStart, getTriggerFromProperty(args));
   const result = await selectAndDebug();

--- a/packages/vscode-extension/src/treeview/treeViewManager.ts
+++ b/packages/vscode-extension/src/treeview/treeViewManager.ts
@@ -200,7 +200,7 @@ class TreeViewManager {
       new TreeViewCommand(
         localize("teamstoolkit.commandsTreeViewProvider.previewTitle"),
         localize("teamstoolkit.commandsTreeViewProvider.previewDescription"),
-        "fx-extension.debug",
+        "fx-extension.localdebug",
         undefined,
         { name: "debug-alt", custom: false }
       ),

--- a/packages/vscode-extension/test/extension/handlers.test.ts
+++ b/packages/vscode-extension/test/extension/handlers.test.ts
@@ -381,17 +381,6 @@ describe("handlers", () => {
       sinon.restore();
     });
 
-    it("debugHandler()", async () => {
-      const sendTelemetryEventStub = sinon.stub(ExtTelemetry, "sendTelemetryEvent");
-      const executeCommandStub = sinon.stub(vscode.commands, "executeCommand");
-
-      await handlers.debugHandler();
-
-      sinon.assert.calledOnceWithExactly(executeCommandStub, "workbench.action.debug.start");
-      sinon.assert.calledOnce(sendTelemetryEventStub);
-      sinon.restore();
-    });
-
     it("treeViewPreviewHandler() - previewWithManifest error", async () => {
       sinon.stub(localizeUtils, "localize").returns("");
       sinon.stub(ExtTelemetry, "sendTelemetryEvent");


### PR DESCRIPTION
Reuse same local debug command.

Related bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/17885287