### PR TITLE
fix(sdk): exception when the bot is added twice

### DIFF
--- a/packages/dotnet-sdk/src/TeamsFx.Test/Conversation/LocalFileStorageTest.cs
+++ b/packages/dotnet-sdk/src/TeamsFx.Test/Conversation/LocalFileStorageTest.cs
@@ -44,5 +44,30 @@ namespace Microsoft.TeamsFx.Test.Conversation
             Assert.IsNotNull(list);
             Assert.AreEqual(0, list.Length);
         }
+
+        [TestMethod]
+        public async Task Add_NonExistingItem()
+        {
+            var storage = new LocalFileStorage(testDir);
+            await storage.Write("key-1", new ConversationReference { ActivityId = "activity-1" });
+
+            var list = await storage.List(CancellationToken.None);
+            Assert.IsNotNull(list);
+            Assert.AreEqual(1, list.Length);
+            Assert.AreEqual("activity-1", list[0].ActivityId);
+        }
+
+        [TestMethod]
+        public async Task Add_ExistingItem()
+        {
+            var storage = new LocalFileStorage(testDir);
+            await storage.Write("key-1", new ConversationReference { ActivityId = "activity-1" });
+            await storage.Write("key-1", new ConversationReference { ActivityId = "activity-2" });
+
+            var list = await storage.List(CancellationToken.None);
+            Assert.IsNotNull(list);
+            Assert.AreEqual(1, list.Length);
+            Assert.AreEqual("activity-2", list[0].ActivityId);
+        }
     }
 }

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/LocalFileStorage.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/LocalFileStorage.cs
@@ -56,7 +56,7 @@ namespace Microsoft.TeamsFx.Conversation
             else
             {
                 var allData = await ReadFromFile(cancellationToken).ConfigureAwait(false);
-                allData.Add(key, reference);
+                allData[key] = reference;
                 await WriteToFile(allData, cancellationToken).ConfigureAwait(false);
             }
         }


### PR DESCRIPTION
Error occurs when the same bot is added twice using the default local file storage in .NET SDK.

>
> The bot encountered an unhandled error: An item with the same key has already been added. Key: _7309892c-5bd2...