### PR TITLE
refactor(core): add list all envs API

### DIFF
--- a/packages/fx-core/src/core/FxCore.ts
+++ b/packages/fx-core/src/core/FxCore.ts
@@ -597,6 +597,15 @@ export class FxCore implements v3.ICore {
   }
 
   /**
+   * get all dot envs
+   */
+  async getDotEnvs(
+    inputs: InputsWithProjectPath
+  ): Promise<Result<{ [name: string]: DotenvParseOutput }, FxError>> {
+    return this.v3Implement.dispatch(this.getDotEnvs, inputs);
+  }
+
+  /**
    * @deprecated in V3
    */
   @hooks([

--- a/packages/fx-core/src/core/FxCoreImplementV3.ts
+++ b/packages/fx-core/src/core/FxCoreImplementV3.ts
@@ -99,7 +99,6 @@ import { Hub } from "../common/m365/constants";
 import { LaunchHelper } from "../common/m365/launchHelper";
 import { NoNeedUpgradeError } from "../error/upgrade";
 import { SPFxVersionOptionIds } from "../component/resource/spfx/utils/question-helper";
-import { deprecate } from "util";
 
 export class FxCoreV3Implement {
   tools: Tools;

--- a/packages/fx-core/tests/component/coordinator.test.ts
+++ b/packages/fx-core/tests/component/coordinator.test.ts
@@ -3284,6 +3284,41 @@ describe("component coordinator test", () => {
     );
     assert.isTrue(res4.isOk());
   });
+  it("getDotEnvs success", async () => {
+    sandbox.stub(envUtil, "listEnv").resolves(ok(["dev1", "dev2"]));
+    sandbox.stub(envUtil, "readEnv").resolves(ok({ k1: "v1" }));
+    const inputs: InputsWithProjectPath = {
+      platform: Platform.VSCode,
+      projectPath: ".",
+    };
+    const fxCore = new FxCore(tools);
+    const res = await fxCore.getDotEnvs(inputs);
+    assert.isTrue(res.isOk());
+    if (res.isOk()) {
+      assert.deepEqual(Object.keys(res.value), ["dev1", "dev2"]);
+    }
+  });
+  it("getDotEnvs error 1", async () => {
+    sandbox.stub(envUtil, "listEnv").resolves(err(new UserError({})));
+    const inputs: InputsWithProjectPath = {
+      platform: Platform.VSCode,
+      projectPath: ".",
+    };
+    const fxCore = new FxCore(tools);
+    const res = await fxCore.getDotEnvs(inputs);
+    assert.isTrue(res.isErr());
+  });
+  it("getDotEnvs error 2", async () => {
+    sandbox.stub(envUtil, "listEnv").resolves(ok(["dev1", "dev2"]));
+    sandbox.stub(envUtil, "readEnv").resolves(err(new UserError({})));
+    const inputs: InputsWithProjectPath = {
+      platform: Platform.VSCode,
+      projectPath: ".",
+    };
+    const fxCore = new FxCore(tools);
+    const res = await fxCore.getDotEnvs(inputs);
+    assert.isTrue(res.isErr());
+  });
   describe("publishInDeveloperPortal", () => {
     afterEach(() => {
       sandbox.restore();


### PR DESCRIPTION
add `getDotEnvs` API to replace the original `getDotEnv API` in FxCore