### PR TITLE
ci: bump up template version

### DIFF
--- a/.github/scripts/fxcore-sync-up-version.js
+++ b/.github/scripts/fxcore-sync-up-version.js
@@ -28,7 +28,7 @@ if (!semver.prerelease(templateVersion)) {
     console.log(
       "================== template config version is not match with template latest release version, need bump up config version ^${templateVersion} =================="
     );
-    templateConfigFile.version = `^${result.major}.${result.minor}.0`;
+    templateConfigFile.version = `${result.major}.${result.minor}.x`;
     fse.writeFileSync(
       templateConfig,
       JSON.stringify(templateConfigFile, null, 4)

--- a/packages/fx-core/src/common/templates-config.json
+++ b/packages/fx-core/src/common/templates-config.json
@@ -1,5 +1,5 @@
 {
-    "version": "^3.0.0",
+    "version": "3.0.x",
     "tagPrefix": "templates@",
     "tagListURL": "https://github.com/OfficeDev/TeamsFx/releases/download/template-tag-list/template-tags.txt",
     "templateDownloadBaseURL": "https://github.com/OfficeDev/TeamsFx/releases/download",

--- a/templates/package.json
+++ b/templates/package.json
@@ -1,6 +1,6 @@
 {
     "name": "templates",
-    "version": "3.0.3",
+    "version": "4.0.0",
     "private": "true",
     "license": "MIT",
     "scripts": {


### PR DESCRIPTION
We are going to release templates@3.0.4, which contains a new template for VS.
To avoid conflict, we have to upgrade template version to 4.0.0 in VSC release/5.2.0. 
This PR also update the version pattern so we can use the minor version for this kind of changes in the future.
```
> node .\.github\scripts\fxcore-sync-up-version.js
================== template version: 4.0.0 ==================
================== template version in fx-core configurate as 3.0.x ==================
================== template config version is not match with template latest release version, need bump up config version ^${templateVersion} ==================
```