### PR TITLE
fix(vsc): not showing treeview when upgrade detects error

### DIFF
--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -46,6 +46,7 @@ import {
   isSPFxProject,
   isTeamsFxProject,
   setUriEventHandler,
+  unsetIsTeamsFxProject,
   workspaceUri,
 } from "./globalVariables";
 import * as handlers from "./handlers";
@@ -1028,10 +1029,12 @@ async function runBackgroundAsyncTasks(
 
 async function runTeamsFxBackgroundTasks() {
   const upgradeable = isV3Enabled() && (await checkProjectUpgradable());
-  await handlers.autoOpenProjectHandler();
-  await handlers.promptSPFxUpgrade();
-  await TreeViewManagerInstance.updateTreeViewsByContent(upgradeable);
-  await AzureAccountManager.updateSubscriptionInfo();
+  if (isTeamsFxProject) {
+    await handlers.autoOpenProjectHandler();
+    await handlers.promptSPFxUpgrade();
+    await TreeViewManagerInstance.updateTreeViewsByContent(upgradeable);
+    await AzureAccountManager.updateSubscriptionInfo();
+  }
 }
 
 function registerInCommandController(
@@ -1053,6 +1056,10 @@ function runCommand(commandName: string, args: unknown[]) {
 
 async function checkProjectUpgradable(): Promise<boolean> {
   const versionCheckResult = await handlers.projectVersionCheck();
+  if (versionCheckResult.isErr()) {
+    unsetIsTeamsFxProject();
+    return false;
+  }
   const upgradeable = versionCheckResult.isOk()
     ? versionCheckResult.value.isSupport == VersionState.upgradeable
     : false;
@@ -1077,6 +1084,8 @@ async function detectedTeamsFxProject(context: vscode.ExtensionContext) {
   }
 
   const upgradeable = await checkProjectUpgradable();
-  await vscode.commands.executeCommand("setContext", "fx-extension.canUpgradeV3", upgradeable);
-  await TreeViewManagerInstance.updateTreeViewsByContent(upgradeable);
+  if (isTeamsFxProject) {
+    await vscode.commands.executeCommand("setContext", "fx-extension.canUpgradeV3", upgradeable);
+    await TreeViewManagerInstance.updateTreeViewsByContent(upgradeable);
+  }
 }

--- a/packages/vscode-extension/src/globalVariables.ts
+++ b/packages/vscode-extension/src/globalVariables.ts
@@ -68,3 +68,8 @@ export function setUriEventHandler(uriHandler: UriHandler) {
 export function setCommandIsRunning(isRunning: boolean) {
   commandIsRunning = isRunning;
 }
+
+// Only used by checkProjectUpgradable() when error happens
+export function unsetIsTeamsFxProject() {
+  isTeamsFxProject = false;
+}

--- a/packages/vscode-extension/src/utils/commonUtils.ts
+++ b/packages/vscode-extension/src/utils/commonUtils.ts
@@ -132,7 +132,7 @@ export function getAppName(): string | undefined {
     const yamlFilPath = path.join(globalVariables.workspaceUri!.fsPath, "teamsapp.yml");
     try {
       const settings = yaml.parse(fs.readFileSync(yamlFilPath, "utf-8"));
-      for (const action of settings?.registerApp) {
+      for (const action of settings?.provision) {
         if (action?.uses === "teamsApp/create") {
           const name = action?.with?.name;
           if (name) {

--- a/packages/vscode-extension/test/extension/commonUtils.test.ts
+++ b/packages/vscode-extension/test/extension/commonUtils.test.ts
@@ -308,7 +308,7 @@ describe("CommonUtils", () => {
 
     it("get app name successfully - v3", () => {
       const ymlData = `# Triggered when 'teamsfx provision' is executed
-      registerApp:
+      provision:
         - uses: aadApp/create # Creates a new AAD app to authenticate users if AAD_APP_CLIENT_ID environment variable is empty
           with:
             name: appNameTest-aad

--- a/packages/vscode-extension/test/extension/commonUtils.test.ts
+++ b/packages/vscode-extension/test/extension/commonUtils.test.ts
@@ -325,6 +325,15 @@ describe("CommonUtils", () => {
       expect(res).equal("appNameTest");
     });
 
+    it("empty yml file - v3", () => {
+      sandbox.stub(globalVariables, "workspaceUri").value(Uri.file("test"));
+      sandbox.stub(fs, "readFileSync").returns("");
+      sandbox.stub(commonTools, "isV3Enabled").returns(true);
+
+      const res = commonUtils.getAppName();
+      expect(res).equal(undefined);
+    });
+
     it("throw exception - v3", () => {
       sandbox.stub(globalVariables, "workspaceUri").value(Uri.file("test"));
       sandbox.stub(fs, "readFileSync").throws();

--- a/packages/vscode-extension/test/extension/globalVariables.test.ts
+++ b/packages/vscode-extension/test/extension/globalVariables.test.ts
@@ -122,5 +122,12 @@ describe("Global Variables", () => {
       chai.expect(globalVariables.commandIsRunning).equals(true);
       sinon.restore();
     });
+
+    it("unsetIsTeamsFxProject()", async () => {
+      globalVariables.unsetIsTeamsFxProject();
+
+      chai.expect(globalVariables.isTeamsFxProject).equals(false);
+      sinon.restore();
+    });
   });
 });


### PR DESCRIPTION
1. Project name display bug.
2. Upgrade bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/19298436