### PR TITLE
build: add annotations to SDK protected methods

### DIFF
--- a/packages/sdk-react/src/BaseDashboard.tsx
+++ b/packages/sdk-react/src/BaseDashboard.tsx
@@ -107,6 +107,7 @@ export class BaseDashboard<P, S> extends Component<P, S & BaseDashboardState> {
   /**
    * Override this method to define the layout of the widget in the dashboard.
    * @returns The layout of the widget in the dashboard.
+   * @public
    */
   protected layout(): JSX.Element | undefined {
     return undefined;
@@ -115,6 +116,7 @@ export class BaseDashboard<P, S> extends Component<P, S & BaseDashboardState> {
   /**
    * Override this method to customize the dashboard style.
    * @returns The className for customizing the dashboard style.
+   * @public
    */
   protected styling(): string {
     return null;

--- a/packages/sdk-react/src/BaseWidget.tsx
+++ b/packages/sdk-react/src/BaseWidget.tsx
@@ -125,7 +125,8 @@ export class BaseWidget<P, S> extends Component<P, S & BaseWidgetState> {
 
   /**
    * Get data required by the widget
-   * @returns data for the widget
+   * @returns Data for the widget
+   * @public
    */
   protected async getData(): Promise<S> {
     return undefined;
@@ -136,6 +137,7 @@ export class BaseWidget<P, S> extends Component<P, S & BaseWidgetState> {
    * By overriding this method, you can add additional functionality or styling to the widget's header.
    * If the method is not overridden, the widget will return undefined as the default value for the header, indicating that no custom header content has been defined.
    * @returns An optional JSX.Element representing the header of the widget.
+   * @public
    */
   protected header(): JSX.Element | undefined {
     return undefined;
@@ -146,6 +148,7 @@ export class BaseWidget<P, S> extends Component<P, S & BaseWidgetState> {
    * By overriding this method, you can add additional functionality or styling to the widget's body.
    * If the method is not overridden, the widget will return undefined as the default value for the body, indicating that no custom body content has been defined.
    * @returns An optional JSX.Element representing the body of the widget.
+   * @public
    */
   protected body(): JSX.Element | undefined {
     return undefined;
@@ -156,6 +159,7 @@ export class BaseWidget<P, S> extends Component<P, S & BaseWidgetState> {
    * By overriding this method, you can add additional functionality or styling to the widget's footer.
    * If the method is not overridden, the widget will return undefined as the default value for the footer, indicating that no custom footer content has been defined.
    * @returns An optional JSX.Element representing the footer of the widget.
+   * @public
    */
   protected footer(): JSX.Element | undefined {
     return undefined;
@@ -166,6 +170,7 @@ export class BaseWidget<P, S> extends Component<P, S & BaseWidgetState> {
    * The `undefined` return value is used to indicate that no loading indicator is required.
    * If a loading indicator is required, the method can return a `JSX.Element` containing the necessary components to render the loading indicator.
    * @returns A JSX element or `undefined` if no loading indicator is required.
+   * @public
    */
   protected loading(): JSX.Element | undefined {
     return undefined;
@@ -175,6 +180,7 @@ export class BaseWidget<P, S> extends Component<P, S & BaseWidgetState> {
    * Override this method to returns an object that defines the class names for the different parts of the widget.
    * The returned object conforms to the {@link IWidgetClassNames} interface which defines the possible keys and values for the class names.
    * @returns An object that defines the class names for the different parts of the widget.
+   * @public
    */
   protected styling(): IWidgetClassNames {
     return {};

--- a/packages/sdk-react/src/useData.ts
+++ b/packages/sdk-react/src/useData.ts
@@ -50,7 +50,7 @@ const createReducer =
  * @param options - if autoLoad is true, reload data immediately
  * @returns data, loading status, error and reload function
  *
- * @beta
+ * @public
  */
 export function useData<T>(
   fetchDataAsync: () => Promise<T>,

--- a/packages/sdk-react/src/useGraph.ts
+++ b/packages/sdk-react/src/useGraph.ts
@@ -30,7 +30,7 @@ type GraphOptionWithCredential = {
  * @param options - teamsfx instance and OAuth resource scope.
  * @returns data, loading status, error and reload function
  *
- * @beta
+ * @public
  */
 export function useGraph<T>(
   fetchGraphDataAsync: (graph: Client, teamsfx: TeamsFx, scope: string[]) => Promise<T>,
@@ -78,7 +78,7 @@ export function useGraph<T>(
  * @param options - Authentication configuration and OAuth resource scope.
  * @returns data, loading status, error and reload function
  *
- * @beta
+ * @public
  */
 export function useGraphWithCredential<T>(
   fetchGraphDataAsync: (

--- a/packages/sdk-react/src/useTeamsFx.ts
+++ b/packages/sdk-react/src/useTeamsFx.ts
@@ -44,7 +44,7 @@ export type TeamsFxContext = {
  * @param teamsfxConfig - custom configuration to override default ones.
  * @returns TeamsFxContext object
  *
- * @beta
+ * @public
  */
 export function useTeamsFx(teamsfxConfig?: Record<string, string>): TeamsFxContext {
   const [result] = useTeams({});

--- a/packages/sdk-react/src/useTeamsUserCredential.ts
+++ b/packages/sdk-react/src/useTeamsUserCredential.ts
@@ -50,7 +50,7 @@ export type TeamsContextWithCredential = {
  * @param authConfig - custom configuration to override default ones.
  * @returns TeamsContextWithCredential object
  *
- * @beta
+ * @public
  */
 export function useTeamsUserCredential(
   authConfig: TeamsUserCredentialAuthConfig


### PR DESCRIPTION
- Add annotations to the protected methods in the SDK so that they can be recognized when the SDK reference is automatically generated on learn.microsoft site.
- Change all `@beta` annotations to `@public`.