### PR TITLE
refactor: adjust sideloading check icon

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -251,8 +251,13 @@
         },
         {
           "command": "fx-extension.refreshSideloading",
-          "when": "view == teamsfx-accounts && viewItem == checkSideloading",
-          "group": "inline"
+          "when": "view == teamsfx-accounts && viewItem =~ /^checkSideloading$|^checkSideloading-info$/",
+          "group": "inline@1"
+        },
+        {
+          "command": "fx-extension.checkSideloading",
+          "when": "view == teamsfx-accounts && viewItem == checkSideloading-info",
+          "group": "inline@2"
         },
         {
           "command": "fx-extension.azureAccountSettings",
@@ -422,6 +427,10 @@
         },
         {
           "command": "fx-extension.refreshSideloading",
+          "when": "false"
+        },
+        {
+          "command": "fx-extension.checkSideloading",
           "when": "false"
         },
         {
@@ -705,6 +714,11 @@
         "command": "fx-extension.refreshSideloading",
         "title": "%teamstoolkit.commands.refresh.title%",
         "icon": "$(refresh)"
+      },
+      {
+        "command": "fx-extension.checkSideloading",
+        "title": "%teamstoolkit.accountTree.sideloadingWarningTooltip%",
+        "icon": "$(info)"
       },
       {
         "command": "fx-extension.signOut",

--- a/packages/vscode-extension/src/treeview/account/common.ts
+++ b/packages/vscode-extension/src/treeview/account/common.ts
@@ -15,7 +15,7 @@ export const errorIcon = new vscode.ThemeIcon(
   "error",
   new vscode.ThemeColor("notificationsErrorIcon.foreground")
 );
-export const infoInco = new vscode.ThemeIcon(
+export const infoIcon = new vscode.ThemeIcon(
   "info",
   new vscode.ThemeColor("notificationsInfoIcon.foreground")
 );

--- a/packages/vscode-extension/src/treeview/account/common.ts
+++ b/packages/vscode-extension/src/treeview/account/common.ts
@@ -15,6 +15,10 @@ export const errorIcon = new vscode.ThemeIcon(
   "error",
   new vscode.ThemeColor("notificationsErrorIcon.foreground")
 );
+export const infoInco = new vscode.ThemeIcon(
+  "info",
+  new vscode.ThemeColor("notificationsInfoIcon.foreground")
+);
 export const warningIcon = new vscode.ThemeIcon(
   "warning",
   new vscode.ThemeColor("editorLightBulb.foreground")

--- a/packages/vscode-extension/src/treeview/account/sideloadingNode.ts
+++ b/packages/vscode-extension/src/treeview/account/sideloadingNode.ts
@@ -9,7 +9,7 @@ import { checkSideloadingCallback } from "../../handlers";
 import { TelemetryTriggerFrom } from "../../telemetry/extTelemetryEvents";
 import { localize } from "../../utils/localizeUtils";
 import { DynamicNode } from "../dynamicNode";
-import { errorIcon, infoInco, passIcon } from "./common";
+import { errorIcon, infoIcon, passIcon } from "./common";
 
 enum ContextValues {
   Normal = "checkSideloading",
@@ -39,7 +39,7 @@ export class SideloadingNode extends DynamicNode {
     }
     if (isSideloadingAllowed === undefined) {
       this.label = localize("teamstoolkit.accountTree.sideloadingStatusUnknown");
-      this.iconPath = infoInco;
+      this.iconPath = infoIcon;
       this.tooltip = localize("teamstoolkit.accountTree.sideloadingStatusUnknownTooltip");
       this.contextValue = ContextValues.Normal;
       this.command = undefined;

--- a/packages/vscode-extension/src/treeview/account/sideloadingNode.ts
+++ b/packages/vscode-extension/src/treeview/account/sideloadingNode.ts
@@ -9,7 +9,12 @@ import { checkSideloadingCallback } from "../../handlers";
 import { TelemetryTriggerFrom } from "../../telemetry/extTelemetryEvents";
 import { localize } from "../../utils/localizeUtils";
 import { DynamicNode } from "../dynamicNode";
-import { errorIcon, passIcon, warningIcon } from "./common";
+import { errorIcon, infoInco, passIcon } from "./common";
+
+enum ContextValues {
+  Normal = "checkSideloading",
+  ShowInfo = "checkSideloading-info",
+}
 
 export class SideloadingNode extends DynamicNode {
   constructor(
@@ -17,7 +22,7 @@ export class SideloadingNode extends DynamicNode {
     public token: string
   ) {
     super("", vscode.TreeItemCollapsibleState.None);
-    this.contextValue = "checkSideloading";
+    this.contextValue = ContextValues.Normal;
   }
 
   public override getChildren(): vscode.ProviderResult<DynamicNode[]> {
@@ -34,16 +39,21 @@ export class SideloadingNode extends DynamicNode {
     }
     if (isSideloadingAllowed === undefined) {
       this.label = localize("teamstoolkit.accountTree.sideloadingStatusUnknown");
-      this.iconPath = warningIcon;
+      this.iconPath = infoInco;
       this.tooltip = localize("teamstoolkit.accountTree.sideloadingStatusUnknownTooltip");
+      this.contextValue = ContextValues.Normal;
+      this.command = undefined;
     } else if (isSideloadingAllowed) {
       this.label = localize("teamstoolkit.accountTree.sideloadingPass");
       this.iconPath = passIcon;
       this.tooltip = localize("teamstoolkit.accountTree.sideloadingPassTooltip");
+      this.contextValue = ContextValues.Normal;
+      this.command = undefined;
     } else {
       this.label = localize("teamstoolkit.accountTree.sideloadingWarning");
       this.iconPath = errorIcon;
       this.tooltip = localize("teamstoolkit.accountTree.sideloadingWarningTooltip");
+      this.contextValue = ContextValues.ShowInfo;
       this.command = {
         title: this.label,
         command: "fx-extension.checkSideloading",

--- a/packages/vscode-extension/test/extension/treeview/account/sideloadingNode.test.ts
+++ b/packages/vscode-extension/test/extension/treeview/account/sideloadingNode.test.ts
@@ -4,7 +4,7 @@ import * as vscode from "vscode";
 
 import * as tools from "@microsoft/teamsfx-core/build/common/tools";
 
-import { errorIcon, passIcon, warningIcon } from "../../../../src/treeview/account/common";
+import { errorIcon, infoIcon, passIcon } from "../../../../src/treeview/account/common";
 import { SideloadingNode } from "../../../../src/treeview/account/sideloadingNode";
 import { DynamicNode } from "../../../../src/treeview/dynamicNode";
 import * as handlers from "../../../../src/handlers";
@@ -21,7 +21,7 @@ describe("sideloadingNode", () => {
     const sideloadingNode = new SideloadingNode(eventEmitter, "");
     const treeItem = await sideloadingNode.getTreeItem();
 
-    chai.assert.equal(treeItem.iconPath, warningIcon);
+    chai.assert.equal(treeItem.iconPath, infoIcon);
   });
 
   it("getTreeItem with invalid token", async () => {


### PR DESCRIPTION
Part of: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/24918417/

- Add info icon when sideloading disabled, including tooltip
- Adjust icon when check fails

Happy Path (unchanged):
<img width="365" alt="image" src="https://github.com/OfficeDev/TeamsFx/assets/7642967/40a6eddd-84bf-498c-a567-34552d63b914">

Disable:
<img width="626" alt="image" src="https://github.com/OfficeDev/TeamsFx/assets/7642967/83577c0c-f28b-4e45-874d-1a3e7d187005">

Unknown:
<img width="368" alt="image" src="https://github.com/OfficeDev/TeamsFx/assets/7642967/e75139d9-e70b-45d3-ae26-d7395f639840">
