### PR TITLE
feat: question to select a local file or enter value

### DIFF
--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -479,7 +479,7 @@ export class QTreeNode {
 }
 
 // @public (undocumented)
-export type Question = SingleSelectQuestion | MultiSelectQuestion | TextInputQuestion | SingleFileQuestion | MultiFileQuestion | FolderQuestion | FuncQuestion | SingleFileQuestion | SelectFileOrInputQuestion;
+export type Question = SingleSelectQuestion | MultiSelectQuestion | TextInputQuestion | SingleFileQuestion | MultiFileQuestion | FolderQuestion | FuncQuestion | SingleFileQuestion | SingleFileOrInputQuestion;
 
 // @public
 export type SelectFileConfig = UIConfig<string> & {
@@ -492,24 +492,6 @@ export type SelectFileConfig = UIConfig<string> & {
         description?: string;
     }[];
 };
-
-// @public (undocumented)
-export interface selectFileOrInputConfig extends SelectFileConfig {
-    // (undocumented)
-    inputBoxConfig: InputTextConfig;
-    // (undocumented)
-    inputOptionItem: OptionItem;
-}
-
-// @public (undocumented)
-export interface SelectFileOrInputQuestion extends UserInputQuestion {
-    // (undocumented)
-    inputBoxConfig: InputTextConfig;
-    // (undocumented)
-    inputOptionItem: OptionItem;
-    // (undocumented)
-    type: "singleFileOrText";
-}
 
 // @public (undocumented)
 export type SelectFileResult = InputResult<string>;
@@ -540,6 +522,24 @@ export interface Settings {
 
 // @public (undocumented)
 export const SettingsFolderName = "teamsfx";
+
+// @public (undocumented)
+export interface singleFileOrInputConfig extends SelectFileConfig {
+    // (undocumented)
+    inputBoxConfig: InputTextConfig;
+    // (undocumented)
+    inputOptionItem: OptionItem;
+}
+
+// @public (undocumented)
+export interface SingleFileOrInputQuestion extends UserInputQuestion {
+    // (undocumented)
+    inputBoxConfig: InputTextConfig;
+    // (undocumented)
+    inputOptionItem: OptionItem;
+    // (undocumented)
+    type: "singleFileOrText";
+}
 
 // @public
 export interface SingleFileQuestion extends UserInputQuestion {
@@ -906,7 +906,6 @@ export interface UserInteraction {
         };
     }): Promise<Result<string, FxError>>;
     selectFile: (config: SelectFileConfig) => Promise<Result<SelectFileResult, FxError>>;
-    selectFileOrInput?(config: selectFileOrInputConfig): Promise<Result<InputResult<string>, FxError>>;
     selectFiles: (config: SelectFilesConfig) => Promise<Result<SelectFilesResult, FxError>>;
     selectFolder: (config: SelectFolderConfig) => Promise<Result<SelectFolderResult, FxError>>;
     selectOption: (config: SingleSelectConfig) => Promise<Result<SingleSelectResult, FxError>>;
@@ -916,6 +915,7 @@ export interface UserInteraction {
         content: string;
         color: Colors;
     }>, modal: boolean, ...items: string[]): Promise<Result<string | undefined, FxError>>;
+    singleFileOrInput?(config: singleFileOrInputConfig): Promise<Result<InputResult<string>, FxError>>;
 }
 
 // @public

--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -524,7 +524,7 @@ export interface Settings {
 export const SettingsFolderName = "teamsfx";
 
 // @public (undocumented)
-export interface singleFileOrInputConfig extends SelectFileConfig {
+export interface SingleFileOrInputConfig extends SelectFileConfig {
     // (undocumented)
     inputBoxConfig: InputTextConfig;
     // (undocumented)
@@ -906,6 +906,7 @@ export interface UserInteraction {
         };
     }): Promise<Result<string, FxError>>;
     selectFile: (config: SelectFileConfig) => Promise<Result<SelectFileResult, FxError>>;
+    selectFileOrInput?(config: SingleFileOrInputConfig): Promise<Result<InputResult<string>, FxError>>;
     selectFiles: (config: SelectFilesConfig) => Promise<Result<SelectFilesResult, FxError>>;
     selectFolder: (config: SelectFolderConfig) => Promise<Result<SelectFolderResult, FxError>>;
     selectOption: (config: SingleSelectConfig) => Promise<Result<SingleSelectResult, FxError>>;
@@ -915,7 +916,6 @@ export interface UserInteraction {
         content: string;
         color: Colors;
     }>, modal: boolean, ...items: string[]): Promise<Result<string | undefined, FxError>>;
-    singleFileOrInput?(config: singleFileOrInputConfig): Promise<Result<InputResult<string>, FxError>>;
 }
 
 // @public

--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -479,7 +479,7 @@ export class QTreeNode {
 }
 
 // @public (undocumented)
