### PR TITLE
perf(specParser): update server url validate logic

### DIFF
--- a/packages/fx-core/src/common/spec-parser/constants.ts
+++ b/packages/fx-core/src/common/spec-parser/constants.ts
@@ -22,6 +22,10 @@ export class ConstantString {
   );
   static readonly SchemaNotSupported = getLocalizedString("core.common.SchemaNotSupported");
   static readonly UnknownSchema = getLocalizedString("core.common.UnknownSchema");
+  // TODO: localization
+  static readonly HttpServerUrlNotSupported =
+    "Http server url is not supported, you should use https instead.";
+  static readonly RelativeServerUrlNotSupported = "Relative server url is not supported.";
   static readonly GetMethod = "get";
   static readonly PostMethod = "post";
   static readonly AdaptiveCardVersion = "1.5";

--- a/packages/fx-core/src/common/spec-parser/constants.ts
+++ b/packages/fx-core/src/common/spec-parser/constants.ts
@@ -23,8 +23,8 @@ export class ConstantString {
   static readonly SchemaNotSupported = getLocalizedString("core.common.SchemaNotSupported");
   static readonly UnknownSchema = getLocalizedString("core.common.UnknownSchema");
   // TODO: localization
-  static readonly HttpServerUrlNotSupported =
-    "Http server url is not supported, you should use https instead.";
+  static readonly UrlProtocolNotSupported =
+    "Protocol %s is not supported, you should use https protocol instead.";
   static readonly RelativeServerUrlNotSupported = "Relative server url is not supported.";
   static readonly GetMethod = "get";
   static readonly PostMethod = "post";

--- a/packages/fx-core/src/common/spec-parser/interfaces.ts
+++ b/packages/fx-core/src/common/spec-parser/interfaces.ts
@@ -71,7 +71,7 @@ export enum ErrorType {
   RemoteRefNotSupported = "remote-ref-not-supported",
   NoServerInformation = "no-server-information",
   MultipleServerInformation = "multiple-server-information",
-  HttpServerUrlNotSupported = "http-server-url-not-supported",
+  UrlProtocolNotSupported = "http-server-url-not-supported",
   RelativeServerUrlNotSupported = "relative-server-url-not-supported",
   NoSupportedApi = "no-supported-api",
 

--- a/packages/fx-core/src/common/spec-parser/interfaces.ts
+++ b/packages/fx-core/src/common/spec-parser/interfaces.ts
@@ -71,6 +71,8 @@ export enum ErrorType {
   RemoteRefNotSupported = "remote-ref-not-supported",
   NoServerInformation = "no-server-information",
   MultipleServerInformation = "multiple-server-information",
+  HttpServerUrlNotSupported = "http-server-url-not-supported",
+  RelativeServerUrlNotSupported = "relative-server-url-not-supported",
   NoSupportedApi = "no-supported-api",
 
   ListFailed = "list-failed",

--- a/packages/fx-core/src/common/spec-parser/specParser.ts
+++ b/packages/fx-core/src/common/spec-parser/specParser.ts
@@ -92,6 +92,23 @@ export class SpecParser {
           content: ConstantString.MultipleServerInformation,
           data: this.spec!.servers,
         });
+      } else if (this.spec!.servers.length === 1) {
+        const serverUrl = this.spec!.servers[0]?.url;
+        if (serverUrl.startsWith("http://")) {
+          // Http server url is not supported
+          errors.push({
+            type: ErrorType.HttpServerUrlNotSupported,
+            content: ConstantString.HttpServerUrlNotSupported,
+            data: this.spec!.servers,
+          });
+        } else if (!serverUrl.startsWith("https://")) {
+          // Relative server url is not supported
+          errors.push({
+            type: ErrorType.RelativeServerUrlNotSupported,
+            content: ConstantString.RelativeServerUrlNotSupported,
+            data: this.spec!.servers,
+          });
+        }
       }
 
       // Remote reference not supported

--- a/packages/fx-core/src/common/spec-parser/specParser.ts
+++ b/packages/fx-core/src/common/spec-parser/specParser.ts
@@ -93,7 +93,7 @@ export class SpecParser {
           data: this.spec!.servers,
         });
       } else if (this.spec!.servers.length === 1) {
-        const serverUrl = this.spec!.servers[0]?.url;
+        const serverUrl = this.spec!.servers[0].url;
         if (serverUrl.startsWith("http://")) {
           // Http server url is not supported
           errors.push({

--- a/packages/fx-core/src/common/spec-parser/utils.ts
+++ b/packages/fx-core/src/common/spec-parser/utils.ts
@@ -7,7 +7,6 @@ import fs from "fs-extra";
 import { ConstantString } from "./constants";
 import { OpenAPIV3 } from "openapi-types";
 import path from "path";
-import url from "url";
 
 export async function isYamlSpecFile(specPath: string): Promise<boolean> {
   if (specPath.endsWith(".yaml") || specPath.endsWith(".yml")) {

--- a/packages/fx-core/src/common/spec-parser/utils.ts
+++ b/packages/fx-core/src/common/spec-parser/utils.ts
@@ -7,6 +7,7 @@ import fs from "fs-extra";
 import { ConstantString } from "./constants";
 import { OpenAPIV3 } from "openapi-types";
 import path from "path";
+import url from "url";
 
 export async function isYamlSpecFile(specPath: string): Promise<boolean> {
   if (specPath.endsWith(".yaml") || specPath.endsWith(".yml")) {
@@ -101,4 +102,13 @@ export function convertPathToCamelCase(path: string): string {
   });
   const camelCasePath = camelCaseSegments.join("");
   return camelCasePath;
+}
+
+export function getUrlProtocol(urlString: string): string | undefined {
+  try {
+    const url = new URL(urlString);
+    return url.protocol;
+  } catch (err) {
+    return undefined;
+  }
 }

--- a/packages/fx-core/tests/common/spec-parser/specParser.test.ts
+++ b/packages/fx-core/tests/common/spec-parser/specParser.test.ts
@@ -130,8 +130,8 @@ describe("SpecParser", () => {
         warnings: [],
         errors: [
           {
-            type: ErrorType.HttpServerUrlNotSupported,
-            content: ConstantString.HttpServerUrlNotSupported,
+            type: ErrorType.UrlProtocolNotSupported,
+            content: util.format(ConstantString.UrlProtocolNotSupported, "http:"),
             data: [{ url: "http://server1" }],
           },
           { type: ErrorType.NoSupportedApi, content: ConstantString.NoSupportedApi },

--- a/packages/fx-core/tests/common/spec-parser/utils.test.ts
+++ b/packages/fx-core/tests/common/spec-parser/utils.test.ts
@@ -11,6 +11,7 @@ import {
   convertPathToCamelCase,
   getRelativePath,
   getResponseJson,
+  getUrlProtocol,
   isSupportedApi,
   isYamlSpecFile,
   updateFirstLetter,
@@ -224,6 +225,32 @@ describe("utils", () => {
       };
       const result = isSupportedApi(method, path, spec as any);
       assert.strictEqual(result, true);
+    });
+  });
+
+  describe("getUrlProtocol", () => {
+    it("should return the protocol of a valid URL", () => {
+      const url = "https://example.com/path/to/file";
+      const protocol = getUrlProtocol(url);
+      expect(protocol).to.equal("https:");
+    });
+
+    it("should return undefined for an invalid URL", () => {
+      const url = "not a url";
+      const protocol = getUrlProtocol(url);
+      expect(protocol).to.be.undefined;
+    });
+
+    it("should return undefined for relative url", () => {
+      const url = "/v3";
+      const protocol = getUrlProtocol(url);
+      expect(protocol).to.be.undefined;
+    });
+
+    it("should return the protocol for other protocol", () => {
+      const url = "ftp://v1";
+      const protocol = getUrlProtocol(url);
+      expect(protocol).to.equal("ftp:");
     });
   });
 


### PR DESCRIPTION
According to Josh's [OpenAPI Spec Rules doc](https://microsoft-my.sharepoint-df.com/:w:/p/jofri/EW-09UM7q8ZDu4Wfloi88bcBYKrOZQ4JXVygXfWtgaa6xQ?e=JoQhpS&clickparams=eyJBcHBOYW1lIjoiVGVhbXMtRGVza3RvcCIsIkFwcFZlcnNpb24iOiIyNy8yMzA4MDQwODYxMyIsIkhhc0ZlZGVyYXRlZFVzZXIiOmZhbHNlfQ%3D%3D), server url should also satisfy the following requirements:
1. should be https
2. should be absolute url