### PR TITLE
fix: convert token fail return empty object

### DIFF
--- a/packages/vscode-extension/src/commonlib/codeFlowLogin.ts
+++ b/packages/vscode-extension/src/commonlib/codeFlowLogin.ts
@@ -523,10 +523,15 @@ export function UserCancelError(source: string): UserError {
   });
 }
 
+// if connot convert token via base64, return empty object
 export function ConvertTokenToJson(token: string): object {
-  const array = token.split(".");
-  const buff = Buffer.from(array[1], "base64");
-  return JSON.parse(buff.toString(UTF8));
+  try {
+    const array = token.split(".");
+    const buff = Buffer.from(array[1], "base64");
+    return JSON.parse(buff.toString(UTF8));
+  } catch (e) {
+    return {};
+  }
 }
 
 export async function checkIsOnline(): Promise<boolean> {

--- a/packages/vscode-extension/src/commonlib/m365Login.ts
+++ b/packages/vscode-extension/src/commonlib/m365Login.ts
@@ -269,7 +269,7 @@ export class M365Login extends BasicLogin implements M365TokenProvider {
         false
       );
       if (tokenRes.isOk()) {
-        let tokenJson = ConvertTokenToJson(tokenRes.value);
+        const tokenJson = ConvertTokenToJson(tokenRes.value);
         // if token is empty, try to get token by app studio scope, normally this should only affect UX
         if (Object.keys(tokenJson).length === 0) {
           const appStudioRes = await M365Login.codeFlowInstance.getTokenByScopes(
@@ -277,11 +277,11 @@ export class M365Login extends BasicLogin implements M365TokenProvider {
             false
           );
           if (appStudioRes.isOk()) {
-            tokenJson = ConvertTokenToJson(appStudioRes.value);
+            const appStudioJson = ConvertTokenToJson(appStudioRes.value);
             return ok({
               status: signedIn,
               token: appStudioRes.value,
-              accountInfo: tokenJson as any,
+              accountInfo: appStudioJson as any,
             });
           }
         }

--- a/packages/vscode-extension/src/commonlib/m365Login.ts
+++ b/packages/vscode-extension/src/commonlib/m365Login.ts
@@ -269,7 +269,22 @@ export class M365Login extends BasicLogin implements M365TokenProvider {
         false
       );
       if (tokenRes.isOk()) {
-        const tokenJson = ConvertTokenToJson(tokenRes.value);
+        let tokenJson = ConvertTokenToJson(tokenRes.value);
+        // if token is empty, try to get token by app studio scope, normally this should only affect UX
+        if (Object.keys(tokenJson).length === 0) {
+          const appStudioRes = await M365Login.codeFlowInstance.getTokenByScopes(
+            AppStudioScopes,
+            false
+          );
+          if (appStudioRes.isOk()) {
+            tokenJson = ConvertTokenToJson(appStudioRes.value);
+            return ok({
+              status: signedIn,
+              token: appStudioRes.value,
+              accountInfo: tokenJson as any,
+            });
+          }
+        }
         return ok({ status: signedIn, token: tokenRes.value, accountInfo: tokenJson as any });
       } else {
         if (


### PR DESCRIPTION
Resolve the issue where login using dev tunnel scope or metaos scope returns a token that cannot be encoded by base64. In this scenario, we will return empty object and for UX we will try to get appStudio token.

[Bug 21597038: [Bug Bash] [v5.0.0] Dev Tunnel fails to start when running from "Tasks: Run Task" - Boards (visualstudio.com)](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/21597038)