### PR TITLE
fix(localdebug): migrate fx-extension.get-func-path to func path + fx-extension.get-path-delimiter

### DIFF
--- a/packages/fx-core/src/core/middleware/projectMigratorV3.ts
+++ b/packages/fx-core/src/core/middleware/projectMigratorV3.ts
@@ -93,6 +93,7 @@ import {
   migrateBackendStart,
   migratePreDebugCheck,
   migrateInstallAppInTeams,
+  migrateGetFuncPathCommand,
 } from "./utils/debug/taskMigrator";
 import { AppLocalYmlGenerator } from "./utils/debug/appLocalYmlGenerator";
 import { EOL } from "os";
@@ -853,6 +854,7 @@ export async function debugMigration(context: MigrationContext): Promise<void> {
     migrateValidateLocalPrerequisites,
     migrateNgrokStartTask,
     migrateNgrokStartCommand,
+    migrateGetFuncPathCommand,
   ];
 
   const oldProjectSettings = await loadProjectSettings(context.projectPath);

--- a/packages/fx-core/tests/core/middleware/debug/taskMigrator.test.ts
+++ b/packages/fx-core/tests/core/middleware/debug/taskMigrator.test.ts
@@ -2003,7 +2003,7 @@ describe("debugMigration", () => {
         "osx": {
           "options": {
             "env": {
-                "path": "\${workspaceFolder}/devTools/func\${command:fx-extension.get-path-delimiter}\${env:path}\${workspaceFolder}/devTools/func\${command:fx-extension.get-path-delimiter}"
+                "path": "\${workspaceFolder}/devTools/func\${command:fx-extension.get-path-delimiter}\${env:path}\${command:fx-extension.get-path-delimiter}\${workspaceFolder}/devTools/func\${command:fx-extension.get-path-delimiter}"
             }
           }
         }

--- a/packages/fx-core/tests/core/middleware/debug/taskMigrator.test.ts
+++ b/packages/fx-core/tests/core/middleware/debug/taskMigrator.test.ts
@@ -18,6 +18,7 @@ import {
   migrateBackendWatch,
   migrateFrontendStart,
   migrateBackendStart,
+  migrateGetFuncPathCommand,
 } from "../../../../src/core/middleware/utils/debug/taskMigrator";
 import { CommentArray, CommentJSONValue, parse, stringify } from "comment-json";
 import { DebugMigrationContext } from "../../../../src/core/middleware/utils/debug/debugMigrationContext";
@@ -1874,6 +1875,153 @@ describe("debugMigration", () => {
       );
       migrateNgrokStartCommand(debugContext);
       chai.assert.equal(stringify(debugContext.tasks, null, 4), stringify(expectedTasks, null, 4));
+    });
+  });
+
+  describe("migrateGetFuncPathCommand", () => {
+    it("happy path", async () => {
+      const migrationContext = await mockMigrationContext(projectPath);
+      const testTaskContent = `[
+        {
+            "label": "Start bot",
+            "type": "shell",
+            "command": "npm run dev:teamsfx",
+            "isBackground": true,
+            "options": {
+                "cwd": "\${workspaceFolder}/bot",
+                "env": {
+                    "PATH": "\${command:fx-extension.get-func-path}\${env:PATH}"
+                }
+            },
+            "problemMatcher": {
+                "pattern": {
+                    "regexp": "^.*$",
+                    "file": 0,
+                    "location": 1,
+                    "message": 2
+                },
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": "^.*(Job host stopped|signaling restart).*$",
+                    "endsPattern": "^.*(Worker process started and initialized|Host lock lease acquired by instance ID).*$"
+                }
+            },
+            "dependsOn": [
+                "Start Azurite emulator",
+                "Watch bot"
+            ]
+        },
+        {
+          "label": "Customized path",
+          "type": "shell",
+          "command": "npm run dev:teamsfx",
+          "isBackground": true,
+          "options": {
+              "cwd": "\${workspaceFolder}/bot",
+              "env": {
+                  "PATH": "\${command:fx-extension.get-func-path}\${env:PATH}"
+              }
+          },
+          "windows": {
+            "options": {
+              "env": {
+                  "PATH": "\${env:PATH}\${command:fx-extension.get-func-path}"
+              }
+            }
+          },
+          "linux": {
+            "options": {
+              "env": {
+                  "PATH": "\${command:fx-extension.get-func-path}"
+              }
+            }
+          },
+          "osx": {
+            "options": {
+              "env": {
+                  "path": "\${command:fx-extension.get-func-path}\${env:path}\${command:fx-extension.get-func-path}"
+              }
+            }
+          }
+        }
+      ]`;
+      const expectedTaskContent = `[
+        {
+          "label": "Start bot",
+          "type": "shell",
+          "command": "npm run dev:teamsfx",
+          "isBackground": true,
+          "options": {
+              "cwd": "\${workspaceFolder}/bot",
+              "env": {
+                  "PATH": "\${workspaceFolder}/devTools/func\${command:fx-extension.get-path-delimiter}\${env:PATH}"
+              }
+          },
+          "problemMatcher": {
+              "pattern": {
+                  "regexp": "^.*$",
+                  "file": 0,
+                  "location": 1,
+                  "message": 2
+              },
+              "background": {
+                  "activeOnStart": true,
+                  "beginsPattern": "^.*(Job host stopped|signaling restart).*$",
+                  "endsPattern": "^.*(Worker process started and initialized|Host lock lease acquired by instance ID).*$"
+              }
+          },
+          "dependsOn": [
+              "Start Azurite emulator",
+              "Watch bot"
+          ]
+      },
+      {
+        "label": "Customized path",
+        "type": "shell",
+        "command": "npm run dev:teamsfx",
+        "isBackground": true,
+        "options": {
+            "cwd": "\${workspaceFolder}/bot",
+            "env": {
+                "PATH": "\${workspaceFolder}/devTools/func\${command:fx-extension.get-path-delimiter}\${env:PATH}"
+            }
+        },
+        "windows": {
+          "options": {
+            "env": {
+                "PATH": "\${env:PATH}\${command:fx-extension.get-path-delimiter}\${workspaceFolder}/devTools/func\${command:fx-extension.get-path-delimiter}"
+            }
+          }
+        },
+        "linux": {
+          "options": {
+            "env": {
+                "PATH": "\${workspaceFolder}/devTools/func\${command:fx-extension.get-path-delimiter}"
+            }
+          }
+        },
+        "osx": {
+          "options": {
+            "env": {
+                "path": "\${workspaceFolder}/devTools/func\${command:fx-extension.get-path-delimiter}\${env:path}\${workspaceFolder}/devTools/func\${command:fx-extension.get-path-delimiter}"
+            }
+          }
+        }
+      }
+      ]`;
+      const testTasks = parse(testTaskContent) as CommentArray<CommentJSONValue>;
+      const oldProjectSettings = {} as ProjectSettings;
+      const debugContext = new DebugMigrationContext(
+        migrationContext,
+        testTasks,
+        oldProjectSettings,
+        {}
+      );
+      await migrateGetFuncPathCommand(debugContext);
+      chai.assert.equal(
+        stringify(testTasks, null, 4),
+        stringify(parse(expectedTaskContent), null, 4)
+      );
     });
   });
 });

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/V3.5.0-V4.0.6-notification-trigger/expected/tasks.json
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/V3.5.0-V4.0.6-notification-trigger/expected/tasks.json
@@ -106,7 +106,7 @@
             "options": {
                 "cwd": "${workspaceFolder}/bot",
                 "env": {
-                    "PATH": "${command:fx-extension.get-func-path}${env:PATH}"
+                    "PATH": "${workspaceFolder}/devTools/func${command:fx-extension.get-path-delimiter}${env:PATH}"
                 }
             },
             "dependsOn": [

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/V3.5.0-V4.0.6-tab-bot-func-node18/expected/tasks.json
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/V3.5.0-V4.0.6-tab-bot-func-node18/expected/tasks.json
@@ -121,7 +121,7 @@
             "options": {
                 "cwd": "${workspaceFolder}/api",
                 "env": {
-                    "PATH": "${command:fx-extension.get-func-path}${env:PATH}"
+                    "PATH": "${workspaceFolder}/devTools/func${command:fx-extension.get-path-delimiter}${env:PATH}"
                 }
             },
             "presentation": {

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/V3.5.0-V4.0.6-tab-bot-func/expected/tasks.json
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/V3.5.0-V4.0.6-tab-bot-func/expected/tasks.json
@@ -121,7 +121,7 @@
             "options": {
                 "cwd": "${workspaceFolder}/api",
                 "env": {
-                    "PATH": "${command:fx-extension.get-func-path}${env:PATH}"
+                    "PATH": "${workspaceFolder}/devTools/func${command:fx-extension.get-path-delimiter}${env:PATH}"
                 }
             },
             "presentation": {

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/beforeV3.4.0-tab-bot-func-node18/expected/tasks.json
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/beforeV3.4.0-tab-bot-func-node18/expected/tasks.json
@@ -176,7 +176,7 @@
             "options": {
                 "cwd": "${workspaceFolder}/api",
                 "env": {
-                    "PATH": "${command:fx-extension.get-func-path}${env:PATH}"
+                    "PATH": "${workspaceFolder}/devTools/func${command:fx-extension.get-path-delimiter}${env:PATH}"
                 }
             },
             "problemMatcher": {

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/beforeV3.4.0-tab-bot-func/expected/tasks.json
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/beforeV3.4.0-tab-bot-func/expected/tasks.json
@@ -176,7 +176,7 @@
             "options": {
                 "cwd": "${workspaceFolder}/api",
                 "env": {
-                    "PATH": "${command:fx-extension.get-func-path}${env:PATH}"
+                    "PATH": "${workspaceFolder}/devTools/func${command:fx-extension.get-path-delimiter}${env:PATH}"
                 }
             },
             "problemMatcher": {

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-notification-node18/expected/tasks.json
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-notification-node18/expected/tasks.json
@@ -92,7 +92,7 @@
             "options": {
                 "cwd": "${workspaceFolder}/bot",
                 "env": {
-                    "PATH": "${command:fx-extension.get-func-path}${env:PATH}"
+                    "PATH": "${workspaceFolder}/devTools/func${command:fx-extension.get-path-delimiter}${env:PATH}"
                 }
             },
             "problemMatcher": {

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-notification/expected/tasks.json
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-notification/expected/tasks.json
@@ -92,7 +92,7 @@
             "options": {
                 "cwd": "${workspaceFolder}/bot",
                 "env": {
-                    "PATH": "${command:fx-extension.get-func-path}${env:PATH}"
+                    "PATH": "${workspaceFolder}/devTools/func${command:fx-extension.get-path-delimiter}${env:PATH}"
                 }
             },
             "problemMatcher": {

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-tab-bot-func/expected/tasks.json
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-tab-bot-func/expected/tasks.json
@@ -119,7 +119,7 @@
             "options": {
                 "cwd": "${workspaceFolder}/api",
                 "env": {
-                    "PATH": "${command:fx-extension.get-func-path}${env:PATH}"
+                    "PATH": "${workspaceFolder}/devTools/func${command:fx-extension.get-path-delimiter}${env:PATH}"
                 }
             },
             "problemMatcher": {
@@ -179,7 +179,7 @@
             "options": {
                 "cwd": "${workspaceFolder}/bot",
                 "env": {
-                    "PATH": "${command:fx-extension.get-func-path}${env:PATH}"
+                    "PATH": "${workspaceFolder}/devTools/func${command:fx-extension.get-path-delimiter}${env:PATH}"
                 }
             },
             "problemMatcher": {

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -285,10 +285,11 @@ function registerInternalCommands(context: vscode.ExtensionContext) {
   context.subscriptions.push(backendExtensionsInstallCmd);
 
   // Referenced by tasks.json
-  const getFuncPathCmd = vscode.commands.registerCommand("fx-extension.get-func-path", () =>
-    Correlator.run(handlers.getFuncPathHandler)
+  const getPathDelimiterCmd = vscode.commands.registerCommand(
+    "fx-extension.get-path-delimiter",
+    () => Correlator.run(handlers.getPathDelimiterHandler)
   );
-  context.subscriptions.push(getFuncPathCmd);
+  context.subscriptions.push(getPathDelimiterCmd);
 
   const getDotnetPathCmd = vscode.commands.registerCommand("fx-extension.get-dotnet-path", () =>
     Correlator.run(handlers.getDotnetPathHandler)

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -1599,16 +1599,11 @@ export async function backendExtensionsInstallHandler(): Promise<string | undefi
 }
 
 /**
- * Get func binary path to be referenced by task definition.
- * Usage like ${command:...}${env:PATH} so need to include delimiter as well
+ * Get path delimiter
+ * Usage like ${workspaceFolder}/devTools/func${command:...}${env:PATH}
  */
-export async function getFuncPathHandler(): Promise<string> {
-  // TODO: remove this command
-  return globalVariables.workspaceUri?.fsPath
-    ? `${path.delimiter}${path.resolve(globalVariables.workspaceUri.fsPath, "./devTools/func")}${
-        path.delimiter
-      }`
-    : path.delimiter;
+export async function getPathDelimiterHandler(): Promise<string> {
+  return path.delimiter;
 }
 
 /**

--- a/packages/vscode-extension/test/extension/handlers.test.ts
+++ b/packages/vscode-extension/test/extension/handlers.test.ts
@@ -2008,25 +2008,9 @@ describe("handlers", () => {
     chai.expect(updateTreeViewsOnSPFxChanged.calledOnce).to.be.true;
   });
 
-  describe("getFuncPathHandler", () => {
-    const sandbox = sinon.createSandbox();
-
-    afterEach(() => {
-      sandbox.restore();
-    });
-
+  describe("getPathDelimiterHandler", () => {
     it("happy path", async () => {
-      sandbox.stub(globalVariables, "workspaceUri").value({ fsPath: "~/" });
-      const actualPath = await handlers.getFuncPathHandler();
-      chai.assert.equal(
-        actualPath,
-        `${path.delimiter}${path.resolve("~/devTools/func")}${path.delimiter}`
-      );
-    });
-
-    it("no workspace opened", async () => {
-      sandbox.stub(globalVariables, "workspaceUri").value({});
-      const actualPath = await handlers.getFuncPathHandler();
+      const actualPath = await handlers.getPathDelimiterHandler();
       chai.assert.equal(actualPath, path.delimiter);
     });
   });


### PR DESCRIPTION
related to https://github.com/OfficeDev/TeamsFx/pull/8482

migrate `${command:fx-extension.get-func-path}${env:PATH}` to be `${workspaceFolder}/devTools/func${command:fx-extension.get-path-delimiter}${env:PATH}`