-export type Question = SingleSelectQuestion | MultiSelectQuestion | TextInputQuestion | SingleFileQuestion | MultiFileQuestion | FolderQuestion | FuncQuestion | SingleFileQuestion;
+export type Question = SingleSelectQuestion | MultiSelectQuestion | TextInputQuestion | SingleFileQuestion | MultiFileQuestion | FolderQuestion | FuncQuestion | SingleFileQuestion | SelectLocalFileOrInputQuestion;
 
 // @public
 export type SelectFileConfig = UIConfig<string> & {
@@ -511,6 +511,24 @@ export type SelectFolderConfig = UIConfig<string>;
 
 // @public (undocumented)
 export type SelectFolderResult = InputResult<string>;
+
+// @public (undocumented)
+export interface selectLocalFileOrInputConfig extends SelectFileConfig {
+    // (undocumented)
+    inputBoxConfig: InputTextConfig;
+    // (undocumented)
+    inputOptionItem: OptionItem;
+}
+
+// @public (undocumented)
+export interface SelectLocalFileOrInputQuestion extends UserInputQuestion {
+    // (undocumented)
+    inputBoxConfig: InputTextConfig;
+    // (undocumented)
+    inputOptionItem: OptionItem;
+    // (undocumented)
+    type: "selectLocalFileOrInput";
+}
 
 // @public
 export interface Settings {
@@ -865,7 +883,7 @@ export interface UserInputQuestion extends BaseQuestion {
     placeholder?: string | LocalFunc<string | undefined>;
     prompt?: string | LocalFunc<string | undefined>;
     title: string | LocalFunc<string | undefined>;
-    type: "singleSelect" | "multiSelect" | "singleFile" | "multiFile" | "folder" | "text";
+    type: "singleSelect" | "multiSelect" | "singleFile" | "multiFile" | "folder" | "text" | "selectLocalFileOrInput";
     validation?: ValidationSchema;
     validationHelp?: string;
 }
@@ -890,6 +908,7 @@ export interface UserInteraction {
     selectFile: (config: SelectFileConfig) => Promise<Result<SelectFileResult, FxError>>;
     selectFiles: (config: SelectFilesConfig) => Promise<Result<SelectFilesResult, FxError>>;
     selectFolder: (config: SelectFolderConfig) => Promise<Result<SelectFolderResult, FxError>>;
+    selectLocalFileOrInput?(config: selectLocalFileOrInputConfig): Promise<Result<InputResult<string>, FxError>>;
     selectOption: (config: SingleSelectConfig) => Promise<Result<SingleSelectResult, FxError>>;
     selectOptions: (config: MultiSelectConfig) => Promise<Result<MultiSelectResult, FxError>>;
     showMessage(level: "info" | "warn" | "error", message: string, modal: boolean, ...items: string[]): Promise<Result<string | undefined, FxError>>;

--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -479,7 +479,7 @@ export class QTreeNode {
 }
 
 // @public (undocumented)
-export type Question = SingleSelectQuestion | MultiSelectQuestion | TextInputQuestion | SingleFileQuestion | MultiFileQuestion | FolderQuestion | FuncQuestion | SingleFileQuestion | SelectLocalFileOrInputQuestion;
+export type Question = SingleSelectQuestion | MultiSelectQuestion | TextInputQuestion | SingleFileQuestion | MultiFileQuestion | FolderQuestion | FuncQuestion | SingleFileQuestion | SelectFileOrInputQuestion;
 
 // @public
 export type SelectFileConfig = UIConfig<string> & {
@@ -492,6 +492,24 @@ export type SelectFileConfig = UIConfig<string> & {
         description?: string;
     }[];
 };
+
+// @public (undocumented)
+export interface selectFileOrInputConfig extends SelectFileConfig {
+    // (undocumented)
+    inputBoxConfig: InputTextConfig;
+    // (undocumented)
+    inputOptionItem: OptionItem;
+}
+
+// @public (undocumented)
+export interface SelectFileOrInputQuestion extends UserInputQuestion {
+    // (undocumented)
+    inputBoxConfig: InputTextConfig;
+    // (undocumented)
+    inputOptionItem: OptionItem;
+    // (undocumented)
+    type: "singleFileOrText";
+}
 
 // @public (undocumented)
 export type SelectFileResult = InputResult<string>;
@@ -511,24 +529,6 @@ export type SelectFolderConfig = UIConfig<string>;
 
 // @public (undocumented)
 export type SelectFolderResult = InputResult<string>;
-
-// @public (undocumented)
-export interface selectLocalFileOrInputConfig extends SelectFileConfig {
-    // (undocumented)
-    inputBoxConfig: InputTextConfig;
-    // (undocumented)
-    inputOptionItem: OptionItem;
-}
-
-// @public (undocumented)
-export interface SelectLocalFileOrInputQuestion extends UserInputQuestion {
-    // (undocumented)
-    inputBoxConfig: InputTextConfig;
-    // (undocumented)
-    inputOptionItem: OptionItem;
-    // (undocumented)
-    type: "selectLocalFileOrInput";
-}
 
 // @public
 export interface Settings {
@@ -883,7 +883,7 @@ export interface UserInputQuestion extends BaseQuestion {
     placeholder?: string | LocalFunc<string | undefined>;
     prompt?: string | LocalFunc<string | undefined>;
     title: string | LocalFunc<string | undefined>;
-    type: "singleSelect" | "multiSelect" | "singleFile" | "multiFile" | "folder" | "text" | "selectLocalFileOrInput";
+    type: "singleSelect" | "multiSelect" | "singleFile" | "multiFile" | "folder" | "text" | "singleFileOrText";
     validation?: ValidationSchema;
     validationHelp?: string;
 }
@@ -906,9 +906,9 @@ export interface UserInteraction {
         };
     }): Promise<Result<string, FxError>>;
     selectFile: (config: SelectFileConfig) => Promise<Result<SelectFileResult, FxError>>;
+    selectFileOrInput?(config: selectFileOrInputConfig): Promise<Result<InputResult<string>, FxError>>;
     selectFiles: (config: SelectFilesConfig) => Promise<Result<SelectFilesResult, FxError>>;
     selectFolder: (config: SelectFolderConfig) => Promise<Result<SelectFolderResult, FxError>>;
-    selectLocalFileOrInput?(config: selectLocalFileOrInputConfig): Promise<Result<InputResult<string>, FxError>>;
     selectOption: (config: SingleSelectConfig) => Promise<Result<SingleSelectResult, FxError>>;
     selectOptions: (config: MultiSelectConfig) => Promise<Result<MultiSelectResult, FxError>>;
     showMessage(level: "info" | "warn" | "error", message: string, modal: boolean, ...items: string[]): Promise<Result<string | undefined, FxError>>;

--- a/packages/api/src/qm/question.ts
+++ b/packages/api/src/qm/question.ts
@@ -314,7 +314,7 @@ export interface FuncQuestion extends BaseQuestion {
   func: LocalFunc<any>;
 }
 
-export interface SelectFileOrInputQuestion extends UserInputQuestion {
+export interface SingleFileOrInputQuestion extends UserInputQuestion {
   type: "singleFileOrText";
   inputOptionItem: OptionItem;
   inputBoxConfig: InputTextConfig;
@@ -337,7 +337,7 @@ export type Question =
   | FolderQuestion
   | FuncQuestion
   | SingleFileQuestion
-  | SelectFileOrInputQuestion;
+  | SingleFileOrInputQuestion;
 
 /**
  * QTreeNode is the tree node data structure, which have three main properties:

--- a/packages/api/src/qm/question.ts
+++ b/packages/api/src/qm/question.ts
@@ -105,7 +105,7 @@ export interface UserInputQuestion extends BaseQuestion {
     | "multiFile"
     | "folder"
     | "text"
-    | "selectLocalFileOrInput";
+    | "singleFileOrText";
   /**
    * title is required for human input question
    */
@@ -314,8 +314,8 @@ export interface FuncQuestion extends BaseQuestion {
   func: LocalFunc<any>;
 }
 
-export interface SelectLocalFileOrInputQuestion extends UserInputQuestion {
-  type: "selectLocalFileOrInput";
+export interface SelectFileOrInputQuestion extends UserInputQuestion {
+  type: "singleFileOrText";
   inputOptionItem: OptionItem;
   inputBoxConfig: InputTextConfig;
 }
@@ -337,7 +337,7 @@ export type Question =
   | FolderQuestion
   | FuncQuestion
   | SingleFileQuestion
-  | SelectLocalFileOrInputQuestion;
+  | SelectFileOrInputQuestion;
 
 /**
  * QTreeNode is the tree node data structure, which have three main properties:

--- a/packages/api/src/qm/question.ts
+++ b/packages/api/src/qm/question.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import { Inputs, OptionItem } from "../types";
+import { InputTextConfig } from "./ui";
 import {
   FuncValidation,
   StringArrayValidation,
@@ -97,7 +98,14 @@ export interface UserInputQuestion extends BaseQuestion {
   /**
    * question type
    */
-  type: "singleSelect" | "multiSelect" | "singleFile" | "multiFile" | "folder" | "text";
+  type:
+    | "singleSelect"
+    | "multiSelect"
+    | "singleFile"
+    | "multiFile"
+    | "folder"
+    | "text"
+    | "selectLocalFileOrInput";
   /**
    * title is required for human input question
    */
@@ -306,6 +314,12 @@ export interface FuncQuestion extends BaseQuestion {
   func: LocalFunc<any>;
 }
 
+export interface SelectLocalFileOrInputQuestion extends UserInputQuestion {
+  type: "selectLocalFileOrInput";
+  inputOptionItem: OptionItem;
+  inputBoxConfig: InputTextConfig;
+}
+
 /**
  * `Group` is a virtual node in the question tree that wraps a group of questions, which share the same activation condition in this group.
  */
@@ -322,7 +336,8 @@ export type Question =
   | MultiFileQuestion
   | FolderQuestion
   | FuncQuestion
-  | SingleFileQuestion;
+  | SingleFileQuestion
+  | SelectLocalFileOrInputQuestion;
 
 /**
  * QTreeNode is the tree node data structure, which have three main properties:

--- a/packages/api/src/qm/ui.ts
+++ b/packages/api/src/qm/ui.ts
@@ -175,7 +175,7 @@ export interface ExecuteFuncConfig extends UIConfig<string> {
   inputs: Inputs;
 }
 
-export interface selectLocalFileOrInputConfig extends SelectFileConfig {
+export interface selectFileOrInputConfig extends SelectFileConfig {
   inputOptionItem: OptionItem;
   inputBoxConfig: InputTextConfig;
 }
@@ -337,8 +337,8 @@ export interface UserInteraction {
    * @returns A promise that resolves to the local file path or the value entered by user or FxError
    * @throws FxError
    */
-  selectLocalFileOrInput?(
-    config: selectLocalFileOrInputConfig
+  selectFileOrInput?(
+    config: selectFileOrInputConfig
   ): Promise<Result<InputResult<string>, FxError>>;
 }
 

--- a/packages/api/src/qm/ui.ts
+++ b/packages/api/src/qm/ui.ts
@@ -175,6 +175,11 @@ export interface ExecuteFuncConfig extends UIConfig<string> {
   inputs: Inputs;
 }
 
+export interface selectLocalFileOrInputConfig extends SelectFileConfig {
+  inputOptionItem: OptionItem;
+  inputBoxConfig: InputTextConfig;
+}
+
 /**
  * a wrapper of user input result
  */
@@ -325,6 +330,16 @@ export interface UserInteraction {
     timeout?: number;
     env?: { [k: string]: string };
   }): Promise<Result<string, FxError>>;
+
+  /**
+   * Shows two options to user, one will open a dialog to the user which allows to select a single file, another one will show an input box asking to enter a value
+   * @param config config to select local file or enter a value
+   * @returns A promise that resolves to the local file path or the value entered by user or FxError
+   * @throws FxError
+   */
+  selectLocalFileOrInput?(
+    config: selectLocalFileOrInputConfig
+  ): Promise<Result<InputResult<string>, FxError>>;
 }
 
 export interface IProgressHandler {

--- a/packages/api/src/qm/ui.ts
+++ b/packages/api/src/qm/ui.ts
@@ -175,7 +175,7 @@ export interface ExecuteFuncConfig extends UIConfig<string> {
   inputs: Inputs;
 }
 
-export interface singleFileOrInputConfig extends SelectFileConfig {
+export interface SingleFileOrInputConfig extends SelectFileConfig {
   inputOptionItem: OptionItem;
   inputBoxConfig: InputTextConfig;
 }
@@ -337,8 +337,8 @@ export interface UserInteraction {
    * @returns A promise that resolves to the local file path or the value entered by user or FxError
    * @throws FxError
    */
-  singleFileOrInput?(
-    config: singleFileOrInputConfig
+  selectFileOrInput?(
+    config: SingleFileOrInputConfig
   ): Promise<Result<InputResult<string>, FxError>>;
 }
 

--- a/packages/api/src/qm/ui.ts
+++ b/packages/api/src/qm/ui.ts
@@ -175,7 +175,7 @@ export interface ExecuteFuncConfig extends UIConfig<string> {
   inputs: Inputs;
 }
 
-export interface selectFileOrInputConfig extends SelectFileConfig {
+export interface singleFileOrInputConfig extends SelectFileConfig {
   inputOptionItem: OptionItem;
   inputBoxConfig: InputTextConfig;
 }
@@ -337,8 +337,8 @@ export interface UserInteraction {
    * @returns A promise that resolves to the local file path or the value entered by user or FxError
    * @throws FxError
    */
-  selectFileOrInput?(
-    config: selectFileOrInputConfig
+  singleFileOrInput?(
+    config: singleFileOrInputConfig
   ): Promise<Result<InputResult<string>, FxError>>;
 }
 

--- a/packages/fx-core/src/ui/visitor.ts
+++ b/packages/fx-core/src/ui/visitor.ts
@@ -228,11 +228,11 @@ const questionVisitor: QuestionTreeVisitor = async function (
         totalSteps: totalSteps,
         validation: validationFunc,
       });
-    } else if (question.type === "singleFileOrText" && !!ui.singleFileOrInput) {
+    } else if (question.type === "singleFileOrText" && !!ui.selectFileOrInput) {
       const validationFunc = question.validation
         ? getValidationFunction<string>(question.validation, inputs)
         : undefined;
-      const res = await ui.singleFileOrInput({
+      const res = await ui.selectFileOrInput({
         name: question.name,
         title: title,
         placeholder: placeholder,

--- a/packages/fx-core/src/ui/visitor.ts
+++ b/packages/fx-core/src/ui/visitor.ts
@@ -228,11 +228,11 @@ const questionVisitor: QuestionTreeVisitor = async function (
         totalSteps: totalSteps,
         validation: validationFunc,
       });
-    } else if (question.type === "singleFileOrText" && !!ui.selectFileOrInput) {
+    } else if (question.type === "singleFileOrText" && !!ui.singleFileOrInput) {
       const validationFunc = question.validation
         ? getValidationFunction<string>(question.validation, inputs)
         : undefined;
-      const res = await ui.selectFileOrInput({
+      const res = await ui.singleFileOrInput({
         name: question.name,
         title: title,
         placeholder: placeholder,

--- a/packages/fx-core/src/ui/visitor.ts
+++ b/packages/fx-core/src/ui/visitor.ts
@@ -228,6 +228,22 @@ const questionVisitor: QuestionTreeVisitor = async function (
         totalSteps: totalSteps,
         validation: validationFunc,
       });
+    } else if (question.type === "selectLocalFileOrInput" && !!ui.selectLocalFileOrInput) {
+      const validationFunc = question.validation
+        ? getValidationFunction<string>(question.validation, inputs)
+        : undefined;
+      const res = await ui.selectLocalFileOrInput({
+        name: question.name,
+        title: title,
+        placeholder: placeholder,
+        prompt: prompt,
+        inputOptionItem: question.inputOptionItem,
+        inputBoxConfig: question.inputBoxConfig,
+        step: step,
+        totalSteps: totalSteps,
+        validation: validationFunc,
+      });
+      return res;
     }
   }
   return err(

--- a/packages/fx-core/src/ui/visitor.ts
+++ b/packages/fx-core/src/ui/visitor.ts
@@ -228,11 +228,11 @@ const questionVisitor: QuestionTreeVisitor = async function (
         totalSteps: totalSteps,
         validation: validationFunc,
       });
-    } else if (question.type === "selectLocalFileOrInput" && !!ui.selectLocalFileOrInput) {
+    } else if (question.type === "singleFileOrText" && !!ui.selectFileOrInput) {
       const validationFunc = question.validation
         ? getValidationFunction<string>(question.validation, inputs)
         : undefined;
-      const res = await ui.selectLocalFileOrInput({
+      const res = await ui.selectFileOrInput({
         name: question.name,
         title: title,
         placeholder: placeholder,

--- a/packages/fx-core/tests/ui/qm.visitor.test.ts
+++ b/packages/fx-core/tests/ui/qm.visitor.test.ts
@@ -9,6 +9,7 @@ import {
   FuncQuestion,
   FxError,
   IProgressHandler,
+  InputResult,
   InputTextConfig,
   InputTextResult,
   Inputs,
@@ -20,6 +21,7 @@ import {
   QTreeNode,
   Result,
   SelectFileConfig,
+  SelectFileOrInputQuestion,
   SelectFileResult,
   SelectFilesConfig,
   SelectFilesResult,
@@ -34,6 +36,7 @@ import {
   UserInteraction,
   err,
   ok,
+  selectFileOrInputConfig,
 } from "@microsoft/teamsfx-api";
 import { EmptyOptionError, UserCancelError } from "../../src/error/common";
 import { traverse } from "../../src/ui/visitor";
@@ -126,6 +129,12 @@ class MockUserInteraction implements UserInteraction {
     throw new Error("Method not implemented.");
   }
   createProgressBar(title: string, totalSteps: number): IProgressHandler {
+    throw new Error("Method not implemented.");
+  }
+
+  selectFileOrInput(
+    config: selectFileOrInputConfig
+  ): Promise<Result<InputResult<string>, FxError>> {
     throw new Error("Method not implemented.");
   }
 }
@@ -702,6 +711,27 @@ describe("Question Model - Visitor Test", () => {
       if (res.isErr()) {
         assert.isTrue(res.error instanceof EmptyOptionError);
       }
+    });
+
+    it("single file or input", async () => {
+      sandbox.stub(mockUI, "selectFileOrInput").resolves(ok({ type: "success", result: "file" }));
+      const question: SelectFileOrInputQuestion = {
+        type: "singleFileOrText",
+        name: "test",
+        title: "test",
+        inputOptionItem: {
+          id: "input",
+          label: "input",
+        },
+        inputBoxConfig: {
+          name: "input",
+          title: "input",
+        },
+      };
+      const inputs = createInputs();
+      const res = await traverse(new QTreeNode(question), inputs, mockUI);
+      assert.isTrue(res.isOk());
+      assert.isTrue(inputs["test"] === "file");
     });
   });
 });

--- a/packages/fx-core/tests/ui/qm.visitor.test.ts
+++ b/packages/fx-core/tests/ui/qm.visitor.test.ts
@@ -733,5 +733,30 @@ describe("Question Model - Visitor Test", () => {
       assert.isTrue(res.isOk());
       assert.isTrue(inputs["test"] === "file");
     });
+
+    it("single file or input with validation", async () => {
+      sandbox.stub(mockUI, "singleFileOrInput").resolves(ok({ type: "success", result: "file" }));
+      const validation: StringValidation = {
+        equals: "test",
+      };
+      const question: SingleFileOrInputQuestion = {
+        type: "singleFileOrText",
+        name: "test",
+        title: "test",
+        inputOptionItem: {
+          id: "input",
+          label: "input",
+        },
+        inputBoxConfig: {
+          name: "input",
+          title: "input",
+        },
+        validation: validation,
+      };
+      const inputs = createInputs();
+      const res = await traverse(new QTreeNode(question), inputs, mockUI);
+      assert.isTrue(res.isOk());
+      assert.isTrue(inputs["test"] === "file");
+    });
   });
 });

--- a/packages/fx-core/tests/ui/qm.visitor.test.ts
+++ b/packages/fx-core/tests/ui/qm.visitor.test.ts
@@ -21,7 +21,7 @@ import {
   QTreeNode,
   Result,
   SelectFileConfig,
-  SelectFileOrInputQuestion,
+  SingleFileOrInputQuestion,
   SelectFileResult,
   SelectFilesConfig,
   SelectFilesResult,
@@ -36,7 +36,7 @@ import {
   UserInteraction,
   err,
   ok,
-  selectFileOrInputConfig,
+  singleFileOrInputConfig,
 } from "@microsoft/teamsfx-api";
 import { EmptyOptionError, UserCancelError } from "../../src/error/common";
 import { traverse } from "../../src/ui/visitor";
@@ -132,8 +132,8 @@ class MockUserInteraction implements UserInteraction {
     throw new Error("Method not implemented.");
   }
 
-  selectFileOrInput(
-    config: selectFileOrInputConfig
+  singleFileOrInput(
+    config: singleFileOrInputConfig
   ): Promise<Result<InputResult<string>, FxError>> {
     throw new Error("Method not implemented.");
   }
@@ -714,8 +714,8 @@ describe("Question Model - Visitor Test", () => {
     });
 
     it("single file or input", async () => {
-      sandbox.stub(mockUI, "selectFileOrInput").resolves(ok({ type: "success", result: "file" }));
-      const question: SelectFileOrInputQuestion = {
+      sandbox.stub(mockUI, "singleFileOrInput").resolves(ok({ type: "success", result: "file" }));
+      const question: SingleFileOrInputQuestion = {
         type: "singleFileOrText",
         name: "test",
         title: "test",

--- a/packages/fx-core/tests/ui/qm.visitor.test.ts
+++ b/packages/fx-core/tests/ui/qm.visitor.test.ts
@@ -36,7 +36,7 @@ import {
   UserInteraction,
   err,
   ok,
-  singleFileOrInputConfig,
+  SingleFileOrInputConfig,
 } from "@microsoft/teamsfx-api";
 import { EmptyOptionError, UserCancelError } from "../../src/error/common";
 import { traverse } from "../../src/ui/visitor";
@@ -132,8 +132,8 @@ class MockUserInteraction implements UserInteraction {
     throw new Error("Method not implemented.");
   }
 
-  singleFileOrInput(
-    config: singleFileOrInputConfig
+  selectFileOrInput(
+    config: SingleFileOrInputConfig
   ): Promise<Result<InputResult<string>, FxError>> {
     throw new Error("Method not implemented.");
   }
@@ -714,7 +714,7 @@ describe("Question Model - Visitor Test", () => {
     });
 
     it("single file or input", async () => {
-      sandbox.stub(mockUI, "singleFileOrInput").resolves(ok({ type: "success", result: "file" }));
+      sandbox.stub(mockUI, "selectFileOrInput").resolves(ok({ type: "success", result: "file" }));
       const question: SingleFileOrInputQuestion = {
         type: "singleFileOrText",
         name: "test",
@@ -735,7 +735,7 @@ describe("Question Model - Visitor Test", () => {
     });
 
     it("single file or input with validation", async () => {
-      sandbox.stub(mockUI, "singleFileOrInput").resolves(ok({ type: "success", result: "file" }));
+      sandbox.stub(mockUI, "selectFileOrInput").resolves(ok({ type: "success", result: "file" }));
       const validation: StringValidation = {
         equals: "test",
       };

--- a/packages/vscode-extension/src/qm/vsc_ui.ts
+++ b/packages/vscode-extension/src/qm/vsc_ui.ts
@@ -734,7 +734,7 @@ export class VsCodeUI implements UserInteraction {
       ...config,
     };
 
-    const selectFileOrItemRes = await this.selectFileInQuickPick(selectFileConfig, "file");
+    const selectFileOrItemRes = await this.selectFile(selectFileConfig);
     if (selectFileOrItemRes.isOk()) {
       if (selectFileOrItemRes.value.result === config.inputOptionItem.id) {
         ExtTelemetry.sendTelemetryEvent(TelemetryEvent.ContinueToInput, {

--- a/packages/vscode-extension/src/qm/vsc_ui.ts
+++ b/packages/vscode-extension/src/qm/vsc_ui.ts
@@ -42,6 +42,7 @@ import {
   SelectFilesResult,
   SelectFolderConfig,
   SelectFolderResult,
+  selectLocalFileOrInputConfig,
   SingleSelectConfig,
   SingleSelectResult,
   StaticOptions,
@@ -723,6 +724,31 @@ export class VsCodeUI implements UserInteraction {
         else resolve(err(internalUIError));
       });
     });
+  }
+
+  async selectLocalFileOrInputRemoteUrl(
+    config: selectLocalFileOrInputConfig
+  ): Promise<Result<InputResult<string>, FxError>> {
+    const selectFileConfig: SelectFileConfig = {
+      possibleFiles: [config.inputOptionItem],
+      ...config,
+    };
+
+    const selectFileOrItemRes = await this.selectFileInQuickPick(selectFileConfig, "file");
+    if (selectFileOrItemRes.isOk()) {
+      if (selectFileOrItemRes.value.result === config.inputOptionItem.id) {
+        const inputRes = await this.inputText(config.inputBoxConfig);
+        if (inputRes.isOk()) {
+          return ok(inputRes.value);
+        } else {
+          return err(inputRes.error);
+        }
+      } else {
+        return ok(selectFileOrItemRes.value);
+      }
+    } else {
+      return err(selectFileOrItemRes.error);
+    }
   }
 
   public async showMessage(

--- a/packages/vscode-extension/src/qm/vsc_ui.ts
+++ b/packages/vscode-extension/src/qm/vsc_ui.ts
@@ -42,7 +42,7 @@ import {
   SelectFilesResult,
   SelectFolderConfig,
   SelectFolderResult,
-  singleFileOrInputConfig,
+  SingleFileOrInputConfig,
   SingleSelectConfig,
   SingleSelectResult,
   StaticOptions,
@@ -726,12 +726,12 @@ export class VsCodeUI implements UserInteraction {
     });
   }
 
-  async singleFileOrInput(
-    config: singleFileOrInputConfig
+  async selectFileOrInput(
+    config: SingleFileOrInputConfig
   ): Promise<Result<InputResult<string>, FxError>> {
     const selectFileConfig: SelectFileConfig = {
-      possibleFiles: [config.inputOptionItem],
       ...config,
+      possibleFiles: [config.inputOptionItem],
     };
 
     const selectFileOrItemRes = await this.selectFile(selectFileConfig);

--- a/packages/vscode-extension/src/qm/vsc_ui.ts
+++ b/packages/vscode-extension/src/qm/vsc_ui.ts
@@ -726,7 +726,7 @@ export class VsCodeUI implements UserInteraction {
     });
   }
 
-  async selectLocalFileOrInputRemoteUrl(
+  async selectLocalFileOrInput(
     config: selectLocalFileOrInputConfig
   ): Promise<Result<InputResult<string>, FxError>> {
     const selectFileConfig: SelectFileConfig = {
@@ -737,6 +737,9 @@ export class VsCodeUI implements UserInteraction {
     const selectFileOrItemRes = await this.selectFileInQuickPick(selectFileConfig, "file");
     if (selectFileOrItemRes.isOk()) {
       if (selectFileOrItemRes.value.result === config.inputOptionItem.id) {
+        ExtTelemetry.sendTelemetryEvent(TelemetryEvent.ContinueToInput, {
+          [TelemetryProperty.SelectedOption]: selectFileOrItemRes.value.result,
+        });
         const inputRes = await this.inputText(config.inputBoxConfig);
         if (inputRes.isOk()) {
           return ok(inputRes.value);

--- a/packages/vscode-extension/src/qm/vsc_ui.ts
+++ b/packages/vscode-extension/src/qm/vsc_ui.ts
@@ -42,7 +42,7 @@ import {
   SelectFilesResult,
   SelectFolderConfig,
   SelectFolderResult,
-  selectLocalFileOrInputConfig,
+  selectFileOrInputConfig,
   SingleSelectConfig,
   SingleSelectResult,
   StaticOptions,
@@ -726,8 +726,8 @@ export class VsCodeUI implements UserInteraction {
     });
   }
 
-  async selectLocalFileOrInput(
-    config: selectLocalFileOrInputConfig
+  async selectFileOrInput(
+    config: selectFileOrInputConfig
   ): Promise<Result<InputResult<string>, FxError>> {
     const selectFileConfig: SelectFileConfig = {
       possibleFiles: [config.inputOptionItem],

--- a/packages/vscode-extension/src/qm/vsc_ui.ts
+++ b/packages/vscode-extension/src/qm/vsc_ui.ts
@@ -42,7 +42,7 @@ import {
   SelectFilesResult,
   SelectFolderConfig,
   SelectFolderResult,
-  selectFileOrInputConfig,
+  singleFileOrInputConfig,
   SingleSelectConfig,
   SingleSelectResult,
   StaticOptions,
@@ -726,8 +726,8 @@ export class VsCodeUI implements UserInteraction {
     });
   }
 
-  async selectFileOrInput(
-    config: selectFileOrInputConfig
+  async singleFileOrInput(
+    config: singleFileOrInputConfig
   ): Promise<Result<InputResult<string>, FxError>> {
     const selectFileConfig: SelectFileConfig = {
       possibleFiles: [config.inputOptionItem],

--- a/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
@@ -228,6 +228,9 @@ export enum TelemetryEvent {
 
   // Update SDK packages
   UpdateSDKPackages = "update-sdk-packages",
+
+  // Select to input a value when choosing between browsing local file or proceeding to input
+  ContinueToInput = "continue-to-input",
 }
 
 export enum TelemetryProperty {

--- a/packages/vscode-extension/test/extension/qm/vsc_ui.test.ts
+++ b/packages/vscode-extension/test/extension/qm/vsc_ui.test.ts
@@ -26,7 +26,7 @@ import {
   SelectFileConfig,
   SelectFileResult,
   SelectFolderConfig,
-  singleFileOrInputConfig,
+  SingleFileOrInputConfig,
   SingleSelectConfig,
   UserError,
 } from "@microsoft/teamsfx-api";
@@ -498,7 +498,7 @@ describe("UI Unit Tests", async () => {
   describe("Select local file or input", () => {
     it("selects local file successfully", async function (this: Mocha.Context) {
       const ui = new VsCodeUI(<ExtensionContext>{});
-      const config: singleFileOrInputConfig = {
+      const config: SingleFileOrInputConfig = {
         name: "name",
         title: "title",
         placeholder: "placeholder",
@@ -518,7 +518,7 @@ describe("UI Unit Tests", async () => {
         .resolves(ok({ type: "success", result: "file" }));
       sinon.stub(ExtTelemetry, "sendTelemetryEvent");
 
-      const result = await ui.singleFileOrInput(config);
+      const result = await ui.selectFileOrInput(config);
 
       expect(result.isOk()).is.true;
       if (result.isOk()) {
@@ -529,7 +529,7 @@ describe("UI Unit Tests", async () => {
 
     it("selects local file error", async function (this: Mocha.Context) {
       const ui = new VsCodeUI(<ExtensionContext>{});
-      const config: singleFileOrInputConfig = {
+      const config: SingleFileOrInputConfig = {
         name: "name",
         title: "title",
         placeholder: "placeholder",
@@ -549,7 +549,7 @@ describe("UI Unit Tests", async () => {
         .resolves(err(new UserError("source", "name", "msg", "msg")));
       sinon.stub(ExtTelemetry, "sendTelemetryEvent");
 
-      const result = await ui.singleFileOrInput(config);
+      const result = await ui.selectFileOrInput(config);
 
       expect(result.isErr()).is.true;
       if (result.isErr()) {
@@ -560,7 +560,7 @@ describe("UI Unit Tests", async () => {
 
     it("inputs a value sucessfully", async function (this: Mocha.Context) {
       const ui = new VsCodeUI(<ExtensionContext>{});
-      const config: singleFileOrInputConfig = {
+      const config: SingleFileOrInputConfig = {
         name: "name",
         title: "title",
         placeholder: "placeholder",
@@ -583,7 +583,7 @@ describe("UI Unit Tests", async () => {
         .resolves(ok({ type: "success", result: "testUrl" }));
       sinon.stub(ExtTelemetry, "sendTelemetryEvent");
 
-      const result = await ui.singleFileOrInput(config);
+      const result = await ui.selectFileOrInput(config);
 
       expect(result.isOk()).is.true;
       if (result.isOk()) {
@@ -594,7 +594,7 @@ describe("UI Unit Tests", async () => {
 
     it("inputs a value error", async function (this: Mocha.Context) {
       const ui = new VsCodeUI(<ExtensionContext>{});
-      const config: singleFileOrInputConfig = {
+      const config: SingleFileOrInputConfig = {
         name: "name",
         title: "title",
         placeholder: "placeholder",
@@ -617,7 +617,7 @@ describe("UI Unit Tests", async () => {
         .resolves(err(new UserError("source", "name", "msg", "msg")));
       sinon.stub(ExtTelemetry, "sendTelemetryEvent");
 
-      const result = await ui.singleFileOrInput(config);
+      const result = await ui.selectFileOrInput(config);
 
       expect(result.isErr()).is.true;
       if (result.isErr()) {

--- a/packages/vscode-extension/test/extension/qm/vsc_ui.test.ts
+++ b/packages/vscode-extension/test/extension/qm/vsc_ui.test.ts
@@ -26,7 +26,7 @@ import {
   SelectFileConfig,
   SelectFileResult,
   SelectFolderConfig,
-  selectFileOrInputConfig,
+  singleFileOrInputConfig,
   SingleSelectConfig,
   UserError,
 } from "@microsoft/teamsfx-api";
@@ -498,7 +498,7 @@ describe("UI Unit Tests", async () => {
   describe("Select local file or input", () => {
     it("selects local file successfully", async function (this: Mocha.Context) {
       const ui = new VsCodeUI(<ExtensionContext>{});
-      const config: selectFileOrInputConfig = {
+      const config: singleFileOrInputConfig = {
         name: "name",
         title: "title",
         placeholder: "placeholder",
@@ -518,7 +518,7 @@ describe("UI Unit Tests", async () => {
         .resolves(ok({ type: "success", result: "file" }));
       sinon.stub(ExtTelemetry, "sendTelemetryEvent");
 
-      const result = await ui.selectFileOrInput(config);
+      const result = await ui.singleFileOrInput(config);
 
       expect(result.isOk()).is.true;
       if (result.isOk()) {
@@ -529,7 +529,7 @@ describe("UI Unit Tests", async () => {
 
     it("selects local file error", async function (this: Mocha.Context) {
       const ui = new VsCodeUI(<ExtensionContext>{});
-      const config: selectFileOrInputConfig = {
+      const config: singleFileOrInputConfig = {
         name: "name",
         title: "title",
         placeholder: "placeholder",
@@ -549,7 +549,7 @@ describe("UI Unit Tests", async () => {
         .resolves(err(new UserError("source", "name", "msg", "msg")));
       sinon.stub(ExtTelemetry, "sendTelemetryEvent");
 
-      const result = await ui.selectFileOrInput(config);
+      const result = await ui.singleFileOrInput(config);
 
       expect(result.isErr()).is.true;
       if (result.isErr()) {
@@ -560,7 +560,7 @@ describe("UI Unit Tests", async () => {
 
     it("inputs a value sucessfully", async function (this: Mocha.Context) {
       const ui = new VsCodeUI(<ExtensionContext>{});
-      const config: selectFileOrInputConfig = {
+      const config: singleFileOrInputConfig = {
         name: "name",
         title: "title",
         placeholder: "placeholder",
@@ -583,7 +583,7 @@ describe("UI Unit Tests", async () => {
         .resolves(ok({ type: "success", result: "testUrl" }));
       sinon.stub(ExtTelemetry, "sendTelemetryEvent");
 
-      const result = await ui.selectFileOrInput(config);
+      const result = await ui.singleFileOrInput(config);
 
       expect(result.isOk()).is.true;
       if (result.isOk()) {
@@ -594,7 +594,7 @@ describe("UI Unit Tests", async () => {
 
     it("inputs a value error", async function (this: Mocha.Context) {
       const ui = new VsCodeUI(<ExtensionContext>{});
-      const config: selectFileOrInputConfig = {
+      const config: singleFileOrInputConfig = {
         name: "name",
         title: "title",
         placeholder: "placeholder",
@@ -617,7 +617,7 @@ describe("UI Unit Tests", async () => {
         .resolves(err(new UserError("source", "name", "msg", "msg")));
       sinon.stub(ExtTelemetry, "sendTelemetryEvent");
 
-      const result = await ui.selectFileOrInput(config);
+      const result = await ui.singleFileOrInput(config);
 
       expect(result.isErr()).is.true;
       if (result.isErr()) {

--- a/packages/vscode-extension/test/extension/qm/vsc_ui.test.ts
+++ b/packages/vscode-extension/test/extension/qm/vsc_ui.test.ts
@@ -26,7 +26,7 @@ import {
   SelectFileConfig,
   SelectFileResult,
   SelectFolderConfig,
-  selectLocalFileOrInputConfig,
+  selectFileOrInputConfig,
   SingleSelectConfig,
   UserError,
 } from "@microsoft/teamsfx-api";
@@ -498,7 +498,7 @@ describe("UI Unit Tests", async () => {
   describe("Select local file or input", () => {
     it("selects local file successfully", async function (this: Mocha.Context) {
       const ui = new VsCodeUI(<ExtensionContext>{});
-      const config: selectLocalFileOrInputConfig = {
+      const config: selectFileOrInputConfig = {
         name: "name",
         title: "title",
         placeholder: "placeholder",
@@ -518,7 +518,7 @@ describe("UI Unit Tests", async () => {
         .resolves(ok({ type: "success", result: "file" }));
       sinon.stub(ExtTelemetry, "sendTelemetryEvent");
 
-      const result = await ui.selectLocalFileOrInput(config);
+      const result = await ui.selectFileOrInput(config);
 
       expect(result.isOk()).is.true;
       if (result.isOk()) {
@@ -529,7 +529,7 @@ describe("UI Unit Tests", async () => {
 
     it("selects local file error", async function (this: Mocha.Context) {
       const ui = new VsCodeUI(<ExtensionContext>{});
-      const config: selectLocalFileOrInputConfig = {
+      const config: selectFileOrInputConfig = {
         name: "name",
         title: "title",
         placeholder: "placeholder",
@@ -549,7 +549,7 @@ describe("UI Unit Tests", async () => {
         .resolves(err(new UserError("source", "name", "msg", "msg")));
       sinon.stub(ExtTelemetry, "sendTelemetryEvent");
 
-      const result = await ui.selectLocalFileOrInput(config);
+      const result = await ui.selectFileOrInput(config);
 
       expect(result.isErr()).is.true;
       if (result.isErr()) {
@@ -560,7 +560,7 @@ describe("UI Unit Tests", async () => {
 
     it("inputs a value sucessfully", async function (this: Mocha.Context) {
       const ui = new VsCodeUI(<ExtensionContext>{});
-      const config: selectLocalFileOrInputConfig = {
+      const config: selectFileOrInputConfig = {
         name: "name",
         title: "title",
         placeholder: "placeholder",
@@ -583,7 +583,7 @@ describe("UI Unit Tests", async () => {
         .resolves(ok({ type: "success", result: "testUrl" }));
       sinon.stub(ExtTelemetry, "sendTelemetryEvent");
 
-      const result = await ui.selectLocalFileOrInput(config);
+      const result = await ui.selectFileOrInput(config);
 
       expect(result.isOk()).is.true;
       if (result.isOk()) {
@@ -594,7 +594,7 @@ describe("UI Unit Tests", async () => {
 
     it("inputs a value error", async function (this: Mocha.Context) {
       const ui = new VsCodeUI(<ExtensionContext>{});
-      const config: selectLocalFileOrInputConfig = {
+      const config: selectFileOrInputConfig = {
         name: "name",
         title: "title",
         placeholder: "placeholder",
@@ -617,7 +617,7 @@ describe("UI Unit Tests", async () => {
         .resolves(err(new UserError("source", "name", "msg", "msg")));
       sinon.stub(ExtTelemetry, "sendTelemetryEvent");
 
-      const result = await ui.selectLocalFileOrInput(config);
+      const result = await ui.selectFileOrInput(config);
 
       expect(result.isErr()).is.true;
       if (result.isErr()) {

--- a/packages/vscode-extension/test/extension/qm/vsc_ui.test.ts
+++ b/packages/vscode-extension/test/extension/qm/vsc_ui.test.ts
@@ -18,8 +18,15 @@ import {
 } from "vscode";
 
 import {
+  err,
+  FxError,
+  InputResult,
+  ok,
+  Result,
   SelectFileConfig,
+  SelectFileResult,
   SelectFolderConfig,
+  selectLocalFileOrInputConfig,
   SingleSelectConfig,
   UserError,
 } from "@microsoft/teamsfx-api";
@@ -484,6 +491,138 @@ describe("UI Unit Tests", async () => {
 
       expect(result.isErr()).is.true;
 
+      sinon.restore();
+    });
+  });
+
+  describe("Select local file or input", () => {
+    it("selects local file successfully", async function (this: Mocha.Context) {
+      const ui = new VsCodeUI(<ExtensionContext>{});
+      const config: selectLocalFileOrInputConfig = {
+        name: "name",
+        title: "title",
+        placeholder: "placeholder",
+        inputOptionItem: {
+          id: "input",
+          label: "input",
+        },
+        inputBoxConfig: {
+          prompt: "prompt",
+          title: "title",
+          name: "input name",
+        },
+      };
+
+      sinon
+        .stub(VsCodeUI.prototype, "selectFile")
+        .resolves(ok({ type: "success", result: "file" }));
+      sinon.stub(ExtTelemetry, "sendTelemetryEvent");
+
+      const result = await ui.selectLocalFileOrInput(config);
+
+      expect(result.isOk()).is.true;
+      if (result.isOk()) {
+        expect(result.value.result).to.equal("file");
+      }
+      sinon.restore();
+    });
+
+    it("selects local file error", async function (this: Mocha.Context) {
+      const ui = new VsCodeUI(<ExtensionContext>{});
+      const config: selectLocalFileOrInputConfig = {
+        name: "name",
+        title: "title",
+        placeholder: "placeholder",
+        inputOptionItem: {
+          id: "input",
+          label: "input",
+        },
+        inputBoxConfig: {
+          prompt: "prompt",
+          title: "title",
+          name: "input name",
+        },
+      };
+
+      sinon
+        .stub(VsCodeUI.prototype, "selectFile")
+        .resolves(err(new UserError("source", "name", "msg", "msg")));
+      sinon.stub(ExtTelemetry, "sendTelemetryEvent");
+
+      const result = await ui.selectLocalFileOrInput(config);
+
+      expect(result.isErr()).is.true;
+      if (result.isErr()) {
+        expect(result.error.name).to.equal("name");
+      }
+      sinon.restore();
+    });
+
+    it("inputs a value sucessfully", async function (this: Mocha.Context) {
+      const ui = new VsCodeUI(<ExtensionContext>{});
+      const config: selectLocalFileOrInputConfig = {
+        name: "name",
+        title: "title",
+        placeholder: "placeholder",
+        inputOptionItem: {
+          id: "input",
+          label: "input",
+        },
+        inputBoxConfig: {
+          prompt: "prompt",
+          title: "title",
+          name: "input name",
+        },
+      };
+
+      sinon
+        .stub(VsCodeUI.prototype, "selectFile")
+        .resolves(ok({ type: "success", result: "input" }));
+      sinon
+        .stub(VsCodeUI.prototype, "inputText")
+        .resolves(ok({ type: "success", result: "testUrl" }));
+      sinon.stub(ExtTelemetry, "sendTelemetryEvent");
+
+      const result = await ui.selectLocalFileOrInput(config);
+
+      expect(result.isOk()).is.true;
+      if (result.isOk()) {
+        expect(result.value.result).to.equal("testUrl");
+      }
+      sinon.restore();
+    });
+
+    it("inputs a value error", async function (this: Mocha.Context) {
+      const ui = new VsCodeUI(<ExtensionContext>{});
+      const config: selectLocalFileOrInputConfig = {
+        name: "name",
+        title: "title",
+        placeholder: "placeholder",
+        inputOptionItem: {
+          id: "input",
+          label: "input",
+        },
+        inputBoxConfig: {
+          prompt: "prompt",
+          title: "title",
+          name: "input name",
+        },
+      };
+
+      sinon
+        .stub(VsCodeUI.prototype, "selectFile")
+        .resolves(ok({ type: "success", result: "input" }));
+      sinon
+        .stub(VsCodeUI.prototype, "inputText")
+        .resolves(err(new UserError("source", "name", "msg", "msg")));
+      sinon.stub(ExtTelemetry, "sendTelemetryEvent");
+
+      const result = await ui.selectLocalFileOrInput(config);
+
+      expect(result.isErr()).is.true;
+      if (result.isErr()) {
+        expect(result.error.name).to.equal("name");
+      }
       sinon.restore();
     });
   });


### PR DESCRIPTION
- add a question type allowing user to select a file or input a value for the file. 
![image](https://github.com/OfficeDev/TeamsFx/assets/86260893/c9b83b87-5fa1-4d83-8b26-9b82deb1ca5b)
![image](https://github.com/OfficeDev/TeamsFx/assets/86260893/ab95fff3-a42c-4b23-a257-d2ffa9d2d42d)

- add VSC implementation. Confirmed with designer that it is recommended to have two steps rather than combine inputting a value and picking an option together.

[Task 24305677](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/24305677): Question to select a file and enter Url