### PR TITLE
fix: manifest related commands behaves wrongly in cli

### DIFF
--- a/packages/cli/src/cmds/package.ts
+++ b/packages/cli/src/cmds/package.ts
@@ -56,14 +56,6 @@ export default class Package extends YargsCommand {
     {
       let result;
       if (isV3Enabled()) {
-        inputs[CoreQuestionNames.TeamsAppManifestFilePath] =
-          args[ManifestFilePathParamName] ?? `${rootFolder}/${AppPackageFolderName}/manifest.json`;
-        inputs[CoreQuestionNames.OutputZipPathParamName] =
-          args[CoreQuestionNames.OutputZipPathParamName] ??
-          `${rootFolder}/${AppPackageFolderName}/${BuildFolderName}/appPackage.${inputs.env}.zip`;
-        inputs[CoreQuestionNames.OutputManifestParamName] =
-          args[CoreQuestionNames.OutputManifestParamName] ??
-          `${rootFolder}/${AppPackageFolderName}/${BuildFolderName}/manifest.${inputs.env}.json`;
         result = await core.createAppPackage(inputs);
       } else {
         const func: Func = {

--- a/packages/cli/src/cmds/validate.ts
+++ b/packages/cli/src/cmds/validate.ts
@@ -54,12 +54,8 @@ export class ManifestValidate extends YargsCommand {
       if (isV3Enabled()) {
         if (args[AppPackageFilePathParamName]) {
           inputs.validateMethod = "validateAgainstAppPackage";
-          inputs[CoreQuestionNames.TeamsAppPackageFilePath] = args[AppPackageFilePathParamName];
         } else {
           inputs.validateMethod = "validateAgainstSchema";
-          inputs[CoreQuestionNames.TeamsAppManifestFilePath] =
-            args[ManifestFilePathParamName] ??
-            `${rootFolder}/${AppPackageFolderName}/manifest.json`;
         }
         result = await core.validateApplication(inputs);
       } else {

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -56,7 +56,7 @@ export const CollaboratorEmailNode = new QTreeNode({
   title: "Input email address of collaborator",
 });
 
-export const ManifestFilePathParamName = "manifest-file-path";
+export const ManifestFilePathParamName = "manifest-path";
 export const AppPackageFilePathParamName = "app-package-file-path";
 export const BuildPackageOptions: OptionsMap = {
   [ManifestFilePathParamName]: {

--- a/packages/fx-core/src/core/question.ts
+++ b/packages/fx-core/src/core/question.ts
@@ -95,7 +95,7 @@ export enum CoreQuestionNames {
   TeamsAppManifestFilePath = "manifest-path",
   LocalTeamsAppManifestFilePath = "local-manifest-path",
   AadAppManifestFilePath = "aadAppManifestFilePath",
-  TeamsAppPackageFilePath = "teamsAppPackageFilePath",
+  TeamsAppPackageFilePath = "app-package-file-path",
   ConfirmManifest = "confirmManifest",
   ConfirmLocalManifest = "confirmLocalManifest",
   OutputZipPathParamName = "output-zip-path",
@@ -924,7 +924,7 @@ export function selectTeamsAppManifestQuestion(inputs: Inputs, isLocal = false):
   };
 
   const res = new QTreeNode(teamsAppManifestNode);
-  if (inputs.platform !== Platform.CLI_HELP) {
+  if (inputs.platform !== Platform.CLI_HELP && inputs.platform !== Platform.CLI) {
     const manifestPath = path.join(
       inputs.projectPath!,
       AppPackageFolderName,

--- a/packages/fx-core/tests/core/collaborator.test.ts
+++ b/packages/fx-core/tests/core/collaborator.test.ts
@@ -1861,7 +1861,7 @@ describe("Collaborator APIs for V3", () => {
         const teamsAppManifestQuestion = node?.children?.[0];
         const aadAppManifestQuestion = node?.children?.[1];
 
-        assert.equal(teamsAppManifestQuestion?.children?.length, 2);
+        assert.equal(teamsAppManifestQuestion?.children?.length, 1);
         assert.isTrue(aadAppManifestQuestion?.children?.length == 2);
 
         const teamsAppConfirmNode = teamsAppManifestQuestion?.children?.[0];

--- a/packages/fx-core/tests/core/collaborator.test.ts
+++ b/packages/fx-core/tests/core/collaborator.test.ts
@@ -1861,7 +1861,7 @@ describe("Collaborator APIs for V3", () => {
         const teamsAppManifestQuestion = node?.children?.[0];
         const aadAppManifestQuestion = node?.children?.[1];
 
-        assert.isTrue(teamsAppManifestQuestion?.children?.length == 2);
+        assert.equal(teamsAppManifestQuestion?.children?.length, 2);
         assert.isTrue(aadAppManifestQuestion?.children?.length == 2);
 
         const teamsAppConfirmNode = teamsAppManifestQuestion?.children?.[0];

--- a/packages/fx-core/tests/core/collaborator.test.ts
+++ b/packages/fx-core/tests/core/collaborator.test.ts
@@ -1861,8 +1861,10 @@ describe("Collaborator APIs for V3", () => {
         const teamsAppManifestQuestion = node?.children?.[0];
         const aadAppManifestQuestion = node?.children?.[1];
 
-        assert.exists((teamsAppManifestQuestion?.children as any)[0].data?.name);
-        assert.exists((teamsAppManifestQuestion?.children as any)[1].data?.name);
+        console.log((teamsAppManifestQuestion?.children as any)[0].data?.name);
+        assert.equal((teamsAppManifestQuestion?.children as any)[0].data?.name, "test");
+        console.log((teamsAppManifestQuestion?.children as any)[1].data?.name);
+        assert.equal((teamsAppManifestQuestion?.children as any)[1].data?.name, "test");
         assert.isTrue(teamsAppManifestQuestion?.children?.length == 2);
         assert.isTrue(aadAppManifestQuestion?.children?.length == 2);
 

--- a/packages/fx-core/tests/core/collaborator.test.ts
+++ b/packages/fx-core/tests/core/collaborator.test.ts
@@ -1861,7 +1861,9 @@ describe("Collaborator APIs for V3", () => {
         const teamsAppManifestQuestion = node?.children?.[0];
         const aadAppManifestQuestion = node?.children?.[1];
 
-        assert.equal(teamsAppManifestQuestion?.children?.length, 1);
+        assert.exists((teamsAppManifestQuestion?.children as any)[0].data?.name);
+        assert.exists((teamsAppManifestQuestion?.children as any)[1].data?.name);
+        assert.isTrue(teamsAppManifestQuestion?.children?.length == 2);
         assert.isTrue(aadAppManifestQuestion?.children?.length == 2);
 
         const teamsAppConfirmNode = teamsAppManifestQuestion?.children?.[0];

--- a/packages/fx-core/tests/core/collaborator.test.ts
+++ b/packages/fx-core/tests/core/collaborator.test.ts
@@ -1830,6 +1830,7 @@ describe("Collaborator APIs for V3", () => {
     });
 
     it("happy path: getQuestionsForGrantPermission", async () => {
+      inputs.platform = Platform.VSCode;
       inputs[CoreQuestionNames.TeamsAppManifestFilePath] = "teamsAppManifest";
       inputs[CoreQuestionNames.AadAppManifestFilePath] = "aadAppManifest";
 
@@ -1861,10 +1862,6 @@ describe("Collaborator APIs for V3", () => {
         const teamsAppManifestQuestion = node?.children?.[0];
         const aadAppManifestQuestion = node?.children?.[1];
 
-        console.log((teamsAppManifestQuestion?.children as any)[0].data?.name);
-        assert.equal((teamsAppManifestQuestion?.children as any)[0].data?.name, "test");
-        console.log((teamsAppManifestQuestion?.children as any)[1].data?.name);
-        assert.equal((teamsAppManifestQuestion?.children as any)[1].data?.name, "test");
         assert.isTrue(teamsAppManifestQuestion?.children?.length == 2);
         assert.isTrue(aadAppManifestQuestion?.children?.length == 2);
 


### PR DESCRIPTION
ADO: https://dev.azure.com/msazure/Microsoft%20Teams%20Extensibility/_workitems/edit/17957099
Trigger validate and select default manifest.json(interactive mode):
![image](https://user-images.githubusercontent.com/73154171/231749338-e6c55914-e4f9-499d-9e6e-3d4bf09db8a4.png)
![image](https://user-images.githubusercontent.com/73154171/231749389-1e91bce8-24ab-4dfc-8807-50976713a966.png)

Trigger validate(non-interactive mode):
![image](https://user-images.githubusercontent.com/73154171/231750935-7cbf0df2-3e63-4b64-a839-975f6708f375.png)

Trigger validate and select customized manifest.json:
![image](https://user-images.githubusercontent.com/73154171/231749509-cba26351-e59f-45b2-87de-842b2a15f9e8.png)

Trigger package:
![image](https://user-images.githubusercontent.com/73154171/231749724-d612eae5-7873-4f16-9973-2f3aa56b0340.png)
![image](https://user-images.githubusercontent.com/73154171/231749617-85108467-217c-4d6d-9e8c-43f0af92df09.png)
