### PR TITLE
build: multi env support for the repair api url

### DIFF
--- a/templates/csharp/copilot-plugin-from-scratch/appPackage/adaptiveCards/repair.data.json
+++ b/templates/csharp/copilot-plugin-from-scratch/appPackage/adaptiveCards/repair.data.json
@@ -1,0 +1,8 @@
+{
+  "id": 1,
+  "title": "Oil change",
+  "description": "Need to drain the old engine oil and replace it with fresh oil to keep the engine lubricated and running smoothly.",
+  "assignedTo": "Karin Blair",
+  "date": "2023-05-23",
+  "image": "https://www.howmuchisit.org/wp-content/uploads/2011/01/oil-change.jpg"
+}

--- a/templates/csharp/copilot-plugin-from-scratch/appPackage/apiSpecFiles/repair.yml
+++ b/templates/csharp/copilot-plugin-from-scratch/appPackage/apiSpecFiles/repair.yml
@@ -3,6 +3,9 @@ info:
   title: Repair Service
   description: A simple service to manage repairs
   version: 1.0.0
+services:
+  - url: {{OPENAPI_SERVER_URL}}
+    description: The repair api server
 paths:
   /repair:
     get:

--- a/templates/csharp/copilot-plugin-from-scratch/appPackage/apiSpecFiles/repair.yml
+++ b/templates/csharp/copilot-plugin-from-scratch/appPackage/apiSpecFiles/repair.yml
@@ -4,7 +4,7 @@ info:
   description: A simple service to manage repairs
   version: 1.0.0
 servers:
-  - url: {{OPENAPI_SERVER_URL}}
+  - url: ${{OPENAPI_SERVER_URL}}/api
     description: The repair api server
 paths:
   /repair:

--- a/templates/csharp/copilot-plugin-from-scratch/appPackage/apiSpecFiles/repair.yml
+++ b/templates/csharp/copilot-plugin-from-scratch/appPackage/apiSpecFiles/repair.yml
@@ -3,7 +3,7 @@ info:
   title: Repair Service
   description: A simple service to manage repairs
   version: 1.0.0
-services:
+servers:
   - url: {{OPENAPI_SERVER_URL}}
     description: The repair api server
 paths:

--- a/templates/csharp/copilot-plugin-from-scratch/appPackage/manifest.json.tpl
+++ b/templates/csharp/copilot-plugin-from-scratch/appPackage/manifest.json.tpl
@@ -19,8 +19,8 @@
         "full": "Full name for {{appName}}"
     },
     "description": {
-        "short": "Easily track and monitor car repair records for stress-free maintenance management.",
-        "full": "The ultimate solution for hassle-free car maintenance management makes tracking and monitoring your vehicle repair records a breeze. With the power of Copilot, you can effortlessly stay informed about your car's maintenance timeline."
+        "short": "Track and monitor car repair records for stress-free maintenance management.",
+        "full": "The ultimate solution for hassle-free car maintenance management makes tracking and monitoring your car repair records a breeze. With the power of Copilot, you can effortlessly stay informed about your car's maintenance timeline."
     },
     "accentColor": "#FFFFFF",
     "composeExtensions": [

--- a/templates/csharp/copilot-plugin-from-scratch/infra/azure.bicep
+++ b/templates/csharp/copilot-plugin-from-scratch/infra/azure.bicep
@@ -78,3 +78,4 @@ var apiEndpoint = 'https://${functionApp.properties.defaultHostName}'
 // The output will be persisted in .env.{envName}. Visit https://aka.ms/teamsfx-actions/arm-deploy for more details.
 output API_FUNCTION_ENDPOINT string = apiEndpoint
 output API_FUNCTION_RESOURCE_ID string = functionApp.id
+output OPENAPI_SERVER_URL string = '${apiEndpoint}/api'

--- a/templates/csharp/copilot-plugin-from-scratch/infra/azure.bicep
+++ b/templates/csharp/copilot-plugin-from-scratch/infra/azure.bicep
@@ -78,4 +78,4 @@ var apiEndpoint = 'https://${functionApp.properties.defaultHostName}'
 // The output will be persisted in .env.{envName}. Visit https://aka.ms/teamsfx-actions/arm-deploy for more details.
 output API_FUNCTION_ENDPOINT string = apiEndpoint
 output API_FUNCTION_RESOURCE_ID string = functionApp.id
-output OPENAPI_SERVER_URL string = '${apiEndpoint}/api'
+output OPENAPI_SERVER_URL string = apiEndpoint

--- a/templates/js/copilot-plugin-from-scratch/.vscode/tasks.json
+++ b/templates/js/copilot-plugin-from-scratch/.vscode/tasks.json
@@ -46,7 +46,7 @@
                         "protocol": "http",
                         "access": "public",
                         "writeToEnvironmentFile": {
-                            "endpoint": "OPENAPI_SERVER_URL",
+                            "endpoint": "OPENAPI_SERVER_URL", // output tunnel endpoint as OPENAPI_SERVER_URL
                         }
                     }
                 ],

