### PR TITLE
fix: add update aadApp success hint for cli

### DIFF
--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -23,6 +23,7 @@
   "core.deploy.noCapabilityFound": "No capability found to %s. Click Get Help to learn more about how to add capabilities.",
   "core.deploy.successNotice": "'%s' successfully deployed.",
   "core.deploy.aadManifestSuccessNotice": "Your Azure Active Directory application has been successfully deployed. Click \"Learn more\" to check how to view your Azure Active Directory application.",
+  "core.deploy.aadManifestOnCLISuccessNotice": "Your Azure Active Directory application has been successfully deployed.",
   "core.deploy.aadManifestLearnMore": "Learn more",
   "core.deploy.failNotice": "Unable to deploy '%s'!",
   "core.deploy.botTroubleShoot": "To troubleshoot bot application in azure, please click learn more for documentation.",

--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -23,7 +23,7 @@
   "core.deploy.noCapabilityFound": "No capability found to %s. Click Get Help to learn more about how to add capabilities.",
   "core.deploy.successNotice": "'%s' successfully deployed.",
   "core.deploy.aadManifestSuccessNotice": "Your Azure Active Directory application has been successfully deployed. Click \"Learn more\" to check how to view your Azure Active Directory application.",
-  "core.deploy.aadManifestOnCLISuccessNotice": "Your Azure Active Directory application has been successfully deployed.",
+  "core.deploy.aadManifestOnCLISuccessNotice": "Your Azure Active Directory application has been successfully updated.",
   "core.deploy.aadManifestLearnMore": "Learn more",
   "core.deploy.failNotice": "Unable to deploy '%s'!",
   "core.deploy.botTroubleShoot": "To troubleshoot bot application in azure, please click learn more for documentation.",

--- a/packages/fx-core/src/component/driver/aad/update.ts
+++ b/packages/fx-core/src/component/driver/aad/update.ts
@@ -78,7 +78,7 @@ export class UpdateAadAppDriver implements StepDriver {
       );
 
       if (context.platform === Platform.CLI) {
-        const msg = getLocalizedString("core.deploy.aadManifestSuccessNotice");
+        const msg = getLocalizedString("core.deploy.aadManifestOnCLISuccessNotice");
         context.ui?.showMessage("info", msg, false);
       }
 

--- a/packages/fx-core/src/component/driver/aad/update.ts
+++ b/packages/fx-core/src/component/driver/aad/update.ts
@@ -4,10 +4,9 @@ import { ExecutionResult, StepDriver } from "../interface/stepDriver";
 import { DriverContext } from "../interface/commonArgs";
 import { UpdateAadAppArgs } from "./interface/updateAadAppArgs";
 import { Service } from "typedi";
-import { ProgressBarSetting } from "./interface/progressBarSetting";
 import { AadAppClient } from "./utility/aadAppClient";
 import axios from "axios";
-import { SystemError, UserError, ok, err, FxError, Result } from "@microsoft/teamsfx-api";
+import { SystemError, UserError, ok, err, FxError, Result, Platform } from "@microsoft/teamsfx-api";
 import { UnhandledSystemError, UnhandledUserError } from "./error/unhandledError";
 import { hooks } from "@feathersjs/hooks/lib";
 import { addStartAndEndTelemetry } from "../middleware/addStartAndEndTelemetry";
