### PR TITLE
feat: add v1.3 schema for test tool

### DIFF
--- a/packages/fx-core/resource/yaml-schema/v1.3/yaml.schema.json
+++ b/packages/fx-core/resource/yaml-schema/v1.3/yaml.schema.json
@@ -1,0 +1,1500 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "projectId": {
+      "type": "string",
+      "description": "The projectId used for telemetry."
+    },
+    "environmentFolderPath": {
+      "type": "string",
+      "description": "The folder path of .env files used for variables and different envrironments."
+    },
+    "version": {
+      "type": "string",
+      "description": "The version of the yaml file schema",
+      "const": "v1.3"
+    },
+    "additionalMetadata": {
+      "type": "object",
+      "description": "Metadata property, used by Teams Toolkit only.",
+      "additionalProperties": true,
+      "properties": {
+        "sampleTag": {
+          "type": ["number","string","boolean","object","array", "null", "integer"],
+          "description": "A tag for the sample app used to track telemetry events sent by Teams Toolkit associated with that sample. Pattern: <sample-repo>:<sample-name>"
+        }
+      }
+    },
+    "provision": {
+      "$ref": "#/definitions/lifeCycleArray",
+      "description": "Called by `teamsfx provision`"
+    },
+    "deploy": {
+      "$ref": "#/definitions/lifeCycleArray",
+      "description": "Called by `teamsfx deploy`"
+    },
+    "publish": {
+      "$ref": "#/definitions/lifeCycleArray",
+      "description": "Called by `teamsfx publish`"
+    }
+  },
+  "required": ["version"],
+  "definitions": {
+    "lifeCycleArray": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          { "$ref": "#/definitions/aadAppCreate" },
+          { "$ref": "#/definitions/aadAppUpdate" },
+          { "$ref": "#/definitions/armDeploy" },
+          { "$ref": "#/definitions/azureStorageEnableStaticWebsite" },
+          { "$ref": "#/definitions/cliRunNpmCommand" },
+          { "$ref": "#/definitions/cliRunDotnetCommand" },
+          { "$ref": "#/definitions/cliRunNpxCommand" },
+          { "$ref": "#/definitions/azureStorageDeploy" },
+          { "$ref": "#/definitions/azureAppServiceZipDeploy" },
+          { "$ref": "#/definitions/azureFunctionsZipDeploy" },
+          { "$ref": "#/definitions/teamsAppCreate" },
+          { "$ref": "#/definitions/teamsAppValidateManifest" },
+          { "$ref": "#/definitions/teamsAppValidateAppPackage" },
+          { "$ref": "#/definitions/teamsAppZipAppPackage" },
+          { "$ref": "#/definitions/teamsAppUpdate" },
+          { "$ref": "#/definitions/teamsAppPublishAppPackage" },
+          { "$ref": "#/definitions/botAadAppCreate" },
+          { "$ref": "#/definitions/botframeworkCreate" },
+          { "$ref": "#/definitions/fileCreateOrUpdateEnvironmentFile" },
+          { "$ref": "#/definitions/fileCreateOrUpdateJsonFile" },
+          { "$ref": "#/definitions/devToolInstall" },
+          { "$ref": "#/definitions/teamsAppExtendToM365" },
+          { "$ref": "#/definitions/spfxDeploy" },
+          { "$ref": "#/definitions/teamsAppCopyAppPackageToSPFx" },
+          { "$ref": "#/definitions/script" }
+        ]
+      }
+    },
+    "aadAppCreateBase": {
+      "type": "object",
+      "description": "Create Azure Active Directory application and client secret (optional). Refer to https://aka.ms/teamsfx-actions/aadapp-create for more details.",
+      "required": ["uses", "writeToEnvironmentFile"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "An optional name of this action."
+        },
+        "env": {
+          "type": "object",
+          "description": "Define environment variables for this action.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "uses": {
+          "type": "string",
+          "description": "Create Azure Active Directory application when the environment variable that stores clientId is empty. Also create client secret for the application when generateClientSecret parameter is true and the environment variable that stores clientSecret is empty. When creating new Azure Active Directory application, this action generates clientId, objectId, tenantId, authority and authorityHost. When creating new client secret, this action generates clientSecret. Refer to https://aka.ms/teamsfx-actions/aadapp-create for more details.",
+          "const": "aadApp/create"
+        }
+      }
+    },
+    "aadAppCreateWithSecret": {
+      "type": "object",
+      "additionalProperties": false,
+      "allOf": [ { "$ref": "#/definitions/aadAppCreateBase" } ],
+      "required": ["with", "writeToEnvironmentFile"],
+      "properties": {
+        "name": {},
+        "uses": {},
+        "env": {},
+        "with": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Parameters for this action",
+          "required": ["name", "generateClientSecret", "signInAudience"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The name of Azure Active Directory application. Note: when you run aadApp/update, the Azure Active Directory application name will be updated based on the definition in manifest. If you don't want to change the name, ensure the name in Azure Active Directory application manifest is the same with the name defined here."
+            },
+            "generateClientSecret": {
+              "type": "boolean",
+              "description": "Whether to generate client secret for the Azure Active Directory application. When the value is true, you need to specify the name of environment variable that stores the value of client secret in writeToEnvironmentVariable. For example: `clientSecret: SECRET_MY_AAD_APP_CLIENT_SECRET`.",
+              "const": true
+            },
+            "signInAudience": {
+              "type": "string",
+              "description": "Specifies what Microsoft accounts are supported for the current application.",
+              "enum": ["AzureADMyOrg", "AzureADMultipleOrgs", "AzureADandPersonalMicrosoftAccount", "PersonalMicrosoftAccount"]
+            }
+          }
+        },
+        "writeToEnvironmentFile": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Write environment variables to environment file",
+          "required": ["clientId", "objectId", "clientSecret"],
+          "properties": {
+            "clientId": {
+              "description": "Required. The client (application) id of created Azure Active Directory application.",
+              "$ref": "#/definitions/envVarName"
+            },
+            "objectId": {
+              "description": "Required. The object id of created Azure Active Directory application.",
+              "$ref": "#/definitions/envVarName"
+            },
+            "clientSecret": {
+              "description": "Required when generateClientSecret is true. The generated client secret of the Azure Active Directory application.",
+              "$ref": "#/definitions/secretEnvVarName"
+            },
+            "tenantId": {
+              "description": "The tenant id of created Azure Active Directory application.",
+              "$ref": "#/definitions/envVarName"
+            },
+            "authority": {
+              "description": "The authority of created Azure Active Directory application.",
+              "$ref": "#/definitions/envVarName"
+            },
+            "authorityHost": {
+              "description": "The authority host name of created Azure Active Directory application.",
+              "$ref": "#/definitions/envVarName"
+            }
+          }
+        }
+      }
+    },
+    "aadAppCreateWithoutSecret": {
+      "type": "object",
+      "allOf": [ { "$ref": "#/definitions/aadAppCreateBase" } ],
+      "required": ["with", "writeToEnvironmentFile"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {},
+        "uses": {},
+        "env": {},
+        "with": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Parameters for this action",
+          "required": ["name", "generateClientSecret", "signInAudience"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The name of Azure Active Directory application. Note: when you run aadApp/update, the Azure Active Directory application name will be updated based on the definition in manifest. If you don't want to change the name, ensure the name in Azure Active Directory application manifest is the same with the name defined here."
+            },
+            "generateClientSecret": {
+              "type": "boolean",
+              "description": "Whether to generate client secret for the Azure Active Directory application. When the value is true, you need to specify the name of environment variable that stores the value of client secret in writeToEnvironmentVariable. For example: `clientSecret: SECRET_MY_AAD_APP_CLIENT_SECRET`.",
+              "const": false
+            },
+            "signInAudience": {
+              "type": "string",
+              "description": "Specifies what Microsoft accounts are supported for the current application.",
+              "enum": ["AzureADMyOrg", "AzureADMultipleOrgs", "AzureADandPersonalMicrosoftAccount", "PersonalMicrosoftAccount"]
+            }
+          }
+        },
+        "writeToEnvironmentFile": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Write environment variables to environment file",
+          "required": ["clientId", "objectId"],
+          "properties": {
+            "clientId": {
+              "description": "Required. The client (application) id of created Azure Active Directory application.",
+              "$ref": "#/definitions/envVarName"
+            },
+            "objectId": {
+              "description": "Required. The object id of created Azure Active Directory application.",
+              "$ref": "#/definitions/envVarName"
+            },
+            "tenantId": {
+              "description": "The tenant id of created Azure Active Directory application.",
+              "$ref": "#/definitions/envVarName"
+            },
+            "authority": {
+              "description": "The authority of created Azure Active Directory application.",
+              "$ref": "#/definitions/envVarName"
+            },
+            "authorityHost": {
+              "description": "The authority host name of created Azure Active Directory application.",
+              "$ref": "#/definitions/envVarName"
+            }
+          }
+        }
+      }
+    },
+    "aadAppCreate": {
+      "type": "object",
+      "oneOf": [
+        { "$ref": "#/definitions/aadAppCreateWithoutSecret" },
+        { "$ref": "#/definitions/aadAppCreateWithSecret" }
+      ]
+    },
+    "aadAppUpdate": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Update Azure Active Directory application. Refer to https://aka.ms/teamsfx-actions/aadapp-update for more details.",
+      "required": ["uses", "with"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "An optional name of this action."
+        },
+        "env": {
+          "type": "object",
+          "description": "Define environment variables for this action.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "uses": {
+          "type": "string",
+          "description": "Update Azure Active Directory application based on the given Azure Active Directory application manifest. If the manifest uses AAD_APP_ACCESS_AS_USER_PERMISSION_ID and the environment variable is empty, this action will generate a random id and output it. Refer to https://aka.ms/teamsfx-actions/aadapp-update for more details.",
+          "const": "aadApp/update"
+        },
+        "with": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Parameters for this action",
+          "required": ["manifestPath", "outputFilePath"],
+          "properties": {
+            "manifestPath": {
+              "type": "string",
+              "description": "Path of Azure Active Directory application manifest. Environment variables in the manifest will be replaced before applying the manifest to Azure Active Directory application."
+            },
+            "outputFilePath": {
+              "type": "string",
+              "description": "Generate the final Azure Active Directory application manifest used to update Azure Active Directory application to this path."
+            }
+          }
+        }
+      }
+    },
+    "armDeploy": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Create Azure resources using the referenced Bicep/JSON files. Refer to https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming convertion rule.",
+      "required": ["uses", "with"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "An optional name of this action."
+        },
+        "env": {
+          "type": "object",
+          "description": "Define environment variables for this action.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "uses": {
+          "type": "string",
+          "description": "Create Azure resources using the referenced Bicep/JSON files. Outputs from Bicep/JSON will be persisted in the current Teams Toolkit environment following certain naming convertion. Refer to https://aka.ms/teamsfx-actions/arm-deploy for more details on the naming convertion rule.",
+          "const": "arm/deploy"
+        },
+        "with": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "parameters for this action",
+          "required": ["subscriptionId", "resourceGroupName", "templates"],
+          "properties": {
+            "subscriptionId": {
+              "type": "string",
+              "description": "The subscription id to deploy to"
+            },
+            "resourceGroupName": {
+              "type": "string",
+              "description": "The resource group name to deploy to"
+            },
+            "bicepCliVersion": {
+              "type": "string",
+              "description": "The Bicep CLI version. Bicep CLI will be downloaded to {Home}/.fx/bin/bicep.\n Teams Toolkit defaults to Bicep in PATH if version is not defined."
+            },
+            "templates": {
+              "type": "array",
+              "description": "The list of templates to deploy",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["deploymentName", "path"],
+                "properties": {
+                  "deploymentName": {
+                    "type": "string",
+                    "description": "The name of ARM deployment"
+                  },
+                  "path": {
+                    "type": "string",
+                    "description": "Relative path to ARM template. Both Bicep and JSON format are supported."
+                  },
+                  "parameters": {
+                    "type": "string",
+                    "description": "Relative path to ARM parameters file. Teams Toolkit will expand the environment variable in the parameters file"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "azureStorageEnableStaticWebsite": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Enable static website config for Azure Storage. Refer to https://aka.ms/teamsfx-actions/azure-storage-enable-static-website for more details.",
+      "required": ["uses", "with"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "An optional name of this action."
+        },
+        "env": {
+          "type": "object",
+          "description": "Define environment variables for this action.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "uses": {
+          "type": "string",
+          "description": "Enable static website config for Azure Storage. This action has no output. Refer to https://aka.ms/teamsfx-actions/azure-storage-enable-static-website for more details.",
+          "const": "azureStorage/enableStaticWebsite"
+        },
+        "with": {
+          "type": "object",
+          "description": "parameters for this action",
+          "additionalProperties": false,
+          "required": ["storageResourceId"],
+          "properties": {
+            "storageResourceId": {
+              "type": "string",
+              "description": "The resource id of the storage account"
+            },
+            "indexPage": {
+              "type": "string",
+              "description": "The index page of the static website, default to 'index.html'"
+            },
+            "errorPage": {
+              "type": "string",
+              "description": "The error page of the static website, default to 'index.html'"
+            }
+          }
+        }
+      }
+    },
+    "cliRunNpmCommand": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Execute npm command with arguments. Refer to https://aka.ms/teamsfx-actions/cli-run-npm-command for more details.",
+      "required": ["uses", "with"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "An optional name of this action."
+        },
+        "env": {
+          "type": "object",
+          "description": "Define environment variables for this action.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "uses": {
+          "type": "string",
+          "description": "Execute npm command with arguments. Refer to https://aka.ms/teamsfx-actions/cli-run-npm-command for more details.",
+          "const": "cli/runNpmCommand"
+        },
+        "with": {
+          "type": "object",
+          "description": "parameters for this action",
+          "additionalProperties": false,
+          "required": ["args"],
+          "properties": {
+            "args": {
+              "type": "string",
+              "description": "The arguments passed to the npm command"
+            },
+            "workingDirectory": {
+              "type": "string",
+              "description": "The working directory, default to './'"
+            }
+          }
+        }
+      }
+    },
+    "cliRunDotnetCommand": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Execute dotnet command with arguments. Refer to https://aka.ms/teamsfx-actions/cli-run-dotnet-command for more details.",
+      "required": ["uses", "with"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "An optional name of this action."
+        },
+        "env": {
+          "type": "object",
+          "description": "Define environment variables for this action.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "uses": {
+          "type": "string",
+          "description": "Execute dotnet command with arguments. Refer to https://aka.ms/teamsfx-actions/cli-run-dotnet-command for more details.",
+          "const": "cli/runDotnetCommand"
+        },
+        "with": {
+          "type": "object",
+          "description": "parameters for this action",
+          "additionalProperties": false,
+          "required": ["args"],
+          "properties": {
+            "args": {
+              "type": "string",
+              "description": "The arguments passed to the dotnet command"
+            },
+            "workingDirectory": {
+              "type": "string",
+              "description": "The working directory, default to './'"
+            },
+            "execPath": {
+              "type": "string",
+              "description": "The path to the dotnet executable, default to system path."
+            }
+          }
+        }
+      }
+    },
+    "cliRunNpxCommand": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Execute npx command with arguments. Refer to https://aka.ms/teamsfx-actions/cli-run-npx-command for more details.",
+      "required": ["uses", "with"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "An optional name of this action."
+        },
+        "env": {
+          "type": "object",
+          "description": "Define environment variables for this action.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "uses": {
+          "type": "string",
+          "description": "Execute npx command with arguments. Refer to https://aka.ms/teamsfx-actions/cli-run-npx-command for more details.",
+          "const": "cli/runNpxCommand"
+        },
+        "with": {
+          "type": "object",
+          "description": "parameters for this action",
+          "additionalProperties": false,
+          "required": ["args"],
+          "properties": {
+            "args": {
+              "type": "string",
+              "description": "The arguments passed to the npm command"
+            },
+            "workingDirectory": {
+              "type": "string",
+              "description": "The working directory, default to './'"
+            }
+          }
+        }
+      }
+    },
+    "azureStorageDeploy": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Upload and deploy the project to Azure Storage Service. Refer to https://aka.ms/teamsfx-actions/azure-storage-deploy for more details.",
+      "required": ["uses", "with"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "An optional name of this action."
+        },
+        "env": {
+          "type": "object",
+          "description": "Define environment variables for this action.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "uses": {
+          "type": "string",
+          "description": "This action will upload and deploy the project to Azure Storage Service. This action has no output. Refer to https://aka.ms/teamsfx-actions/azure-storage-deploy for more details.",
+          "const": "azureStorage/deploy"
+        },
+        "with": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "parameters for this action",
+          "required": ["artifactFolder", "resourceId"],
+          "properties": {
+            "artifactFolder": {
+              "type": "string",
+              "description": "Path to the distribution folder that contains the files to deploy."
+            },
+            "resourceId": {
+              "type": "string",
+              "description": "The resource id of the storage account."
+            },
+            "workingDirectory": {
+              "type": "string",
+              "description": "The working directory, deploy program will find ignore file and create upload package file based on this directory, default to './'"
+            },
+            "ignoreFile": {
+              "type": "string",
+              "description": "The path to the ignore file. Any files listed in this file will be ignored during upload. default ignores nothing."
+            }
+          }
+        }
+      }
+    },
+    "azureAppServiceZipDeploy": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Upload and deploy the project to Azure App Service. Refer to https://aka.ms/teamsfx-actions/azure-app-service-deploy for more details.",
+      "required": ["uses", "with"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "An optional name of this action."
+        },
+        "env": {
+          "type": "object",
+          "description": "Define environment variables for this action.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "uses": {
+          "type": "string",
+          "description": "This action will upload and deploy the project to Azure App Service. This action has no output. Refer to https://aka.ms/teamsfx-actions/azure-app-service-deploy for more details.",
+          "const": "azureAppService/zipDeploy"
+        },
+        "with": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "parameters for this action",
+          "required": ["artifactFolder", "resourceId"],
+          "properties": {
+            "artifactFolder": {
+              "type": "string",
+              "description": "Path to the distribution folder that contains the files to deploy."
+            },
+            "resourceId": {
+              "type": "string",
+              "description": "The resource id of the Azure App Service."
+            },
+            "workingDirectory": {
+              "type": "string",
+              "description": "The working directory, deploy program will find ignore file and create upload package file based on this directory, default to './'"
+            },
+            "ignoreFile": {
+              "type": "string",
+              "description": "The path to the ignore file. Any files listed in this file will be ignored during upload. default ignores nothing."
+            },
+            "dryRun": {
+              "type": "boolean",
+              "description": "If true, the action will only package the files to be deployed without actually deploying them. Default to false."
+            },
+            "outputZipFile": {
+              "type": "string",
+              "description": "The path to the packaged zip file. If not specified, the zip file will be saved to the workingDirectory/.deployment/deployment.zip."
+            }
+          }
+        }
+      }
+    },
+    "azureFunctionsZipDeploy": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Upload and deploy the project to Azure Functions. Refer to https://aka.ms/teamsfx-actions/azure-functions-deploy for more details.",
+      "required": ["uses", "with"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "An optional name of this action."
+        },
+        "env": {
+          "type": "object",
+          "description": "Define environment variables for this action.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "uses": {
+          "type": "string",
+          "description": "This action will upload and deploy the project to Azure Functions. This action has no output. Refer to https://aka.ms/teamsfx-actions/azure-functions-deploy for more details.",
+          "const": "azureFunctions/zipDeploy"
+        },
+        "with": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "parameters for this action",
+          "required": ["artifactFolder", "resourceId"],
+          "properties": {
+            "artifactFolder": {
+              "type": "string",
+              "description": "Path to the distribution folder that contains the files to deploy."
+            },
+            "resourceId": {
+              "type": "string",
+              "description": "The resource id of the Azure Functions."
+            },
+            "workingDirectory": {
+              "type": "string",
+              "description": "The working directory, deploy program will find ignore file based on this directory, default to './'"
+            },
+            "ignoreFile": {
+              "type": "string",
+              "description": "The path to the ignore file. Any files listed in this file will be ignored during upload. default ignores nothing."
+            },
+            "dryRun": {
+              "type": "boolean",
+              "description": "If true, the action will only package the files to be deployed without actually deploying them. Default to false."
+            },
+            "outputZipFile": {
+              "type": "string",
+              "description": "The path to the packaged zip file. If not specified, the zip file will be saved to the workingDirectory/.deployment/deployment.zip."
+            }
+          }
+        }
+      }
+    },
+    "teamsAppCreate": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Create a Teams app in Teams Developer Portal. Refer to https://aka.ms/teamsfx-actions/teamsapp-create for more details.",
+      "required": ["uses", "with", "writeToEnvironmentFile"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "An optional name of this action."
+        },
+        "env": {
+          "type": "object",
+          "description": "Define environment variables for this action.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "uses": {
+          "type": "string",
+          "description": "This action will create a new Teams app for you if TEAMS_APP_ID environment variable is empty or the app with TEAMS_APP_ID is not found from Teams Developer Portal. Refer to https://aka.ms/teamsfx-actions/teamsapp-create for more details",
+          "const": "teamsApp/create"
+        },
+        "with": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Parameters for this action",
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Name of the Teams app"
+            }
+          }
+        },
+        "writeToEnvironmentFile": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Write environment variables to environment file",
+          "required": ["teamsAppId"],
+          "properties": {
+            "teamsAppId": {
+              "$ref": "#/definitions/envVarName"
+            }
+          }
+        }
+      }
+    },
+    "teamsAppValidateManifest": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Validate Teams app manifest. Refer to https://aka.ms/teamsfx-actions/teamsapp-validate for more details.",
+      "required": ["uses", "with"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "An optional name of this action."
+        },
+        "env": {
+          "type": "object",
+          "description": "Define environment variables for this action.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "uses": {
+          "type": "string",
+          "description": "This action will validate Teams app manifest with manifest schema. Refer to https://aka.ms/teamsfx-actions/teamsapp-validate for more details.",
+          "const": "teamsApp/validateManifest"
+        },
+        "with": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Parameters for this action",
+          "required": ["manifestPath"],
+          "properties": {
+            "manifestPath": {
+              "type": "string",
+              "description": "Path to Teams app manifest file."
+            }
+          }
+        }
+      }
+    },
+    "teamsAppValidateAppPackage": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Validate Teams app manifest. Refer to https://aka.ms/teamsfx-actions/teamsapp-validate for more details.",
+      "required": ["uses", "with"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "An optional name of this action."
+        },
+        "env": {
+          "type": "object",
+          "description": "Define environment variables for this action.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "uses": {
+          "type": "string",
+          "description": "This action will validate Teams app package file using validation rules. Refer to https://aka.ms/teamsfx-actions/teamsapp-validate for more details.",
+          "const": "teamsApp/validateAppPackage"
+        },
+        "with": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Parameters for this action",
+          "required": ["appPackagePath"],
+          "properties": {
+            "appPackagePath": {
+              "type": "string",
+              "description": "Path to zipped Teams app package file."
+            }
+          }
+        }
+      }
+    },
+    "teamsAppZipAppPackage": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Zip app package with manifest file and icons. Refer to https://aka.ms/teamsfx-actions/teamsapp-zipAppPackage for more details.",
+      "required": ["uses", "with"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "An optional name of this action."
+        },
+        "env": {
+          "type": "object",
+          "description": "Define environment variables for this action.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "uses": {
+          "type": "string",
+          "description": "This action will render Teams app manifest template with environment variables, and zip manifest file with two icons. Refer to https://aka.ms/teamsfx-actions/teamsapp-zipAppPackage for more details.",
+          "const": "teamsApp/zipAppPackage"
+        },
+        "with": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "parameters for this action",
+          "required": ["manifestPath", "outputZipPath", "outputJsonPath"],
+          "properties": {
+            "manifestPath": {
+              "type": "string",
+              "description": "Path to Teams app manifest file"
+            },
+            "outputZipPath": {
+              "type": "string",
+              "description": "Path to the output zip package"
+            },
+            "outputJsonPath": {
+              "type": "string",
+              "description": "Path to the output manifest file"
+            }
+          }
+        }
+      }
+    },
+    "teamsAppUpdate": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Update Teams app in Teams Developer Portal. Refer to https://aka.ms/teamsfx-actions/teamsapp-update for more details.",
+      "required": ["uses", "with"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "An optional name of this action."
+        },
+        "env": {
+          "type": "object",
+          "description": "Define environment variables for this action.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "uses": {
+          "type": "string",
+          "description": "Apply the Teams app manifest to an existing Teams app in Teams Developer Portal. Will use the app id in manifest.json file to determine which Teams app to update. Refer to https://aka.ms/teamsfx-actions/teamsapp-update for more details.",
+          "const": "teamsApp/update"
+        },
+        "with": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "parameters for this action",
+          "required": ["appPackagePath"],
+          "properties": {
+            "appPackagePath": {
+              "type": "string",
+              "description": "Path to Teams app package"
+            }
+          }
+        }
+      }
+    },
+    "teamsAppPublishAppPackage": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Publish Teams app package to Teams Admin center. Refer to https://aka.ms/teamsfx-actions/teamsapp-publish for more details.",
+      "required": ["uses", "with", "writeToEnvironmentFile"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "An optional name of this action."
+        },
+        "env": {
+          "type": "object",
+          "description": "Define environment variables for this action.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "uses": {
+          "type": "string",
+          "description": "Publish Teams app package to Teams Admin center. Refer to https://aka.ms/teamsfx-actions/teamsapp-publish for more details.",
+          "const": "teamsApp/publishAppPackage"
+        },
+        "with": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "parameters for this action",
+          "required": ["appPackagePath"],
+          "properties": {
+            "appPackagePath": {
+              "type": "string",
+              "description": "Path to Teams app package to be published."
+            }
+          }
+        },
+        "writeToEnvironmentFile": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Write environment variables to environment file",
+          "required": ["publishedAppId"],
+          "properties": {
+            "publishedAppId": {
+              "$ref": "#/definitions/envVarName"
+            }
+          }
+        }
+      }
+    },
+    "botAadAppCreate": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Create a new or reuse an existing Azure Active Directory application for bot. Refer to https://aka.ms/teamsfx-actions/botaadapp-create for more details.",
+      "required": ["uses", "with", "writeToEnvironmentFile"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "An optional name of this action."
+        },
+        "env": {
+          "type": "object",
+          "description": "Define environment variables for this action.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "uses": {
+          "type": "string",
+          "description": "Create a new or reuse an existing Azure Active Directory application for bot. Refer to https://aka.ms/teamsfx-actions/botaadapp-create for more details.",
+          "const": "botAadApp/create"
+        },
+        "with": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Parameters for this action",
+          "required": ["name"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "The user-facing display name for this Azure Active Directory application"
+            }
+          }
+        },
+        "writeToEnvironmentFile": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Write environment variables to environment file",
+          "required": ["botId", "botPassword"],
+          "properties": {
+            "botId": {
+              "description": "Required. Client (application) id of the Azure Active Directory application created for bot.",
+              "$ref": "#/definitions/envVarName"
+            },
+            "botPassword": {
+              "description": "Required. Client secret of the Azure Active Directory application created for bot.",
+              "$ref": "#/definitions/secretEnvVarName"
+            }
+          }
+        }        
+      }
+    },
+    "botframeworkCreate": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Create or update the bot registration on dev.botframework.com. Refer to https://aka.ms/teamsfx-actions/botframework-create for more details.",
+      "required": ["uses", "with"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "An optional name of this action."
+        },
+        "env": {
+          "type": "object",
+          "description": "Define environment variables for this action.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "uses": {
+          "type": "string",
+          "description": "Create or update the bot registration on dev.botframework.com. Refer to https://aka.ms/teamsfx-actions/botframework-create for more details.",
+          "const": "botFramework/create"
+        },
+        "with": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "parameters for this action",
+          "required": ["botId", "name", "messagingEndpoint"],
+          "properties": {
+            "botId": {
+              "type": "string",
+              "description": "the AAD app client id of the bot"
+            },
+            "name": {
+              "type": "string",
+              "description": "the name of the bot"
+            },
+            "messagingEndpoint": {
+              "type": "string",
+              "description": "the messaging endpoint of the bot"
+            },
+            "description": {
+              "type": "string",
+              "description": "the long description of the bot"
+            },
+            "iconUrl": {
+              "type": "string",
+              "description": "the icon of the bot, pointed to an existing URL"
+            },
+            "channels": {
+              "type": "array",
+              "description": "the channel(s) to be enabled of the bot",
+              "items": {
+                "oneOf": [{ "$ref": "#/definitions/MsTeamsChannel" }, { "$ref": "#/definitions/M365ExtensionsChannel" }]
+              }
+            }
+          }
+        }
+      }
+    },
+    "MsTeamsChannel": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Microsoft Teams channel",
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Microsoft Teams channel",
+          "enum": ["msteams"]
+        },
+        "callingWebhook": {
+          "type": "string",
+          "description": "Webhook for Microsoft Teams channel calls"
+        }
+      }
+    },
+    "M365ExtensionsChannel": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Microsoft 365 Extensions channel",
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Microsoft 365 Extensions channel",
+          "enum": ["m365extensions"]
+        }
+      }
+    },
+    "fileCreateOrUpdateEnvironmentFile": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Create or update variables to environment file. Refer to https://aka.ms/teamsfx-actions/file-createorupdateenvironmentfile for more details.",
+      "required": ["uses", "with"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "An optional name of this action."
+        },
+        "env": {
+          "type": "object",
+          "description": "Define environment variables for this action.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "uses": {
+          "type": "string",
+          "description": "Create or update variables to environment file. Refer to https://aka.ms/teamsfx-actions/file-createorupdateenvironmentfile for more details.",
+          "const": "file/createOrUpdateEnvironmentFile"
+        },
+        "with": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "parameters for this action",
+          "required": ["envs", "target"],
+          "properties": {
+            "envs": {
+              "type": "object",
+              "description": "the environment variable(s) to be generated",
+              "additionalProperties": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              }
+            },
+            "target": {
+              "type": "string",
+              "description": "The target environment file to be created or updated"
+            }
+          }
+        }
+      }
+    },
+    "fileCreateOrUpdateJsonFile": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Create or update JSON file. Refer to https://aka.ms/teamsfx-actions/file-createorupdatejsonfile for more details.",
+      "required": ["uses", "with"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "An optional name of this action."
+        },
+        "env": {
+          "type": "object",
+          "description": "Define environment variables for this action.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "uses": {
+          "type": "string",
+          "description": "Create or update JSON file. Refer to https://aka.ms/teamsfx-actions/file-createorupdatejsonfile for more details.",
+          "const": "file/createOrUpdateJsonFile"
+        },
+        "with": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "parameters for this action",
+          "required": ["target"],
+          "properties": {
+            "appsettings": {
+              "type": "object",
+              "description": "the app settings to be generated"
+            },
+            "target": {
+              "type": "string",
+              "description": "the target file"
+            },
+            "content": {
+              "type": "object",
+              "description": "the json content to be created or updated, will be merged with existing content"
+            }
+          }
+        }
+      }
+    },
+    "devToolInstall": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Install development tool(s). Refer to https://aka.ms/teamsfx-actions/devtool-install for more details.",
+      "required": ["uses", "with"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "An optional name of this action."
+        },
+        "env": {
+          "type": "object",
+          "description": "Define environment variables for this action.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "uses": {
+          "type": "string",
+          "description": "Install development tool(s). Refer to https://aka.ms/teamsfx-actions/devtool-install for more details.",
+          "const": "devTool/install"
+        },
+        "with": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "parameters for this action",
+          "properties": {
+            "devCert": {
+              "type": "object",
+              "description": "Generate an SSL certificate and install it to the system certificate management center. This will output environment variables specified by `sslCertFile` and `sslKeyFile` to current environment's .env file.",
+              "additionalProperties": false,
+              "required": ["trust"],
+              "properties": {
+                "trust": {
+                  "type": "boolean",
+                  "description": "whether to trust the SSL certificate or not"
+                }
+              }
+            },
+            "func": {
+              "type": "object",
+              "description": "Install Azure Functions Core Tools. This will output environment variable specified by `funcPath` to current environment's .env file.",
+              "additionalProperties": false,
+              "required": [
+                "version"
+              ],
+              "properties": {
+                "version": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "integer"
+                    }
+                  ],
+                  "description": "The version number of Azure Functions Core Tools that follow the Semantic Versioning scheme."
+                },
+                "symlinkDir": {
+                  "type": "string",
+                  "description": "The path of the symlink target for the folder containing Azure Functions Core Tools binaries."
+                }
+              }
+            },
+            "dotnet": {
+              "type": "boolean",
+              "description": "Install .NET SDK. This will output environment variables specified by `dotnetPath` to current environment's .env file."
+            },
+            "testTool": {
+              "type": "object",
+              "description": "Install Teams App Test Tool. This will output environment variables specified by `testToolPath` to current environment's .env file.",
+              "additionalProperties": false,
+              "required": [
+                "version",
+                "symlinkDir"
+              ],
+              "properties": {
+                "version": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "integer"
+                    }
+                  ],
+                  "description": "The version number of Teams App Test Tool npm package that follow the Semantic Versioning scheme."
+                },
+                "symlinkDir": {
+                  "type": "string",
+                  "description": "The path of the symlink target for the folder containing Teams App Test Tool binaries."
+                }
+              }
+            }
+          }
+        },
+        "writeToEnvironmentFile": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Write environment variables to environment file",
+          "properties": {
+            "sslCertFile": {
+              "description": "The path of the certificate file of the SSL certificate. This parameter takes effect only when `devCert` is specified.",
+              "$ref": "#/definitions/envVarName"
+            },
+            "sslKeyFile": {
+              "description": "The path of the key file of the SSL certificate. This parameter takes effect only when `devCert` is specified.",
+              "$ref": "#/definitions/envVarName"
+            },
+            "funcPath": {
+              "description": "The path of the Azure Functions Core Tools binary. This parameter takes effect only when `func` is `true`.",
+              "$ref": "#/definitions/envVarName"
+            },
+            "dotnetPath": {
+              "description": "The path of the .NET binary. This parameter takes effect only when `dotnet` is `true`.",
+              "$ref": "#/definitions/envVarName"
+            }
+          }
+        }
+      }
+    },
+    "teamsAppExtendToM365": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Extend Teams app across Microsoft 365. Refer to https://aka.ms/teamsfx-actions/teamsapp-extendToM365 for more details.",
+      "required": ["uses", "with"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "An optional name of this action."
+        },
+        "env": {
+          "type": "object",
+          "description": "Define environment variables for this action.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "uses": {
+          "type": "string",
+          "description": "Extend Teams app across Microsoft 365. Refer to https://aka.ms/teamsfx-actions/teamsapp-extendToM365 for more details.",
+          "const": "teamsApp/extendToM365"
+        },
+        "with": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "parameters for this action",
+          "required": ["appPackagePath"],
+          "properties": {
+            "appPackagePath": {
+              "type": "string",
+              "description": "path to Teams app package"
+            }
+          }
+        },
+        "writeToEnvironmentFile": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Write environment variables to environment file",
+          "required": ["titleId", "appId"],
+          "properties": {
+            "titleId": {
+              "description": "Required. The ID of M365 title.",
+              "$ref": "#/definitions/envVarName"
+            },
+            "appId": {
+              "description": "Required. The app ID of M365 title.",
+              "$ref": "#/definitions/envVarName"
+            }
+          }
+        }
+      }
+    },
+    "spfxDeploy": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Deploy the SPFx package to SharePoint app catalog. Refer to https://aka.ms/teamsfx-actions/spfx-deploy for more details.",
+      "required": ["uses", "with"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "An optional name of this action."
+        },
+        "env": {
+          "type": "object",
+          "description": "Define environment variables for this action.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "uses": {
+          "type": "string",
+          "description": "Deploy the SPFx package to SharePoint app catalog. Refer to https://aka.ms/teamsfx-actions/spfx-deploy for more details.",
+          "const": "spfx/deploy"
+        },
+        "with": {
+          "type": "object",
+          "description": "parameters for this action",
+          "additionalProperties": false,
+          "required": ["packageSolutionPath"],
+          "properties": {
+            "createAppCatalogIfNotExist": {
+              "type": "boolean",
+              "description": "Whether to create tenant app catalog first if not exist, default value is `false`"
+            },
+            "packageSolutionPath": {
+              "type": "string",
+              "description": "The path to package-solution.json in SPFx project"
+            }
+          }
+        }
+      }
+    },
+    "teamsAppCopyAppPackageToSPFx": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Copy the generated Teams app package to SPFx solution. Refer to https://aka.ms/teamsfx-actions/teams-app-copy-app-package-to-spfx for more details.",
+      "required": ["uses", "with"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "An optional name of this action."
+        },
+        "env": {
+          "type": "object",
+          "description": "Define environment variables for this action.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "uses": {
+          "type": "string",
+          "description": "Copy the generated Teams app package to SPFx solution. Refer to https://aka.ms/teamsfx-actions/teams-app-copy-app-package-to-spfx for more details.",
+          "const": "teamsApp/copyAppPackageToSPFx"
+        },
+        "with": {
+          "type": "object",
+          "description": "parameters for this action",
+          "additionalProperties": false,
+          "required": ["appPackagePath", "spfxFolder"],
+          "properties": {
+            "spfxFolder": {
+              "type": "string",
+              "description": "The source folder to the SPFx project"
+            },
+            "appPackagePath": {
+              "type": "string",
+              "description": "The path to the zipped Teams app package"
+            }
+          }
+        }
+      }
+    },
+    "script": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Execute a user defined script. Refer to https://aka.ms/teamsfx-actions/script for more details.",
+      "required": ["uses", "with"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "An optional name of this action."
+        },
+        "env": {
+          "type": "object",
+          "description": "Define environment variables for this action.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "uses": {
+          "type": "string",
+          "description": "Execute a user defined script. Refer to https://aka.ms/teamsfx-actions/script for more details.",
+          "const": "script"
+        },
+        "with": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Parameters for this action",
+          "required": ["run"],
+          "properties": {
+            "run": {
+              "type": "string",
+              "description": "The command for this action to run or path to the script. Succeeds if exit code is 0."
+            },
+            "workingDirectory": {
+              "type": "string",
+              "description": "current working directory. Defaults to the directory of this file."
+            },
+            "shell": {
+              "type": "string",
+              "enum": ["bash", "sh", "powershell", "pwsh", "cmd"],
+              "description": "The shell type. Can be omitted. If omitted, it defaults to bash on Linux/MacOS, defaults to pwsh on windows."
+            },
+            "timeout": {
+              "type": "number",
+              "description": "timeout in ms"
+            },
+            "redirectTo": {
+              "type": "string",
+              "description": "redirect stdout and stderr to a file"
+            }
+          }
+        }        
+      }
+    },
+    "relativePath": {
+      "type": "string",
+      "maxLength": 2048
+    },
+    "httpsUrl": {
+      "type": "string",
+      "maxLength": 2048,
+      "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
+    },
+    "semver": {
+      "type": "string",
+      "maxLength": 256,
+      "pattern": "^([0-9]|[1-9]+[0-9]*)\\.([0-9]|[1-9]+[0-9]*)\\.([0-9]|[1-9]+[0-9]*)$"
+    },
+    "hexColor": {
+      "type": "string",
+      "pattern": "^#[0-9a-fA-F]{6}$"
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$"
+    },
+    "languageTag": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9]{1,8}(-[A-Za-z0-9]{1,8}){0,2}$"
+    },
+    "taskInfoDimension": {
+      "type": "string",
+      "pattern": "^((([0-9]*\\.)?[0-9]+)|[lL][aA][rR][gG][eE]|[mM][eE][dD][iI][uU][mM]|[sS][mM][aA][lL][lL])$",
+      "maxLength": 16
+    },
+    "secretEnvVarName": {
+      "type": "string",
+      "pattern": "^SECRET_[A-Z0-9_]+$",
+      "maxLength": 256
+    },
+    "envVarName": {
+      "type": "string",
+      "pattern": "^[A-Z][A-Z0-9_]*$",
+      "maxLength": 256
+    }
+  }
+}

