### PR TITLE
fix: add region telemetry property

### DIFF
--- a/packages/fx-core/src/component/driver/teamsApp/clients/appStudioClient.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/clients/appStudioClient.ts
@@ -127,6 +127,7 @@ export namespace AppStudioClient {
   ): Promise<AppDefinition> {
     const telemetryProperties: { [key: string]: string } = {
       [TelemetryPropertyKey.OverwriteIfAppAlreadyExists]: String(overwrite),
+      [TelemetryPropertyKey.region]: String(region?.substring(32)),
     };
     sendStartEvent(APP_STUDIO_API_NAMES.CREATE_APP, telemetryProperties);
     try {

--- a/packages/fx-core/src/component/driver/teamsApp/clients/appStudioClient.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/clients/appStudioClient.ts
@@ -129,7 +129,7 @@ export namespace AppStudioClient {
       [TelemetryPropertyKey.OverwriteIfAppAlreadyExists]: String(overwrite),
       // To avoid url be redacted in telemetry, get region from full base url
       // E.g. https://dev.teams.microsoft.com/amer => amer
-      [TelemetryPropertyKey.region]: String(region?.substring(32)),
+      [TelemetryPropertyKey.region]: String(extractRegionFromBaseUrl(region)),
     };
     sendStartEvent(APP_STUDIO_API_NAMES.CREATE_APP, telemetryProperties);
     try {
@@ -650,6 +650,13 @@ export namespace AppStudioClient {
       }
     } while (++retry < 3);
 
+    return undefined;
+  }
+
+  function extractRegionFromBaseUrl(url: string | undefined): string | undefined {
+    if (region && region.length >= 32) {
+      return region.substring(32);
+    }
     return undefined;
   }
 }