@@ -77,6 +76,11 @@ export class UpdateAadAppDriver implements StepDriver {
       context.logProvider?.info(
         getLocalizedString(logMessageKeys.successExecuteDriver, actionName)
       );
+
+      if (context.platform === Platform.CLI) {
+        const msg = getLocalizedString("core.deploy.aadManifestSuccessNotice");
+        context.ui?.showMessage("info", msg, false);
+      }
 
       return {
         result: ok(

--- a/packages/fx-core/tests/component/driver/aad/update.test.ts
+++ b/packages/fx-core/tests/component/driver/aad/update.test.ts
@@ -122,9 +122,9 @@ describe("aadAppUpdate", async () => {
       manifestPath: path.join(testAssetsRoot, "manifest.json"),
       outputFilePath: outputPath,
     };
-
+    const showMessage = sinon.spy(mockedDriverContext.ui, "showMessage");
     const result = await updateAadAppDriver.execute(args, mockedDriverContext);
-
+    chai.assert.isFalse(showMessage.called);
     expect(result.result.isOk()).to.be.true;
     expect(result.result._unsafeUnwrap().get(outputKeys.AAD_APP_ACCESS_AS_USER_PERMISSION_ID)).to.be
       .not.empty;
@@ -147,6 +147,7 @@ describe("aadAppUpdate", async () => {
     expect(result.summaries).includes(
       `Applied manifest ${args.manifestPath} to Azure Active Directory application with object id ${expectedObjectId}`
     );
+    showMessage.restore();
   });
   it("should success with valid manifest on cli", async () => {
     sinon.stub(AadAppClient.prototype, "updateAadApp").resolves();

--- a/packages/fx-core/tests/component/driver/aad/update.test.ts
+++ b/packages/fx-core/tests/component/driver/aad/update.test.ts
@@ -170,8 +170,26 @@ describe("aadAppUpdate", async () => {
       showMessage.getCall(0).args[1],
       "Your Azure Active Directory application has been successfully updated."
     );
+    chai.assert.isFalse(showMessage.getCall(0).args[2]);
     expect(result.result.isOk()).to.be.true;
     showMessage.restore();
+  });
+  it("should success while context ui not support on cli", async () => {
+    sinon.stub(AadAppClient.prototype, "updateAadApp").resolves();
+    envRestore = mockedEnv({
+      AAD_APP_OBJECT_ID: expectedObjectId,
+      AAD_APP_CLIENT_ID: expectedClientId,
+    });
+
+    const outputPath = path.join(outputRoot, "manifest.output.json");
+    const args = {
+      manifestPath: path.join(testAssetsRoot, "manifest.json"),
+      outputFilePath: outputPath,
+    };
+    delete mockedDriverContext.ui;
+    mockedDriverContext.platform = Platform.CLI;
+    const result = await updateAadAppDriver.execute(args, mockedDriverContext);
+    expect(result.result.isOk()).to.be.true;
   });
 
   it("should use absolute path in args directly", async () => {


### PR DESCRIPTION
@microsoft/adaptivecards-tools	v1.3.1-beta.2023041407.0
@microsoft/teamsfx-api	v0.22.2-beta.2023041407.0
@microsoft/teamsfx-cli	v2.0.0-beta.2023041407.0
@microsoft/teamsfx-core	v2.0.0-beta.2023041407.0
@microsoft/teams-manifest	v0.0.10-beta.2023041407.0
@microsoft/metrics-ts	v0.0.4-beta.2023041407.0
@microsoft/teamsfx	v2.2.1-beta.2023041407.0
@microsoft/teamsfx-react	v3.0.0-beta.2023041407.0
ms-teams-vscode-extension	v4.99.0-beta.2023041407.0

Fx-core feat commits:
 feat(core): provision command ---> provision lifecycle (#8016) 757a32da7
feat: enable spfx decouple (#8052) d259e4204
feat: split validate to teamsApp/validateManifest and teamsApp/validateAppPackage actions (#8026) 790b90d99
feat: add web part command in command palette 0c3b0fd17
feat: support 2 validation method (#7959) 4cd3b652b
feat: onboard dev-assist-dashboard sample cf8be4865
feat: add debug task to launch Teams web client for codespaces (#7938) e754914ab
feat: validate against app package (#7753) 0b99cd614
feat(localdebug): init basis tunnel service task (#7899) c3e56206c
feat: remove duplicate notifications for add sql (#7774) e3ab845fd
feat(spfx): support debugging in Office and Outlook (#7712) 57812fb6b
feat: dotenv parser (#7717) f937894f3
feat: up (#7594) 1ed59de30
feat: replace teamsfx with env (#7538) 7fba16a0d
feat: add m365 action (#7510) 2f87ca728
feat: init question (#7489) ad19ae846
feat: up 3547e4662
feat: up 5c3500e22
feat: remove hello world app and refine titles 602855892
feat: localization part 1 (#7391) a893cc649
feat: scratch question default for create new (#7316) af350d80c
feat: skip none secret value (#7289) 424f62114
feat(vsc): account help itp (#6808) a64e8650d
feat: up (#7109) 2b35aab91
feat: help link for unresolve placeholder error (#7097) 1ac9d9891
feat: up (#7092) 5419f92c8
feat: upgrade SPFx version to 1.16 2d4cb7812
feat: support scaffolding dashboard tab in VSC c49691046
feat: remove spfx version select configuration and related code logic 8c266f8ad
feat: add init command telemetry (#7034) 8d6b3be01
feat(vsc): change "Tutorials" to "How-to guides" (#6965) d61be28f3
feat: built in env TEAMSFX_ENV (#6989) 6c74722c8
feat: init vs csproj (#6980) 3fa89ba4b
feat(sample): add sample app for video filter (#6924) c77eb6917
feat: add .env file for init question (#6926) 840456053
feat: onboard deeplinking sample app 9f852e948
feat: duplicated return char (#6877) ab75e8f9d
feat(vsc): v3 add "Add Environment" command in development view (#6820) 1ad44e96d
feat: remove core log (#6857) 26f309de1
feat(video-filter): add installOptions for dependency checker (#6773) 5059aa34b
feat(video-filter): add VxTestAppChecker boilerplate code (#6757) 8e5aa6cb8
feat(localdebug): add func to tools/install driver (#6758) 66dda049c
feat(vsc): add in-product guide (#6703) 5b8e93cb3
feat(debug): add m365 bot driver (#6667) f6569f941
feat: up (#6639) 82660df1b
feat: tacking id issue (#6633) c88d42e3f
feat: up (#6585) 2f58040fb
feat: default resource group name (#6576) 1492139c9
feat: add feature question (#6546) b99888e7c
feat: ut b4081ccde
feat: up 651a78a8d
feat: up 004bc2a8b
feat: up 99a0f3fca
feat: project validator for v3 1e66a99ca
feat(templates): update templates to use SDK v2 (#6404) a0b5241bc
feat: revert 9b4723626
feat: up 9d6612c8c
feat: localize constant strings 530ad22e3
feat: lowercase 4595a15b4
feat: localize strings 371be8a70
feat: coordinator (#6296) acbc5092c
feat: clean 6d5fe71e0
feat: ut pass 43a0032ea
feat: clean up local debug 6d18d3513
feat: merge 45b64db19
feat: merge 0b1b26fa2
feat: ut c6973c267
feat: merge 765c4a42c
feat: up e3859f740
feat: up 6774e7141
feat: up 55dd0fec4
feat: up fdfba3e2f
feat: up 91cc6d876
feat: up f357d031c
feat: clean up identity 3a4f77fd3
feat: notify user about configuration file not exist and provide inst… (#6187) 4c2a5fbc6
feat: up 3504046c9
feat: support both spfx 1.15 and 1.16 beta  (#6150) 0d532389e
feat(debug): scaffold transparent tasks.json and launch.json (#6123) 79f6a1d84
feat: update add sso for command bot (#6106) 78c0a711d
feat: fix env name (#6049) c6a926102
feat: download sample (#6027) c4ddd7b89
feat(cli): support new/add capability for workflow bot (#6008) 46663f250
feat: onboard stock update sample app (#5856) 494f4b6f3
feat: support create and add workflow bot in VSC toolkit (#5950) a639d9f2e
feat: block user from adding feature if web part name duplicated (#5949) 51c974195
feat: create app package message (#5937) 460d195cc
feat: provsion with config (#5922) a85beac03
feat(templates): update templates to use teamsjs v2 (#5907) 692416c89
feat: up e24513e9d
feat: up 0956bcd1a
feat: up 96869e3bd
feat: up 9f526fa33
feat: up 4fb97f022
feat: up f3f45f889
feat: up 9e8c23203
feat: up 765e6e0a5
feat: up (#5886) 84e60f5aa
feat: v3 is default 6d857f45b
feat: enable v3 feature flag 2d7d329c3
feat: simple auth telemetry (#5849) fc9ff91b3
feat: simple auth configure (#5845) 280e5fe2c
feat: remove duplicated notification after add bot 314ed0ed7
feat: add feature notification (#5822) 7b9cb384a
feat: run yeoman cli to add webpart when user select spfx for add feature (#5796) 9273b7922
feat: allow user to add spfx feature for spfx project (#5767) fa242da28
feat: switch m365 account when provision & new provision confirm dialog (#5701) 17d49b361
feat: fix apim provision (#5673) 01bdf507d
feat: enable switch tenant for local debug (#5637) ae549cb45
feat: send telemetry api fix (#5555) 697ee059d
feat: fix for versions c43f74dcf
feat: bot reprovision 78a5b6ad2
feat: enable switch azure sub 0620ad420
feat: upgrade spfx version to 1.15 (#5525) 6618e49d8 

CLI feat commits:
 feat: enable add spfx web part in cli 9baf382fd
feat: support 2 validation method (#7959) 4cd3b652b
feat(vsc): account help itp (#6808) a64e8650d
feat: upgrade SPFx version to 1.16 2d4cb7812
feat(video-filter): add VxTestAppChecker boilerplate code (#6757) 8e5aa6cb8
feat(sdk-react): update to sdk 2.0 and merge useTeams (#6362) 6dcf1320c
feat: up ff8539a61
feat: up 9716235ec
feat(cli): support new/add capability for workflow bot (#6008) 46663f250
feat: up (#5697) c00520609
feat: up (#5677) f4b2f935a
feat: prompt user to upgrade spfx project or toolkit to match spfx ve… (#5642) 0f8ca327c 

Extension-toolkit feat commits:
 feat: remove useless how-to guide for spfx (#8083) e4d699907
feat: enable spfx decouple (#8052) d259e4204
feat(vsc): reorganize tree view UI (#8040) 71fbf8ea7
feat: split validate to teamsApp/validateManifest and teamsApp/validateAppPackage actions (#8026) 790b90d99
feat: add web part command in command palette 0c3b0fd17
feat: remove spfx guide in how-to-guide list dfc54fcb4
feat: support 2 validation method (#7959) 4cd3b652b
feat: onboard dev-assist-dashboard sample cf8be4865
feat: add debug task to launch Teams web client for codespaces (#7938) e754914ab
feat: validate against app package (#7753) 0b99cd614
feat(localdebug): init basis tunnel service task (#7899) c3e56206c
feat: new feedback survey and add feedback section in treeview (#7663) 31f71e5fa
feat(vsc): support V3 migration (#7419) f7a8ef9d3
feat: localization part 1 (#7391) a893cc649
feat(vsc): account help itp (#6808) a64e8650d
feat(vsc): support openFile API (#7149) ee1653316
feat(vsc): codelens crypto support for v3 (#7106) c6814c6c4
feat: upgrade SPFx version to 1.16 2d4cb7812
feat: add tutorial entry for dashboard scenario 0ef5a5316
feat: remove spfx version select configuration and related code logic 8c266f8ad
feat(vsc): change "Tutorials" to "How-to guides" (#6965) d61be28f3
feat(sample): add sample app for video filter (#6924) c77eb6917
feat: onboard deeplinking sample app 9f852e948
feat(vsc): v3 add "Add Environment" command in development view (#6820) 1ad44e96d
feat(video-filter): add installOptions for dependency checker (#6773) 5059aa34b
feat(video-filter): add VxTestAppChecker boilerplate code (#6757) 8e5aa6cb8
feat(vsc): remove subscription node and adapt to new API in v3 (#6755) c79be147e
feat: up (#6741) 663a58586
feat(vsc): add in-product guide (#6703) 5b8e93cb3
feat(templates): update templates to use SDK v2 (#6404) a0b5241bc
feat: update sdk to use teamsjs v2 (#6195) 7e5ed2148
feat(vsc): add support for untrusted workspace (#6279) 540807041
feat(vsc): add tutorial for card action response (#6261) 242e92b52
feat: support both spfx 1.15 and 1.16 beta  (#6150) 0d532389e
feat: onboard stock update sample app (#5856) 494f4b6f3
feat(vsc): add preview command in treeview to run F5 directly in A/B test (#5878) d9048ba59
feat(vsc): open created project in new window by default (#5870) 83d3dc316
feat: notification when switch account for local debug in vs code (#5781) cfe223dbc
feat: prompt user to upgrade spfx project or toolkit to match spfx ve… (#5642) 0f8ca327c
feat: enable switch tenant for local debug (#5637) ae549cb45 

SDK feat commits:
 feat: @microsoft/teamsfx-react migrated to support React 18 and Fluent UI V9 (#7861) 46da7cd00
feat(sdk): update to use cloudAdapter (#7325) 6241a1bc3
feat(vsc): account help itp (#6808) a64e8650d
feat(templates): update templates to use SDK v2 (#6404) a0b5241bc
feat(sdk-react): update to sdk 2.0 and merge useTeams (#6362) 6dcf1320c
feat: update sdk to use teamsjs v2 (#6195) 7e5ed2148
feat(sdk): add methods to find member/channel (#6076) 8d60b4f8e
feat(sdk): add sso command bot support (#5905) 8c2ca8bb2
feat: dastewa/full trust apps support pass 0 (#6019) 81cfe1d2c
feat: add authConfig to customConfig (#6002) 8125df394
feat(sdk): add card action handler in conversation SDK (#5847) 523528c23
feat(sdk): return tenantId in getUserInfo() (#5624) 221f01500 

SDK React feat commits:
 feat: dashboard sdk (#8238) 592ff981d
feat: @microsoft/teamsfx-react migrated to support React 18 and Fluent UI V9 (#7861) 46da7cd00
feat(vsc): account help itp (#6808) a64e8650d
feat(sdk-react): update to sdk 2.0 and merge useTeams (#6362) 6dcf1320c
feat: update sdk to use teamsjs v2 (#6195) 7e5ed2148 

.Net SDK feat commits:
 feat: update .NET SDK to use Teams JS V2 (#6516) e4788c9d9
feat(sdk): add method to find member/channel (#6130) c6c36e1a1
feat(sdk): add dotnet sdk for adaptive card actions (#6068) 68ee9df53
feat(dotnet-sdk): add teamsbotssoprompt (#5177) 13ef61877 


Fx-core fix commits:
 fix: update word 8420b7f4c
fix: add update aadApp success hint for cli 914fba469
fix: manifest related commands behaves wrongly in cli 1d3473ec7
fix: update teams app command f849114ef
fix: view in developer portal with correct teams app id (#8374) 26a0ba169
fix: refine telemetry for validate and output message (#8343) c32baf8e2
fix: correct local debug content url for adding web part (#8353) 9dc1a8864
fix: component property is redacted in action telemetry (#8345) 92571d877
fix: fix test a1b358448
fix: rename to devTool/install bbfcedd71
fix: update string to avoid 2 spaces (#8328) b1db3270f
fix: localized deployment progress (#8297) f8a0a41f2
fix(core): refine yml error (#8321) ed48d2f73
fix(core): script driver error messasge on prerelease (#8314) a6d0c3e60
fix: new bot if azure function bot and switch tenant (#8248) c3f671a50
fix(v2): use 127.0.0.1 instead of localhost for node 18 to get ngrok url ff92c4843
fix: fix userdata resolve logic in v5 migration (#8127) 2c8d8b30d
fix: unit test 0e483dfd0
fix: code coverage 70131143e
fix: masked task label for v3 (#8054) 292261ae7
fix: teamsApp/update action will only update app, not create (#8021) a6da125ca
fix: fix bot resource id logic 20aad6578
fix: build error 5c2fda9fa
fix(project-check): fix error message 0e5aa5c96
fix: publish failed with migrated spfx project 785b1db06
fix: remove duplicated sample config for org user sample 17d1f50ae
fix(migration): update error message for migration v3 (#7925) b3a0f3f55
fix(v3): fix dotnet installation not show path (#7898) 1d941b010
fix: download sample fail 79364f8fe
fix: bicep checker hang if network error happens during downloading (#7387) 9c707872b
fix: end progress handler (#7870) b15202a0f
fix: handle # character in state values 0e43881d6
fix(vsc): restore Office add-in string e086f6371
fix: external sample cant be downloaded in v3 2e63260d1
fix(vsc): restore Office add-in string 63262cf20
fix: update link name as action name has been updated 6ddf13c40
fix: warning to remind user 2bcbb9d2e
fix: stop publish progress b6169f49e
fix: update ut 4fbb7b754
fix: update ut 935a9c4fd
fix: disable validation triggered from open tdp e1f2f0b03
fix: disable validate for schema breaking change 3bbbdf469
fix: download sample fail with PathNotExistError (#7722) c69c78361
fix: update wording to avoid outdated yml file string 92242a88c
fix: fix upgrade dialog message as no args (#7701) 9a8a97c4c
fix: wrong arm help link in migrated yaml (#7676) 064236917
fix(debug): fix file/updateEnv handling boolean args (#7670) 493010670
fix: output bicep issue if there is no teamsfx folder 4b49ca599
fix: compatible with utf8-bom encoding (#7602) 48146ba51
fix: not hint users to provision when update aad manifest with missing env (#7500) 31088e13b
fix: codelens doesn't show for V3, bot template issue (#7459) d010f5f72
fix: remove duplicate code 7393683eb
fix(apim): use default user id to create apim resource (#7422) 0600a1c4e
fix(apim): remove dupliate api call in apimService.listApi (#7380) 7939644df
fix(migrationV3): add a missing name in convert list (#7340) 36fa9fa23
fix: add sso for bot not work in VS 7a2a233e1
fix: add hardcoded vs tab indexpath to migrated project 95d2aa3da
fix: do not use regional api f092ad095
fix: add app name in context (#7319) 8b940b47c
fix: upgrade yo to 4.3.1 to avoid the break on macos 4c62a9a98
fix(vsc): guides entries and add environment 804da5807
fix: list rg does not support `maxPageSize` 464a9a9c3
fix: judge 'components' exists and iterable (#7239) 90cd576da
fix: keep error pattern (#7237) a588f046e
fix: .env.teamsfx.local path for video filter app for cert (#7205) 4ac813a80
fix(core): env create middleware (#7196) f4b2e474f
fix: remove dashboard entry for v3 (#7099) ffaac87ce
fix: fallback certificate to certutil on windows (#7095) f614a9e3d
fix: resource group (#7041) 7a64533a1
fix: create resource group after user confirmation (#6960) bba7f59eb
fix: bot only project developer (#6946) 688b2e067
fix: spfx fail when space exist in directory 65577e124
fix(generator): sample relative path (#6916) 388be73e5
fix: add support for msal redirect URL in aad template (#6843) d6f774315
fix: create resource maxPageSize error 503476264
fix(localdebug): fix the preview button for incoming webhook (#6817) 14d45b0c6
fix: create resource maxPageSize error (#6816) 8db1830c5
fix(cicd): revert README link in vsc notification (#6775) 6a4406dc5
fix: create spfx results in unexpected folder structure (#6704) 8f3bed415
fix: build with localization file (#6701) baa50ae5e
fix: add await, refine comments (#6671) 330ae315b
fix: fix compliance alert (#6656) c87921c46
fix: do not show dialog for VS (#6602) e6dea631d
fix(debug): save project settings in debug handler 53e6d156b
fix: provision Teams app (#6521) d11a5452e
fix: some bugs in teams app driver (#6513) c0503be87
fix(vsc): feature question placeholder (#6494) 7e62cd40f
fix: create new teams app if account in same tenant (#6462) 89978a5af
fix(sso): add port to application id uri (#6417) ae868ab74
fix: telemetry properties (#6408) 55230015c
fix: aad related bugs (#6410) abc2c08df
fix(core): show success notification when adding bot + me (#6398) 4b12077a6
fix(core): use projectId in inputs if available e611c23ff
fix(debug): fix(debug): allow debug after m365 account swtiched 1a2907d9f
fix: print std as error when error occurs (#6308) f1ee8b0b1
fix: wrong scenario id cause invalid state c7400f723
fix: user is asked to select resource when deploy spfx project (#6268) 39751981b
fix: create env failed in spfx project (#6263) 1303cf42d
fix: state value may be empty string 83669f724
fix: forward compatible state key 584c9f8da
fix: migrate bot 6d700a662
fix: dont ask user to provision when local debug failed def259cf0
fix: dotnet bot can not run from package b9a3d4ec8
fix: sso bot bicep compile error 8fa037ce1
fix: migrate vs tab project lost provision 3bb947ec8
fix: ut 83410a389
fix: migrator 28b131c2a
fix: not allow '&' (#6207) 1a392f51a
fix: simple auth configure fa47bfdbb
fix: bug a8c0e2aac
fix: fix comment in local env file (#6178) 3662d14ad
fix: use botId && botPassword 2011debb3
fix: get project config v3 6b5bd5938
fix: ut 43a7120ec
fix: ut 60eff8b25
fix: get config 44f3ba922
fix: provision message dedup 64b6797ae
fix: consolidate migration ba7dc64af
fix(cli): show error when cannot add some feature (#6144) ae60c0638
fix: botwebapp resource id dc1f33f9c
fix: debug 53c1ee3be
fix: remove deprecated code a10d9b977
fix: remove UpdateManifestCancelError 90ac7cb4d
fix: update ut e8f40f195
fix: user cancel error d20ca8a7c
fix: ut 0a0fb10bd
fix: sample manifest compatible process 394bf20d9
fix: remove trailing slash for source addr and dist addr (#6104) 5d77e43ec
fix: app id conflict with published app (#6095) 56a26b88b
fix: migration 4 (#6091) 9d488528e
fix: hide debug console for teams web client (#6085) 683ea8e35
fix: switch account under same tenant, will cause 409 conflict for creating Teams app (#6044) 9e8c767a6
fix: tab local env file & build:teamsfx (#6072) 3474919f9
fix: deploy (#6054) 471931fc4
fix: migration (#6051) aaed88f79
fix: update appsettings.development.json if switch m365 tenant (#6042) 5d917ae40
fix: app studio telemetry v3 (#6037) e626ea7fd
fix: reduce ut time (#6003) 901ef99a3
fix: string (#5991) df7cb43be
fix: make features order and condition consistent with v2 (#6007) 5769ba309
fix(sso): fix add sso in v3 (#5984) aac49314e
fix: web app should be always on when hosting bot (#5985) 65785bfac
fix: update bot state key in local debug (#5967) e834eb1be
fix: missing app setting in bot bicep (#5969) d7c50f043
fix: missing tab state configs in vs (#5962) 33da99a8d
fix: add feature boundary (#5930) facbc8010
fix: add message extension over bot project  (#5919) 7fc09c7db
fix: import (#5921) 215baa0d1
fix: configure app setting when local debug in .NET (#5914) c46d33f34
fix: ut ac4d258da
fix: ut a80b9d0d1
fix: ut 7eb39bd99
fix: ut 9370135b6
fix: ut bee795fad
fix: ut 488250cf2
fix: ut 77adaeadb
fix(v3): bot plugin error is wrapped twice in v3 (#5880) a7f3e8381
fix: correct report name (#5873) 1dc4c29d0
fix: ut eeb49614a
fix: ut 0d50f4ed7
fix: ut c0c46249c
fix: ut 9bd0af426
fix: ut 4e29d588c
fix: ut 6943c1955
fix: update readme file in spfx cd0e2c17d
fix: ut 086c7295e
fix: local debug hotfix efb545967
fix: update test case to increase coverage 88ec7629a
fix(v3): deploy failed with message Working directory is missing (#5834) 19525d08d
fix: add try catch logic to compatible with different api 59145a942
fix(collaborator): grant permission failed due to app studio api changes 7bf5e7048
fix: fix ut 2203cc846
fix: project settings migration (#5812) b2bf982b5
fix: site endpoint and domain key (#5808) 4f1f0e018
fix: template folder for vs (#5803) d14edb62a
fix: spfx v3 (#5779) 570b98545
fix: e2e provision (#5776) d33deb57f
fix: spfx debug scripts (#5773) ef411ea09
fix: set error to warning when func v3 and node 16 (#5755) 5f14cfafd
fix: build v3 (#5739) 7f2995939
fix: env state (#5727) f4587c1d0
fix: bicep compile error (#5724) d0d61affe
fix: folder could be empty string (#5715) 8a5e004d3
fix: function config bicep (#5710) 8bb007fa3
fix: generate watch bot task (#5678) 4c931e4ee
fix(vsc): show "Add Features" in SPFx project (#5651) 176746ce3
fix(core): order of capability question options (#5652) 3d9f3943a
fix: local debug failed for the first time (#5570) 8018f94c4
fix: notification bot should not have command (#5567) ddaa67486
fix: codelens with v3 key and state (#5566) 21f134ac5
fix: allow switching rg 02d67c549
fix: run yeoman by generator name when checker disabled (#5554) 340f1b612
fix: local debug without app id (#5551) 02d7032e7
fix: env info writer b908232e2
fix: env info writer 0564cf5b3
fix: programming language (#5537) 095bc6309 

CLI fix commits:
 fix: manifest related commands behaves wrongly in cli 1d3473ec7
fix: add web part in cli interactive mode doesnt ask web part name (#8357) 911dfc362
fix: unit test 2712d1e4f
fix: init command d83b37b48
fix: new template should not check version 46f35e5fb
fix(cli): unit test 7029c48d3
fix: ut failure due to v5 enabled and add SPFx feature (#8071) 5439d1cff
fix: spfx e2e test fail 5ec114c70
fix: npm run setup error fee8743b6
fix: .env.teamsfx.local path for video filter app for cert (#7205) 4ac813a80
fix: fix compliance alert (#6656) c87921c46
fix(cli): preview 96fdceac5
fix: fix service principal get json method (#6259) 81d5d972b
fix: bump core version 4fb2af8b5
fix: bump core version 60f13c866
fix(cli): fix cli preview for spfx remote 84ee78a52
fix: deploy name test case (#5955) 783653777
fix(cli): replace m365 to Microsoft 365 (#5874) 8893d4114
fix: preview (#5860) 8a376dcaf
fix: prompt issue (#5783) 1b242bc71
fix: add feature (#5713) 64912fbd7
fix: logout and reprovision in cli (#5632) c580d88b2 

Extension-toolkit fix commits:
 fix(vsc): v4 project structure pattern (#8381) c526c4bae
fix: refine telemetry for validate and output message (#8343) c32baf8e2
fix(vsc): hide decrypt secret when command is running (#8338) 3779c10c3
fix(localdebug): less log in basis terminal 77b288872
fix(localdebug): remove template arg in lifecycle task e0c418ac3
fix(localdebug): fix the error message of tunnelEndpointNotFoundError ac4b758da
fix(vsc): regex to match link (#8239) 75965989c
fix(bi): remove activation event dotnet-check-skipped (#8229) eefb51795
fix(localdebug): avoid show error message twice (#8213) 8d467faf6
fix(localdebug): output the correct env keys in the summary (#8208) e6f4667cc
fix: masked task label for v3 (#8054) 292261ae7
fix: build error bcb0d9eca
fix(vsc): treeview UI d98f1ae76
fix(vsc): empty path exceptions (#7887) b8625ed7c
fix(vsc): app name not displayed in v3 (#7839) 36f540c83
fix(vsc): aka links (#7830) 2bdff9e9a
fix(vsc): the timing of enabling buttons after activation 5b1dbaa21
fix(vsc): the timing of enabling buttons after activation 2ecc309dc
fix(vsc): upgrade button position f13a03c73
fix(debug): fix resolving msedge configuration (#7767) bf8a165c6
fix(debug): fix resolving msedge configuration without url d07bf5712
fix(vsc): handle upgrade error 71e730da7
fix: update teams app context menu (#7755) cc0bf9f6b
fix: commands list 9d9e1e8a2
fix: development commands not shown after upgrade a08ec6412
fix(debug): fix get-func-path empty if funcCoreTools settings unchecked (#7708) 80d47bac1
fix(vsc): change the upgrade dialog behavior in v3 (#7702) d8301e3a2
fix(vsc): upgrade detection registration (#7706) 81acf95b0
fix: update file path based on folder structure change (#7685) 50391e27b
fix(vsc): use file watcher to detect teamsfx project after activation (#7614) ed00e135a
fix: fix ux error (#7527) c0126420d
fix(vsc): popup upgrade prompt for v2 projects (#7511) d78fae756
fix(collaboration): fix output when grant permission (#7497) d2fbcaf19
fix: codelens doesn't show for V3, bot template issue (#7459) d010f5f72
fix(localdebug): support empty space in the ngrok path (#7376) fab4a2da3
fix: npm run setup error fee8743b6
fix(vsc): guides entries and add environment 804da5807
fix: prerequisite check stucked when extracting asar from zip (#7222) 78535e123
fix: .env.teamsfx.local path for video filter app for cert (#7205) 4ac813a80
fix(localdebug): fix get started prerequisite check in v3 (#7156) af870f080
fix(vsc): open readme in v3 (#7137) dd5e3508b
fix(vsc): disable "add feature" from command palette in v3 (#7108) e4abb7cf3
fix: local state file not found message is incorrect (#6963) fd351d440
fix(vsc): enable the click of QuickPick icon button (#6811) 7b4536e2f
fix(debug): fix debug provider (#6833) f11ea6b69
fix: fix teamsAppId placeholder not resolved for remote preview 51d7a5f49
fix(vsc): provison select subscription failed in v3 (#6770) 3b12218f6
fix(debug): do not load to process when reading env (#6748) 76a3f932a
fix: sample gallery is broken (#6695) 9e5279d1a
fix: sample gallery is broken (#6695) 8c75dc764
fix(localdebug): fix typo in package.nls.json (#6654) 1ac4c9642
fix: fix compliance alert (#6656) c87921c46
fix: build output path (#6586) 9ac566b89
fix(localdebug): make local debug task args can be empty (#6483) e1dfabf89
fix(localdebug): fix correlation id in debug-all event when task failed (#6482) aa058d742
fix(debug): fix(debug): allow debug after m365 account swtiched 1a2907d9f
fix(acc): fix click sample card with keyboard doesnt go to detail page issue (#6377) e8170e1dc
fix: azure display name empty when sign out and sign in again 5f0912487
fix: update package-lock.json (#6352) 012611228
fix: deploy aad manifest condition update (#6333) 98ff932e1
fix(localdebug): add missing import in baseTaskTerminal (#6316) 485c79a87
fix(vsc): select workspace folder canceled in WSL (#6284) 8c90e38a2
fix: bump core version 4fb2af8b5
fix: bump core version 60f13c866
fix(debug): fix killing tunnel crashes on MacOS (#6210) 9aaaf75f2
fix(localdebug): return dotnet bin folder dir (#6208) b34129af3
fix(vsc): progressbar not disappear (#6188) 1c38fe90d
fix(debug): stop debugging immediately when starting local tunnel fails (#6192) ec579d20d
fix(debug): fix debug provider when app id is empty (#6171) 0451a28ae
fix(vsc): remove command disable restriction ec9a33088
fix(localdebug): get node version from project settings (#6081) dae0090b8
fix(localdebug): support relative path in npm install task (#6079) 3b9c47bcd
fix(localdebug): kill the child process of ngrok task (#6052) 89a3f20c9
fix(vsc): unnecessary work in non-teamsfx project (#6015) 5653928fe
fix(vsc): tooltip display (#5993) 3ac38e913
fix(vsc): initialize exp order (#5923) b322ad654
fix(vsc): progress bar not disappear (#5885) f70f22ad8
fix(vsc): create project blocked 2ab219e56
fix(vsc): trigger-from when welcome page is shown after installation (#5712) e49733854
fix(vsc): show "Add Features" in SPFx project (#5651) 176746ce3
fix: fix get started page acc visual bugs (#5594) ca0d967ec
fix: codelens with v3 key and state (#5566) 21f134ac5 

SDK fix commits:
 fix: fix compliance alert (#6656) c87921c46
fix(sdk): fix the fallback logic to get teams id 9203ba80a
fix: teamsBotSsoPrompt e2e test failed (#6364) 8145c23c5 

SDK React fix commits:
  

.Net SDK fix commits: