### PR TITLE
fix: handler deps checker error when the error exist

### DIFF
--- a/packages/vscode-extension/src/debug/prerequisitesHandler.ts
+++ b/packages/vscode-extension/src/debug/prerequisitesHandler.ts
@@ -516,7 +516,9 @@ async function checkNode(
             ? doctorConstant.NodeSuccess.split("@Version").join(nodeStatus.details.installVersion)
             : nodeStatus.name,
           failureMsg: nodeStatus.name,
-          error: handleDepsCheckerError(nodeStatus.error, nodeStatus),
+          error: nodeStatus.error
+            ? handleDepsCheckerError(nodeStatus.error, nodeStatus)
+            : undefined,
         };
       } catch (error: unknown) {
         return {


### PR DESCRIPTION
Detail: [Bug 24198255](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/24198255): [VSC] teamsfx project local debug "node.js check" failed