### PR TITLE
fix: add filters when selecting file for api spec

### DIFF
--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -535,18 +535,20 @@ export interface Settings {
 export const SettingsFolderName = "teamsfx";
 
 // @public (undocumented)
-export interface SingleFileOrInputConfig extends SelectFileConfig {
-    // (undocumented)
+export interface SingleFileOrInputConfig extends UIConfig<string> {
+    filters?: {
+        [name: string]: string[];
+    };
     inputBoxConfig: InputTextConfig;
-    // (undocumented)
     inputOptionItem: OptionItem;
 }
 
 // @public (undocumented)
 export interface SingleFileOrInputQuestion extends UserInputQuestion {
-    // (undocumented)
+    filters?: {
+        [name: string]: string[];
+    };
     inputBoxConfig: InputTextConfig;
-    // (undocumented)
     inputOptionItem: OptionItem;
     // (undocumented)
     type: "singleFileOrText";
@@ -555,6 +557,9 @@ export interface SingleFileOrInputQuestion extends UserInputQuestion {
 // @public
 export interface SingleFileQuestion extends UserInputQuestion {
     default?: string | LocalFunc<string | undefined>;
+    filters?: {
+        [name: string]: string[];
+    };
     // (undocumented)
     type: "singleFile";
     validation?: FuncValidation<string>;

--- a/packages/api/src/qm/question.ts
+++ b/packages/api/src/qm/question.ts
@@ -269,6 +269,19 @@ export interface SingleFileQuestion extends UserInputQuestion {
    * validation function
    */
   validation?: FuncValidation<string>;
+
+  /**
+   * This will only take effect in VSC.
+   * A set of file filters that are used by the dialog. Each entry is a human-readable label,
+   * like "TypeScript", and an array of extensions, e.g.
+   * ```ts
+   * {
+   *     'Images': ['png', 'jpg']
+   *     'TypeScript': ['ts', 'tsx']
+   * }
+   * ```
+   */
+  filters?: { [name: string]: string[] };
 }
 
 export interface MultiFileQuestion extends UserInputQuestion {
@@ -317,8 +330,28 @@ export interface FuncQuestion extends BaseQuestion {
 
 export interface SingleFileOrInputQuestion extends UserInputQuestion {
   type: "singleFileOrText";
+  /**
+   * An item shown in the list in VSC that user can click to input text.
+   */
   inputOptionItem: OptionItem;
+
+  /**
+   * Config for the input box.
+   */
   inputBoxConfig: InputTextConfig;
+
+  /**
+   * This will only take effect in VSC.
+   * A set of file filters that are used by the dialog. Each entry is a human-readable label,
+   * like "TypeScript", and an array of extensions, e.g.
+   * ```ts
+   * {
+   *     'Images': ['png', 'jpg']
+   *     'TypeScript': ['ts', 'tsx']
+   * }
+   * ```
+   */
+  filters?: { [name: string]: string[] };
 }
 
 /**

--- a/packages/api/src/qm/ui.ts
+++ b/packages/api/src/qm/ui.ts
@@ -123,6 +123,7 @@ export interface InputTextConfig extends UIConfig<string> {
  */
 export type SelectFileConfig = UIConfig<string> & {
   /**
+   * This will only take effect in VSC.
    * A set of file filters that are used by the dialog. Each entry is a human-readable label,
    * like "TypeScript", and an array of extensions, e.g.
    * ```ts
@@ -150,6 +151,7 @@ export type SelectFileConfig = UIConfig<string> & {
  */
 export type SelectFilesConfig = UIConfig<string[]> & {
   /**
+   * This will only take effect in VSC.
    * A set of file filters that are used by the dialog. Each entry is a human-readable label,
    * like "TypeScript", and an array of extensions, e.g.
    * ```ts
@@ -175,9 +177,29 @@ export interface ExecuteFuncConfig extends UIConfig<string> {
   inputs: Inputs;
 }
 
-export interface SingleFileOrInputConfig extends SelectFileConfig {
+export interface SingleFileOrInputConfig extends UIConfig<string> {
+  /**
+   * An item shown in the list in VSC that user can click to input text.
+   */
   inputOptionItem: OptionItem;
+
+  /**
+   * Config for the input box.
+   */
   inputBoxConfig: InputTextConfig;
+
+  /**
+   * This will only take effect in VSC.
+   * A set of file filters that are used by the dialog. Each entry is a human-readable label,
+   * like "TypeScript", and an array of extensions, e.g.
+   * ```ts
+   * {
+   *     'Images': ['png', 'jpg']
+   *     'TypeScript': ['ts', 'tsx']
+   * }
+   * ```
+   */
+  filters?: { [name: string]: string[] };
 }
 
 /**
@@ -332,7 +354,8 @@ export interface UserInteraction {
   }): Promise<Result<string, FxError>>;
 
   /**
-   * Shows two options to user, one will open a dialog to the user which allows to select a single file, another one will show an input box asking to enter a value
+   * In VSC, it shows two options to user, one will open a dialog to the user which allows to select a single file, another one will show an input box asking to enter a value.
+   * If CLI, it will directly asks user to enter a value.
    * @param config config to select local file or enter a value
    * @returns A promise that resolves to the local file path or the value entered by user or FxError
    * @throws FxError

--- a/packages/fx-core/src/question/create.ts
+++ b/packages/fx-core/src/question/create.ts
@@ -1280,6 +1280,9 @@ function apiSpecLocationQuestion(): SingleFileOrInputQuestion {
       id: "input",
       label: getLocalizedString("core.createProjectQuestion.apiSpecInputUrl.label"),
     },
+    filters: {
+      files: ["json", "yml", "yaml"],
+    },
   };
 }
 

--- a/packages/fx-core/src/ui/visitor.ts
+++ b/packages/fx-core/src/ui/visitor.ts
@@ -214,6 +214,7 @@ const questionVisitor: QuestionTreeVisitor = async function (
         step: step,
         totalSteps: totalSteps,
         validation: validationFunc,
+        filters: question.filters,
       });
     } else if (question.type === "folder") {
       const validationFunc = question.validation
@@ -240,6 +241,7 @@ const questionVisitor: QuestionTreeVisitor = async function (
         prompt: prompt,
         inputOptionItem: question.inputOptionItem,
         inputBoxConfig: question.inputBoxConfig,
+        filters: question.filters,
         step: step,
         totalSteps: totalSteps,
         validation: validationFunc,


### PR DESCRIPTION
- We already have "filters" on SelectFileConfig today, also add it in "SingleFileOrInputConfig"
- "filters" will only take effect in VSC, but not in CLI. Also added this in comment in api.