### PR TITLE
fix: add local runtime configs to template

### DIFF
--- a/templates/scenarios/js/command-and-response/.localConfigs
+++ b/templates/scenarios/js/command-and-response/.localConfigs
@@ -1,0 +1,3 @@
+# A gitignored place holder file for local runtime configurations
+BOT_ID=
+BOT_PASSWORD=

--- a/templates/scenarios/js/dashboard-tab/.localConfigs
+++ b/templates/scenarios/js/dashboard-tab/.localConfigs
@@ -1,0 +1,6 @@
+# A gitignored place holder file for local runtime configurations
+BROWSER=none
+HTTPS=true
+PORT=
+SSL_CRT_FILE=
+SSL_KEY_FILE=

--- a/templates/scenarios/js/default-bot-message-extension/.localConfigs
+++ b/templates/scenarios/js/default-bot-message-extension/.localConfigs
@@ -1,0 +1,3 @@
+# A gitignored place holder file for local runtime configurations
+BOT_ID=
+BOT_PASSWORD=

--- a/templates/scenarios/js/default-bot/.localConfigs
+++ b/templates/scenarios/js/default-bot/.localConfigs
@@ -1,0 +1,3 @@
+# A gitignored place holder file for local runtime configurations
+BOT_ID=
+BOT_PASSWORD=

--- a/templates/scenarios/js/m365-message-extension/.localConfigs
+++ b/templates/scenarios/js/m365-message-extension/.localConfigs
@@ -1,0 +1,3 @@
+# A gitignored place holder file for local runtime configurations
+BOT_ID=
+BOT_PASSWORD=

--- a/templates/scenarios/js/m365-tab/.localConfigs
+++ b/templates/scenarios/js/m365-tab/.localConfigs
@@ -1,0 +1,6 @@
+# A gitignored place holder file for local runtime configurations
+BROWSER=none
+HTTPS=true
+PORT=
+SSL_CRT_FILE=
+SSL_KEY_FILE=

--- a/templates/scenarios/js/message-extension/.localConfigs
+++ b/templates/scenarios/js/message-extension/.localConfigs
@@ -1,0 +1,3 @@
+# A gitignored place holder file for local runtime configurations
+BOT_ID=
+BOT_PASSWORD=

--- a/templates/scenarios/js/non-sso-tab-default-bot/bot/.localConfigs
+++ b/templates/scenarios/js/non-sso-tab-default-bot/bot/.localConfigs
@@ -1,0 +1,3 @@
+# A gitignored place holder file for local runtime configurations
+BOT_ID=
+BOT_PASSWORD=

--- a/templates/scenarios/js/non-sso-tab-default-bot/tab/.localConfigs
+++ b/templates/scenarios/js/non-sso-tab-default-bot/tab/.localConfigs
@@ -1,0 +1,6 @@
+# A gitignored place holder file for local runtime configurations
+BROWSER=none
+HTTPS=true
+PORT=
+SSL_CRT_FILE=
+SSL_KEY_FILE=

--- a/templates/scenarios/js/non-sso-tab/.localConfigs
+++ b/templates/scenarios/js/non-sso-tab/.localConfigs
@@ -1,0 +1,6 @@
+# A gitignored place holder file for local runtime configurations
+BROWSER=none
+HTTPS=true
+PORT=
+SSL_CRT_FILE=
+SSL_KEY_FILE=

--- a/templates/scenarios/js/notification-http-timer-trigger/.localConfigs
+++ b/templates/scenarios/js/notification-http-timer-trigger/.localConfigs
@@ -1,0 +1,3 @@
+# A gitignored place holder file for local runtime configurations
+BOT_ID=
+BOT_PASSWORD=

--- a/templates/scenarios/js/notification-http-trigger/.localConfigs
+++ b/templates/scenarios/js/notification-http-trigger/.localConfigs
@@ -1,0 +1,3 @@
+# A gitignored place holder file for local runtime configurations
+BOT_ID=
+BOT_PASSWORD=

--- a/templates/scenarios/js/notification-restify/.localConfigs
+++ b/templates/scenarios/js/notification-restify/.localConfigs
@@ -1,0 +1,3 @@
+# A gitignored place holder file for local runtime configurations
+BOT_ID=
+BOT_PASSWORD=

--- a/templates/scenarios/js/notification-timer-trigger/.localConfigs
+++ b/templates/scenarios/js/notification-timer-trigger/.localConfigs
@@ -1,0 +1,3 @@
+# A gitignored place holder file for local runtime configurations
+BOT_ID=
+BOT_PASSWORD=

--- a/templates/scenarios/js/sso-tab/.localConfigs
+++ b/templates/scenarios/js/sso-tab/.localConfigs
@@ -1,0 +1,6 @@
+# A gitignored place holder file for local runtime configurations
+BROWSER=none
+HTTPS=true
+PORT=
+SSL_CRT_FILE=
+SSL_KEY_FILE=

--- a/templates/scenarios/js/workflow/.localConfigs
+++ b/templates/scenarios/js/workflow/.localConfigs
@@ -1,0 +1,3 @@
+# A gitignored place holder file for local runtime configurations
+BOT_ID=
+BOT_PASSWORD=

--- a/templates/scenarios/ts/command-and-response/.localConfigs
+++ b/templates/scenarios/ts/command-and-response/.localConfigs
@@ -1,0 +1,3 @@
+# A gitignored place holder file for local runtime configurations
+BOT_ID=
+BOT_PASSWORD=

