### PR TITLE
build: update the eslint version according to the version upgrade

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -31,7 +31,7 @@
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
     "@microsoft/api-documenter": "^7.15.3",
     "@microsoft/api-extractor": "^7.18.4",
-    "@microsoft/eslint-plugin-teamsfx": "^0.0.3",
+    "@microsoft/eslint-plugin-teamsfx": "^0.0.4",
     "@types/chai": "^4.2.14",
     "@types/chai-as-promised": "^7.1.3",
     "@types/chai-spies": "^1.0.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,7 +38,7 @@
   "aiKey": "1c56be97-bb74-42cf-b04b-8f1aabf04592",
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
-    "@microsoft/eslint-plugin-teamsfx": "^0.0.3",
+    "@microsoft/eslint-plugin-teamsfx": "^0.0.4",
     "@microsoft/extra-shot-mocha": "0.0.1",
     "@types/adm-zip": "^0.4.34",
     "@types/chai": "^4.2.14",

--- a/packages/extra-shot-mocha/package.json
+++ b/packages/extra-shot-mocha/package.json
@@ -32,7 +32,7 @@
     "eslint-plugin-import": "^2.25.2",
     "eslint-plugin-no-secrets": "^0.8.9",
     "eslint-plugin-prettier": "^4.0.0",
-    "@microsoft/eslint-plugin-teamsfx": "^0.0.3",
+    "@microsoft/eslint-plugin-teamsfx": "^0.0.4",
     "lint-staged": "^13.2.1",
     "nyc": "^15.1.0",
     "prettier": "^2.4.1",

--- a/packages/failpoint-ts/package.json
+++ b/packages/failpoint-ts/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
-    "@microsoft/eslint-plugin-teamsfx": "^0.0.3",
+    "@microsoft/eslint-plugin-teamsfx": "^0.0.4",
     "@types/chai": "^4.2.21",
     "@types/mocha": "^8.2.3",
     "@types/node": "^16.0.0",

--- a/packages/fx-core/package.json
+++ b/packages/fx-core/package.json
@@ -135,7 +135,7 @@
   "devDependencies": {
     "@azure/storage-blob": "^12.5.0",
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
-    "@microsoft/eslint-plugin-teamsfx": "^0.0.3",
+    "@microsoft/eslint-plugin-teamsfx": "^0.0.4",
     "@types/adm-zip": "^0.4.33",
     "@types/chai": "^4.2.14",
     "@types/chai-as-promised": "^7.1.3",

--- a/packages/manifest/package.json
+++ b/packages/manifest/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
-    "@microsoft/eslint-plugin-teamsfx": "^0.0.3",
+    "@microsoft/eslint-plugin-teamsfx": "^0.0.4",
     "@types/chai": "^4.2.21",
     "@types/chai-as-promised": "^7.1.3",
     "@types/mocha": "^8.2.3",

--- a/packages/metrics-ts/package.json
+++ b/packages/metrics-ts/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
-    "@microsoft/eslint-plugin-teamsfx": "^0.0.3",
+    "@microsoft/eslint-plugin-teamsfx": "^0.0.4",
     "@types/chai": "^4.2.21",
     "@types/mocha": "^8.2.3",
     "@types/node": "^16.0.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
-    "@microsoft/eslint-plugin-teamsfx": "^0.0.3",
+    "@microsoft/eslint-plugin-teamsfx": "^0.0.4",
     "@mochajs/json-file-reporter": "^1.3.0",
     "@types/adm-zip": "^0.4.34",
     "@types/chai": "^4.2.14",

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -19,7 +19,7 @@
     "@microsoft/dev-tunnels-contracts": "~1.0.7360",
     "@microsoft/dev-tunnels-management": "~1.0.7360",
     "@microsoft/dev-tunnels-ssh": "~3.11.1",
-    "@microsoft/eslint-plugin-teamsfx": "^0.0.3",
+    "@microsoft/eslint-plugin-teamsfx": "^0.0.4",
     "@microsoft/extra-shot-mocha": "0.0.1",
     "@microsoft/teamsfx-core": "^2.0.2",
     "@types/chai": "^4.2.19",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -1203,7 +1203,7 @@
     "@azure/ms-rest-azure-env": "^2.0.0",
     "@fluentui/react": "^8.5.1",
     "@istanbuljs/nyc-config-typescript": "^1.0.2",
-    "@microsoft/eslint-plugin-teamsfx": "^0.0.3",
+    "@microsoft/eslint-plugin-teamsfx": "^0.0.4",
     "@types/chai": "^4.2.14",
     "@types/chai-as-promised": "^7.1.3",
     "@types/chai-spies": "^1.0.3",

--- a/templates/package.json
+++ b/templates/package.json
@@ -40,7 +40,7 @@
         "ts/sso-tab-with-obo-flow"
     ],
     "devDependencies": {
-        "@microsoft/eslint-plugin-teamsfx": "^0.0.3",
+        "@microsoft/eslint-plugin-teamsfx": "^0.0.4",
         "@typescript-eslint/eslint-plugin": "^4.19.0",
         "@typescript-eslint/parser": "^4.19.0",
         "eslint": "^7.22.0",


### PR DESCRIPTION
will convert eslint as a config instead of package.
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_testPlans/define?planId=24569079&opId=5682&suiteId=24569087