### PR TITLE
refactor: copilot plugin feature flags

### DIFF
--- a/packages/cli/src/commands/models/create.ts
+++ b/packages/cli/src/commands/models/create.ts
@@ -14,7 +14,7 @@ import {
   CreateProjectInputs,
   CreateProjectOptions,
   QuestionNames,
-  isCopilotPluginEnabled,
+  isApiCopilotPluginEnabled,
 } from "@microsoft/teamsfx-core";
 import chalk from "chalk";
 import { assign } from "lodash";
@@ -26,8 +26,8 @@ import { TelemetryEvent, TelemetryProperty } from "../../telemetry/cliTelemetryE
 import { createSampleCommand } from "./createSample";
 
 function adjustOptions(options: CLICommandOption[]) {
-  if (!isCopilotPluginEnabled()) {
-    //skip copilot plugin options if copilot plugin is not enabled
+  if (!isApiCopilotPluginEnabled()) {
+    //skip copilot plugin options if API copilot plugin is not enabled
     const copilotPluginQuestionNames = [
       QuestionNames.ApiSpecLocation.toString(),
       QuestionNames.OpenAIPluginDomain.toString(),

--- a/packages/cli/tests/unit/commands.tests.ts
+++ b/packages/cli/tests/unit/commands.tests.ts
@@ -103,9 +103,10 @@ describe("CLI commands", () => {
       assert.isTrue(res.isOk());
     });
 
-    it("createProjectOptions - copilot plugin enabled", async () => {
+    it("createProjectOptions - API copilot plugin enabled", async () => {
       mockedEnvRestore = mockedEnv({
         COPILOT_PLUGIN: "true",
+        API_COPILOT_PLUGIN: "true",
       });
       sandbox.stub(activate, "getFxCore").returns(new FxCore({} as any));
       sandbox.stub(FxCore.prototype, "createProject").resolves(ok({ projectPath: "..." }));
@@ -127,6 +128,35 @@ describe("CLI commands", () => {
       );
       assert.isTrue(res.isOk());
     });
+
+    it("createProjectOptions - API copilot plugin disabled but bot Copilot plugin enabled", async () => {
+      mockedEnvRestore = mockedEnv({
+        COPILOT_PLUGIN: "true",
+        API_COPILOT_PLUGIN: "false",
+      });
+      sandbox.stub(activate, "getFxCore").returns(new FxCore({} as any));
+      sandbox.stub(FxCore.prototype, "createProject").resolves(ok({ projectPath: "..." }));
+
+      const ctx: CLIContext = {
+        command: { ...getCreateCommand(), fullName: "teamsfx new" },
+        optionValues: {},
+        globalOptionValues: {},
+        argumentValues: [],
+        telemetryProperties: {},
+      };
+
+      const copilotPluginQuestionNames = [
+        QuestionNames.ApiSpecLocation.toString(),
+        QuestionNames.OpenAIPluginDomain.toString(),
+        QuestionNames.ApiOperation.toString(),
+      ];
+      assert.isTrue(
+        ctx.command.options?.filter((o) => copilotPluginQuestionNames.includes(o.name)).length === 0
+      );
+      const res = await getCreateCommand().handler!(ctx);
+      assert.isTrue(res.isOk());
+    });
+
     it("core return error", async () => {
       sandbox.stub(activate, "getFxCore").returns(new FxCore({} as any));
       sandbox.stub(FxCore.prototype, "createProject").resolves(err(new UserCancelError()));
@@ -967,7 +997,7 @@ describe("CLI read-only commands", () => {
       };
       const res = await listTemplatesCommand.handler!(ctx);
       assert.isTrue(res.isOk());
-      assert.isFalse(!!messages.find((msg) => msg.includes("copilot-plugin-capability")));
+      assert.isFalse(!!messages.find((msg) => msg.includes("copilot-plugin-existing-api")));
     });
     it("table with description", async () => {
       const ctx: CLIContext = {
@@ -991,9 +1021,28 @@ describe("CLI read-only commands", () => {
       const res = await listTemplatesCommand.handler!(ctx);
       assert.isTrue(res.isOk());
     });
-    it("json copilot plugin feature flag enabled", async () => {
+
+    it("json: bot Copilot plugin enabled only", async () => {
       mockedEnvRestore = mockedEnv({
         COPILOT_PLUGIN: "true",
+        API_COPILOT_PLUGIN: "false",
+      });
+      const ctx: CLIContext = {
+        command: { ...listTemplatesCommand, fullName: "teamsfx ..." },
+        optionValues: { format: "json" },
+        globalOptionValues: {},
+        argumentValues: ["key", "value"],
+        telemetryProperties: {},
+      };
+      const res = await listTemplatesCommand.handler!(ctx);
+      assert.isTrue(res.isOk());
+      assert.isFalse(!!messages.find((msg) => msg.includes("copilot-plugin-existing-api")));
+    });
+
+    it("json: API Copilot plugin feature flag enabled", async () => {
+      mockedEnvRestore = mockedEnv({
+        COPILOT_PLUGIN: "true",
+        API_COPILOT_PLUGIN: "true",
       });
       const ctx: CLIContext = {
         command: { ...listTemplatesCommand, fullName: "teamsfx ..." },

--- a/packages/fx-core/src/common/featureFlags.ts
+++ b/packages/fx-core/src/common/featureFlags.ts
@@ -45,7 +45,8 @@ export function isCopilotPluginEnabled(): boolean {
 }
 
 export function isApiCopilotPluginEnabled(): boolean {
-  return isFeatureFlagEnabled(FeatureFlagName.ApiCopilotPlugin, false) && isCopilotPluginEnabled();
+  return isFeatureFlagEnabled(FeatureFlagName.ApiCopilotPlugin, true) && isCopilotPluginEnabled();
+  // return isFeatureFlagEnabled(FeatureFlagName.ApiCopilotPlugin, false) && isCopilotPluginEnabled(); // TODO: update default value to false for September release
 }
 
 export function isCliNewUxEnabled(): boolean {

--- a/packages/fx-core/src/common/featureFlags.ts
+++ b/packages/fx-core/src/common/featureFlags.ts
@@ -45,13 +45,9 @@ export function isCopilotPluginEnabled(): boolean {
 }
 
 export function isApiCopilotPluginEnabled(): boolean {
-  return isFeatureFlagEnabled(FeatureFlagName.ApiCopilotPlugin, false);
+  return isFeatureFlagEnabled(FeatureFlagName.ApiCopilotPlugin, false) && isCopilotPluginEnabled();
 }
 
 export function isCliNewUxEnabled(): boolean {
   return isFeatureFlagEnabled("TEAMSFX_CLI_NEW_UX", false);
-}
-
-export function isApiCopilotPluginEnabled(): boolean {
-  return isCopilotPluginEnabled();
 }

--- a/packages/fx-core/src/common/featureFlags.ts
+++ b/packages/fx-core/src/common/featureFlags.ts
@@ -51,3 +51,7 @@ export function isApiCopilotPluginEnabled(): boolean {
 export function isCliNewUxEnabled(): boolean {
   return isFeatureFlagEnabled("TEAMSFX_CLI_NEW_UX", false);
 }
+
+export function isApiCopilotPluginEnabled(): boolean {
+  return isCopilotPluginEnabled();
+}

--- a/packages/fx-core/src/question/create.ts
+++ b/packages/fx-core/src/question/create.ts
@@ -21,7 +21,7 @@ import { cloneDeep } from "lodash";
 import * as os from "os";
 import * as path from "path";
 import { ConstantString } from "../common/constants";
-import { isCLIDotNetEnabled, isCopilotPluginEnabled } from "../common/featureFlags";
+import { isCLIDotNetEnabled, isCopilotPluginEnabled，  isApiCopilotPluginEnabled, } from "../common/featureFlags";
 import { getLocalizedString } from "../common/localizeUtils";
 import { sampleProvider } from "../common/samples";
 import { convertToAlphanumericOnly } from "../common/utils";
@@ -139,7 +139,7 @@ function projectTypeQuestion(): SingleSelectQuestion {
     dynamicOptions: (inputs: Inputs) => {
       let staticOptions: StaticOptions;
 
-      if (isCopilotPluginEnabled()) {
+      if (isApiCopilotPluginEnabled()) {
         staticOptions = [
           ProjectTypeOptions.copilotPlugin(inputs.platform),
           ProjectTypeOptions.bot(inputs.platform),
@@ -469,7 +469,7 @@ export class CapabilityOptions {
       ...CapabilityOptions.tabs(),
       ...CapabilityOptions.collectMECaps(true),
     ];
-    if (isCopilotPluginEnabled()) {
+    if (isApiCopilotPluginEnabled()) {
       capabilityOptions.push(...CapabilityOptions.copilotPlugins());
     }
     return capabilityOptions;
@@ -1685,7 +1685,7 @@ export function createProjectCliHelpNode(): IQTreeNode {
   if (!isCLIDotNetEnabled()) {
     deleteNames.push(QuestionNames.Runtime);
   }
-  if (!isCopilotPluginEnabled()) {
+  if (!isApiCopilotPluginEnabled()) {
     deleteNames.push(QuestionNames.CopilotPluginExistingApi);
   }
   trimQuestionTreeForCliHelp(node, deleteNames);

--- a/packages/fx-core/src/question/create.ts
+++ b/packages/fx-core/src/question/create.ts
@@ -21,7 +21,11 @@ import { cloneDeep } from "lodash";
 import * as os from "os";
 import * as path from "path";
 import { ConstantString } from "../common/constants";
-import { isCLIDotNetEnabled, isCopilotPluginEnabled，  isApiCopilotPluginEnabled, } from "../common/featureFlags";
+import {
+  isCLIDotNetEnabled,
+  isCopilotPluginEnabled,
+  isApiCopilotPluginEnabled,
+} from "../common/featureFlags";
 import { getLocalizedString } from "../common/localizeUtils";
 import { sampleProvider } from "../common/samples";
 import { convertToAlphanumericOnly } from "../common/utils";

--- a/packages/fx-core/tests/core/FxCore.test.ts
+++ b/packages/fx-core/tests/core/FxCore.test.ts
@@ -1307,9 +1307,10 @@ describe("isEnvFile", async () => {
       }
     });
 
-    it("happy path: copilot feature flag", async () => {
+    it("happy path: API Copilot plugin enabled", async () => {
       const restore = mockedEnv({
         [FeatureFlagName.CopilotPlugin]: "true",
+        [FeatureFlagName.ApiCopilotPlugin]: "true",
       });
       const core = new FxCore(tools);
       const res = await core.getQuestions(Stage.create, { platform: Platform.CLI_HELP });
@@ -1329,6 +1330,34 @@ describe("isEnvFile", async () => {
           "openapi-spec-location",
           "openai-plugin-domain",
           "api-operation",
+          "programming-language",
+          "folder",
+          "app-name",
+        ]);
+      }
+      restore();
+    });
+
+    it("happy path: copilot feature enabled but not API Copilot plugin", async () => {
+      const restore = mockedEnv({
+        [FeatureFlagName.CopilotPlugin]: "true",
+        [FeatureFlagName.ApiCopilotPlugin]: "false",
+      });
+      const core = new FxCore(tools);
+      const res = await core.getQuestions(Stage.create, { platform: Platform.CLI_HELP });
+      assert.isTrue(res.isOk());
+      if (res.isOk()) {
+        const node = res.value;
+        const names: string[] = [];
+        collectNodeNames(node!, names);
+        assert.deepEqual(names, [
+          "capabilities",
+          "bot-host-type-trigger",
+          "spfx-solution",
+          "spfx-install-latest-package",
+          "spfx-framework-type",
+          "spfx-webpart-name",
+          "spfx-folder",
           "programming-language",
           "folder",
           "app-name",

--- a/packages/fx-core/tests/question/create.test.ts
+++ b/packages/fx-core/tests/question/create.test.ts
@@ -1578,7 +1578,7 @@ describe("scaffold question", () => {
       assert.equal(options.length, 17);
     });
   });
-  describe("ME copilot plugin template", () => {
+  describe("ME copilot plugin template only", () => {
     const ui = new MockUserInteraction();
     let mockedEnvRestore: RestoreFn;
     const tools = new MockTools();
@@ -1612,7 +1612,7 @@ describe("scaffold question", () => {
         if (question.name === QuestionNames.ProjectType) {
           const select = question as SingleSelectQuestion;
           const options = await select.dynamicOptions!(inputs);
-          assert.isTrue(options.length === 5);
+          assert.isTrue(options.length === 4);
           return ok({ type: "success", result: ProjectTypeOptions.me().id });
         } else if (question.name === QuestionNames.Capabilities) {
           const select = question as SingleSelectQuestion;

--- a/packages/fx-core/tests/question/create.test.ts
+++ b/packages/fx-core/tests/question/create.test.ts
@@ -663,6 +663,7 @@ describe("scaffold question", () => {
       beforeEach(() => {
         mockedEnvRestore = mockedEnv({
           [FeatureFlagName.CopilotPlugin]: "true",
+          [FeatureFlagName.ApiCopilotPlugin]: "true",
         });
       });
 

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -19,6 +19,7 @@ import {
   VersionState,
   setRegion,
   isCopilotPluginEnabled,
+  isApiCopilotPluginEnabled,
 } from "@microsoft/teamsfx-core";
 
 import {
@@ -590,7 +591,7 @@ function registerMenuCommands(context: vscode.ExtensionContext) {
   );
   context.subscriptions.push(openManifestSchemaCmd);
 
-  if (isCopilotPluginEnabled()) {
+  if (isApiCopilotPluginEnabled()) {
     const addAPICmd = vscode.commands.registerCommand(
       "fx-extension.copilotPluginAddAPI",
       async (...args) => {


### PR DESCRIPTION
COPILOT_PLUGIN: Bot Copilot plugin enabled
API_COPILOT_PLUGIN && COPILOT_PLUGIN: API Copilot Plugin enabled. 

API_COPILOT_PLUGIN - Default is true for now for Dogfood bits. Will update to false before Sept. prerelease.  