### PR TITLE
fix: unify /validateManifest output

### DIFF
--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -938,6 +938,7 @@
   "driver.teamsApp.summary.copyAppPackageSuccess": "Teams app %s was successfully copied to %s.",
   "driver.teamsApp.summary.copyIconSuccess": "%s icon(s) were successfully updated under %s.",
   "driver.teamsApp.summary.validate": "Teams Toolkit has checked against all validation rules:\n\nSummary:\n%s.\n%s\n%s\n\nA complete log of validations can be found in %s",
+  "driver.teamsApp.summary.validateManifest": "Teams Toolkit has checked manifest with its schema:\n\nSummary:\n%s.\n%s\n",
   "driver.teamsApp.summary.validate.succeed": "%s passed",
   "driver.teamsApp.summary.validate.failed": "%s failed",
   "driver.teamsApp.summary.validate.warning": "%s warning",

--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -942,6 +942,7 @@
   "driver.teamsApp.summary.validate.succeed": "%s passed",
   "driver.teamsApp.summary.validate.failed": "%s failed",
   "driver.teamsApp.summary.validate.warning": "%s warning",
+  "driver.teamsApp.summary.validate.all": "All",
   "driver.teamsApp.validate.result": "Teams Toolkit has completed checking your app package against validation rules. %s.",
   "driver.teamsApp.validate.result.display": "Teams Toolkit has completed checking your app package against validation rules. %s. Check [Output panel](command:fx-extension.showOutputChannel) for details.",
   "error.teamsApp.validate.apiFailed": "Teams app package validation failed due to  %s",

--- a/packages/fx-core/src/component/driver/teamsApp/interfaces/ValidateManifestArgs.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/interfaces/ValidateManifestArgs.ts
@@ -6,4 +6,9 @@ export interface ValidateManifestArgs {
    * Teams app manifest path
    */
   manifestPath: string;
+  /**
+   * Internal arguments
+   * Show message for non-life cycle command
+   */
+  showMessage?: boolean;
 }

--- a/packages/fx-core/src/component/driver/teamsApp/validate.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/validate.ts
@@ -4,6 +4,7 @@
 import { Result, FxError, ok, err, Platform, ManifestUtil } from "@microsoft/teamsfx-api";
 import { hooks } from "@feathersjs/hooks/lib";
 import { Service } from "typedi";
+import { EOL } from "os";
 import { StepDriver, ExecutionResult } from "../interface/stepDriver";
 import { DriverContext } from "../interface/commonArgs";
 import { WrapDriverContext } from "../util/wrapUtil";
@@ -16,6 +17,7 @@ import { manifestUtils } from "../../resource/appManifest/utils/ManifestUtils";
 import { getDefaultString, getLocalizedString } from "../../../common/localizeUtils";
 import { HelpLinks } from "../../../common/constants";
 import { getAbsolutePath } from "../../utils/common";
+import { SummaryConstant } from "../../configManager/constant";
 import { updateProgress } from "../middleware/updateProgress";
 import { InvalidActionInputError } from "../../../error/common";
 
@@ -100,19 +102,38 @@ export class ValidateManifestDriver implements StepDriver {
       );
     }
 
+    const summaryStr = getLocalizedString(
+      "driver.teamsApp.summary.validate.failed",
+      validationResult.length
+    );
     if (validationResult.length > 0) {
-      const errMessage = AppStudioError.ValidationFailedError.message(validationResult);
-      context.logProvider?.error(getLocalizedString("plugins.appstudio.validationFailedNotice"));
-      const validationFailed = AppStudioResultFactory.UserError(
-        AppStudioError.ValidationFailedError.name,
-        errMessage,
-        "https://aka.ms/teamsfx-actions/teamsapp-validate"
+      // logs in output window
+      const errors = validationResult
+        .map((error: string) => {
+          return `${SummaryConstant.Failed} ${error}`;
+        })
+        .join(EOL);
+      const outputMessage =
+        EOL + getLocalizedString("driver.teamsApp.summary.validateManifest", summaryStr, errors);
+
+      context.logProvider?.info(outputMessage);
+
+      return err(
+        AppStudioResultFactory.UserError(AppStudioError.ValidationFailedError.name, [
+          getDefaultString("driver.teamsApp.validate.result", summaryStr),
+          getLocalizedString("driver.teamsApp.validate.result.display", summaryStr),
+        ])
       );
-      return err(validationFailed);
     }
-    const validationSuccess = getLocalizedString("plugins.appstudio.validationSucceedNotice");
+    const validationSuccess = getLocalizedString(
+      "driver.teamsApp.validate.result.display",
+      summaryStr
+    );
     if (context.platform === Platform.VS) {
       context.logProvider.info(validationSuccess);
+    }
+    if (args.showMessage) {
+      context.ui?.showMessage("info", validationSuccess, false);
     }
     return ok(new Map());
   }

--- a/packages/fx-core/src/component/driver/teamsApp/validate.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/validate.ts
@@ -102,11 +102,11 @@ export class ValidateManifestDriver implements StepDriver {
       );
     }
 
