### PR TITLE
feat(sdk): notification sdk enhancement for .NET

### DIFF
--- a/packages/dotnet-sdk/src/TeamsFx.Test/Conversation/DefaultConversationReferenceStoreTest.cs
+++ b/packages/dotnet-sdk/src/TeamsFx.Test/Conversation/DefaultConversationReferenceStoreTest.cs
@@ -1,0 +1,167 @@
+﻿namespace Microsoft.TeamsFx.Test.Conversation
+{
+    using Microsoft.Bot.Schema;
+    using Microsoft.TeamsFx.Conversation;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using System;
+    using System.Threading.Tasks;
+
+    [Obsolete]
+    internal class DefaultConversationReferenceStoreTest
+    {
+        private readonly InMemoryStorage _storage;
+        private readonly DefaultConversationReferenceStore _store;
+
+        public DefaultConversationReferenceStoreTest()
+        {
+            _storage = new InMemoryStorage();
+            _store = new DefaultConversationReferenceStore(_storage);
+        }
+
+        [TestMethod]
+        public async Task Add_NonExistItem()
+        {
+            var storage = new InMemoryStorage();
+            var store = new DefaultConversationReferenceStore(storage);
+
+            const string key = "key";
+            const string activityId = "add_nonexistitem";
+            var reference = new ConversationReference
+            {
+                ActivityId = activityId
+            };
+            var isAdded = await store.Add(key, reference, new ConversationReferenceStoreAddOptions { });
+
+            Assert.IsTrue(isAdded);
+            Assert.Equals(activityId, storage.Items[key].ActivityId);
+        }
+
+        [TestMethod]
+        public async Task Add_OverwriteExistItem()
+        {
+            var storage = new InMemoryStorage();
+            var store = new DefaultConversationReferenceStore(storage);
+
+            const string key = "key";
+            const string oldActivityId = "add_existitem_old";
+            const string newActivityId = "add_existitem_new";
+
+            storage.Items[key] = new ConversationReference
+            {
+                ActivityId = oldActivityId
+            };
+
+            var reference = new ConversationReference
+            {
+                ActivityId = newActivityId
+            };
+            var isAdded = await store.Add(key, reference, new ConversationReferenceStoreAddOptions { Overwrite = true });
+
+            Assert.IsTrue(isAdded);
+            Assert.Equals(newActivityId, storage.Items[key].ActivityId);
+        }
+
+        [TestMethod]
+        public async Task Add_NotOverwriteExistItem()
+        {
+            var storage = new InMemoryStorage();
+            var store = new DefaultConversationReferenceStore(storage);
+
+            const string key = "key";
+            const string oldActivityId = "add_existitem_old";
+            const string newActivityId = "add_existitem_new";
+
+            storage.Items[key] = new ConversationReference
+            {
+                ActivityId = oldActivityId
+            };
+
+            var reference = new ConversationReference
+            {
+                ActivityId = newActivityId
+            };
+            var isAdded = await store.Add(key, reference, new ConversationReferenceStoreAddOptions { Overwrite = false });
+
+            Assert.IsFalse(isAdded);
+            Assert.Equals(oldActivityId, storage.Items[key].ActivityId);
+        }
+
+        [TestMethod]
+        public async Task Add_NotOverwriteExistItemByDefault()
+        {
+            var storage = new InMemoryStorage();
+            var store = new DefaultConversationReferenceStore(storage);
+
+            const string key = "key";
+            const string oldActivityId = "add_existitem_old";
+            const string newActivityId = "add_existitem_new";
+
+            storage.Items[key] = new ConversationReference
+            {
+                ActivityId = oldActivityId
+            };
+
+            var reference = new ConversationReference
+            {
+                ActivityId = newActivityId
+            };
+            var isAdded = await store.Add(key, reference, new ConversationReferenceStoreAddOptions { });
+
+            Assert.IsFalse(isAdded);
+            Assert.Equals(oldActivityId, storage.Items[key].ActivityId);
+        }
+
+        [TestMethod]
+        public async Task Remove_ExistItem()
+        {
+            var storage = new InMemoryStorage();
+            var store = new DefaultConversationReferenceStore(storage);
+
+            const string key = "key";
+            const string activityId = "remove_existitem";
+
+            var reference = new ConversationReference
+            {
+                ActivityId = activityId
+            };
+            storage.Items[key] = reference;
+
+            var isRemoved = await store.Remove(key, reference);
+            Assert.IsTrue(isRemoved);
+            Assert.IsTrue(!storage.Items.ContainsKey(key));
+        }
+
+        [TestMethod]
+        public async Task Remove_NonExistItem()
+        {
+            var storage = new InMemoryStorage();
+            var store = new DefaultConversationReferenceStore(storage);
+
+            const string key = "key";
+            const string activityId = "remove_existitem";
+
+            var reference = new ConversationReference
+            {
+                ActivityId = activityId
+            };
+
+            var isRemoved = await store.Remove(key, reference);
+            Assert.IsFalse(isRemoved);
+        }
+
+        [TestMethod]
+        public async Task List()
+        {
+            var storage = new InMemoryStorage();
+            var store = new DefaultConversationReferenceStore(storage);
+
+            storage.Items.Add("key1", new ConversationReference { ActivityId = "activity-1" });
+            storage.Items.Add("key2", new ConversationReference { ActivityId = "activity-2" });
+            storage.Items.Add("key3", new ConversationReference { ActivityId = "activity-3" });
+
+            var items = await store.List();
+            Assert.AreEqual(3, items.Data.Length);
+            Assert.IsNull(items.ContinuationToken);
+        }
+    }
+}

