### PR TITLE
ci: Update .prettierrc.js

### DIFF
--- a/templates/.prettierrc.js
+++ b/templates/.prettierrc.js
@@ -1,3 +1,7 @@
+// Imports the default export from the "../packages/prettier-config" module
+const prettierConfig = require("../packages/prettier-config").default;
+
+// Exports an object that includes the imported prettierConfig as a property
 module.exports = {
-  ...require("../packages/prettier-config"),
+  ...prettierConfig,
 };


### PR DESCRIPTION
In the original code, the line ...require("../packages/prettier-config") uses the spread syntax to include all of the exported properties from the prettier-config module in the exported object. However, it's not clear from this line what the default export of the prettier-config module is or what its properties are.

To make the code more clear and explicit, I replaced that line with two lines of code:

The first line imports the default export from the ../packages/prettier-config module and assigns it to the variable prettierConfig. The second line exports an object that includes all of the properties from the prettierConfig object using the spread syntax. By doing this, it's clear that the exported object is simply a copy of the prettierConfig object, and it's easy to see what properties are included in that object.