-    const summaryStr = getLocalizedString(
-      "driver.teamsApp.summary.validate.failed",
-      validationResult.length
-    );
     if (validationResult.length > 0) {
+      const summaryStr = getLocalizedString(
+        "driver.teamsApp.summary.validate.failed",
+        validationResult.length
+      );
       // logs in output window
       const errors = validationResult
         .map((error: string) => {
@@ -124,18 +124,28 @@ export class ValidateManifestDriver implements StepDriver {
           getLocalizedString("driver.teamsApp.validate.result.display", summaryStr),
         ])
       );
+    } else {
+      // logs in output window
+      const summaryStr = getLocalizedString(
+        "driver.teamsApp.summary.validate.succeed",
+        getLocalizedString("driver.teamsApp.summary.validate.all")
+      );
+      const outputMessage =
+        EOL + getLocalizedString("driver.teamsApp.summary.validateManifest", summaryStr, "");
+      context.logProvider?.info(outputMessage);
+
+      const validationSuccess = getLocalizedString(
+        "driver.teamsApp.validate.result.display",
+        summaryStr
+      );
+      if (context.platform === Platform.VS) {
+        context.logProvider.info(validationSuccess);
+      }
+      if (args.showMessage) {
+        context.ui?.showMessage("info", validationSuccess, false);
+      }
+      return ok(new Map());
     }
-    const validationSuccess = getLocalizedString(
-      "driver.teamsApp.validate.result.display",
-      summaryStr
-    );
-    if (context.platform === Platform.VS) {
-      context.logProvider.info(validationSuccess);
-    }
-    if (args.showMessage) {
-      context.ui?.showMessage("info", validationSuccess, false);
-    }
-    return ok(new Map());
   }
 
   private loadCurrentState() {

--- a/packages/fx-core/src/core/FxCoreImplementV3.ts
+++ b/packages/fx-core/src/core/FxCoreImplementV3.ts
@@ -576,13 +576,10 @@ export class FxCoreV3Implement {
     const teamsAppManifestFilePath = inputs?.[CoreQuestionNames.TeamsAppManifestFilePath] as string;
     const args: ValidateManifestArgs = {
       manifestPath: teamsAppManifestFilePath,
+      showMessage: true,
     };
     const driver: ValidateManifestDriver = Container.get("teamsApp/validateManifest");
     const result = await driver.run(args, context);
-    if (result.isOk() && context.platform !== Platform.VS) {
-      const validationSuccess = getLocalizedString("plugins.appstudio.validationSucceedNotice");
-      context.ui?.showMessage("info", validationSuccess, false);
-    }
     return result;
   }
 

--- a/packages/manifest/src/index.ts
+++ b/packages/manifest/src/index.ts
@@ -54,7 +54,7 @@ export class ManifestUtil {
     manifest: T,
     schema: JSONSchemaType<T>
   ): Promise<string[]> {
-    const ajv = new Ajv({ formats: { uri: true } });
+    const ajv = new Ajv({ formats: { uri: true }, allErrors: true });
     const validate = ajv.compile(schema);
     const valid = validate(manifest);
     if (!valid && validate.errors) {

--- a/packages/manifest/test/index.test.ts
+++ b/packages/manifest/test/index.test.ts
@@ -98,7 +98,7 @@ describe("Manifest manipulation", async () => {
       chai.expect(manifest.manifestVersion).equals("1.15");
       const result = await ManifestUtil.validateManifestAgainstSchema(manifest, schema);
       chai.expect(result).not.to.be.empty;
-      chai.expect(result.length).equals(1);
+      chai.expect(result.length).equals(2);
       // 1.15 doesn't match 1.11, so it should return an error
       chai.expect(result[0]).to.contain("/manifestVersion");
     });

--- a/packages/vscode-extension/syntaxes/teamsfx-toolkit-output.tmLanguage
+++ b/packages/vscode-extension/syntaxes/teamsfx-toolkit-output.tmLanguage
@@ -200,7 +200,7 @@
                     </dict>
                 </dict>
                 <key>match</key>
-                <string>([0-9]+ failed[,. ]+)?([0-9]+ warning[s,. ]+)?([0-9]+ passed.)</string>
+                <string>([0-9]+ failed[,. ]+)?([0-9]+ warning[s,. ]+)?([0-9]+ passed.)?</string>
                 <key>name</key>
                 <string>teamsfx-toolkit.validate.summary</string>
             </dict>

--- a/packages/vscode-extension/syntaxes/teamsfx-toolkit-output.tmLanguage
+++ b/packages/vscode-extension/syntaxes/teamsfx-toolkit-output.tmLanguage
@@ -200,7 +200,7 @@
                     </dict>
                 </dict>
                 <key>match</key>
-                <string>([0-9]+ failed[,. ]+)?([0-9]+ warning[s,. ]+)?([0-9]+ passed.)?</string>
+                <string>([0-9]+ failed[,. ]+)?([0-9]+ warning[s,. ]+)?([0-9a-zA-Z]+ passed.)?</string>
                 <key>name</key>
                 <string>teamsfx-toolkit.validate.summary</string>
             </dict>


### PR DESCRIPTION
1) Unify teamsApp/validateManifest output with teamsApp/validateAppPackge
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/17885306
![image](https://user-images.githubusercontent.com/71362691/234195137-3c6d66cc-114b-4d6d-8f05-8ecee2bc203c.png)

![image](https://user-images.githubusercontent.com/71362691/234203067-6b4cc11b-7699-4421-87c9-eeb533c764e3.png)


2) Show all validation errors
Ajv only return first error by default: https://ajv.js.org/options.html#allerrors