--- a/packages/dotnet-sdk/src/TeamsFx.Test/Conversation/InMemoryStorage.cs
+++ b/packages/dotnet-sdk/src/TeamsFx.Test/Conversation/InMemoryStorage.cs
@@ -3,6 +3,7 @@
     using Microsoft.Bot.Schema;
     using Microsoft.TeamsFx.Conversation;
 
+    [Obsolete]
     public sealed class InMemoryStorage : INotificationTargetStorage
     {
         public InMemoryStorage()

--- a/packages/dotnet-sdk/src/TeamsFx.Test/Conversation/LocalFileStorageTest.cs
+++ b/packages/dotnet-sdk/src/TeamsFx.Test/Conversation/LocalFileStorageTest.cs
@@ -6,6 +6,7 @@ namespace Microsoft.TeamsFx.Test.Conversation
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
+    [Obsolete]
     public class LocalFileStorageTest
     {
         private const string testDir = "./test-local";

--- a/packages/dotnet-sdk/src/TeamsFx.Test/Conversation/NotificationMiddlewareTest.cs
+++ b/packages/dotnet-sdk/src/TeamsFx.Test/Conversation/NotificationMiddlewareTest.cs
@@ -10,6 +10,7 @@
     using System.Text.Json;
 
     [TestClass]
+    [Obsolete]
     public class NotificationMiddlewareTest
     {
         private readonly InMemoryStorage _storage;
@@ -18,7 +19,8 @@
         public NotificationMiddlewareTest()
         {
             _storage = new InMemoryStorage();
-            _middleware = new NotificationMiddleware(_storage);
+            var store = new DefaultConversationReferenceStore(_storage);
+            _middleware = new NotificationMiddleware(store);
         }
 
         [TestMethod]
@@ -185,12 +187,12 @@
             await _middleware.OnTurnAsync(mockContext.Object, (ctx) => Task.CompletedTask, CancellationToken.None);
 
             Assert.AreEqual(1, _storage.Items.Count);
-            var reference = _storage.Items.GetValueOrDefault($"_a_{teamId}", null);
+            var reference = _storage.Items.GetValueOrDefault($"_a_{conversationId}", null);
             Assert.IsNotNull(reference);
             Assert.AreEqual(activityId, reference.ActivityId);
             Assert.AreEqual("x", reference.ChannelId);
             Assert.AreEqual("a", reference.Conversation.TenantId);
-            Assert.AreEqual(teamId, reference.Conversation.Id);
+            Assert.AreEqual(conversationId, reference.Conversation.Id);
         }
 
         [TestMethod]

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/DefaultConversationReferenceStore.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/DefaultConversationReferenceStore.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.TeamsFx.Conversation
+{
+    using Microsoft.Bot.Schema;
+
+    [Obsolete]
+    internal sealed class DefaultConversationReferenceStore : IConversationReferenceStore
+    {
+        private readonly INotificationTargetStorage _storage;
+
+        public DefaultConversationReferenceStore(INotificationTargetStorage storage)
+        {
+            _storage = storage;
+        }
+
+        public async Task<bool> Add(
+            string key,
+            ConversationReference reference,
+            ConversationReferenceStoreAddOptions options,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(key))
+            {
+                throw new ArgumentException($"{nameof(key)} can't be null or empty.");
+            }
+
+            if (reference == null)
+            {
+                throw new ArgumentNullException(nameof(reference));
+            }
+
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            var overwrite = options.Overwrite ?? false;
+            if (overwrite)
+            {
+                await _storage.Write(key, reference, cancellationToken).ConfigureAwait(false);
+                return true;
+            }
+
+            var result = await _storage.Read(key, cancellationToken).ConfigureAwait(false);
+            if (result == null)
+            {
+                await _storage.Write(key, reference, cancellationToken).ConfigureAwait(false);
+                return true;
+            }
+
+            return false;
+        }
+
+        public async Task<bool> Remove(
+            string key,
+            ConversationReference reference,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(key))
+            {
+                throw new ArgumentException($"{nameof(key)} can't be null or empty.");
+            }
+
+            if (reference == null)
+            {
+                throw new ArgumentNullException(nameof(reference));
+            }
+
+            var result = await _storage.Read(key, cancellationToken).ConfigureAwait(false);
+            if (result == null)
+            {
+                return false;
+            }
+
+            await _storage.Delete(key, cancellationToken).ConfigureAwait(false);
+            return true;
+        }
+
+        public async Task<PagedData<ConversationReference>> List(
+            int? pageSize = null,
+            string continuationToken = null,
+            CancellationToken cancellationToken = default)
+        {
+            var data = await _storage.List(cancellationToken).ConfigureAwait(false);
+            return new PagedData<ConversationReference> {
+                Data = data,
+                ContinuationToken = null,
+            };
+        }
+    }
+}

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/IConversationReferenceStore.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/IConversationReferenceStore.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.TeamsFx.Conversation
+{
+    using Microsoft.Bot.Schema;
+
+    /// <summary>
+    /// Interface for a store provider that manages notification target references.
+    /// </summary>
+    public interface IConversationReferenceStore
+    {
+        /// <summary>
+        /// Add a conversation reference to the store. If overwrite, update the existing one, otherwise add when not exist.
+        /// </summary>
+        /// <param name="key">The target key.</param>
+        /// <param name="reference">The conversation reference to be added.</param>
+        /// <param name="options">The options to add the conversation reference.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>true if added or updated, false if not changed.</returns>
+        public Task<bool> Add(
+            string key,
+            ConversationReference reference,
+            ConversationReferenceStoreAddOptions options,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Remove a conversation reference from the store.
+        /// </summary>
+        /// <param name="key">The target key.</param>
+        /// <param name="reference">The conversation reference to be removed.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>true if exist and removed, false if not changed.</returns>
+        public Task<bool> Remove(
+            string key,
+            ConversationReference reference,
+            CancellationToken cancellationToken = default);
+
+
+        /// <summary>
+        /// List stored conversation reference by page.
+        /// </summary>
+        /// <param name="pageSize">The page size.</param>
+        /// <param name="continuationToken">The continuation token.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A paged list of conversation references.</returns>
+        public Task<PagedData<ConversationReference>> List(
+            int? pageSize = default,
+            string continuationToken = default,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/IConversationReferenceStoreAddOptions.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/IConversationReferenceStoreAddOptions.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.TeamsFx.Conversation
+{
+    /// <summary>
+    /// The options to add a conversation reference.
+    /// </summary>
+    public class ConversationReferenceStoreAddOptions
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether to overwrite the existing conversation reference.
+        /// </summary>
+        public bool? Overwrite { get; set; }
+    }
+}

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/INotificationTargetStorage.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/INotificationTargetStorage.cs
@@ -5,6 +5,7 @@
     /// <summary>
     /// Interface for a storage provider that stores and retrieves notification target references.
     /// </summary>
+    [Obsolete($"Use {nameof(IConversationReferenceStore)} to customize the way to persist bot notification connections instead.")]
     public interface INotificationTargetStorage
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/LocalFileStorage.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/LocalFileStorage.cs
@@ -7,6 +7,7 @@ namespace Microsoft.TeamsFx.Conversation
 
     using Microsoft.Bot.Schema;
 
+    [Obsolete]
     internal sealed class LocalFileStorage : INotificationTargetStorage
     {
         private const string LocalFileName = ".notification.localstore.json";

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/NotificationOptions.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/NotificationOptions.cs
@@ -14,6 +14,30 @@ namespace Microsoft.TeamsFx.Conversation
         public string BotAppId { get; set; } = string.Empty;
 
         /// <summary>
+        /// An optional store to persist bot notification connections.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// If <c>Store</c> is not provided, a default local store will be used, which stores notification connections into:
+        /// </para>
+        /// <list type="bullet">
+        ///     <item>
+        ///         <description>"{$env:TEAMSFX_NOTIFICATION_LOCALSTORE_DIR}/.notification.localstore.json" if running locally.</description>
+        ///     </item>
+        ///     <item>
+        ///         <description>"{$env:TEMP}/.notification.localstore.json" if {$env:RUNNING_ON_AZURE} is set to "1".</description>
+        ///     </item>
+        ///     <item>
+        ///         <description>"{<see cref="Environment.CurrentDirectory"/>}/.notification.localstore.json" if all above environment variables are not set.</description>
+        ///     </item>
+        /// </list>
+        /// <para>
+        /// It's recommended to use your own shared store for production environment.
+        /// </para>
+        /// </remarks>
+        public IConversationReferenceStore Store { get; set; }
+
+        /// <summary>
         /// An optional storage to persist bot notification connections.
         /// </summary>
         /// <remarks>
@@ -35,6 +59,7 @@ namespace Microsoft.TeamsFx.Conversation
         /// It's recommended to use your own shared storage for production environment.
         /// </para>
         /// </remarks>
+        [Obsolete($"Use {nameof(Store)} to customize the way to persist bot notification connections instead.")]
         public INotificationTargetStorage Storage { get; set; }
     }
 }

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/NotificationOptions.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/NotificationOptions.cs
@@ -14,11 +14,11 @@ namespace Microsoft.TeamsFx.Conversation
         public string BotAppId { get; set; } = string.Empty;
 
         /// <summary>
-        /// An optional store to persist bot notification connections.
+        /// An optional store to persist bot notification target references.
         /// </summary>
         /// <remarks>
         /// <para>
-        /// If <c>Store</c> is not provided, a default local store will be used, which stores notification connections into:
+        /// If <c>Store</c> is not provided, a default local store will be used, which stores notification target references into:
         /// </para>
         /// <list type="bullet">
         ///     <item>
@@ -38,11 +38,11 @@ namespace Microsoft.TeamsFx.Conversation
         public IConversationReferenceStore Store { get; set; }
 
         /// <summary>
-        /// An optional storage to persist bot notification connections.
+        /// An optional storage to persist bot notification target references.
         /// </summary>
         /// <remarks>
         /// <para>
-        /// If <c>Storage</c> is not provided, a default local file storage will be used, which stores notification connections into:
+        /// If <c>Storage</c> is not provided, a default local file storage will be used, which stores notification target references into:
         /// </para>
         /// <list type="bullet">
         ///     <item>
@@ -59,7 +59,7 @@ namespace Microsoft.TeamsFx.Conversation
         /// It's recommended to use your own shared storage for production environment.
         /// </para>
         /// </remarks>
-        [Obsolete($"Use {nameof(Store)} to customize the way to persist bot notification connections instead.")]
+        [Obsolete($"Use {nameof(Store)} to customize the way to persist bot notification target references instead.")]
         public INotificationTargetStorage Storage { get; set; }
     }
 }

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/PagedData.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/PagedData.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.TeamsFx.Conversation
+{
+    /// <summary>
+    /// Represents a page of data.
+    /// </summary>
+    public class PagedData<T>
+    {
+        /// <summary>
+        /// Gets or sets the page of items.
+        /// </summary>
+        /// <value>
+        /// The array of items.
+        /// </value>
+        public T[] Data { get; set; } = Array.Empty<T>();
+
+        /// <summary>
+        /// Gets or sets a token for retrieving the next page of results.
+        /// </summary>
+        /// <value>
+        /// The Continuation Token to pass to get the next page of results.
+        /// </value>
+        public string ContinuationToken { get; set; }
+    }
+}

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/PagedData.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/PagedData.cs
@@ -21,6 +21,7 @@ namespace Microsoft.TeamsFx.Conversation
         /// </summary>
         /// <value>
         /// The Continuation Token to pass to get the next page of results.
+        /// Null or empty token means the page reaches the end.
         /// </value>
         public string ContinuationToken { get; set; }
     }


### PR DESCRIPTION
Work item: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/17902085/

Updates in this PR:
1. Add new interface `IConversationReferenceStore`.
2. Add new option `store` in `NotificationBot`.
3. Deprecate the interface `INotificationTargetStorage` and the option `storage` in `NotificationBot`.
4. Add new pagaination API `GetPagedInstallationsAsync`, `GetPagedMembersAsync`.
5. Deprecated API `GetMembersAsync`.
6. Add API `BuildTeamsBotInstallation`.

Incoming PR:
1. Bump new version. (after the 2.0.0 is released)
2. Update README and Change log.
3. Update templates.