### PR TITLE
fix(e2e): update sdk version to fix e2e test

### DIFF
--- a/templates/scenarios/js/notification-http-timer-trigger/package.json.tpl
+++ b/templates/scenarios/js/notification-http-timer-trigger/package.json.tpl
@@ -20,7 +20,7 @@
     },
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
-        "@microsoft/teamsfx": "^2.2.0-alpha",
+        "@microsoft/teamsfx": "^2.2.2-alpha",
         "botbuilder": "^4.18.0"
     },
     "devDependencies": {

--- a/templates/scenarios/js/notification-http-trigger/package.json.tpl
+++ b/templates/scenarios/js/notification-http-trigger/package.json.tpl
@@ -20,7 +20,7 @@
     },
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
-        "@microsoft/teamsfx": "^2.2.0-alpha",
+        "@microsoft/teamsfx": "^2.2.2-alpha",
         "botbuilder": "^4.18.0"
     },
     "devDependencies": {

--- a/templates/scenarios/js/notification-restify/package.json.tpl
+++ b/templates/scenarios/js/notification-restify/package.json.tpl
@@ -21,7 +21,7 @@
     },
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
-        "@microsoft/teamsfx": "^2.2.0-alpha",
+        "@microsoft/teamsfx": "^2.2.2-alpha",
         "botbuilder": "^4.18.0",
         "restify": "^10.0.0"
     },

--- a/templates/scenarios/js/notification-timer-trigger/package.json.tpl
+++ b/templates/scenarios/js/notification-timer-trigger/package.json.tpl
@@ -20,7 +20,7 @@
     },
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
-        "@microsoft/teamsfx": "^2.2.0-alpha",
+        "@microsoft/teamsfx": "^2.2.2-alpha",
         "botbuilder": "^4.18.0"
     },
     "devDependencies": {

--- a/templates/scenarios/ts/notification-http-timer-trigger/package.json.tpl
+++ b/templates/scenarios/ts/notification-http-timer-trigger/package.json.tpl
@@ -24,7 +24,7 @@
     },
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
-        "@microsoft/teamsfx": "^2.2.0-alpha",
+        "@microsoft/teamsfx": "^2.2.2-alpha",
         "botbuilder": "^4.18.0"
     },
     "devDependencies": {

--- a/templates/scenarios/ts/notification-http-trigger/package.json.tpl
+++ b/templates/scenarios/ts/notification-http-trigger/package.json.tpl
@@ -24,7 +24,7 @@
     },
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
-        "@microsoft/teamsfx": "^2.2.0-alpha",
+        "@microsoft/teamsfx": "^2.2.2-alpha",
         "botbuilder": "^4.18.0"
     },
     "devDependencies": {

--- a/templates/scenarios/ts/notification-restify/package.json.tpl
+++ b/templates/scenarios/ts/notification-restify/package.json.tpl
@@ -22,7 +22,7 @@
     },
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
-        "@microsoft/teamsfx": "^2.2.0-alpha",
+        "@microsoft/teamsfx": "^2.2.2-alpha",
         "botbuilder": "^4.18.0",
         "restify": "^10.0.0"
     },

--- a/templates/scenarios/ts/notification-timer-trigger/package.json.tpl
+++ b/templates/scenarios/ts/notification-timer-trigger/package.json.tpl
@@ -24,7 +24,7 @@
     },
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
-        "@microsoft/teamsfx": "^2.2.0-alpha",
+        "@microsoft/teamsfx": "^2.2.2-alpha",
         "botbuilder": "^4.18.0"
     },
     "devDependencies": {


### PR DESCRIPTION
work item: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/23286405/

Fix E2E test failure that TeamsFx SDK `2.1.0` will be installed instead of `2.2.0-alpha...` with `2.0.0-alpha` defined in package.json.
E2E TEST: https://github.com/OfficeDev/TeamsFx/actions/runs/5064753554