### PR TITLE
refactor: use app name entered during scaffolding for name field in manifest

### DIFF
--- a/packages/fx-core/src/common/spec-parser/interfaces.ts
+++ b/packages/fx-core/src/common/spec-parser/interfaces.ts
@@ -121,11 +121,6 @@ export interface PartialManifest {
   composeExtensions: ComposeExtension[];
 }
 
-export interface Name {
-  short: string;
-  full: string;
-}
-
 export interface Description {
   short: string;
   full: string;

--- a/packages/fx-core/src/common/spec-parser/interfaces.ts
+++ b/packages/fx-core/src/common/spec-parser/interfaces.ts
@@ -117,7 +117,6 @@ export interface AdaptiveCard {
 }
 
 export interface PartialManifest {
-  name: Name;
   description: Description;
   composeExtensions: ComposeExtension[];
 }

--- a/packages/fx-core/src/common/spec-parser/manifestUpdater.ts
+++ b/packages/fx-core/src/common/spec-parser/manifestUpdater.ts
@@ -26,13 +26,9 @@ export async function updateManifest(
   };
 
   const updatedPart: PartialManifest = {
-    name: {
-      short: spec.info.title,
-      full: spec.info.title,
-    },
     description: {
       short: spec.info.title,
-      full: spec.info.description ?? "",
+      full: spec.info.description ?? originalManifest.description.full,
     },
     composeExtensions: [ComposeExtension],
   };

--- a/packages/fx-core/src/component/generator/copilotPlugin/helper.ts
+++ b/packages/fx-core/src/component/generator/copilotPlugin/helper.ts
@@ -96,9 +96,7 @@ export class OpenAIPluginManifestHelper {
     teamsAppManifest: TeamsAppManifest,
     manifestPath: string
   ): Promise<Result<undefined, FxError>> {
-    teamsAppManifest.name.full = openAiPluginManifest.name_for_model;
-    teamsAppManifest.name.short = openAiPluginManifest.name_for_human;
-    teamsAppManifest.description.full = openAiPluginManifest.description_for_model;
+    teamsAppManifest.description.full = openAiPluginManifest.description_for_human;
     teamsAppManifest.description.short = openAiPluginManifest.description_for_human;
     teamsAppManifest.developer.websiteUrl = openAiPluginManifest.legal_info_url;
     teamsAppManifest.developer.privacyUrl = openAiPluginManifest.legal_info_url;

--- a/packages/fx-core/tests/common/spec-parser/manifestUpdater.test.ts
+++ b/packages/fx-core/tests/common/spec-parser/manifestUpdater.test.ts
@@ -46,8 +46,8 @@ describe("manifestUpdater", () => {
       composeExtensions: [],
     };
     const expectedManifest = {
-      name: { short: spec.info.title, full: spec.info.title },
-      description: { short: spec.info.title, full: spec.info.description ?? "" },
+      name: { short: "Original Name", full: "Original Full Name" },
+      description: { short: spec.info.title, full: spec.info.description },
       composeExtensions: [
         {
           type: "apiBased",

--- a/packages/fx-core/tests/common/spec-parser/manifestUpdater.test.ts
+++ b/packages/fx-core/tests/common/spec-parser/manifestUpdater.test.ts
@@ -75,6 +75,50 @@ describe("manifestUpdater", () => {
     expect(result).to.deep.equal(expectedManifest);
     readJSONStub.restore();
   });
+
+  it("should skip updating full/description if missing info/description", async () => {
+    const manifestPath = "/path/to/your/manifest.json";
+    const outputSpecPath = "/path/to/your/spec/outputSpec.yaml";
+    const adaptiveCardFolder = "/path/to/your/adaptiveCards";
+
+    const originalManifest = {
+      name: { short: "Original Name", full: "Original Full Name" },
+      description: { short: "Original Short Description", full: "Original Full Description" },
+      composeExtensions: [],
+    };
+    const expectedManifest = {
+      name: { short: "Original Name", full: "Original Full Name" },
+      description: { short: spec.info.title, full: "Original Full Description" },
+      composeExtensions: [
+        {
+          type: "apiBased",
+          supportsConversationalAI: true,
+          apiSpecFile: "spec/outputSpec.yaml",
+          commands: [
+            {
+              context: ["compose"],
+              type: "query",
+              title: "Get all pets",
+              id: "getPets",
+              parameters: [
+                { name: "limit", title: "Limit", description: "Maximum number of pets to return" },
+              ],
+              apiResponseRenderingTemplate: "adaptiveCards/getPets.json",
+            },
+          ],
+        },
+      ],
+    };
+    const readJSONStub = sinon.stub(fs, "readJSON").resolves(originalManifest);
+
+    const result = await updateManifest(manifestPath, outputSpecPath, adaptiveCardFolder, {
+      ...spec,
+      info: { title: "My API" },
+    });
+
+    expect(result).to.deep.equal(expectedManifest);
+    readJSONStub.restore();
+  });
 });
 
 describe("generateCommands", () => {

--- a/packages/fx-core/tests/component/generator/copilotPluginGenerator.test.ts
+++ b/packages/fx-core/tests/component/generator/copilotPluginGenerator.test.ts
@@ -378,8 +378,6 @@ describe("OpenAIManifestHelper", async () => {
     assert.isFalse(updateColor);
 
     const updatedTeamsManifest = JSON.parse(updatedManifestData!) as TeamsAppManifest;
-    assert.equal(updatedTeamsManifest!.name.short, "TODO List");
-    assert.equal(updatedTeamsManifest!.name.full, openAIPluginManifest.name_for_model);
     assert.equal(
       updatedTeamsManifest!.description.short,
       openAIPluginManifest.description_for_human

--- a/packages/fx-core/tests/component/generator/copilotPluginGenerator.test.ts
+++ b/packages/fx-core/tests/component/generator/copilotPluginGenerator.test.ts
@@ -384,7 +384,7 @@ describe("OpenAIManifestHelper", async () => {
     );
     assert.equal(
       updatedTeamsManifest!.description.full,
-      openAIPluginManifest.description_for_model
+      openAIPluginManifest.description_for_human
     );
     assert.equal(updatedTeamsManifest!.developer.privacyUrl, openAIPluginManifest.legal_info_url);
     assert.equal(updatedTeamsManifest!.developer.websiteUrl, openAIPluginManifest.legal_info_url);

--- a/templates/common/simplified-message-extension-existing-api/appPackage/manifest.json.tpl
+++ b/templates/common/simplified-message-extension-existing-api/appPackage/manifest.json.tpl
@@ -16,7 +16,7 @@
     },
     "name": {
         "short": "{{appName}}-${{TEAMSFX_ENV}}",
-        "full": "full name for {{appName}}"
+        "full": "Full name for {{appName}}"
     },
     "description": {
         "short": "Short description for {{appName}}",

--- a/templates/csharp/simplified-message-extension-existing-api/appPackage/manifest.json.tpl
+++ b/templates/csharp/simplified-message-extension-existing-api/appPackage/manifest.json.tpl
@@ -16,7 +16,7 @@
     },
     "name": {
         "short": "{{appName}}-${{TEAMSFX_ENV}}",
-        "full": "full name for {{appName}}"
+        "full": "Full name for {{appName}}"
     },
     "description": {
         "short": "Short description for {{appName}}",


### PR DESCRIPTION
- no need to update name in manifest.json. We will use the appName entered by users during scaffolding.