### PR TITLE
perf: enable loading indicator for all tab templates

### DIFF
--- a/templates/scenarios/js/dashboard-tab/appPackage/manifest.json.tpl
+++ b/templates/scenarios/js/dashboard-tab/appPackage/manifest.json.tpl
@@ -43,5 +43,6 @@
     ],
     "validDomains": [
         "${{TAB_DOMAIN}}"
-    ]
+    ],
+    "showLoadingIndicator": true
 }

--- a/templates/scenarios/js/dashboard-tab/src/App.css
+++ b/templates/scenarios/js/dashboard-tab/src/App.css
@@ -1,7 +1,3 @@
 #fluent-provider {
   background: var(--colorTransparentBackground);
 }
-
-#spinner {
-  margin: 100;
-}

--- a/templates/scenarios/js/dashboard-tab/src/App.jsx
+++ b/templates/scenarios/js/dashboard-tab/src/App.jsx
@@ -1,14 +1,15 @@
 import "./App.css";
 
+import { useEffect } from "react";
 import { HashRouter as Router, Navigate, Route, Routes } from "react-router-dom";
 
 import {
   FluentProvider,
-  Spinner,
   teamsLightTheme,
   teamsDarkTheme,
   teamsHighContrastTheme,
 } from "@fluentui/react-components";
+import { app } from "@microsoft/teams-js";
 import { useTeamsUserCredential } from "@microsoft/teamsfx-react";
 
 import SampleDashboard from "./dashboards/SampleDashboard";
@@ -26,6 +27,12 @@ export default function App() {
     initiateLoginEndpoint: process.env.REACT_APP_START_LOGIN_PAGE_URL,
     clientId: process.env.REACT_APP_CLIENT_ID,
   });
