### PR TITLE
fix(cli): provision/deploy message

### DIFF
--- a/packages/cli/src/resource/strings.json
+++ b/packages/cli/src/resource/strings.json
@@ -11,10 +11,10 @@
   "warning.prefix": "(!) Warning: ",
   "command": {
     "provision": {
-      "description": "Run the provision stage in teamsapp.yml."
+      "description": "Run the provision stage in teamsapp.yml or teamsapp.local.yml."
     },
     "deploy": {
-      "description": "Run the deploy stage in teamsapp.yml."
+      "description": "Run the deploy stage in teamsapp.yml or teamsapp.local.yml."
     },
     "publish": {
       "description": "Run the publish stage in teamsapp.yml."


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/21049380
Add the `or teamsapp.local.yml` in the provision/deploy help message.
![image](https://github.com/OfficeDev/TeamsFx/assets/15262146/5a06fa93-0db5-41bb-bd9c-8671ff459f8a)
