### PR TITLE
refactor(cli): log color and add a new log API

### DIFF
--- a/packages/cli/src/colorize.ts
+++ b/packages/cli/src/colorize.ts
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import chalk from "chalk";
+import { strings } from "./resource";
+
+export enum TextType {
+  Success = "success",
+  Error = "error",
+  Warning = "warning",
+  Info = "info",
+  Hyperlink = "hyperlink",
+  Email = "email",
+  Important = "important",
+  Details = "details",
+}
+
+export function colorize(message: string, type: TextType): string {
+  if (!process.stdout.isTTY) {
+    return message;
+  }
+  switch (type) {
+    case TextType.Success:
+      return chalk.greenBright(message);
+    case TextType.Error:
+      return chalk.redBright(message);
+    case TextType.Warning:
+      return chalk.yellowBright(message);
+    case TextType.Info:
+      return chalk.whiteBright(message);
+    case TextType.Hyperlink:
+      return chalk.cyanBright(message);
+    case TextType.Email:
+    case TextType.Important:
+      return chalk.magentaBright(message);
+    case TextType.Details:
+      return chalk.white(message);
+  }
+}
+
+export const SuccessText = colorize(strings["success.prefix"], TextType.Success);
+export const WarningText = colorize(strings["warning.prefix"], TextType.Success);
+
+export function replaceTemplateString(template: string, ...args: string[]): string {
+  let result = template;
+  for (let i = 0; i < args.length; i++) {
+    result = result.replace(`%s`, args[i]);
+  }
+  return result;
+}

--- a/packages/cli/src/commonlib/codeFlowLogin.ts
+++ b/packages/cli/src/commonlib/codeFlowLogin.ts
@@ -1,36 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { PublicClientApplication, AccountInfo, Configuration, TokenCache } from "@azure/msal-node";
-import express from "express";
-import * as http from "http";
-import * as fs from "fs-extra";
-import * as path from "path";
+import { AccountInfo, Configuration, PublicClientApplication, TokenCache } from "@azure/msal-node";
+import { FxError, LogLevel, Result, SystemError, UserError, err, ok } from "@microsoft/teamsfx-api";
 import { Mutex } from "async-mutex";
-import {
-  UserError,
-  LogLevel,
-  Colors,
-  SystemError,
-  Result,
-  FxError,
-  ok,
-  err,
-} from "@microsoft/teamsfx-api";
-
-import CliCodeLogInstance from "./log";
 import * as crypto from "crypto";
+import express from "express";
+import * as fs from "fs-extra";
+import * as http from "http";
 import { AddressInfo } from "net";
-import { loadAccountId, saveAccountId, UTF8 } from "./cacheAccess";
 import open from "open";
