### PR TITLE
fix: cannot create blazor tab from cli in non-interactive mode

### DIFF
--- a/packages/fx-core/src/question/create.ts
+++ b/packages/fx-core/src/question/create.ts
@@ -349,6 +349,7 @@ export class CapabilityOptions {
     return [
       CapabilityOptions.notificationBot(),
       CapabilityOptions.commandBot(),
+      CapabilityOptions.nonSsoTab(),
       CapabilityOptions.tab(),
       CapabilityOptions.me(),
     ];

--- a/packages/fx-core/tests/question/create.test.ts
+++ b/packages/fx-core/tests/question/create.test.ts
@@ -632,7 +632,7 @@ describe("scaffold question", () => {
         } else if (question.name === QuestionNames.Capabilities) {
           const select = question as SingleSelectQuestion;
           const options = await select.dynamicOptions!(inputs);
-          assert.isTrue(options.length === 4);
+          assert.isTrue(options.length === 5);
           return ok({ type: "success", result: CapabilityOptions.notificationBot().id });
         } else if (question.name === QuestionNames.BotTrigger) {
           const select = question as SingleSelectQuestion;


### PR DESCRIPTION
Ensure non-interactive cli command can create blazor non sso tab. This command is used in our E2E test:
teamsfx new --runtime dotnet --interactive false --app-name appName --capabilities tab-non-sso