### PR TITLE
fix: change hash encoding to hex to avoid slash char in base64

### DIFF
--- a/packages/fx-core/src/component/utils/metadataUtil.ts
+++ b/packages/fx-core/src/component/utils/metadataUtil.ts
@@ -47,16 +47,14 @@ class MetadataUtil {
     props[prefix + "staticTabs.contentUrl"] =
       manifest.staticTabs
         ?.map((tab) =>
-          tab.contentUrl
-            ? createHash("sha256").update(tab.contentUrl).digest("base64")
-            : "undefined"
+          tab.contentUrl ? createHash("sha256").update(tab.contentUrl).digest("hex") : "undefined"
         )
         .toString() ?? "";
     props[prefix + "configurableTabs.configurationUrl"] =
       manifest.configurableTabs
         ?.map((tab) =>
           tab.configurationUrl
-            ? createHash("sha256").update(tab.configurationUrl).digest("base64")
+            ? createHash("sha256").update(tab.configurationUrl).digest("hex")
             : "undefined"
         )
         .toString() ?? "";

--- a/packages/fx-core/tests/component/util/metadataUtil.test.ts
+++ b/packages/fx-core/tests/component/util/metadataUtil.test.ts
@@ -173,12 +173,12 @@ describe("metadata util", () => {
         "manifest.bots": "bot1,bot2",
         "manifest.composeExtensions": "bot1,bot2",
         "manifest.staticTabs.contentUrl": `${[
-          createHash("sha256").update(manifest.staticTabs[0].contentUrl).digest("base64"),
-          createHash("sha256").update(manifest.staticTabs[1].contentUrl).digest("base64"),
+          createHash("sha256").update(manifest.staticTabs[0].contentUrl).digest("hex"),
+          createHash("sha256").update(manifest.staticTabs[1].contentUrl).digest("hex"),
         ].toString()}`,
         "manifest.configurableTabs.configurationUrl": `${createHash("sha256")
           .update(manifest.configurableTabs[0].configurationUrl)
-          .digest("base64")}`,
+          .digest("hex")}`,
         "manifest.webApplicationInfo.id": "web-app-id",
         "manifest.extensions": "true",
       })
@@ -196,12 +196,12 @@ describe("metadata util", () => {
         "manifest.bots": "bot1,bot2",
         "manifest.composeExtensions": "bot1,bot2",
         "manifest.staticTabs.contentUrl": `${[
-          createHash("sha256").update(manifest.staticTabs[0].contentUrl).digest("base64"),
-          createHash("sha256").update(manifest.staticTabs[1].contentUrl).digest("base64"),
+          createHash("sha256").update(manifest.staticTabs[0].contentUrl).digest("hex"),
+          createHash("sha256").update(manifest.staticTabs[1].contentUrl).digest("hex"),
         ].toString()}`,
         "manifest.configurableTabs.configurationUrl": `${createHash("sha256")
           .update(manifest.configurableTabs[0].configurationUrl)
-          .digest("base64")}`,
+          .digest("hex")}`,
         "manifest.webApplicationInfo.id": "web-app-id",
         "manifest.extensions": "false",
       })
