### PR TITLE
fix(localdebug): update template to support versioning func installation

### DIFF
--- a/templates/scenarios/js/notification-http-timer-trigger/.funcignore
+++ b/templates/scenarios/js/notification-http-timer-trigger/.funcignore
@@ -21,3 +21,4 @@ teamsapp.*.yml
 /appPackage/
 /infra/
 /teamsfx/
+/devTools/

--- a/templates/scenarios/js/notification-http-timer-trigger/.gitignore
+++ b/templates/scenarios/js/notification-http-timer-trigger/.gitignore
@@ -29,4 +29,4 @@ _storage_emulator
 /build
 
 # Dev tool directories
-devTools
+/devTools/

--- a/templates/scenarios/js/notification-http-timer-trigger/.gitignore
+++ b/templates/scenarios/js/notification-http-timer-trigger/.gitignore
@@ -27,3 +27,6 @@ _storage_emulator
 
 # production
 /build
+
+# Dev tool directories
+devTools

--- a/templates/scenarios/js/notification-http-timer-trigger/.vscode/tasks.json
+++ b/templates/scenarios/js/notification-http-timer-trigger/.vscode/tasks.json
@@ -84,10 +84,8 @@
             "isBackground": true,
             "options": {
                 "cwd": "${workspaceFolder}",
-                "options": {
-                    "env": {
-                        "PATH": "${workspaceFolder}/devTools/func:${env:PATH}"
-                    }
+                "env": {
+                    "PATH": "${workspaceFolder}/devTools/func:${env:PATH}"
                 }
             },
             "windows": {

--- a/templates/scenarios/js/notification-http-timer-trigger/.vscode/tasks.json
+++ b/templates/scenarios/js/notification-http-timer-trigger/.vscode/tasks.json
@@ -84,8 +84,17 @@
             "isBackground": true,
             "options": {
                 "cwd": "${workspaceFolder}",
-                "env": {
-                    "PATH": "${command:fx-extension.get-func-path}${env:PATH}"
+                "options": {
+                    "env": {
+                        "PATH": "${workspaceFolder}/devTools/func:${env:PATH}"
+                    }
+                }
+            },
+            "windows": {
+                "options": {
+                    "env": {
+                        "PATH": "${workspaceFolder}/devTools/func;${env:PATH}"
+                    }
                 }
             },
             "problemMatcher": {

--- a/templates/scenarios/js/notification-http-timer-trigger/teamsapp.local.yml.tpl
+++ b/templates/scenarios/js/notification-http-timer-trigger/teamsapp.local.yml.tpl
@@ -46,7 +46,9 @@ provision:
 deploy:
   - uses: devTool/install # Install development tool(s)
     with:
-      func: true
+      func:
+        version: ~4.0.4670
+        symlinkDir: ./devTools/func
     writeToEnvironmentFile: # Write the information of installed development tool(s) into environment file for the specified environment variable(s).
       funcPath: FUNC_PATH
 

--- a/templates/scenarios/js/notification-http-trigger/.funcignore
+++ b/templates/scenarios/js/notification-http-trigger/.funcignore
@@ -21,3 +21,4 @@ teamsapp.*.yml
 /appPackage/
 /infra/
 /teamsfx/
+/devTools/

--- a/templates/scenarios/js/notification-http-trigger/.gitignore
+++ b/templates/scenarios/js/notification-http-trigger/.gitignore
@@ -29,4 +29,4 @@ _storage_emulator
 /build
 
 # Dev tool directories
-devTools
+/devTools/

--- a/templates/scenarios/js/notification-http-trigger/.gitignore
+++ b/templates/scenarios/js/notification-http-trigger/.gitignore
@@ -27,3 +27,6 @@ _storage_emulator
 
 # production
 /build
+
+# Dev tool directories
+devTools

--- a/templates/scenarios/js/notification-http-trigger/.vscode/tasks.json
+++ b/templates/scenarios/js/notification-http-trigger/.vscode/tasks.json
@@ -84,10 +84,8 @@
             "isBackground": true,
             "options": {
                 "cwd": "${workspaceFolder}",
-                "options": {
-                    "env": {
-                        "PATH": "${workspaceFolder}/devTools/func:${env:PATH}"
-                    }
+                "env": {
+                    "PATH": "${workspaceFolder}/devTools/func:${env:PATH}"
                 }
             },
             "windows": {

--- a/templates/scenarios/js/notification-http-trigger/.vscode/tasks.json
+++ b/templates/scenarios/js/notification-http-trigger/.vscode/tasks.json
@@ -84,8 +84,17 @@
             "isBackground": true,
             "options": {
                 "cwd": "${workspaceFolder}",
-                "env": {
-                    "PATH": "${command:fx-extension.get-func-path}${env:PATH}"
+                "options": {
+                    "env": {
+                        "PATH": "${workspaceFolder}/devTools/func:${env:PATH}"
+                    }
+                }
+            },
+            "windows": {
+                "options": {
+                    "env": {
+                        "PATH": "${workspaceFolder}/devTools/func;${env:PATH}"
+                    }
                 }
             },
             "problemMatcher": {

--- a/templates/scenarios/js/notification-http-trigger/teamsapp.local.yml.tpl
+++ b/templates/scenarios/js/notification-http-trigger/teamsapp.local.yml.tpl
@@ -46,7 +46,9 @@ provision:
 deploy:
   - uses: devTool/install # Install development tool(s)
     with:
-      func: true
+      func:
+        version: ~4.0.4670
+        symlinkDir: ./devTools/func
     writeToEnvironmentFile: # Write the information of installed development tool(s) into environment file for the specified environment variable(s).
       funcPath: FUNC_PATH
 

--- a/templates/scenarios/js/notification-timer-trigger/.funcignore
+++ b/templates/scenarios/js/notification-timer-trigger/.funcignore
@@ -21,3 +21,4 @@ teamsapp.*.yml
 /appPackage/
 /infra/
 /teamsfx/
+/devTools/

--- a/templates/scenarios/js/notification-timer-trigger/.gitignore
+++ b/templates/scenarios/js/notification-timer-trigger/.gitignore
@@ -29,4 +29,4 @@ _storage_emulator
 /build
 
 # Dev tool directories
-devTools
+/devTools/

--- a/templates/scenarios/js/notification-timer-trigger/.gitignore
+++ b/templates/scenarios/js/notification-timer-trigger/.gitignore
@@ -27,3 +27,6 @@ _storage_emulator
 
 # production
 /build
+
+# Dev tool directories
+devTools

--- a/templates/scenarios/js/notification-timer-trigger/.vscode/tasks.json
+++ b/templates/scenarios/js/notification-timer-trigger/.vscode/tasks.json
@@ -84,10 +84,8 @@
             "isBackground": true,
             "options": {
                 "cwd": "${workspaceFolder}",
-                "options": {
-                    "env": {
-                        "PATH": "${workspaceFolder}/devTools/func:${env:PATH}"
-                    }
+                "env": {
+                    "PATH": "${workspaceFolder}/devTools/func:${env:PATH}"
                 }
             },
             "windows": {

--- a/templates/scenarios/js/notification-timer-trigger/.vscode/tasks.json
+++ b/templates/scenarios/js/notification-timer-trigger/.vscode/tasks.json
@@ -84,8 +84,17 @@
             "isBackground": true,
             "options": {
                 "cwd": "${workspaceFolder}",
-                "env": {
-                    "PATH": "${command:fx-extension.get-func-path}${env:PATH}"
+                "options": {
+                    "env": {
+                        "PATH": "${workspaceFolder}/devTools/func:${env:PATH}"
+                    }
+                }
+            },
+            "windows": {
+                "options": {
+                    "env": {
+                        "PATH": "${workspaceFolder}/devTools/func;${env:PATH}"
+                    }
                 }
             },
             "problemMatcher": {

--- a/templates/scenarios/js/notification-timer-trigger/teamsapp.local.yml.tpl
+++ b/templates/scenarios/js/notification-timer-trigger/teamsapp.local.yml.tpl
@@ -46,7 +46,9 @@ provision:
 deploy:
   - uses: devTool/install # Install development tool(s)
     with:
-      func: true
+      func:
+        version: ~4.0.4670
+        symlinkDir: ./devTools/func
     writeToEnvironmentFile: # Write the information of installed development tool(s) into environment file for the specified environment variable(s).
       funcPath: FUNC_PATH
 

--- a/templates/scenarios/ts/notification-http-timer-trigger/.funcignore
+++ b/templates/scenarios/ts/notification-http-timer-trigger/.funcignore
@@ -21,3 +21,4 @@ teamsapp.*.yml
 /appPackage/
 /infra/
 /teamsfx/
+/devTools/

--- a/templates/scenarios/ts/notification-http-timer-trigger/.gitignore
+++ b/templates/scenarios/ts/notification-http-timer-trigger/.gitignore
@@ -30,3 +30,6 @@ _storage_emulator
 
 # production
 /build
+
+# Dev tool directories
+devTools

--- a/templates/scenarios/ts/notification-http-timer-trigger/.gitignore
+++ b/templates/scenarios/ts/notification-http-timer-trigger/.gitignore
@@ -32,4 +32,4 @@ _storage_emulator
 /build
 
 # Dev tool directories
-devTools
+/devTools/

--- a/templates/scenarios/ts/notification-http-timer-trigger/.vscode/tasks.json
+++ b/templates/scenarios/ts/notification-http-timer-trigger/.vscode/tasks.json
@@ -84,10 +84,8 @@
             "isBackground": true,
             "options": {
                 "cwd": "${workspaceFolder}",
-                "options": {
-                    "env": {
-                        "PATH": "${workspaceFolder}/devTools/func:${env:PATH}"
-                    }
+                "env": {
+                    "PATH": "${workspaceFolder}/devTools/func:${env:PATH}"
                 }
             },
             "windows": {

--- a/templates/scenarios/ts/notification-http-timer-trigger/.vscode/tasks.json
+++ b/templates/scenarios/ts/notification-http-timer-trigger/.vscode/tasks.json
@@ -84,8 +84,17 @@
             "isBackground": true,
             "options": {
                 "cwd": "${workspaceFolder}",
-                "env": {
-                    "PATH": "${command:fx-extension.get-func-path}${env:PATH}"
+                "options": {
+                    "env": {
+                        "PATH": "${workspaceFolder}/devTools/func:${env:PATH}"
+                    }
+                }
+            },
+            "windows": {
+                "options": {
+                    "env": {
+                        "PATH": "${workspaceFolder}/devTools/func;${env:PATH}"
+                    }
                 }
             },
             "problemMatcher": {

--- a/templates/scenarios/ts/notification-http-timer-trigger/teamsapp.local.yml.tpl
+++ b/templates/scenarios/ts/notification-http-timer-trigger/teamsapp.local.yml.tpl
@@ -46,7 +46,9 @@ provision:
 deploy:
   - uses: devTool/install # Install development tool(s)
     with:
-      func: true
+      func:
+        version: ~4.0.4670
+        symlinkDir: ./devTools/func
     writeToEnvironmentFile: # Write the information of installed development tool(s) into environment file for the specified environment variable(s).
       funcPath: FUNC_PATH
 

--- a/templates/scenarios/ts/notification-http-trigger/.funcignore
+++ b/templates/scenarios/ts/notification-http-trigger/.funcignore
@@ -21,3 +21,4 @@ teamsapp.*.yml
 /appPackage/
 /infra/
 /teamsfx/
+/devTools/

--- a/templates/scenarios/ts/notification-http-trigger/.gitignore
+++ b/templates/scenarios/ts/notification-http-trigger/.gitignore
@@ -30,3 +30,6 @@ _storage_emulator
 
 # production
 /build
+
+# Dev tool directories
+devTools

--- a/templates/scenarios/ts/notification-http-trigger/.gitignore
+++ b/templates/scenarios/ts/notification-http-trigger/.gitignore
@@ -32,4 +32,4 @@ _storage_emulator
 /build
 
 # Dev tool directories
-devTools
+/devTools/

--- a/templates/scenarios/ts/notification-http-trigger/.vscode/tasks.json
+++ b/templates/scenarios/ts/notification-http-trigger/.vscode/tasks.json
@@ -84,10 +84,8 @@
             "isBackground": true,
             "options": {
                 "cwd": "${workspaceFolder}",
-                "options": {
-                    "env": {
-                        "PATH": "${workspaceFolder}/devTools/func:${env:PATH}"
-                    }
+                "env": {
+                    "PATH": "${workspaceFolder}/devTools/func:${env:PATH}"
                 }
             },
             "windows": {

--- a/templates/scenarios/ts/notification-http-trigger/.vscode/tasks.json
+++ b/templates/scenarios/ts/notification-http-trigger/.vscode/tasks.json
@@ -84,8 +84,17 @@
             "isBackground": true,
             "options": {
                 "cwd": "${workspaceFolder}",
-                "env": {
-                    "PATH": "${command:fx-extension.get-func-path}${env:PATH}"
+                "options": {
+                    "env": {
+                        "PATH": "${workspaceFolder}/devTools/func:${env:PATH}"
+                    }
+                }
+            },
+            "windows": {
+                "options": {
+                    "env": {
+                        "PATH": "${workspaceFolder}/devTools/func;${env:PATH}"
+                    }
                 }
             },
             "problemMatcher": {

--- a/templates/scenarios/ts/notification-http-trigger/teamsapp.local.yml.tpl
+++ b/templates/scenarios/ts/notification-http-trigger/teamsapp.local.yml.tpl
@@ -46,7 +46,9 @@ provision:
 deploy:
   - uses: devTool/install # Install development tool(s)
     with:
-      func: true
+      func:
+        version: ~4.0.4670
+        symlinkDir: ./devTools/func
     writeToEnvironmentFile: # Write the information of installed development tool(s) into environment file for the specified environment variable(s).
       funcPath: FUNC_PATH
 

--- a/templates/scenarios/ts/notification-timer-trigger/.funcignore
+++ b/templates/scenarios/ts/notification-timer-trigger/.funcignore
@@ -21,3 +21,4 @@ teamsapp.*.yml
 /appPackage/
 /infra/
 /teamsfx/
+/devTools/

--- a/templates/scenarios/ts/notification-timer-trigger/.gitignore
+++ b/templates/scenarios/ts/notification-timer-trigger/.gitignore
@@ -30,3 +30,6 @@ _storage_emulator
 
 # production
 /build
+
+# Dev tool directories
+devTools

--- a/templates/scenarios/ts/notification-timer-trigger/.gitignore
+++ b/templates/scenarios/ts/notification-timer-trigger/.gitignore
@@ -32,4 +32,4 @@ _storage_emulator
 /build
 
 # Dev tool directories
-devTools
+/devTools/

--- a/templates/scenarios/ts/notification-timer-trigger/.vscode/tasks.json
+++ b/templates/scenarios/ts/notification-timer-trigger/.vscode/tasks.json
@@ -84,10 +84,8 @@
             "isBackground": true,
             "options": {
                 "cwd": "${workspaceFolder}",
-                "options": {
-                    "env": {
-                        "PATH": "${workspaceFolder}/devTools/func:${env:PATH}"
-                    }
+                "env": {
+                    "PATH": "${workspaceFolder}/devTools/func:${env:PATH}"
                 }
             },
             "windows": {

--- a/templates/scenarios/ts/notification-timer-trigger/.vscode/tasks.json
+++ b/templates/scenarios/ts/notification-timer-trigger/.vscode/tasks.json
@@ -84,8 +84,17 @@
             "isBackground": true,
             "options": {
                 "cwd": "${workspaceFolder}",
-                "env": {
-                    "PATH": "${command:fx-extension.get-func-path}${env:PATH}"
+                "options": {
+                    "env": {
+                        "PATH": "${workspaceFolder}/devTools/func:${env:PATH}"
+                    }
+                }
+            },
+            "windows": {
+                "options": {
+                    "env": {
+                        "PATH": "${workspaceFolder}/devTools/func;${env:PATH}"
+                    }
                 }
             },
             "problemMatcher": {

--- a/templates/scenarios/ts/notification-timer-trigger/teamsapp.local.yml.tpl
+++ b/templates/scenarios/ts/notification-timer-trigger/teamsapp.local.yml.tpl
@@ -46,7 +46,9 @@ provision:
 deploy:
   - uses: devTool/install # Install development tool(s)
     with:
-      func: true
+      func:
+        version: ~4.0.4670
+        symlinkDir: ./devTools/func
     writeToEnvironmentFile: # Write the information of installed development tool(s) into environment file for the specified environment variable(s).
       funcPath: FUNC_PATH
 


### PR DESCRIPTION
Detail: 
[Bug 17943760](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/17943760): [V3] Replace "command:get-func-path" with soft link after support versioning installation
[Bug 17920588](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/17920588): [V3] Support versioning install

Related tp PR: https://github.com/OfficeDev/TeamsFx/pull/8482
