### PR TITLE
build: update dotnet sdk version to stable

### DIFF
--- a/packages/dotnet-sdk/CHANGELOG.md
+++ b/packages/dotnet-sdk/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 2.1.0-rc
+# 2.1.0
 
 - Add new interface `IConversationReferenceStore` to manage notification target references.
 - Support to get a paginated list of targets where the bot is installed in notification bot.

--- a/packages/dotnet-sdk/src/TeamsFx/Microsoft.TeamsFx.csproj
+++ b/packages/dotnet-sdk/src/TeamsFx/Microsoft.TeamsFx.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Microsoft.TeamsFx</AssemblyName>
     <RootNamespace>Microsoft.TeamsFx</RootNamespace>
-    <Version>2.1.0-rc</Version>
+    <Version>2.1.0</Version>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
     <RepositoryUrl>https://github.com/OfficeDev/TeamsFx</RepositoryUrl>


### PR DESCRIPTION
Update .NET SDK from `2.1.0-rc` to `2.1.0`.
Work item: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/17979742/