### PR TITLE
fix: use safe project name from vs

### DIFF
--- a/packages/fx-core/src/component/coordinator/index.ts
+++ b/packages/fx-core/src/component/coordinator/index.ts
@@ -257,7 +257,9 @@ export class Coordinator {
         const templateName = Feature2TemplateName[`${feature}:${trigger}`];
         if (templateName) {
           const langKey = convertToLangKey(language);
-          context.templateVariables = Generator.getDefaultVariables(appName);
+          const safeProjectNameFromVS =
+            language === "csharp" ? inputs[CoreQuestionNames.SafeProjectName] : undefined;
+          context.templateVariables = Generator.getDefaultVariables(appName, safeProjectNameFromVS);
           const res = await Generator.generateTemplate(context, projectPath, templateName, langKey);
           if (res.isErr()) return err(res.error);
         }

--- a/packages/fx-core/src/component/generator/generator.ts
+++ b/packages/fx-core/src/component/generator/generator.ts
@@ -35,11 +35,14 @@ import {
 } from "./utils";
 
 export class Generator {
-  public static getDefaultVariables(appName: string): { [key: string]: string } {
+  public static getDefaultVariables(
+    appName: string,
+    safeProjectNameFromVS?: string
+  ): { [key: string]: string } {
     return {
       appName: appName,
       ProjectName: appName,
-      SafeProjectName: convertToAlphanumericOnly(appName),
+      SafeProjectName: safeProjectNameFromVS ?? convertToAlphanumericOnly(appName),
     };
   }
   @hooks([

--- a/packages/fx-core/tests/component/coordinator.test.ts
+++ b/packages/fx-core/tests/component/coordinator.test.ts
@@ -185,6 +185,27 @@ describe("component coordinator test", () => {
     assert.isTrue(res2.isOk());
   });
 
+  it("create project from VS", async () => {
+    sandbox.stub(Generator, "generateSample").resolves(ok(undefined));
+    sandbox.stub(Generator, "generateTemplate").resolves(ok(undefined));
+    sandbox
+      .stub(settingsUtil, "readSettings")
+      .resolves(ok({ trackingId: "mockId", version: V3Version }));
+    sandbox.stub(settingsUtil, "writeSettings").resolves(ok(""));
+    const inputs: Inputs = {
+      platform: Platform.VS,
+      folder: ".",
+      [CoreQuestionNames.AppName]: randomAppName(),
+      [CoreQuestionNames.CreateFromScratch]: ScratchOptionYes().id,
+      [CoreQuestionNames.Capabilities]: [TabOptionItem().id],
+      [CoreQuestionNames.ProgrammingLanguage]: "csharp",
+      [CoreQuestionNames.SafeProjectName]: "safeprojectname",
+    };
+    const fxCore = new FxCore(tools);
+    const res2 = await fxCore.createProject(inputs);
+    assert.isTrue(res2.isOk());
+  });
+
   it("create m365 project from scratch", async () => {
     sandbox.stub(Generator, "generateSample").resolves(ok(undefined));
     sandbox.stub(Generator, "generateTemplate").resolves(ok(undefined));


### PR DESCRIPTION
[Bug 18299994](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/18299994): [VS] Deploy failed if project name has dot symbol
We should use SafeProjectName from VS
E2E TEST: N/A