### PR TITLE
Updates adaptive card to make use of passed in values

### DIFF
--- a/templates/ts/command-and-response/README.md
+++ b/templates/ts/command-and-response/README.md
@@ -92,11 +92,11 @@ To respond with an Adaptive Card, define your card in its JSON format. Create a 
       "type": "TextBlock",
       "size": "Medium",
       "weight": "Bolder",
-      "text": "Your doSomething Command is added!"
+      "text": "${title}"
     },
     {
       "type": "TextBlock",
-      "text": "Congratulations! Your hello world bot now includes a new DoSomething Command",
+      "text": "${body}",
       "wrap": true
     }
   ],


### PR DESCRIPTION
The sample code for `doSomethingCommandHandler.ts` provides values for the `title` and `body` properties that will never be used.

```
const cardData: CardData = {
      title: "doSomething command is added",
      body: "Congratulations! You have responded to doSomething command",
};
```

This is because `doSomethingCommandResponse.json` has hard coded values, instead of using the `${title}` and `${body}` directives.

I have fixed this behaviour.