### PR TITLE
refactor: move adaptive cards to json file for ts/js message extension templates

### DIFF
--- a/templates/js/link-unfurling/src/adaptiveCards/helloWorldCard.json
+++ b/templates/js/link-unfurling/src/adaptiveCards/helloWorldCard.json
@@ -23,11 +23,11 @@
                             "size": "Large",
                             "weight": "Bolder",
                             "text": "Link Unfurling card"
-                          },
-                          {
+                        },
+                        {
                             "type": "TextBlock",
                             "text": "This a sample card for Link Unfurling"
-                          }
+                        }
                     ]
                 }
             ]
@@ -35,11 +35,11 @@
     ],
     "actions": [
         {
-          "type": "Action.OpenUrl",
-          "title": "Link Unfurling Docs",
-          "url": "https://learn.microsoft.com/en-us/microsoftteams/platform/messaging-extensions/how-to/link-unfurling"
+            "type": "Action.OpenUrl",
+            "title": "Link Unfurling Docs",
+            "url": "https://learn.microsoft.com/en-us/microsoftteams/platform/messaging-extensions/how-to/link-unfurling"
         }
-      ],
+    ],
     "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
     "version": "1.4"
-  }
+}

--- a/templates/js/link-unfurling/src/adaptiveCards/helloWorldCard.json
+++ b/templates/js/link-unfurling/src/adaptiveCards/helloWorldCard.json
@@ -1,45 +1,45 @@
 {
-    "type": "AdaptiveCard",
-    "body": [
+  "type": "AdaptiveCard",
+  "body": [
+    {
+      "type": "ColumnSet",
+      "columns": [
         {
-            "type": "ColumnSet",
-            "columns": [
-                {
-                    "type": "Column",
-                    "width": "1",
-                    "items": [
-                        {
-                            "type": "Image",
-                            "url": "https://raw.githubusercontent.com/microsoft/botframework-sdk/master/icon.png"
-                        }
-                    ]
-                },
-                {
-                    "type": "Column",
-                    "width": "2",
-                    "items": [
-                        {
-                            "type": "TextBlock",
-                            "size": "Large",
-                            "weight": "Bolder",
-                            "text": "Link Unfurling card"
-                        },
-                        {
-                            "type": "TextBlock",
-                            "text": "This a sample card for Link Unfurling"
-                        }
-                    ]
-                }
-            ]
-        }
-    ],
-    "actions": [
+          "type": "Column",
+          "width": "1",
+          "items": [
+            {
+              "type": "Image",
+              "url": "https://raw.githubusercontent.com/microsoft/botframework-sdk/master/icon.png"
+            }
+          ]
+        },
         {
-            "type": "Action.OpenUrl",
-            "title": "Link Unfurling Docs",
-            "url": "https://learn.microsoft.com/en-us/microsoftteams/platform/messaging-extensions/how-to/link-unfurling"
+          "type": "Column",
+          "width": "2",
+          "items": [
+            {
+              "type": "TextBlock",
+              "size": "Large",
+              "weight": "Bolder",
+              "text": "Link Unfurling card"
+            },
+            {
+              "type": "TextBlock",
+              "text": "This a sample card for Link Unfurling"
+            }
+          ]
         }
-    ],
-    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
-    "version": "1.4"
+      ]
+    }
+  ],
+  "actions": [
+    {
+      "type": "Action.OpenUrl",
+      "title": "Link Unfurling Docs",
+      "url": "https://learn.microsoft.com/en-us/microsoftteams/platform/messaging-extensions/how-to/link-unfurling"
+    }
+  ],
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.4"
 }

--- a/templates/js/m365-message-extension/package.json.tpl
+++ b/templates/js/m365-message-extension/package.json.tpl
@@ -18,6 +18,8 @@
     "watch": "nodemon ./src/index.js"
   },
   "dependencies": {
+    "adaptive-expressions": "^4.20.0",
+    "adaptivecards-templating": "^2.3.1",
     "botbuilder": "^4.20.0",
     "restify": "^10.0.0"
   },

--- a/templates/js/m365-message-extension/src/adaptiveCards/helloWorldCard.json
+++ b/templates/js/m365-message-extension/src/adaptiveCards/helloWorldCard.json
@@ -1,0 +1,19 @@
+{
+  "type": "AdaptiveCard",
+  "body": [
+    {
+      "type": "TextBlock",
+      "text": "${name}",
+      "wrap": true,
+      "size": "Large"
+    },
+    {
+      "type": "TextBlock",
+      "text": "${description}",
+      "wrap": true,
+      "size": "Medium"
+    }
+  ],
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.4"
+}