--- a/templates/js/copilot-plugin-from-scratch/.vscode/tasks.json
+++ b/templates/js/copilot-plugin-from-scratch/.vscode/tasks.json
@@ -8,6 +8,7 @@
             "label": "Start Teams App Locally",
             "dependsOn": [
                 "Validate prerequisites",
+                "Start local tunnel",
                 "Create resources",
                 "Build project",
                 "Start application"
@@ -30,6 +31,29 @@
                     9229
                 ]
             }
+        },
+        {
+            // Start the local tunnel service to forward public URL to local port and inspect traffic.
+            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions.
+            "label": "Start local tunnel",
+            "type": "teamsfx",
+            "command": "debug-start-local-tunnel",
+            "args": {
+                "type": "dev-tunnel",
+                "ports": [
+                    {
+                        "portNumber": 7071,
+                        "protocol": "http",
+                        "access": "public",
+                        "writeToEnvironmentFile": {
+                            "endpoint": "OPENAPI_SERVER_URL",
+                        }
+                    }
+                ],
+                "env": "local"
+            },
+            "isBackground": true,
+            "problemMatcher": "$teamsfx-local-tunnel-watch"
         },
         {
             "label": "Create resources",

--- a/templates/js/copilot-plugin-from-scratch/appPackage/adaptiveCards/repair.data.json
+++ b/templates/js/copilot-plugin-from-scratch/appPackage/adaptiveCards/repair.data.json
@@ -1,0 +1,8 @@
+{
+  "id": 1,
+  "title": "Oil change",
+  "description": "Need to drain the old engine oil and replace it with fresh oil to keep the engine lubricated and running smoothly.",
+  "assignedTo": "Karin Blair",
+  "date": "2023-05-23",
+  "image": "https://www.howmuchisit.org/wp-content/uploads/2011/01/oil-change.jpg"
+}

--- a/templates/js/copilot-plugin-from-scratch/appPackage/apiSpecFiles/repair.yml
+++ b/templates/js/copilot-plugin-from-scratch/appPackage/apiSpecFiles/repair.yml
@@ -3,6 +3,9 @@ info:
   title: Repair Service
   description: A simple service to manage repairs
   version: 1.0.0
+services:
+  - url: {{OPENAPI_SERVER_URL}}
+    description: The repair api server
 paths:
   /repair:
     get:

--- a/templates/js/copilot-plugin-from-scratch/appPackage/apiSpecFiles/repair.yml
+++ b/templates/js/copilot-plugin-from-scratch/appPackage/apiSpecFiles/repair.yml
@@ -4,7 +4,7 @@ info:
   description: A simple service to manage repairs
   version: 1.0.0
 servers:
-  - url: {{OPENAPI_SERVER_URL}}
+  - url: ${{OPENAPI_SERVER_URL}}/api
     description: The repair api server
 paths:
   /repair:

--- a/templates/js/copilot-plugin-from-scratch/appPackage/apiSpecFiles/repair.yml
+++ b/templates/js/copilot-plugin-from-scratch/appPackage/apiSpecFiles/repair.yml
@@ -3,7 +3,7 @@ info:
   title: Repair Service
   description: A simple service to manage repairs
   version: 1.0.0
-services:
+servers:
   - url: {{OPENAPI_SERVER_URL}}
     description: The repair api server
 paths:

--- a/templates/js/copilot-plugin-from-scratch/appPackage/manifest.json.tpl
+++ b/templates/js/copilot-plugin-from-scratch/appPackage/manifest.json.tpl
@@ -19,8 +19,8 @@
         "full": "Full name for {{appName}}"
     },
     "description": {
-        "short": "Easily track and monitor car repair records for stress-free maintenance management.",
-        "full": "The ultimate solution for hassle-free car maintenance management makes tracking and monitoring your vehicle repair records a breeze. With the power of Copilot, you can effortlessly stay informed about your car's maintenance timeline."
+        "short": "Track and monitor car repair records for stress-free maintenance management.",
+        "full": "The ultimate solution for hassle-free car maintenance management makes tracking and monitoring your car repair records a breeze. With the power of Copilot, you can effortlessly stay informed about your car's maintenance timeline."
     },
     "accentColor": "#FFFFFF",
     "composeExtensions": [

--- a/templates/js/copilot-plugin-from-scratch/infra/azure.bicep
+++ b/templates/js/copilot-plugin-from-scratch/infra/azure.bicep
@@ -78,3 +78,4 @@ var apiEndpoint = 'https://${functionApp.properties.defaultHostName}'
 // The output will be persisted in .env.{envName}. Visit https://aka.ms/teamsfx-actions/arm-deploy for more details.
 output API_FUNCTION_ENDPOINT string = apiEndpoint
 output API_FUNCTION_RESOURCE_ID string = functionApp.id
+output OPENAPI_SERVER_URL string = '${apiEndpoint}/api'

--- a/templates/js/copilot-plugin-from-scratch/infra/azure.bicep
+++ b/templates/js/copilot-plugin-from-scratch/infra/azure.bicep
@@ -78,4 +78,4 @@ var apiEndpoint = 'https://${functionApp.properties.defaultHostName}'
 // The output will be persisted in .env.{envName}. Visit https://aka.ms/teamsfx-actions/arm-deploy for more details.
 output API_FUNCTION_ENDPOINT string = apiEndpoint
 output API_FUNCTION_RESOURCE_ID string = functionApp.id
-output OPENAPI_SERVER_URL string = '${apiEndpoint}/api'
+output OPENAPI_SERVER_URL string = apiEndpoint

--- a/templates/ts/copilot-plugin-from-scratch/.vscode/tasks.json
+++ b/templates/ts/copilot-plugin-from-scratch/.vscode/tasks.json
@@ -46,7 +46,7 @@
                         "protocol": "http",
                         "access": "public",
                         "writeToEnvironmentFile": {
-                            "endpoint": "OPENAPI_SERVER_URL",
+                            "endpoint": "OPENAPI_SERVER_URL", // output tunnel endpoint as OPENAPI_SERVER_URL
                         }
                     }
                 ],

