### PR TITLE
fix(localdebug): fix the dev tool telemetry which are masked by GDPR

### DIFF
--- a/packages/fx-core/src/common/deps-checker/internal/funcToolChecker.ts
+++ b/packages/fx-core/src/common/deps-checker/internal/funcToolChecker.ts
@@ -411,12 +411,9 @@ export class FuncToolChecker implements DepsChecker {
     } catch (error: any) {
       await this.cleanup(tmpVersion);
       // ${funcPackageName}@${expectedFuncVersion} is incorrectly identified as an email format.
-      this.telemetryProperties[TelemetryProperties.InstallFuncError] = (
-        error.message as string
-      )?.replace(
-        `${funcPackageName}@${expectedFuncVersion}`,
-        `${funcPackageName}{at}${expectedFuncVersion}`
-      );
+      this.telemetryProperties[TelemetryProperties.InstallFuncError] = (error.message as string)
+        ?.split(`${funcPackageName}@${expectedFuncVersion}`)
+        ?.join(`${funcPackageName}{at}${expectedFuncVersion}`);
       throw new DepsCheckerError(
         getLocalizedString("error.common.InstallSoftwareError", funcToolName),
         v3DefaultHelpLink

--- a/packages/fx-core/src/common/deps-checker/internal/funcToolChecker.ts
+++ b/packages/fx-core/src/common/deps-checker/internal/funcToolChecker.ts
@@ -410,7 +410,13 @@ export class FuncToolChecker implements DepsChecker {
       await fs.ensureFile(FuncToolChecker.getVersioningSentinelPath(tmpVersion));
     } catch (error: any) {
       await this.cleanup(tmpVersion);
-      this.telemetryProperties[TelemetryProperties.InstallFuncError] = error.message;
+      // ${funcPackageName}@${expectedFuncVersion} is incorrectly identified as an email format.
+      this.telemetryProperties[TelemetryProperties.InstallFuncError] = (
+        error.message as string
+      )?.replace(
+        `${funcPackageName}@${expectedFuncVersion}`,
+        `${funcPackageName}{at}${expectedFuncVersion}`
+      );
       throw new DepsCheckerError(
         getLocalizedString("error.common.InstallSoftwareError", funcToolName),
         v3DefaultHelpLink

--- a/packages/fx-core/src/component/driver/devTool/error/dotnetInstallationUserError.ts
+++ b/packages/fx-core/src/component/driver/devTool/error/dotnetInstallationUserError.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import { UserError } from "@microsoft/teamsfx-api";
+import { camelCase } from "lodash";
 import { DepsCheckerError } from "../../../../common/deps-checker/depsError";
 import { getDefaultString, getLocalizedString } from "../../../../common/localizeUtils";
 
@@ -11,7 +12,7 @@ const messageKey = "driver.prerequisite.error.dotnetInstallationError";
 export class DotnetInstallationUserError extends UserError {
   constructor(actionName: string, error: any, helpLink?: string) {
     super({
-      source: actionName,
+      source: camelCase(actionName),
       name: errorCode,
       message: error instanceof DepsCheckerError ? error.message : getDefaultString(messageKey),
       displayMessage:

--- a/packages/fx-core/src/component/driver/devTool/error/funcInstallationUserError.ts
+++ b/packages/fx-core/src/component/driver/devTool/error/funcInstallationUserError.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import { UserError } from "@microsoft/teamsfx-api";
+import { camelCase } from "lodash";
 import { DepsCheckerError } from "../../../../common/deps-checker/depsError";
 import { getDefaultString, getLocalizedString } from "../../../../common/localizeUtils";
 
@@ -11,7 +12,7 @@ const messageKey = "driver.prerequisite.error.funcInstallationError";
 export class FuncInstallationUserError extends UserError {
   constructor(actionName: string, error: any, helpLink?: string) {
     super({
-      source: actionName,
+      source: camelCase(actionName),
       name: errorCode,
       message: error instanceof DepsCheckerError ? error.message : getDefaultString(messageKey),
       displayMessage:

--- a/packages/fx-core/src/component/driver/devTool/installDriver.ts
+++ b/packages/fx-core/src/component/driver/devTool/installDriver.ts
@@ -54,39 +54,40 @@ const outputKeys = {
 export class ToolsInstallDriver implements StepDriver {
   description = toolsInstallDescription();
 
-  @hooks([
-    addStartAndEndTelemetry(ACTION_NAME, ACTION_NAME),
-    updateProgress(getLocalizedString("driver.prerequisite.progressBar")),
-  ])
   async run(
     args: InstallToolArgs,
     context: DriverContext
   ): Promise<Result<Map<string, string>, FxError>> {
-    return wrapRun(async () => {
-      const wrapContext = new WrapDriverContext(context, ACTION_NAME, ACTION_NAME);
-      const impl = new ToolsInstallDriverImpl(wrapContext);
-      return await impl.run(args);
-    });
+    const wrapContext = new WrapDriverContext(context, ACTION_NAME, ACTION_NAME);
+    return await this._run(args, wrapContext);
   }
 
-  @hooks([
-    addStartAndEndTelemetry(ACTION_NAME, ACTION_NAME),
-    updateProgress(getLocalizedString("driver.prerequisite.progressBar")),
-  ])
   async execute(
     args: InstallToolArgs,
     context: DriverContext,
     outputEnvVarNames?: Map<string, string>
   ): Promise<ExecutionResult> {
     const wrapContext = new WrapDriverContext(context, ACTION_NAME, ACTION_NAME);
-    const result = await wrapRun(async () => {
-      const impl = new ToolsInstallDriverImpl(wrapContext);
-      return await impl.run(args, outputEnvVarNames);
-    });
+    const result = await this._run(args, wrapContext, outputEnvVarNames);
     return {
       result: result,
       summaries: wrapContext.summaries,
     };
+  }
+
+  @hooks([
+    addStartAndEndTelemetry(ACTION_NAME, ACTION_NAME),
+    updateProgress(getLocalizedString("driver.prerequisite.progressBar")),
+  ])
+  async _run(
+    args: InstallToolArgs,
+    wrapContext: WrapDriverContext,
+    outputEnvVarNames?: Map<string, string>
+  ): Promise<Result<Map<string, string>, FxError>> {
+    return wrapRun(async () => {
+      const impl = new ToolsInstallDriverImpl(wrapContext);
+      return await impl.run(args, outputEnvVarNames);
+    });
   }
 }
 


### PR DESCRIPTION
1. Hook `addStartAndEndTelemetry` should be used in the `WrapDriverContext`.
1. Avoid the error code to be redacted. `error-code: <REDACTED: user-file-path>`
1. Avoid the install error message to be redacted. `install-func-error: <REDACTED: email>`