### PR TITLE
fix: add ngrok warning message

### DIFF
--- a/packages/cli/src/cmds/preview/constants.ts
+++ b/packages/cli/src/cmds/preview/constants.ts
@@ -116,6 +116,8 @@ export const doctorResult = {
   SignInSuccess: `Microsoft 365 Account (@account) is logged in and sideloading enabled`,
   SkipTrustingCert: "Skip trusting development certificate for localhost",
   HelpLink: `Please refer to @Link for more information.`,
+  NgrokWarning:
+    "This software downloads v2.3.40 from NGROK. Customer must have a valid license to use NGROK software. Microsoft does not license use of the NGROK v2.3.40.",
 };
 
 export const installApp = {

--- a/packages/cli/src/cmds/preview/preview.ts
+++ b/packages/cli/src/cmds/preview/preview.ts
@@ -1285,6 +1285,9 @@ export default class Preview extends YargsCommand {
           const bar = CLIUIInstance.createProgressBar(DepsDisplayName[dep], 1);
           await bar.start(ProgressMessage[dep]);
           await bar.next(ProgressMessage[dep]);
+          if (dep === DepsType.Ngrok) {
+            cliLogger.necessaryLog(LogLevel.Warning, doctorResult.NgrokWarning);
+          }
           const depStatus = (
             await depsManager.ensureDependencies([dep], {
               fastFail: false,

--- a/packages/vscode-extension/package.nls.json
+++ b/packages/vscode-extension/package.nls.json
@@ -504,5 +504,6 @@
     "teamstoolkit.walkthroughs.steps.teamsToolkitExploreMore.title": "What's next?",
     "teamstoolkit.walkthroughs.steps.teamsToolkitPreview.description": "Press [F5](command:fx-extension.selectAndDebug?%5B%22WalkThrough%22%5D) or discover '[Run and Debug](command:workbench.view.debug)' panel on the activity bar, and click the play icon to locally preview your app in Teams context.\n[Run local preview (F5)](command:fx-extension.selectAndDebug?%5B%22WalkThrough%22%5D)\n__Tip: To run local preview, sign in to Microsoft 365 (organizational account) with sideloading option.__",
     "teamstoolkit.walkthroughs.steps.teamsToolkitPreview.title": "Preview your Teams app locally",
-    "teamstoolkit.walkthroughs.title": "Get started with Teams Toolkit"
+    "teamstoolkit.walkthroughs.title": "Get started with Teams Toolkit",
+    "teamstoolkit.prerequisite.ngrok.warning": "This software downloads v2.3.40 from NGROK. Customer must have a valid license to use NGROK software. Microsoft does not license use of the NGROK v2.3.40."
 }

--- a/packages/vscode-extension/src/debug/depsChecker/vscodeChecker.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/vscodeChecker.ts
@@ -13,6 +13,7 @@ import {
   Messages,
 } from "@microsoft/teamsfx-core/build/common/deps-checker";
 import * as os from "os";
+import { localize } from "../../utils/localizeUtils";
 import { vscodeHelper } from "./vscodeHelper";
 
 export class VSCodeDepsChecker {
@@ -30,6 +31,10 @@ export class VSCodeDepsChecker {
 
   public async resolve(deps: DepsType[]): Promise<boolean> {
     const enabledDeps = await VSCodeDepsChecker.getEnabledDepsWithFolder(deps);
+    if (enabledDeps.includes(DepsType.Ngrok)) {
+      await this.logger.warning(localize("teamstoolkit.prerequisite.ngrok.warning"));
+    }
+
     const depsStatus = await this.ensure(enabledDeps);
 
     const shouldContinue = await this.handleLinux(depsStatus);

--- a/packages/vscode-extension/src/debug/prerequisitesHandler.ts
+++ b/packages/vscode-extension/src/debug/prerequisitesHandler.ts
@@ -898,7 +898,6 @@ async function checkDependency(
 ): Promise<CheckResult> {
   try {
     VsCodeLogInstance.outputChannel.appendLine(`${prefix} ${ProgressMessage[nonNodeDep]} ...`);
-
     const dep = await localTelemetryReporter.runWithTelemetryGeneric(
       TelemetryEvent.DebugPrereqsCheckDependencies,
       async (ctx: TelemetryContext) => {
@@ -922,6 +921,24 @@ async function checkDependency(
       },
       additionalTelemetryProperties
     );
+
+    if (nonNodeDep === DepsType.Ngrok) {
+      const ngrokWarning = localize("teamstoolkit.prerequisite.ngrok.warning");
+      return {
+        checker: dep.name,
+        result: dep.isInstalled ? ResultStatus.warn : ResultStatus.failed,
+        warnMsg:
+          ngrokWarning +
+          " " +
+          (dep.details.binFolders
+            ? doctorConstant.DepsSuccess.replace("@depsName", dep.name).replace(
+                "@binFolder",
+                dep.details.binFolders?.[0]
+              )
+            : dep.name),
+        error: handleDepsCheckerError(dep.error, dep),
+      };
+    }
 
     return {
       checker: dep.name,


### PR DESCRIPTION
Detail: [Bug 19655680](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/19655680): Fixing ngrok install legal concerns for existing TTK for VSC v4.*

## VSC
### fx-extension.validate-dependencies (< 3.4.0)
![image](https://user-images.githubusercontent.com/49138419/234515001-928b120c-d0fc-4b1d-9fba-a2933f8b9a5f.png)
### fx-extension.validate-local-prerequisites (3.4.0 - 4.1.0)
![image](https://user-images.githubusercontent.com/49138419/234515179-b16d7701-bceb-4acf-a5c1-f99d1b504d71.png)
### teamsfx:debug-check-prerequisites (>= 4.1.0)
![image](https://user-images.githubusercontent.com/49138419/234515457-4ba712cb-f4e2-478b-a93e-c48dec94fc68.png)

## CLI
![image](https://user-images.githubusercontent.com/49138419/234515528-aa643af7-2611-43ed-8b86-2fdbab1daf5f.png)
