### PR TITLE
fix: filter operations

### DIFF
--- a/packages/fx-core/src/component/generator/copilotPlugin/helper.ts
+++ b/packages/fx-core/src/component/generator/copilotPlugin/helper.ts
@@ -154,8 +154,10 @@ export async function listOperations(
       const manifest = await manifestUtils._readAppManifest(teamsManifestPath);
       if (manifest.isOk()) {
         const existingOperationIds = manifestUtils.getOperationIds(manifest.value);
+        const operationMaps = await specParser.listOperationMap();
+        const existingOperations = existingOperationIds.map((key) => operationMaps.get(key));
         operations = operations.filter(
-          (operation: string) => !existingOperationIds.includes(operation)
+          (operation: string) => !existingOperations.includes(operation)
         );
       } else {
         throw manifest.error;

--- a/packages/fx-core/tests/core/FxCore.test.ts
+++ b/packages/fx-core/tests/core/FxCore.test.ts
@@ -1355,7 +1355,7 @@ describe("copilotPlugin", async () => {
       platform: Platform.VSCode,
       [QuestionNames.Folder]: os.tmpdir(),
       [QuestionNames.ApiSpecLocation]: "test.json",
-      [QuestionNames.ApiOperation]: ["testOperation"],
+      [QuestionNames.ApiOperation]: ["GET /user/{userId}"],
       [QuestionNames.ManifestPath]: "manifest.json",
       projectPath: path.join(os.tmpdir(), appName),
     };
@@ -1367,8 +1367,13 @@ describe("copilotPlugin", async () => {
         commands: [],
       },
     ];
+    const operationMap = new Map<string, string>([
+      ["getUserById", "GET /user/{userId}"],
+      ["getStoreOrder", "GET /store/order"],
+    ]);
     const core = new FxCore(tools);
     sinon.stub(SpecParser.prototype, "generate").resolves();
+    sinon.stub(SpecParser.prototype, "listOperationMap").resolves(operationMap);
     sinon.stub(manifestUtils, "_readAppManifest").resolves(ok(manifest));
     sinon.stub(validationUtils, "validateInputs").resolves(undefined);
     const result = await core.copilotPluginAddAPI(inputs);

--- a/packages/fx-core/tests/question/create.test.ts
+++ b/packages/fx-core/tests/question/create.test.ts
@@ -1070,19 +1070,26 @@ describe("scaffold question", () => {
             platform: Platform.VSCode,
             "manifest-path": "fakePath",
           };
+          const operationMap = new Map<string, string>([
+            ["getUserById", "GET /user/{userId}"],
+            ["getStoreOrder", "GET /store/order"],
+          ]);
 
           sandbox
             .stub(SpecParser.prototype, "validate")
             .resolves({ status: ValidationStatus.Valid, errors: [], warnings: [] });
-          sandbox.stub(SpecParser.prototype, "list").resolves(["get operation1", "get operation2"]);
+          sandbox
+            .stub(SpecParser.prototype, "list")
+            .resolves(["GET /user/{userId}", "GET /store/order"]);
+          sandbox.stub(SpecParser.prototype, "listOperationMap").resolves(operationMap);
           sandbox.stub(manifestUtils, "_readAppManifest").resolves(ok({} as any));
-          sandbox.stub(manifestUtils, "getOperationIds").returns(["get operation1"]);
+          sandbox.stub(manifestUtils, "getOperationIds").returns(["getUserById"]);
           sandbox.stub(fs, "pathExists").resolves(true);
 
           const validationSchema = question.validation as FuncValidation<string>;
           const res = await validationSchema.validFunc!("file", inputs);
           assert.deepEqual(inputs.supportedApisFromApiSpec, [
-            { id: "get operation2", label: "get operation2", groupName: "GET" },
+            { id: "GET /store/order", label: "GET /store/order", groupName: "GET" },
           ]);
           assert.isUndefined(res);
         });


### PR DESCRIPTION
1) Filter operations with correct Id
2) Should include existing operations, otherwise it will be removed from manifest/openAPI spec.