### PR TITLE
refactor: update eslintrc

### DIFF
--- a/packages/adaptivecards-tools-sdk/.eslintrc.js
+++ b/packages/adaptivecards-tools-sdk/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  parser: "@typescript-eslint/parser",
   parserOptions: {
     tsconfigRootDir: __dirname,
   },

--- a/packages/api/.eslintrc.js
+++ b/packages/api/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  parser: "@typescript-eslint/parser",
   parserOptions: {
     tsconfigRootDir: __dirname,
   },

--- a/packages/cli/.eslintrc.js
+++ b/packages/cli/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  parser: "@typescript-eslint/parser",
   parserOptions: {
     tsconfigRootDir: __dirname,
   },

--- a/packages/eslint-plugin-teamsfx/config/promise.js
+++ b/packages/eslint-plugin-teamsfx/config/promise.js
@@ -6,7 +6,6 @@ module.exports = {
     es6: true,
     node: true,
   },
-  // parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaVersion: 2018,
     sourceType: "module",

--- a/packages/eslint-plugin-teamsfx/config/type.js
+++ b/packages/eslint-plugin-teamsfx/config/type.js
@@ -6,7 +6,6 @@ module.exports = {
     es6: true,
     node: true,
   },
-  // parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaVersion: 2018,
     sourceType: "module",

--- a/packages/extra-shot-mocha/.eslintrc.js
+++ b/packages/extra-shot-mocha/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  parser: "@typescript-eslint/parser",
   parserOptions: {
     tsconfigRootDir: __dirname,
   },

--- a/packages/fx-core/.eslintrc.js
+++ b/packages/fx-core/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  parser: "@typescript-eslint/parser",
   parserOptions: {
     tsconfigRootDir: __dirname,
   },

--- a/packages/manifest/.eslintrc.js
+++ b/packages/manifest/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  parser: "@typescript-eslint/parser",
   parserOptions: {
     tsconfigRootDir: __dirname,
   },

--- a/packages/metrics-ts/.eslintrc.js
+++ b/packages/metrics-ts/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  parser: "@typescript-eslint/parser",
   parserOptions: {
     tsconfigRootDir: __dirname,
   },

--- a/packages/sdk-react/.eslintrc.js
+++ b/packages/sdk-react/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  parser: "@typescript-eslint/parser",
   parserOptions: {
     tsconfigRootDir: __dirname,
   },

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -36,7 +36,7 @@
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
     "@typescript-eslint/eslint-plugin": "^5.13.0",
-    "@typescript-eslint/parser": "^5.13.0",
+    "@typescript-eslint/parser": "^6.5.0",
     "eslint": "^8.15.0",
     "eslint-config-standard": "^17.0.0",
     "eslint-plugin-header": "^3.1.1",

--- a/packages/sdk/.eslintrc.js
+++ b/packages/sdk/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  parser: "@typescript-eslint/parser",
   parserOptions: {
     tsconfigRootDir: __dirname,
   },

--- a/packages/server/.eslintrc.js
+++ b/packages/server/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  parser: "@typescript-eslint/parser",
   parserOptions: {
     tsconfigRootDir: __dirname,
   },

--- a/packages/tests/.eslintrc.js
+++ b/packages/tests/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  parser: "@typescript-eslint/parser",
   parserOptions: {
     tsconfigRootDir: __dirname,
   },

