### PR TITLE
fix: set allowUnionTypes to silence ajv's warnings

### DIFF
--- a/packages/fx-core/src/component/configManager/validator.ts
+++ b/packages/fx-core/src/component/configManager/validator.ts
@@ -20,7 +20,7 @@ export class Validator {
   }
 
   private initVersion(version: string) {
-    const ajv = new Ajv();
+    const ajv = new Ajv({ allowUnionTypes: true });
     ajv.addKeyword("deprecationMessage");
     const schemaPath = path.join(getResourceFolder(), "yaml-schema", version, "yaml.schema.json");
     const schema = fs.readJSONSync(schemaPath);


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/24793298

The [failed case](https://github.com/OfficeDev/TeamsFx/actions/runs/5814509072/job/15768466891) succeeds now https://github.com/OfficeDev/TeamsFx/actions/runs/5816553382/job/15769935815

@microsoft/adaptivecards-tools	v1.3.3-rc.0
@microsoft/teamsfx-api	v0.23.0-rc.0
@microsoft/teamsfx-cli	v2.1.0-rc.0
@microsoft/teamsfx-core	v2.1.0-rc.0
@microsoft/teams-manifest	v0.2.0-rc.0
@microsoft/metrics-ts	v0.0.5-rc.0
@microsoft/teamsfx	v2.3.0-rc.0
@microsoft/teamsfx-react	v3.1.0-rc.0

Fx-core feat commits:
  

CLI feat commits:
  

Extension-toolkit feat commits:
  

SDK feat commits:
  

SDK React feat commits:
  

.Net SDK feat commits:
  


Fx-core fix commits:
 fix: set allUnionTypes to silence ajv's warnings e61b42186 

CLI fix commits:
  

Extension-toolkit fix commits:
  

SDK fix commits:
  

SDK React fix commits:
  

.Net SDK fix commits: