### PR TITLE
refactor: add error class for AAD app name too long error

### DIFF
--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -469,7 +469,7 @@
   "driver.aadApp.error.missingEnv": "Environment variable %s is not set.",
   "driver.aadApp.error.generateSecretFailed": "Cannot generate client secret.",
   "driver.aadApp.error.invalidFieldInManifest": "Field %s is missing or invalid in Azure Active Directory app manifest.",
-  "driver.aadApp.error.appNameTooLong": "The name of Azure Active Directory app is too long. The maximum length is 120.",
+  "driver.aadApp.error.appNameTooLong": "The name for this Azure Active Directory app is too long. The maximum length is 120.",
   "driver.aadApp.progressBar.createAadAppTitle": "Creating Azure Active Directory application...",
   "driver.aadApp.progressBar.updateAadAppTitle": "Updating Azure Active Directory application...",
   "driver.aadApp.log.startExecuteDriver": "Executing action %s",

--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -469,6 +469,7 @@
   "driver.aadApp.error.missingEnv": "Environment variable %s is not set.",
   "driver.aadApp.error.generateSecretFailed": "Cannot generate client secret.",
   "driver.aadApp.error.invalidFieldInManifest": "Field %s is missing or invalid in Azure Active Directory app manifest.",
+  "driver.aadApp.error.appNameTooLong": "The name of Azure Active Directory app is too long. The maximum length is 120.",
   "driver.aadApp.progressBar.createAadAppTitle": "Creating Azure Active Directory application...",
   "driver.aadApp.progressBar.updateAadAppTitle": "Updating Azure Active Directory application...",
   "driver.aadApp.log.startExecuteDriver": "Executing action %s",

--- a/packages/fx-core/src/component/driver/aad/create.ts
+++ b/packages/fx-core/src/component/driver/aad/create.ts
@@ -32,6 +32,7 @@ import {
 import { loadStateFromEnv, mapStateToEnv } from "../util/utils";
 import { SignInAudience } from "./interface/signInAudience";
 import { OutputEnvironmentVariableUndefinedError } from "../error/outputEnvironmentVariableUndefinedError";
+import { AadAppNameTooLongError } from "./error/aadAppNameTooLongError";
 
 const actionName = "aadApp/create"; // DO NOT MODIFY the name
 const helpLink = "https://aka.ms/teamsfx-actions/aadapp-create";
@@ -196,6 +197,10 @@ export class CreateAadAppDriver implements StepDriver {
 
     if (invalidParameters.length > 0) {
       throw new InvalidActionInputError(actionName, invalidParameters, helpLink);
+    }
+
+    if (args.name.length > 120) {
+      throw new AadAppNameTooLongError(actionName);
     }
   }
 

--- a/packages/fx-core/src/component/driver/aad/error/aadAppNameTooLongError.ts
+++ b/packages/fx-core/src/component/driver/aad/error/aadAppNameTooLongError.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { UserError } from "@microsoft/teamsfx-api";
+import { getDefaultString, getLocalizedString } from "../../../../common/localizeUtils";
+
+const errorCode = "AadAppNameTooLong";
+const messageKey = "driver.aadApp.error.appNameTooLong";
+
+export class AadAppNameTooLongError extends UserError {
+  constructor(actionName: string) {
+    super({
+      source: actionName,
+      name: errorCode,
+      message: getDefaultString(messageKey),
+      displayMessage: getLocalizedString(messageKey),
+    });
+  }
+}

--- a/packages/fx-core/src/component/driver/botAadApp/create.ts
+++ b/packages/fx-core/src/component/driver/botAadApp/create.ts
@@ -26,6 +26,7 @@ import {
 import { OutputEnvironmentVariableUndefinedError } from "../error/outputEnvironmentVariableUndefinedError";
 import { AadAppClient } from "../aad/utility/aadAppClient";
 import { SignInAudience } from "../aad/interface/signInAudience";
+import { AadAppNameTooLongError } from "../aad/error/aadAppNameTooLongError";
 
 const actionName = "botAadApp/create"; // DO NOT MODIFY the name
 const helpLink = "https://aka.ms/teamsfx-actions/botaadapp-create";
@@ -174,6 +175,10 @@ export class CreateBotAadAppDriver implements StepDriver {
 
     if (invalidParameters.length > 0) {
       throw new InvalidActionInputError(actionName, invalidParameters, helpLink);
+    }
+
+    if (args.name.length > 120) {
+      throw new AadAppNameTooLongError(actionName);
     }
   }
 }

--- a/packages/fx-core/tests/component/driver/aad/create.test.ts
+++ b/packages/fx-core/tests/component/driver/aad/create.test.ts
@@ -22,6 +22,7 @@ import {
 } from "../../../../src/error/common";
 import { UserError } from "@microsoft/teamsfx-api";
 import { OutputEnvironmentVariableUndefinedError } from "../../../../src/component/driver/error/outputEnvironmentVariableUndefinedError";
+import { AadAppNameTooLongError } from "../../../../src/component/driver/aad/error/aadAppNameTooLongError";
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;
@@ -103,6 +104,17 @@ describe("aadAppCreate", async () => {
     result = await createAadAppDriver.execute(args, mockedDriverContext, outputEnvVarNames);
     expect(result.result.isErr()).to.be.true;
     expect(result.result._unsafeUnwrapErr()).is.instanceOf(InvalidActionInputError);
+  });
+
+  it("should throw error if AAD app name exceeds 120 characters", async () => {
+    const invalidAppName = "a".repeat(121);
+    const args: any = {
+      name: invalidAppName,
+      generateClientSecret: false,
+    };
+    const result = await createAadAppDriver.execute(args, mockedDriverContext, outputEnvVarNames);
+    expect(result.result.isErr()).to.be.true;
+    expect(result.result._unsafeUnwrapErr()).is.instanceOf(AadAppNameTooLongError);
   });
 
   it("should throw error if outputEnvVarNames is undefined", async () => {

--- a/packages/fx-core/tests/component/driver/botAadApp/create.test.ts
+++ b/packages/fx-core/tests/component/driver/botAadApp/create.test.ts
@@ -23,6 +23,7 @@ import {
 import { AadAppClient } from "../../../../src/component/driver/aad/utility/aadAppClient";
 import { AADApplication } from "../../../../src/component/driver/aad/interface/AADApplication";
 import { OutputEnvironmentVariableUndefinedError } from "../../../../src/component/driver/error/outputEnvironmentVariableUndefinedError";
+import { AadAppNameTooLongError } from "../../../../src/component/driver/aad/error/aadAppNameTooLongError";
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;
@@ -70,6 +71,20 @@ describe("botAadAppCreate", async () => {
     await expect(
       createBotAadAppDriver.handler(args, mockedDriverContext, outputEnvVarNames)
     ).to.rejectedWith(InvalidActionInputError);
+  });
+
+  it("should throw error if AAD app name exceeds 120 characters", async () => {
+    const invalidAppName = "a".repeat(121);
+    const args: any = {
+      name: invalidAppName,
+    };
+    const result = await createBotAadAppDriver.execute(
+      args,
+      mockedDriverContext,
+      outputEnvVarNames
+    );
+    expect(result.result.isErr()).to.be.true;
+    expect(result.result._unsafeUnwrapErr()).is.instanceOf(AadAppNameTooLongError);
   });
 
   it("should throw error if outputEnvVarNames is undefined", async () => {


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/25051224

Can't reuse `InvalidActionInputError` because it does not contain error details, which is important for this error to tell users how to fix it.
