### PR TITLE
feat: expose app name question in import spfx flow

### DIFF
--- a/packages/fx-core/src/question/questionNames.ts
+++ b/packages/fx-core/src/question/questionNames.ts
@@ -19,7 +19,6 @@ export enum QuestionNames {
   OfficeAddinTemplate = "addin-template-select",
   OfficeAddinHost = "addin-host",
   OfficeAddinImport = "addin-import",
-  SkipAppName = "skip-app-name",
   Samples = "samples",
   ReplaceContentUrl = "replaceContentUrl",
   ReplaceWebsiteUrl = "replaceWebsiteUrl",

--- a/packages/fx-core/tests/plugins/resource/spfx/unit/utils.test.ts
+++ b/packages/fx-core/tests/plugins/resource/spfx/unit/utils.test.ts
@@ -18,12 +18,12 @@ import { cpUtils } from "../../../../../src";
 import { getLocalizedString } from "../../../../../src/common/localizeUtils";
 import { Utils } from "../../../../../src/component/generator/spfx/utils/utils";
 import {
-  fillInAppNameFuncQuestion,
   PackageSelectOptionsHelper,
   SPFxVersionOptionIds,
   QuestionNames,
   SPFxPackageSelectQuestion,
   SPFxWebpartNameQuestion,
+  appNameQuestion,
 } from "../../../../../src/question";
 
 describe("utils", () => {
@@ -234,39 +234,19 @@ describe("utils", () => {
     chai.expect(res.length === 0).to.be.true;
   });
 
-  it("Returns error when path already exists", async () => {
+  it("Returns solution name as default app name", async () => {
     const inputs: Inputs = {
       platform: Platform.VSCode,
       folder: "c:\\testApp",
-      [QuestionNames.AppName]: "",
       [QuestionNames.SPFxFolder]: "c:\\test",
+      [QuestionNames.SPFxSolution]: "import",
     };
     sinon
       .stub(fs, "readJson")
       .resolves({ "@microsoft/generator-sharepoint": { solutionName: "fakedSolutionName" } });
     sinon.stub(fs, "pathExists").resolves(true);
 
-    try {
-      await (fillInAppNameFuncQuestion() as any).func(inputs);
-    } catch (e) {
-      chai.expect(e.name).equal("PathAlreadyExists");
-    }
-  });
-
-  it("Returns error when invalid SPFx solution", async () => {
-    const inputs: Inputs = {
-      platform: Platform.VSCode,
-      [QuestionNames.AppName]: "",
-      [QuestionNames.SPFxSolution]: "import",
-      [QuestionNames.SPFxFolder]: "c:\\test",
-    };
-    sinon.stub(fs, "readJson").resolves({ "@microsoft/generator-sharepoint": {} });
-    sinon.stub(fs, "pathExists").resolves(true);
-
-    try {
-      await (fillInAppNameFuncQuestion() as any).func(inputs);
-    } catch (e) {
-      chai.expect(e.name).equal("RetrieveSPFxInfoFailed");
-    }
+    const defaultName = await (appNameQuestion() as any).default(inputs);
+    chai.expect(defaultName).equal("fakedSolutionName");
   });
 });

--- a/packages/fx-core/tests/question/create.test.ts
+++ b/packages/fx-core/tests/question/create.test.ts
@@ -376,8 +376,6 @@ describe("scaffold question", () => {
           return ok({ type: "success", result: "import" });
         } else if (question.name === QuestionNames.SPFxFolder) {
           return ok({ type: "success", result: "" });
-        } else if (question.name === QuestionNames.SkipAppName) {
-          return ok({ type: "success", result: "" });
         } else if (question.name === QuestionNames.ProgrammingLanguage) {
           const select = question as SingleSelectQuestion;
           const options = await select.dynamicOptions!(inputs);
@@ -397,7 +395,6 @@ describe("scaffold question", () => {
         QuestionNames.Capabilities,
         QuestionNames.SPFxSolution,
         QuestionNames.SPFxFolder,
-        QuestionNames.SkipAppName,
         QuestionNames.ProgrammingLanguage,
         QuestionNames.Folder,
         QuestionNames.AppName,


### PR DESCRIPTION
As confirmed with PM & UX, expose app name question in import SPFx solution flow and make solution name as default value for app name
![importspfx_name](https://github.com/OfficeDev/TeamsFx/assets/73154171/5cdd5e21-358a-45c6-ba47-77348546fe40)
E2E TEST: NA
