### PR TITLE
fix: cli error print on main

### DIFF
--- a/packages/cli/src/yargsCommand.ts
+++ b/packages/cli/src/yargsCommand.ts
@@ -8,6 +8,7 @@ import {
   UnhandledError,
   VersionState,
   isUserCancelError,
+  assembleError,
 } from "@microsoft/teamsfx-core";
 import { Argv, Options, exit } from "yargs";
 import activate from "./activate";
@@ -18,7 +19,6 @@ import * as constants from "./constants";
 import CliTelemetryInstance from "./telemetry/cliTelemetry";
 import UI from "./userInteraction";
 import { getSystemInputs } from "./utils";
-import { assembleError } from "@microsoft/teamsfx-core";
 
 export abstract class YargsCommand {
   /**
@@ -172,8 +172,6 @@ export function printError(fxError: FxError): void {
     );
   }
   if (CLILogProvider.getLogLevel() === constants.CLILogLevel.debug) {
-    CLILogProvider.outputError(
-      `Call stack: ${fxError.stack || fxError.innerError?.stack || "undefined"}`
-    );
+    CLILogProvider.outputError(`Call stack: ${fxError.stack || fxError.innerError?.stack || ""}`);
   }
 }

--- a/packages/cli/src/yargsCommand.ts
+++ b/packages/cli/src/yargsCommand.ts
@@ -18,6 +18,7 @@ import * as constants from "./constants";
 import CliTelemetryInstance from "./telemetry/cliTelemetry";
 import UI from "./userInteraction";
 import { getSystemInputs } from "./utils";
+import { assembleError } from "@microsoft/teamsfx-core";
 
 export abstract class YargsCommand {
   /**
@@ -137,8 +138,7 @@ export abstract class YargsCommand {
     } catch (e: any) {
       Progress.end(false);
 
-      const FxError: UserError | SystemError =
-        "source" in e ? e : new UnhandledError(e, constants.cliSource);
+      const FxError = assembleError(e, constants.cliSource);
 
       printError(FxError);
 

--- a/packages/cli/tests/unit/yargsCommand.tests.ts
+++ b/packages/cli/tests/unit/yargsCommand.tests.ts
@@ -102,19 +102,23 @@ describe("Yargs Command Tests", function () {
     const cmd = new TestCommand();
     await expect(cmd.handler({ folder: "test" })).to.be.rejected;
   });
+});
 
-  describe("printError", async () => {
-    it("happy path", async () => {
-      const stub = sandbox.stub(CLILogProvider, "outputError").returns();
-      printError(new MissingEnvironmentVariablesError("test", "test"));
-      const error = new SystemError({ issueLink: "http://aka.ms/teamsfx-cli-help" });
-      printError(error);
-      expect(stub.called).to.be.true;
-    });
-    it("canceled", async () => {
-      const stub = sandbox.stub(CLILogProvider, "necessaryLog").returns();
-      printError(new UserCancelError("test"));
-      expect(stub.called).to.be.true;
-    });
+describe("printError", async () => {
+  const sandbox = sinon.createSandbox();
+  afterEach(() => {
+    sandbox.restore();
+  });
+  it("happy path", async () => {
+    const stub = sandbox.stub(CLILogProvider, "outputError").returns();
+    printError(new MissingEnvironmentVariablesError("test", "test"));
+    const error = new SystemError({ issueLink: "http://aka.ms/teamsfx-cli-help" });
+    printError(error);
+    expect(stub.called).to.be.true;
+  });
+  it("canceled", async () => {
+    const stub = sandbox.stub(CLILogProvider, "necessaryLog").returns();
+    printError(new UserCancelError("test"));
+    expect(stub.called).to.be.true;
   });
 });

--- a/packages/cli/tests/unit/yargsCommand.tests.ts
+++ b/packages/cli/tests/unit/yargsCommand.tests.ts
@@ -17,6 +17,7 @@ import { default as CLIUIInstance, default as UI } from "../../src/userInteracti
 import { printError, YargsCommand } from "../../src/yargsCommand";
 import { expect, mockLogProvider } from "./utils";
 import CLILogProvider from "../../src/commonlib/log";
+import { CLILogLevel } from "../../src/constants";
 
 class TestCommand extends YargsCommand {
   public commandHead = "test";
@@ -110,9 +111,11 @@ describe("printError", async () => {
     sandbox.restore();
   });
   it("happy path", async () => {
+    sandbox.stub(CLILogProvider, "getLogLevel").returns(CLILogLevel.debug);
     const stub = sandbox.stub(CLILogProvider, "outputError").returns();
     printError(new MissingEnvironmentVariablesError("test", "test"));
     const error = new SystemError({ issueLink: "http://aka.ms/teamsfx-cli-help" });
+    error.innerError = new Error("test");
     printError(error);
     expect(stub.called).to.be.true;
   });

--- a/packages/cli/tests/unit/yargsCommand.tests.ts
+++ b/packages/cli/tests/unit/yargsCommand.tests.ts
@@ -4,8 +4,8 @@
 /**
  * @author Alive-Fish <547850391@qq.com>
  */
-import { err, FxError, ok, Result, Void } from "@microsoft/teamsfx-api";
-import { FxCore } from "@microsoft/teamsfx-core";
+import { err, FxError, ok, Result, SystemError, Void } from "@microsoft/teamsfx-api";
+import { FxCore, MissingEnvironmentVariablesError, UserCancelError } from "@microsoft/teamsfx-core";
 import { VersionState } from "@microsoft/teamsfx-core";
 import { VersionCheckRes } from "@microsoft/teamsfx-core";
 import "mocha";
@@ -14,8 +14,9 @@ import sinon from "sinon";
 import yargs, { Options } from "yargs";
 import { WorkspaceNotSupported } from "../../src/cmds/preview/errors";
 import { default as CLIUIInstance, default as UI } from "../../src/userInteraction";
-import { YargsCommand } from "../../src/yargsCommand";
+import { printError, YargsCommand } from "../../src/yargsCommand";
 import { expect, mockLogProvider } from "./utils";
+import CLILogProvider from "../../src/commonlib/log";
 
 class TestCommand extends YargsCommand {
   public commandHead = "test";
@@ -100,5 +101,20 @@ describe("Yargs Command Tests", function () {
     sandbox.stub(FxCore.prototype, "phantomMigrationV3").resolves(err(WorkspaceNotSupported("./")));
     const cmd = new TestCommand();
     await expect(cmd.handler({ folder: "test" })).to.be.rejected;
+  });
+
+  describe("printError", async () => {
+    it("happy path", async () => {
+      const stub = sandbox.stub(CLILogProvider, "outputError").returns();
+      printError(new MissingEnvironmentVariablesError("test", "test"));
+      const error = new SystemError({ issueLink: "http://aka.ms/teamsfx-cli-help" });
+      printError(error);
+      expect(stub.called).to.be.true;
+    });
+    it("canceled", async () => {
+      const stub = sandbox.stub(CLILogProvider, "necessaryLog").returns();
+      printError(new UserCancelError("test"));
+      expect(stub.called).to.be.true;
+    });
   });
 });