--- a/templates/js/m365-message-extension/src/searchApp.js
+++ b/templates/js/m365-message-extension/src/searchApp.js
@@ -1,6 +1,8 @@
 const axios = require("axios");
 const querystring = require("querystring");
 const { TeamsActivityHandler, CardFactory } = require("botbuilder");
+const ACData = require("adaptivecards-templating");
+const helloWorldCard = require("./adaptiveCards/helloWorldCard.json");
 
 class SearchApp extends TeamsActivityHandler {
   constructor() {
@@ -20,24 +22,12 @@ class SearchApp extends TeamsActivityHandler {
 
     const attachments = [];
     response.data.objects.forEach((obj) => {
-      const adaptiveCard = CardFactory.adaptiveCard({
-        $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
-        type: "AdaptiveCard",
-        version: "1.4",
-        body: [
-          {
-            type: "TextBlock",
-            text: `${obj.package.name}`,
-            wrap: true,
-            size: "Large",
-          },
-          {
-            type: "TextBlock",
-            text: `${obj.package.description}`,
-            wrap: true,
-            size: "medium",
-          },
-        ],
+      const template = new ACData.Template(helloWorldCard);
+      const adaptiveCard = template.expand({
+        $root: {
+          name: obj.package.name,
+          description: obj.package.description,
+        },
       });
       const preview = CardFactory.heroCard(obj.package.name);
       const attachment = { ...adaptiveCard, preview };

--- a/templates/js/m365-message-extension/src/searchApp.js
+++ b/templates/js/m365-message-extension/src/searchApp.js
@@ -23,14 +23,14 @@ class SearchApp extends TeamsActivityHandler {
     const attachments = [];
     response.data.objects.forEach((obj) => {
       const template = new ACData.Template(helloWorldCard);
-      const adaptiveCard = template.expand({
+      const card = template.expand({
         $root: {
           name: obj.package.name,
           description: obj.package.description,
         },
       });
       const preview = CardFactory.heroCard(obj.package.name);
-      const attachment = { ...adaptiveCard, preview };
+      const attachment = { ...CardFactory.adaptiveCard(card), preview };
       attachments.push(attachment);
     });
 

--- a/templates/js/message-extension-action/package.json.tpl
+++ b/templates/js/message-extension-action/package.json.tpl
@@ -20,6 +20,8 @@
         "url": "https://github.com"
     },
     "dependencies": {
+        "adaptive-expressions": "^4.20.0",
+        "adaptivecards-templating": "^2.3.1",
         "botbuilder": "^4.20.0",
         "restify": "^10.0.0"
     },

--- a/templates/js/message-extension-action/src/actionApp.js
+++ b/templates/js/message-extension-action/src/actionApp.js
@@ -1,35 +1,20 @@
 const { TeamsActivityHandler, CardFactory } = require("botbuilder");
+const ACData = require("adaptivecards-templating");
+const helloWorldCard = require("./adaptiveCards/helloWorldCard.json");
 
 class ActionApp extends TeamsActivityHandler {
   // Action.
   handleTeamsMessagingExtensionSubmitAction(context, action) {
     // The user has chosen to create a card by choosing the 'Create Card' context menu command.
-    const data = action.data;
-    const attachment = CardFactory.adaptiveCard({
-      $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
-      type: "AdaptiveCard",
-      version: "1.4",
-      body: [
-        {
-          type: "TextBlock",
-          text: `${data.title}`,
-          wrap: true,
-          size: "Large",
-        },
-        {
-          type: "TextBlock",
-          text: `${data.subTitle}`,
-          wrap: true,
-          size: "Medium",
-        },
-        {
-          type: "TextBlock",
-          text: `${data.text}`,
-          wrap: true,
-          size: "Small",
-        },
-      ],
+    const template = new ACData.Template(helloWorldCard);
+    const card = template.expand({
+      $root: {
+        title: action.data.title,
+        subTitle: action.data.subTitle,
+        text: action.data.text,
+      },
     });
+    const attachment = CardFactory.adaptiveCard(card);
     return {
       composeExtension: {
         type: "result",

--- a/templates/js/message-extension-action/src/adaptiveCards/helloWorldCard.json
+++ b/templates/js/message-extension-action/src/adaptiveCards/helloWorldCard.json
@@ -1,0 +1,25 @@
+{
+    "type": "AdaptiveCard",
+    "body": [
+        {
+            "type": "TextBlock",
+            "text": "${title}",
+            "wrap": true,
+            "size": "Large"
+          },
+          {
+            "type": "TextBlock",
+            "text": "${subTitle}",
+            "wrap": true,
+            "size": "Medium"
+          },
+          {
+            "type": "TextBlock",
+            "text": "${text}",
+            "wrap": true,
+            "size": "Small"
+          }
+    ],
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "version": "1.4"
+}

--- a/templates/ts/link-unfurling/src/adaptiveCards/helloWorldCard.json
+++ b/templates/ts/link-unfurling/src/adaptiveCards/helloWorldCard.json
@@ -23,11 +23,11 @@
                             "size": "Large",
                             "weight": "Bolder",
                             "text": "Link Unfurling card"
-                          },
-                          {
+                        },
+                        {
                             "type": "TextBlock",
                             "text": "This a sample card for Link Unfurling"
-                          }
+                        }
                     ]
                 }
             ]
@@ -35,11 +35,11 @@
     ],
     "actions": [
         {
-          "type": "Action.OpenUrl",
-          "title": "Link Unfurling Docs",
-          "url": "https://learn.microsoft.com/en-us/microsoftteams/platform/messaging-extensions/how-to/link-unfurling"
+            "type": "Action.OpenUrl",
+            "title": "Link Unfurling Docs",
+            "url": "https://learn.microsoft.com/en-us/microsoftteams/platform/messaging-extensions/how-to/link-unfurling"
         }
-      ],
+    ],
     "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
     "version": "1.4"
-  }
+}

--- a/templates/ts/link-unfurling/src/adaptiveCards/helloWorldCard.json
+++ b/templates/ts/link-unfurling/src/adaptiveCards/helloWorldCard.json
@@ -1,45 +1,45 @@
 {
-    "type": "AdaptiveCard",
-    "body": [
+  "type": "AdaptiveCard",
+  "body": [
+    {
+      "type": "ColumnSet",
+      "columns": [
         {
-            "type": "ColumnSet",
-            "columns": [
-                {
-                    "type": "Column",
-                    "width": "1",
-                    "items": [
-                        {
-                            "type": "Image",
-                            "url": "https://raw.githubusercontent.com/microsoft/botframework-sdk/master/icon.png"
-                        }
-                    ]
-                },
-                {
-                    "type": "Column",
-                    "width": "2",
-                    "items": [
-                        {
-                            "type": "TextBlock",
-                            "size": "Large",
-                            "weight": "Bolder",
-                            "text": "Link Unfurling card"
-                        },
-                        {
-                            "type": "TextBlock",
-                            "text": "This a sample card for Link Unfurling"
-                        }
-                    ]
-                }
-            ]
-        }
-    ],
-    "actions": [
+          "type": "Column",
+          "width": "1",
+          "items": [
+            {
+              "type": "Image",
+              "url": "https://raw.githubusercontent.com/microsoft/botframework-sdk/master/icon.png"
+            }
+          ]
+        },
         {
-            "type": "Action.OpenUrl",
-            "title": "Link Unfurling Docs",
-            "url": "https://learn.microsoft.com/en-us/microsoftteams/platform/messaging-extensions/how-to/link-unfurling"
+          "type": "Column",
+          "width": "2",
+          "items": [
+            {
+              "type": "TextBlock",
+              "size": "Large",
+              "weight": "Bolder",
+              "text": "Link Unfurling card"
+            },
+            {
+              "type": "TextBlock",
+              "text": "This a sample card for Link Unfurling"
+            }
+          ]
         }
-    ],
-    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
-    "version": "1.4"
+      ]
+    }
+  ],
+  "actions": [
+    {
+      "type": "Action.OpenUrl",
+      "title": "Link Unfurling Docs",
+      "url": "https://learn.microsoft.com/en-us/microsoftteams/platform/messaging-extensions/how-to/link-unfurling"
+    }
+  ],
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.4"
 }

--- a/templates/ts/m365-message-extension/package.json.tpl
+++ b/templates/ts/m365-message-extension/package.json.tpl
@@ -21,6 +21,8 @@
         "url": "https://github.com"
     },
     "dependencies": {
+        "adaptive-expressions": "^4.20.0",
+        "adaptivecards-templating": "^2.3.1",
         "botbuilder": "^4.20.0",
         "restify": "^10.0.0"
     },

--- a/templates/ts/m365-message-extension/src/adaptiveCards/helloWorldCard.json
+++ b/templates/ts/m365-message-extension/src/adaptiveCards/helloWorldCard.json
@@ -1,0 +1,19 @@
+{
+  "type": "AdaptiveCard",
+  "body": [
+    {
+      "type": "TextBlock",
+      "text": "${name}",
+      "wrap": true,
+      "size": "Large"
+    },
+    {
+      "type": "TextBlock",
+      "text": "${description}",
+      "wrap": true,
+      "size": "Medium"
+    }
+  ],
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.4"
+}

--- a/templates/ts/m365-message-extension/src/searchApp.ts
+++ b/templates/ts/m365-message-extension/src/searchApp.ts
@@ -7,6 +7,8 @@ import {
   MessagingExtensionQuery,
   MessagingExtensionResponse,
 } from "botbuilder";
+import * as ACData from "adaptivecards-templating";
+import helloWorldCard from "./adaptiveCards/helloWorldCard.json";
 
 export class SearchApp extends TeamsActivityHandler {
   constructor() {
@@ -28,24 +30,12 @@ export class SearchApp extends TeamsActivityHandler {
 
     const attachments = [];
     response.data.objects.forEach((obj) => {
-      const adaptiveCard = CardFactory.adaptiveCard({
-        $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
-        type: "AdaptiveCard",
-        version: "1.4",
-        body: [
-          {
-            type: "TextBlock",
-            text: `${obj.package.name}`,
-            wrap: true,
-            size: "Large",
-          },
-          {
-            type: "TextBlock",
-            text: `${obj.package.description}`,
-            wrap: true,
-            size: "medium",
-          },
-        ],
+      const template = new ACData.Template(helloWorldCard);
+      const adaptiveCard = template.expand({
+        $root: {
+          name: obj.package.name,
+          description: obj.package.description,
+        },
       });
       const preview = CardFactory.heroCard(obj.package.name);
       const attachment = { ...adaptiveCard, preview };

--- a/templates/ts/m365-message-extension/src/searchApp.ts
+++ b/templates/ts/m365-message-extension/src/searchApp.ts
@@ -31,14 +31,14 @@ export class SearchApp extends TeamsActivityHandler {
     const attachments = [];
     response.data.objects.forEach((obj) => {
       const template = new ACData.Template(helloWorldCard);
-      const adaptiveCard = template.expand({
+      const card = template.expand({
         $root: {
           name: obj.package.name,
           description: obj.package.description,
         },
       });
       const preview = CardFactory.heroCard(obj.package.name);
-      const attachment = { ...adaptiveCard, preview };
+      const attachment = { ...CardFactory.adaptiveCard(card), preview };
       attachments.push(attachment);
     });
 

--- a/templates/ts/message-extension-action/package.json.tpl
+++ b/templates/ts/message-extension-action/package.json.tpl
@@ -21,6 +21,8 @@
         "url": "https://github.com"
     },
     "dependencies": {
+        "adaptive-expressions": "^4.20.0",
+        "adaptivecards-templating": "^2.3.1",
         "botbuilder": "^4.20.0",
         "restify": "^10.0.0"
     },

--- a/templates/ts/message-extension-action/src/actionApp.ts
+++ b/templates/ts/message-extension-action/src/actionApp.ts
@@ -5,6 +5,8 @@ import {
   MessagingExtensionAction,
   MessagingExtensionActionResponse,
 } from "botbuilder";
+import * as ACData from "adaptivecards-templating";
+import helloWorldCard from "./adaptiveCards/helloWorldCard.json";
 
 export class ActionApp extends TeamsActivityHandler {
   //Action
@@ -13,32 +15,15 @@ export class ActionApp extends TeamsActivityHandler {
     action: MessagingExtensionAction
   ): Promise<MessagingExtensionActionResponse> {
     // The user has chosen to create a card by choosing the 'Create Card' context menu command.
-    const data = action.data;
-    const attachment = CardFactory.adaptiveCard({
-      $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
-      type: "AdaptiveCard",
-      version: "1.4",
-      body: [
-        {
-          type: "TextBlock",
-          text: `${data.title}`,
-          wrap: true,
-          size: "Large",
-        },
-        {
-          type: "TextBlock",
-          text: `${data.subTitle}`,
-          wrap: true,
-          size: "Medium",
-        },
-        {
-          type: "TextBlock",
-          text: `${data.text}`,
-          wrap: true,
-          size: "Small",
-        },
-      ],
+    const template = new ACData.Template(helloWorldCard);
+    const card = template.expand({
+      $root: {
+        title: action.data.title,
+        subTitle: action.data.subTitle,
+        text: action.data.text,
+      },
     });
+    const attachment = CardFactory.adaptiveCard(card);
     return {
       composeExtension: {
         type: "result",

--- a/templates/ts/message-extension-action/src/adaptiveCards/helloWorldCard.json
+++ b/templates/ts/message-extension-action/src/adaptiveCards/helloWorldCard.json
@@ -1,0 +1,25 @@
+{
+    "type": "AdaptiveCard",
+    "body": [
+        {
+            "type": "TextBlock",
+            "text": "${title}",
+            "wrap": true,
+            "size": "Large"
+          },
+          {
+            "type": "TextBlock",
+            "text": "${subTitle}",
+            "wrap": true,
+            "size": "Medium"
+          },
+          {
+            "type": "TextBlock",
+            "text": "${text}",
+            "wrap": true,
+            "size": "Small"
+          }
+    ],
+    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+    "version": "1.4"
+}


### PR DESCRIPTION
1. format link unfurling adaptive card json file;
2. move adaptive card to json file for action and search template.

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/24869801/