### PR TITLE
chore: update the code owners of deps checker

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -229,8 +229,9 @@
 /packages/fx-core/src/component @jayzhang @xzf0587 @hund030 @LongOddCode
 /packages/fx-core/test/component @jayzhang @xzf0587 @hund030 @LongOddCode
 
-/packages/fx-core/src/common/deps-checker @qinezh @a1exwang @kimizhu @swatDong
-/packages/fx-core/tests/common/deps-checker @qinezh @a1exwang @kimizhu @swatDong
+/packages/fx-core/src/common/deps-checker @qinezh @a1exwang @kimizhu @swatDong @XiaofuHuang
+/packages/fx-core/tests/common/deps-checker @qinezh @a1exwang @kimizhu @swatDong @XiaofuHuang
+/packages/fx-core/resource/deps-checker @qinezh @a1exwang @kimizhu @swatDong @XiaofuHuang
 
 /packages/fx-core/src/component/resource/aadApp @KennethBWSong @adashen @SLdragon
 /packages/fx-core/tests/component/resource/aadApp @KennethBWSong @adashen @SLdragon


### PR DESCRIPTION
detail: [Bug 24332668](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/24332668): Update codeowners