### PR TITLE
docs: Fix typo in sample code

### DIFF
--- a/docs/sdk/teamsfx.createmicrosoftgraphclient.md
+++ b/docs/sdk/teamsfx.createmicrosoftgraphclient.md
@@ -51,7 +51,7 @@ const config: Configuration = {
 };
 const prompt = new TeamsBotSsoPrompt(dialogId, {
    config: config
-   scopes: '["User.Read"],
+   scopes: ["User.Read"],
 });
 this.addDialog(prompt);
 

--- a/packages/sdk/src/core/msGraphClientProvider.ts
+++ b/packages/sdk/src/core/msGraphClientProvider.ts
@@ -29,7 +29,7 @@ import { TokenCredential } from "@azure/identity";
  * };
  * const prompt = new TeamsBotSsoPrompt(dialogId, {
  *    config: config
- *    scopes: '["User.Read"],
+ *    scopes: ["User.Read"],
  * });
  * this.addDialog(prompt);
  *


### PR DESCRIPTION
Fix extraneous single quote in sample code, as reported here: https://github.com/MicrosoftDocs/msteams-docs/issues/8024