### PR TITLE
fix: reserve option values for interactive mode

### DIFF
--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -133,6 +133,7 @@ export interface CLICommand {
     hidden?: boolean;
     name: string;
     options?: CLICommandOption[];
+    reservedOptionNamesInInteractiveMode?: string[];
     sortCommands?: boolean;
     sortOptions?: boolean;
     telemetry?: {

--- a/packages/api/src/cli.ts
+++ b/packages/api/src/cli.ts
@@ -83,6 +83,11 @@ export interface CLICommand {
    * @description default value of global option "--interactive", default value is true
    */
   defaultInteractiveOption?: boolean;
+
+  /**
+   * @description reserve option values in interactive mode
+   */
+  reservedOptionNamesInInteractiveMode?: string[];
 }
 
 export interface CLIFoundCommand extends CLICommand {

--- a/packages/cli/src/commands/engine.ts
+++ b/packages/cli/src/commands/engine.ts
@@ -183,13 +183,10 @@ class CLIEngine {
       }
     } else {
       // discard other options and args for interactive mode
-      const trimOptionValues = pick(context.optionValues, [
-        "projectPath",
-        "env",
-        "correlationId",
-        "platform",
-        "nonInteractive",
-      ]);
+      const reservedOptionNames = (
+        context.command.reservedOptionNamesInInteractiveMode || []
+      ).concat(["projectPath", "env", "correlationId", "platform", "nonInteractive"]);
+      const trimOptionValues = pick(context.optionValues, reservedOptionNames);
       if (
         Object.keys(trimOptionValues).length < Object.keys(context.optionValues).length ||
         context.argumentValues.length

--- a/packages/cli/src/commands/models/permissionGrant.ts
+++ b/packages/cli/src/commands/models/permissionGrant.ts
@@ -18,12 +18,11 @@ export const permissionGrantCommand: CLICommand = {
   examples: [
     {
       command:
-        "teamsfx permission grant --teams-manifest-file ./appPackage/manifest.json --env dev --email other@email.com",
+        "teamsfx permission grant -i false --teams-manifest-file ./appPackage/manifest.json --env dev --email other@email.com",
       description:
         "Grant permission for another Microsoft 365 account to collaborate on the Teams app.",
     },
   ],
-  defaultInteractiveOption: false,
   handler: async (ctx) => {
     const inputs = ctx.optionValues as PermissionGrantInputs & InputsWithProjectPath;
     // print necessary messages

--- a/packages/cli/src/commands/models/permissionStatus.ts
+++ b/packages/cli/src/commands/models/permissionStatus.ts
@@ -25,7 +25,7 @@ export const permissionStatusCommand: CLICommand = {
   telemetry: {
     event: TelemetryEvent.CheckPermission,
   },
-  defaultInteractiveOption: false,
+  reservedOptionNamesInInteractiveMode: ["all"],
   handler: async (ctx) => {
     const inputs = ctx.optionValues as PermissionListInputs & InputsWithProjectPath;
     const listAll = inputs.all || false;

--- a/packages/cli/src/commands/models/provision.ts
+++ b/packages/cli/src/commands/models/provision.ts
@@ -27,7 +27,6 @@ export const provisionCommand: CLICommand = {
       hidden: true,
     },
   ],
-  reservedOptionNamesInInteractiveMode: ["resource-group", "region"],
   telemetry: {
     event: TelemetryEvent.Provision,
   },

--- a/packages/cli/src/commands/models/provision.ts
+++ b/packages/cli/src/commands/models/provision.ts
@@ -5,17 +5,45 @@ import { getFxCore } from "../../activate";
 import { strings } from "../../resource";
 import { TelemetryEvent } from "../../telemetry/cliTelemetryEvents";
 import { EnvOption, ProjectFolderOption } from "../common";
+import { CoreQuestionNames } from "@microsoft/teamsfx-core";
+import { newResourceGroupOption } from "@microsoft/teamsfx-core/build/question/other";
 
 export const provisionCommand: CLICommand = {
   name: "provision",
   description: strings.command.provision.description,
-  options: [EnvOption, ProjectFolderOption],
+  options: [
+    EnvOption,
+    ProjectFolderOption,
+    {
+      name: "resource-group",
+      description: "Specifies resource group name.",
+      type: "string",
+      hidden: true,
+    },
+    {
+      name: "region",
+      description: "Specifies resource group region.",
+      type: "string",
+      hidden: true,
+    },
+  ],
+  reservedOptionNamesInInteractiveMode: ["resource-group", "region"],
   telemetry: {
     event: TelemetryEvent.Provision,
   },
   handler: async (ctx: CLIContext) => {
     const core = getFxCore();
     const inputs = ctx.optionValues as InputsWithProjectPath;
+    if (!ctx.globalOptionValues.interactive) {
+      if (inputs["region"]) {
+        inputs[CoreQuestionNames.TargetResourceGroupName] = {
+          id: newResourceGroupOption,
+          label: newResourceGroupOption,
+        };
+        inputs[CoreQuestionNames.NewResourceGroupName] = inputs["resource-group"];
+        inputs[CoreQuestionNames.NewResourceGroupLocation] = inputs["region"];
+      }
+    }
     const res = await core.provisionResources(inputs);
     return res;
   },

--- a/packages/cli/src/userInteraction.ts
+++ b/packages/cli/src/userInteraction.ts
@@ -434,9 +434,9 @@ class CLIUserInteraction implements UserInteraction {
     config: MultiSelectConfig | SingleSelectConfig
   ): Promise<Result<undefined, FxError>> {
     if (typeof config.options === "function" || typeof config.default === "function") {
-      const bar = this.createProgressBar(config.title, 1);
-      await bar.start();
-      await bar.next(loadingOptionsPlaceholder());
+      // const bar = this.createProgressBar(config.title, 1);
+      // await bar.start();
+      // await bar.next(loadingOptionsPlaceholder());
       try {
         if (typeof config.options === "function") {
           const options = await config.options();
@@ -449,7 +449,7 @@ class CLIUserInteraction implements UserInteraction {
       } catch (e) {
         return err(assembleError(e));
       } finally {
-        await bar.end(true, true);
+        // await bar.end(true, true);
       }
     }
     return ok(undefined);

--- a/packages/cli/src/userInteraction.ts
+++ b/packages/cli/src/userInteraction.ts
@@ -459,9 +459,9 @@ class CLIUserInteraction implements UserInteraction {
     config: InputTextConfig | SelectFileConfig | SelectFilesConfig
   ): Promise<Result<undefined, FxError>> {
     if (typeof config.default === "function") {
-      const bar = this.createProgressBar(config.title, 1);
-      await bar.start();
-      await bar.next(loadingOptionsPlaceholder());
+      // const bar = this.createProgressBar(config.title, 1);
+      // await bar.start();
+      // await bar.next(loadingOptionsPlaceholder());
       try {
         if (typeof config.default === "function") {
           config.default = await config.default();
@@ -470,7 +470,7 @@ class CLIUserInteraction implements UserInteraction {
       } catch (e) {
         return err(assembleError(e));
       } finally {
-        await bar.end(true, true);
+        // await bar.end(true, true);
       }
     }
     return ok(undefined);

--- a/packages/cli/tests/unit/commands.tests.ts
+++ b/packages/cli/tests/unit/commands.tests.ts
@@ -365,6 +365,18 @@ describe("CLI commands", () => {
       const res = await provisionCommand.handler!(ctx);
       assert.isTrue(res.isOk());
     });
+    it("non interactive mode", async () => {
+      sandbox.stub(FxCore.prototype, "provisionResources").resolves(ok(undefined));
+      const ctx: CLIContext = {
+        command: { ...provisionCommand, fullName: "teamsfx" },
+        optionValues: { nonInteractive: true, region: "East US" },
+        globalOptionValues: {},
+        argumentValues: [],
+        telemetryProperties: {},
+      };
+      const res = await provisionCommand.handler!(ctx);
+      assert.isTrue(res.isOk());
+    });
   });
   describe("packageCommand", async () => {
     it("success", async () => {


### PR DESCRIPTION
fix: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/24894372

1. provision add region option for e2e
2. remove prograss bar when loading options
3. reverve option values for interactive model (such as `teamsfx permission status`)