### PR TITLE
refactor: show loading indicator for tab template

### DIFF
--- a/templates/scenarios/ts/sso-tab/appPackage/manifest.json.tpl
+++ b/templates/scenarios/ts/sso-tab/appPackage/manifest.json.tpl
@@ -56,5 +56,6 @@
     "webApplicationInfo": {
         "id": "${{AAD_APP_CLIENT_ID}}",
         "resource": "api://${{TAB_DOMAIN}}/${{AAD_APP_CLIENT_ID}}"
-    }
+    },
+    "showLoadingIndicator": true
 }

--- a/templates/scenarios/ts/sso-tab/src/components/App.tsx
+++ b/templates/scenarios/ts/sso-tab/src/components/App.tsx
@@ -1,6 +1,4 @@
 // https://fluentsite.z22.web.core.windows.net/quick-start
-import { app } from "@microsoft/teams-js";
-import { useEffect } from "react";
 import {
   FluentProvider,
   teamsLightTheme,
@@ -8,7 +6,9 @@ import {
   teamsHighContrastTheme,
   tokens,
 } from "@fluentui/react-components";
+import { useEffect } from "react";
 import { HashRouter as Router, Navigate, Route, Routes } from "react-router-dom";
+import { app } from "@microsoft/teams-js";
 import { useTeamsUserCredential } from "@microsoft/teamsfx-react";
 import Privacy from "./Privacy";
 import TermsOfUse from "./TermsOfUse";

--- a/templates/scenarios/ts/sso-tab/src/components/App.tsx
+++ b/templates/scenarios/ts/sso-tab/src/components/App.tsx
@@ -1,10 +1,11 @@
 // https://fluentsite.z22.web.core.windows.net/quick-start
+import { app } from "@microsoft/teams-js";
+import { useEffect } from "react";
 import {
   FluentProvider,
   teamsLightTheme,
   teamsDarkTheme,
   teamsHighContrastTheme,
-  Spinner,
   tokens,
 } from "@fluentui/react-components";
 import { HashRouter as Router, Navigate, Route, Routes } from "react-router-dom";
@@ -25,6 +26,12 @@ export default function App() {
     initiateLoginEndpoint: config.initiateLoginEndpoint!,
     clientId: config.clientId!,
   });
+  useEffect(() => {
+    loading &&
+      app.initialize().then(() => {
+        app.notifySuccess();
+      });
+  }, [loading]);
   return (
     <TeamsFxContext.Provider value={{ theme, themeString, teamsUserCredential }}>
       <FluentProvider
@@ -41,9 +48,7 @@ export default function App() {
         style={{ background: tokens.colorNeutralBackground3 }}
       >
         <Router>
-          {loading ? (
-            <Spinner style={{ margin: 100 }} />
-          ) : (
+          {!loading && (
             <Routes>
               <Route path="/privacy" element={<Privacy />} />
               <Route path="/termsofuse" element={<TermsOfUse />} />


### PR DESCRIPTION
It's recommended to display a loading indicator while the Teams app is loading. 
[Create a content page - Teams | Microsoft Learn](https://learn.microsoft.com/en-us/microsoftteams/platform/tabs/how-to/create-tab-pages/content-page?tabs=teamsjs-v2#show-a-native-loading-indicator)

I will apply the change to other tab templates.

before:
![no loading indicator](https://user-images.githubusercontent.com/26134943/233273183-8d7cb5b8-7fc0-482e-ad23-2f39a750f252.gif)

after:
![loading indicator](https://user-images.githubusercontent.com/26134943/233273095-ba52f7bd-bca5-4409-aeb5-423a946a9576.gif)

