### PR TITLE
fix(core): use default env folder path when read env

### DIFF
--- a/packages/fx-core/src/component/utils/pathUtils.ts
+++ b/packages/fx-core/src/component/utils/pathUtils.ts
@@ -41,11 +41,11 @@ export class PathUtils {
     const parseRes = await yamlParser.parse(ymlFilePath);
     if (parseRes.isErr()) return err(parseRes.error);
     const projectModel = parseRes.value;
-    if (!projectModel.environmentFolderPath) return ok(undefined); //err(new InvalidEnvFolderPath("missing field: environmentFolderPath"));
+    if (!projectModel.environmentFolderPath) projectModel.environmentFolderPath = "./env";
     const envFolderPath = path.isAbsolute(projectModel.environmentFolderPath)
       ? projectModel.environmentFolderPath
       : path.join(projectPath, projectModel.environmentFolderPath);
-    if (!(await fs.pathExists(envFolderPath))) return ok(undefined); //err(new InvalidEnvFolderPath("environment folder not exist: " + envFolderPath));
+    if (!(await fs.pathExists(envFolderPath))) return ok(undefined);
     return ok(envFolderPath);
   }
   async getEnvFilePath(

--- a/packages/fx-core/tests/component/envUtil.test.ts
+++ b/packages/fx-core/tests/component/envUtil.test.ts
@@ -74,15 +74,15 @@ describe("env utils", () => {
       assert.equal(res.value, "/home/envs");
     }
   });
-  it("pathUtils.getEnvFolderPath returns undefined", async () => {
+  it("pathUtils.getEnvFolderPath returns default value", async () => {
     const mockProjectModel: ProjectModel = {};
-    sandbox.stub(pathUtils, "getYmlFilePath").resolves("./xxx");
+    sandbox.stub(pathUtils, "getYmlFilePath").resolves("./teamsapp.yml");
     sandbox.stub(yamlParser, "parse").resolves(ok(mockProjectModel));
     sandbox.stub(fs, "pathExists").resolves(true);
-    const res = await pathUtils.getEnvFolderPath(".");
+    const res = await pathUtils.getEnvFolderPath("");
     assert.isTrue(res.isOk());
     if (res.isOk()) {
-      assert.isUndefined(res.value);
+      assert.equal(res.value, path.join("", "./env"));
     }
   });
   it("pathUtils.getEnvFilePath", async () => {
@@ -98,7 +98,7 @@ describe("env utils", () => {
       assert.equal(res.value, path.join("/home/envs", ".env.dev"));
     }
   });
-  it("pathUtils.getEnvFilePath returns undefined", async () => {
+  it("pathUtils.getEnvFilePath returns default value", async () => {
     const mockProjectModel: ProjectModel = {};
     sandbox.stub(yamlParser, "parse").resolves(ok(mockProjectModel));
     sandbox.stub(fs, "pathExists").resolves(true);
@@ -106,7 +106,7 @@ describe("env utils", () => {
     const res = await pathUtils.getEnvFilePath(".", "dev");
     assert.isTrue(res.isOk());
     if (res.isOk()) {
-      assert.isUndefined(res.value);
+      assert.equal(res.value, path.join("./env", ".env.dev"));
     }
   });
   it("envUtil.readEnv", async () => {

--- a/packages/fx-core/tests/component/envUtil.test.ts
+++ b/packages/fx-core/tests/component/envUtil.test.ts
@@ -85,6 +85,17 @@ describe("env utils", () => {
       assert.equal(res.value, path.join("", "./env"));
     }
   });
+  it("pathUtils.getEnvFolderPath returns undefined value", async () => {
+    const mockProjectModel: ProjectModel = {};
+    sandbox.stub(pathUtils, "getYmlFilePath").resolves("./teamsapp.yml");
+    sandbox.stub(yamlParser, "parse").resolves(ok(mockProjectModel));
+    sandbox.stub(fs, "pathExists").resolves(false);
+    const res = await pathUtils.getEnvFolderPath("");
+    assert.isTrue(res.isOk());
+    if (res.isOk()) {
+      assert.isUndefined(res.value);
+    }
+  });
   it("pathUtils.getEnvFilePath", async () => {
     const mockProjectModel: ProjectModel = {
       environmentFolderPath: "/home/envs",


### PR DESCRIPTION
to fix: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_sprints/taskboard/Teams%20Extensibility%20E2E%20Team/Microsoft%20Teams%20Extensibility/CY23-5.2?workitem=22491976