### PR TITLE
fix: revert cli rename

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,8 +36,7 @@
   ],
   "preferGlobal": true,
   "bin": {
-    "teamsfx": "./cliold.js",
-    "teamsapp": "./cli.js"
+    "teamsfx": "./cliold.js"
   },
   "aiKey": "1c56be97-bb74-42cf-b04b-8f1aabf04592",
   "devDependencies": {


### PR DESCRIPTION
fix: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/25096039
revert rename