### PR TITLE
test: fix migration bot validation string

### DIFF
--- a/packages/tests/src/ui-test/migration/4.0.0-notification-bot-restify/4.0.0-notification-bot-restify-debug-upgrade-debug-ts.test.ts
+++ b/packages/tests/src/ui-test/migration/4.0.0-notification-bot-restify/4.0.0-notification-bot-restify-debug-upgrade-debug-ts.test.ts
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/**
+ * @author Helly Zhang <v-helzha@microsoft.com>
+ */
 import { MigrationTestContext } from "../migrationContext";
 import {
   Timeout,

--- a/packages/tests/src/ui-test/migration/4.0.0-notification-bot-restify/4.0.0-notification-bot-restify-debug-upgrade-debug-ts.test.ts
+++ b/packages/tests/src/ui-test/migration/4.0.0-notification-bot-restify/4.0.0-notification-bot-restify-debug-upgrade-debug-ts.test.ts
@@ -1,6 +1,6 @@
-/**
- * @author Frank Qian <frankqian@microsoft.com>
- */
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { MigrationTestContext } from "../migrationContext";
 import {
   Timeout,
@@ -10,6 +10,7 @@ import {
   LocalDebugTaskLabel,
   LocalDebugTaskResult,
   CliVersion,
+  LocalDebugTaskLabel2,
 } from "../../../utils/constants";
 import { it } from "../../../utils/it";
 import { Env } from "../../../utils/env";
@@ -29,9 +30,10 @@ import { VSBrowser } from "vscode-extension-tester";
 import { getScreenshotName } from "../../../utils/nameUtil";
 import { execCommand } from "../../../utils/execCommand";
 import { expect } from "chai";
+import { updateDeverloperInManifestFile } from "../../../utils/commonUtils";
 
 describe("Migration Tests", function () {
-  this.timeout(Timeout.testCase);
+  this.timeout(Timeout.migrationTestCase);
   let mirgationDebugTestContext: MigrationTestContext;
   CliHelper.setV3Enable();
 
@@ -74,6 +76,10 @@ describe("Migration Tests", function () {
       // enable cli v3
       CliHelper.setV3Enable();
 
+      await updateDeverloperInManifestFile(
+        mirgationDebugTestContext.projectPath
+      );
+
       // local debug with TTK
       try {
         await startDebugging();
@@ -86,7 +92,7 @@ describe("Migration Tests", function () {
 
         console.log("Start Bot");
         await waitForTerminal(
-          LocalDebugTaskLabel.StartBot,
+          LocalDebugTaskLabel2.StartBot2,
           LocalDebugTaskResult.AppSuccess
         );
       } catch (error) {

--- a/packages/tests/src/ui-test/migration/4.0.0-notification-bot-restify/4.0.0-notification-bot-restify-debug-upgrade-debug.test.ts
+++ b/packages/tests/src/ui-test/migration/4.0.0-notification-bot-restify/4.0.0-notification-bot-restify-debug-upgrade-debug.test.ts
@@ -1,6 +1,6 @@
-/**
- * @author Frank Qian <frankqian@microsoft.com>
- */
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { MigrationTestContext } from "../migrationContext";
 import {
   Timeout,
@@ -10,6 +10,7 @@ import {
   LocalDebugTaskLabel,
   LocalDebugTaskResult,
   CliVersion,
+  LocalDebugTaskLabel2,
 } from "../../../utils/constants";
 import { it } from "../../../utils/it";
 import { Env } from "../../../utils/env";
@@ -29,9 +30,10 @@ import { VSBrowser } from "vscode-extension-tester";
 import { getScreenshotName } from "../../../utils/nameUtil";
 import { execCommand } from "../../../utils/execCommand";
 import { expect } from "chai";
+import { updateDeverloperInManifestFile } from "../../../utils/commonUtils";
 
 describe("Migration Tests", function () {
-  this.timeout(Timeout.testCase);
+  this.timeout(Timeout.migrationTestCase);
   let mirgationDebugTestContext: MigrationTestContext;
   CliHelper.setV3Enable();
 
@@ -67,6 +69,10 @@ describe("Migration Tests", function () {
       // local debug
       await mirgationDebugTestContext.debugWithCLI("local");
 
+      await updateDeverloperInManifestFile(
+        mirgationDebugTestContext.projectPath
+      );
+
       // upgrade
       await upgradeByTreeView();
       //verify upgrade
@@ -86,7 +92,7 @@ describe("Migration Tests", function () {
 
         console.log("Start Bot");
         await waitForTerminal(
-          LocalDebugTaskLabel.StartBot,
+          LocalDebugTaskLabel2.StartBot2,
           LocalDebugTaskResult.AppSuccess
         );
       } catch (error) {

--- a/packages/tests/src/ui-test/migration/4.0.0-notification-bot-restify/4.0.0-notification-bot-restify-debug-upgrade-debug.test.ts
+++ b/packages/tests/src/ui-test/migration/4.0.0-notification-bot-restify/4.0.0-notification-bot-restify-debug-upgrade-debug.test.ts
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/**
+ * @author Helly Zhang <v-helzha@microsoft.com>
+ */
 import { MigrationTestContext } from "../migrationContext";
 import {
   Timeout,

--- a/packages/tests/src/ui-test/migration/4.0.0-notification-bot-restify/4.0.0-notification-bot-restify-upgrade-debug-ts.test.ts
+++ b/packages/tests/src/ui-test/migration/4.0.0-notification-bot-restify/4.0.0-notification-bot-restify-upgrade-debug-ts.test.ts
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/**
+ * @author Helly Zhang <v-helzha@microsoft.com>
+ */
 import { MigrationTestContext } from "../migrationContext";
 import {
   Timeout,

--- a/packages/tests/src/ui-test/migration/4.0.0-notification-bot-restify/4.0.0-notification-bot-restify-upgrade-debug-ts.test.ts
+++ b/packages/tests/src/ui-test/migration/4.0.0-notification-bot-restify/4.0.0-notification-bot-restify-upgrade-debug-ts.test.ts
@@ -1,6 +1,6 @@
-/**
- * @author Frank Qian <frankqian@microsoft.com>
- */
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { MigrationTestContext } from "../migrationContext";
 import {
   Timeout,
@@ -10,6 +10,7 @@ import {
   LocalDebugTaskLabel,
   LocalDebugTaskResult,
   CliVersion,
+  LocalDebugTaskLabel2,
 } from "../../../utils/constants";
 import { it } from "../../../utils/it";
 import { Env } from "../../../utils/env";
@@ -28,10 +29,11 @@ import {
 import { VSBrowser } from "vscode-extension-tester";
 import { getScreenshotName } from "../../../utils/nameUtil";
 import { execCommand } from "../../../utils/execCommand";
+import { updateDeverloperInManifestFile } from "../../../utils/commonUtils";
 import { expect } from "chai";
 
 describe("Migration Tests", function () {
-  this.timeout(Timeout.testCase);
+  this.timeout(Timeout.migrationTestCase);
   let mirgationDebugTestContext: MigrationTestContext;
   CliHelper.setV3Enable();
 
@@ -71,6 +73,10 @@ describe("Migration Tests", function () {
       // enable cli v3
       CliHelper.setV3Enable();
 
+      await updateDeverloperInManifestFile(
+        mirgationDebugTestContext.projectPath
+      );
+
       // local debug with TTK
       try {
         await startDebugging();
@@ -83,7 +89,7 @@ describe("Migration Tests", function () {
 
         console.log("Start Bot");
         await waitForTerminal(
-          LocalDebugTaskLabel.StartBot,
+          LocalDebugTaskLabel2.StartBot2,
           LocalDebugTaskResult.AppSuccess
         );
       } catch (error) {

--- a/packages/tests/src/ui-test/migration/4.0.0-notification-bot-restify/4.0.0-notification-bot-restify-upgrade-debug.test.ts
+++ b/packages/tests/src/ui-test/migration/4.0.0-notification-bot-restify/4.0.0-notification-bot-restify-upgrade-debug.test.ts
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/**
+ * @author Helly Zhang <v-helzha@microsoft.com>
+ */
 import { MigrationTestContext } from "../migrationContext";
 import {
   Timeout,

--- a/packages/tests/src/ui-test/migration/4.0.0-notification-bot-restify/4.0.0-notification-bot-restify-upgrade-debug.test.ts
+++ b/packages/tests/src/ui-test/migration/4.0.0-notification-bot-restify/4.0.0-notification-bot-restify-upgrade-debug.test.ts
@@ -1,6 +1,6 @@
-/**
- * @author Frank Qian <frankqian@microsoft.com>
- */
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { MigrationTestContext } from "../migrationContext";
 import {
   Timeout,
@@ -10,6 +10,7 @@ import {
   LocalDebugTaskLabel,
   LocalDebugTaskResult,
   CliVersion,
+  LocalDebugTaskLabel2,
 } from "../../../utils/constants";
 import { it } from "../../../utils/it";
 import { Env } from "../../../utils/env";
@@ -29,9 +30,10 @@ import { VSBrowser } from "vscode-extension-tester";
 import { getScreenshotName } from "../../../utils/nameUtil";
 import { execCommand } from "../../../utils/execCommand";
 import { expect } from "chai";
+import { updateDeverloperInManifestFile } from "../../../utils/commonUtils";
 
 describe("Migration Tests", function () {
-  this.timeout(Timeout.testCase);
+  this.timeout(Timeout.migrationTestCase);
   let mirgationDebugTestContext: MigrationTestContext;
   CliHelper.setV3Enable();
 
@@ -71,6 +73,10 @@ describe("Migration Tests", function () {
       // enable cli v3
       CliHelper.setV3Enable();
 
+      await updateDeverloperInManifestFile(
+        mirgationDebugTestContext.projectPath
+      );
+
       // local debug with TTK
       try {
         await startDebugging();
@@ -83,7 +89,7 @@ describe("Migration Tests", function () {
 
         console.log("Start Bot");
         await waitForTerminal(
-          LocalDebugTaskLabel.StartBot,
+          LocalDebugTaskLabel2.StartBot2,
           LocalDebugTaskResult.AppSuccess
         );
       } catch (error) {

--- a/packages/tests/src/ui-test/migration/bot/bot-debug-upgrade-debug-ts.test.ts
+++ b/packages/tests/src/ui-test/migration/bot/bot-debug-upgrade-debug-ts.test.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+
 import { MigrationTestContext } from "../migrationContext";
 import {
   Timeout,
@@ -12,10 +13,10 @@ import { it } from "../../../utils/it";
 import { Env } from "../../../utils/env";
 import { initPage, validateBot } from "../../../utils/playwrightOperation";
 import {
-  validateNotification,
   startDebugging,
-  upgradeByTreeView,
   waitForTerminal,
+  validateNotification,
+  upgradeByTreeView,
   validateUpgrade,
 } from "../../../utils/vscodeOperation";
 import { CliHelper } from "../../cliHelper";
@@ -23,7 +24,7 @@ import { VSBrowser } from "vscode-extension-tester";
 import { getScreenshotName } from "../../../utils/nameUtil";
 
 describe("Migration Tests", function () {
-  this.timeout(Timeout.migrationTestCase);
+  this.timeout(Timeout.testAzureCase);
   let mirgationDebugTestContext: MigrationTestContext;
 
   beforeEach(async function () {
@@ -31,8 +32,8 @@ describe("Migration Tests", function () {
     this.timeout(Timeout.prepareTestCase);
 
     mirgationDebugTestContext = new MigrationTestContext(
-      Capability.CommandBot,
-      "javascript"
+      Capability.Bot,
+      "typescript"
     );
     await mirgationDebugTestContext.before();
   });
@@ -43,9 +44,9 @@ describe("Migration Tests", function () {
   });
 
   it(
-    "[auto] V2 command bot migrate test - js",
+    "[auto] V2 bot migrate test - ts",
     {
-      testPlanCaseId: 17183669,
+      testPlanCaseId: 17184118,
       author: "frankqian@microsoft.com",
     },
     async () => {
@@ -71,16 +72,14 @@ describe("Migration Tests", function () {
           LocalDebugTaskLabel.StartLocalTunnel,
           LocalDebugTaskResult.StartSuccess
         );
-        await waitForTerminal(
-          LocalDebugTaskLabel.StartBot,
-          LocalDebugTaskResult.AppSuccess
-        );
+
+        await waitForTerminal("Start Bot", "Bot started");
       } catch (error) {
         await VSBrowser.instance.takeScreenshot(getScreenshotName("debug"));
         console.log("[Skip Error]: ", error);
         await VSBrowser.instance.driver.sleep(Timeout.playwrightDefaultTimeout);
       }
-      const teamsAppId = await mirgationDebugTestContext.getTeamsAppId();
+      const teamsAppId = await mirgationDebugTestContext.getTeamsAppId("local");
 
       // UI verify
       const page = await initPage(
@@ -89,10 +88,7 @@ describe("Migration Tests", function () {
         Env.username,
         Env.password
       );
-      await validateBot(page, {
-        botCommand: "helloWorld",
-        expected: "Your Hello World Bot is Running",
-      });
+      await validateBot(page);
     }
   );
 });

--- a/packages/tests/src/ui-test/migration/bot/bot-debug-upgrade-debug-ts.test.ts
+++ b/packages/tests/src/ui-test/migration/bot/bot-debug-upgrade-debug-ts.test.ts
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/**
+ * @author Helly Zhang <v-helzha@microsoft.com>
+ */
 import { MigrationTestContext } from "../migrationContext";
 import {
   Timeout,

--- a/packages/tests/src/ui-test/migration/bot/bot-upgrade-debug-ts.test.ts
+++ b/packages/tests/src/ui-test/migration/bot/bot-upgrade-debug-ts.test.ts
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/**
+ * @author Helly Zhang <v-helzha@microsoft.com>
+ */
 import { MigrationTestContext } from "../migrationContext";
 import {
   Timeout,

--- a/packages/tests/src/ui-test/migration/bot/bot-upgrade-debug-ts.test.ts
+++ b/packages/tests/src/ui-test/migration/bot/bot-upgrade-debug-ts.test.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+
 import { MigrationTestContext } from "../migrationContext";
 import {
   Timeout,
@@ -23,7 +24,7 @@ import { VSBrowser } from "vscode-extension-tester";
 import { getScreenshotName } from "../../../utils/nameUtil";
 
 describe("Migration Tests", function () {
-  this.timeout(Timeout.migrationTestCase);
+  this.timeout(Timeout.testAzureCase);
   let mirgationDebugTestContext: MigrationTestContext;
 
   beforeEach(async function () {
@@ -31,8 +32,8 @@ describe("Migration Tests", function () {
     this.timeout(Timeout.prepareTestCase);
 
     mirgationDebugTestContext = new MigrationTestContext(
-      Capability.CommandBot,
-      "javascript"
+      Capability.Bot,
+      "typescript"
     );
     await mirgationDebugTestContext.before();
   });
@@ -43,9 +44,9 @@ describe("Migration Tests", function () {
   });
 
   it(
-    "[auto] V2 command bot migrate test - js",
+    "[auto] V2 bot migrate test - ts",
     {
-      testPlanCaseId: 17183669,
+      testPlanCaseId: 17184117,
       author: "frankqian@microsoft.com",
     },
     async () => {
@@ -53,9 +54,6 @@ describe("Migration Tests", function () {
       await mirgationDebugTestContext.createProjectCLI(false);
       // verify popup
       await validateNotification(Notification.Upgrade);
-
-      // local debug
-      await mirgationDebugTestContext.debugWithCLI("local");
 
       // upgrade
       await upgradeByTreeView();
@@ -71,16 +69,15 @@ describe("Migration Tests", function () {
           LocalDebugTaskLabel.StartLocalTunnel,
           LocalDebugTaskResult.StartSuccess
         );
-        await waitForTerminal(
-          LocalDebugTaskLabel.StartBot,
-          LocalDebugTaskResult.AppSuccess
-        );
+
+        await waitForTerminal("Start Bot", "Bot started");
       } catch (error) {
         await VSBrowser.instance.takeScreenshot(getScreenshotName("debug"));
         console.log("[Skip Error]: ", error);
         await VSBrowser.instance.driver.sleep(Timeout.playwrightDefaultTimeout);
       }
-      const teamsAppId = await mirgationDebugTestContext.getTeamsAppId();
+
+      const teamsAppId = await mirgationDebugTestContext.getTeamsAppId("local");
 
       // UI verify
       const page = await initPage(
@@ -89,10 +86,7 @@ describe("Migration Tests", function () {
         Env.username,
         Env.password
       );
-      await validateBot(page, {
-        botCommand: "helloWorld",
-        expected: "Your Hello World Bot is Running",
-      });
+      await validateBot(page);
     }
   );
 });

--- a/packages/tests/src/ui-test/migration/command-bot/command-bot-debug-upgrade-debug.test.ts
+++ b/packages/tests/src/ui-test/migration/command-bot/command-bot-debug-upgrade-debug.test.ts
@@ -1,5 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+/**
+ * @author Helly Zhang <v-helzha@microsoft.com>
+ */
 import { MigrationTestContext } from "../migrationContext";
 import {
   Timeout,

--- a/packages/tests/src/ui-test/migration/command-bot/command-bot-provision-upgrade-provision-debug.test.ts
+++ b/packages/tests/src/ui-test/migration/command-bot/command-bot-provision-upgrade-provision-debug.test.ts
@@ -1,5 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+/**
+ * @author Helly Zhang <v-helzha@microsoft.com>
+ */
 import { MigrationTestContext } from "../migrationContext";
 import { Timeout, Capability, Notification } from "../../../utils/constants";
 import { it } from "../../../utils/it";

--- a/packages/tests/src/ui-test/migration/command-bot/command-bot-provision-upgrade-provision-debug.test.ts
+++ b/packages/tests/src/ui-test/migration/command-bot/command-bot-provision-upgrade-provision-debug.test.ts
@@ -80,7 +80,7 @@ describe("Migration Tests", function () {
       );
       await validateBot(page, {
         botCommand: "helloWorld",
-        expected: "Your Hello World App is Running",
+        expected: "Your Hello World Bot is Running",
       });
     }
   );

--- a/packages/tests/src/ui-test/migration/command-bot/command-bot-upgrade-debug.test.ts
+++ b/packages/tests/src/ui-test/migration/command-bot/command-bot-upgrade-debug.test.ts
@@ -23,7 +23,7 @@ import { VSBrowser } from "vscode-extension-tester";
 import { getScreenshotName } from "../../../utils/nameUtil";
 
 describe("Migration Tests", function () {
-  this.timeout(Timeout.testAzureCase);
+  this.timeout(Timeout.migrationTestCase);
   let mirgationDebugTestContext: MigrationTestContext;
 
   beforeEach(async function () {
@@ -88,7 +88,7 @@ describe("Migration Tests", function () {
       );
       await validateBot(page, {
         botCommand: "helloWorld",
-        expected: "Your Hello World App is Running",
+        expected: "Your Hello World Bot is Running",
       });
     }
   );

--- a/packages/tests/src/ui-test/migration/command-bot/command-bot-upgrade-debug.test.ts
+++ b/packages/tests/src/ui-test/migration/command-bot/command-bot-upgrade-debug.test.ts
@@ -1,5 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+/**
+ * @author Helly Zhang <v-helzha@microsoft.com>
+ */
 import { MigrationTestContext } from "../migrationContext";
 import {
   Timeout,

--- a/packages/tests/src/ui-test/migration/command-bot/command-bot-upgrade-provision-debug.test.ts
+++ b/packages/tests/src/ui-test/migration/command-bot/command-bot-upgrade-provision-debug.test.ts
@@ -76,7 +76,7 @@ describe("Migration Tests", function () {
       );
       await validateBot(page, {
         botCommand: "helloWorld",
-        expected: "Your Hello World App is Running",
+        expected: "Your Hello World Bot is Running",
       });
     }
   );

--- a/packages/tests/src/ui-test/migration/command-bot/command-bot-upgrade-provision-debug.test.ts
+++ b/packages/tests/src/ui-test/migration/command-bot/command-bot-upgrade-provision-debug.test.ts
@@ -1,5 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+/**
+ * @author Helly Zhang <v-helzha@microsoft.com>
+ */
 import { MigrationTestContext } from "../migrationContext";
 import { Timeout, Capability, Notification } from "../../../utils/constants";
 import { it } from "../../../utils/it";

--- a/packages/tests/src/utils/commonUtils.ts
+++ b/packages/tests/src/utils/commonUtils.ts
@@ -251,3 +251,20 @@ function findNextEndLineIndexOfWord(content: string, key: string): number {
   const result = content.indexOf("\n", index);
   return result;
 }
+
+export async function updateDeverloperInManifestFile(
+  projectPath: string
+): Promise<void> {
+  const manifestFile = path.join(projectPath, "appPackage", `manifest.json`);
+  const context = await fs.readJSON(manifestFile);
+  //const context = await fs.readJSON(azureParametersFilePath);
+  try {
+    context["developer"]["websiteUrl"] = "https://www.example.com";
+    context["developer"]["privacyUrl"] = "https://www.example.com/privacy";
+    context["developer"]["termsOfUseUrl"] = "https://www.example.com/termofuse";
+  } catch {
+    console.log("Cannot set the propertie.");
+  }
+  console.log("Replaced the properties of developer in manifest file");
+  await fs.writeJSON(manifestFile, context, { spaces: 4 });
+}

--- a/packages/tests/src/utils/constants.ts
+++ b/packages/tests/src/utils/constants.ts
@@ -325,6 +325,10 @@ export class LocalDebugTaskResult {
   static readonly DebuggerAttached = "Debugger attached";
 }
 
+export enum LocalDebugTaskLabel2 {
+  StartBot2 = "Start Bot",
+}
+
 export class LocalDebugTaskInfo {
   static readonly StartBotAppInfo = "App Started";
   static readonly StartBotInfo = "Bot Started";


### PR DESCRIPTION
1. update bot validation string for migration command bot test cases
2. add two bot typescript local debug migration cases
3. update notification bot terminal task name for 4.0.0
4. replace manifest developer properties which is known issue with unrecognized variable.