--- a/templates/scenarios/ts/dashboard-tab/.localConfigs
+++ b/templates/scenarios/ts/dashboard-tab/.localConfigs
@@ -1,0 +1,6 @@
+# A gitignored place holder file for local runtime configurations
+BROWSER=none
+HTTPS=true
+PORT=
+SSL_CRT_FILE=
+SSL_KEY_FILE=

--- a/templates/scenarios/ts/default-bot-message-extension/.localConfigs
+++ b/templates/scenarios/ts/default-bot-message-extension/.localConfigs
@@ -1,0 +1,3 @@
+# A gitignored place holder file for local runtime configurations
+BOT_ID=
+BOT_PASSWORD=

--- a/templates/scenarios/ts/default-bot/.localConfigs
+++ b/templates/scenarios/ts/default-bot/.localConfigs
@@ -1,0 +1,3 @@
+# A gitignored place holder file for local runtime configurations
+BOT_ID=
+BOT_PASSWORD=

--- a/templates/scenarios/ts/m365-message-extension/.localConfigs
+++ b/templates/scenarios/ts/m365-message-extension/.localConfigs
@@ -1,0 +1,3 @@
+# A gitignored place holder file for local runtime configurations
+BOT_ID=
+BOT_PASSWORD=

--- a/templates/scenarios/ts/m365-tab/.localConfigs
+++ b/templates/scenarios/ts/m365-tab/.localConfigs
@@ -1,0 +1,6 @@
+# A gitignored place holder file for local runtime configurations
+BROWSER=none
+HTTPS=true
+PORT=
+SSL_CRT_FILE=
+SSL_KEY_FILE=

--- a/templates/scenarios/ts/message-extension/.localConfigs
+++ b/templates/scenarios/ts/message-extension/.localConfigs
@@ -1,0 +1,3 @@
+# A gitignored place holder file for local runtime configurations
+BOT_ID=
+BOT_PASSWORD=

--- a/templates/scenarios/ts/non-sso-tab-default-bot/bot/.localConfigs
+++ b/templates/scenarios/ts/non-sso-tab-default-bot/bot/.localConfigs
@@ -1,0 +1,3 @@
+# A gitignored place holder file for local runtime configurations
+BOT_ID=
+BOT_PASSWORD=

--- a/templates/scenarios/ts/non-sso-tab-default-bot/tab/.localConfigs
+++ b/templates/scenarios/ts/non-sso-tab-default-bot/tab/.localConfigs
@@ -1,0 +1,6 @@
+# A gitignored place holder file for local runtime configurations
+BROWSER=none
+HTTPS=true
+PORT=
+SSL_CRT_FILE=
+SSL_KEY_FILE=

--- a/templates/scenarios/ts/non-sso-tab/.localConfigs
+++ b/templates/scenarios/ts/non-sso-tab/.localConfigs
@@ -1,0 +1,6 @@
+# A gitignored place holder file for local runtime configurations
+BROWSER=none
+HTTPS=true
+PORT=
+SSL_CRT_FILE=
+SSL_KEY_FILE=

--- a/templates/scenarios/ts/notification-http-timer-trigger/.localConfigs
+++ b/templates/scenarios/ts/notification-http-timer-trigger/.localConfigs
@@ -1,0 +1,3 @@
+# A gitignored place holder file for local runtime configurations
+BOT_ID=
+BOT_PASSWORD=

--- a/templates/scenarios/ts/notification-http-trigger/.localConfigs
+++ b/templates/scenarios/ts/notification-http-trigger/.localConfigs
@@ -1,0 +1,3 @@
+# A gitignored place holder file for local runtime configurations
+BOT_ID=
+BOT_PASSWORD=

--- a/templates/scenarios/ts/notification-restify/.localConfigs
+++ b/templates/scenarios/ts/notification-restify/.localConfigs
@@ -1,0 +1,3 @@
+# A gitignored place holder file for local runtime configurations
+BOT_ID=
+BOT_PASSWORD=

--- a/templates/scenarios/ts/notification-timer-trigger/.localConfigs
+++ b/templates/scenarios/ts/notification-timer-trigger/.localConfigs
@@ -1,0 +1,3 @@
+# A gitignored place holder file for local runtime configurations
+BOT_ID=
+BOT_PASSWORD=

--- a/templates/scenarios/ts/sso-tab/.localConfigs
+++ b/templates/scenarios/ts/sso-tab/.localConfigs
@@ -1,0 +1,6 @@
+# A gitignored place holder file for local runtime configurations
+BROWSER=none
+HTTPS=true
+PORT=
+SSL_CRT_FILE=
+SSL_KEY_FILE=

--- a/templates/scenarios/ts/workflow/.localConfigs
+++ b/templates/scenarios/ts/workflow/.localConfigs
@@ -1,0 +1,3 @@
+# A gitignored place holder file for local runtime configurations
+BOT_ID=
+BOT_PASSWORD=


### PR DESCRIPTION
Fix https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/17945814/

To keep the same behavior as V4 `.env.teamsfx.local`, generating `.localConfigs` place holder file in template.

E2E TEST: https://github.com/OfficeDev/TeamsFx/blob/dev/packages/cli/tests/e2e/debug/DebugSsoTab.tests.ts