--- a/templates/ts/copilot-plugin-from-scratch/.vscode/tasks.json
+++ b/templates/ts/copilot-plugin-from-scratch/.vscode/tasks.json
@@ -8,6 +8,7 @@
             "label": "Start Teams App Locally",
             "dependsOn": [
                 "Validate prerequisites",
+                "Start local tunnel",
                 "Create resources",
                 "Build project",
                 "Start application"
@@ -30,6 +31,29 @@
                     9229
                 ]
             }
+        },
+        {
+            // Start the local tunnel service to forward public URL to local port and inspect traffic.
+            // See https://aka.ms/teamsfx-tasks/local-tunnel for the detailed args definitions.
+            "label": "Start local tunnel",
+            "type": "teamsfx",
+            "command": "debug-start-local-tunnel",
+            "args": {
+                "type": "dev-tunnel",
+                "ports": [
+                    {
+                        "portNumber": 7071,
+                        "protocol": "http",
+                        "access": "public",
+                        "writeToEnvironmentFile": {
+                            "endpoint": "OPENAPI_SERVER_URL",
+                        }
+                    }
+                ],
+                "env": "local"
+            },
+            "isBackground": true,
+            "problemMatcher": "$teamsfx-local-tunnel-watch"
         },
         {
             "label": "Create resources",

--- a/templates/ts/copilot-plugin-from-scratch/appPackage/adaptiveCards/repair.data.json
+++ b/templates/ts/copilot-plugin-from-scratch/appPackage/adaptiveCards/repair.data.json
@@ -1,0 +1,8 @@
+{
+  "id": 1,
+  "title": "Oil change",
+  "description": "Need to drain the old engine oil and replace it with fresh oil to keep the engine lubricated and running smoothly.",
+  "assignedTo": "Karin Blair",
+  "date": "2023-05-23",
+  "image": "https://www.howmuchisit.org/wp-content/uploads/2011/01/oil-change.jpg"
+}

--- a/templates/ts/copilot-plugin-from-scratch/appPackage/apiSpecFiles/repair.yml
+++ b/templates/ts/copilot-plugin-from-scratch/appPackage/apiSpecFiles/repair.yml
@@ -3,6 +3,9 @@ info:
   title: Repair Service
   description: A simple service to manage repairs
   version: 1.0.0
+services:
+  - url: {{OPENAPI_SERVER_URL}}
+    description: The repair api server
 paths:
   /repair:
     get:

--- a/templates/ts/copilot-plugin-from-scratch/appPackage/apiSpecFiles/repair.yml
+++ b/templates/ts/copilot-plugin-from-scratch/appPackage/apiSpecFiles/repair.yml
@@ -4,7 +4,7 @@ info:
   description: A simple service to manage repairs
   version: 1.0.0
 servers:
-  - url: {{OPENAPI_SERVER_URL}}
+  - url: ${{OPENAPI_SERVER_URL}}/api
     description: The repair api server
 paths:
   /repair:

--- a/templates/ts/copilot-plugin-from-scratch/appPackage/apiSpecFiles/repair.yml
+++ b/templates/ts/copilot-plugin-from-scratch/appPackage/apiSpecFiles/repair.yml
@@ -3,7 +3,7 @@ info:
   title: Repair Service
   description: A simple service to manage repairs
   version: 1.0.0
-services:
+servers:
   - url: {{OPENAPI_SERVER_URL}}
     description: The repair api server
 paths:

--- a/templates/ts/copilot-plugin-from-scratch/appPackage/manifest.json.tpl
+++ b/templates/ts/copilot-plugin-from-scratch/appPackage/manifest.json.tpl
@@ -19,8 +19,8 @@
         "full": "Full name for {{appName}}"
     },
     "description": {
-        "short": "Easily track and monitor car repair records for stress-free maintenance management.",
-        "full": "The ultimate solution for hassle-free car maintenance management makes tracking and monitoring your vehicle repair records a breeze. With the power of Copilot, you can effortlessly stay informed about your car's maintenance timeline."
+        "short": "Track and monitor car repair records for stress-free maintenance management.",
+        "full": "The ultimate solution for hassle-free car maintenance management makes tracking and monitoring your car repair records a breeze. With the power of Copilot, you can effortlessly stay informed about your car's maintenance timeline."
     },
     "accentColor": "#FFFFFF",
     "composeExtensions": [

--- a/templates/ts/copilot-plugin-from-scratch/infra/azure.bicep
+++ b/templates/ts/copilot-plugin-from-scratch/infra/azure.bicep
@@ -78,3 +78,4 @@ var apiEndpoint = 'https://${functionApp.properties.defaultHostName}'
 // The output will be persisted in .env.{envName}. Visit https://aka.ms/teamsfx-actions/arm-deploy for more details.
 output API_FUNCTION_ENDPOINT string = apiEndpoint
 output API_FUNCTION_RESOURCE_ID string = functionApp.id
+output OPENAPI_SERVER_URL string = '${apiEndpoint}/api'

--- a/templates/ts/copilot-plugin-from-scratch/infra/azure.bicep
+++ b/templates/ts/copilot-plugin-from-scratch/infra/azure.bicep
@@ -78,4 +78,4 @@ var apiEndpoint = 'https://${functionApp.properties.defaultHostName}'
 // The output will be persisted in .env.{envName}. Visit https://aka.ms/teamsfx-actions/arm-deploy for more details.
 output API_FUNCTION_ENDPOINT string = apiEndpoint
 output API_FUNCTION_RESOURCE_ID string = functionApp.id
-output OPENAPI_SERVER_URL string = '${apiEndpoint}/api'
+output OPENAPI_SERVER_URL string = apiEndpoint


### PR DESCRIPTION
- Add relevant configurations to allow the URL in [openAPI yaml file](https://github.com/OfficeDev/TeamsFx/pull/9806/files#diff-81e2ba4c92c3a0bf9c08569ac24f2f5983197aeeedc2b76fb3e70fb2cdf134d5R6) to support multi envs.
- Add [repair.data.json](https://github.com/OfficeDev/TeamsFx/pull/9806/files#diff-4ffb9be6d6db1e9828fdd4cb8634e51db10360c4f9453ce9911dcf2b51b4e9c8R1-R8) file to allow users to load sample data when previewing adaptive cards.