--- a/packages/fx-core/src/common/constants.ts
+++ b/packages/fx-core/src/common/constants.ts
@@ -59,4 +59,5 @@ export class FeatureFlagName {
   static readonly CopilotPlugin = "COPILOT_PLUGIN";
   static readonly ApiCopilotPlugin = "API_COPILOT_PLUGIN";
   static readonly SampleConfigBranch = "TEAMSFX_SAMPLE_CONFIG_BRANCH";
+  static readonly TestTool = "TEAMSFX_TEST_TOOL";
 }

--- a/packages/fx-core/src/common/featureFlags.ts
+++ b/packages/fx-core/src/common/featureFlags.ts
@@ -52,3 +52,7 @@ export function isApiCopilotPluginEnabled(): boolean {
 export function isCliNewUxEnabled(): boolean {
   return isFeatureFlagEnabled("TEAMSFX_CLI_NEW_UX", false);
 }
+
+export function isTestToolEnabled(): boolean {
+  return isFeatureFlagEnabled(FeatureFlagName.TestTool, false);
+}

--- a/packages/fx-core/src/component/configManager/validator.ts
+++ b/packages/fx-core/src/component/configManager/validator.ts
@@ -8,14 +8,14 @@ import { getResourceFolder } from "../../folder";
 import { isTestToolEnabled } from "../../common/featureFlags";
 
 type Version = string;
-const supportedVersions = ["1.0.0", "1.1.0", "v1.2", ...(isTestToolEnabled() ? ["v1.3"] : [])];
+const supportedVersions = ["1.0.0", "1.1.0", "v1.2"];
 
 export class Validator {
   impl: Map<Version, { validator: ValidateFunction }>;
 
   constructor() {
     this.impl = new Map();
-    for (const version of supportedVersions) {
+    for (const version of this.supportedVersions()) {
       this.initVersion(version);
     }
   }
@@ -36,11 +36,11 @@ export class Validator {
   }
 
   supportedVersions(): string[] {
-    return supportedVersions;
+    return [...supportedVersions, ...(isTestToolEnabled() ? ["v1.3"] : [])];
   }
 
   private latestSupportedVersion(): string {
-    return supportedVersions[supportedVersions.length - 1];
+    return this.supportedVersions()[this.supportedVersions().length - 1];
   }
 
   validate(obj: Record<string, unknown>, version?: string): boolean {

--- a/packages/fx-core/src/component/configManager/validator.ts
+++ b/packages/fx-core/src/component/configManager/validator.ts
@@ -5,9 +5,10 @@ import Ajv, { ValidateFunction } from "ajv";
 import fs from "fs-extra";
 import path from "path";
 import { getResourceFolder } from "../../folder";
+import { isTestToolEnabled } from "../../common/featureFlags";
 
 type Version = string;
-const supportedVersions = ["1.0.0", "1.1.0", "v1.2"];
+const supportedVersions = ["1.0.0", "1.1.0", "v1.2", ...(isTestToolEnabled() ? ["v1.3"] : [])];
 
 export class Validator {
   impl: Map<Version, { validator: ValidateFunction }>;

--- a/packages/fx-core/tests/component/configManager/validator.test.ts
+++ b/packages/fx-core/tests/component/configManager/validator.test.ts
@@ -8,9 +8,15 @@
 import chai from "chai";
 import { describe, it } from "mocha";
 import { Validator } from "../../../src/component/configManager/validator";
+import * as sinon from "sinon";
+import * as featureFlags  from "../../../src/common/featureFlags";
 
 describe("yaml validator", () => {
   const validator = new Validator();
+  afterEach(() => {
+    sinon.restore();
+  });
+
   it("should not support invalid versions", () => {
     chai.expect(validator.isVersionSupported("invalid version")).to.be.false;
   });
@@ -21,5 +27,10 @@ describe("yaml validator", () => {
       .contains("1.0.0")
       .and.contains("1.1.0")
       .and.contains("v1.2");
+  });
+
+  it("should support v1.3 for test tool", () => {
+    sinon.stub(featureFlags, "isTestToolEnabled").resolves(true);
+    chai.expect(validator.supportedVersions()).contain("v1.3");
   });
 });

--- a/packages/fx-core/tests/component/configManager/validator.test.ts
+++ b/packages/fx-core/tests/component/configManager/validator.test.ts
@@ -9,7 +9,7 @@ import chai from "chai";
 import { describe, it } from "mocha";
 import { Validator } from "../../../src/component/configManager/validator";
 import * as sinon from "sinon";
-import * as featureFlags  from "../../../src/common/featureFlags";
+import * as featureFlags from "../../../src/common/featureFlags";
 
 describe("yaml validator", () => {
   const validator = new Validator();


### PR DESCRIPTION
Add devTool/install argument schema for test tool 

<img width="362" alt="image" src="https://github.com/OfficeDev/TeamsFx/assets/9698542/2a9ede72-5dc4-46c7-9d04-e65158771c78">

Diff with version 1.2 for easier viewing:

<img width="1597" alt="image" src="https://github.com/OfficeDev/TeamsFx/assets/9698542/e1c5a899-5568-46bf-8cbf-a6b295fa87bf">

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/16357625