### PR TITLE
perf(specParser): save file with original format, only support get with 1 param without auth

### DIFF
--- a/packages/fx-core/package.json
+++ b/packages/fx-core/package.json
@@ -55,6 +55,7 @@
     "test:coll": "nyc mocha \"tests/core/collaborator.test.ts\"",
     "test:specParser": "npx mocha \"tests/common/spec-parser/**/specParser.test.ts\"",
     "test:specFilter": "npx mocha \"tests/common/spec-parser/**/specFilter.test.ts\"",
+    "test:specParserUtils": "npx mocha \"tests/common/spec-parser/**/utils.test.ts\"",
     "test:error": "nyc mocha \"tests/error/*.test.ts\"",
     "clean": "rm -rf build",
     "build": "rimraf build && npx tsc -p ./",

--- a/packages/fx-core/src/common/spec-parser/specParser.ts
+++ b/packages/fx-core/src/common/spec-parser/specParser.ts
@@ -18,7 +18,7 @@ import { ConstantString } from "./constants";
 import jsyaml from "js-yaml";
 import fs from "fs-extra";
 import { specFilter } from "./specFilter";
-import { isSupportedApi, isYamlSpecFile } from "./utils";
+import { isSupportedApi } from "./utils";
 
 /**
  * A class that parses an OpenAPI specification file and provides methods to validate, list, and generate artifacts.
@@ -173,7 +173,7 @@ export class SpecParser {
     const newUnResolvedSpec = await specFilter(filter, this.unResolveSpec!);
     if (outputSpecPath) {
       let resultStr;
-      if (await isYamlSpecFile(this.specPath)) {
+      if (this.specPath.endsWith(".yaml")) {
         resultStr = jsyaml.dump(newUnResolvedSpec);
       } else {
         resultStr = JSON.stringify(newUnResolvedSpec, null, 2);

--- a/packages/fx-core/src/common/spec-parser/specParser.ts
+++ b/packages/fx-core/src/common/spec-parser/specParser.ts
@@ -18,6 +18,7 @@ import { ConstantString } from "./constants";
 import jsyaml from "js-yaml";
 import fs from "fs-extra";
 import { specFilter } from "./specFilter";
+import { isSupportedApi, isYamlSpecFile } from "./utils";
 
 /**
  * A class that parses an OpenAPI specification file and provides methods to validate, list, and generate artifacts.
@@ -171,8 +172,13 @@ export class SpecParser {
     await this.loadSpec();
     const newUnResolvedSpec = await specFilter(filter, this.unResolveSpec!);
     if (outputSpecPath) {
-      const ymlString = jsyaml.dump(newUnResolvedSpec);
-      await fs.writeFile(outputSpecPath, ymlString);
+      let resultStr;
+      if (await isYamlSpecFile(this.specPath)) {
+        resultStr = jsyaml.dump(newUnResolvedSpec);
+      } else {
+        resultStr = JSON.stringify(newUnResolvedSpec, null, 2);
+      }
+      await fs.writeFile(outputSpecPath, resultStr);
     }
 
     // TODO: other implementations
@@ -196,12 +202,10 @@ export class SpecParser {
     for (const path in paths) {
       const methods = paths[path];
       for (const method in methods) {
-        // only list get and post method without auth
-        if (
-          (method === ConstantString.GetMethod || method === ConstantString.PostMethod) &&
-          !methods[method]?.security
-        ) {
-          result[`${method.toUpperCase()} ${path}`] = methods[method] as OpenAPIV3.OperationObject;
+        // For developer preview, only support GET operation with only 1 parameter without auth
+        if (isSupportedApi(method, path, spec)) {
+          const operationObject = (methods as any)[method] as OpenAPIV3.OperationObject;
+          result[`${method.toUpperCase()} ${path}`] = operationObject;
         }
       }
     }

--- a/packages/fx-core/src/common/spec-parser/utils.ts
+++ b/packages/fx-core/src/common/spec-parser/utils.ts
@@ -8,6 +8,11 @@ import { ConstantString } from "./constants";
 import { OpenAPIV3 } from "openapi-types";
 
 export async function isYamlSpecFile(specPath: string): Promise<boolean> {
+  if (specPath.endsWith(".yaml") || specPath.endsWith(".yml")) {
+    return true;
+  } else if (specPath.endsWith(".json")) {
+    return false;
+  }
   const isRemoteFile = specPath.startsWith("http:") || specPath.startsWith("https:");
   const fileContent = isRemoteFile
     ? (await axios.get(specPath)).data
@@ -28,8 +33,13 @@ export function isSupportedApi(method: string, path: string, spec: OpenAPIV3.Doc
   if (pathObj) {
     if (method === ConstantString.GetMethod && !pathObj[method]?.security) {
       const operationObject = pathObj[method] as OpenAPIV3.OperationObject;
-      if (operationObject.parameters?.length === 1) {
-        const paramObject = operationObject.parameters;
+      const paramObject = operationObject.parameters;
+
+      if (!paramObject || paramObject.length === 0) {
+        return true;
+      }
+
+      if (paramObject && paramObject.length === 1) {
         for (const index in paramObject) {
           const param = paramObject[index] as OpenAPIV3.ParameterObject;
           if (param.in === "query" || param.in === "path") {

--- a/packages/fx-core/src/common/spec-parser/utils.ts
+++ b/packages/fx-core/src/common/spec-parser/utils.ts
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+"use strict";
+
+import axios from "axios";
+import fs from "fs-extra";
+import { ConstantString } from "./constants";
+import { OpenAPIV3 } from "openapi-types";
+
+export async function isYamlSpecFile(specPath: string): Promise<boolean> {
+  const isRemoteFile = specPath.startsWith("http:") || specPath.startsWith("https:");
+  const fileContent = isRemoteFile
+    ? (await axios.get(specPath)).data
+    : await fs.readFile(specPath, "utf-8");
+
+  try {
+    JSON.parse(fileContent);
+    return false;
+  } catch (error) {
+    return true;
+  }
+}
+
+export function isSupportedApi(method: string, path: string, spec: OpenAPIV3.Document): boolean {
+  debugger;
+  const pathObj = spec.paths[path];
+  method = method.toLocaleLowerCase();
+  if (pathObj) {
+    if (method === ConstantString.GetMethod && !pathObj[method]?.security) {
+      const operationObject = pathObj[method] as OpenAPIV3.OperationObject;
+      if (operationObject.parameters?.length === 1) {
+        const paramObject = operationObject.parameters;
+        for (const index in paramObject) {
+          const param = paramObject[index] as OpenAPIV3.ParameterObject;
+          if (param.in === "query" || param.in === "path") {
+            const schema = param.schema as OpenAPIV3.SchemaObject;
+            if (
+              schema.type === "boolean" ||
+              schema.type === "integer" ||
+              schema.type === "number" ||
+              schema.type === "string"
+            ) {
+              return true;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return false;
+}

--- a/packages/fx-core/tests/common/spec-parser/specParser.test.ts
+++ b/packages/fx-core/tests/common/spec-parser/specParser.test.ts
@@ -17,7 +17,7 @@ import { SpecParserError } from "../../../src/common/spec-parser/specParserError
 import { ConstantString } from "../../../src/common/spec-parser/constants";
 import { OpenAPIV3 } from "openapi-types";
 import * as SpecFilter from "../../../src/common/spec-parser/specFilter";
-import { write } from "fs";
+import * as Utils from "../../../src/common/spec-parser/utils";
 
 describe("SpecParser", () => {
   afterEach(() => {
@@ -183,9 +183,19 @@ describe("SpecParser", () => {
         ],
         paths: {
           "/pet": {
-            post: {
+            get: {
               tags: ["pet"],
-              summary: "Add a new pet to the store",
+              summary: "Get pet information from the store",
+              parameters: [
+                {
+                  name: "tags",
+                  in: "query",
+                  description: "Tags to filter by",
+                  schema: {
+                    type: "string",
+                  },
+                },
+              ],
               responses: {
                 "200": {
                   content: {
@@ -212,7 +222,7 @@ describe("SpecParser", () => {
         warnings: [
           {
             type: WarningType.OperationIdMissing,
-            content: util.format(ConstantString.MissingOperationId, "POST /pet"),
+            content: util.format(ConstantString.MissingOperationId, "GET /pet"),
           },
         ],
         errors: [],
@@ -231,10 +241,20 @@ describe("SpecParser", () => {
         ],
         paths: {
           "/pet": {
-            post: {
+            get: {
               tags: ["pet"],
-              operationId: "addPet",
-              summary: "Add a new pet to the store",
+              operationId: "getPet",
+              summary: "Get pet information from the store",
+              parameters: [
+                {
+                  name: "tags",
+                  in: "query",
+                  description: "Tags to filter by",
+                  schema: {
+                    type: "string",
+                  },
+                },
+              ],
               responses: {
                 "200": {
                   content: {
@@ -255,7 +275,7 @@ describe("SpecParser", () => {
       const parseStub = sinon.stub(specParser.parser, "parse").resolves(spec as any);
       const dereferenceStub = sinon.stub(specParser.parser, "dereference").resolves(spec as any);
       const result = await specParser.validate();
-
+      console.log(result);
       expect(result.status).to.equal(ValidationStatus.Valid);
       expect(result.warnings).to.be.an("array").that.is.empty;
       expect(result.errors).to.be.an("array").that.is.empty;
@@ -288,6 +308,7 @@ describe("SpecParser", () => {
       const dereferenceStub = sinon.stub(specParser.parser, "dereference").resolves(spec as any);
       const specFilterStub = sinon.stub(SpecFilter, "specFilter").resolves();
       const writeFileStub = sinon.stub(fs, "writeFile").resolves();
+      const isYamlSpecFileStub = sinon.stub(Utils, "isYamlSpecFile").resolves(true);
 
       const filter = ["get /hello"];
 
@@ -317,12 +338,12 @@ describe("SpecParser", () => {
   });
 
   describe("list", () => {
-    it("should return a list of HTTP methods and paths for all GET and POST operations without security", async () => {
+    it("should return a list of HTTP methods and paths for all GET with 1 parameter and without security", async () => {
       const specPath = "valid-spec.yaml";
       const specParser = new SpecParser(specPath);
       const spec = {
         paths: {
-          "/pets/{petId}": {
+          "/pets": {
             get: {
               operationId: "getPetById",
               security: [{ api_key: [] }],
@@ -331,6 +352,15 @@ describe("SpecParser", () => {
           "/user/{userId}": {
             get: {
               operationId: "getUserById",
+              parameters: [
+                {
+                  name: "userId",
+                  in: "path",
+                  schema: {
+                    type: "string",
+                  },
+                },
+              ],
             },
             post: {
               operationId: "createUser",
@@ -350,7 +380,7 @@ describe("SpecParser", () => {
 
       const result = await specParser.list();
 
-      expect(result).to.deep.equal(["GET /user/{userId}", "POST /store/order"]);
+      expect(result).to.deep.equal(["GET /user/{userId}"]);
     });
 
     it("should throw an error when the SwaggerParser library throws an error", async () => {

--- a/packages/fx-core/tests/common/spec-parser/specParser.test.ts
+++ b/packages/fx-core/tests/common/spec-parser/specParser.test.ts
@@ -17,7 +17,6 @@ import { SpecParserError } from "../../../src/common/spec-parser/specParserError
 import { ConstantString } from "../../../src/common/spec-parser/constants";
 import { OpenAPIV3 } from "openapi-types";
 import * as SpecFilter from "../../../src/common/spec-parser/specFilter";
-import * as Utils from "../../../src/common/spec-parser/utils";
 
 describe("SpecParser", () => {
   afterEach(() => {
@@ -308,7 +307,6 @@ describe("SpecParser", () => {
       const dereferenceStub = sinon.stub(specParser.parser, "dereference").resolves(spec as any);
       const specFilterStub = sinon.stub(SpecFilter, "specFilter").resolves();
       const writeFileStub = sinon.stub(fs, "writeFile").resolves();
-      const isYamlSpecFileStub = sinon.stub(Utils, "isYamlSpecFile").resolves(true);
 
       const filter = ["get /hello"];
 

--- a/packages/fx-core/tests/common/spec-parser/utils.test.ts
+++ b/packages/fx-core/tests/common/spec-parser/utils.test.ts
@@ -1,0 +1,117 @@
+import { assert, expect } from "chai";
+import sinon from "sinon";
+import axios from "axios";
+import fs from "fs-extra";
+import "mocha";
+import { isSupportedApi, isYamlSpecFile } from "../../../src/common/spec-parser/utils";
+
+describe("utils", () => {
+  describe("isYamlSpecFile", () => {
+    afterEach(() => {
+      sinon.restore();
+    });
+    it("should return false for a valid JSON file", async () => {
+      const readFileStub = sinon.stub(fs, "readFile").resolves('{"name": "test"}' as any);
+      const result = await isYamlSpecFile("test.json");
+      expect(result).to.be.false;
+    });
+
+    it("should return true for an yaml file", async () => {
+      const readFileStub = sinon.stub(fs, "readFile").resolves("openapi: 3.0.2" as any);
+      const result = await isYamlSpecFile("test.json");
+      expect(result).to.be.true;
+    });
+
+    it("should handle remote files", async () => {
+      const axiosStub = sinon.stub(axios, "get").resolves({ data: '{"name": "test"}' });
+      const result = await isYamlSpecFile("http://example.com/test.json");
+      expect(result).to.be.false;
+    });
+  });
+
+  describe("isSupportedApi", () => {
+    it("should return true if method is GET, path is valid, and parameter is supported", () => {
+      const method = "GET";
+      const path = "/users";
+      const spec = {
+        paths: {
+          "/users": {
+            get: {
+              parameters: [
+                {
+                  in: "query",
+                  schema: { type: "string" },
+                },
+              ],
+            },
+          },
+        },
+      };
+      const result = isSupportedApi(method, path, spec as any);
+      assert.strictEqual(result, true);
+    });
+
+    it("should return false if method is not GET", () => {
+      const method = "POST";
+      const path = "/users";
+      const spec = {
+        paths: {
+          "/users": {
+            get: {
+              parameters: [
+                {
+                  in: "query",
+                  schema: { type: "string" },
+                },
+              ],
+            },
+          },
+        },
+      };
+      const result = isSupportedApi(method, path, spec as any);
+      assert.strictEqual(result, false);
+    });
+
+    it("should return false if path is not valid", () => {
+      const method = "GET";
+      const path = "/invalid";
+      const spec = {
+        paths: {
+          "/users": {
+            get: {
+              parameters: [
+                {
+                  in: "query",
+                  schema: { type: "string" },
+                },
+              ],
+            },
+          },
+        },
+      };
+      const result = isSupportedApi(method, path, spec as any);
+      assert.strictEqual(result, false);
+    });
+
+    it("should return false if parameter is not supported", () => {
+      const method = "GET";
+      const path = "/users";
+      const spec = {
+        paths: {
+          "/users": {
+            get: {
+              parameters: [
+                {
+                  in: "query",
+                  schema: { type: "object" },
+                },
+              ],
+            },
+          },
+        },
+      };
+      const result = isSupportedApi(method, path, spec as any);
+      assert.strictEqual(result, false);
+    });
+  });
+});

--- a/packages/fx-core/tests/common/spec-parser/utils.test.ts
+++ b/packages/fx-core/tests/common/spec-parser/utils.test.ts
@@ -11,20 +11,24 @@ describe("utils", () => {
       sinon.restore();
     });
     it("should return false for a valid JSON file", async () => {
-      const readFileStub = sinon.stub(fs, "readFile").resolves('{"name": "test"}' as any);
       const result = await isYamlSpecFile("test.json");
       expect(result).to.be.false;
     });
 
     it("should return true for an yaml file", async () => {
-      const readFileStub = sinon.stub(fs, "readFile").resolves("openapi: 3.0.2" as any);
-      const result = await isYamlSpecFile("test.json");
+      const result = await isYamlSpecFile("test.yaml");
       expect(result).to.be.true;
+    });
+
+    it("should handle local json files", async () => {
+      const readFileStub = sinon.stub(fs, "readFile").resolves('{"name": "test"}' as any);
+      const result = await isYamlSpecFile("path/to/localfile");
+      expect(result).to.be.false;
     });
 
     it("should handle remote files", async () => {
       const axiosStub = sinon.stub(axios, "get").resolves({ data: '{"name": "test"}' });
-      const result = await isYamlSpecFile("http://example.com/test.json");
+      const result = await isYamlSpecFile("http://example.com/remotefile");
       expect(result).to.be.false;
     });
   });
@@ -112,6 +116,36 @@ describe("utils", () => {
       };
       const result = isSupportedApi(method, path, spec as any);
       assert.strictEqual(result, false);
+    });
+
+    it("should return true if parameter length is 0", () => {
+      const method = "GET";
+      const path = "/users";
+      const spec = {
+        paths: {
+          "/users": {
+            get: {
+              parameters: [],
+            },
+          },
+        },
+      };
+      const result = isSupportedApi(method, path, spec as any);
+      assert.strictEqual(result, true);
+    });
+
+    it("should return true if parameter is null", () => {
+      const method = "GET";
+      const path = "/users";
+      const spec = {
+        paths: {
+          "/users": {
+            get: {},
+          },
+        },
+      };
+      const result = isSupportedApi(method, path, spec as any);
+      assert.strictEqual(result, true);
     });
   });
 });


### PR DESCRIPTION
- Save new OpenAPI spec file based on its original format
- Update filter logic:
   - Only GET operation with 1 param without auth
   - Doesn't support array/object type
   - Only support parameter in query or path, and in header or cookie are not supported 
