### PR TITLE
chore(vsc): support custom Teams app id key

### DIFF
--- a/packages/vscode-extension/src/debug/commonUtils.ts
+++ b/packages/vscode-extension/src/debug/commonUtils.ts
@@ -19,6 +19,8 @@ import { environmentManager } from "@microsoft/teamsfx-core/build/core/environme
 import { getResourceGroupInPortal } from "@microsoft/teamsfx-core/build/common/tools";
 import { PluginNames, GLOBAL_CONFIG } from "@microsoft/teamsfx-core/build/component/constants";
 import { envUtil } from "@microsoft/teamsfx-core/build/component/utils/envUtil";
+import { metadataUtil } from "@microsoft/teamsfx-core/build/component/utils/metadataUtil";
+import { pathUtils } from "@microsoft/teamsfx-core/build/component/utils/pathUtils";
 import { allRunningDebugSessions } from "./teamsfxTaskHandler";
 import { ExtensionErrors, ExtensionSource } from "../error";
 import { localize } from "../utils/localizeUtils";
@@ -400,7 +402,8 @@ export async function getV3TeamsAppId(projectPath: string, env: string): Promise
     throw result.error;
   }
 
-  const teamsAppId = result.value.TEAMS_APP_ID;
+  const teamsAppIdKey = (await getTeamsAppKeyName(env)) || "TEAMS_APP_ID";
+  const teamsAppId = result.value[teamsAppIdKey];
   if (teamsAppId === undefined) {
     throw new UserError(
       ExtensionSource,
@@ -410,6 +413,23 @@ export async function getV3TeamsAppId(projectPath: string, env: string): Promise
   }
 
   return teamsAppId;
+}
+
+export async function getTeamsAppKeyName(env?: string): Promise<string | undefined> {
+  const templatePath = pathUtils.getYmlFilePath(globalVariables.workspaceUri!.fsPath, env);
+  const maybeProjectModel = await metadataUtil.parse(templatePath, env);
+  if (maybeProjectModel.isErr()) {
+    return undefined;
+  }
+  const projectModel = maybeProjectModel.value;
+  if (projectModel.provision?.driverDefs && projectModel.provision.driverDefs.length > 0) {
+    for (const driver of projectModel.provision.driverDefs) {
+      if (driver.uses === "teamsApp/create") {
+        return driver.writeToEnvironmentFile?.teamsAppId;
+      }
+    }
+  }
+  return undefined;
 }
 
 export async function getV3M365TitleId(

--- a/packages/vscode-extension/test/extension/commonUtils.test.ts
+++ b/packages/vscode-extension/test/extension/commonUtils.test.ts
@@ -23,6 +23,8 @@ import { TelemetryProperty, TelemetryTriggerFrom } from "../../src/telemetry/ext
 import { expect } from "chai";
 import * as commonTools from "@microsoft/teamsfx-core/build/common/tools";
 import { envUtil } from "@microsoft/teamsfx-core/build/component/utils/envUtil";
+import { metadataUtil } from "@microsoft/teamsfx-core/build/component/utils/metadataUtil";
+import { pathUtils } from "@microsoft/teamsfx-core/build/component/utils/pathUtils";
 
 describe("CommonUtils", () => {
   describe("getPackageVersion", () => {
@@ -362,6 +364,9 @@ describe("CommonUtils", () => {
           TEAMS_APP_ID: "xxx",
         })
       );
+      sandbox.stub(globalVariables, "workspaceUri").value(Uri.file("test"));
+      sandbox.stub(pathUtils, "getYmlFilePath");
+      sandbox.stub(metadataUtil, "parse").resolves(ok({} as any));
 
       const result = await commonUtils.getProvisionSucceedFromEnv("test");
 

--- a/packages/vscode-extension/test/localdebug/commonUtils.test.ts
+++ b/packages/vscode-extension/test/localdebug/commonUtils.test.ts
@@ -4,8 +4,13 @@
 import * as chai from "chai";
 import * as fs from "fs-extra";
 import * as path from "path";
+import * as sinon from "sinon";
+import { ok } from "@microsoft/teamsfx-api";
 
 import * as commonUtils from "../../src/debug/commonUtils";
+import { metadataUtil } from "@microsoft/teamsfx-core/build/component/utils/metadataUtil";
+import { pathUtils } from "@microsoft/teamsfx-core/build/component/utils/pathUtils";
+import { envUtil } from "@microsoft/teamsfx-core/build/component/utils/envUtil";
 
 const testDataFolder = path.resolve(__dirname, "test-data");
 
@@ -53,6 +58,41 @@ describe("[debug > commonUtils]", () => {
 
       const packageJson = await commonUtils.loadPackageJson(packageJsonPath);
       chai.expect(packageJson).to.be.undefined;
+    });
+  });
+
+  describe("getV3TeamsAppId", () => {
+    const sandbox = sinon.createSandbox();
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it("returns teamsAppId successfully", async () => {
+      sandbox.stub(pathUtils, "getYmlFilePath");
+      sandbox.stub(metadataUtil, "parse").resolves(
+        ok({
+          provision: {
+            driverDefs: [
+              {
+                uses: "teamsApp/create",
+                writeToEnvironmentFile: {
+                  teamsAppId: "TeamsAppId",
+                },
+              },
+            ],
+          },
+        } as any)
+      );
+      sandbox.stub(envUtil, "readEnv").resolves(
+        ok({
+          TeamsAppId: "testId",
+        } as any)
+      );
+
+      const result = await commonUtils.getV3TeamsAppId("testProjectPath", "test");
+
+      chai.expect(result).equals("testId");
     });
   });
 });

--- a/packages/vscode-extension/test/localdebug/commonUtils.test.ts
+++ b/packages/vscode-extension/test/localdebug/commonUtils.test.ts
@@ -8,9 +8,11 @@ import * as sinon from "sinon";
 import { ok } from "@microsoft/teamsfx-api";
 
 import * as commonUtils from "../../src/debug/commonUtils";
+import * as globalVariables from "../../src/globalVariables";
 import { metadataUtil } from "@microsoft/teamsfx-core/build/component/utils/metadataUtil";
 import { pathUtils } from "@microsoft/teamsfx-core/build/component/utils/pathUtils";
 import { envUtil } from "@microsoft/teamsfx-core/build/component/utils/envUtil";
+import { Uri } from "vscode";
 
 const testDataFolder = path.resolve(__dirname, "test-data");
 
@@ -69,6 +71,7 @@ describe("[debug > commonUtils]", () => {
     });
 
     it("returns teamsAppId successfully", async () => {
+      sandbox.stub(globalVariables, "workspaceUri").value(Uri.file("test"));
       sandbox.stub(pathUtils, "getYmlFilePath");
       sandbox.stub(metadataUtil, "parse").resolves(
         ok({


### PR DESCRIPTION
Related bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/17902656