### PR TITLE
fix: fix zip path doesn't work properly under windows

### DIFF
--- a/packages/fx-core/src/component/utils/fileOperation.ts
+++ b/packages/fx-core/src/component/utils/fileOperation.ts
@@ -69,7 +69,8 @@ export async function zipFolderAsync(
         }
 
         // If fail to reuse cached entry, load it from disk.
-        const fullPath = path.join(sourceDir, relativePath);
+        // path doesn't work properly under windows
+        const fullPath = path.normalize(path.join(sourceDir, relativePath)).split("\\").join("/");
         const task = addFileIntoZip(zip, fullPath, relativePath, stats);
         tasks.push(task);
       }


### PR DESCRIPTION
fix: #8943 

also: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/24213431