### PR TITLE
refactor: cleanup sample codes and download according to package version

### DIFF
--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -127,7 +127,7 @@ export const templates = sampleProvider.SampleCollection.samples.map((sample) =>
     title: sample.title,
     description: sample.shortDescription,
     sampleAppName: sample.id,
-    sampleAppUrl: sample.link,
+    sampleAppUrl: sample.url,
   };
 });
 

--- a/packages/fx-core/src/common/samples-config-v3.json
+++ b/packages/fx-core/src/common/samples-config-v3.json
@@ -1,7 +1,5 @@
 {
     "baseUrl": "https://github.com/OfficeDev/TeamsFx-Samples/tree/v2.1.0/",
-    "defaultPackageLink": "https://github.com/OfficeDev/TeamsFx-Samples/archive/refs/tags/v2.1.0.zip",
-    "baseFolderName": "TeamsFx-Samples-2.1.0",
     "samples": [
         {
             "id": "hello-world-tab-with-backend",
@@ -94,9 +92,7 @@
             "time": "5min to run",
             "configuration": "Ready for debug",
             "suggested": false,
-            "url": "https://github.com/OfficeDev/Microsoft-Teams-Samples/tree/main/samples/bot-proactive-messaging-teamsfx",
-            "packageLink": "https://github.com/OfficeDev/Microsoft-Teams-Samples/archive/refs/heads/main.zip",
-            "relativePath": "Microsoft-Teams-Samples-main/samples/bot-proactive-messaging-teamsfx"
+            "url": "https://github.com/OfficeDev/Microsoft-Teams-Samples/tree/main/samples/bot-proactive-messaging-teamsfx"
         },
         {
             "id": "adaptive-card-notification",
@@ -211,9 +207,7 @@
           "time": "5min to run",
           "configuration": "Ready for debug",
           "suggested": false,
-          "url": "https://github.com/OfficeDev/Office-Add-in-samples/tree/main/Samples/outlook-set-signature",
-          "packageLink": "https://github.com/OfficeDev/Office-Add-in-samples/archive/refs/heads/main.zip",
-          "relativePath": "Office-Add-in-samples-main/Samples/outlook-set-signature"
+          "url": "https://github.com/OfficeDev/Office-Add-in-samples/tree/main/Samples/outlook-set-signature"
         },
         {
             "id": "developer-assist-dashboard",

--- a/packages/fx-core/src/common/samples.ts
+++ b/packages/fx-core/src/common/samples.ts
@@ -25,10 +25,8 @@ export interface SampleInfo {
   tags: string[];
   time: string;
   configuration: string;
-  link: string;
   suggested: boolean;
   url: string;
-  relativePath?: string;
 }
 
 interface SampleCollection {
@@ -70,19 +68,13 @@ class SampleProvider {
         tags: sample.tags,
         time: sample.time,
         configuration: sample.configuration,
-        link:
-          (sample as any).packageLink ??
-          (this.isStableRelease() ? this.sampleConfigs ?? sampleConfigV3 : preReleaseConfig)
-            .defaultPackageLink,
         suggested: sample.suggested,
-        url:
-          (sample as any).relativePath && (sample as any).url
-            ? (sample as any).url
-            : `${
-                (this.isStableRelease() ? this.sampleConfigs ?? sampleConfigV3 : preReleaseConfig)
-                  .baseUrl
-              }${sample.id}`,
-        relativePath: (sample as any).relativePath,
+        url: (sample as any).url
+          ? (sample as any).url
+          : `${
+              (this.isStableRelease() ? this.sampleConfigs ?? sampleConfigV3 : preReleaseConfig)
+                .baseUrl
+            }${sample.id}`,
       } as SampleInfo;
     });
 

--- a/packages/fx-core/src/common/samples.ts
+++ b/packages/fx-core/src/common/samples.ts
@@ -11,12 +11,6 @@ class configInfo {
   static readonly file = ".config/samples-config-v3.json";
 }
 
-class preReleaseConfig {
-  static readonly baseUrl = "https://github.com/OfficeDev/TeamsFx-Samples/tree/dev/";
-  static readonly defaultPackageLink =
-    "https://github.com/OfficeDev/TeamsFx-Samples/archive/refs/heads/dev.zip";
-}
-
 export interface SampleInfo {
   id: string;
   title: string;
@@ -69,12 +63,7 @@ class SampleProvider {
         time: sample.time,
         configuration: sample.configuration,
         suggested: sample.suggested,
-        url: (sample as any).url
-          ? (sample as any).url
-          : `${
-              (this.isStableRelease() ? this.sampleConfigs ?? sampleConfigV3 : preReleaseConfig)
-                .baseUrl
-            }${sample.id}`,
+        url: (sample as any).url ? (sample as any).url : `${this.getBaseSampleUrl()}${sample.id}`,
       } as SampleInfo;
     });
 
@@ -94,12 +83,15 @@ class SampleProvider {
     return this.sampleCollection;
   }
 
-  private isStableRelease(): boolean {
-    const version = packageJson.version;
-    if (version.includes("alpha") || version.includes("beta") || version.includes("rc")) {
-      return false;
+  private getBaseSampleUrl(): string {
+    const version: string = packageJson.version;
+    if (version.includes("alpha")) {
+      return "https://github.com/OfficeDev/TeamsFx-Samples/tree/dev/";
     }
-    return true;
+    if (version.includes("rc")) {
+      return "https://github.com/OfficeDev/TeamsFx-Samples/tree/v3/";
+    }
+    return this.sampleConfigs ?? sampleConfigV3.baseUrl;
   }
 }
 

--- a/packages/fx-core/src/common/samples.ts
+++ b/packages/fx-core/src/common/samples.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 import { sendRequestWithTimeout } from "../component/generator/utils";
 import sampleConfigV3 from "./samples-config-v3.json";
 import { isVideoFilterEnabled } from "./featureFlags";
-import * as packageJson from "../../package.json";
+const packageJson = require("../../package.json");
 
 class configInfo {
   static readonly owner = "OfficeDev";

--- a/packages/fx-core/src/common/samples.ts
+++ b/packages/fx-core/src/common/samples.ts
@@ -91,7 +91,7 @@ class SampleProvider {
     if (version.includes("rc")) {
       return "https://github.com/OfficeDev/TeamsFx-Samples/tree/v3/";
     }
-    return this.sampleConfigs ?? sampleConfigV3.baseUrl;
+    return (this.sampleConfigs ?? sampleConfigV3).baseUrl;
   }
 }
 

--- a/packages/fx-core/src/component/generator/generator.ts
+++ b/packages/fx-core/src/component/generator/generator.ts
@@ -31,12 +31,7 @@ import {
   GeneratorContext,
   TemplateActionSeq,
 } from "./generatorAction";
-import {
-  getSampleInfoFromName,
-  getSampleRelativePath,
-  renderTemplateFileData,
-  renderTemplateFileName,
-} from "./utils";
+import { getSampleInfoFromName, renderTemplateFileData, renderTemplateFileName } from "./utils";
 
 export class Generator {
   public static getDefaultVariables(
@@ -119,7 +114,6 @@ export class Generator {
       logProvider: ctx.logProvider,
       url: sample.url,
       timeoutInMs: sampleDefaultTimeoutInMs,
-      relativePath: sample.relativePath ?? getSampleRelativePath(sampleName),
       onActionError: sampleDefaultOnActionError,
     };
     await actionContext?.progressBar?.next(ProgressMessages.generateSample(sampleName));

--- a/packages/fx-core/src/component/generator/utils.ts
+++ b/packages/fx-core/src/component/generator/utils.ts
@@ -226,10 +226,6 @@ export function getSampleInfoFromName(sampleName: string): SampleInfo {
   return sample;
 }
 
-export function getSampleRelativePath(sampleName: string): string {
-  return `${sampleConfig.baseFolderName}/${sampleName}/`;
-}
-
 export function zipFolder(folderPath: string): AdmZip {
   const zip = new AdmZip();
   zip.addLocalFolder(folderPath);

--- a/packages/fx-core/src/question/create.ts
+++ b/packages/fx-core/src/question/create.ts
@@ -993,7 +993,6 @@ function sampleSelectQuestion(): SingleSelectQuestion {
         label: sample.title,
         description: `${sample.time} • ${sample.configuration}`,
         detail: sample.shortDescription,
-        data: sample.link,
       } as OptionItem;
     }),
     placeholder: getLocalizedString("core.SampleSelect.placeholder"),

--- a/packages/fx-core/tests/common/samples.test.ts
+++ b/packages/fx-core/tests/common/samples.test.ts
@@ -57,7 +57,6 @@ describe("Samples", () => {
       configuration: "Ready for debug",
       suggested: false,
       url: "https://faked-external-sample",
-      packageLink: "https://faked-external-sample/archive/refs/heads/main.zip",
     };
     sampleConfigV3.samples.push(fakedExternalSample as any);
 
@@ -65,7 +64,6 @@ describe("Samples", () => {
     const faked = samples.find((sample) => sample.id === fakedExternalSample.id);
     chai.expect(faked).exist;
     chai.expect(faked?.url).equals(fakedExternalSample.url);
-    chai.expect(faked?.link).equals(fakedExternalSample.packageLink);
 
     restore();
     (sampleProvider as any).sampleCollection = undefined;
@@ -86,7 +84,6 @@ describe("Samples", () => {
       time: "5min to run",
       configuration: "Ready for debug",
       suggested: false,
-      packageLink: "https://faked-external-sample/archive/refs/heads/main.zip",
     };
     sampleConfigV3.samples.push(fakedExternalSample as any);
 
@@ -94,7 +91,6 @@ describe("Samples", () => {
     const faked = samples.find((sample) => sample.id === fakedExternalSample.id);
     chai.expect(faked).exist;
     chai.expect(faked?.url).equals(sampleConfigV3.baseUrl + fakedExternalSample.id);
-    chai.expect(faked?.link).equals(fakedExternalSample.packageLink);
 
     restore();
     (sampleProvider as any).sampleCollection = undefined;
@@ -120,8 +116,6 @@ describe("Samples", () => {
     const sha = "fakedsha";
     const fakedSampleConfig = {
       baseUrl: "https://github.com/OfficeDev/TeamsFx-Samples/tree/v1.1.0/",
-      defaultPackageLink:
-        "https://github.com/OfficeDev/TeamsFx-Samples/archive/refs/tags/v1.1.0.zip",
       samples: [
         {
           id: "hello-world-tab-with-backend",

--- a/packages/fx-core/tests/common/samples.test.ts
+++ b/packages/fx-core/tests/common/samples.test.ts
@@ -6,6 +6,7 @@ import { sampleProvider } from "../../src/common/samples";
 import sampleConfigV3 from "../../src/common/samples-config-v3.json";
 import axios from "axios";
 import { err } from "@microsoft/teamsfx-api";
+const packageJson = require("../../package.json");
 
 describe("Samples", () => {
   afterEach(() => {
@@ -14,23 +15,15 @@ describe("Samples", () => {
   });
 
   it("Get v3 samples - default sample config", () => {
-    const restore = mockedEnv({
-      TEAMSFX_V3: "true",
-    });
-
     const samples = sampleProvider.SampleCollection.samples;
     for (const sample of samples) {
       chai.expect(sampleConfigV3.samples.find((sampleInConfig) => sampleInConfig.id === sample.id))
         .exist;
     }
-    restore();
     (sampleProvider as any).sampleCollection = undefined;
   });
 
   it("Get v3 samples - online sample config", () => {
-    const restore = mockedEnv({
-      TEAMSFX_V3: "true",
-    });
     sampleProvider["sampleConfigs"] = sampleConfigV3;
 
     const samples = sampleProvider.SampleCollection.samples;
@@ -38,15 +31,10 @@ describe("Samples", () => {
       chai.expect(sampleConfigV3.samples.find((sampleInConfig) => sampleInConfig.id === sample.id))
         .exist;
     }
-    restore();
     (sampleProvider as any).sampleCollection = undefined;
   });
 
   it("External sample url can be retrieved correctly in v3", () => {
-    const restore = mockedEnv({
-      TEAMSFX_V3: "true",
-    });
-
     const fakedExternalSample = {
       id: "external-sample",
       title: "Test external sample",
@@ -65,16 +53,11 @@ describe("Samples", () => {
     chai.expect(faked).exist;
     chai.expect(faked?.url).equals(fakedExternalSample.url);
 
-    restore();
     (sampleProvider as any).sampleCollection = undefined;
     sampleConfigV3.samples.splice(sampleConfigV3.samples.length - 1, 1);
   });
 
   it("External sample url fallback to base url in v3", () => {
-    const restore = mockedEnv({
-      TEAMSFX_V3: "true",
-    });
-
     const fakedExternalSample = {
       id: "external-sample",
       title: "Test external sample",
@@ -92,7 +75,6 @@ describe("Samples", () => {
     chai.expect(faked).exist;
     chai.expect(faked?.url).equals(sampleConfigV3.baseUrl + fakedExternalSample.id);
 
-    restore();
     (sampleProvider as any).sampleCollection = undefined;
     sampleConfigV3.samples.splice(sampleConfigV3.samples.length - 1, 1);
   });
@@ -113,7 +95,6 @@ describe("Samples", () => {
   });
 
   it("fetchSampleConfig - online sample config succeeds to obtain", async () => {
-    const sha = "fakedsha";
     const fakedSampleConfig = {
       baseUrl: "https://github.com/OfficeDev/TeamsFx-Samples/tree/v1.1.0/",
       samples: [
@@ -143,5 +124,61 @@ describe("Samples", () => {
     await sampleProvider.fetchSampleConfig();
 
     chai.expect(sampleProvider["sampleConfigs"]).equals(fakedSampleConfig);
+  });
+
+  it("Download sample from dev branch for alpha build", () => {
+    const fakedSampleConfig = {
+      baseUrl: "https://github.com/OfficeDev/TeamsFx-Samples/tree/v1.1.0/",
+      samples: [
+        {
+          id: "hello-world-tab-with-backend",
+          title: "Tab App with Azure Backend",
+          shortDescription:
+            "A Hello World app of Microsoft Teams Tab app which has a backend service",
+          fullDescription:
+            "This is a Hello World app of Microsoft Teams Tab app which accomplishes very simple function like single-sign on. You can run this app locally or deploy it to Microsoft Azure. This app has a Tab frontend and a backend service using Azure Function.",
+          tags: ["Tab", "TS", "Azure function"],
+          time: "5min to run",
+          configuration: "Ready for debug",
+          suggested: true,
+        },
+      ],
+    };
+    sampleProvider["sampleConfigs"] = fakedSampleConfig;
+    packageJson.version = "2.0.4-alpha.888a35067.0";
+
+    const samples = sampleProvider.SampleCollection.samples;
+    chai
+      .expect(samples[0].url)
+      .equal(`https://github.com/OfficeDev/TeamsFx-Samples/tree/dev/hello-world-tab-with-backend`);
+    (sampleProvider as any).sampleCollection = undefined;
+  });
+
+  it("Download sample from v3 branch for rc build", () => {
+    const fakedSampleConfig = {
+      baseUrl: "https://github.com/OfficeDev/TeamsFx-Samples/tree/v1.1.0/",
+      samples: [
+        {
+          id: "hello-world-tab-with-backend",
+          title: "Tab App with Azure Backend",
+          shortDescription:
+            "A Hello World app of Microsoft Teams Tab app which has a backend service",
+          fullDescription:
+            "This is a Hello World app of Microsoft Teams Tab app which accomplishes very simple function like single-sign on. You can run this app locally or deploy it to Microsoft Azure. This app has a Tab frontend and a backend service using Azure Function.",
+          tags: ["Tab", "TS", "Azure function"],
+          time: "5min to run",
+          configuration: "Ready for debug",
+          suggested: true,
+        },
+      ],
+    };
+    sampleProvider["sampleConfigs"] = fakedSampleConfig;
+    packageJson.version = "2.0.3-rc.1";
+
+    const samples = sampleProvider.SampleCollection.samples;
+    chai
+      .expect(samples[0].url)
+      .equal(`https://github.com/OfficeDev/TeamsFx-Samples/tree/v3/hello-world-tab-with-backend`);
+    (sampleProvider as any).sampleCollection = undefined;
   });
 });

--- a/packages/fx-core/tests/common/samples.test.ts
+++ b/packages/fx-core/tests/common/samples.test.ts
@@ -58,7 +58,6 @@ describe("Samples", () => {
       suggested: false,
       url: "https://faked-external-sample",
       packageLink: "https://faked-external-sample/archive/refs/heads/main.zip",
-      relativePath: "faked-external-sample",
     };
     sampleConfigV3.samples.push(fakedExternalSample as any);
 
@@ -67,7 +66,6 @@ describe("Samples", () => {
     chai.expect(faked).exist;
     chai.expect(faked?.url).equals(fakedExternalSample.url);
     chai.expect(faked?.link).equals(fakedExternalSample.packageLink);
-    chai.expect(faked?.relativePath).equals(fakedExternalSample.relativePath);
 
     restore();
     (sampleProvider as any).sampleCollection = undefined;

--- a/packages/fx-core/tests/component/generator/generator.test.ts
+++ b/packages/fx-core/tests/component/generator/generator.test.ts
@@ -46,7 +46,6 @@ const mockedSampleInfo: SampleInfo = {
   tags: [],
   time: "",
   configuration: "test-configuration",
-  link: "test-link",
   suggested: false,
   url: "https://github.com/OfficeDev/TeamsFx-Samples/tree/dev/test",
 };

--- a/packages/vscode-extension/src/controls/ISamples.ts
+++ b/packages/vscode-extension/src/controls/ISamples.ts
@@ -6,10 +6,8 @@ export interface SampleInfo {
   tags: string[];
   time: string;
   configuration: string;
-  link: string;
   suggested: boolean;
   url: string;
-  relativePath?: string;
 }
 
 export interface SampleCollection {
@@ -35,7 +33,5 @@ export type SampleDetailProps = {
   title: string;
   description: string;
   sampleAppFolder: string;
-  sampleAppUrl: string;
-  relativePath?: string;
   highlightSample: (id: string) => void;
 };

--- a/packages/vscode-extension/src/controls/SampleGallery.tsx
+++ b/packages/vscode-extension/src/controls/SampleGallery.tsx
@@ -120,8 +120,6 @@ export default class SampleGallery extends React.Component<any, any> {
             title={hightSample.title}
             description={hightSample.fullDescription}
             sampleAppFolder={hightSample.id}
-            sampleAppUrl={hightSample.link}
-            relativePath={hightSample.relativePath}
             highlightSample={this.highlightSample}
           ></SampleDetailPage>
         )}

--- a/packages/vscode-extension/src/controls/SampleGallery.tsx
+++ b/packages/vscode-extension/src/controls/SampleGallery.tsx
@@ -167,7 +167,6 @@ class SampleAppCardList extends React.Component<SampleListProps, any> {
             title={sample.title}
             description={sample.fullDescription}
             sampleAppFolder={sample.id}
-            sampleAppUrl={sample.link}
             suggested={sample.suggested}
             order={index + 1}
             highlightSample={this.props.highlightSample}

--- a/packages/vscode-extension/src/controls/sampleDetailPage.tsx
+++ b/packages/vscode-extension/src/controls/sampleDetailPage.tsx
@@ -65,7 +65,6 @@ export default class SampleDetailPage extends React.Component<SampleDetailProps,
       command: Commands.CloneSampleApp,
       data: {
         appName: this.props.title,
-        appUrl: this.props.sampleAppUrl,
         appFolder: this.props.sampleAppFolder,
       },
     });


### PR DESCRIPTION
1. Remove `packageLink` and `relativePath` fields in sample config, cleanup related codes
2. Download/View sample per package version:
     For alpha releases, download from dev branch;
     For rc releases, download from v3 branch;
     For beta and stable release, download from tag;