### PR TITLE
fix(localdebug): update query portable func version

### DIFF
--- a/packages/fx-core/src/common/deps-checker/internal/funcToolChecker.ts
+++ b/packages/fx-core/src/common/deps-checker/internal/funcToolChecker.ts
@@ -286,15 +286,13 @@ export class FuncToolChecker implements DepsChecker {
 
   private async queryFuncVersion(funcBinFolder: string | undefined): Promise<FuncVersion | null> {
     try {
-      const env = funcBinFolder
-        ? { PATH: `${funcBinFolder}${path.delimiter}${process.env.PATH}` }
-        : undefined;
+      const execPath = funcBinFolder ? path.resolve(funcBinFolder, "func") : "func";
       const output = await cpUtils.executeCommand(
         undefined,
         undefined,
         // same as backend start, avoid powershell execution policy issue.
-        { shell: isWindows() ? "cmd.exe" : true, env },
-        "func",
+        { shell: isWindows() ? "cmd.exe" : true },
+        execPath,
         "--version"
       );
       return mapToFuncToolsVersion(output);

--- a/packages/fx-core/tests/common/deps-checker/funcToolChecker.test.ts
+++ b/packages/fx-core/tests/common/deps-checker/funcToolChecker.test.ts
@@ -868,15 +868,15 @@ describe("Func Tools Checker Test", () => {
               throw new Error("Mock node not installed.");
             }
             return `v${nodeVersion}`;
-          } else if (command === "func" && args.length == 1 && args[0] === "--version") {
-            if (!options?.env?.PATH) {
+          } else if (command.endsWith("func") && args.length == 1 && args[0] === "--version") {
+            if (command === "func") {
               // Mock query global func version
               if (!globalFuncVersion) {
                 throw new Error("Mock global func not installed.");
               }
               return globalFuncVersion;
             } else {
-              const funcBinPath = options.env.PATH.split(path.delimiter)[0];
+              const funcBinPath = path.dirname(command);
               return await mockGetVersion(funcBinPath);
             }
           } else if (command === "npm" && args.length == 1 && args[0] === "--version") {


### PR DESCRIPTION
 Avoid return the global func version when query the portable func version.