--- a/packages/vscode-extension/.eslintrc.js
+++ b/packages/vscode-extension/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  parser: "@typescript-eslint/parser",
   parserOptions: {
     tsconfigRootDir: __dirname,
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1406,10 +1406,10 @@ importers:
         version: 18.0.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.13.0
-        version: 5.13.0(@typescript-eslint/parser@5.13.0)(eslint@8.15.0)(typescript@5.2.2)
+        version: 5.13.0(@typescript-eslint/parser@6.5.0)(eslint@8.15.0)(typescript@5.2.2)
       '@typescript-eslint/parser':
-        specifier: ^5.13.0
-        version: 5.13.0(eslint@8.15.0)(typescript@5.2.2)
+        specifier: ^6.5.0
+        version: 6.5.0(eslint@8.15.0)(typescript@5.2.2)
       eslint:
         specifier: ^8.15.0
         version: 8.15.0(supports-color@9.4.0)
@@ -1421,7 +1421,7 @@ importers:
         version: 3.1.1(eslint@8.15.0)
       eslint-plugin-import:
         specifier: ^2.25.4
-        version: 2.25.4(@typescript-eslint/parser@5.13.0)(eslint@8.15.0)
+        version: 2.25.4(@typescript-eslint/parser@6.5.0)(eslint@8.15.0)
       eslint-plugin-jest:
         specifier: ^27.2.1
         version: 27.2.1(@typescript-eslint/eslint-plugin@5.13.0)(eslint@8.15.0)(jest@29.4.0)(typescript@5.2.2)
@@ -9026,7 +9026,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin@5.13.0(@typescript-eslint/parser@5.13.0)(eslint@8.15.0)(typescript@5.2.2):
+  /@typescript-eslint/eslint-plugin@5.13.0(@typescript-eslint/parser@6.5.0)(eslint@8.15.0)(typescript@5.2.2):
     resolution: {integrity: sha512-vLktb2Uec81fxm/cfz2Hd6QaWOs8qdmVAZXLdOBX6JFJDhf6oDZpMzZ4/LZ6SFM/5DgDcxIMIvy3F+O9yZBuiQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -9037,7 +9037,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.13.0(eslint@8.15.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 6.5.0(eslint@8.15.0)(typescript@5.2.2)
       '@typescript-eslint/scope-manager': 5.13.0
       '@typescript-eslint/type-utils': 5.13.0(eslint@8.15.0)(typescript@5.2.2)
       '@typescript-eslint/utils': 5.13.0(eslint@8.15.0)(typescript@5.2.2)
@@ -9306,26 +9306,6 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@5.13.0(eslint@8.15.0)(typescript@5.2.2):
-    resolution: {integrity: sha512-GdrU4GvBE29tm2RqWOM0P5QfCtgCyN4hXICj/X9ibKED16136l9ZpoJvCL5pSKtmJzA+NRDzQ312wWMejCVVfg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/scope-manager': 5.13.0
-      '@typescript-eslint/types': 5.13.0
-      '@typescript-eslint/typescript-estree': 5.13.0(typescript@5.2.2)
-      debug: 4.3.4(supports-color@9.4.0)
-      eslint: 8.15.0(supports-color@9.4.0)
-      typescript: 5.2.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/parser@5.62.0(eslint@7.29.0)(typescript@5.0.4):
     resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -9342,6 +9322,27 @@ packages:
       debug: 4.3.4(supports-color@9.4.0)
       eslint: 7.29.0
       typescript: 5.0.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/parser@6.5.0(eslint@8.15.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-LMAVtR5GN8nY0G0BadkG0XIe4AcNMeyEy3DyhKGAh9k4pLSMBO7rF29JvDBpZGCmp5Pgz5RLHP6eCpSYZJQDuQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 6.5.0
+      '@typescript-eslint/types': 6.5.0
+      '@typescript-eslint/typescript-estree': 6.5.0(typescript@5.2.2)
+      '@typescript-eslint/visitor-keys': 6.5.0
+      debug: 4.3.4(supports-color@9.4.0)
+      eslint: 8.15.0(supports-color@9.4.0)
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -9368,6 +9369,14 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
+    dev: true
+
+  /@typescript-eslint/scope-manager@6.5.0:
+    resolution: {integrity: sha512-A8hZ7OlxURricpycp5kdPTH3XnjG85UpJS6Fn4VzeoH4T388gQJ/PGP4ole5NfKt4WDVhmLaQ/dBLNDC4Xl/Kw==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    dependencies:
+      '@typescript-eslint/types': 6.5.0
+      '@typescript-eslint/visitor-keys': 6.5.0
     dev: true
 
   /@typescript-eslint/type-utils@5.13.0(eslint@8.15.0)(supports-color@9.4.0)(typescript@4.5.5):
@@ -9479,6 +9488,11 @@ packages:
   /@typescript-eslint/types@5.62.0:
     resolution: {integrity: sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
+  /@typescript-eslint/types@6.5.0:
+    resolution: {integrity: sha512-eqLLOEF5/lU8jW3Bw+8auf4lZSbbljHR2saKnYqON12G/WsJrGeeDHWuQePoEf9ro22+JkbPfWQwKEC5WwLQ3w==}
+    engines: {node: ^16.0.0 || >=18.0.0}
     dev: true
 
   /@typescript-eslint/typescript-estree@4.28.1(supports-color@9.4.0)(typescript@4.5.5):
@@ -9691,6 +9705,27 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/typescript-estree@6.5.0(typescript@5.2.2):
+    resolution: {integrity: sha512-q0rGwSe9e5Kk/XzliB9h2LBc9tmXX25G0833r7kffbl5437FPWb2tbpIV9wAATebC/018pGa9fwPDuvGN+LxWQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 6.5.0
+      '@typescript-eslint/visitor-keys': 6.5.0
+      debug: 4.3.4(supports-color@9.4.0)
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.5.4
+      ts-api-utils: 1.0.2(typescript@5.2.2)
+      typescript: 5.2.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/utils@5.13.0(eslint@8.15.0)(supports-color@9.4.0)(typescript@4.5.5):
     resolution: {integrity: sha512-+9oHlPWYNl6AwwoEt5TQryEHwiKRVjz7Vk6kaBeD3/kwHE5YqTGHtm/JZY8Bo9ITOeKutFaXnBlMgSATMJALUQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -9824,6 +9859,14 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       '@typescript-eslint/types': 5.62.0
+      eslint-visitor-keys: 3.4.2
+    dev: true
+
+  /@typescript-eslint/visitor-keys@6.5.0:
+    resolution: {integrity: sha512-yCB/2wkbv3hPsh02ZS8dFQnij9VVQXJMN/gbQsaaY+zxALkZnxa/wagvLEFsAWMPv7d7lxQmNsIzGU1w/T/WyA==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    dependencies:
+      '@typescript-eslint/types': 6.5.0
       eslint-visitor-keys: 3.4.2
     dev: true
 
@@ -13947,7 +13990,7 @@ packages:
       eslint-plugin-promise: ^6.0.0
     dependencies:
       eslint: 8.15.0(supports-color@9.4.0)
-      eslint-plugin-import: 2.25.4(@typescript-eslint/parser@5.13.0)(eslint@8.15.0)
+      eslint-plugin-import: 2.25.4(@typescript-eslint/parser@6.5.0)(eslint@8.15.0)
       eslint-plugin-n: 15.6.1(eslint@8.15.0)
       eslint-plugin-promise: 6.1.1(eslint@8.15.0)
     dev: true
@@ -14070,7 +14113,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.13.0(eslint@8.15.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 5.13.0(eslint@8.15.0)(typescript@4.3.2)
       debug: 3.2.7(supports-color@9.4.0)
       eslint: 8.15.0(supports-color@9.4.0)
       eslint-import-resolver-node: 0.3.9(supports-color@9.4.0)
@@ -14102,6 +14145,35 @@ packages:
       '@typescript-eslint/parser': 5.62.0(eslint@7.29.0)(typescript@5.0.4)
       debug: 3.2.7(supports-color@9.4.0)
       eslint: 7.29.0
+      eslint-import-resolver-node: 0.3.9(supports-color@9.4.0)
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /eslint-module-utils@2.8.0(@typescript-eslint/parser@6.5.0)(eslint-import-resolver-node@0.3.9)(eslint@8.15.0):
+    resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 6.5.0(eslint@8.15.0)(typescript@5.2.2)
+      debug: 3.2.7(supports-color@9.4.0)
+      eslint: 8.15.0(supports-color@9.4.0)
       eslint-import-resolver-node: 0.3.9(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
@@ -14285,7 +14357,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.13.0(eslint@8.15.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 5.13.0(eslint@8.15.0)(typescript@4.3.2)
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       debug: 2.6.9(supports-color@9.4.0)
@@ -14337,6 +14409,37 @@ packages:
       - supports-color
     dev: true
 
+  /eslint-plugin-import@2.25.4(@typescript-eslint/parser@6.5.0)(eslint@8.15.0):
+    resolution: {integrity: sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 6.5.0(eslint@8.15.0)(typescript@5.2.2)
+      array-includes: 3.1.6
+      array.prototype.flat: 1.3.1
+      debug: 2.6.9(supports-color@9.4.0)
+      doctrine: 2.1.0
+      eslint: 8.15.0(supports-color@9.4.0)
+      eslint-import-resolver-node: 0.3.9(supports-color@9.4.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.5.0)(eslint-import-resolver-node@0.3.9)(eslint@8.15.0)
+      has: 1.0.3
+      is-core-module: 2.13.0
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.values: 1.1.6
+      resolve: 1.22.4
+      tsconfig-paths: 3.14.2
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+    dev: true
+
   /eslint-plugin-jest@25.7.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@7.29.0)(typescript@5.0.4):
     resolution: {integrity: sha512-PWLUEXeeF7C9QGKqvdSbzLOiLTx+bno7/HC9eefePfEb257QFHg7ye3dh80AZVkaa/RQsBB1Q/ORQvg2X7F0NQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
@@ -14371,7 +14474,7 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.13.0(@typescript-eslint/parser@5.13.0)(eslint@8.15.0)(typescript@5.2.2)
+      '@typescript-eslint/eslint-plugin': 5.13.0(@typescript-eslint/parser@6.5.0)(eslint@8.15.0)(typescript@5.2.2)
       '@typescript-eslint/utils': 5.62.0(eslint@8.15.0)(typescript@5.2.2)
       eslint: 8.15.0(supports-color@9.4.0)
       jest: 29.4.0(@types/node@14.17.4)(ts-node@10.9.1)
@@ -24443,6 +24546,15 @@ packages:
     resolution: {integrity: sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==}
     dependencies:
       utf8-byte-length: 1.0.4
+    dev: true
+
+  /ts-api-utils@1.0.2(typescript@5.2.2):
+    resolution: {integrity: sha512-Cbu4nIqnEdd+THNEsBdkolnOXhg0I8XteoHaEKgvsxpsbWda4IsUut2c187HxywQCvveojow0Dgw/amxtSKVkQ==}
+    engines: {node: '>=16.13.0'}
+    peerDependencies:
+      typescript: '>=4.2.0'
+    dependencies:
+      typescript: 5.2.2
     dev: true
 
   /ts-essentials@9.3.2(typescript@5.0.4):


### PR DESCRIPTION
change the place of importing `typescript-eslint/parser` to make it compatible with typescript version