### PR TITLE
fix: TestToolChecker special characters in file path

### DIFF
--- a/packages/fx-core/src/common/deps-checker/internal/testToolChecker.ts
+++ b/packages/fx-core/src/common/deps-checker/internal/testToolChecker.ts
@@ -4,6 +4,7 @@
 import * as fs from "fs-extra";
 import * as os from "os";
 import * as path from "path";
+import * as url from "url";
 import semver from "semver";
 import * as uuid from "uuid";
 import { ConfigFolderName, err, ok, Result } from "@microsoft/teamsfx-api";
@@ -190,7 +191,8 @@ export class TestToolChecker implements DepsChecker {
           try {
             const st = await fs.stat(fullPath);
             if (st.isFile()) {
-              return fullPath;
+              // encode special characters in path
+              return url.pathToFileURL(fullPath).toString();
             }
           } catch {
             // ignore invalid files


### PR DESCRIPTION
If the tgz file path contains special characters, npm install will fail.

<img width="1267" alt="image" src="https://github.com/OfficeDev/TeamsFx/assets/9698542/3217432f-85b7-46df-aa0b-d3b5d15a2d4f">
