### PR TITLE
test(e2e): remove teamsApp/extendToM365 to unblock e2e

### DIFF
--- a/packages/cli/tests/e2e/debug/DebugNonSsoTab.tests.ts
+++ b/packages/cli/tests/e2e/debug/DebugNonSsoTab.tests.ts
@@ -21,7 +21,8 @@ import {
   getUniqueAppName,
   readContextMultiEnvV3,
 } from "../commonUtils";
-import { deleteAadAppByObjectId, deleteTeamsApp, getTeamsApp } from "./utility";
+import { deleteTeamsApp, getTeamsApp } from "./utility";
+import { removeTeamsAppExtendToM365 } from "../commonUtils";
 
 describe("Debug V3 tab-non-sso template", () => {
   const testFolder = getTestFolder();
@@ -49,6 +50,9 @@ describe("Debug V3 tab-non-sso template", () => {
     // create
     await CliHelper.createProjectWithCapability(appName, testFolder, Capability.TabNonSso);
     console.log(`[Successfully] scaffold to ${projectPath}`);
+
+    // remove teamsApp/extendToM365 in case it fails
+    removeTeamsAppExtendToM365(path.join(projectPath, "teamsapp.local.yml"));
 
     // provision
     await CliHelper.provisionProject(projectPath, "", "local");

--- a/packages/cli/tests/e2e/frontend/BasicTabHappyPath.tests.ts
+++ b/packages/cli/tests/e2e/frontend/BasicTabHappyPath.tests.ts
@@ -15,6 +15,7 @@ import {
   getUniqueAppName,
   readContextMultiEnvV3,
   setProvisionParameterValueV3,
+  removeTeamsAppExtendToM365,
 } from "../commonUtils";
 import { Capability, EnvConstants } from "../../commonlib/constants";
 import { CliHelper } from "../../commonlib/cliHelper";
@@ -61,6 +62,9 @@ describe("Basic Tab", function () {
       fs.access(indexFile, fs.constants.F_OK, (err) => {
         assert.notExists(err);
       });
+
+      // remove teamsApp/extendToM365 in case it fails
+      removeTeamsAppExtendToM365(path.join(projectPath, "teamsapp.yml"));
 
       // Provision
       await setProvisionParameterValueV3(projectPath, env, {

--- a/packages/cli/tests/e2e/frontend/CanDeployToCustomizedRg.tests.ts
+++ b/packages/cli/tests/e2e/frontend/CanDeployToCustomizedRg.tests.ts
@@ -19,6 +19,7 @@ import {
   deleteResourceGroupByName,
   customizeBicepFilesToCustomizedRg,
   readContextMultiEnvV3,
+  removeTeamsAppExtendToM365,
 } from "../commonUtils";
 import M365Login from "../../../src/commonlib/m365Login";
 import { environmentManager, isV3Enabled } from "@microsoft/teamsfx-core";
@@ -49,6 +50,9 @@ describe("Deploy to customized resource group", function () {
           testFolder,
           Capability.M365SsoLaunchPage
         );
+
+        // remove teamsApp/extendToM365 in case it fails
+        removeTeamsAppExtendToM365(path.join(projectPath, "teamsapp.yml"));
 
         // Create empty resource group
         const customizedRgName = `${appName}-customized-rg`;

--- a/packages/cli/tests/e2e/frontend/TestCreateTab.tests.ts
+++ b/packages/cli/tests/e2e/frontend/TestCreateTab.tests.ts
@@ -22,6 +22,7 @@ import {
   getSubscriptionId,
   getTestFolder,
   getUniqueAppName,
+  removeTeamsAppExtendToM365,
 } from "../commonUtils";
 
 describe("Create single tab", function () {
@@ -55,6 +56,9 @@ describe("Create single tab", function () {
 
     it(`Provision Resource: React app without function`, { testPlanCaseId: 10298738 }, async () => {
       await CliHelper.setSubscription(subscription, projectPath);
+
+      // remove teamsApp/extendToM365 in case it fails
+      removeTeamsAppExtendToM365(path.join(projectPath, "teamsapp.yml"));
 
       await CliHelper.provisionProject(projectPath);
 

--- a/packages/cli/tests/e2e/multienv/TestRemoteHappyPathSPFx.tests.ts
+++ b/packages/cli/tests/e2e/multienv/TestRemoteHappyPathSPFx.tests.ts
@@ -18,6 +18,7 @@ import {
   getUniqueAppName,
   mockTeamsfxMultiEnvFeatureFlag,
   readContextMultiEnvV3,
+  removeTeamsAppExtendToM365,
 } from "../commonUtils";
 import { AppPackageFolderName, BuildFolderName } from "@microsoft/teamsfx-api";
 import { AppStudioValidator, SharepointValidator } from "../../commonlib";
@@ -97,6 +98,9 @@ describe("Multi Env Happy Path for SPFx", function () {
       console.log(
         `[Successfully] env list, stdout: '${result.stdout}', stderr: '${result.stderr}'`
       );
+
+      // remove teamsApp/extendToM365 in case it fails
+      removeTeamsAppExtendToM365(path.join(projectPath, "teamsapp.yml"));
 
       // provision
       result = await execAsyncWithRetry(`teamsfx provision --env ${env}`, {

--- a/packages/cli/tests/e2e/samples/ProvisionDeveloperDashboard.tests.ts
+++ b/packages/cli/tests/e2e/samples/ProvisionDeveloperDashboard.tests.ts
@@ -9,7 +9,7 @@ import { expect } from "chai";
 import fs from "fs-extra";
 import path from "path";
 import { it } from "@microsoft/extra-shot-mocha";
-import { getTestFolder, getUniqueAppName } from "../commonUtils";
+import { getTestFolder, getUniqueAppName, removeTeamsAppExtendToM365 } from "../commonUtils";
 import { Executor } from "../../utils/executor";
 import { Cleaner } from "../../utils/cleaner";
 import { TemplateProject } from "../../commonlib/constants";
@@ -23,6 +23,9 @@ describe("teamsfx new template", function () {
     await Executor.openTemplateProject(appName, testFolder, TemplateProject.AssistDashboard);
     expect(fs.pathExistsSync(projectPath)).to.be.true;
     expect(fs.pathExistsSync(path.resolve(projectPath, "infra"))).to.be.true;
+
+    // remove teamsApp/extendToM365 in case it fails
+    removeTeamsAppExtendToM365(path.join(projectPath, "teamsapp.local.yml"));
 
     // Provision
     {

--- a/packages/cli/tests/e2e/samples/ProvisionDeveloperDashboard.tests.ts
+++ b/packages/cli/tests/e2e/samples/ProvisionDeveloperDashboard.tests.ts
@@ -25,7 +25,7 @@ describe("teamsfx new template", function () {
     expect(fs.pathExistsSync(path.resolve(projectPath, "infra"))).to.be.true;
 
     // remove teamsApp/extendToM365 in case it fails
-    removeTeamsAppExtendToM365(path.join(projectPath, "teamsapp.local.yml"));
+    removeTeamsAppExtendToM365(path.join(projectPath, "teamsapp.yml"));
 
     // Provision
     {

--- a/templates/ts/non-sso-tab/teamsapp.yml.tpl
+++ b/templates/ts/non-sso-tab/teamsapp.yml.tpl
@@ -66,11 +66,14 @@ provision:
     with:
       # Relative path to this file. This is the path for built zip file.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
-  - uses: teamsApp/extendToM365 # Extend your Teams app to Outlook and the Microsoft 365 app
+  # Extend your Teams app to Outlook and the Microsoft 365 app
+  - uses: teamsApp/extendToM365
     with:
-      appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip # Relative path to the build app package.
+      # Relative path to the build app package.
+      appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
+    # Write the information of created resources into environment file for
+    # the specified environment variable(s).
     writeToEnvironmentFile:
-      # Write the information of created resources into environment file for the specified environment variable(s).
       titleId: M365_TITLE_ID
       appId: M365_APP_ID
 


### PR DESCRIPTION
`teamsApp/extendToM365` will be covered in `./m365/*`.

https://github.com/OfficeDev/TeamsFx/actions/runs/5130815186