### PR TITLE
refactor: show validation error in question related to copilot plugin

### DIFF
--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -287,6 +287,8 @@ export interface Inputs extends Record<string, any> {
     // (undocumented)
     stage?: Stage;
     // (undocumented)
+    supportedApisFromApiSpec?: string[];
+    // (undocumented)
     targetEnvName?: string;
     // (undocumented)
     targetResourceGroupName?: string;
@@ -307,7 +309,7 @@ export type InputsWithProjectPath = Inputs & {
 
 // @public
 export interface InputTextConfig extends UIConfig<string> {
-    additionalValidationOnAccept?: (input: string, inputs?: Inputs) => string | undefined | Promise<string | undefined>;
+    additionalValidationOnAccept?: ValidateFunc<string>;
     // (undocumented)
     default?: string | (() => Promise<string>);
     password?: boolean;

--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -307,6 +307,7 @@ export type InputsWithProjectPath = Inputs & {
 
 // @public
 export interface InputTextConfig extends UIConfig<string> {
+    additionalValidationOnAccept?: (input: string, inputs?: Inputs) => string | undefined | Promise<string | undefined>;
     // (undocumented)
     default?: string | (() => Promise<string>);
     password?: boolean;
@@ -822,6 +823,7 @@ export const TemplateFolderName = "templates";
 
 // @public
 export interface TextInputQuestion extends UserInputQuestion {
+    additionalValidationOnAccept?: StringValidation | FuncValidation<string>;
     default?: string | LocalFunc<string | undefined>;
     password?: boolean;
     // (undocumented)

--- a/packages/api/src/qm/question.ts
+++ b/packages/api/src/qm/question.ts
@@ -250,6 +250,10 @@ export interface TextInputQuestion extends UserInputQuestion {
    * validation schema, which can be a dynamic function closure
    */
   validation?: StringValidation | FuncValidation<string>;
+  /**
+   * validation when user confirms the input.
+   */
+  additionalValidationOnAccept?: StringValidation | FuncValidation<string>;
 }
 
 /**

--- a/packages/api/src/qm/ui.ts
+++ b/packages/api/src/qm/ui.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { Result } from "neverthrow";
-import { LocalFunc } from ".";
+import { LocalFunc, ValidateFunc } from ".";
 import { FxError } from "../error";
 import { OnSelectionChangeFunc, StaticOptions } from "../qm/question";
 import { Inputs, OptionItem } from "../types";
@@ -133,10 +133,7 @@ export interface InputTextConfig extends UIConfig<string> {
    * @return A human-readable string which is presented as diagnostic message.
    * Return `undefined` when 'value' is valid.
    */
-  additionalValidationOnAccept?: (
-    input: string,
-    inputs?: Inputs
-  ) => string | undefined | Promise<string | undefined>;
+  additionalValidationOnAccept?: ValidateFunc<string>;
 }
 
 /**

--- a/packages/api/src/qm/ui.ts
+++ b/packages/api/src/qm/ui.ts
@@ -124,6 +124,19 @@ export interface InputTextConfig extends UIConfig<string> {
   password?: boolean;
 
   default?: string | (() => Promise<string>);
+
+  /**
+   * A function that will be called to validate the input that user accepted.
+   *
+   * @param input The current value of the input to be validated.
+   * @param inputs The current values of all inputs.
+   * @return A human-readable string which is presented as diagnostic message.
+   * Return `undefined` when 'value' is valid.
+   */
+  additionalValidationOnAccept?: (
+    input: string,
+    inputs?: Inputs
+  ) => string | undefined | Promise<string | undefined>;
 }
 
 /**

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -85,6 +85,7 @@ export interface Inputs extends Record<string, any> {
   inProductDoc?: boolean; // AB test for in product doc feature
   teamsAppFromTdp?: any;
   openAIPluginManifest?: OpenAIPluginManifest;
+  supportedApisFromApiSpec?: string[];
   globalYeomanPackageVersion?: string;
   globalSpfxPackageVersion?: string;
   latestSpfxPackageVersion?: string;

--- a/packages/fx-core/src/component/generator/copilotPlugin/constant.ts
+++ b/packages/fx-core/src/component/generator/copilotPlugin/constant.ts
@@ -1,6 +1,0 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
-
-export enum TelemetryEvents {
-  CannotGetLogoFromOpenAIPlugin = "cannot-get-logo-from-openai-plugin",
-}

--- a/packages/fx-core/src/component/generator/copilotPlugin/helper.ts
+++ b/packages/fx-core/src/component/generator/copilotPlugin/helper.ts
@@ -8,6 +8,8 @@
 import {
   Context,
   FxError,
+  Inputs,
+  LogLevel,
   OpenAIManifestAuthType,
   OpenAIPluginManifest,
   Result,
@@ -26,6 +28,7 @@ import fs from "fs-extra";
 import { manifestUtils } from "../../driver/teamsApp/utils/ManifestUtils";
 import path from "path";
 import { getLocalizedString } from "../../../common/localizeUtils";
+import { assembleError } from "../../../error";
 
 const manifestFilePath = "/.well-known/ai-plugin.json";
 const teamsFxEnv = "${{TEAMSFX_ENV}}";
@@ -111,6 +114,9 @@ export async function listOperations(
   const validationRes = await specParser.validate();
 
   if (validationRes.status === ValidationStatus.Error) {
+    for (const error of validationRes.errors) {
+      context.logProvider?.error(error.content);
+    }
     return err(validationRes.errors);
   }
 

--- a/packages/fx-core/src/component/generator/copilotPlugin/helper.ts
+++ b/packages/fx-core/src/component/generator/copilotPlugin/helper.ts
@@ -112,7 +112,7 @@ export async function listOperations(
 
   if (validationRes.status === ValidationStatus.Error) {
     for (const error of validationRes.errors) {
-      context.logProvider?.error(error.content);
+      context.logProvider.error(error.content);
     }
     return err(validationRes.errors);
   }

--- a/packages/fx-core/src/component/generator/copilotPlugin/helper.ts
+++ b/packages/fx-core/src/component/generator/copilotPlugin/helper.ts
@@ -8,8 +8,6 @@
 import {
   Context,
   FxError,
-  Inputs,
-  LogLevel,
   OpenAIManifestAuthType,
   OpenAIPluginManifest,
   Result,
@@ -28,7 +26,6 @@ import fs from "fs-extra";
 import { manifestUtils } from "../../driver/teamsApp/utils/ManifestUtils";
 import path from "path";
 import { getLocalizedString } from "../../../common/localizeUtils";
-import { assembleError } from "../../../error";
 
 const manifestFilePath = "/.well-known/ai-plugin.json";
 const teamsFxEnv = "${{TEAMSFX_ENV}}";

--- a/packages/fx-core/src/question/create.ts
+++ b/packages/fx-core/src/question/create.ts
@@ -1211,6 +1211,25 @@ function selectBotIdsQuestion(): MultiSelectQuestion {
 }
 
 export function apiSpecLocationQuestion(): SingleFileOrInputQuestion {
+  const context = createContextV3();
+  const validationOnAccept = async (
+    input: string,
+    inputs?: Inputs
+  ): Promise<string | undefined> => {
+    try {
+      const res = await listOperations(context, undefined, input, true);
+      if (res.isOk()) {
+        inputs!.supportedApisFromApiSpec = res.value;
+      } else {
+        // TODO: get validationErrorMessage based on error length
+        const errors = res.error;
+        return errors[0].content;
+      }
+    } catch (e) {
+      const error = assembleError(e);
+      throw error;
+    }
+  };
   return {
     type: "singleFileOrText",
     name: QuestionNames.ApiSpecLocation,
@@ -1226,6 +1245,7 @@ export function apiSpecLocationQuestion(): SingleFileOrInputQuestion {
           ? undefined
           : getLocalizedString("core.createProjectQuestion.invalidUrl.message");
       },
+      additionalValidationOnAccept: validationOnAccept,
     },
     inputOptionItem: {
       id: "input",
@@ -1233,6 +1253,15 @@ export function apiSpecLocationQuestion(): SingleFileOrInputQuestion {
     },
     filters: {
       files: ["json", "yml", "yaml"],
+    },
+    validation: {
+      validFunc: async (input: string, inputs?: Inputs): Promise<string | undefined> => {
+        if (input === "input") {
+          return undefined;
+        }
+
+        return await validationOnAccept(input, inputs);
+      },
     },
   };
 }
@@ -1249,6 +1278,39 @@ function openAIPluginManifestLocationQuestion(): TextInputQuestion {
         return isValidHttpUrl(input)
           ? undefined
           : getLocalizedString("core.createProjectQuestion.invalidUrl.message");
+      },
+    },
+    additionalValidationOnAccept: {
+      validFunc: async (input: string, inputs?: Inputs): Promise<string | undefined> => {
+        let manifest;
+
+        try {
+          manifest = await OpenAIPluginManifestHelper.loadOpenAIPluginManifest(input);
+          inputs!.openAIPluginManifest = manifest;
+        } catch (e) {
+          const error = assembleError(e);
+          return error.message;
+        }
+
+        const context = createContextV3();
+        try {
+          const res = await listOperations(
+            context,
+            manifest,
+            inputs![QuestionNames.ApiSpecLocation],
+            true
+          );
+          if (res.isOk()) {
+            inputs!.supportedApisFromApiSpec = res.value;
+          } else {
+            // TODO: get validationErrorMessage based on error length
+            const errors = res.error;
+            return errors[0].content;
+          }
+        } catch (e) {
+          const error = assembleError(e);
+          throw error;
+        }
       },
     },
   };
@@ -1269,41 +1331,29 @@ export function apiOperationQuestion(includeExistingAPIs = true): MultiSelectQue
       minItems: 1,
     },
     dynamicOptions: async (inputs: Inputs): Promise<OptionItem[]> => {
-      let manifest;
-      if (inputs[QuestionNames.OpenAIPluginManifestLocation]) {
-        manifest = await OpenAIPluginManifestHelper.loadOpenAIPluginManifest(
-          inputs[QuestionNames.OpenAIPluginManifestLocation] as string
-        );
-        inputs.openAIPluginManifest = manifest;
+      if (!inputs.supportedApisFromApiSpec) {
+        throw new EmptyOptionError();
       }
-      const context = createContextV3();
-      try {
-        const res = await listOperations(context, manifest, inputs[QuestionNames.ApiSpecLocation]);
-        if (res.isOk()) {
-          if (includeExistingAPIs) {
-            return res.value.map((operation) => {
+      if (includeExistingAPIs) {
+        return inputs.supportedApisFromApiSpec.map((operation: string) => {
+          return {
+            id: operation,
+            label: operation,
+          };
+        });
+      } else {
+        const teamsManifestPath = inputs.teamsManifestPath;
+        const manifest = await manifestUtils._readAppManifest(teamsManifestPath);
+        if (manifest.isOk()) {
+          const existingOperationIds = manifestUtils.getOperationIds(manifest.value);
+          return inputs.supportedApisFromApiSpec
+            .filter((operation: string) => !existingOperationIds.includes(operation))
+            .map((operation: string) => {
               return { id: operation, label: operation };
             });
-          } else {
-            const teamsManifestPath = inputs.teamsManifestPath;
-            const manifest = await manifestUtils._readAppManifest(teamsManifestPath);
-            if (manifest.isOk()) {
-              const existingOperationIds = manifestUtils.getOperationIds(manifest.value);
-              return res.value
-                .filter((operation: string) => !existingOperationIds.includes(operation))
-                .map((operation: string) => {
-                  return { id: operation, label: operation };
-                });
-            } else {
-              throw manifest.error;
-            }
-          }
         } else {
-          throw new EmptyOptionError(); // TODO: handle errors based on error results
+          throw manifest.error;
         }
-      } catch (e) {
-        const error = assembleError(e);
-        throw error;
       }
     },
   };

--- a/packages/fx-core/src/question/create.ts
+++ b/packages/fx-core/src/question/create.ts
@@ -1213,12 +1213,12 @@ function selectBotIdsQuestion(): MultiSelectQuestion {
 }
 
 export function apiSpecLocationQuestion(): SingleFileOrInputQuestion {
-  const context = createContextV3();
   const validationOnAccept = async (
     input: string,
     inputs?: Inputs
   ): Promise<string | undefined> => {
     try {
+      const context = createContextV3();
       const res = await listOperations(context, undefined, input, true);
       if (res.isOk()) {
         inputs!.supportedApisFromApiSpec = res.value;

--- a/packages/fx-core/src/question/create.ts
+++ b/packages/fx-core/src/question/create.ts
@@ -991,6 +991,8 @@ export function appNameQuestion(): TextInputQuestion {
         defaultName = convertToAlphanumericOnly(inputs.teamsAppFromTdp?.appName);
       } else if (inputs[QuestionNames.SPFxSolution] == "import") {
         defaultName = await SPFxGenerator.getSolutionName(inputs[QuestionNames.SPFxFolder]);
+      } else if (inputs.openAIPluginManifest) {
+        defaultName = inputs.openAIPluginManifest.name_for_human;
       }
       return defaultName;
     },

--- a/packages/fx-core/src/question/create.ts
+++ b/packages/fx-core/src/question/create.ts
@@ -1266,7 +1266,8 @@ export function apiSpecLocationQuestion(): SingleFileOrInputQuestion {
   };
 }
 
-function openAIPluginManifestLocationQuestion(): TextInputQuestion {
+export function openAIPluginManifestLocationQuestion(): TextInputQuestion {
+  // export for unit test
   return {
     type: "text",
     name: QuestionNames.OpenAIPluginManifestLocation,

--- a/packages/fx-core/src/ui/visitor.ts
+++ b/packages/fx-core/src/ui/visitor.ts
@@ -136,6 +136,9 @@ const questionVisitor: QuestionTreeVisitor = async function (
       const validationFunc = question.validation
         ? getValidationFunction<string>(question.validation, inputs)
         : undefined;
+      const additionalValidationOnAcceptFunc = question.additionalValidationOnAccept
+        ? getValidationFunction<string>(question.additionalValidationOnAccept, inputs)
+        : undefined;
       const inputQuestion = question as TextInputQuestion;
       return await ui.inputText({
         name: question.name,
@@ -147,6 +150,7 @@ const questionVisitor: QuestionTreeVisitor = async function (
         validation: validationFunc,
         step: step,
         totalSteps: totalSteps,
+        additionalValidationOnAccept: additionalValidationOnAcceptFunc,
       });
     } else if (question.type === "singleSelect" || question.type === "multiSelect") {
       const selectQuestion = question as SingleSelectQuestion | MultiSelectQuestion;
@@ -250,6 +254,13 @@ const questionVisitor: QuestionTreeVisitor = async function (
       const validationFunc = question.validation
         ? getValidationFunction<string>(question.validation, inputs)
         : undefined;
+      const additionalValidationOnAcceptFunc = question.inputBoxConfig.additionalValidationOnAccept
+        ? getValidationFunction<string>(
+            { validFunc: question.inputBoxConfig.additionalValidationOnAccept },
+            inputs
+          )
+        : undefined;
+      question.inputBoxConfig.additionalValidationOnAccept = additionalValidationOnAcceptFunc;
       const res = await ui.selectFileOrInput({
         name: question.name,
         title: title,

--- a/packages/fx-core/tests/question/create.test.ts
+++ b/packages/fx-core/tests/question/create.test.ts
@@ -10,7 +10,10 @@ import {
   Platform,
   Question,
   SingleSelectQuestion,
+  UserError,
   UserInteraction,
+  ValidateFunc,
+  ValidationSchema,
   ok,
 } from "@microsoft/teamsfx-api";
 import { assert } from "chai";
@@ -28,10 +31,12 @@ import {
   SPFxVersionOptionIds,
   ScratchOptions,
   apiOperationQuestion,
+  apiSpecLocationQuestion,
   appNameQuestion,
   createProjectQuestionNode,
   getLanguageOptions,
   getTemplate,
+  openAIPluginManifestLocationQuestion,
   programmingLanguageQuestion,
 } from "../../src/question/create";
 import { QuestionNames } from "../../src/question/questionNames";
@@ -690,6 +695,8 @@ describe("scaffold question", () => {
 
     describe("copilot plugin enabled", () => {
       let mockedEnvRestore: RestoreFn;
+      const tools = new MockTools();
+      setTools(tools);
       beforeEach(() => {
         mockedEnvRestore = mockedEnv({
           [FeatureFlagName.CopilotPlugin]: "true",
@@ -914,18 +921,14 @@ describe("scaffold question", () => {
         ]);
       });
 
-      describe("validate and list operations", async () => {
-        const tools = new MockTools();
-        setTools(tools);
-        it("valid api spec and list operations successfully", async () => {
+      describe("list operations", async () => {
+        it(" list operations successfully", async () => {
           const question = apiOperationQuestion();
           const inputs: Inputs = {
             platform: Platform.VSCode,
             [QuestionNames.ApiSpecLocation]: "apispec",
+            supportedApisFromApiSpec: ["operation1", "operation2"],
           };
-          sandbox
-            .stub(SpecParser.prototype, "validate")
-            .resolves({ status: ValidationStatus.Valid, errors: [], warnings: [] });
           sandbox.stub(SpecParser.prototype, "list").resolves(["operation1", "operation2"]);
 
           const options = (await question.dynamicOptions!(inputs)) as OptionItem[];
@@ -935,30 +938,43 @@ describe("scaffold question", () => {
           assert.isTrue(options[1].id === "operation2");
         });
 
-        it("valid api spec and list operations error", async () => {
+        it(" list operations error", async () => {
           const question = apiOperationQuestion();
           const inputs: Inputs = {
             platform: Platform.VSCode,
             [QuestionNames.ApiSpecLocation]: "apispec",
           };
-          sandbox.stub(SpecParser.prototype, "validate").resolves({
-            status: ValidationStatus.Valid,
-            errors: [],
-            warnings: [{ type: WarningType.AuthNotSupported, content: "" }],
-          });
-          sandbox.stub(SpecParser.prototype, "list").throws(new Error("error1"));
-          let fxError: FxError;
+
+          let fxError: FxError | undefined = undefined;
           try {
             await question.dynamicOptions!(inputs);
           } catch (e) {
             fxError = e;
           }
 
-          assert.isTrue(fxError!.message.includes("error1"));
+          assert.isTrue(fxError !== undefined);
+        });
+      });
+
+      describe("apiSpecLocationQuestion", async () => {
+        it("valid API spec selecting from local file", async () => {
+          const question = apiSpecLocationQuestion();
+          const inputs: Inputs = {
+            platform: Platform.VSCode,
+          };
+
+          sandbox
+            .stub(SpecParser.prototype, "validate")
+            .resolves({ status: ValidationStatus.Valid, errors: [], warnings: [] });
+          sandbox.stub(SpecParser.prototype, "list").resolves(["operation1", "operation2"]);
+
+          const validationSchema = question.validation as FuncValidation<string>;
+          const res = await validationSchema.validFunc!("file", inputs);
+          assert.isUndefined(res);
         });
 
         it("invalid api spec", async () => {
-          const question = apiOperationQuestion();
+          const question = apiSpecLocationQuestion();
           const inputs: Inputs = {
             platform: Platform.VSCode,
             [QuestionNames.ApiSpecLocation]: "apispec",
@@ -974,18 +990,57 @@ describe("scaffold question", () => {
             warnings: [],
           });
 
+          const validationSchema = question.validation as FuncValidation<string>;
+          const res = await validationSchema.validFunc!("file", inputs);
+
+          assert.equal(res, "error");
+        });
+
+        it("valid API spec from remote URL", async () => {
+          const question = apiSpecLocationQuestion();
+          const inputs: Inputs = {
+            platform: Platform.VSCode,
+          };
+
+          sandbox
+            .stub(SpecParser.prototype, "validate")
+            .resolves({ status: ValidationStatus.Valid, errors: [], warnings: [] });
+          sandbox.stub(SpecParser.prototype, "list").resolves(["operation1", "operation2"]);
+
+          const validate = question.inputBoxConfig.additionalValidationOnAccept!;
+          const res = await validate("url1", inputs);
+          assert.isUndefined(res);
+        });
+
+        it("valid api spec and list operations error", async () => {
+          const question = apiSpecLocationQuestion();
+          const inputs: Inputs = {
+            platform: Platform.VSCode,
+            [QuestionNames.ApiSpecLocation]: "apispec",
+          };
+          sandbox.stub(SpecParser.prototype, "validate").resolves({
+            status: ValidationStatus.Valid,
+            errors: [],
+            warnings: [{ type: WarningType.AuthNotSupported, content: "" }],
+          });
+          sandbox.stub(SpecParser.prototype, "list").throws(new Error("error1"));
+
+          const validate = question.inputBoxConfig.additionalValidationOnAccept!;
+
           let fxError: FxError;
           try {
-            await question.dynamicOptions!(inputs);
+            await validate("url1", inputs);
           } catch (e) {
             fxError = e;
           }
 
-          assert.isTrue(fxError! instanceof EmptyOptionError);
+          assert.isTrue(fxError!.message.includes("error1"));
         });
+      });
 
+      describe("openAIPluginManifestLocationQuestion", async () => {
         it("valid openAI plugin manifest spec and list operations successfully", async () => {
-          const question = apiOperationQuestion();
+          const question = openAIPluginManifestLocationQuestion();
           const inputs: Inputs = {
             platform: Platform.VSCode,
             [QuestionNames.OpenAIPluginManifestLocation]: "openAIPluginManifest",
@@ -1004,15 +1059,13 @@ describe("scaffold question", () => {
             .resolves({ status: ValidationStatus.Valid, errors: [], warnings: [] });
           sandbox.stub(SpecParser.prototype, "list").resolves(["operation1", "operation2"]);
 
-          const options = (await question.dynamicOptions!(inputs)) as OptionItem[];
+          const res = await (question.additionalValidationOnAccept as any).validFunc("url", inputs);
 
-          assert.isTrue(options.length === 2);
-          assert.isTrue(options[0].id === "operation1");
-          assert.isTrue(options[1].id === "operation2");
+          assert.isUndefined(res);
         });
 
-        it("invalid openAI plugin manifest", async () => {
-          const question = apiOperationQuestion();
+        it("cannot load openAI plugin manifest", async () => {
+          const question = openAIPluginManifestLocationQuestion();
           const inputs: Inputs = {
             platform: Platform.VSCode,
             [QuestionNames.OpenAIPluginManifestLocation]: "openAIPluginManifest",
@@ -1024,20 +1077,41 @@ describe("scaffold question", () => {
             },
             auth: "oauth",
           };
-          sandbox.stub(axios, "get").resolves({ status: 200, data: manifest });
+          sandbox.stub(axios, "get").throws(new Error("error1"));
           sandbox
             .stub(SpecParser.prototype, "validate")
             .resolves({ status: ValidationStatus.Valid, errors: [], warnings: [] });
           sandbox.stub(SpecParser.prototype, "list").resolves(["operation1", "operation2"]);
 
-          let fxError: FxError;
-          try {
-            await question.dynamicOptions!(inputs);
-          } catch (e) {
-            fxError = e;
-          }
+          const res = await (question.additionalValidationOnAccept as any).validFunc("url", inputs);
 
-          assert.isTrue(fxError! instanceof EmptyOptionError);
+          assert.isFalse(res === undefined);
+        });
+
+        it("invalid openAI plugin manifest spec", async () => {
+          const question = openAIPluginManifestLocationQuestion();
+          const inputs: Inputs = {
+            platform: Platform.VSCode,
+            [QuestionNames.OpenAIPluginManifestLocation]: "openAIPluginManifest",
+          };
+          const manifest = {
+            schema_version: "1.0.0",
+            api: {
+              type: "openapi",
+              url: "test",
+            },
+            auth: { type: "none" },
+          };
+          sandbox.stub(axios, "get").resolves({ status: 200, data: manifest });
+          sandbox.stub(SpecParser.prototype, "validate").resolves({
+            status: ValidationStatus.Error,
+            errors: [{ content: "error", type: ErrorType.NoSupportedApi }],
+            warnings: [],
+          });
+
+          const res = await (question.additionalValidationOnAccept as any).validFunc("url", inputs);
+
+          assert.equal(res, "error");
         });
       });
     });

--- a/packages/fx-core/tests/ui/qm.visitor.test.ts
+++ b/packages/fx-core/tests/ui/qm.visitor.test.ts
@@ -734,7 +734,7 @@ describe("Question Model - Visitor Test", () => {
       assert.isTrue(inputs["test"] === "file");
     });
 
-    it("single file or input with validation", async () => {
+    it("single file or input with validation and additional validation", async () => {
       sandbox.stub(mockUI, "selectFileOrInput").resolves(ok({ type: "success", result: "file" }));
       const validation: StringValidation = {
         equals: "test",
@@ -750,6 +750,9 @@ describe("Question Model - Visitor Test", () => {
         inputBoxConfig: {
           name: "input",
           title: "input",
+          additionalValidationOnAccept: async (input) => {
+            return undefined;
+          },
         },
         validation: validation,
       };

--- a/packages/vscode-extension/package.nls.json
+++ b/packages/vscode-extension/package.nls.json
@@ -283,7 +283,7 @@
     "teamstoolkit.qm.defaultFile": "Default file(s)",
     "teamstoolkit.qm.emptySelection": "select option is empty",
     "teamstoolkit.qm.multiSelectKeyboard": " (Space key to check/uncheck)",
-    "teamstoolkit.qm.validatingInput": "validating...",
+    "teamstoolkit.qm.validatingInput": "Validating...",
     "teamstoolkit.survey.banner.message": "userAsked",
     "teamstoolkit.survey.banner.title": "Tell us what you think about Teams Toolkit.",
     "teamstoolkit.survey.cancelMessage": "userCancelled",

--- a/packages/vscode-extension/package.nls.json
+++ b/packages/vscode-extension/package.nls.json
@@ -283,6 +283,7 @@
     "teamstoolkit.qm.defaultFile": "Default file(s)",
     "teamstoolkit.qm.emptySelection": "select option is empty",
     "teamstoolkit.qm.multiSelectKeyboard": " (Space key to check/uncheck)",
+    "teamstoolkit.qm.validatingInput": "validating...",
     "teamstoolkit.survey.banner.message": "userAsked",
     "teamstoolkit.survey.banner.title": "Tell us what you think about Teams Toolkit.",
     "teamstoolkit.survey.cancelMessage": "userCancelled",

--- a/packages/vscode-extension/src/qm/vsc_ui.ts
+++ b/packages/vscode-extension/src/qm/vsc_ui.ts
@@ -799,6 +799,7 @@ export class VsCodeUI implements UserInteraction {
               quickPick.busy = false;
               quickPick.enabled = true;
               if (validationResult) {
+                this.showMessage("error", validationResult, false);
                 quickPick.selectedItems = [];
                 quickPick.activeItems = [];
                 return;

--- a/packages/vscode-extension/test/extension/qm/vsc_ui.test.ts
+++ b/packages/vscode-extension/test/extension/qm/vsc_ui.test.ts
@@ -283,7 +283,7 @@ describe("UI Unit Tests", async () => {
       sinon.restore();
     });
 
-    it("has returns invalid input", async function (this: Mocha.Context) {
+    it("has returns invalid input item id", async function (this: Mocha.Context) {
       const ui = new VsCodeUI(<ExtensionContext>{});
       const config: SelectFileConfig = {
         name: "name",
@@ -304,6 +304,91 @@ describe("UI Unit Tests", async () => {
       if (result.isErr()) {
         expect(result.error.name).to.equal("InvalidInput");
       }
+      sinon.restore();
+    });
+
+    it("selects a file which pass validation", async function (this: Mocha.Context) {
+      const ui = new VsCodeUI(<ExtensionContext>{});
+      const config: SelectFileConfig = {
+        name: "name",
+        title: "title",
+        placeholder: "placeholder",
+        default: "default file",
+        validation: (input: string) => {
+          if (input === "default file") {
+            return undefined;
+          }
+          return "validation failed";
+        },
+      };
+
+      const mockQuickPick = stubInterface<QuickPick<FxQuickPickItem>>();
+      const mockDisposable = stubInterface<Disposable>();
+      let acceptListener: (e: void) => any;
+      mockQuickPick.onDidAccept.callsFake((listener: (e: void) => unknown) => {
+        acceptListener = listener;
+        return mockDisposable;
+      });
+      mockQuickPick.onDidHide.callsFake((listener: (e: void) => unknown) => {
+        return mockDisposable;
+      });
+      mockQuickPick.onDidTriggerButton.callsFake((listener: (e: QuickInputButton) => unknown) => {
+        return mockDisposable;
+      });
+      mockQuickPick.show.callsFake(() => {
+        mockQuickPick.selectedItems = [{ id: "default" } as FxQuickPickItem];
+        acceptListener();
+      });
+      sinon.stub(window, "createQuickPick").callsFake(() => {
+        return mockQuickPick;
+      });
+
+      sinon.stub(ExtTelemetry, "sendTelemetryEvent");
+
+      const res = await ui.selectFile(config);
+      expect(res.isOk()).is.true;
+
+      sinon.restore();
+    });
+
+    it("selects a file with error thrown when validating result", async function (this: Mocha.Context) {
+      const ui = new VsCodeUI(<ExtensionContext>{});
+      const config: SelectFileConfig = {
+        name: "name",
+        title: "title",
+        placeholder: "placeholder",
+        default: "default file",
+        validation: (input: string) => {
+          throw new UserError("source", "name", "", "");
+        },
+      };
+
+      const mockQuickPick = stubInterface<QuickPick<FxQuickPickItem>>();
+      const mockDisposable = stubInterface<Disposable>();
+      let acceptListener: (e: void) => any;
+      mockQuickPick.onDidAccept.callsFake((listener: (e: void) => unknown) => {
+        acceptListener = listener;
+        return mockDisposable;
+      });
+      mockQuickPick.onDidHide.callsFake((listener: (e: void) => unknown) => {
+        return mockDisposable;
+      });
+      mockQuickPick.onDidTriggerButton.callsFake((listener: (e: QuickInputButton) => unknown) => {
+        return mockDisposable;
+      });
+      mockQuickPick.show.callsFake(() => {
+        mockQuickPick.selectedItems = [{ id: "default" } as FxQuickPickItem];
+        acceptListener();
+      });
+      sinon.stub(window, "createQuickPick").callsFake(() => {
+        return mockQuickPick;
+      });
+
+      sinon.stub(ExtTelemetry, "sendTelemetryEvent");
+
+      const res = await ui.selectFile(config);
+      expect(res.isErr()).is.true;
+
       sinon.restore();
     });
   });


### PR DESCRIPTION
- add additionalValidationOnAccept for input box. This validation will run when user accepts the input, which usually should be a check that will take some time that we should not run when user still inputs. 
   - Ideally we will show busy state when validating, but due to issues on VSCode side, for now we will show "Validating..." indicating the progress
     ![image](https://github.com/OfficeDev/TeamsFx/assets/86260893/3bfdbca6-5839-488e-beeb-03b7774ce3a3)
  - If validation error, we will log the error and show validation message 
   ![image](https://github.com/OfficeDev/TeamsFx/assets/86260893/8ed4d50b-ad97-4082-9042-88904e39d1c8)

- add validation after user selects a file. 
   - if validation failed, we will show notification and log the error (currently validationMessage is not an exposed property on quickpick https://github.com/microsoft/vscode/issues/121205). And user could try select another one (no need to start all over again)
   ![image](https://github.com/OfficeDev/TeamsFx/assets/86260893/4dec5d66-57e7-4e46-82cd-daf9525edd7e)


 **TODO**: 
- create item to track CLI ui update
- validation error message shown to users
