### PR TITLE
fix: add log for zip app package vsc

### DIFF
--- a/packages/fx-core/src/component/driver/teamsApp/createAppPackage.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/createAppPackage.ts
@@ -210,7 +210,7 @@ export class CreateAppPackageDriver implements StepDriver {
     if (context.platform === Platform.VS || context.platform === Platform.VSCode) {
       context.logProvider.info(builtSuccess);
     } else {
-      context.ui?.showMessage("info", builtSuccess, false);
+      context.ui!.showMessage("info", builtSuccess, false);
     }
 
     return ok(new Map());

--- a/packages/fx-core/src/component/driver/teamsApp/createAppPackage.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/createAppPackage.ts
@@ -208,7 +208,7 @@ export class CreateAppPackageDriver implements StepDriver {
       { content: " built successfully!", color: Colors.BRIGHT_WHITE },
     ];
     if (context.platform === Platform.VS || context.platform === Platform.VSCode) {
-      context.logProvider?.info(builtSuccess);
+      context.logProvider.info(builtSuccess);
     } else {
       context.ui?.showMessage("info", builtSuccess, false);
     }

--- a/packages/fx-core/src/component/driver/teamsApp/createAppPackage.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/createAppPackage.ts
@@ -201,18 +201,16 @@ export class CreateAppPackageDriver implements StepDriver {
     await fs.writeFile(jsonFileName, JSON.stringify(manifest, null, 4));
     await fs.chmod(jsonFileName, 0o444);
 
-    if (context.platform === Platform.CLI || context.platform === Platform.VS) {
-      const builtSuccess = [
-        { content: "(√)Done: ", color: Colors.BRIGHT_GREEN },
-        { content: "Teams Package ", color: Colors.BRIGHT_WHITE },
-        { content: zipFileName, color: Colors.BRIGHT_MAGENTA },
-        { content: " built successfully!", color: Colors.BRIGHT_WHITE },
-      ];
-      if (context.platform === Platform.VS) {
-        context.logProvider?.info(builtSuccess);
-      } else {
-        context.ui?.showMessage("info", builtSuccess, false);
-      }
+    const builtSuccess = [
+      { content: "(√)Done: ", color: Colors.BRIGHT_GREEN },
+      { content: "Teams Package ", color: Colors.BRIGHT_WHITE },
+      { content: zipFileName, color: Colors.BRIGHT_MAGENTA },
+      { content: " built successfully!", color: Colors.BRIGHT_WHITE },
+    ];
+    if (context.platform === Platform.VS || context.platform === Platform.VSCode) {
+      context.logProvider?.info(builtSuccess);
+    } else {
+      context.ui?.showMessage("info", builtSuccess, false);
     }
 
     return ok(new Map());

--- a/packages/fx-core/tests/component/driver/teamsApp/createAppPackage.test.ts
+++ b/packages/fx-core/tests/component/driver/teamsApp/createAppPackage.test.ts
@@ -306,10 +306,6 @@ describe("teamsApp/createAppPackage", async () => {
     if (await fs.pathExists(args.outputZipPath)) {
       await fs.remove(args.outputZipPath);
     }
-
-    mockedCliDriverContext.ui = undefined;
-    const executeResult = await teamsAppDriver.execute(args, mockedDriverContext);
-    chai.assert.isTrue(executeResult.result.isOk());
   });
 
   it("happy path - relative path", async () => {

--- a/packages/fx-core/tests/component/driver/teamsApp/createAppPackage.test.ts
+++ b/packages/fx-core/tests/component/driver/teamsApp/createAppPackage.test.ts
@@ -12,14 +12,14 @@ import { MockedM365Provider } from "../../../plugins/solution/util";
 import { FileNotFoundError } from "../../../../src/error/common";
 import { FeatureFlagName } from "../../../../src/common/constants";
 import { manifestUtils } from "../../../../src/component/driver/teamsApp/utils/ManifestUtils";
-import { ok, TeamsAppManifest } from "@microsoft/teamsfx-api";
-import AdmZip from "adm-zip";
+import { ok, Platform, TeamsAppManifest } from "@microsoft/teamsfx-api";
 
 describe("teamsApp/createAppPackage", async () => {
   const teamsAppDriver = new CreateAppPackageDriver();
   const mockedDriverContext: any = {
     m365TokenProvider: new MockedM365Provider(),
     projectPath: "./",
+    platform: Platform.VSCode,
   };
   let mockedEnvRestore: RestoreFn;
 
@@ -246,6 +246,58 @@ describe("teamsApp/createAppPackage", async () => {
 
     const executeResult = await teamsAppDriver.execute(args, mockedDriverContext);
     chai.assert.isTrue(executeResult.result.isOk());
+  });
+
+  it("happy path - CLI", async () => {
+    const cliContext = mockedDriverContext;
+    cliContext.platform = Platform.CLI;
+    const args: CreateAppPackageArgs = {
+      manifestPath:
+        "./tests/plugins/resource/appstudio/resources-multi-env/templates/appPackage/v3.manifest.template.json",
+      outputZipPath:
+        "./tests/plugins/resource/appstudio/resources-multi-env/build/appPackage/appPackage.dev.zip",
+      outputJsonPath:
+        "./tests/plugins/resource/appstudio/resources-multi-env/build/appPackage/manifest.dev.json",
+    };
+
+    const manifest = new TeamsAppManifest();
+    manifest.composeExtensions = [
+      {
+        type: "apiBased",
+        apiSpecFile: "resources/openai.yml",
+        commands: [
+          {
+            id: "GET /repairs",
+            apiResponseRenderingTemplate: "resources/repairs.json",
+            title: "fake",
+          },
+        ],
+        botId: "",
+      },
+    ];
+    manifest.icons = {
+      color: "resources/color.png",
+      outline: "resources/outline.png",
+    };
+    manifest.localizationInfo = {
+      defaultLanguageTag: "en",
+      additionalLanguages: [
+        {
+          languageTag: "de",
+          file: "resources/de.json",
+        },
+      ],
+    };
+    sinon.stub(manifestUtils, "getManifestV3").resolves(ok(manifest));
+
+    sinon.stub(fs, "chmod").callsFake(async () => {});
+    sinon.stub(fs, "writeFile").callsFake(async () => {});
+
+    const result = await teamsAppDriver.run(args, cliContext);
+    chai.assert(result.isOk());
+    if (await fs.pathExists(args.outputZipPath)) {
+      await fs.remove(args.outputZipPath);
+    }
   });
 
   it("happy path - relative path", async () => {


### PR DESCRIPTION
For bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/24818129

VSC output:
Triggered by lifecycle commands:
![image](https://github.com/OfficeDev/TeamsFx/assets/71362691/08f4648b-dd56-48af-b204-f632b1c37d64)

Triggered by Zip app package Treeview command:
![image](https://github.com/OfficeDev/TeamsFx/assets/71362691/1158ea1a-6404-43d8-81c9-bc9507edd8eb)
