### PR TITLE
fix: not show outlook option if scaffolding from TDP

### DIFF
--- a/packages/fx-core/src/component/developerPortalScaffoldUtils.ts
+++ b/packages/fx-core/src/component/developerPortalScaffoldUtils.ts
@@ -370,8 +370,8 @@ export function updateScope(scopes: string[]): string[] {
   return scopes.map((o) => o.toLowerCase());
 }
 
-export function isFromDevPortal(inputs: Inputs): boolean {
-  return !!inputs.teamsAppFromTdp;
+export function isFromDevPortal(inputs: Inputs | undefined): boolean {
+  return !!inputs?.teamsAppFromTdp;
 }
 
 export const developerPortalScaffoldUtils = new DeveloperPortalScaffoldUtils();

--- a/packages/fx-core/src/core/question.ts
+++ b/packages/fx-core/src/core/question.ts
@@ -64,6 +64,7 @@ import {
 import {
   answerToRepaceBotId,
   answerToReplaceMessageExtensionBotId,
+  isFromDevPortal,
 } from "../component/developerPortalScaffoldUtils";
 import {
   ImportAddinProjectItem,
@@ -421,8 +422,11 @@ export function createNewProjectQuestionWith2Layers(inputs?: Inputs): SingleSele
     NewProjectTypeBotOptionItem(),
     NewProjectTypeTabOptionItem(),
     NewProjectTypeMessageExtensionOptionItem(),
-    NewProjectTypeOutlookAddinOptionItem(),
   ];
+
+  if (!isFromDevPortal(inputs)) {
+    staticOptions.push(NewProjectTypeOutlookAddinOptionItem());
+  }
 
   return {
     name: CoreQuestionNames.ProjectType,

--- a/packages/fx-core/tests/core/question.test.ts
+++ b/packages/fx-core/tests/core/question.test.ts
@@ -252,7 +252,6 @@ describe("Capability Questions", () => {
     });
 
     it("should return 3 type options in first layer question if from TDP", () => {
-      // TODO: fix
       // Act
       const question = createNewProjectQuestionWith2Layers({
         teamsAppFromTdp: { id: "1" },

--- a/packages/fx-core/tests/core/question.test.ts
+++ b/packages/fx-core/tests/core/question.test.ts
@@ -236,7 +236,7 @@ describe("Capability Questions", () => {
       sandbox.restore();
     });
 
-    it("should return 4 type options in first layer question", () => {
+    it("should return 4 type options in first layer question if not from TDP", () => {
       // Act
       const question = createNewProjectQuestionWith2Layers();
       // Assert
@@ -248,6 +248,24 @@ describe("Capability Questions", () => {
         NewProjectTypeTabOptionItem(),
         NewProjectTypeMessageExtensionOptionItem(),
         NewProjectTypeOutlookAddinOptionItem(),
+      ]);
+    });
+
+    it("should return 3 type options in first layer question if from TDP", () => {
+      // TODO: fix
+      // Act
+      const question = createNewProjectQuestionWith2Layers({
+        teamsAppFromTdp: { id: "1" },
+        platform: Platform.VSCode,
+      });
+      // Assert
+      chai.assert.equal(question.type, "singleSelect");
+      chai.assert.equal(question.name, "project-type");
+      chai.assert.equal(question.title, getLocalizedString("core.createProjectQuestion.title"));
+      chai.assert.deepEqual(question.staticOptions, [
+        NewProjectTypeBotOptionItem(),
+        NewProjectTypeTabOptionItem(),
+        NewProjectTypeMessageExtensionOptionItem(),
       ]);
     });
 


### PR DESCRIPTION
@microsoft/teamsfx-cli	v2.0.0-rc.1
@microsoft/teamsfx-core	v2.0.0-rc.1
@microsoft/teamsfx-react	v3.0.0-rc.1
ms-teams-vscode-extension	v5.0.0-rc.1

Fx-core feat commits:
  

CLI feat commits:
  

Extension-toolkit feat commits:
  

SDK feat commits:
  

SDK React feat commits:
  

.Net SDK feat commits:
  


Fx-core fix commits:
  

CLI fix commits:
  

Extension-toolkit fix commits:
  

SDK fix commits:
  

SDK React fix commits:
  

.Net SDK fix commits: