### PR TITLE
fix: hide developer portal in non-teams app

### DIFF
--- a/packages/fx-core/src/component/driver/teamsApp/configure.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/configure.ts
@@ -97,7 +97,7 @@ export class ConfigureTeamsAppDriver implements StepDriver {
     if (manifest.isErr()) {
       return err(manifest.error);
     }
-    const capabilities = manifestUtils._getCapabilities(manifest.value).map((x) => {
+    const capabilities = manifestUtils.getCapabilities(manifest.value).map((x) => {
       if (x == "staticTab" || x == "configurableTab") {
         return "Tab";
       } else {

--- a/packages/fx-core/src/component/driver/teamsApp/utils/ManifestUtils.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/utils/ManifestUtils.ts
@@ -241,7 +241,7 @@ export class ManifestUtils {
         return false;
     }
   }
-  _getCapabilities(template: TeamsAppManifest): string[] {
+  public getCapabilities(template: TeamsAppManifest): string[] {
     const capabilities: string[] = [];
     if (template.staticTabs && template.staticTabs!.length > 0) {
       capabilities.push("staticTab");

--- a/packages/fx-core/src/core/FxCoreImplementV3.ts
+++ b/packages/fx-core/src/core/FxCoreImplementV3.ts
@@ -677,7 +677,7 @@ export class FxCoreV3Implement {
     }
 
     const teamsAppId = manifestRes.value.id;
-    const capabilities = manifestUtils._getCapabilities(manifestRes.value);
+    const capabilities = manifestUtils.getCapabilities(manifestRes.value);
 
     const launchHelper = new LaunchHelper(
       this.tools.tokenProvider.m365TokenProvider,

--- a/packages/fx-core/src/index.ts
+++ b/packages/fx-core/src/index.ts
@@ -31,6 +31,7 @@ export { AppStudioClient } from "./component/driver/teamsApp/clients/appStudioCl
 export { getPermissionMap } from "./component/resource/aadApp/permissions/index";
 export { AppDefinition } from "./component/driver/teamsApp/interfaces/appdefinitions/appDefinition";
 export * from "./component/driver/teamsApp/utils/utils";
+export { manifestUtils } from "./component/driver/teamsApp/utils/ManifestUtils";
 export { CollaborationConstants } from "./core/collaborator";
 export { environmentManager } from "./core/environment";
 export * from "./core/error";

--- a/packages/vscode-extension/src/treeview/treeViewManager.ts
+++ b/packages/vscode-extension/src/treeview/treeViewManager.ts
@@ -3,9 +3,10 @@
 import * as vscode from "vscode";
 
 import { TreeCategory } from "@microsoft/teamsfx-api";
+import { manifestUtils } from "@microsoft/teamsfx-core";
 
 import { AdaptiveCardCodeLensProvider } from "../codeLensProvider";
-import { isSPFxProject } from "../globalVariables";
+import { isSPFxProject, workspaceUri } from "../globalVariables";
 import { localize } from "../utils/localizeUtils";
 import accountTreeViewProviderInstance from "./account/accountTreeViewProvider";
 import { CommandsTreeViewProvider } from "./commandsTreeViewProvider";
@@ -48,6 +49,12 @@ class TreeViewManager {
 
   public async updateTreeViewsByContent(removeProjectRelatedCommands = false): Promise<void> {
     const hasAdaptiveCard = await AdaptiveCardCodeLensProvider.detectedAdaptiveCards();
+    let isTeamsApp = false;
+    const manifestRes = await manifestUtils.readAppManifest(workspaceUri?.fsPath || "");
+    if (manifestRes.isOk()) {
+      isTeamsApp = manifestUtils.getCapabilities(manifestRes.value).length > 0;
+    }
+
     if (removeProjectRelatedCommands) {
       const developmentTreeviewProvider = this.getTreeView(
         "teamsfx-development"
@@ -57,7 +64,8 @@ class TreeViewManager {
       developmentCommands.push(...this.getDevelopmentCommands());
       developmentCommands.splice(3);
       developmentTreeviewProvider.refresh();
-    } else if (hasAdaptiveCard) {
+    }
+    if (hasAdaptiveCard) {
       // after "Validate application" command, the adaptive card will be shown
       const utilityTreeviewProvider = this.getTreeView(
         "teamsfx-utility"
@@ -78,6 +86,21 @@ class TreeViewManager {
             { name: "eye", custom: false }
           )
         );
+      }
+      utilityTreeviewProvider.refresh();
+    }
+    if (!isTeamsApp) {
+      const utilityTreeviewProvider = this.getTreeView(
+        "teamsfx-utility"
+      ) as CommandsTreeViewProvider;
+      const utilityCommands = utilityTreeviewProvider.getCommands();
+      const validateCommandIndex = utilityCommands.findIndex(
+        (command) =>
+          command.commandId === "fx-extension.openAppManagement" ||
+          command.commandId === "fx-extension.publishInDeveloperPortal"
+      );
+      if (validateCommandIndex >= 0) {
+        utilityCommands.splice(validateCommandIndex, 1);
       }
       utilityTreeviewProvider.refresh();
     }


### PR DESCRIPTION
Related task: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/21605701