### PR TITLE
fix: no detailed error message in AAD app actions

### DIFF
--- a/packages/fx-core/src/component/driver/aad/create.ts
+++ b/packages/fx-core/src/component/driver/aad/create.ts
@@ -160,12 +160,12 @@ export class CreateAadAppDriver implements StepDriver {
         );
         if (error.response!.status >= 400 && error.response!.status < 500) {
           return {
-            result: err(new UnhandledUserError(error as Error, actionName, helpLink)),
+            result: err(new UnhandledUserError(new Error(message), actionName, helpLink)),
             summaries: summaries,
           };
         } else {
           return {
-            result: err(new UnhandledError(error as Error, actionName)),
+            result: err(new UnhandledError(new Error(message), actionName)),
             summaries: summaries,
           };
         }

--- a/packages/fx-core/src/component/driver/aad/update.ts
+++ b/packages/fx-core/src/component/driver/aad/update.ts
@@ -101,12 +101,12 @@ export class UpdateAadAppDriver implements StepDriver {
         );
         if (error.response!.status >= 400 && error.response!.status < 500) {
           return {
-            result: err(new UnhandledUserError(error as Error, actionName, helpLink)),
+            result: err(new UnhandledUserError(new Error(message), actionName, helpLink)),
             summaries: summaries,
           };
         } else {
           return {
-            result: err(new UnhandledError(error as Error, actionName)),
+            result: err(new UnhandledError(new Error(message), actionName)),
             summaries: summaries,
           };
         }

--- a/packages/fx-core/tests/component/driver/aad/create.test.ts
+++ b/packages/fx-core/tests/component/driver/aad/create.test.ts
@@ -327,7 +327,9 @@ describe("aadAppCreate", async () => {
     expect(result.result._unsafeUnwrapErr())
       .is.instanceOf(UnhandledUserError)
       .and.has.property("message")
-      .and.contains("An unexpected error has occurred while performing the aadApp/create task");
+      .and.equals(
+        'An unexpected error has occurred while performing the aadApp/create task. {"error":{"code":"Request_BadRequest","message":"Invalid value specified for property \'displayName\' of resource \'Application\'."}}'
+      );
   });
 
   it("should throw system error when AadAppClient failed with non 4xx error", async () => {
@@ -354,7 +356,9 @@ describe("aadAppCreate", async () => {
     expect(result.result._unsafeUnwrapErr())
       .is.instanceOf(UnhandledError)
       .and.has.property("message")
-      .and.contains("An unexpected error has occurred while performing the aadApp/create task");
+      .and.equals(
+        'An unexpected error has occurred while performing the aadApp/create task. {"error":{"code":"InternalServerError","message":"Internal server error"}}'
+      );
   });
 
   it("should send telemetries when success", async () => {

--- a/packages/fx-core/tests/component/driver/aad/update.test.ts
+++ b/packages/fx-core/tests/component/driver/aad/update.test.ts
@@ -415,7 +415,9 @@ describe("aadAppUpdate", async () => {
     expect(result.result._unsafeUnwrapErr())
       .is.instanceOf(UnhandledUserError)
       .and.property("message")
-      .contain("An unexpected error has occurred while performing the aadApp/update task");
+      .equals(
+        'An unexpected error has occurred while performing the aadApp/update task. {"error":{"code":"Request_BadRequest","message":"Invalid value specified for property \'displayName\' of resource \'Application\'."}}'
+      );
   });
 
   it("should throw system error when AadAppClient failed with non 4xx error", async () => {
@@ -447,7 +449,9 @@ describe("aadAppUpdate", async () => {
     expect(result.result._unsafeUnwrapErr())
       .is.instanceOf(UnhandledError)
       .and.property("message")
-      .contain("An unexpected error has occurred while performing the aadApp/update task");
+      .equals(
+        'An unexpected error has occurred while performing the aadApp/update task. {"error":{"code":"InternalServerError","message":"Internal server error"}}'
+      );
   });
 
   it("should send telemetries when success", async () => {


### PR DESCRIPTION
Bug: https://dev.azure.com/msazure/Microsoft%20Teams%20Extensibility/_workitems/edit/23074298

The message in axios error only includes the status code, which can not help users fix the actual problem. Return the response in axiosError.response.data to tell users more details about the error.

This can improve the troubleshooting experience in issue https://github.com/OfficeDev/TeamsFx/issues/8733