--- a/packages/fx-core/src/component/driver/teamsApp/clients/appStudioClient.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/clients/appStudioClient.ts
@@ -127,6 +127,8 @@ export namespace AppStudioClient {
   ): Promise<AppDefinition> {
     const telemetryProperties: { [key: string]: string } = {
       [TelemetryPropertyKey.OverwriteIfAppAlreadyExists]: String(overwrite),
+      // To avoid url be redacted in telemetry, get region from full base url
+      // E.g. https://dev.teams.microsoft.com/amer => amer
       [TelemetryPropertyKey.region]: String(region?.substring(32)),
     };
     sendStartEvent(APP_STUDIO_API_NAMES.CREATE_APP, telemetryProperties);

--- a/packages/fx-core/src/component/driver/teamsApp/utils/telemetry.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/utils/telemetry.ts
@@ -19,6 +19,7 @@ export enum TelemetryPropertyKey {
   validationErrors = "validation-errors",
   validationWarnings = "validation-warnings",
   OverwriteIfAppAlreadyExists = "overwrite-if-app-already-exists",
+  region = "region",
 }
 
 enum TelemetryPropertyValue {

--- a/packages/fx-core/tests/component/driver/teamsApp/appstudioclient.test.ts
+++ b/packages/fx-core/tests/component/driver/teamsApp/appstudioclient.test.ts
@@ -150,6 +150,8 @@ describe("App Studio API Test", () => {
       };
       sinon.stub(fakeAxiosInstance, "post").resolves(response);
 
+      AppStudioClient.setRegion("https://dev.teams.microsoft.com/amer");
+
       const res = await AppStudioClient.importApp(Buffer.from(""), appStudioToken);
       chai.assert.equal(res, appDef);
     });

--- a/packages/fx-core/tests/component/driver/teamsApp/appstudioclient.test.ts
+++ b/packages/fx-core/tests/component/driver/teamsApp/appstudioclient.test.ts
@@ -154,7 +154,7 @@ describe("App Studio API Test", () => {
       chai.assert.equal(res, appDef);
     });
 
-    it("Happy path - with region", async () => {
+    it("Happy path - with wrong region", async () => {
       const fakeAxiosInstance = axios.create();
       sinon.stub(axios, "create").returns(fakeAxiosInstance);
 
@@ -162,7 +162,7 @@ describe("App Studio API Test", () => {
         data: appDef,
       };
       sinon.stub(fakeAxiosInstance, "post").resolves(response);
-      AppStudioClient.setRegion("https://dev.teams.microsoft.com/amer");
+      AppStudioClient.setRegion("https://dev.teams.microsoft.com");
 
       const res = await AppStudioClient.importApp(Buffer.from(""), appStudioToken);
       chai.assert.equal(res, appDef);

--- a/packages/fx-core/tests/component/driver/teamsApp/appstudioclient.test.ts
+++ b/packages/fx-core/tests/component/driver/teamsApp/appstudioclient.test.ts
@@ -7,16 +7,16 @@ import * as sinon from "sinon";
 import axios from "axios";
 import { v4 as uuid } from "uuid";
 import { Context, TeamsAppManifest, ok, err } from "@microsoft/teamsfx-api";
-import { AppStudioClient } from "../../../../../src/component/driver/teamsApp/clients/appStudioClient";
-import { AppDefinition } from "../../../../../src/component/driver/teamsApp/interfaces/appdefinitions/appDefinition";
-import { AppUser } from "../../../../../src/component/driver/teamsApp/interfaces/appdefinitions/appUser";
-import { AppStudioError } from "../../../../../src/component/driver/teamsApp/errors";
-import { TelemetryUtils } from "../../../../../src/component/driver/teamsApp/utils/telemetry";
-import { RetryHandler } from "../../../../../src/component/driver/teamsApp/utils/utils";
-import { PublishingState } from "../../../../../src/component/driver/teamsApp/interfaces/appdefinitions/IPublishingAppDefinition";
-import { manifestUtils } from "../../../../../src/component/driver/teamsApp/utils/ManifestUtils";
-import { AppStudioResultFactory } from "../../../../../src/component/driver/teamsApp/results";
-import { Constants } from "../../../../../src/component/driver/teamsApp/constants";
+import { AppStudioClient } from "../../../../src/component/driver/teamsApp/clients/appStudioClient";
+import { AppDefinition } from "../../../../src/component/driver/teamsApp/interfaces/appdefinitions/appDefinition";
+import { AppUser } from "../../../../src/component/driver/teamsApp/interfaces/appdefinitions/appUser";
+import { AppStudioError } from "../../../../src/component/driver/teamsApp/errors";
+import { TelemetryUtils } from "../../../../src/component/driver/teamsApp/utils/telemetry";
+import { RetryHandler } from "../../../../src/component/driver/teamsApp/utils/utils";
+import { PublishingState } from "../../../../src/component/driver/teamsApp/interfaces/appdefinitions/IPublishingAppDefinition";
+import { manifestUtils } from "../../../../src/component/driver/teamsApp/utils/ManifestUtils";
+import { AppStudioResultFactory } from "../../../../src/component/driver/teamsApp/results";
+import { Constants } from "../../../../src/component/driver/teamsApp/constants";
 
 function newEnvInfo() {
   return {
@@ -149,6 +149,20 @@ describe("App Studio API Test", () => {
         data: appDef,
       };
       sinon.stub(fakeAxiosInstance, "post").resolves(response);
+
+      const res = await AppStudioClient.importApp(Buffer.from(""), appStudioToken);
+      chai.assert.equal(res, appDef);
+    });
+
+    it("Happy path - with region", async () => {
+      const fakeAxiosInstance = axios.create();
+      sinon.stub(axios, "create").returns(fakeAxiosInstance);
+
+      const response = {
+        data: appDef,
+      };
+      sinon.stub(fakeAxiosInstance, "post").resolves(response);
+      AppStudioClient.setRegion("https://dev.teams.microsoft.com/amer");
 
       const res = await AppStudioClient.importApp(Buffer.from(""), appStudioToken);
       chai.assert.equal(res, appDef);


### PR DESCRIPTION
![image](https://github.com/OfficeDev/TeamsFx/assets/71362691/7d7b3af1-b484-4f98-8b3a-21c5f0b19484)

For bug https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/24254022, add region property to check if it's caused by wrong regional API.