@@ -219,12 +219,12 @@ describe("metadata util", () => {
         "manifest.bots": "bot1,bot2",
         "manifest.composeExtensions": "bot1,bot2",
         "manifest.staticTabs.contentUrl": `${[
-          createHash("sha256").update(manifest.staticTabs[0].contentUrl).digest("base64"),
-          createHash("sha256").update(manifest.staticTabs[1].contentUrl).digest("base64"),
+          createHash("sha256").update(manifest.staticTabs[0].contentUrl).digest("hex"),
+          createHash("sha256").update(manifest.staticTabs[1].contentUrl).digest("hex"),
         ].toString()}`,
         "manifest.configurableTabs.configurationUrl": `${createHash("sha256")
           .update(manifest.configurableTabs[0].configurationUrl)
-          .digest("base64")}`,
+          .digest("hex")}`,
         "manifest.webApplicationInfo.id": "web-app-id",
         "manifest.extensions": "false",
       })

--- a/packages/fx-core/tests/component/util/metadataUtil.test.ts
+++ b/packages/fx-core/tests/component/util/metadataUtil.test.ts
@@ -234,4 +234,36 @@ describe("metadata util", () => {
       })
     );
   });
+
+  it("parseManifest with undefined urls", () => {
+    const manifest: any = {
+      id: "test-id",
+      version: "1.0",
+      manifestVersion: "1.0",
+      bots: [{ botId: "bot1" }, { botId: "bot2" }],
+      composeExtensions: [{ botId: "bot1" }, { botId: "bot2" }],
+      staticTabs: [{ contentUrl: undefined }, { contentUrl: undefined }],
+      configurableTabs: [{ configurationUrl: undefined }],
+      webApplicationInfo: { id: "web-app-id" },
+    };
+    const spy = sandbox.spy(tools.telemetryReporter, "sendTelemetryEvent");
+    const hashSpy = sandbox.spy(Hash.prototype);
+
+    metadataUtil.parseManifest(manifest as unknown as TeamsAppManifest);
+    assert.isTrue(hashSpy.update.notCalled);
+    assert.isTrue(hashSpy.digest.notCalled);
+    assert.isTrue(
+      spy.calledOnceWith(TelemetryEvent.MetaData, {
+        "manifest.id": "test-id",
+        "manifest.version": "1.0",
+        "manifest.manifestVersion": "1.0",
+        "manifest.bots": "bot1,bot2",
+        "manifest.composeExtensions": "bot1,bot2",
+        "manifest.staticTabs.contentUrl": "undefined,undefined",
+        "manifest.configurableTabs.configurationUrl": "undefined",
+        "manifest.webApplicationInfo.id": "web-app-id",
+        "manifest.extensions": "false",
+      })
+    );
+  });
 });

--- a/packages/fx-core/tests/component/util/metadataUtil.test.ts
+++ b/packages/fx-core/tests/component/util/metadataUtil.test.ts
@@ -21,7 +21,7 @@ import { DriverContext } from "../../../src/component/driver/interface/commonArg
 import { metadataUtil } from "../../../src/component/utils/metadataUtil";
 import { setTools } from "../../../src/core/globalVars";
 import { MockTools } from "../../core/utils";
-import { createHash } from "crypto";
+import { createHash, Hash } from "crypto";
 
 function mockedResolveDriverInstances(log: LogProvider): Result<DriverInstance[], FxError> {
   return ok([
@@ -161,10 +161,14 @@ describe("metadata util", () => {
       extensions: [{}],
     };
     const spy = sandbox.spy(tools.telemetryReporter, "sendTelemetryEvent");
+    const createHashSpy = sandbox.spy(createHash);
+    const hashSpy = sandbox.spy(Hash.prototype);
 
     manifest.extensions = [{}];
     metadataUtil.parseManifest(manifest as unknown as TeamsAppManifest);
-
+    assert.isTrue(createHashSpy.calledWith("sha256"));
+    assert.isTrue(hashSpy.update.called);
+    assert.isTrue(hashSpy.digest.calledWith("hex"));
     assert.isTrue(
       spy.calledOnceWith(TelemetryEvent.MetaData, {
         "manifest.id": "test-id",
@@ -187,7 +191,9 @@ describe("metadata util", () => {
     // If extensions is empty, it should report false in telemetry event
     manifest.extensions = [];
     metadataUtil.parseManifest(manifest as unknown as TeamsAppManifest);
-
+    assert.isTrue(createHashSpy.calledWith("sha256"));
+    assert.isTrue(hashSpy.update.called);
+    assert.isTrue(hashSpy.digest.calledWith("hex"));
     assert.isTrue(
       spy.calledWith(TelemetryEvent.MetaData, {
         "manifest.id": "test-id",
@@ -210,7 +216,9 @@ describe("metadata util", () => {
     // If extensions is undefined, it should report false in telemetry event
     manifest.extensions = undefined;
     metadataUtil.parseManifest(manifest as unknown as TeamsAppManifest);
-
+    assert.isTrue(createHashSpy.calledWith("sha256"));
+    assert.isTrue(hashSpy.update.called);
+    assert.isTrue(hashSpy.digest.calledWith("hex"));
     assert.isTrue(
       spy.calledWith(TelemetryEvent.MetaData, {
         "manifest.id": "test-id",

--- a/packages/fx-core/tests/component/util/metadataUtil.test.ts
+++ b/packages/fx-core/tests/component/util/metadataUtil.test.ts
@@ -161,12 +161,10 @@ describe("metadata util", () => {
       extensions: [{}],
     };
     const spy = sandbox.spy(tools.telemetryReporter, "sendTelemetryEvent");
-    const createHashSpy = sandbox.spy(createHash);
     const hashSpy = sandbox.spy(Hash.prototype);
 
     manifest.extensions = [{}];
     metadataUtil.parseManifest(manifest as unknown as TeamsAppManifest);
-    assert.isTrue(createHashSpy.calledWith("sha256"));
     assert.isTrue(hashSpy.update.called);
     assert.isTrue(hashSpy.digest.calledWith("hex"));
     assert.isTrue(
@@ -191,7 +189,6 @@ describe("metadata util", () => {
     // If extensions is empty, it should report false in telemetry event
     manifest.extensions = [];
     metadataUtil.parseManifest(manifest as unknown as TeamsAppManifest);
-    assert.isTrue(createHashSpy.calledWith("sha256"));
     assert.isTrue(hashSpy.update.called);
     assert.isTrue(hashSpy.digest.calledWith("hex"));
     assert.isTrue(
@@ -216,7 +213,6 @@ describe("metadata util", () => {
     // If extensions is undefined, it should report false in telemetry event
     manifest.extensions = undefined;
     metadataUtil.parseManifest(manifest as unknown as TeamsAppManifest);
-    assert.isTrue(createHashSpy.calledWith("sha256"));
     assert.isTrue(hashSpy.update.called);
     assert.isTrue(hashSpy.digest.calledWith("hex"));
     assert.isTrue(


### PR DESCRIPTION
fix: change hash encoding to hex to avoid slash char in base64

This is because "base64" encoding have "/" charactor. It make GDPR treat the hash string as file path. So need to change encoding to "hex" to avoid this case.

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/24539488