### PR TITLE
refactor: add error stack to action telemetries

### DIFF
--- a/packages/fx-core/src/component/constants.ts
+++ b/packages/fx-core/src/component/constants.ts
@@ -76,6 +76,7 @@ export const TelemetryConstants = {
     errorCode: "error-code",
     errorType: "error-type",
     errorMessage: "error-message",
+    errorStack: "error-stack",
     timeCost: "time-cost",
   },
   values: {

--- a/packages/fx-core/src/component/utils/teamsFxTelemetryReporter.ts
+++ b/packages/fx-core/src/component/utils/teamsFxTelemetryReporter.ts
@@ -54,6 +54,7 @@ export class TeamsFxTelemetryReporter {
           [TelemetryConstants.properties.errorCode]: errorCode,
           [TelemetryConstants.properties.errorType]: errorType,
           [TelemetryConstants.properties.errorMessage]: error.message,
+          [TelemetryConstants.properties.errorStack]: error.stack !== undefined ? error.stack : "",
           ...actualConfig.properties,
         };
 

--- a/packages/vscode-extension/src/commonlib/telemetry.ts
+++ b/packages/vscode-extension/src/commonlib/telemetry.ts
@@ -106,6 +106,12 @@ export class VSCodeTelemetryReporter extends vscode.Disposable implements Teleme
       );
     }
 
+    if (TelemetryProperty.ErrorStack in properties) {
+      properties[TelemetryProperty.ErrorStack] = anonymizeFilePaths(
+        properties[TelemetryProperty.ErrorStack]
+      );
+    }
+
     if (this.testFeatureFlag) {
       this.logTelemetryErrorEvent(eventName, properties, measurements, errorProps);
     } else {

--- a/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
@@ -243,6 +243,7 @@ export enum TelemetryProperty {
   ErrorType = "error-type",
   ErrorCode = "error-code",
   ErrorMessage = "error-message",
+  ErrorStack = "error-stack",
   Errors = "errors",
   DebugSessionId = "session-id",
   DebugType = "type",

--- a/packages/vscode-extension/test/extension/telemetry.test.ts
+++ b/packages/vscode-extension/test/extension/telemetry.test.ts
@@ -86,17 +86,17 @@ describe("telemetry", () => {
       "sampleErrorEvent",
       {
         stringProp: "some string",
-        stackProp: "some user stack trace",
+        "error-stack": "some user stack trace at C:/fake_path/fake_file:1:1",
       },
       { numericMeasure: 123 },
-      ["stackProp"]
+      ["error-stack"]
     );
 
     expect(reporterSpy.sendTelemetryErrorEvent).to.have.been.called.with(
       "sampleErrorEvent",
       {
         stringProp: "some string",
-        stackProp: "some user stack trace",
+        "error-stack": "some user stack trace at <REDACTED: user-file-path>:1:1",
         "project-id": "",
         "correlation-id": "",
         "feature-flags": featureFlags,


### PR DESCRIPTION
Add error stack to help better troubleshoot system errors in our code
Also update vscode telemetry reporter to remove file path per suggestion.