### PR TITLE
fix: list collaborator issue

### DIFF
--- a/packages/fx-core/src/core/collaborator.ts
+++ b/packages/fx-core/src/core/collaborator.ts
@@ -262,14 +262,14 @@ export class CollaborationUtil {
   }
 
   static requireEnvQuestion(appId: string): boolean {
-    return !!CollaborationConstants.placeholderRegex.exec(appId);
+    return !!appId.match(CollaborationConstants.placeholderRegex);
   }
 
   static parseManifestId(appId: string): string | undefined {
     // Hardcoded id in manifest
     if (uuidValidate(appId)) {
       return appId;
-    } else if (CollaborationConstants.placeholderRegex.exec(appId)) {
+    } else if (appId.match(CollaborationConstants.placeholderRegex)) {
       // Reference value in .env file
       const envName = appId
         .replace(/\$*\{+/g, "")


### PR DESCRIPTION
exec has a global internal lastIndex property which case the bug, and fix it using match instead:
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/24741853