-import {
-  azureLoginMessage,
-  env,
-  m365LoginMessage,
-  MFACode,
-  sendFileTimeout,
-} from "./common/constant";
-import * as constants from "../constants";
+import os from "os";
+import * as path from "path";
+import { TextType, colorize } from "../colorize";
 import CliTelemetry from "../telemetry/cliTelemetry";
 import {
   TelemetryErrorType,
@@ -38,8 +20,15 @@ import {
   TelemetryProperty,
   TelemetrySuccess,
 } from "../telemetry/cliTelemetryEvents";
-import { getColorizedString } from "../utils";
-import os from "os";
+import { UTF8, loadAccountId, saveAccountId } from "./cacheAccess";
+import {
+  MFACode,
+  azureLoginMessage,
+  env,
+  m365LoginMessage,
+  sendFileTimeout,
+} from "./common/constant";
+import CliCodeLogInstance from "./log";
 
 export class ErrorMessage {
   static readonly loginFailureTitle = "LoginFail";
@@ -203,20 +192,13 @@ export class CodeFlowLogin {
       this.pca.getAuthCodeUrl(authCodeUrlParameters).then(async (url: string) => {
         url += "#";
         if (this.accountName == "azure") {
-          const message = [
-            {
-              content: `[${constants.cliSource}] ${azureLoginMessage}`,
-              color: Colors.BRIGHT_WHITE,
-            },
-            { content: url, color: Colors.BRIGHT_CYAN },
-          ];
-          CliCodeLogInstance.necessaryLog(LogLevel.Info, getColorizedString(message));
+          CliCodeLogInstance.outputInfo(
+            azureLoginMessage + colorize(url, TextType.Hyperlink) + os.EOL
+          );
         } else {
-          const message = [
-            { content: `[${constants.cliSource}] ${m365LoginMessage}`, color: Colors.BRIGHT_WHITE },
-            { content: url, color: Colors.BRIGHT_CYAN },
-          ];
-          CliCodeLogInstance.necessaryLog(LogLevel.Info, getColorizedString(message));
+          CliCodeLogInstance.outputInfo(
+            m365LoginMessage + colorize(url, TextType.Hyperlink) + os.EOL
+          );
         }
         open(url);
       });

--- a/packages/cli/src/commonlib/codeFlowTenantLogin.ts
+++ b/packages/cli/src/commonlib/codeFlowTenantLogin.ts
@@ -1,27 +1,21 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { PublicClientApplication, AccountInfo, Configuration, TokenCache } from "@azure/msal-node";
-import express from "express";
-import * as http from "http";
-import * as fs from "fs-extra";
-import * as path from "path";
+import { AccountInfo, Configuration, PublicClientApplication, TokenCache } from "@azure/msal-node";
+import { LogLevel, SystemError, UserError } from "@microsoft/teamsfx-api";
 import { Mutex } from "async-mutex";
-import { LogLevel, UserError, Colors, SystemError } from "@microsoft/teamsfx-api";
-import CliCodeLogInstance from "./log";
 import * as crypto from "crypto";
+import express from "express";
+import * as fs from "fs-extra";
+import * as http from "http";
 import { AddressInfo } from "net";
-import { loadAccountId, saveAccountId, UTF8 } from "./cacheAccess";
 import open from "open";
-import {
-  azureLoginMessage,
-  changeLoginTenantMessage,
-  env,
-  m365LoginMessage,
-  MFACode,
-} from "./common/constant";
-import * as constants from "../constants";
-import { getColorizedString } from "../utils";
+import os from "os";
+import * as path from "path";
+import { TextType, colorize } from "../colorize";
+import { UTF8, loadAccountId, saveAccountId } from "./cacheAccess";
+import { azureLoginMessage, m365LoginMessage } from "./common/constant";
+import CliCodeLogInstance from "./log";
 
 class ErrorMessage {
   static readonly loginError: string = "LoginError";
@@ -156,20 +150,13 @@ export class CodeFlowTenantLogin {
       this.pca.getAuthCodeUrl(authCodeUrlParameters).then(async (response: string) => {
         response += "#";
         if (this.accountName == "azure") {
-          const message = [
-            {
-              content: `[${constants.cliSource}] ${azureLoginMessage}`,
-              color: Colors.BRIGHT_WHITE,
-            },
-            { content: response, color: Colors.BRIGHT_CYAN },
-          ];
-          CliCodeLogInstance.necessaryLog(LogLevel.Info, getColorizedString(message));
+          CliCodeLogInstance.outputInfo(
+            azureLoginMessage + colorize(response, TextType.Hyperlink) + os.EOL
+          );
         } else {
-          const message = [
-            { content: `[${constants.cliSource}] ${m365LoginMessage}`, color: Colors.BRIGHT_WHITE },
-            { content: response, color: Colors.BRIGHT_CYAN },
-          ];
-          CliCodeLogInstance.necessaryLog(LogLevel.Info, getColorizedString(message));
+          CliCodeLogInstance.outputInfo(
+            m365LoginMessage + colorize(response, TextType.Hyperlink) + os.EOL
+          );
         }
         open(response);
       });

--- a/packages/cli/src/console/progress.ts
+++ b/packages/cli/src/console/progress.ts
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { IProgressHandler } from "@microsoft/teamsfx-api";
 import figures from "figures";
-
-import { Colors, IProgressHandler } from "@microsoft/teamsfx-api";
-
-import { getColorizedString } from "../utils";
+import { TextType, colorize } from "../colorize";
 import ScreenManager, { Row } from "./screen";
 
 export default class Progress implements IProgressHandler {
@@ -105,14 +103,10 @@ export default class Progress implements IProgressHandler {
         : this.status === "error"
         ? this.errorMessage
         : this.message;
-    return getColorizedString([
-      {
-        content: `${this.barStatus}  ${Math.round(this.currentPercentage)}% ${
-          this.runningChar
-        } ${message}`,
-        color: Colors.BRIGHT_WHITE,
-      },
-    ]);
+    return colorize(
+      `${this.barStatus}  ${Math.round(this.currentPercentage)}% ${this.runningChar} ${message}`,
+      TextType.Info
+    );
   }
 
   get barStatus(): string {
@@ -126,35 +120,25 @@ export default class Progress implements IProgressHandler {
   }
 
   get doneMessage(): string {
-    return getColorizedString([
-      {
-        content: `[${this.totalSteps}/${this.totalSteps}] ${this.title} `,
-        color: Colors.BRIGHT_WHITE,
-      },
-      { content: `(${figures.tick}) Done.`, color: Colors.BRIGHT_GREEN },
-    ]);
+    return (
+      colorize(`[${this.totalSteps}/${this.totalSteps}] ${this.title} `, TextType.Info) +
+      colorize(` (${figures.cross}) Done.`, TextType.Success)
+    );
   }
 
   get errorMessage(): string {
-    return getColorizedString([
-      {
-        content: `[${this.currentStep}/${this.totalSteps}] ${this.title}: ${
-          this.detail || "starting."
-        }`,
-        color: Colors.BRIGHT_WHITE,
-      },
-      { content: ` (${figures.cross}) Failed.`, color: Colors.BRIGHT_RED },
-    ]);
+    return (
+      colorize(
+        `[${this.currentStep}/${this.totalSteps}] ${this.title}: ${this.detail || "starting."}`,
+        TextType.Info
+      ) + colorize(` (${figures.cross}) Failed.`, TextType.Error)
+    );
   }
 
   get message(): string {
-    return getColorizedString([
-      {
-        content: `[${this.currentStep}/${this.totalSteps}] ${this.title}: ${
-          this.detail || "starting."
-        }`,
-        color: Colors.BRIGHT_WHITE,
-      },
-    ]);
+    return colorize(
+      `[${this.currentStep}/${this.totalSteps}] ${this.title}: ${this.detail || "starting."}`,
+      TextType.Info
+    );
   }
 }

--- a/packages/cli/src/error.ts
+++ b/packages/cli/src/error.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-"use strict";
-
 import { ConfigFolderName, StatesFolderName, SystemError, UserError } from "@microsoft/teamsfx-api";
 import * as constants from "./constants";
 import { strings } from "./resource";
@@ -39,8 +37,7 @@ export function NotFoundSubscriptionId(): UserError {
   return new UserError(
     constants.cliSource,
     "NotFoundSubscriptionId",
-    "Cannot find selected subscription. Ensure your signed-in account has access to this subscription. " +
-      "You can also select another subscription using 'teamsfx account set`."
+    strings["error.NotFoundSubscriptionId"]
   );
 }
 
@@ -175,7 +172,7 @@ export class NotAllowedMigrationError extends UserError {
   constructor() {
     super({
       source: constants.cliSource,
-      message: strings.error.NotAllowedMigrationErrorMessage,
+      message: strings["error.NotAllowedMigrationErrorMessage"],
     });
   }
 }

--- a/packages/cli/src/resource/strings.json
+++ b/packages/cli/src/resource/strings.json
@@ -1,7 +1,14 @@
 {
-  "error": {
-    "NotAllowedMigrationErrorMessage": "Teams Toolkit's Pre-Release version supports new project configuration and is incompatible with previous versions. Try it by creating a new project or run \"teamsfx upgrade\" to upgrade your project first."
-  },
+  "account.login.azure": "You have sucessfully logged into Azure.",
+  "account.login.m365": "You have sucessfully logged into Microsoft 365.",
+  "account.show.azure": "Your Azure account is: %s. Your subscriptions are: %s",
+  "account.show.m365": "Your Microsoft 365 account is: %s.",
+  "account.show.info": "Your %s account is: %s.",
+  "error.prefix": "(x) Error: ",
+  "error.NotAllowedMigrationErrorMessage": "Teams Toolkit's Pre-Release version supports new project configuration and is incompatible with previous versions. Try it by creating a new project or run \"teamsfx upgrade\" to upgrade your project first.",
+  "error.NotFoundSubscriptionId": "Cannot find selected subscription. Ensure your signed-in account has access to this subscription.",
+  "success.prefix": "(✓) Success: ",
+  "warning.prefix": "(!) Warning: ",
   "command": {
     "provision": {
       "description": "Run the provision stage in teamsapp.yml."

--- a/packages/cli/tests/unit/cmds/account.tests.ts
+++ b/packages/cli/tests/unit/cmds/account.tests.ts
@@ -1,296 +1,247 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import sinon from "sinon";
-import yargs, { Options } from "yargs";
-
-import { err, LogLevel, ok, UserError } from "@microsoft/teamsfx-api";
-
-import Account, { AzureLogin, M365Login } from "../../../src/cmds/account";
-import * as Utils from "../../../src/utils";
-import LogProvider from "../../../src/commonlib/log";
-import { expect } from "../utils";
-import { NotFoundSubscriptionId } from "../../../src/error";
-import M365TokenProvider from "../../../src/commonlib/m365Login";
-import AzureTokenProvider from "../../../src/commonlib/azureLogin";
-import { signedIn, signedOut } from "../../../src/commonlib/common/constant";
-import { AccessToken, GetTokenOptions, TokenCredential } from "@azure/identity";
-import * as tools from "@microsoft/teamsfx-core/build/common/tools";
+import { LogLevel, err, ok } from "@microsoft/teamsfx-api";
+import "mocha";
 import mockedEnv, { RestoreFn } from "mocked-env";
-class MockTokenCredentials implements TokenCredential {
-  public async getToken(
-    scopes: string | string[],
-    options?: GetTokenOptions
-  ): Promise<AccessToken | null> {
-    return {
-      token: "a.eyJ1c2VySWQiOiJ0ZXN0QHRlc3QuY29tIn0=.c",
-      expiresOnTimestamp: 1234,
-    };
-  }
-}
+import sinon from "sinon";
+import yargs from "yargs";
+import Account, { AzureLogin, M365Login } from "../../../src/cmds/account";
+import { replaceTemplateString } from "../../../src/colorize";
+import AzureTokenProvider from "../../../src/commonlib/azureLogin";
+import * as codeFlowLogin from "../../../src/commonlib/codeFlowLogin";
+import { signedIn, signedOut } from "../../../src/commonlib/common/constant";
+import LogProvider from "../../../src/commonlib/log";
+import M365TokenProvider from "../../../src/commonlib/m365Login";
+import { ConfigNotFoundError, NotFoundSubscriptionId } from "../../../src/error";
+import * as Utils from "../../../src/utils";
+import { expect } from "../utils";
 
 describe("Account Command Tests", function () {
   const sandbox = sinon.createSandbox();
-  let registeredCommands: string[] = [];
-  let options: string[] = [];
-  let positionals: string[] = [];
-  let loglevels: LogLevel[] = [];
-  let mockedEnvRestore: RestoreFn;
-  before(() => {
+  let messages: string[] = [];
+  let mockedEnvRestore: RestoreFn = () => {};
+
+  beforeEach(() => {
     sandbox.stub(process, "exit");
     sandbox
       .stub<any, any>(yargs, "command")
-      .callsFake((command: string, description: string, builder: any, handler: any) => {
-        registeredCommands.push(command);
-        builder(yargs);
+      .callsFake((cmd: any, desc: any, builder: any, handler: any) => {
+        return builder(yargs);
       });
-    sandbox.stub(yargs, "options").callsFake((ops: { [key: string]: Options }) => {
-      if (typeof ops === "string") {
-        options.push(ops);
-      } else {
-        options = options.concat(...Object.keys(ops));
-      }
-      return yargs;
-    });
-    sandbox.stub(yargs, "positional").callsFake((name: string) => {
-      positionals.push(name);
-      return yargs;
-    });
+    sandbox.stub(yargs, "options").returns(yargs);
+    sandbox.stub(yargs, "positional").returns(yargs);
     sandbox.stub(yargs, "exit").callsFake((code: number, err: Error) => {
       throw err;
     });
     sandbox.stub(LogProvider, "necessaryLog").callsFake((level: LogLevel, message: string) => {
-      loglevels.push(level);
+      messages.push(message);
     });
-
-    sandbox.stub(Utils, "setSubscriptionId").callsFake(async (id?: string, folder?: string) => {
-      if (!id) return ok(null);
-      else return err(NotFoundSubscriptionId());
+    sandbox.stub(LogProvider, "outputInfo").callsFake((message: string, ...args: string[]) => {
+      messages.push(replaceTemplateString(message, ...args));
     });
-    sandbox.stub(tools, "setRegion").callsFake(async () => {});
-
-    sandbox.stub(M365TokenProvider, "setStatusChangeMap").resolves(ok(true));
-    sandbox
-      .stub(M365TokenProvider, "getStatus")
-      .onFirstCall()
-      .returns(Promise.resolve(ok({ status: signedIn })))
-      .onSecondCall()
-      .returns(Promise.resolve(ok({ status: signedOut })))
-      .onThirdCall()
-      .returns(Promise.resolve(ok({ status: signedOut })));
-    sandbox.stub(M365TokenProvider, "getAccessToken").resolves(ok(""));
-    sandbox
-      .stub(M365TokenProvider, "getJsonObject")
-      .onFirstCall()
-      .returns(Promise.resolve(ok({ upn: "M365@xxx.com" })))
-      .onSecondCall()
-      .returns(Promise.resolve(ok({ upn: "M365@xxx.com" })))
-      .onThirdCall()
-      .returns(Promise.resolve(err(new UserError("login", "not login", "not login"))));
-    sandbox
-      .stub(M365TokenProvider, "signout")
-      .onFirstCall()
-      .returns(Promise.resolve(true))
-      .onSecondCall()
-      .returns(Promise.resolve(true))
-      .onThirdCall()
-      .returns(Promise.resolve(true))
-      .onCall(4)
-      .returns(Promise.resolve(false));
-
-    sandbox
-      .stub(AzureTokenProvider, "getStatus")
-      .onFirstCall()
-      .returns(Promise.resolve({ status: signedIn }))
-      .onSecondCall()
-      .returns(Promise.resolve({ status: signedIn }))
-      .onThirdCall()
-      .returns(Promise.resolve({ status: signedOut }));
-    sandbox
-      .stub(AzureTokenProvider, "getIdentityCredentialAsync")
-      .onFirstCall()
-      .returns(Promise.resolve(new MockTokenCredentials()))
-      .onSecondCall()
-      .returns(Promise.resolve(new MockTokenCredentials()))
-      .onThirdCall()
-      .returns(Promise.resolve(new MockTokenCredentials()))
-      .onCall(4)
-      .returns(Promise.resolve(undefined))
-      .onCall(5)
-      .returns(Promise.resolve(undefined))
-      .onCall(6)
-      .returns(Promise.resolve(undefined));
-    sandbox
-      .stub(AzureTokenProvider, "getJsonObject")
-      .onFirstCall()
-      .returns(Promise.resolve({}))
-      .onSecondCall()
-      .returns(Promise.resolve({}))
-      .onThirdCall()
-      .returns(Promise.resolve({}))
-      .onCall(4)
-      .returns(Promise.resolve(undefined))
-      .onCall(5)
-      .returns(Promise.resolve(undefined))
-      .onCall(6)
-      .returns(Promise.resolve(undefined));
-    sandbox.stub(AzureTokenProvider, "listSubscriptions").returns(Promise.resolve([]));
-    sandbox
-      .stub(AzureTokenProvider, "readSubscription")
-      .onFirstCall()
-      .returns(
-        Promise.resolve({
-          subscriptionName: "",
-          subscriptionId: "",
-          tenantId: "",
-        })
-      )
-      .onSecondCall()
-      .returns(Promise.resolve(undefined));
-    sandbox
-      .stub(AzureTokenProvider, "signout")
-      .onFirstCall()
-      .returns(Promise.resolve(true))
-      .onSecondCall()
-      .returns(Promise.resolve(true))
-      .onThirdCall()
-      .returns(Promise.resolve(true))
-      .onCall(4)
-      .returns(Promise.resolve(false));
+    sandbox.stub(LogProvider, "outputWarning").callsFake((message: string, ...args: string[]) => {
+      messages.push(replaceTemplateString(message, ...args));
+    });
+    sandbox.stub(LogProvider, "outputError").callsFake((message: string, ...args: string[]) => {
+      messages.push(replaceTemplateString(message, ...args));
+    });
+    sandbox.stub(LogProvider, "outputSuccess").callsFake((message: string, ...args: string[]) => {
+      messages.push(replaceTemplateString(message, ...args));
+    });
+    sandbox.stub(LogProvider, "outputDetails").callsFake((message: string, ...args: string[]) => {
+      messages.push(replaceTemplateString(message, ...args));
+    });
   });
 
-  after(() => {
-    sandbox.restore();
-  });
-
-  beforeEach(() => {
-    registeredCommands = [];
-    options = [];
-    positionals = [];
-    loglevels = [];
-    mockedEnvRestore = mockedEnv({ TEAMSFX_V3: "false" });
-  });
   afterEach(() => {
+    sandbox.restore();
+    messages = [];
     mockedEnvRestore();
   });
 
   it("Builder Check", () => {
     const cmd = new Account();
     yargs.command(cmd.command, cmd.description, cmd.builder.bind(cmd), cmd.handler.bind(cmd));
-    expect(registeredCommands).deep.equals([
-      "account <action>",
-      "show",
-      "login <service>",
-      "m365",
-      "azure",
-      "logout <service>",
-      "set",
-    ]);
-    expect(options).deep.equals([
-      "action",
-      "tenant",
-      "service-principal",
-      "username",
-      "password",
-      "folder",
-      "subscription",
-    ]);
-    expect(positionals).deep.equals(["service"]);
+    expect(cmd.subCommands).to.be.lengthOf(3);
+  });
+
+  it("Builder Check - V2", () => {
+    mockedEnvRestore = mockedEnv({ TEAMSFX_V3: "false" });
+    const cmd = new Account();
+    yargs.command(cmd.command, cmd.description, cmd.builder.bind(cmd), cmd.handler.bind(cmd));
+    expect(cmd.subCommands).to.be.lengthOf(4);
   });
 
   it("Account Command Running Check", async () => {
     const cmd = new Account();
-    await cmd.handler({});
+    await cmd.runCommand({});
   });
 
-  it("Account Show Command Running Check - signedIn", async () => {
+  it("Account Show Command Running Check - signedIn - V2", async () => {
+    mockedEnvRestore = mockedEnv({ TEAMSFX_V3: "false" });
+    sandbox.stub(M365TokenProvider, "getStatus").resolves(ok({ status: signedIn }));
+    sandbox.stub(M365TokenProvider, "getJsonObject").resolves(ok({ upn: "M365@xxx.com" }));
+    sandbox.stub(AzureTokenProvider, "getStatus").resolves({ status: signedIn });
+    sandbox.stub(AzureTokenProvider, "getJsonObject").resolves({ upn: "Azure@xxx.com" });
+    sandbox.stub(AzureTokenProvider, "listSubscriptions").resolves([]);
+    sandbox.stub(AzureTokenProvider, "readSubscription").resolves({
+      subscriptionName: "",
+      subscriptionId: "",
+      tenantId: "",
+    });
+    sandbox.stub(AzureTokenProvider, "setRootPath");
+    sandbox.stub(codeFlowLogin, "checkIsOnline").resolves(true);
     const cmd = new Account();
     const show = cmd.subCommands.find((cmd) => cmd.commandHead === "show");
-    await show!.handler({});
-    expect(loglevels).deep.equals([LogLevel.Info, LogLevel.Info]);
+    expect(show).not.to.be.undefined;
+    await show!.runCommand({});
+    expect(messages).to.be.lengthOf(2);
   });
 
-  it("Account Show Command Running Check - Azure signedIn but no Active Sub", async () => {
+  it("Account Show Command Running Check - Azure signedIn but no Active Sub - V2", async () => {
+    mockedEnvRestore = mockedEnv({ TEAMSFX_V3: "false" });
+    sandbox.stub(M365TokenProvider, "getStatus").resolves(ok({ status: signedIn }));
+    sandbox.stub(M365TokenProvider, "getJsonObject").resolves(ok({ upn: "M365@xxx.com" }));
+    sandbox.stub(AzureTokenProvider, "getStatus").resolves({ status: signedIn });
+    sandbox.stub(AzureTokenProvider, "getJsonObject").resolves({ upn: "Azure@xxx.com" });
+    sandbox.stub(AzureTokenProvider, "listSubscriptions").resolves([]);
+    sandbox.stub(AzureTokenProvider, "readSubscription").resolves(undefined);
+    sandbox.stub(codeFlowLogin, "checkIsOnline").resolves(true);
     const cmd = new Account();
     const show = cmd.subCommands.find((cmd) => cmd.commandHead === "show");
-    await show!.handler({});
-    expect(loglevels).deep.equals([LogLevel.Info, LogLevel.Info, LogLevel.Info]);
+    expect(show).not.to.be.undefined;
+    await show!.runCommand({});
+    expect(messages).to.be.lengthOf(4);
   });
 
   it("Account Show Command Running Check - signedOut", async () => {
+    sandbox.stub(M365TokenProvider, "getStatus").resolves(ok({ status: signedOut }));
+    sandbox.stub(AzureTokenProvider, "getStatus").resolves({ status: signedOut });
     const cmd = new Account();
     const show = cmd.subCommands.find((cmd) => cmd.commandHead === "show");
-    await show!.handler({});
-    expect(loglevels).deep.equals([LogLevel.Info]);
+    expect(show).not.to.be.undefined;
+    await show!.runCommand({});
+    expect(messages).to.be.lengthOf(1);
+  });
+
+  it("Account Show Command Running Check - Failed - V2", async () => {
+    mockedEnvRestore = mockedEnv({ TEAMSFX_V3: "false" });
+    sandbox.stub(M365TokenProvider, "getStatus").resolves(ok({ status: signedIn }));
+    sandbox.stub(M365TokenProvider, "getJsonObject").resolves(ok({ upn: "M365@xxx.com" }));
+    sandbox.stub(AzureTokenProvider, "getStatus").resolves({ status: signedIn });
+    sandbox.stub(AzureTokenProvider, "getJsonObject").resolves({ upn: "Azure@xxx.com" });
+    sandbox.stub(AzureTokenProvider, "listSubscriptions").resolves([]);
+    sandbox.stub(AzureTokenProvider, "readSubscription").rejects(ConfigNotFoundError("test"));
+    sandbox.stub(codeFlowLogin, "checkIsOnline").resolves(true);
+    const cmd = new Account();
+    const show = cmd.subCommands.find((cmd) => cmd.commandHead === "show");
+    expect(show).not.to.be.undefined;
+    await show!.runCommand({});
+    expect(messages).to.be.lengthOf(3);
   });
 
   it("Account Login Azure Command Running Check - Success", async () => {
+    sandbox.stub(AzureTokenProvider, "signout");
+    sandbox.stub(AzureTokenProvider, "getJsonObject").resolves({ upn: "Azure@xxx.com" });
+    sandbox.stub(AzureTokenProvider, "listSubscriptions").resolves([]);
     const cmd = new AzureLogin();
-    await cmd!.handler({});
-    expect(loglevels).deep.equals([LogLevel.Info, LogLevel.Info, LogLevel.Info]);
+    await cmd!.runCommand({});
+    expect(messages).to.be.lengthOf(2);
+  });
+
+  it("Account Login Azure Command Running Check - Success - V2", async () => {
+    mockedEnvRestore = mockedEnv({ TEAMSFX_V3: "false" });
+    sandbox.stub(AzureTokenProvider, "signout");
+    sandbox.stub(AzureTokenProvider, "getJsonObject").resolves({ upn: "Azure@xxx.com" });
+    sandbox.stub(AzureTokenProvider, "listSubscriptions").resolves([]);
+    const cmd = new AzureLogin();
+    await cmd!.runCommand({});
+    expect(messages).to.be.lengthOf(3);
   });
 
   it("Account Login Azure Command Running Check - Failed", async () => {
+    sandbox.stub(AzureTokenProvider, "signout");
+    sandbox.stub(AzureTokenProvider, "getJsonObject").resolves(undefined);
     const cmd = new AzureLogin();
-    await cmd!.handler({});
-    expect(loglevels).deep.equals([LogLevel.Error]);
+    await cmd!.runCommand({});
+    expect(messages).to.be.lengthOf(1);
   });
 
   it("Account Login M365 Command Running Check - Success", async () => {
+    sandbox.stub(M365TokenProvider, "signout");
+    sandbox.stub(M365TokenProvider, "getJsonObject").resolves(ok({ upn: "M365@xxx.com" }));
     const cmd = new M365Login();
-    await cmd!.handler({});
-    expect(loglevels).deep.equals([LogLevel.Info]);
+    await cmd!.runCommand({});
+    expect(messages).to.be.lengthOf(2);
+  });
+
+  it("Account Login M365 Command Running Check - Success - V2", async () => {
+    mockedEnvRestore = mockedEnv({ TEAMSFX_V3: "false" });
+    sandbox.stub(M365TokenProvider, "signout");
+    sandbox.stub(M365TokenProvider, "getJsonObject").resolves(ok({ upn: "M365@xxx.com" }));
+    const cmd = new M365Login();
+    await cmd!.runCommand({});
+    expect(messages).to.be.lengthOf(1);
   });
 
   it("Account Login M365 Command Running Check - Failed", async () => {
+    sandbox.stub(M365TokenProvider, "signout");
+    sandbox.stub(M365TokenProvider, "getJsonObject").resolves(err(ConfigNotFoundError("test")));
     const cmd = new M365Login();
-    await cmd!.handler({});
-    expect(loglevels).deep.equals([LogLevel.Error]);
+    await cmd!.runCommand({});
+    expect(messages).to.be.lengthOf(1);
   });
 
   it("Account Logout Azure Command Running Check - Success", async () => {
+    sandbox.stub(AzureTokenProvider, "signout").resolves(true);
     const cmd = new Account();
     const logout = cmd.subCommands.find((cmd) => cmd.commandHead === "logout");
-    await logout!.handler({ service: "azure" });
-    expect(loglevels).deep.equals([LogLevel.Info]);
+    await logout!.runCommand({ service: "azure" });
+    expect(messages).to.be.lengthOf(1);
   });
 
   it("Account Logout Azure Command Running Check - Failed", async () => {
+    sandbox.stub(AzureTokenProvider, "signout").resolves(false);
     const cmd = new Account();
     const logout = cmd.subCommands.find((cmd) => cmd.commandHead === "logout");
-    await logout!.handler({ service: "azure" });
-    expect(loglevels).deep.equals([LogLevel.Error]);
+    await logout!.runCommand({ service: "azure" });
+    expect(messages).to.be.lengthOf(1);
   });
 
   it("Account Logout M365 Command Running Check - Success", async () => {
+    sandbox.stub(AzureTokenProvider, "signout").resolves(true);
     const cmd = new Account();
     const logout = cmd.subCommands.find((cmd) => cmd.commandHead === "logout");
-    await logout!.handler({ service: "m365" });
-    expect(loglevels).deep.equals([LogLevel.Info]);
+    await logout!.runCommand({ service: "m365" });
+    expect(messages).to.be.lengthOf(1);
   });
 
   it("Account Logout M365 Command Running Check - Failed", async () => {
+    sandbox.stub(AzureTokenProvider, "signout").resolves(false);
     const cmd = new Account();
     const logout = cmd.subCommands.find((cmd) => cmd.commandHead === "logout");
-    await logout!.handler({ service: "m365" });
-    expect(loglevels).deep.equals([LogLevel.Error]);
+    await logout!.runCommand({ service: "m365" });
+    expect(messages).to.be.lengthOf(1);
   });
 
   it("Account Set Subscription Command Running Check - Success", async () => {
+    mockedEnvRestore = mockedEnv({ TEAMSFX_V3: "false" });
+    sandbox.stub(Utils, "setSubscriptionId").resolves(ok(null));
+    sandbox.stub(AzureTokenProvider, "getJsonObject").resolves({ upn: "Azure@xxx.com" });
+    sandbox.stub(AzureTokenProvider, "listSubscriptions").resolves([]);
     const cmd = new Account();
     const set = cmd.subCommands.find((cmd) => cmd.commandHead === "set");
-    await set!.handler({});
+    await set!.runCommand({});
+    expect(messages).to.be.lengthOf(3);
   });
 
   it("Account Set Subscription Command Running Check - Failed", async () => {
+    mockedEnvRestore = mockedEnv({ TEAMSFX_V3: "false" });
+    sandbox.stub(Utils, "setSubscriptionId").resolves(err(NotFoundSubscriptionId()));
     const cmd = new Account();
     const set = cmd.subCommands.find((cmd) => cmd.commandHead === "set");
-    try {
-      await set!.handler({ subscription: "fake" });
-      throw new Error("Should throw an error.");
-    } catch (e) {
-      expect(e).instanceOf(UserError);
-      expect(e.name).equals("NotFoundSubscriptionId");
-    }
+    const result = await set!.runCommand({});
+    expect(result.isErr()).to.be.true;
   });
 });

--- a/packages/cli/tests/unit/cmds/env.tests.ts
+++ b/packages/cli/tests/unit/cmds/env.tests.ts
@@ -215,7 +215,7 @@ describe("Env Add Command Tests", function () {
       // Assert
       expect(error).instanceOf(UserError);
       expect(error.name).equals("ProjectEnvAlreadyExistError");
-      expect(vars.value.logs).to.equal(
+      expect(vars.value.logs).to.contain(
         "Core.ProjectEnvAlreadyExistError: Project environment dev already exists.\n"
       );
     }
@@ -242,7 +242,7 @@ describe("Env Add Command Tests", function () {
       // Assert
       expect(error).instanceOf(UserError);
       expect(error.name).equals("InvalidEnvNameError");
-      expect(vars.value.logs).to.equal(
+      expect(vars.value.logs).to.contain(
         "Core.InvalidEnvNameError: Environment name can only contain letters, digits, _ and -.\n"
       );
     }
@@ -271,7 +271,7 @@ describe("Env Add Command Tests", function () {
       // Assert
       expect(error).instanceOf(UserError);
       expect(error.name).equals("MockCreateEnvError");
-      expect(vars.value.logs).to.equal("CLII.MockCreateEnvError: mock createEnv error\n");
+      expect(vars.value.logs).to.contain("CLII.MockCreateEnvError: mock createEnv error\n");
     }
 
     expect(exceptionThrown).to.be.true;

--- a/packages/cli/tests/unit/cmds/env.tests.ts
+++ b/packages/cli/tests/unit/cmds/env.tests.ts
@@ -93,6 +93,18 @@ function mockCommonUtils(sandbox: SinonSandbox, vars: Reference<MockVars>) {
   sandbox.stub(LogProvider, "necessaryLog").callsFake((level: LogLevel, message: string) => {
     vars.value.logs += message + "\n";
   });
+
+  sandbox.stub(LogProvider, "outputInfo").callsFake((message: string) => {
+    vars.value.logs += message + "\n";
+  });
+
+  sandbox.stub(LogProvider, "outputSuccess").callsFake((message: string) => {
+    vars.value.logs += message + "\n";
+  });
+
+  sandbox.stub(LogProvider, "outputError").callsFake((message: string) => {
+    vars.value.logs += message + "\n";
+  });
 }
 
 describe("Env Add Command Tests", function () {
@@ -204,7 +216,7 @@ describe("Env Add Command Tests", function () {
       expect(error).instanceOf(UserError);
       expect(error.name).equals("ProjectEnvAlreadyExistError");
       expect(vars.value.logs).to.equal(
-        "[Core.ProjectEnvAlreadyExistError]: Project environment dev already exists.\n"
+        "Core.ProjectEnvAlreadyExistError: Project environment dev already exists.\n"
       );
     }
 
@@ -231,7 +243,7 @@ describe("Env Add Command Tests", function () {
       expect(error).instanceOf(UserError);
       expect(error.name).equals("InvalidEnvNameError");
       expect(vars.value.logs).to.equal(
-        "[Core.InvalidEnvNameError]: Environment name can only contain letters, digits, _ and -.\n"
+        "Core.InvalidEnvNameError: Environment name can only contain letters, digits, _ and -.\n"
       );
     }
 
@@ -259,7 +271,7 @@ describe("Env Add Command Tests", function () {
       // Assert
       expect(error).instanceOf(UserError);
       expect(error.name).equals("MockCreateEnvError");
-      expect(vars.value.logs).to.equal("[CLII.MockCreateEnvError]: mock createEnv error\n");
+      expect(vars.value.logs).to.equal("CLII.MockCreateEnvError: mock createEnv error\n");
     }
 
     expect(exceptionThrown).to.be.true;

--- a/packages/cli/tests/unit/cmds/preview/previewEnv.tests.ts
+++ b/packages/cli/tests/unit/cmds/preview/previewEnv.tests.ts
@@ -57,6 +57,15 @@ describe("Preview --env", () => {
     sandbox.stub(cliLogger, "necessaryLog").callsFake((lv, msg, white) => {
       logs.push(msg);
     });
+    sandbox.stub(cliLogger, "outputInfo").callsFake((message: string) => {
+      logs.push(message);
+    });
+    sandbox.stub(cliLogger, "outputError").callsFake((message: string) => {
+      logs.push(message);
+    });
+    sandbox.stub(cliLogger, "outputSuccess").callsFake((message: string) => {
+      logs.push(message);
+    });
     sandbox.stub(cliTelemetry, "sendTelemetryEvent").callsFake((eventName, properties) => {
       telemetries.push([eventName, properties]);
     });

--- a/packages/cli/tests/unit/colorize.tests.ts
+++ b/packages/cli/tests/unit/colorize.tests.ts
@@ -13,7 +13,6 @@ describe("colorize", () => {
 
   beforeEach(() => {
     sandox.stub(ScreenManager, "writeLine").callsFake((msg: string) => (message += msg));
-    sandox.stub(process.stdout, "isTTY").returns(true);
   });
 
   afterEach(() => {

--- a/packages/cli/tests/unit/colorize.tests.ts
+++ b/packages/cli/tests/unit/colorize.tests.ts
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { expect } from "chai";
+import "mocha";
+import sinon from "sinon";
+import { TextType, colorize, replaceTemplateString } from "../../src/colorize";
+import ScreenManager from "../../src/console/screen";
+
+describe("colorize", () => {
+  const sandox = sinon.createSandbox();
+  let message = "";
+
+  beforeEach(() => {
+    sandox.stub(ScreenManager, "writeLine").callsFake((msg: string) => (message += msg));
+  });
+
+  afterEach(() => {
+    sandox.restore();
+    message = "";
+  });
+
+  it("colorize - Success", async () => {
+    colorize("test", TextType.Success);
+  });
+
+  it("colorize - Error", async () => {
+    colorize("test", TextType.Error);
+  });
+
+  it("colorize - Warning", async () => {
+    colorize("test", TextType.Warning);
+  });
+
+  it("colorize - Info", async () => {
+    colorize("test", TextType.Info);
+  });
+
+  it("colorize - Hyperlink", async () => {
+    colorize("test", TextType.Hyperlink);
+  });
+
+  it("colorize - Email", async () => {
+    colorize("test", TextType.Email);
+  });
+
+  it("colorize - Important", async () => {
+    colorize("test", TextType.Important);
+  });
+
+  it("colorize - Details", async () => {
+    colorize("test", TextType.Details);
+  });
+
+  it("replace template string", async () => {
+    const template = "test %s";
+    const result = replaceTemplateString(template, "test");
+    expect(result).to.equal("test test");
+  });
+});

--- a/packages/cli/tests/unit/colorize.tests.ts
+++ b/packages/cli/tests/unit/colorize.tests.ts
@@ -13,6 +13,7 @@ describe("colorize", () => {
 
   beforeEach(() => {
     sandox.stub(ScreenManager, "writeLine").callsFake((msg: string) => (message += msg));
+    sandox.stub(process.stdout, "isTTY").returns(true);
   });
 
   afterEach(() => {

--- a/packages/cli/tests/unit/commonlib/log.tests.ts
+++ b/packages/cli/tests/unit/commonlib/log.tests.ts
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { LogLevel } from "@microsoft/teamsfx-api";
+import { expect } from "chai";
+import "mocha";
+import sinon from "sinon";
+import { CLILogProvider } from "../../../src/commonlib/log";
+import ScreenManager from "../../../src/console/screen";
+import { CLILogLevel } from "../../../src/constants";
+
+describe("CLILogProvider", () => {
+  const logger = new CLILogProvider();
+  logger.setLogLevel(CLILogLevel.debug);
+  const sandox = sinon.createSandbox();
+  let message = "";
+
+  beforeEach(() => {
+    sandox.stub(ScreenManager, "writeLine").callsFake((msg: string) => (message += msg));
+  });
+
+  afterEach(() => {
+    sandox.restore();
+    message = "";
+  });
+
+  it("Log - Trace", async () => {
+    await logger.trace("trace");
+    expect(message).to.contain("trace");
+  });
+
+  it("Log - Debug", async () => {
+    await logger.debug("debug");
+    expect(message).to.contain("debug");
+  });
+
+  it("Log - Info", async () => {
+    await logger.debug("info");
+    expect(message).to.contain("info");
+  });
+
+  it("Log - Warning", async () => {
+    await logger.debug("warning");
+    expect(message).to.contain("warning");
+  });
+
+  it("Log - Error", async () => {
+    await logger.debug("error");
+    expect(message).to.contain("error");
+  });
+
+  it("Log - Fatal", async () => {
+    await logger.debug("fatal");
+    expect(message).to.contain("fatal");
+  });
+
+  it("OutputSuccess", async () => {
+    logger.outputSuccess("success");
+    expect(message).to.contain("success");
+  });
+
+  it("NecessaryLog - Trace", async () => {
+    logger.necessaryLog(LogLevel.Trace, "trace");
+    expect(message).to.contain("trace");
+  });
+
+  it("NecessaryLog - Debug", async () => {
+    logger.necessaryLog(LogLevel.Debug, "debug");
+    expect(message).to.contain("debug");
+  });
+
+  it("NecessaryLog - Info", async () => {
+    logger.necessaryLog(LogLevel.Info, "info");
+    expect(message).to.contain("info");
+  });
+
+  it("NecessaryLog - Info - White", async () => {
+    logger.necessaryLog(LogLevel.Info, "info", true);
+    expect(message).to.contain("info");
+  });
+
+  it("NecessaryLog - Warning", async () => {
+    logger.necessaryLog(LogLevel.Warning, "warning");
+    expect(message).to.contain("warning");
+  });
+
+  it("NecessaryLog - Error", async () => {
+    logger.necessaryLog(LogLevel.Error, "error");
+    expect(message).to.contain("error");
+  });
+
+  it("NecessaryLog - Fatal", async () => {
+    logger.necessaryLog(LogLevel.Fatal, "fatal");
+    expect(message).to.contain("fatal");
+  });
+});

--- a/packages/cli/tests/unit/yargsCommand.tests.ts
+++ b/packages/cli/tests/unit/yargsCommand.tests.ts
@@ -68,7 +68,8 @@ describe("Yargs Command Tests", function () {
         allArguments.set(key, args[key]);
       }
     });
-    sandbox.stub(LogProvider, "necessaryLog").returns();
+    sandbox.stub(LogProvider, "outputInfo").returns();
+    sandbox.stub(LogProvider, "outputSuccess").returns();
     sandbox.stub(environmentManager, "listAllEnvConfigs").resolves(ok(["dev", "local"]));
     CLIUIInstance.interactive = false;
     telemetryEvents = [];


### PR DESCRIPTION
Fix the error message occurred in https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/17981062.

![image](https://user-images.githubusercontent.com/15262146/233575238-bf943f04-2443-47a9-b899-8b63a20409f6.png)

Discussed with Ellie, refactor the CLI color (success/error/warn/info/importance message).

![image](https://user-images.githubusercontent.com/15262146/233575575-19e49f06-bb9f-4913-b390-1f718c3abf4a.png)
![image](https://user-images.githubusercontent.com/15262146/233575651-faadfb57-6daf-495b-82a6-062ed5dc0c0c.png)
![image](https://user-images.githubusercontent.com/15262146/233575705-0e94a021-68b4-4f93-b784-67e3d80eef58.png)
