### PR TITLE
fix: not show outlook option if scaffolding from TDP

### DIFF
--- a/packages/fx-core/src/component/developerPortalScaffoldUtils.ts
+++ b/packages/fx-core/src/component/developerPortalScaffoldUtils.ts
@@ -357,8 +357,8 @@ export function updateScope(scopes: string[]): string[] {
   return scopes.map((o) => o.toLowerCase());
 }
 
-export function isFromDevPortal(inputs: Inputs): boolean {
-  return !!inputs.teamsAppFromTdp;
+export function isFromDevPortal(inputs: Inputs | undefined): boolean {
+  return !!inputs?.teamsAppFromTdp;
 }
 
 export const developerPortalScaffoldUtils = new DeveloperPortalScaffoldUtils();

--- a/packages/fx-core/src/core/question.ts
+++ b/packages/fx-core/src/core/question.ts
@@ -64,6 +64,7 @@ import {
 import {
   answerToRepaceBotId,
   answerToReplaceMessageExtensionBotId,
+  isFromDevPortal,
 } from "../component/developerPortalScaffoldUtils";
 import {
   ImportAddinProjectItem,
@@ -422,8 +423,11 @@ export function createNewProjectQuestionWith2Layers(inputs?: Inputs): SingleSele
     NewProjectTypeBotOptionItem(),
     NewProjectTypeTabOptionItem(),
     NewProjectTypeMessageExtensionOptionItem(),
-    NewProjectTypeOutlookAddinOptionItem(),
   ];
+
+  if (!isFromDevPortal(inputs)) {
+    staticOptions.push(NewProjectTypeOutlookAddinOptionItem());
+  }
 
   return {
     name: CoreQuestionNames.ProjectType,

--- a/packages/fx-core/tests/core/question.test.ts
+++ b/packages/fx-core/tests/core/question.test.ts
@@ -237,7 +237,7 @@ describe("Capability Questions", () => {
       sandbox.restore();
     });
 
-    it("should return 4 type options in first layer question", () => {
+    it("should return 4 type options in first layer question if not from TDP", () => {
       // Act
       const question = createNewProjectQuestionWith2Layers();
       // Assert
@@ -249,6 +249,23 @@ describe("Capability Questions", () => {
         NewProjectTypeTabOptionItem(),
         NewProjectTypeMessageExtensionOptionItem(),
         NewProjectTypeOutlookAddinOptionItem(),
+      ]);
+    });
+
+    it("should return 3 type options in first layer question if from TDP", () => {
+      // Act
+      const question = createNewProjectQuestionWith2Layers({
+        teamsAppFromTdp: { id: "1" },
+        platform: Platform.VSCode,
+      });
+      // Assert
+      chai.assert.equal(question.type, "singleSelect");
+      chai.assert.equal(question.name, "project-type");
+      chai.assert.equal(question.title, getLocalizedString("core.createProjectQuestion.title"));
+      chai.assert.deepEqual(question.staticOptions, [
+        NewProjectTypeBotOptionItem(),
+        NewProjectTypeTabOptionItem(),
+        NewProjectTypeMessageExtensionOptionItem(),
       ]);
     });
 


### PR DESCRIPTION
[Bug 21605540](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/21605540): TDP: should not show outlook addin option when scaffolding from TDP