### PR TITLE
refactor: update templates scripts to catch up CD changes

### DIFF
--- a/.github/scripts/fxcore-sync-up-version.js
+++ b/.github/scripts/fxcore-sync-up-version.js
@@ -45,14 +45,16 @@ if (!semver.prerelease(templateVersion)) {
   console.log("sync up template in fx-core as 0.0.0-alpha");
   templateConfigFile.version = "0.0.0-alpha";
   templateConfigFile.tagPrefix = "templates-";
+  templateConfigFile.useLocalTemplate = false;
   fse.writeFileSync(
     templateConfig,
     JSON.stringify(templateConfigFile, null, 4)
   );
 } else if (templateVersion.includes("beta")) {
-  console.log("sync up template in fx-core as 0.0.0-prerelease");
-  templateConfigFile.version = "0.0.0-prerelease";
+  console.log("sync up template in fx-core as 0.0.0-beta");
+  templateConfigFile.version = "0.0.0-beta";
   templateConfigFile.tagPrefix = "templates-";
+  templateConfigFile.useLocalTemplate = false;
   fse.writeFileSync(
     templateConfig,
     JSON.stringify(templateConfigFile, null, 4)

--- a/.github/scripts/fxcore-sync-up-version.js
+++ b/.github/scripts/fxcore-sync-up-version.js
@@ -45,7 +45,7 @@ if (!semver.prerelease(templateVersion)) {
   console.log("sync up template in fx-core as 0.0.0-alpha");
   templateConfigFile.version = "0.0.0-alpha";
   templateConfigFile.tagPrefix = "templates-";
-  templateConfigFile.useLocalTemplate = false;
+  templateConfigFile.useLocalTemplate = true;
   fse.writeFileSync(
     templateConfig,
     JSON.stringify(templateConfigFile, null, 4)
@@ -54,7 +54,7 @@ if (!semver.prerelease(templateVersion)) {
   console.log("sync up template in fx-core as 0.0.0-beta");
   templateConfigFile.version = "0.0.0-beta";
   templateConfigFile.tagPrefix = "templates-";
-  templateConfigFile.useLocalTemplate = false;
+  templateConfigFile.useLocalTemplate = true;
   fse.writeFileSync(
     templateConfig,
     JSON.stringify(templateConfigFile, null, 4)

--- a/.github/scripts/template-zip-autogen-v3.sh
+++ b/.github/scripts/template-zip-autogen-v3.sh
@@ -14,18 +14,16 @@ TEMPLATE_OUTPUT_DIR=$1
 mkdir -p ${TEMPLATE_OUTPUT_DIR}
 
 TEMPLATE_BASE_DIR="./templates"
-cd ${TEMPLATE_BASE_DIR}
-TEMPLATE_NAMES=$(ls -d *)
-cd -
+TEMPLATE_NAMES=(common csharp js ts)
 
 for TEMPLATE_NAME in ${TEMPLATE_NAMES[@]}; do
     TEMPLATE_PATH=${TEMPLATE_BASE_DIR}/${TEMPLATE_NAME}
-    if [ ! -d ${TEMPLATE_PATH} ]; then
+    if [ ! -d "${TEMPLATE_PATH}" ]; then
         echo "The folder ${TEMPLATE_PATH} does not exist."
         exit -1
     fi
 
-    cd ${TEMPLATE_PATH}
+    cd "${TEMPLATE_PATH}"
     zip -rq ${TEMPLATE_OUTPUT_DIR}/${TEMPLATE_NAME}.zip .
     cd -
 done

--- a/.github/scripts/template-zip-autogen-v3.sh
+++ b/.github/scripts/template-zip-autogen-v3.sh
@@ -18,12 +18,12 @@ TEMPLATE_NAMES=(common csharp js ts)
 
 for TEMPLATE_NAME in ${TEMPLATE_NAMES[@]}; do
     TEMPLATE_PATH=${TEMPLATE_BASE_DIR}/${TEMPLATE_NAME}
-    if [ ! -d "${TEMPLATE_PATH}" ]; then
+    if [ ! -d ${TEMPLATE_PATH} ]; then
         echo "The folder ${TEMPLATE_PATH} does not exist."
         exit -1
     fi
 
-    cd "${TEMPLATE_PATH}"
+    cd ${TEMPLATE_PATH}
     zip -rq ${TEMPLATE_OUTPUT_DIR}/${TEMPLATE_NAME}.zip .
     cd -
 done

--- a/packages/fx-core/src/common/templates-config.json
+++ b/packages/fx-core/src/common/templates-config.json
@@ -5,5 +5,6 @@
     "templateDownloadBaseURL": "https://github.com/OfficeDev/TeamsFx/releases/download",
     "templateReleaseURL": "https://github.com/OfficeDev/TeamsFx/releases/expanded_assets",
     "templateDownloadBasePath": "/OfficeDev/TeamsFx/releases/download",
-    "templateExt": ".zip"
+    "templateExt": ".zip",
+    "useLocalTemplate": false
 }

--- a/packages/fx-core/src/component/generator/utils.ts
+++ b/packages/fx-core/src/component/generator/utils.ts
@@ -30,10 +30,10 @@ async function selectTemplateTag(getTags: () => Promise<string[]>): Promise<stri
     : "";
   const templateVersion = templateConfig.version;
   const templateTagPrefix = templateConfig.tagPrefix;
+  const useLocal = templateConfig.useLocalTemplate;
   const versionPattern = preRelease || templateVersion;
 
-  // To avoid incompatible, alpha release does not download latest template.
-  if ([templateAlphaVersion, templatePrereleaseVersion].includes(versionPattern)) {
+  if (useLocal.toString() === "true") {
     throw new CancelDownloading();
   }
 

--- a/packages/fx-core/tests/component/generator/generator.test.ts
+++ b/packages/fx-core/tests/component/generator/generator.test.ts
@@ -74,11 +74,11 @@ describe("Generator utils", () => {
     assert.isTrue(url.includes("0.0.0-rc"));
   });
 
-  it("alpha or prerelease should return error to use fallback", async () => {
+  it("set useLocalTemplate flag to true", async () => {
     mockedEnvRestore = mockedEnv({
       TEAMSFX_TEMPLATE_PRERELEASE: "",
     });
-    sandbox.replace(templateConfig, "version", "0.0.0-alpha");
+    sandbox.replace(templateConfig, "useLocalTemplate", true);
     const tagList = "1.0.0\n 2.0.0\n 2.1.0\n 3.0.0";
     sandbox.stub(axios, "get").resolves({ data: tagList, status: 200 } as AxiosResponse);
     try {


### PR DESCRIPTION
1. Use beta tag for prerelease template.
2. Update generation script since scenario folder has been removed.
3. Add UseLocalTemplate flag in template config.