### PR TITLE
fix: add missing properties for metadata event

### DIFF
--- a/packages/fx-core/src/component/utils/metadataUtil.ts
+++ b/packages/fx-core/src/component/utils/metadataUtil.ts
@@ -38,6 +38,8 @@ export class MetadataUtil {
     props[prefix + "version"] = manifest.version ?? "";
     props[prefix + "manifestVersion"] = manifest.manifestVersion ?? "";
     props[prefix + "bots"] = manifest.bots?.map((bot) => bot.botId).toString() ?? "";
+    props[prefix + "composeExtensions"] =
+      manifest.composeExtensions?.map((bot) => bot.botId).toString() ?? "";
     props[prefix + "staticTabs.contentUrl"] =
       manifest.staticTabs
         ?.map((tab) =>

--- a/packages/fx-core/tests/component/util/metadataUtil.test.ts
+++ b/packages/fx-core/tests/component/util/metadataUtil.test.ts
@@ -137,6 +137,7 @@ describe("metadata util", () => {
         "manifest.version": "",
         "manifest.manifestVersion": "",
         "manifest.bots": "",
+        "manifest.composeExtensions": "",
         "manifest.staticTabs.contentUrl": "",
         "manifest.configurableTabs.configurationUrl": "",
         "manifest.webApplicationInfo.id": "",
@@ -150,6 +151,7 @@ describe("metadata util", () => {
       version: "1.0",
       manifestVersion: "1.0",
       bots: [{ botId: "bot1" }, { botId: "bot2" }],
+      composeExtensions: [{ botId: "bot1" }, { botId: "bot2" }],
       staticTabs: [
         { contentUrl: "https://example.com/tab1" },
         { contentUrl: "https://example.com/tab2" },
@@ -168,6 +170,7 @@ describe("metadata util", () => {
         "manifest.version": "1.0",
         "manifest.manifestVersion": "1.0",
         "manifest.bots": "bot1,bot2",
+        "manifest.composeExtensions": "bot1,bot2",
         "manifest.staticTabs.contentUrl": `${[
           createHash("sha256").update(manifest.staticTabs[0].contentUrl).digest("base64"),
           createHash("sha256").update(manifest.staticTabs[1].contentUrl).digest("base64"),


### PR DESCRIPTION
fix: add missing properties for metadata event

Add 'composeExtensions' property to metadata. this is useful for message extension project.
![image](https://github.com/OfficeDev/TeamsFx/assets/831821/2bb4601b-f0da-419f-9c33-0cde558e10f7)

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/23517592