### PR TITLE
fix: set env better format

### DIFF
--- a/packages/fx-core/templates/core/v3Migration/csharp.app.local.yml
+++ b/packages/fx-core/templates/core/v3Migration/csharp.app.local.yml
@@ -53,17 +53,11 @@ provision:
 {{/if}}
 {{#if activePlugins.fx-resource-frontend-hosting}}
   - uses: script # Set env for local launch
-    name: Set {{placeholderMappings.tabDomain}} for local launch
     with:
-      run: echo "::set-teamsfx-env {{placeholderMappings.tabDomain}}=localhost:44302"
-  - uses: script # Set env for local launch
-    name: Set {{placeholderMappings.tabEndpoint}} for local launch
-    with:
-      run: echo "::set-teamsfx-env {{placeholderMappings.tabEndpoint}}=https://localhost:44302"
-  - uses: script # Set env for local launch
-    name: Set {{placeholderMappings.tabIndexPath}} for local launch
-    with:
-      run: echo "::set-teamsfx-env {{placeholderMappings.tabIndexPath}}=#"
+      run:
+        echo "::set-teamsfx-env {{placeholderMappings.tabDomain}}=localhost:44302";
+        echo "::set-teamsfx-env {{placeholderMappings.tabEndpoint}}=https://localhost:44302";
+        echo "::set-teamsfx-env {{placeholderMappings.tabIndexPath}}=#";
   {{#if activePlugins.fx-resource-aad-app-for-teams}}
   - uses: file/createOrUpdateJsonFile
     with:

--- a/packages/fx-core/templates/core/v3Migration/js.ts.app.local.yml
+++ b/packages/fx-core/templates/core/v3Migration/js.ts.app.local.yml
@@ -55,17 +55,11 @@ provision:
   {{#configureApp}}
   {{#tab}}
   - uses: script # Set env for local launch
-    name: Set {{../../../placeholderMappings.tabDomain}} for local launch
     with:
-      run: echo "::set-teamsfx-env {{../../../placeholderMappings.tabDomain}}={{domain}}"
-  - uses: script # Set env for local launch
-    name: Set {{../../../placeholderMappings.tabEndpoint}} for local launch
-    with:
-      run: echo "::set-teamsfx-env {{../../../placeholderMappings.tabEndpoint}}={{endpoint}}"
-  - uses: script # Set env for local launch
-    name: Set {{../../../placeholderMappings.tabIndexPath}} for local launch
-    with:
-      run: echo "::set-teamsfx-env {{../../../placeholderMappings.tabIndexPath}}=/index.html#"
+      run:
+        echo "::set-teamsfx-env {{../../../placeholderMappings.tabDomain}}={{domain}}";
+        echo "::set-teamsfx-env {{../../../placeholderMappings.tabEndpoint}}={{endpoint}}";
+        echo "::set-teamsfx-env {{../../../placeholderMappings.tabIndexPath}}=/index.html#";
 
   {{/tab}}
   {{#if aad}}

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/V3.5.0-V4.0.6-tab-bot-func/expected/app.local.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/V3.5.0-V4.0.6-tab-bot-func/expected/app.local.yml
@@ -41,17 +41,11 @@ provision:
         - name: msteams
 
   - uses: script # Set env for local launch
-    name: Set PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__DOMAIN for local launch
     with:
-      run: echo "::set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__DOMAIN=localhost:53000"
-  - uses: script # Set env for local launch
-    name: Set PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__ENDPOINT for local launch
-    with:
-      run: echo "::set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__ENDPOINT=https://localhost:53000"
-  - uses: script # Set env for local launch
-    name: Set PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH for local launch
-    with:
-      run: echo "::set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH=/index.html#"
+      run:
+        echo "::set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__DOMAIN=localhost:53000";
+        echo "::set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__ENDPOINT=https://localhost:53000";
+        echo "::set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH=/index.html#";
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/V3.5.0-V4.0.6-tab/expected/app.local.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/V3.5.0-V4.0.6-tab/expected/app.local.yml
@@ -25,17 +25,11 @@ provision:
       teamsAppId: TEAMS_APP_ID
 
   - uses: script # Set env for local launch
-    name: Set PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__DOMAIN for local launch
     with:
-      run: echo "::set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__DOMAIN=localhost:53000"
-  - uses: script # Set env for local launch
-    name: Set PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__ENDPOINT for local launch
-    with:
-      run: echo "::set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__ENDPOINT=https://localhost:53000"
-  - uses: script # Set env for local launch
-    name: Set PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH for local launch
-    with:
-      run: echo "::set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH=/index.html#"
+      run:
+        echo "::set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__DOMAIN=localhost:53000";
+        echo "::set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__ENDPOINT=https://localhost:53000";
+        echo "::set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH=/index.html#";
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/beforeV3.4.0-tab-bot-func/expected/app.local.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/beforeV3.4.0-tab-bot-func/expected/app.local.yml
@@ -41,17 +41,11 @@ provision:
         - name: msteams
 
   - uses: script # Set env for local launch
-    name: Set PROVISIONOUTPUT__FRONTENDHOSTINGOUTPUT__DOMAIN for local launch
     with:
-      run: echo "::set-teamsfx-env PROVISIONOUTPUT__FRONTENDHOSTINGOUTPUT__DOMAIN=localhost:53000"
-  - uses: script # Set env for local launch
-    name: Set PROVISIONOUTPUT__FRONTENDHOSTINGOUTPUT__ENDPOINT for local launch
-    with:
-      run: echo "::set-teamsfx-env PROVISIONOUTPUT__FRONTENDHOSTINGOUTPUT__ENDPOINT=https://localhost:53000"
-  - uses: script # Set env for local launch
-    name: Set PROVISIONOUTPUT__FRONTENDHOSTINGOUTPUT__INDEXPATH for local launch
-    with:
-      run: echo "::set-teamsfx-env PROVISIONOUTPUT__FRONTENDHOSTINGOUTPUT__INDEXPATH=/index.html#"
+      run:
+        echo "::set-teamsfx-env PROVISIONOUTPUT__FRONTENDHOSTINGOUTPUT__DOMAIN=localhost:53000";
+        echo "::set-teamsfx-env PROVISIONOUTPUT__FRONTENDHOSTINGOUTPUT__ENDPOINT=https://localhost:53000";
+        echo "::set-teamsfx-env PROVISIONOUTPUT__FRONTENDHOSTINGOUTPUT__INDEXPATH=/index.html#";
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/beforeV3.4.0-tab/expected/app.local.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/beforeV3.4.0-tab/expected/app.local.yml
@@ -25,17 +25,11 @@ provision:
       teamsAppId: TEAMS_APP_ID
 
   - uses: script # Set env for local launch
-    name: Set PROVISIONOUTPUT__FRONTENDHOSTINGOUTPUT__DOMAIN for local launch
     with:
-      run: echo "::set-teamsfx-env PROVISIONOUTPUT__FRONTENDHOSTINGOUTPUT__DOMAIN=localhost:53000"
-  - uses: script # Set env for local launch
-    name: Set PROVISIONOUTPUT__FRONTENDHOSTINGOUTPUT__ENDPOINT for local launch
-    with:
-      run: echo "::set-teamsfx-env PROVISIONOUTPUT__FRONTENDHOSTINGOUTPUT__ENDPOINT=https://localhost:53000"
-  - uses: script # Set env for local launch
-    name: Set PROVISIONOUTPUT__FRONTENDHOSTINGOUTPUT__INDEXPATH for local launch
-    with:
-      run: echo "::set-teamsfx-env PROVISIONOUTPUT__FRONTENDHOSTINGOUTPUT__INDEXPATH=/index.html#"
+      run:
+        echo "::set-teamsfx-env PROVISIONOUTPUT__FRONTENDHOSTINGOUTPUT__DOMAIN=localhost:53000";
+        echo "::set-teamsfx-env PROVISIONOUTPUT__FRONTENDHOSTINGOUTPUT__ENDPOINT=https://localhost:53000";
+        echo "::set-teamsfx-env PROVISIONOUTPUT__FRONTENDHOSTINGOUTPUT__INDEXPATH=/index.html#";
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-m365-tab/expected/app.local.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-m365-tab/expected/app.local.yml
@@ -25,17 +25,11 @@ provision:
       teamsAppId: TEAMS_APP_ID
 
   - uses: script # Set env for local launch
-    name: Set PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__DOMAIN for local launch
     with:
-      run: echo "::set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__DOMAIN=localhost:53000"
-  - uses: script # Set env for local launch
-    name: Set PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__ENDPOINT for local launch
-    with:
-      run: echo "::set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__ENDPOINT=https://localhost:53000"
-  - uses: script # Set env for local launch
-    name: Set PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH for local launch
-    with:
-      run: echo "::set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH=/index.html#"
+      run:
+        echo "::set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__DOMAIN=localhost:53000";
+        echo "::set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__ENDPOINT=https://localhost:53000";
+        echo "::set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH=/index.html#";
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-sso-tab/expected/app.local.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-sso-tab/expected/app.local.yml
@@ -25,17 +25,11 @@ provision:
       teamsAppId: TEAMS_APP_ID
 
   - uses: script # Set env for local launch
-    name: Set PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__DOMAIN for local launch
     with:
-      run: echo "::set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__DOMAIN=localhost:53000"
-  - uses: script # Set env for local launch
-    name: Set PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__ENDPOINT for local launch
-    with:
-      run: echo "::set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__ENDPOINT=https://localhost:53000"
-  - uses: script # Set env for local launch
-    name: Set PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH for local launch
-    with:
-      run: echo "::set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH=/index.html#"
+      run:
+        echo "::set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__DOMAIN=localhost:53000";
+        echo "::set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__ENDPOINT=https://localhost:53000";
+        echo "::set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH=/index.html#";
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-tab-bot-func/expected/app.local.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-tab-bot-func/expected/app.local.yml
@@ -41,17 +41,11 @@ provision:
         - name: msteams
 
   - uses: script # Set env for local launch
-    name: Set PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__DOMAIN for local launch
     with:
-      run: echo "::set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__DOMAIN=localhost:53000"
-  - uses: script # Set env for local launch
-    name: Set PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__ENDPOINT for local launch
-    with:
-      run: echo "::set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__ENDPOINT=https://localhost:53000"
-  - uses: script # Set env for local launch
-    name: Set PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH for local launch
-    with:
-      run: echo "::set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH=/index.html#"
+      run:
+        echo "::set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__DOMAIN=localhost:53000";
+        echo "::set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__ENDPOINT=https://localhost:53000";
+        echo "::set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH=/index.html#";
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-tab/expected/app.local.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-tab/expected/app.local.yml
@@ -12,17 +12,11 @@ provision:
       teamsAppId: TEAMS_APP_ID
 
   - uses: script # Set env for local launch
-    name: Set PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__DOMAIN for local launch
     with:
-      run: echo "::set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__DOMAIN=localhost:53000"
-  - uses: script # Set env for local launch
-    name: Set PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__ENDPOINT for local launch
-    with:
-      run: echo "::set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__ENDPOINT=https://localhost:53000"
-  - uses: script # Set env for local launch
-    name: Set PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH for local launch
-    with:
-      run: echo "::set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH=/index.html#"
+      run:
+        echo "::set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__DOMAIN=localhost:53000";
+        echo "::set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__ENDPOINT=https://localhost:53000";
+        echo "::set-teamsfx-env PROVISIONOUTPUT__AZURESTORAGETABOUTPUT__INDEXPATH=/index.html#";
 
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:

--- a/templates/scenarios/csharp/non-sso-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/csharp/non-sso-tab/teamsapp.local.yml.tpl
@@ -5,14 +5,11 @@ version: 1.0.0
 
 
 provision:
-  - uses: script # Set TAB_DOMAIN for local launch
-    name: Set TAB_DOMAIN for local launch
+  - uses: script # Set TAB_DOMAIN and TAB_ENDPOINT for local launch
     with:
-      run: echo "::set-teamsfx-env TAB_DOMAIN=localhost:44302"
-  - uses: script # Set TAB_ENDPOINT for local launch
-    name: Set TAB_ENDPOINT for local launch
-    with:
-      run: echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:44302"
+      run:
+        echo "::set-teamsfx-env TAB_DOMAIN=localhost:44302";
+        echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:44302";
 
   - uses: teamsApp/create # Creates a Teams app
     with:

--- a/templates/scenarios/csharp/sso-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/csharp/sso-tab/teamsapp.local.yml.tpl
@@ -23,14 +23,11 @@ provision:
     writeToEnvironmentFile: # Write the information of created resources into environment file for the specified environment variable(s).
       teamsAppId: TEAMS_APP_ID
 
-  - uses: script # Set TAB_DOMAIN for local launch
-    name: Set TAB_DOMAIN for local launch
+  - uses: script # Set TAB_DOMAIN and TAB_ENDPOINT for local launch
     with:
-      run: echo "::set-teamsfx-env TAB_DOMAIN=localhost:44302"
-  - uses: script # Set TAB_ENDPOINT for local launch
-    name: Set TAB_ENDPOINT for local launch
-    with:
-      run: echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:44302"
+      run:
+        echo "::set-teamsfx-env TAB_DOMAIN=localhost:44302";
+        echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:44302";
 
   - uses: file/createOrUpdateJsonFile # Generate runtime appsettings to JSON file
     with:

--- a/templates/scenarios/js/dashboard-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/js/dashboard-tab/teamsapp.local.yml.tpl
@@ -10,14 +10,11 @@ provision:
     writeToEnvironmentFile: # Write the information of created resources into environment file for the specified environment variable(s).
       teamsAppId: TEAMS_APP_ID
 
-  - uses: script # Set TAB_DOMAIN for local launch
-    name: Set TAB_DOMAIN for local launch
+  - uses: script # Set TAB_DOMAIN and TAB_ENDPOINT for local launch
     with:
-      run: echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000"
-  - uses: script # Set TAB_ENDPOINT for local launch
-    name: Set TAB_ENDPOINT for local launch
-    with:
-      run: echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000"
+      run:
+        echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000";
+        echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000";
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template

--- a/templates/scenarios/js/m365-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/js/m365-tab/teamsapp.local.yml.tpl
@@ -23,14 +23,11 @@ provision:
     writeToEnvironmentFile: # Write the information of created resources into environment file for the specified environment variable(s).
       teamsAppId: TEAMS_APP_ID
 
-  - uses: script # Set TAB_DOMAIN for local launch
-    name: Set TAB_DOMAIN for local launch
+  - uses: script # Set TAB_DOMAIN and TAB_ENDPOINT for local launch
     with:
-      run: echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000"
-  - uses: script # Set TAB_ENDPOINT for local launch
-    name: Set TAB_ENDPOINT for local launch
-    with:
-      run: echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000"
+      run:
+        echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000";
+        echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000";
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:

--- a/templates/scenarios/js/non-sso-tab-default-bot/teamsapp.local.yml.tpl
+++ b/templates/scenarios/js/non-sso-tab-default-bot/teamsapp.local.yml.tpl
@@ -26,14 +26,11 @@ provision:
       channels:
         - name: msteams
 
-  - uses: script # Set TAB_DOMAIN for local launch
-    name: Set TAB_DOMAIN for local launch
+  - uses: script # Set TAB_DOMAIN and TAB_ENDPOINT for local launch
     with:
-      run: echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000"
-  - uses: script # Set TAB_ENDPOINT for local launch
-    name: Set TAB_ENDPOINT for local launch
-    with:
-      run: echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000"
+      run:
+        echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000";
+        echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000";
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template

--- a/templates/scenarios/js/non-sso-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/js/non-sso-tab/teamsapp.local.yml.tpl
@@ -10,14 +10,11 @@ provision:
     writeToEnvironmentFile: # Write the information of created resources into environment file for the specified environment variable(s).
       teamsAppId: TEAMS_APP_ID
 
-  - uses: script # Set TAB_DOMAIN for local launch
-    name: Set TAB_DOMAIN for local launch
+  - uses: script # Set TAB_DOMAIN and TAB_ENDPOINT for local launch
     with:
-      run: echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000"
-  - uses: script # Set TAB_ENDPOINT for local launch
-    name: Set TAB_ENDPOINT for local launch
-    with:
-      run: echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000"
+      run:
+        echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000";
+        echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000";
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template

--- a/templates/scenarios/js/sso-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/js/sso-tab/teamsapp.local.yml.tpl
@@ -23,14 +23,11 @@ provision:
     writeToEnvironmentFile: # Write the information of created resources into environment file for the specified environment variable(s).
       teamsAppId: TEAMS_APP_ID
 
-  - uses: script # Set TAB_DOMAIN for local launch
-    name: Set TAB_DOMAIN for local launch
+  - uses: script # Set TAB_DOMAIN and TAB_ENDPOINT for local launch
     with:
-      run: echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000"
-  - uses: script # Set TAB_ENDPOINT for local launch
-    name: Set TAB_ENDPOINT for local launch
-    with:
-      run: echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000"
+      run:
+        echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000";
+        echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000";
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:

--- a/templates/scenarios/ts/dashboard-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/ts/dashboard-tab/teamsapp.local.yml.tpl
@@ -10,14 +10,11 @@ provision:
     writeToEnvironmentFile: # Write the information of created resources into environment file for the specified environment variable(s).
       teamsAppId: TEAMS_APP_ID
 
-  - uses: script # Set TAB_DOMAIN for local launch
-    name: Set TAB_DOMAIN for local launch
+  - uses: script # Set TAB_DOMAIN and TAB_ENDPOINT for local launch
     with:
-      run: echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000"
-  - uses: script # Set TAB_ENDPOINT for local launch
-    name: Set TAB_ENDPOINT for local launch
-    with:
-      run: echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000"
+      run:
+        echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000";
+        echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000";
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template

--- a/templates/scenarios/ts/m365-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/ts/m365-tab/teamsapp.local.yml.tpl
@@ -23,14 +23,11 @@ provision:
     writeToEnvironmentFile: # Write the information of created resources into environment file for the specified environment variable(s).
       teamsAppId: TEAMS_APP_ID
 
-  - uses: script # Set TAB_DOMAIN for local launch
-    name: Set TAB_DOMAIN for local launch
+  - uses: script # Set TAB_DOMAIN and TAB_ENDPOINT for local launch
     with:
-      run: echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000"
-  - uses: script # Set TAB_ENDPOINT for local launch
-    name: Set TAB_ENDPOINT for local launch
-    with:
-      run: echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000"
+      run:
+        echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000";
+        echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000";
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:

--- a/templates/scenarios/ts/non-sso-tab-default-bot/teamsapp.local.yml.tpl
+++ b/templates/scenarios/ts/non-sso-tab-default-bot/teamsapp.local.yml.tpl
@@ -26,14 +26,11 @@ provision:
       channels:
         - name: msteams
 
-  - uses: script # Set TAB_DOMAIN for local launch
-    name: Set TAB_DOMAIN for local launch
+  - uses: script # Set TAB_DOMAIN and TAB_ENDPOINT for local launch
     with:
-      run: echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000"
-  - uses: script # Set TAB_ENDPOINT for local launch
-    name: Set TAB_ENDPOINT for local launch
-    with:
-      run: echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000"
+      run:
+        echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000";
+        echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000";
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template

--- a/templates/scenarios/ts/non-sso-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/ts/non-sso-tab/teamsapp.local.yml.tpl
@@ -9,14 +9,11 @@ provision:
       name: {{appName}}-${{TEAMSFX_ENV}} # Teams app name
     writeToEnvironmentFile: # Write the information of created resources into environment file for the specified environment variable(s).
       teamsAppId: TEAMS_APP_ID
-  - uses: script # Set TAB_DOMAIN for local launch
-    name: Set TAB_DOMAIN for local launch
+  - uses: script # Set TAB_DOMAIN and TAB_ENDPOINT for local launch
     with:
-      run: echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000"
-  - uses: script # Set TAB_ENDPOINT for local launch
-    name: Set TAB_ENDPOINT for local launch
-    with:
-      run: echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000"
+      run:
+        echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000";
+        echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000";
   - uses: teamsApp/validateManifest # Validate using manifest schema
     with:
       manifestPath: ./appPackage/manifest.json # Path to manifest template

--- a/templates/scenarios/ts/sso-tab/teamsapp.local.yml.tpl
+++ b/templates/scenarios/ts/sso-tab/teamsapp.local.yml.tpl
@@ -23,14 +23,11 @@ provision:
     writeToEnvironmentFile: # Write the information of created resources into environment file for the specified environment variable(s).
       teamsAppId: TEAMS_APP_ID
 
-  - uses: script # Set TAB_DOMAIN for local launch
-    name: Set TAB_DOMAIN for local launch
+  - uses: script # Set TAB_DOMAIN and TAB_ENDPOINT for local launch
     with:
-      run: echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000"
-  - uses: script # Set TAB_ENDPOINT for local launch
-    name: Set TAB_ENDPOINT for local launch
-    with:
-      run: echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000"
+      run:
+        echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000";
+        echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000";
 
   - uses: aadApp/update # Apply the AAD manifest to an existing AAD app. Will use the object id in manifest file to determine which AAD app to update.
     with:


### PR DESCRIPTION
Fix https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/17884838/
Merge multiple `::set-teamsfx-env` to one action to make template clearer.
The semicolon(`;`) works as separator in both pwsh and bash which are the default shell of script action.

E2E TEST: https://github.com/OfficeDev/TeamsFx/blob/dev/packages/cli/tests/e2e/debug/DebugSsoTab.tests.ts