### PR TITLE
fix(env): not persist .env.xxx.user if there is no secret variables

### DIFF
--- a/packages/fx-core/src/component/utils/envUtil.ts
+++ b/packages/fx-core/src/component/utils/envUtil.ts
@@ -193,14 +193,13 @@ export class EnvUtil {
     const contentSecret = dotenvUtil.serialize(parsedDotenvSecret);
 
     //persist
-    if (!envFileExists) await fs.ensureFile(dotEnvFilePath);
-    if (!envSecretFileExists) await fs.ensureFile(dotEnvSecretFilePath);
     await fs.writeFile(dotEnvFilePath, content, { encoding: "utf8" });
-    await fs.writeFile(dotEnvSecretFilePath, contentSecret, { encoding: "utf8" });
+    if (Object.keys(parsedDotenvSecret.obj).length > 0)
+      await fs.writeFile(dotEnvSecretFilePath, contentSecret, { encoding: "utf8" });
     if (!envFileExists) {
       TOOLS.logProvider.info("  Created environment file at " + dotEnvFilePath + EOL + EOL);
     }
-    if (!envSecretFileExists) {
+    if (!envSecretFileExists && Object.keys(parsedDotenvSecret.obj).length > 0) {
       TOOLS.logProvider.info(
         "  Created environment file (secret) at " + dotEnvSecretFilePath + EOL + EOL
       );

--- a/packages/fx-core/tests/component/envUtil.test.ts
+++ b/packages/fx-core/tests/component/envUtil.test.ts
@@ -188,6 +188,7 @@ describe("env utils", () => {
   it("envUtil.writeEnv to default path", async () => {
     sandbox.stub(pathUtils, "getEnvFilePath").resolves(ok(undefined));
     sandbox.stub(settingsUtil, "readSettings").resolves(ok(mockSettings));
+    sandbox.stub(fs, "writeFile").resolves();
     const res = await envUtil.writeEnv(".", "dev", { SECRET_ABC: decrypted });
     assert.isTrue(res.isOk());
   });

--- a/packages/fx-core/tests/component/envUtil.test.ts
+++ b/packages/fx-core/tests/component/envUtil.test.ts
@@ -185,6 +185,15 @@ describe("env utils", () => {
     assert.isTrue(decRes.isOk());
     assert.equal(decRes.value, decrypted);
   });
+  it("envUtil.writeEnv no variables", async () => {
+    sandbox.stub(pathUtils, "getEnvFilePath").resolves(ok(".env.dev"));
+    sandbox.stub(fs, "readFile").resolves("" as any);
+    sandbox.stub(fs, "writeFile").resolves();
+    sandbox.stub(fs, "pathExists").resolves(true);
+    sandbox.stub(settingsUtil, "readSettings").resolves(ok(mockSettings));
+    const res = await envUtil.writeEnv(".", "dev", {});
+    assert.isTrue(res.isOk());
+  });
   it("envUtil.writeEnv to default path", async () => {
     sandbox.stub(pathUtils, "getEnvFilePath").resolves(ok(undefined));
     sandbox.stub(settingsUtil, "readSettings").resolves(ok(mockSettings));

--- a/packages/fx-core/tests/core/FxCore.test.ts
+++ b/packages/fx-core/tests/core/FxCore.test.ts
@@ -913,6 +913,7 @@ describe("createEnvCopyV3", async () => {
 
   it("should create new .env file with desired content", async () => {
     sandbox.stub(pathUtils, "getEnvFilePath").resolves(ok("./env/.env.dev"));
+    sandbox.stub(fs, "pathExists").resolves(true);
     const core = new FxCore(tools);
     const res = await core.v3Implement.createEnvCopyV3("newEnv", "dev", "./");
     assert(res.isOk());


### PR DESCRIPTION
To fix: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_sprints/taskboard/Teams%20Extensibility%20E2E%20Team/Microsoft%20Teams%20Extensibility/CY23-4.2?workitem=17926448

E2T TEST: N/A