### PR TITLE
refactor(debug): retire provideTasks in task provider

### DIFF
--- a/packages/vscode-extension/src/debug/commonUtils.ts
+++ b/packages/vscode-extension/src/debug/commonUtils.ts
@@ -37,51 +37,6 @@ export async function getProjectRoot(
   return projectExists ? projectRoot : undefined;
 }
 
-function getLocalEnvWithPrefix(
-  env: { [key: string]: string } | undefined,
-  prefix: string
-): { [key: string]: string } | undefined {
-  if (env === undefined) {
-    return undefined;
-  }
-  const result: { [key: string]: string } = {};
-  for (const key of Object.keys(env)) {
-    if (key.startsWith(prefix) && env[key]) {
-      result[key.slice(prefix.length)] = env[key];
-    }
-  }
-  return Object.keys(result).length > 0 ? result : undefined;
-}
-
-export function getFrontendLocalEnv(
-  env: { [key: string]: string } | undefined
-): { [key: string]: string } | undefined {
-  return getLocalEnvWithPrefix(env, constants.frontendLocalEnvPrefix);
-}
-
-export function getBackendLocalEnv(
-  env: { [key: string]: string } | undefined
-): { [key: string]: string } | undefined {
-  return getLocalEnvWithPrefix(env, constants.backendLocalEnvPrefix);
-}
-
-export function getAuthLocalEnv(
-  env: { [key: string]: string } | undefined
-): { [key: string]: string } | undefined {
-  // SERVICE_PATH will also be included, but it has no side effect
-  return getLocalEnvWithPrefix(env, constants.authLocalEnvPrefix);
-}
-
-export function getAuthServicePath(env: { [key: string]: string } | undefined): string | undefined {
-  return env ? env[constants.authServicePathEnvKey] : undefined;
-}
-
-export function getBotLocalEnv(
-  env: { [key: string]: string } | undefined
-): { [key: string]: string } | undefined {
-  return getLocalEnvWithPrefix(env, constants.botLocalEnvPrefix);
-}
-
 export async function hasTeamsfxBackend(): Promise<boolean> {
   if (!globalVariables.workspaceUri) {
     return false;

--- a/packages/vscode-extension/src/debug/constants.ts
+++ b/packages/vscode-extension/src/debug/constants.ts
@@ -7,23 +7,7 @@ import { TaskLabel } from "@microsoft/teamsfx-core/build/common/local";
 import { ExtensionErrors } from "../error";
 import { getDefaultString, localize } from "../utils/localizeUtils";
 
-export const openWenClientCommand = "launch Teams web client";
-export const npmRunDevRegex = /npm[\s]+run[\s]+dev/im;
-
-export const frontendProblemMatcher = "$teamsfx-frontend-watch";
-export const backendProblemMatcher = "$teamsfx-backend-watch";
-export const authProblemMatcher = "$teamsfx-auth-watch";
-export const ngrokProblemMatcher = "$teamsfx-ngrok-watch";
-export const botProblemMatcher = "$teamsfx-bot-watch";
-export const tscWatchProblemMatcher = "$tsc-watch";
-
 export const localSettingsJsonName = "localSettings.json";
-
-export const frontendLocalEnvPrefix = "FRONTEND_";
-export const backendLocalEnvPrefix = "BACKEND_";
-export const authLocalEnvPrefix = "AUTH_";
-export const authServicePathEnvKey = "AUTH_SERVICE_PATH";
-export const botLocalEnvPrefix = "BOT_";
 
 export const issueChooseLink = "https://github.com/OfficeDev/TeamsFx/issues/new/choose";
 export const issueLink = "https://github.com/OfficeDev/TeamsFx/issues/new?";

--- a/packages/vscode-extension/src/debug/teamsfxTaskProvider.ts
+++ b/packages/vscode-extension/src/debug/teamsfxTaskProvider.ts
@@ -3,44 +3,14 @@
 
 import * as vscode from "vscode";
 
-import {
-  assembleError,
-  err,
-  FxError,
-  Json,
-  ok,
-  ProductName,
-  ProjectSettings,
-  Result,
-  Stage,
-  v2,
-  VsCodeEnv,
-} from "@microsoft/teamsfx-api";
-import { isV3Enabled, ProgrammingLanguage, TunnelType } from "@microsoft/teamsfx-core";
+import { ProductName, Stage, ok } from "@microsoft/teamsfx-api";
+import { isV3Enabled, TunnelType } from "@microsoft/teamsfx-core";
 import { Correlator } from "@microsoft/teamsfx-core/build/common/correlator";
-import { DepsType } from "@microsoft/teamsfx-core/build/common/deps-checker";
-import {
-  FolderName,
-  ITaskDefinition,
-  LocalEnvManager,
-  TaskCommand,
-  TaskDefinition,
-} from "@microsoft/teamsfx-core/build/common/local";
-import {
-  isValidProject,
-  isValidProjectV3,
-} from "@microsoft/teamsfx-core/build/common/projectSettingsHelper";
+import { ITaskDefinition, TaskCommand } from "@microsoft/teamsfx-core/build/common/local";
+import { isValidProjectV3 } from "@microsoft/teamsfx-core/build/common/projectSettingsHelper";
 
-import VsCodeLogInstance from "../commonlib/log";
-import { detectVsCodeEnv, showError } from "../handlers";
-import { ExtTelemetry } from "../telemetry/extTelemetry";
 import { TelemetryEvent } from "../telemetry/extTelemetryEvents";
 import * as commonUtils from "./commonUtils";
-import * as constants from "./constants";
-import { VSCodeDepsChecker } from "./depsChecker/vscodeChecker";
-import { vscodeHelper } from "./depsChecker/vscodeHelper";
-import { vscodeLogger } from "./depsChecker/vscodeLogger";
-import { vscodeTelemetry } from "./depsChecker/vscodeTelemetry";
 import { localTelemetryReporter } from "./localTelemetryReporter";
 import { LifecycleTaskTerminal } from "./taskTerminal/lifecycleTaskTerminal";
 import { NgrokTunnelTaskTerminal } from "./taskTerminal/ngrokTunnelTaskTerminal";
@@ -53,6 +23,23 @@ import { SetUpTabTaskTerminal } from "./taskTerminal/setUpTabTaskTerminal";
 import * as globalVariables from "../globalVariables";
 import { DevTunnelTaskTerminal } from "./taskTerminal/devTunnelTaskTerminal";
 import { LaunchTeamsClientTerminal } from "./taskTerminal/launchTeamsClientTerminal";
+import { showError } from "../handlers";
+
+const deprecatedTasks = [
+  "frontend start",
+  "backend start",
+  "backend watch",
+  "auth start",
+  "bot start",
+  "bot watch",
+  "ngrok start",
+  "launch Teams web client",
+  TaskCommand.npmInstall,
+  TaskCommand.setUpTab,
+  TaskCommand.setUpBot,
+  TaskCommand.setUpSSO,
+  TaskCommand.prepareManifest,
+];
 
 const customTasks = Object.freeze({
   [TaskCommand.checkPrerequisites]: {
@@ -128,129 +115,38 @@ const customTasks = Object.freeze({
 export class TeamsfxTaskProvider implements vscode.TaskProvider {
   public static readonly type: string = ProductName;
 
-  public provideTasks(token?: vscode.CancellationToken | undefined): Promise<vscode.Task[]> {
+  public async provideTasks(
+    token?: vscode.CancellationToken | undefined
+  ): Promise<vscode.Task[] | undefined> {
+    return undefined;
+  }
+
+  public async resolveTask(
+    task: vscode.Task,
+    token?: vscode.CancellationToken | undefined
+  ): Promise<vscode.Task | undefined> {
     return Correlator.runWithId(
       commonUtils.getLocalDebugSessionId(),
-      async (): Promise<vscode.Task[]> => {
-        const tasks: vscode.Task[] = [];
+      async (): Promise<vscode.Task | undefined> => {
+        let resolvedTask: vscode.Task | undefined = undefined;
         if (commonUtils.getLocalDebugSessionId() === commonUtils.DebugNoSessionId) {
-          await this._provideTasks(tasks, token);
+          resolvedTask = await this._resolveTask(task, token);
         } else {
           // Only send telemetry within a local debug session.
-          await localTelemetryReporter.runWithTelemetry(TelemetryEvent.DebugTaskProvider, () =>
-            this._provideTasks(tasks, token)
+          await localTelemetryReporter.runWithTelemetry(
+            TelemetryEvent.DebugTaskProvider,
+            async () => {
+              resolvedTask = await this._resolveTask(task, token);
+              return ok(resolvedTask);
+            }
           );
-
-          // Currently do not send end event if task provider failed.
-          // The reason:
-          // If task provider fails (only for ngrok task),
-          // vscode will continue to run "prepare local environment" task (after a long timeout).
-          // "prepare local environment" will fail when checking ngrok.
-          // The "debug-all" event will be sent in "pre-debug-check" command.
         }
-        return tasks;
+        return resolvedTask;
       }
     );
   }
 
-  private async _provideTasks(
-    tasks: vscode.Task[],
-    token?: vscode.CancellationToken | undefined
-  ): Promise<Result<void, FxError>> {
-    if (vscode.workspace.workspaceFolders) {
-      const workspaceFolder: vscode.WorkspaceFolder = vscode.workspace.workspaceFolders[0];
-      const workspacePath: string = workspaceFolder.uri.fsPath;
-
-      if (!isValidProject(workspacePath)) {
-        return ok(undefined);
-      }
-
-      // migrate to v3
-      if (isV3Enabled()) {
-        try {
-          await commonUtils.triggerV3Migration();
-          return ok(undefined);
-        } catch (error: any) {
-          showError(error);
-          throw error;
-        }
-      }
-
-      const localEnvManager = new LocalEnvManager(VsCodeLogInstance, ExtTelemetry.reporter);
-      let projectSettings: ProjectSettings;
-      let localSettings: Json | undefined;
-      let localEnvInfo: v2.EnvInfoV2 | undefined;
-      let localEnv: { [key: string]: string } | undefined;
-
-      try {
-        projectSettings = await localEnvManager.getProjectSettings(workspacePath);
-        localSettings = await localEnvManager.getLocalSettings(workspacePath, {
-          projectId: projectSettings.projectId,
-        });
-        localEnvInfo = await localEnvManager.getLocalEnvInfo(workspacePath, {
-          projectId: projectSettings.projectId,
-        });
-        localEnv = await localEnvManager.getLocalDebugEnvs(
-          workspacePath,
-          projectSettings,
-          localSettings,
-          localEnvInfo
-        );
-      } catch (error: unknown) {
-        const fxError = assembleError(error);
-        showError(fxError);
-        return err(fxError);
-      }
-
-      const programmingLanguage = projectSettings?.programmingLanguage;
-
-      // Always provide the following tasks no matter whether it is defined in tasks.json
-      const frontendRoot = await commonUtils.getProjectRoot(workspacePath, FolderName.Frontend);
-      if (frontendRoot) {
-        tasks.push(await this.createFrontendStartTask(workspaceFolder, localEnv));
-      }
-
-      const backendRoot = await commonUtils.getProjectRoot(workspacePath, FolderName.Function);
-      if (backendRoot) {
-        tasks.push(
-          await this.createBackendStartTask(workspaceFolder, programmingLanguage, localEnv)
-        );
-        if (programmingLanguage === ProgrammingLanguage.TS) {
-          tasks.push(await this.createBackendWatchTask(workspaceFolder));
-        }
-      }
-
-      const authRoot = commonUtils.getAuthServicePath(localEnv);
-      if (authRoot) {
-        tasks.push(await this.createAuthStartTask(workspaceFolder, authRoot, localEnv));
-      }
-
-      const botRoot = await commonUtils.getProjectRoot(workspacePath, FolderName.Bot);
-      if (botRoot) {
-        const skipNgrok = !vscodeHelper.isNgrokCheckerEnabled();
-        tasks.push(await this.createNgrokStartTask(workspaceFolder, botRoot, skipNgrok));
-        const silent: boolean = frontendRoot !== undefined;
-        tasks.push(
-          await this.createBotStartTask(workspaceFolder, programmingLanguage, localEnv, silent)
-        );
-      }
-
-      const vscodeEnv = detectVsCodeEnv();
-      const isCodeSpaceEnv =
-        vscodeEnv === VsCodeEnv.codespaceBrowser || vscodeEnv === VsCodeEnv.codespaceVsCode;
-      if (isCodeSpaceEnv) {
-        const localTeamsAppId = localSettings?.teamsApp?.teamsAppId as string;
-        const debugConfig = { appId: localTeamsAppId };
-        tasks.push(await this.createOpenTeamsWebClientTask(workspaceFolder, debugConfig));
-      }
-
-      return ok(undefined);
-    }
-
-    return ok(undefined);
-  }
-
-  public async resolveTask(
+  private async _resolveTask(
     task: vscode.Task,
     token?: vscode.CancellationToken | undefined
   ): Promise<vscode.Task | undefined> {
@@ -258,34 +154,33 @@ export class TeamsfxTaskProvider implements vscode.TaskProvider {
       return undefined;
     }
 
+    if (isV3Enabled()) {
+      let needsMigration = false;
+      if (deprecatedTasks.includes(task.definition.command)) {
+        needsMigration = true;
+      } else if (
+        task.definition.command === TaskCommand.checkPrerequisites &&
+        !isValidProjectV3(globalVariables.workspaceUri!.fsPath)
+      ) {
+        needsMigration = true;
+      }
+      if (needsMigration) {
+        // migrate to v3
+        try {
+          await commonUtils.triggerV3Migration();
+          return undefined;
+        } catch (error: any) {
+          showError(error);
+          throw error;
+        }
+      }
+    }
+
     const customTask = Object.entries(customTasks).find(
       ([k]) => k === task.definition.command
     )?.[1];
     if (!customTask) {
       return undefined;
-    }
-
-    // migrate to v3
-    if (isV3Enabled()) {
-      let needsMigration = false;
-      if (task.definition.command === TaskCommand.checkPrerequisites) {
-        if (!isValidProjectV3(globalVariables.workspaceUri!.fsPath)) {
-          needsMigration = true;
-        }
-      } else if (
-        task.definition.command === TaskCommand.npmInstall ||
-        task.definition.command === TaskCommand.setUpTab ||
-        task.definition.command === TaskCommand.setUpBot ||
-        task.definition.command === TaskCommand.setUpSSO ||
-        task.definition.command === TaskCommand.prepareManifest
-      ) {
-        needsMigration = true;
-      }
-
-      if (needsMigration) {
-        // if returning undefined, vscode will resolve the task from task provider and migration will be triggered then
-        return undefined;
-      }
     }
 
     const newTask = new vscode.Task(
@@ -300,135 +195,6 @@ export class TeamsfxTaskProvider implements vscode.TaskProvider {
     newTask.presentationOptions.echo = customTask.presentationEcho;
     newTask.presentationOptions.showReuseMessage = customTask.presentationshowReuseMessage;
     return newTask;
-  }
-
-  private async createFrontendStartTask(
-    workspaceFolder: vscode.WorkspaceFolder,
-    localEnv: { [key: string]: string } | undefined,
-    definition?: vscode.TaskDefinition,
-    problemMatchers?: string | string[]
-  ): Promise<vscode.Task> {
-    return createTask(
-      TaskDefinition.frontendStart(workspaceFolder.uri.fsPath),
-      workspaceFolder,
-      commonUtils.getFrontendLocalEnv(localEnv),
-      definition,
-      problemMatchers || constants.frontendProblemMatcher
-    );
-  }
-
-  private async createBackendStartTask(
-    workspaceFolder: vscode.WorkspaceFolder,
-    programmingLanguage: string | undefined,
-    localEnv: { [key: string]: string } | undefined,
-    definition?: vscode.TaskDefinition,
-    problemMatchers?: string | string[]
-  ): Promise<vscode.Task> {
-    const depsChecker = new VSCodeDepsChecker(vscodeLogger, vscodeTelemetry);
-    const funcCoreTools = await depsChecker.getDepsStatus(DepsType.FuncCoreTools);
-
-    return createTask(
-      TaskDefinition.backendStart(
-        workspaceFolder.uri.fsPath,
-        programmingLanguage,
-        funcCoreTools.command,
-        true
-      ),
-      workspaceFolder,
-      commonUtils.getBackendLocalEnv(localEnv),
-      definition,
-      problemMatchers || constants.backendProblemMatcher,
-      true
-    );
-  }
-
-  private async createAuthStartTask(
-    workspaceFolder: vscode.WorkspaceFolder,
-    authRoot: string,
-    localEnv: { [key: string]: string } | undefined,
-    definition?: vscode.TaskDefinition
-  ): Promise<vscode.Task> {
-    const depsChecker = new VSCodeDepsChecker(vscodeLogger, vscodeTelemetry);
-    const dotnet = await depsChecker.getDepsStatus(DepsType.Dotnet);
-    return createTask(
-      TaskDefinition.authStart(dotnet.command, authRoot),
-      workspaceFolder,
-      commonUtils.getAuthLocalEnv(localEnv),
-      definition,
-      constants.authProblemMatcher,
-      true
-    );
-  }
-
-  private async createNgrokStartTask(
-    workspaceFolder: vscode.WorkspaceFolder,
-    projectRoot: string,
-    isSkipped: boolean,
-    definition?: vscode.TaskDefinition
-  ): Promise<vscode.Task> {
-    // prepare PATH to execute `ngrok`
-    const depsChecker = new VSCodeDepsChecker(vscodeLogger, vscodeTelemetry);
-    const ngrok = await depsChecker.getDepsStatus(DepsType.Ngrok);
-    return createTask(
-      TaskDefinition.ngrokStart(workspaceFolder.uri.fsPath, isSkipped, ngrok.details.binFolders),
-      workspaceFolder,
-      undefined,
-      definition,
-      constants.ngrokProblemMatcher
-    );
-  }
-
-  private async createBotStartTask(
-    workspaceFolder: vscode.WorkspaceFolder,
-    programmingLanguage: string | undefined,
-    localEnv: { [key: string]: string } | undefined,
-    silent: boolean,
-    definition?: vscode.TaskDefinition
-  ): Promise<vscode.Task> {
-    return createTask(
-      TaskDefinition.botStart(workspaceFolder.uri.fsPath, programmingLanguage, true),
-      workspaceFolder,
-      commonUtils.getBotLocalEnv(localEnv),
-      definition,
-      constants.botProblemMatcher,
-      silent
-    );
-  }
-
-  private async createOpenTeamsWebClientTask(
-    workspaceFolder: vscode.WorkspaceFolder,
-    debugConfig: any,
-    definition?: vscode.TaskDefinition
-  ): Promise<vscode.Task> {
-    const command: string = constants.openWenClientCommand;
-    definition = definition || { type: TeamsfxTaskProvider.type, command };
-
-    const localTeamsAppId: string | undefined = debugConfig?.appId;
-    const commandLine = `npx open-cli https://teams.microsoft.com/_#/l/app/${localTeamsAppId}?installAppPackage=true`;
-
-    const task = new vscode.Task(
-      definition,
-      workspaceFolder,
-      command,
-      TeamsfxTaskProvider.type,
-      new vscode.ShellExecution(commandLine)
-    );
-
-    return task;
-  }
-
-  private async createBackendWatchTask(
-    workspaceFolder: vscode.WorkspaceFolder,
-    definition?: vscode.TaskDefinition
-  ): Promise<vscode.Task> {
-    return createTask(
-      TaskDefinition.backendWatch(workspaceFolder.uri.fsPath),
-      workspaceFolder,
-      undefined,
-      definition,
-      constants.tscWatchProblemMatcher,
-      true
-    );
   }
 }
 


### PR DESCRIPTION
Retire provideTasks and trigger migration when resolving a teamsfx task.

This PR also fixes https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/17943725.