+  useEffect(() => {
+    loading &&
+      app.initialize().then(() => {
+        app.notifySuccess();
+      });
+  }, [loading]);
   return (
     <TeamsFxContext.Provider value={{ themeString, teamsUserCredential }}>
       <FluentProvider
@@ -39,9 +46,7 @@ export default function App() {
         }
       >
         <Router>
-          {loading ? (
-            <Spinner id="spinner" />
-          ) : (
+          {!loading && (
             <Routes>
               <Route path="/privacy" element={<Privacy />} />
               <Route path="/termsofuse" element={<TermsOfUse />} />

--- a/templates/scenarios/js/dashboard-tab/src/App.jsx
+++ b/templates/scenarios/js/dashboard-tab/src/App.jsx
@@ -30,6 +30,7 @@ export default function App() {
   useEffect(() => {
     loading &&
       app.initialize().then(() => {
+        // Hide the loading indicator.
         app.notifySuccess();
       });
   }, [loading]);

--- a/templates/scenarios/js/m365-tab/appPackage/manifest.json.tpl
+++ b/templates/scenarios/js/m365-tab/appPackage/manifest.json.tpl
@@ -47,5 +47,6 @@
     "webApplicationInfo": {
         "id": "${{AAD_APP_CLIENT_ID}}",
         "resource": "api://${{TAB_DOMAIN}}/${{AAD_APP_CLIENT_ID}}"
-    }
+    },
+    "showLoadingIndicator": true
 }

--- a/templates/scenarios/js/m365-tab/src/components/App.jsx
+++ b/templates/scenarios/js/m365-tab/src/components/App.jsx
@@ -4,10 +4,11 @@ import {
   teamsLightTheme,
   teamsDarkTheme,
   teamsHighContrastTheme,
-  Spinner,
   tokens,
 } from "@fluentui/react-components";
+import { useEffect } from "react";
 import { HashRouter as Router, Navigate, Route, Routes } from "react-router-dom";
+import { app } from "@microsoft/teams-js";
 import { useTeamsUserCredential } from "@microsoft/teamsfx-react";
 import Privacy from "./Privacy";
 import TermsOfUse from "./TermsOfUse";
@@ -25,6 +26,12 @@ export default function App() {
     initiateLoginEndpoint: config.initiateLoginEndpoint,
     clientId: config.clientId,
   });
+  useEffect(() => {
+    loading &&
+      app.initialize().then(() => {
+        app.notifySuccess();
+      });
+  }, [loading]);
   return (
     <TeamsFxContext.Provider value={{ theme, themeString, teamsUserCredential }}>
       <FluentProvider
@@ -41,9 +48,7 @@ export default function App() {
         style={{ background: tokens.colorNeutralBackground3 }}
       >
         <Router>
-          {loading ? (
-            <Spinner style={{ margin: 100 }} />
-          ) : (
+          {!loading && (
             <Routes>
               <Route path="/privacy" element={<Privacy />} />
               <Route path="/termsofuse" element={<TermsOfUse />} />

--- a/templates/scenarios/js/m365-tab/src/components/App.jsx
+++ b/templates/scenarios/js/m365-tab/src/components/App.jsx
@@ -29,6 +29,7 @@ export default function App() {
   useEffect(() => {
     loading &&
       app.initialize().then(() => {
+        // Hide the loading indicator.
         app.notifySuccess();
       });
   }, [loading]);

--- a/templates/scenarios/js/non-sso-tab-default-bot/appPackage/manifest.json.tpl
+++ b/templates/scenarios/js/non-sso-tab-default-bot/appPackage/manifest.json.tpl
@@ -82,5 +82,6 @@
     ],
     "validDomains": [
         "${{TAB_DOMAIN}}"
-    ]
+    ],
+    "showLoadingIndicator": true
 }

--- a/templates/scenarios/js/non-sso-tab-default-bot/tab/src/components/App.jsx
+++ b/templates/scenarios/js/non-sso-tab-default-bot/tab/src/components/App.jsx
@@ -18,6 +18,7 @@ export default function App() {
   const { theme } = useTeams({})[0];
   useEffect(() => {
     app.initialize().then(() => {
+      // Hide loading indicator
       app.notifySuccess();
     });
   }, []);

--- a/templates/scenarios/js/non-sso-tab-default-bot/tab/src/components/App.jsx
+++ b/templates/scenarios/js/non-sso-tab-default-bot/tab/src/components/App.jsx
@@ -1,7 +1,9 @@
 import React from "react";
 // https://fluentsite.z22.web.core.windows.net/quick-start
 import { FluentProvider, teamsLightTheme, tokens } from "@fluentui/react-components";
+import { useEffect } from "react";
 import { HashRouter as Router, Navigate, Route, Routes } from "react-router-dom";
+import { app } from "@microsoft/teams-js";
 import Privacy from "./Privacy";
 import TermsOfUse from "./TermsOfUse";
 import Tab from "./Tab";
@@ -14,6 +16,11 @@ import { useTeams } from "@microsoft/teamsfx-react";
  */
 export default function App() {
   const { theme } = useTeams({})[0];
+  useEffect(() => {
+    app.initialize().then(() => {
+      app.notifySuccess();
+    });
+  }, []);
   return (
     <FluentProvider
       theme={

--- a/templates/scenarios/js/non-sso-tab/appPackage/manifest.json.tpl
+++ b/templates/scenarios/js/non-sso-tab/appPackage/manifest.json.tpl
@@ -22,7 +22,6 @@
         "short": "Short description of {{appName}}",
         "full": "Full description of {{appName}}"
     },
-    "showLoadingIndicator": true,
     "accentColor": "#FFFFFF",
     "bots": [],
     "composeExtensions": [],
@@ -43,5 +42,6 @@
     ],
     "validDomains": [
         "${{TAB_DOMAIN}}"
-    ]
+    ],
+    "showLoadingIndicator": true
 }

--- a/templates/scenarios/js/non-sso-tab/src/views/hello.html
+++ b/templates/scenarios/js/non-sso-tab/src/views/hello.html
@@ -23,6 +23,7 @@
       </span>
     </div>
     <script type="text/javascript">
+      // Hide the loading indicator
       microsoftTeams.appInitialization.notifySuccess();
     </script>
   </body>

--- a/templates/scenarios/js/sso-tab/appPackage/manifest.json.tpl
+++ b/templates/scenarios/js/sso-tab/appPackage/manifest.json.tpl
@@ -56,5 +56,6 @@
     "webApplicationInfo": {
         "id": "${{AAD_APP_CLIENT_ID}}",
         "resource": "api://${{TAB_DOMAIN}}/${{AAD_APP_CLIENT_ID}}"
-    }
+    },
+    "showLoadingIndicator": true
 }

--- a/templates/scenarios/js/sso-tab/src/components/App.jsx
+++ b/templates/scenarios/js/sso-tab/src/components/App.jsx
@@ -4,10 +4,11 @@ import {
   teamsLightTheme,
   teamsDarkTheme,
   teamsHighContrastTheme,
-  Spinner,
   tokens,
 } from "@fluentui/react-components";
+import { useEffect } from "react";
 import { HashRouter as Router, Navigate, Route, Routes } from "react-router-dom";
+import { app } from "@microsoft/teams-js";
 import { useTeamsUserCredential } from "@microsoft/teamsfx-react";
 import Privacy from "./Privacy";
 import TermsOfUse from "./TermsOfUse";
@@ -25,6 +26,12 @@ export default function App() {
     initiateLoginEndpoint: config.initiateLoginEndpoint,
     clientId: config.clientId,
   });
+  useEffect(() => {
+    loading &&
+      app.initialize().then(() => {
+        app.notifySuccess();
+      });
+  }, [loading]);
   return (
     <TeamsFxContext.Provider value={{ theme, themeString, teamsUserCredential }}>
       <FluentProvider
@@ -41,9 +48,7 @@ export default function App() {
         style={{ background: tokens.colorNeutralBackground3 }}
       >
         <Router>
-          {loading ? (
-            <Spinner style={{ margin: 100 }} />
-          ) : (
+          {!loading && (
             <Routes>
               <Route path="/privacy" element={<Privacy />} />
               <Route path="/termsofuse" element={<TermsOfUse />} />

--- a/templates/scenarios/js/sso-tab/src/components/App.jsx
+++ b/templates/scenarios/js/sso-tab/src/components/App.jsx
@@ -29,6 +29,7 @@ export default function App() {
   useEffect(() => {
     loading &&
       app.initialize().then(() => {
+        // Hide the loading indicator.
         app.notifySuccess();
       });
   }, [loading]);

--- a/templates/scenarios/ts/dashboard-tab/appPackage/manifest.json.tpl
+++ b/templates/scenarios/ts/dashboard-tab/appPackage/manifest.json.tpl
@@ -43,5 +43,6 @@
     ],
     "validDomains": [
         "${{TAB_DOMAIN}}"
-    ]
+    ],
+    "showLoadingIndicator": true
 }

--- a/templates/scenarios/ts/dashboard-tab/src/App.css
+++ b/templates/scenarios/ts/dashboard-tab/src/App.css
@@ -1,7 +1,3 @@
 #fluent-provider {
   background: var(--colorTransparentBackground);
 }
-
-#spinner {
-  margin: 100;
-}

--- a/templates/scenarios/ts/dashboard-tab/src/App.tsx
+++ b/templates/scenarios/ts/dashboard-tab/src/App.tsx
@@ -1,14 +1,15 @@
 import "./App.css";
 
+import { useEffect } from "react";
 import { HashRouter as Router, Navigate, Route, Routes } from "react-router-dom";
 
 import {
   FluentProvider,
-  Spinner,
   teamsDarkTheme,
   teamsHighContrastTheme,
   teamsLightTheme,
 } from "@fluentui/react-components";
+import { app } from "@microsoft/teams-js";
 import { useTeamsUserCredential } from "@microsoft/teamsfx-react";
 
 import SampleDashboard from "./dashboards/SampleDashboard";
@@ -26,6 +27,12 @@ export default function App() {
     initiateLoginEndpoint: process.env.REACT_APP_START_LOGIN_PAGE_URL!,
     clientId: process.env.REACT_APP_CLIENT_ID!,
   });
+  useEffect(() => {
+    loading &&
+      app.initialize().then(() => {
+        app.notifySuccess();
+      });
+  }, [loading]);
   return (
     <TeamsFxContext.Provider value={{ themeString, teamsUserCredential }}>
       <FluentProvider
@@ -39,9 +46,7 @@ export default function App() {
         }
       >
         <Router>
-          {loading ? (
-            <Spinner id="spinner" />
-          ) : (
+          {!loading && (
             <Routes>
               <Route path="/privacy" element={<Privacy />} />
               <Route path="/termsofuse" element={<TermsOfUse />} />

--- a/templates/scenarios/ts/dashboard-tab/src/App.tsx
+++ b/templates/scenarios/ts/dashboard-tab/src/App.tsx
@@ -30,6 +30,7 @@ export default function App() {
   useEffect(() => {
     loading &&
       app.initialize().then(() => {
+        // Hide the loading indicator.
         app.notifySuccess();
       });
   }, [loading]);

--- a/templates/scenarios/ts/m365-tab/appPackage/manifest.json.tpl
+++ b/templates/scenarios/ts/m365-tab/appPackage/manifest.json.tpl
@@ -47,5 +47,6 @@
     "webApplicationInfo": {
         "id": "${{AAD_APP_CLIENT_ID}}",
         "resource": "api://${{TAB_DOMAIN}}/${{AAD_APP_CLIENT_ID}}"
-    }
+    },
+    "showLoadingIndicator": true
 }

--- a/templates/scenarios/ts/m365-tab/src/components/App.tsx
+++ b/templates/scenarios/ts/m365-tab/src/components/App.tsx
@@ -4,10 +4,11 @@ import {
   teamsLightTheme,
   teamsDarkTheme,
   teamsHighContrastTheme,
-  Spinner,
   tokens,
 } from "@fluentui/react-components";
+import { useEffect } from "react";
 import { HashRouter as Router, Navigate, Route, Routes } from "react-router-dom";
+import { app } from "@microsoft/teams-js";
 import { useTeamsUserCredential } from "@microsoft/teamsfx-react";
 import Privacy from "./Privacy";
 import TermsOfUse from "./TermsOfUse";
@@ -25,6 +26,12 @@ export default function App() {
     initiateLoginEndpoint: config.initiateLoginEndpoint!,
     clientId: config.clientId!,
   });
+  useEffect(() => {
+    loading &&
+      app.initialize().then(() => {
+        app.notifySuccess();
+      });
+  }, [loading]);
   return (
     <TeamsFxContext.Provider value={{ theme, themeString, teamsUserCredential }}>
       <FluentProvider
@@ -41,9 +48,7 @@ export default function App() {
         style={{ background: tokens.colorNeutralBackground3 }}
       >
         <Router>
-          {loading ? (
-            <Spinner style={{ margin: 100 }} />
-          ) : (
+          {!loading && (
             <Routes>
               <Route path="/privacy" element={<Privacy />} />
               <Route path="/termsofuse" element={<TermsOfUse />} />

--- a/templates/scenarios/ts/m365-tab/src/components/App.tsx
+++ b/templates/scenarios/ts/m365-tab/src/components/App.tsx
@@ -29,6 +29,7 @@ export default function App() {
   useEffect(() => {
     loading &&
       app.initialize().then(() => {
+        // Hide the loading indicator.
         app.notifySuccess();
       });
   }, [loading]);

--- a/templates/scenarios/ts/non-sso-tab-default-bot/appPackage/manifest.json.tpl
+++ b/templates/scenarios/ts/non-sso-tab-default-bot/appPackage/manifest.json.tpl
@@ -82,5 +82,6 @@
     ],
     "validDomains": [
         "${{TAB_DOMAIN}}"
-    ]
+    ],
+    "showLoadingIndicator": true
 }

--- a/templates/scenarios/ts/non-sso-tab-default-bot/tab/src/components/App.tsx
+++ b/templates/scenarios/ts/non-sso-tab-default-bot/tab/src/components/App.tsx
@@ -18,6 +18,7 @@ export default function App() {
   const { theme } = useTeams({})[0];
   useEffect(() => {
     app.initialize().then(() => {
+      // Hide the loading indicator.
       app.notifySuccess();
     });
   }, []);

--- a/templates/scenarios/ts/non-sso-tab-default-bot/tab/src/components/App.tsx
+++ b/templates/scenarios/ts/non-sso-tab-default-bot/tab/src/components/App.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 // https://fluentsite.z22.web.core.windows.net/quick-start
 import { FluentProvider, teamsLightTheme, tokens } from "@fluentui/react-components";
+import { useEffect } from "react";
 import { HashRouter as Router, Navigate, Route, Routes } from "react-router-dom";
+import { app } from "@microsoft/teams-js";
 import Privacy from "./Privacy";
 import TermsOfUse from "./TermsOfUse";
 import Tab from "./Tab";
@@ -14,6 +16,11 @@ import { useTeams } from "@microsoft/teamsfx-react";
  */
 export default function App() {
   const { theme } = useTeams({})[0];
+  useEffect(() => {
+    app.initialize().then(() => {
+      app.notifySuccess();
+    });
+  }, []);
   return (
     <FluentProvider
       theme={

--- a/templates/scenarios/ts/non-sso-tab/appPackage/manifest.json.tpl
+++ b/templates/scenarios/ts/non-sso-tab/appPackage/manifest.json.tpl
@@ -22,7 +22,6 @@
         "short": "Short description of {{appName}}",
         "full": "Full description of {{appName}}"
     },
-    "showLoadingIndicator": true,
     "accentColor": "#FFFFFF",
     "bots": [],
     "composeExtensions": [],
@@ -43,5 +42,6 @@
     ],
     "validDomains": [
         "${{TAB_DOMAIN}}"
-    ]
+    ],
+    "showLoadingIndicator": true
 }

--- a/templates/scenarios/ts/non-sso-tab/src/views/hello.html
+++ b/templates/scenarios/ts/non-sso-tab/src/views/hello.html
@@ -23,6 +23,7 @@
       </span>
     </div>
     <script type="text/javascript">
+      // Hide the loading indicator
       microsoftTeams.appInitialization.notifySuccess();
     </script>
   </body>

--- a/templates/scenarios/ts/sso-tab/src/components/App.tsx
+++ b/templates/scenarios/ts/sso-tab/src/components/App.tsx
@@ -29,6 +29,7 @@ export default function App() {
   useEffect(() => {
     loading &&
       app.initialize().then(() => {
+        // Hide the loading indicator.
         app.notifySuccess();
       });
   }, [loading]);


### PR DESCRIPTION
It's recommended to display a loading indicator while the Teams app is loading. 
[Create a content page - Teams | Microsoft Learn](https://learn.microsoft.com/en-us/microsoftteams/platform/tabs/how-to/create-tab-pages/content-page?tabs=teamsjs-v2#show-a-native-loading-indicator)

before:
![no loading indicator](https://user-images.githubusercontent.com/26134943/233273183-8d7cb5b8-7fc0-482e-ad23-2f39a750f252.gif)

after:
![loading indicator](https://user-images.githubusercontent.com/26134943/233273095-ba52f7bd-bca5-4409-aeb5-423a946a9576.gif)

