### PR TITLE
fix: check personal app from users

### DIFF
--- a/packages/fx-core/src/component/driver/teamsApp/utils/utils.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/utils/utils.ts
@@ -43,9 +43,18 @@ export function renderTemplate(manifestString: string, view: any): string {
 }
 
 export function isPersonalApp(appDefinition: AppDefinition): boolean {
+  const restrictedEntityIds: Array<string> = [
+    "conversations",
+    "recent",
+    "about",
+    "alltabs",
+    "chat",
+  ];
   if (!!appDefinition.staticTabs && appDefinition.staticTabs.length > 0) {
-    const tabsWithUrls = appDefinition.staticTabs.filter((tab) => !!tab.contentUrl);
-    return tabsWithUrls.length > 0;
+    return (
+      appDefinition.staticTabs.filter((tab) => !restrictedEntityIds.includes(tab.entityId)).length >
+      0
+    );
   }
 
   return false;

--- a/packages/fx-core/tests/component/resource/appManifest/utils.test.ts
+++ b/packages/fx-core/tests/component/resource/appManifest/utils.test.ts
@@ -137,11 +137,11 @@ describe("utils", () => {
       chai.assert.isTrue(needTab);
     });
 
-    it("static tabs without url: returns false", () => {
+    it("static tabs with reserved entity id: returns false", () => {
       const appDefinition: AppDefinition = {
         teamsAppId: "mockAppId",
         tenantId: "mockTenantId",
-        staticTabs: [{ ...validStaticTab, contentUrl: "" }],
+        staticTabs: [{ ...validStaticTab, entityId: "about" }],
         bots: [validBot],
       };
 


### PR DESCRIPTION
We previously check contentUrl to determine whether a personal tab is created by users or TDP. However, engineers from TDP mentioned that it is better to check entity id as content URL might be an optional field in the future.

This is similar to https://domoreexp.visualstudio.com/Teamspace/_git/teams-devapp/pullrequest/783679

[Bug 24318226](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/24318226): [TDP&TTK] Update to check tab using entityIds