--- a/packages/cli/tests/unit/yargsCommand.tests.ts
+++ b/packages/cli/tests/unit/yargsCommand.tests.ts
@@ -117,7 +117,12 @@ describe("printError", async () => {
     const error = new SystemError({ issueLink: "http://aka.ms/teamsfx-cli-help" });
     error.innerError = new Error("test");
     printError(error);
-    expect(stub.called).to.be.true;
+    error.stack = undefined;
+    printError(error);
+    error.stack = undefined;
+    printError(error);
+    error.innerError!.stack = undefined;
+    printError(error);
   });
   it("canceled", async () => {
     const stub = sandbox.stub(CLILogProvider, "necessaryLog").returns();

--- a/packages/cli/tests/unit/yargsCommand.tests.ts
+++ b/packages/cli/tests/unit/yargsCommand.tests.ts
@@ -110,19 +110,31 @@ describe("printError", async () => {
   afterEach(() => {
     sandbox.restore();
   });
-  it("happy path", async () => {
+  it("happy path user error", async () => {
     sandbox.stub(CLILogProvider, "getLogLevel").returns(CLILogLevel.debug);
     const stub = sandbox.stub(CLILogProvider, "outputError").returns();
     printError(new MissingEnvironmentVariablesError("test", "test"));
+    expect(stub.called).to.be.true;
+  });
+  it("happy path system error", async () => {
+    sandbox.stub(CLILogProvider, "getLogLevel").returns(CLILogLevel.debug);
+    const stub = sandbox.stub(CLILogProvider, "outputError").returns();
     const error = new SystemError({ issueLink: "http://aka.ms/teamsfx-cli-help" });
-    error.innerError = new Error("test");
     printError(error);
+    expect(stub.called).to.be.true;
+  });
+  it("happy path inner error", async () => {
+    sandbox.stub(CLILogProvider, "getLogLevel").returns(CLILogLevel.debug);
+    const stub = sandbox.stub(CLILogProvider, "outputError").returns();
+    const error = new SystemError({ issueLink: "http://aka.ms/teamsfx-cli-help" });
+    const innerError = new Error("test");
+    error.innerError = innerError;
+    error.message = "";
     error.stack = undefined;
     printError(error);
-    error.stack = undefined;
+    innerError.stack = undefined;
     printError(error);
-    error.innerError!.stack = undefined;
-    printError(error);
+    expect(stub.called).to.be.true;
   });
   it("canceled", async () => {
     const stub = sandbox.stub(CLILogProvider, "necessaryLog").returns();


### PR DESCRIPTION
@microsoft/adaptivecards-tools	v1.3.3-rc.0
@microsoft/teamsfx-api	v0.23.0-rc.0
@microsoft/teamsfx-cli	v2.1.0-rc.0
@microsoft/teamsfx-core	v2.1.0-rc.0
@microsoft/teams-manifest	v0.2.0-rc.0
@microsoft/metrics-ts	v0.0.5-rc.0
@microsoft/teamsfx	v2.3.0-rc.0
@microsoft/teamsfx-react	v3.1.0-rc.0

Fx-core feat commits:
  

CLI feat commits:
  

Extension-toolkit feat commits:
  

SDK feat commits:
  

SDK React feat commits:
  

.Net SDK feat commits:
  


Fx-core fix commits:
  

CLI fix commits:
 fix: cli error print 3077e25be 

Extension-toolkit fix commits:
  

SDK fix commits:
  

SDK React fix commits:
  

.Net SDK fix commits: