### PR TITLE
perf(spec-parser): only allow single parameter to manifest for post

### DIFF
--- a/packages/fx-core/src/common/spec-parser/constants.ts
+++ b/packages/fx-core/src/common/spec-parser/constants.ts
@@ -25,8 +25,12 @@ export class ConstantString {
   static readonly UnknownSchema = getLocalizedString("core.common.UnknownSchema");
   // TODO: localization
   static readonly UrlProtocolNotSupported =
-    "Protocol %s is not supported, you should use https protocol instead.";
-  static readonly RelativeServerUrlNotSupported = "Relative server url is not supported.";
+    "Sever url is not correct: protocol %s is not supported, you should use https protocol instead.";
+  static readonly RelativeServerUrlNotSupported =
+    "Server url is not correct: relative server url is not supported.";
+  static readonly ResolveServerUrlFailed =
+    "Resolve server Url failed: environment variable %s is not defined";
+
   static readonly GetMethod = "get";
   static readonly PostMethod = "post";
   static readonly AdaptiveCardVersion = "1.5";

--- a/packages/fx-core/src/common/spec-parser/interfaces.ts
+++ b/packages/fx-core/src/common/spec-parser/interfaces.ts
@@ -78,6 +78,7 @@ export enum ErrorType {
   UrlProtocolNotSupported = "url-protocol-not-supported",
   RelativeServerUrlNotSupported = "relative-server-url-not-supported",
   NoSupportedApi = "no-supported-api",
+  ResolveServerUrlFailed = "resolve-server-url-failed",
 
   ListFailed = "list-failed",
   ListOperationMapFailed = "list-operation-map-failed",

--- a/packages/fx-core/src/common/spec-parser/manifestUpdater.ts
+++ b/packages/fx-core/src/common/spec-parser/manifestUpdater.ts
@@ -55,11 +55,13 @@ export function generateParametersFromSchema(
     schema.type === "boolean" ||
     schema.type === "number"
   ) {
-    parameters.push({
-      name: name,
-      title: updateFirstLetter(name),
-      description: schema.description ?? "",
-    });
+    if (schema.required) {
+      parameters.push({
+        name: name,
+        title: updateFirstLetter(name),
+        description: schema.description ?? "",
+      });
+    }
   } else if (schema.type === "object") {
     const { properties } = schema;
     for (const property in properties) {
@@ -98,11 +100,13 @@ export async function generateCommands(
 
               if (paramObject) {
                 paramObject.forEach((param: OpenAPIV3.ParameterObject) => {
-                  parameters.push({
-                    name: param.name,
-                    title: updateFirstLetter(param.name),
-                    description: param.description ?? "",
-                  });
+                  if (param.required) {
+                    parameters.push({
+                      name: param.name,
+                      title: updateFirstLetter(param.name),
+                      description: param.description ?? "",
+                    });
+                  }
                 });
               }
 

--- a/packages/fx-core/src/common/spec-parser/utils.ts
+++ b/packages/fx-core/src/common/spec-parser/utils.ts
@@ -219,7 +219,7 @@ export function resolveServerUrl(url: string): string {
 export function checkServerUrl(servers: OpenAPIV3.ServerObject[]): ErrorResult[] {
   const errors: ErrorResult[] = [];
 
-  let serverUrl = servers[0].url;
+  let serverUrl;
   try {
     serverUrl = resolveServerUrl(servers[0].url);
   } catch (err) {

--- a/packages/fx-core/tests/common/spec-parser/utils.test.ts
+++ b/packages/fx-core/tests/common/spec-parser/utils.test.ts
@@ -9,6 +9,7 @@ import os from "os";
 import * as util from "util";
 import "mocha";
 import {
+  checkPostBodyRequiredParameters,
   checkRequiredParameters,
   checkServerUrl,
   convertPathToCamelCase,
@@ -16,7 +17,6 @@ import {
   getResponseJson,
   getUrlProtocol,
   isSupportedApi,
-  isSupportedSchema,
   isYamlSpecFile,
   updateFirstLetter,
   validateServer,
@@ -132,6 +132,7 @@ describe("utils", () => {
                 {
                   in: "query",
                   schema: { type: "string" },
+                  required: true,
                 },
               ],
               responses: {
@@ -158,7 +159,7 @@ describe("utils", () => {
       assert.strictEqual(result, true);
     });
 
-    it("should return true if method is POST, path is valid, and parameter is supported", () => {
+    it("should return true if method is POST, path is valid, and no required parameters", () => {
       const method = "POST";
       const path = "/users";
       const spec = {
@@ -210,6 +211,205 @@ describe("utils", () => {
       assert.strictEqual(result, true);
     });
 
+    it("should return true if method is POST, path is valid, parameter is supported and only one required param in parameters", () => {
+      const method = "POST";
+      const path = "/users";
+      const spec = {
+        paths: {
+          "/users": {
+            post: {
+              parameters: [
+                {
+                  in: "query",
+                  required: false,
+                  schema: { type: "string" },
+                },
+              ],
+              requestBody: {
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "object",
+                      properties: {
+                        name: {
+                          type: "string",
+                          required: true,
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+              responses: {
+                200: {
+                  content: {
+                    "application/json": {
+                      schema: {
+                        type: "object",
+                        properties: {
+                          name: {
+                            type: "string",
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      const result = isSupportedApi(method, path, spec as any);
+      assert.strictEqual(result, true);
+    });
+
+    it("should return false if method is POST, path is valid, parameter is supported and both postBody and parameters contains required param", () => {
+      const method = "POST";
+      const path = "/users";
+      const spec = {
+        paths: {
+          "/users": {
+            post: {
+              parameters: [
+                {
+                  in: "query",
+                  required: true,
+                  schema: { type: "string" },
+                },
+              ],
+              requestBody: {
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "object",
+                      properties: {
+                        name: {
+                          type: "string",
+                          required: true,
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+              responses: {
+                200: {
+                  content: {
+                    "application/json": {
+                      schema: {
+                        type: "object",
+                        properties: {
+                          name: {
+                            type: "string",
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      const result = isSupportedApi(method, path, spec as any);
+      assert.strictEqual(result, false);
+    });
+
+    it("should return false if method is POST, but requestBody contains unsupported parameter", () => {
+      const method = "POST";
+      const path = "/users";
+      const spec = {
+        paths: {
+          "/users": {
+            post: {
+              parameters: [
+                {
+                  in: "query",
+                  required: true,
+                  schema: { type: "string" },
+                },
+              ],
+              requestBody: {
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "object",
+                      properties: {
+                        name: {
+                          type: "array",
+                          items: {
+                            type: "string",
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+              responses: {
+                200: {
+                  content: {
+                    "application/json": {
+                      schema: {
+                        type: "object",
+                        properties: {
+                          name: {
+                            type: "string",
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      const result = isSupportedApi(method, path, spec as any);
+      assert.strictEqual(result, false);
+    });
+
+    it("should return true if method is POST, path is valid, parameter is supported and only one required param in postBody", () => {
+      const method = "POST";
+      const path = "/users";
+      const spec = {
+        paths: {
+          "/users": {
+            post: {
+              parameters: [
+                {
+                  in: "query",
+                  required: true,
+                  schema: { type: "string" },
+                },
+              ],
+              responses: {
+                200: {
+                  content: {
+                    "application/json": {
+                      schema: {
+                        type: "object",
+                        properties: {
+                          name: {
+                            type: "string",
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      const result = isSupportedApi(method, path, spec as any);
+      assert.strictEqual(result, true);
+    });
+
     it("should return false if method is GET, path is valid, parameter is supported, but response is empty", () => {
       const method = "GET";
       const path = "/users";
@@ -221,6 +421,7 @@ describe("utils", () => {
                 {
                   in: "query",
                   schema: { type: "string" },
+                  required: true,
                 },
               ],
               responses: {
@@ -464,74 +665,78 @@ describe("utils", () => {
     });
   });
 
-  describe("isSupportedSchema", () => {
-    it("should return true for an empty schema", () => {
+  describe("checkPostBodyRequiredParameters", () => {
+    it("should return 0 for an empty schema", () => {
       const schema = {};
-      expect(isSupportedSchema(schema as OpenAPIV3.SchemaObject)).to.be.true;
+      const result = checkPostBodyRequiredParameters(schema as any);
+      assert.strictEqual(result, 0);
     });
 
-    it("should return true for supported schema types", () => {
-      const schema = { type: "string" };
-      expect(isSupportedSchema(schema as OpenAPIV3.SchemaObject)).to.be.true;
-    });
-
-    it("should return false for unsupported schema types", () => {
-      const schema = { type: "array" };
-      expect(isSupportedSchema(schema as OpenAPIV3.SchemaObject)).to.be.false;
-    });
-
-    it("should return false for nested unsupported schema types", () => {
+    it("should return 1 if the schema has a required string property", () => {
       const schema = {
         type: "object",
         properties: {
-          prop1: { type: "string" },
-          prop2: { type: "array" },
+          name: {
+            type: "string",
+            required: true,
+          },
         },
       };
-      expect(isSupportedSchema(schema as OpenAPIV3.SchemaObject)).to.be.false;
+      const result = checkPostBodyRequiredParameters(schema as any);
+      assert.strictEqual(result, 1);
     });
 
-    it("should return true for nested supported schema types", () => {
+    it("should return 0 if the schema has an optional string property", () => {
       const schema = {
         type: "object",
         properties: {
-          prop1: { type: "string" },
-          prop2: { type: "integer" },
+          name: {
+            type: "string",
+            required: false,
+          },
         },
       };
-      expect(isSupportedSchema(schema as OpenAPIV3.SchemaObject)).to.be.true;
+      const result = checkPostBodyRequiredParameters(schema as any);
+      assert.strictEqual(result, 0);
     });
 
-    it("should return false for complicated unsupported schema types", () => {
+    it("should return the correct count for a nested schema", () => {
       const schema = {
         type: "object",
         properties: {
-          prop1: { type: "string" },
-          prop2: {
+          name: {
+            type: "string",
+            required: true,
+          },
+          address: {
             type: "object",
             properties: {
-              prop3: { type: "array" },
+              street: {
+                type: "string",
+                required: true,
+              },
+              city: {
+                type: "string",
+                required: false,
+              },
             },
           },
         },
       };
-      expect(isSupportedSchema(schema as OpenAPIV3.SchemaObject)).to.be.false;
+      const result = checkPostBodyRequiredParameters(schema as any);
+      assert.strictEqual(result, 2);
     });
 
-    it("should return false for complicated unsupported schema types", () => {
+    it("should return NaN for an unsupported schema type", () => {
       const schema = {
-        type: "object",
-        properties: {
-          prop1: { type: "string" },
-          prop2: {
-            type: "object",
-            properties: {
-              prop3: { type: "string" },
-            },
-          },
+        type: "array",
+        items: {
+          type: "string",
+          required: true,
         },
       };
-      expect(isSupportedSchema(schema as OpenAPIV3.SchemaObject)).to.be.true;
+      const result = checkPostBodyRequiredParameters(schema as any);
+      assert.isNaN(result);
     });
   });
 


### PR DESCRIPTION
1. Each post body property should be a parameter
2. Optional parameter should not map to manifest
3. Resolve server url environment variables