### PR TITLE
fix(localdebug): shorter func installation tmp folder length

### DIFF
--- a/packages/fx-core/src/common/deps-checker/internal/funcToolChecker.ts
+++ b/packages/fx-core/src/common/deps-checker/internal/funcToolChecker.ts
@@ -305,7 +305,7 @@ export class FuncToolChecker implements DepsChecker {
       throw new DepsCheckerError(Messages.needInstallNpm(), v3DefaultHelpLink);
     }
 
-    const tmpVersion = uuid.v4();
+    const tmpVersion = `tmp-${uuid.v4().slice(0, 6)}`;
     await this.installFunc(tmpVersion, expectedFuncVersion);
 
     const funcVersionRes = await this.checkFuncVersion(


### PR DESCRIPTION
In windows, `npm install azure-functions-core-tools@4 --prefix ${path} --no-audit` has a 256 character limit on file paths

To reduce the risk of exceeding the limit, shorten the temporary folder length.

Error message:
[Error: ENOENT: no such file or directory, realpath '${path}\\.fx\bin\azfunc\27eb88e2-dcde-4b00-9737-42b7a13c0c8d\node_modules\azure-functions-core-tools\bin\workers\python\3.10\WINDOWS\X64\azure_functions_worker-4.10.1-py3.10.egg-info'] {
  errno: -4058,
  code: 'ENOENT',
  syscall: 'realpath',
  path: '${path}\\.fx\\bin\\azfunc\\27eb88e2-dcde-4b00-9737-42b7a13c0c8d\\node_modules\\azure-functions-core-tools\\bin\\workers\\python\\3.10\\WINDOWS\\X64\\azure_functions_worker-4.10.1-py3.10.egg-info'
  
  