### PR TITLE
refactor: check app feature based on app definition

### DIFF
--- a/packages/fx-core/src/component/developerPortalScaffoldUtils.ts
+++ b/packages/fx-core/src/component/developerPortalScaffoldUtils.ts
@@ -35,7 +35,7 @@ import { TelemetryUtils } from "./driver/teamsApp/utils/telemetry";
 import {
   isBot,
   isBotAndMessageExtension,
-  isMessageExtension,
+  isBotBasedMessageExtension,
   needTabAndBotCode,
   needTabCode,
 } from "./driver/teamsApp/utils/utils";
@@ -307,8 +307,8 @@ export function getProjectTypeAndCapability(
     return { projectType: "bot-me-type", templateId: CapabilityOptions.botAndMe().id };
   }
 
-  // message extension
-  if (isMessageExtension(teamsApp)) {
+  // bot based message extension
+  if (isBotBasedMessageExtension(teamsApp)) {
     return { projectType: "me-type", templateId: CapabilityOptions.me().id };
   }
 

--- a/packages/fx-core/src/component/developerPortalScaffoldUtils.ts
+++ b/packages/fx-core/src/component/developerPortalScaffoldUtils.ts
@@ -34,7 +34,7 @@ import { manifestUtils } from "./driver/teamsApp/utils/ManifestUtils";
 import { TelemetryUtils } from "./driver/teamsApp/utils/telemetry";
 import {
   isBot,
-  isBotAndMessageExtension,
+  isBotAndBotBasedMessageExtension,
   isBotBasedMessageExtension,
   needTabAndBotCode,
   needTabCode,
@@ -303,7 +303,7 @@ export function getProjectTypeAndCapability(
   }
 
   // bot and message extension
-  if (isBotAndMessageExtension(teamsApp)) {
+  if (isBotAndBotBasedMessageExtension(teamsApp)) {
     return { projectType: "bot-me-type", templateId: CapabilityOptions.botAndMe().id };
   }
 

--- a/packages/fx-core/src/component/driver/teamsApp/utils/utils.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/utils/utils.ts
@@ -72,16 +72,28 @@ export function isBot(appDefinition: AppDefinition): boolean {
   return !!appDefinition.bots && appDefinition.bots.length > 0;
 }
 
-export function isMessageExtension(appDefinition: AppDefinition): boolean {
-  return !!appDefinition.messagingExtensions && appDefinition.messagingExtensions.length > 0;
+export function isBotBasedMessageExtension(appDefinition: AppDefinition): boolean {
+  return (
+    !!appDefinition.messagingExtensions &&
+    appDefinition.messagingExtensions.length > 0 &&
+    !!appDefinition.messagingExtensions[0].botId
+  );
 }
 
 export function isBotAndMessageExtension(appDefinition: AppDefinition): boolean {
-  return isBot(appDefinition) && isMessageExtension(appDefinition);
+  return isBot(appDefinition) && isBotBasedMessageExtension(appDefinition);
 }
 
 export function needBotCode(appDefinition: AppDefinition): boolean {
-  return isBot(appDefinition) || isMessageExtension(appDefinition);
+  return isBot(appDefinition) || isBotBasedMessageExtension(appDefinition);
+}
+
+function isApiBasedMessageExtension(appDefinition: AppDefinition): boolean {
+  return (
+    !!appDefinition.messagingExtensions &&
+    appDefinition.messagingExtensions.length > 0 &&
+    appDefinition.messagingExtensions[0].type === "äpiBased"
+  );
 }
 
 export function containsUnsupportedFeature(appDefinition: AppDefinition): boolean {
@@ -89,7 +101,13 @@ export function containsUnsupportedFeature(appDefinition: AppDefinition): boolea
   const hasConnector = !!appDefinition?.connectors?.length;
   const hasActivies = appDefinition?.activities?.activityTypes?.length;
 
-  return !!hasScene || !!hasConnector || !!hasActivies || hasMeetingExtension(appDefinition);
+  return (
+    !!hasScene ||
+    !!hasConnector ||
+    !!hasActivies ||
+    hasMeetingExtension(appDefinition) ||
+    isApiBasedMessageExtension(appDefinition)
+  );
 }
 
 export function getFeaturesFromAppDefinition(appDefinition: AppDefinition): string[] {
@@ -111,7 +129,7 @@ export function getFeaturesFromAppDefinition(appDefinition: AppDefinition): stri
     features.push(bot);
   }
 
-  if (isMessageExtension(appDefinition)) {
+  if (isBotBasedMessageExtension(appDefinition)) {
     features.push(messageExtension);
   }
 

--- a/packages/fx-core/src/component/driver/teamsApp/utils/utils.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/utils/utils.ts
@@ -92,7 +92,7 @@ function isApiBasedMessageExtension(appDefinition: AppDefinition): boolean {
   return (
     !!appDefinition.messagingExtensions &&
     appDefinition.messagingExtensions.length > 0 &&
-    appDefinition.messagingExtensions[0].type === "äpiBased"
+    appDefinition.messagingExtensions[0].type === "apiBased"
   );
 }
 

--- a/packages/fx-core/src/component/driver/teamsApp/utils/utils.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/utils/utils.ts
@@ -80,7 +80,7 @@ export function isBotBasedMessageExtension(appDefinition: AppDefinition): boolea
   );
 }
 
-export function isBotAndMessageExtension(appDefinition: AppDefinition): boolean {
+export function isBotAndBotBasedMessageExtension(appDefinition: AppDefinition): boolean {
   return isBot(appDefinition) && isBotBasedMessageExtension(appDefinition);
 }
 

--- a/packages/fx-core/tests/component/generator/copilotPluginGenerator.test.ts
+++ b/packages/fx-core/tests/component/generator/copilotPluginGenerator.test.ts
@@ -501,6 +501,7 @@ describe("generateScaffoldingSummary", () => {
     const composeExtension: IComposeExtension = {
       type: "apiBased",
       commands: [{ id: "command1", type: "query", title: "" }],
+      supportsConversationalAI: true,
     };
     const res = generateScaffoldingSummary(
       [],
@@ -517,6 +518,7 @@ describe("generateScaffoldingSummary", () => {
   it("warnings about missing adaptive card template", () => {
     const composeExtension: IComposeExtension = {
       type: "apiBased",
+      supportsConversationalAI: true,
       commands: [
         { id: "command1", type: "query", apiResponseRenderingTemplate: "test", title: "" },
       ],

--- a/packages/fx-core/tests/component/resource/appManifest/utils.test.ts
+++ b/packages/fx-core/tests/component/resource/appManifest/utils.test.ts
@@ -431,21 +431,19 @@ describe("utils", () => {
       chai.assert.isTrue(res);
     });
 
-    it("contains SME", () => {
+    it("contains activities", () => {
       const appDefinition: AppDefinition = {
         teamsAppId: "mockAppId",
         tenantId: "mockTenantId",
-        configurableTabs: [
-          {
-            objectId: "81747dd8-0e3c-4a25-beda-604db9699bb8",
-            configurationUrl: "https://www.test.com",
-            canUpdateConfiguration: false,
-            context: ["meetingSidePanel"],
-            scopes: ["groupChat"],
-            sharePointPreviewImage: "",
-            supportedSharePointHosts: [],
-          },
-        ],
+        activities: {
+          activityTypes: [
+            {
+              type: "type",
+              description: "description",
+              templateText: "text",
+            },
+          ],
+        },
       };
 
       const res = containsUnsupportedFeature(appDefinition);

--- a/packages/fx-core/tests/component/resource/appManifest/utils.test.ts
+++ b/packages/fx-core/tests/component/resource/appManifest/utils.test.ts
@@ -392,19 +392,18 @@ describe("utils", () => {
       chai.assert.isTrue(res);
     });
 
-    it("contains activities", () => {
+    it("contains SME", () => {
       const appDefinition: AppDefinition = {
         teamsAppId: "mockAppId",
         tenantId: "mockTenantId",
-        activities: {
-          activityTypes: [
-            {
-              type: "type",
-              description: "description",
-              templateText: "text",
-            },
-          ],
-        },
+        messagingExtensions: [
+          {
+            type: "apiBased",
+            commands: [],
+            canUpdateConfiguration: false,
+            messageHandlers: [],
+          },
+        ],
       };
 
       const res = containsUnsupportedFeature(appDefinition);
@@ -412,6 +411,27 @@ describe("utils", () => {
     });
 
     it("contains meeting extension", () => {
+      const appDefinition: AppDefinition = {
+        teamsAppId: "mockAppId",
+        tenantId: "mockTenantId",
+        configurableTabs: [
+          {
+            objectId: "81747dd8-0e3c-4a25-beda-604db9699bb8",
+            configurationUrl: "https://www.test.com",
+            canUpdateConfiguration: false,
+            context: ["meetingSidePanel"],
+            scopes: ["groupChat"],
+            sharePointPreviewImage: "",
+            supportedSharePointHosts: [],
+          },
+        ],
+      };
+
+      const res = containsUnsupportedFeature(appDefinition);
+      chai.assert.isTrue(res);
+    });
+
+    it("contains SME", () => {
       const appDefinition: AppDefinition = {
         teamsAppId: "mockAppId",
         tenantId: "mockTenantId",

--- a/packages/manifest/src/ManifestCommonProperties.ts
+++ b/packages/manifest/src/ManifestCommonProperties.ts
@@ -26,4 +26,9 @@ export interface ManifestCommonProperties {
    * Whether it's SPFx Teams app
    */
   isSPFx: boolean;
+
+  /**
+   * Whether it's apiBased MessageExtension but not copilot plugin
+   */
+  isApiBasedMe: boolean;
 }

--- a/packages/manifest/src/index.ts
+++ b/packages/manifest/src/index.ts
@@ -124,16 +124,20 @@ export class ManifestUtil {
       manifestVersion: manifest.manifestVersion,
       isCopilotPlugin: false,
       isSPFx: false,
+      isApiBasedMe: false,
     };
 
     // If it's copilot plugin app
     if (
       manifest.composeExtensions &&
       manifest.composeExtensions.length > 0 &&
-      (manifest.composeExtensions[0] as IComposeExtension).type == "apiBased" &&
-      (manifest.composeExtensions[0] as IComposeExtension).supportsConversationalAI
+      (manifest.composeExtensions[0] as IComposeExtension).type == "apiBased"
     ) {
-      properties.isCopilotPlugin = true;
+      if ((manifest.composeExtensions[0] as IComposeExtension).supportsConversationalAI) {
+        properties.isCopilotPlugin = true;
+      } else {
+        properties.isApiBasedMe = true;
+      }
     }
 
     // If it's SPFx app

--- a/packages/manifest/src/index.ts
+++ b/packages/manifest/src/index.ts
@@ -135,9 +135,9 @@ export class ManifestUtil {
     ) {
       if ((manifest.composeExtensions[0] as IComposeExtension).supportsConversationalAI) {
         properties.isCopilotPlugin = true;
-      } else {
-        properties.isApiBasedMe = true;
       }
+
+      properties.isApiBasedMe = true;
     }
 
     // If it's SPFx app

--- a/packages/manifest/src/index.ts
+++ b/packages/manifest/src/index.ts
@@ -130,7 +130,8 @@ export class ManifestUtil {
     if (
       manifest.composeExtensions &&
       manifest.composeExtensions.length > 0 &&
-      (manifest.composeExtensions[0] as IComposeExtension).type == "apiBased"
+      (manifest.composeExtensions[0] as IComposeExtension).type == "apiBased" &&
+      (manifest.composeExtensions[0] as IComposeExtension).supportsConversationalAI
     ) {
       properties.isCopilotPlugin = true;
     }

--- a/packages/vscode-extension/src/codeLensProvider.ts
+++ b/packages/vscode-extension/src/codeLensProvider.ts
@@ -534,7 +534,7 @@ export class CopilotPluginCodeLensProvider implements vscode.CodeLensProvider {
 
     const manifest: TeamsAppManifest = JSON.parse(document.getText());
     const manifestProperties = ManifestUtil.parseCommonProperties(manifest);
-    if (!manifestProperties.isCopilotPlugin && !manifestProperties.isApiBasedMe) {
+    if (!manifestProperties.isApiBasedMe) {
       return codeLenses;
     }
 

--- a/packages/vscode-extension/src/codeLensProvider.ts
+++ b/packages/vscode-extension/src/codeLensProvider.ts
@@ -533,7 +533,8 @@ export class CopilotPluginCodeLensProvider implements vscode.CodeLensProvider {
     const codeLenses: vscode.CodeLens[] = [];
 
     const manifest: TeamsAppManifest = JSON.parse(document.getText());
-    if (!ManifestUtil.parseCommonProperties(manifest).isCopilotPlugin) {
+    const manifestProperties = ManifestUtil.parseCommonProperties(manifest);
+    if (!manifestProperties.isCopilotPlugin && !manifestProperties.isApiBasedMe) {
       return codeLenses;
     }
 

--- a/packages/vscode-extension/test/extension/handlers.test.ts
+++ b/packages/vscode-extension/test/extension/handlers.test.ts
@@ -2140,6 +2140,7 @@ describe("autoOpenProjectHandler", () => {
       manifestVersion: "",
       isCopilotPlugin: true,
       isSPFx: false,
+      isApiBasedMe: false,
     };
     const parseManifestStub = sandbox.stub(ManifestUtil, "parseCommonProperties").returns(parseRes);
     VsCodeLogInstance.outputChannel = {

--- a/packages/vscode-extension/test/extension/handlers.test.ts
+++ b/packages/vscode-extension/test/extension/handlers.test.ts
@@ -2140,7 +2140,7 @@ describe("autoOpenProjectHandler", () => {
       manifestVersion: "",
       isCopilotPlugin: true,
       isSPFx: false,
-      isApiBasedMe: false,
+      isApiBasedMe: true,
     };
     const parseManifestStub = sandbox.stub(ManifestUtil, "parseCommonProperties").returns(parseRes);
     VsCodeLogInstance.outputChannel = {


### PR DESCRIPTION
- adjust checking app features based on appDefinition so that it will work with new TDP app definition response.
- block SME for now if TDP->TTK