### PR TITLE
fix(localdebug): fix DebugNotificationHttpTrigger e2e test case

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -125,7 +125,13 @@ jobs:
 
       - name: Setup Azure Functions Core Tools For Linux
         run: |
-          sudo npm install --unsafe-perm -g azure-functions-core-tools@4
+          curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
+          sudo mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg
+          sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-$(lsb_release -cs)-prod $(lsb_release -cs) main" > /etc/apt/sources.list.d/dotnetdev.list'
+          sudo apt-get update
+          sudo apt-get install azure-functions-core-tools-4
+          which func
+          func --version
 
       - name: Setup legacy-peer-deps
         run: |


### PR DESCRIPTION
Fix the failure of DebugNotificationHttpTrigger e2e test case
https://github.com/OfficeDev/TeamsFx/actions/runs/4780617978/jobs/8499121943

Use `sudo npm install --unsafe-perm -g azure-functions-core-tools@4` can not correctly install func in github action.
The result of the test script
```
sudo npm install --unsafe-perm -g azure-functions-core-tools@4
which func
func --version
```
![image](https://user-images.githubusercontent.com/49138419/233970767-3d5ecc60-baae-4125-b5f0-0a3914cbeaf9.png)

Use the func installation script used in UI test instead.

Updated script result:
![image](https://user-images.githubusercontent.com/49138419/233974520-30f9c096-ac8a-4bc8-a165-fb7500edd618.png)
Run: https://github.com/OfficeDev/TeamsFx/actions/runs/4785254229/jobs/8507886126
