### PR TITLE
fix: aad manifest codelens not work issue

### DIFF
--- a/packages/vscode-extension/src/codeLensProvider.ts
+++ b/packages/vscode-extension/src/codeLensProvider.ts
@@ -489,12 +489,23 @@ export class AadAppTemplateCodeLensProvider implements vscode.CodeLensProvider {
     };
     codeLenses.push(new vscode.CodeLens(new vscode.Range(0, 0, 0, 0), updateCmd));
 
-    const editTemplateCmd = {
-      title: "⚠️This file is auto-generated, click here to edit the manifest template file",
-      command: "fx-extension.editAadManifestTemplate",
-      arguments: [{ fsPath: document.fileName }, TelemetryTriggerFrom.CodeLens],
-    };
-    codeLenses.push(new vscode.CodeLens(new vscode.Range(0, 0, 0, 0), editTemplateCmd));
+    if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
+      const workspaceFolder = vscode.workspace.workspaceFolders[0];
+      const workspacePath: string = workspaceFolder.uri.fsPath;
+      const aadTemplateFileExist = fs.pathExistsSync(
+        `${workspacePath}/${MetadataV3.aadManifestFileName}`
+      );
+
+      if (aadTemplateFileExist) {
+        const editTemplateCmd = {
+          title: "⚠️This file is auto-generated, click here to edit the manifest template file",
+          command: "fx-extension.editAadManifestTemplate",
+          arguments: [{ fsPath: document.fileName }, TelemetryTriggerFrom.CodeLens],
+        };
+        codeLenses.push(new vscode.CodeLens(new vscode.Range(0, 0, 0, 0), editTemplateCmd));
+      }
+    }
+
     return codeLenses;
   }
 }

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -132,6 +132,7 @@ import {
 } from "./utils/commonUtils";
 import { getDefaultString, localize, parseLocale } from "./utils/localizeUtils";
 import { ExtensionSurvey } from "./utils/survey";
+import { MetadataV3 } from "@microsoft/teamsfx-core";
 
 export let core: FxCore;
 export let tools: Tools;
@@ -2149,9 +2150,7 @@ export function editAadManifestTemplate(args: any[]) {
   );
   if (args && args.length > 1) {
     const workspacePath = globalVariables.workspaceUri?.fsPath;
-    const manifestPath = `${
-      workspacePath as string
-    }/${TemplateFolderName}/${AppPackageFolderName}/aad.template.json`;
+    const manifestPath = `${workspacePath as string}/${MetadataV3.aadManifestFileName}`;
     void workspace.openTextDocument(manifestPath).then((document) => {
       void window.showTextDocument(document);
     });

--- a/packages/vscode-extension/test/extension/handlers.test.ts
+++ b/packages/vscode-extension/test/extension/handlers.test.ts
@@ -2185,7 +2185,7 @@ describe("editAadManifestTemplate", () => {
 
     sandbox.assert.calledOnceWithExactly(
       openTextDocumentStub as any,
-      `${workspaceUri.fsPath}/templates/appPackage/aad.template.json`
+      `${workspaceUri.fsPath}/aad.manifest.json`
     );
   });
 
@@ -2217,7 +2217,7 @@ describe("editAadManifestTemplate", () => {
 
     sandbox.assert.calledOnceWithExactly(
       openTextDocumentStub as any,
-      `${workspaceUri}/templates/appPackage/aad.template.json`
+      `${workspaceUri}/aad.manifest.json`
     );
   });
 });


### PR DESCRIPTION
Fix: [Bug 24818861](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/24818861): Click "This file is auto-generated, click here to edit the manifest template file" doesn't response