### PR TITLE
fix(localdebug): support home dir with space

### DIFF
--- a/packages/fx-core/src/common/deps-checker/internal/funcToolChecker.ts
+++ b/packages/fx-core/src/common/deps-checker/internal/funcToolChecker.ts
@@ -370,7 +370,7 @@ export class FuncToolChecker implements DepsChecker {
       undefined,
       // same as backend start, avoid powershell execution policy issue.
       { shell: isWindows() ? "cmd.exe" : true },
-      execPath,
+      `"${execPath}"`,
       "--version"
     );
     return mapToFuncToolsVersion(output);

--- a/packages/fx-core/tests/common/deps-checker/funcToolChecker.test.ts
+++ b/packages/fx-core/tests/common/deps-checker/funcToolChecker.test.ts
@@ -991,15 +991,15 @@ describe("Func Tools Checker Test", () => {
               throw new Error("Mock node not installed.");
             }
             return `v${nodeVersion}`;
-          } else if (command.endsWith("func") && args.length == 1 && args[0] === "--version") {
-            if (command === "func") {
+          } else if (command.endsWith('func"') && args.length == 1 && args[0] === "--version") {
+            if (command === '"func"') {
               // Mock query global func version
               if (!globalFuncVersion) {
                 throw new Error("Mock global func not installed.");
               }
               return globalFuncVersion;
             } else {
-              const funcBinPath = path.dirname(command);
+              const funcBinPath = path.dirname(command.substring(1, command.length - 1));
               return await mockGetVersion(funcBinPath);
             }
           } else if (command === "npm" && args.length == 1 && args[0] === "--version") {


### PR DESCRIPTION
detail: [Bug 21448658](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/21448658): Failed to install func when home dir contains empty space

@microsoft/teamsfx-cli	v2.0.0-rc.1
@microsoft/teamsfx-core	v2.0.0-rc.1
@microsoft/teamsfx-react	v3.0.0-rc.1
ms-teams-vscode-extension	v5.0.0-rc.1

Fx-core feat commits:
  

CLI feat commits:
  

Extension-toolkit feat commits:
  

SDK feat commits:
  

SDK React feat commits:
  

.Net SDK feat commits:
  


Fx-core fix commits:
  

CLI fix commits:
  

Extension-toolkit fix commits:
  

SDK fix commits:
  

SDK React fix commits:
  

.Net SDK fix commits: