### PR TITLE
refactor: update CLI with new ux

### DIFF
--- a/packages/cli/src/commands/models/package.ts
+++ b/packages/cli/src/commands/models/package.ts
@@ -28,6 +28,7 @@ export const packageCommand: CLICommand = {
     EnvOption,
     ProjectFolderOption,
   ],
+  defaultInteractiveOption: false,
   telemetry: {
     event: TelemetryEvent.Build,
   },

--- a/packages/cli/src/commands/models/publish.ts
+++ b/packages/cli/src/commands/models/publish.ts
@@ -14,6 +14,7 @@ export const publishCommand: CLICommand = {
   telemetry: {
     event: TelemetryEvent.Publish,
   },
+  defaultInteractiveOption: false,
   handler: async (ctx: CLIContext) => {
     const inputs = ctx.optionValues as InputsWithProjectPath;
     const core = getFxCore();

--- a/packages/cli/src/commands/models/updateTeamsApp.ts
+++ b/packages/cli/src/commands/models/updateTeamsApp.ts
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { CLICommand, InputsWithProjectPath } from "@microsoft/teamsfx-api";
+import { CLICommand, InputsWithProjectPath, ok, err, Result } from "@microsoft/teamsfx-api";
 import { SelectTeamsManifestOptions } from "@microsoft/teamsfx-core";
 import { getFxCore } from "../../activate";
 import { TelemetryEvent } from "../../telemetry/cliTelemetryEvents";
 import { EnvOption, ProjectFolderOption } from "../common";
+import { MissingRequiredOptionError } from "../../error";
 
 export const updateTeamsAppCommand: CLICommand = {
   name: "teams-app",
@@ -16,8 +17,25 @@ export const updateTeamsAppCommand: CLICommand = {
   defaultInteractiveOption: false,
   handler: async (ctx) => {
     const inputs = ctx.optionValues as InputsWithProjectPath;
+
+    const validateInputsRes = validateInputs(inputs);
+    if (validateInputsRes.isErr()) {
+      return err(validateInputsRes.error);
+    }
+
     const core = getFxCore();
     const res = await core.deployTeamsManifest(inputs);
     return res;
   },
 };
+
+function validateInputs(
+  inputs: InputsWithProjectPath
+): Result<undefined, MissingRequiredOptionError> {
+  if (inputs["manifest-path"] && !inputs.env) {
+    return err(
+      new MissingRequiredOptionError(`teamsfx update ${updateTeamsAppCommand.name}`, "--env")
+    );
+  }
+  return ok(undefined);
+}

--- a/packages/cli/src/commands/models/validate.ts
+++ b/packages/cli/src/commands/models/validate.ts
@@ -16,8 +16,12 @@ export const validateCommand: CLICommand = {
   },
   examples: [
     {
-      command: "teamsfx validate --app-package-file ./appPackage/build/appPackage.zip",
+      command: "teamsfx validate --app-package-file ./appPackage/build/appPackage.dev.zip",
       description: "Validate the Microsoft Teams application package.",
+    },
+    {
+      command: "teamsfx validate --teams-manifest-file ./appPackage/manifest.json --env dev",
+      description: "Validate the Microsoft Teams manifest using its schema.",
     },
   ],
   defaultInteractiveOption: false,

--- a/packages/cli/tests/unit/commands.tests.ts
+++ b/packages/cli/tests/unit/commands.tests.ts
@@ -523,6 +523,22 @@ describe("CLI commands", () => {
       const res = await updateTeamsAppCommand.handler!(ctx);
       assert.isTrue(res.isOk());
     });
+
+    it("MissingRequiredOptionError", async () => {
+      sandbox.stub(FxCore.prototype, "deployTeamsManifest").resolves(ok(undefined));
+      const ctx: CLIContext = {
+        command: { ...updateTeamsAppCommand, fullName: "teamsfx" },
+        optionValues: { "manifest-path": "fakePath" },
+        globalOptionValues: {},
+        argumentValues: [],
+        telemetryProperties: {},
+      };
+      const res = await updateTeamsAppCommand.handler!(ctx);
+      assert.isTrue(res.isErr());
+      if (res.isErr()) {
+        assert.equal(res.error.name, MissingRequiredOptionError.name);
+      }
+    });
   });
   describe("upgradeCommand", async () => {
     it("success", async () => {

--- a/packages/fx-core/src/component/driver/teamsApp/validate.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/validate.ts
@@ -160,7 +160,20 @@ export class ValidateManifestDriver implements StepDriver {
         context.logProvider.info(validationSuccess);
       }
       if (args.showMessage) {
-        context.ui?.showMessage("info", validationSuccess, false);
+        if (context.platform === Platform.CLI) {
+          const outputMessage: Array<{ content: string; color: Colors }> = [
+            {
+              content:
+                "Teams Toolkit has completed checking your app package against validation rules. " +
+                summaryStr +
+                ".",
+              color: Colors.BRIGHT_GREEN,
+            },
+          ];
+          context.logProvider.info(outputMessage);
+        } else {
+          context.ui?.showMessage("info", validationSuccess, false);
+        }
       }
       return ok(new Map());
     }

--- a/packages/fx-core/tests/component/driver/teamsApp/validate.test.ts
+++ b/packages/fx-core/tests/component/driver/teamsApp/validate.test.ts
@@ -99,6 +99,21 @@ describe("teamsApp/validateManifest", async () => {
     chai.assert(result.isOk());
   });
 
+  it("happy path- CLI", async () => {
+    const args: ValidateManifestArgs = {
+      manifestPath:
+        "./tests/plugins/resource/appstudio/resources-multi-env/templates/appPackage/v3.manifest.template.json",
+      showMessage: true,
+    };
+
+    mockedDriverContext.platform = Platform.CLI;
+
+    process.env.CONFIG_TEAMS_APP_NAME = "fakeName";
+
+    const result = (await teamsAppDriver.execute(args, mockedDriverContext)).result;
+    chai.assert(result.isOk());
+  });
+
   it("validation error - no schema", async () => {
     const args: ValidateManifestArgs = {
       manifestPath:


### PR DESCRIPTION
1) Set default mode and examples
2) Update log:
![image](https://github.com/OfficeDev/TeamsFx/assets/71362691/6acdc897-aa37-42ee-855b-b824b79ad7a8)
3) Validate options:
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/25051130
![image](https://github.com/OfficeDev/TeamsFx/assets/71362691/dcb5e300-a53e-4d4f-a8d5-0d858a9b2145)
