### PR TITLE
feat: test tool corner cases

### DIFF
--- a/packages/fx-core/src/common/deps-checker/constant/telemetry.ts
+++ b/packages/fx-core/src/common/deps-checker/constant/telemetry.ts
@@ -35,10 +35,15 @@ export enum TelemetryProperties {
   VersioningFuncVersionError = "versioning-func-version-error",
   GlobalFuncVersionError = "global-func-version-error",
   InstallFuncError = "install-func-error",
+
   InstalledTestToolVersion = "installed-test-tool-version",
   InstallTestToolError = "install-test-tool-error",
   SymlinkTestToolVersion = "symlink-test-tool-version",
   SymlinkTestToolVersionError = "symlink-test-tool-version-error",
+  SelectedPortableTestToolVersion = "selected-test-tool-version",
+  VersioningTestToolVersionError = "versioning-test-tool-version-error",
+  GlobalTestToolVersion = "global-test-tool-version",
+  GlobalTestToolVersionError = "global-test-tool-version-error",
 }
 
 export enum TelemetryMessurement {

--- a/packages/fx-core/src/common/deps-checker/internal/testToolChecker.ts
+++ b/packages/fx-core/src/common/deps-checker/internal/testToolChecker.ts
@@ -35,17 +35,39 @@ export class TestToolChecker implements DepsChecker {
   ): Promise<DependencyStatus> {
     const symlinkDir = path.resolve(installOptions.projectPath, installOptions.symlinkDir);
 
-    const versionResult = await this.checkVersion(installOptions.versionRange, symlinkDir);
-    if (versionResult.isOk()) {
-      this.telemetryProperties[TelemetryProperties.SymlinkTestToolVersion] = versionResult.value;
-      return await this.getSuccessDepsInfo(versionResult.value, symlinkDir);
+    // check version in project devTools
+    const versionRes = await this.checkVersion(
+      installOptions.versionRange,
+      this.getBinFolder(symlinkDir)
+    );
+    if (versionRes.isOk()) {
+      this.telemetryProperties[TelemetryProperties.SymlinkTestToolVersion] = versionRes.value;
+      return await this.getSuccessDepsInfo(versionRes.value, symlinkDir);
     } else {
       this.telemetryProperties[TelemetryProperties.SymlinkTestToolVersionError] =
-        versionResult.error.message;
+        versionRes.error.message;
       await unlinkSymlink(symlinkDir);
     }
 
-    // TODO: check and use global version in case installation failure
+    // check version in ${HOME}/.fx/bin
+    const version = await this.findLatestInstalledPortableVersion(installOptions.versionRange);
+    if (version) {
+      const portablePath = path.join(this.getPortableVersionsDir(), version);
+      this.telemetryProperties[TelemetryProperties.SelectedPortableTestToolVersion] = version;
+      await createSymlink(portablePath, symlinkDir);
+      return await this.getSuccessDepsInfo(version, symlinkDir);
+    }
+
+    // check global version in PATH
+    const globalVersionRes = await this.checkVersion(installOptions.versionRange);
+    if (globalVersionRes.isOk()) {
+      const version = globalVersionRes.value;
+      this.telemetryProperties[TelemetryProperties.GlobalTestToolVersion] = version;
+      return this.getSuccessDepsInfo(version, undefined);
+    } else {
+      this.telemetryProperties[TelemetryProperties.GlobalTestToolVersionError] =
+        globalVersionRes.error.message;
+    }
 
     return this.createFailureDepsInfo(installOptions.versionRange, undefined);
   }
@@ -102,15 +124,51 @@ export class TestToolChecker implements DepsChecker {
     const actualPath = this.getPortableInstallPath(actualVersion);
     await rename(tmpPath, actualPath);
 
-    const binFolder = this.getBinFolder(actualPath);
-    await createSymlink(binFolder, symlinkDir);
+    await createSymlink(actualPath, symlinkDir);
 
     return await this.getSuccessDepsInfo(versionRange, symlinkDir);
   }
 
+  private async findLatestInstalledPortableVersion(
+    versionRange: string
+  ): Promise<string | undefined> {
+    let portablePath: string | undefined;
+    try {
+      const portableVersionsDir = this.getPortableVersionsDir();
+      const dirs = await fs.readdir(portableVersionsDir, { withFileTypes: true });
+      const satisfiedVersions = dirs
+        .filter(
+          (dir) =>
+            dir.isDirectory() && semver.valid(dir.name) && semver.satisfies(dir.name, versionRange)
+        )
+        .map((dir) => dir.name);
+
+      // sort by version desc
+      satisfiedVersions.sort((a, b) => semver.rcompare(a, b));
+
+      // find the latest version that is working
+      for (const version of satisfiedVersions) {
+        portablePath = path.join(portableVersionsDir, version);
+        const checkVersionRes = await this.checkVersion(
+          versionRange,
+          this.getBinFolder(portablePath)
+        );
+        if (checkVersionRes.isOk()) {
+          return version;
+        }
+        this.telemetryProperties[TelemetryProperties.VersioningFuncVersionError] =
+          (this.telemetryProperties[TelemetryProperties.VersioningFuncVersionError] ?? "") +
+          `[${version}] ${checkVersionRes.error.message}`;
+      }
+    } catch {
+      // ignore errors if portable dir doesn't exist
+    }
+    return undefined;
+  }
+
   private async checkVersion(
     versionRange: string,
-    binFolder: string
+    binFolder?: string
   ): Promise<Result<string, DepsCheckerError>> {
     try {
       const actualVersion = await this.queryVersion(binFolder);
@@ -208,10 +266,13 @@ export class TestToolChecker implements DepsChecker {
   private getBinFolder(installPath: string) {
     return path.join(installPath, "node_modules", ".bin");
   }
-  private getPortableInstallPath(version: string): string {
-    return path.join(os.homedir(), `.${ConfigFolderName}`, "bin", this.portableDirName, version);
+  private getPortableVersionsDir(): string {
+    return path.join(os.homedir(), `.${ConfigFolderName}`, "bin", this.portableDirName);
   }
-  private async getSuccessDepsInfo(version: string, binFolder: string): Promise<DependencyStatus> {
+  private getPortableInstallPath(version: string): string {
+    return path.join(this.getPortableVersionsDir(), version);
+  }
+  private async getSuccessDepsInfo(version: string, binFolder?: string): Promise<DependencyStatus> {
     return Promise.resolve({
       name: this.name,
       type: DepsType.TestTool,
@@ -220,7 +281,7 @@ export class TestToolChecker implements DepsChecker {
       details: {
         isLinuxSupported: true,
         supportedVersions: [], // unused
-        binFolders: [binFolder],
+        binFolders: binFolder ? [binFolder] : [],
         installVersion: version,
       },
       telemetryProperties: this.telemetryProperties,

--- a/packages/fx-core/tests/common/deps-checker/testToolChecker.test.ts
+++ b/packages/fx-core/tests/common/deps-checker/testToolChecker.test.ts
@@ -7,219 +7,430 @@ import { expect } from "chai";
 import * as sinon from "sinon";
 import * as path from "path";
 import * as url from "url";
+import * as os from "os";
+import mockfs from "mock-fs";
+import cp from "child_process";
 import { cpUtils } from "../../../src/common/deps-checker/util/cpUtils";
 import { TestToolChecker } from "../../../src/common/deps-checker/internal/testToolChecker";
-import mockfs from "mock-fs";
 import * as fileHelper from "../../../src/common/deps-checker/util/fileHelper";
 import { DepsCheckerError } from "../../../src/common/deps-checker/depsError";
-import cp from "child_process";
+
+function isAncesterDir(parent: string, dir: string) {
+  const relative = path.relative(parent, dir);
+  return relative && !relative.startsWith("..") && !path.isAbsolute(relative);
+}
+
+function pathSplit(p: string) {
+  return p.split(/[\/\\]+/);
+}
 
 describe("Test Tool Checker Test", () => {
   const sandbox = sinon.createSandbox();
   const projectPath = "projectPath";
+  const homePortablesDir = path.join(os.homedir(), ".fx", "bin", "testTool");
 
   afterEach(async () => {
     sandbox.restore();
     mockfs.restore();
   });
 
-  it("Already installed", async () => {
-    const checker = new TestToolChecker();
-    const symlinkDir = "symlinkDir";
-    const versionRange = "~1.2.3";
-    let npmInstalled = false;
-    sandbox
-      .stub(cpUtils, "executeCommand")
-      .callsFake(async (_cwd, _logger, _options, command, ...args) => {
-        if (args.includes("--version")) {
-          return "1.2.3";
-        } else if (args.includes("install")) {
-          npmInstalled = true;
-        }
-        return "";
-      });
-
-    // Act
-    const status = await checker.resolve({ projectPath, symlinkDir, versionRange });
-
-    // Assert
-    expect(status.isInstalled).to.be.true;
-    expect(status.details.binFolders).not.empty;
-    expect(status.error).to.be.undefined;
-    expect(npmInstalled).to.be.false;
-  });
-
-  it("Installed but version not match", async () => {
-    const checker = new TestToolChecker();
-    const symlinkDir = "symlinkDir";
-    const versionRange = "~1.2.3";
-    let npmInstalled = false;
-    sandbox.stub(fileHelper, "rename").resolves();
-    sandbox.stub(fileHelper, "createSymlink").resolves();
-    sandbox
-      .stub(cpUtils, "executeCommand")
-      .callsFake(async (_cwd, _logger, _options, command, ...args) => {
-        if (args.includes("--version")) {
-          if (npmInstalled) {
-            return "1.2.3";
-          } else {
-            return "1.2.2";
+  describe("Clean install", () => {
+    it("Not installed", async () => {
+      const checker = new TestToolChecker();
+      const symlinkDir = "symlinkDir";
+      const versionRange = "~1.2.3";
+      let npmInstalled = false;
+      sandbox.stub(fileHelper, "rename").resolves();
+      sandbox.stub(fileHelper, "createSymlink").resolves();
+      sandbox
+        .stub(cpUtils, "executeCommand")
+        .callsFake(async (_cwd, _logger, _options, command, ...args) => {
+          if (args.includes("--version")) {
+            if (npmInstalled) {
+              return "1.2.3";
+            } else {
+              throw new Error("not installed");
+            }
+          } else if (args.includes("install")) {
+            npmInstalled = true;
           }
-        } else if (args.includes("install")) {
-          npmInstalled = true;
-        }
-        return "";
-      });
+          return "";
+        });
 
-    // Act
-    const status = await checker.resolve({ projectPath, symlinkDir, versionRange });
+      // Act
+      const status = await checker.resolve({ projectPath, symlinkDir, versionRange });
 
-    // Assert
-    expect(status.isInstalled).to.be.true;
-    expect(status.details.binFolders).not.empty;
-    expect(status.error).to.be.undefined;
-    expect(npmInstalled).to.be.true;
+      // Assert
+      expect(status.isInstalled).to.be.true;
+      expect(status.details.binFolders).not.empty;
+      expect(status.error).to.be.undefined;
+      expect(npmInstalled).to.be.true;
+    });
   });
 
-  it("Not installed", async () => {
-    const checker = new TestToolChecker();
-    const symlinkDir = "symlinkDir";
-    const versionRange = "~1.2.3";
-    let npmInstalled = false;
-    sandbox.stub(fileHelper, "rename").resolves();
-    sandbox.stub(fileHelper, "createSymlink").resolves();
-    sandbox
-      .stub(cpUtils, "executeCommand")
-      .callsFake(async (_cwd, _logger, _options, command, ...args) => {
-        if (args.includes("--version")) {
-          if (npmInstalled) {
+  describe("Already installed", () => {
+    it("Already installed and symlink created", async () => {
+      const checker = new TestToolChecker();
+      const symlinkDir = "symlinkDir";
+      const versionRange = "~1.2.3";
+      let npmInstalled = false;
+      sandbox
+        .stub(cpUtils, "executeCommand")
+        .callsFake(async (_cwd, _logger, _options, command, ...args) => {
+          if (args.includes("--version")) {
             return "1.2.3";
-          } else {
+          } else if (args.includes("install")) {
+            npmInstalled = true;
+          }
+          return "";
+        });
+
+      // Act
+      const status = await checker.resolve({ projectPath, symlinkDir, versionRange });
+
+      // Assert
+      expect(status.isInstalled).to.be.true;
+      expect(status.details.binFolders).not.empty;
+      expect(status.error).to.be.undefined;
+      expect(npmInstalled).to.be.false;
+    });
+
+    it("Already installed in home", async () => {
+      const checker = new TestToolChecker();
+      const symlinkDir = "symlinkDir";
+      const versionRange = "~1.2.3";
+      let npmInstalled = false;
+      const homePortableDir = path.join(os.homedir(), ".fx", "bin", "testTool", "1.2.3");
+      const homePortableExec = path.join(homePortableDir, "node_modules", ".bin", "teamsapptester");
+      mockfs({
+        [homePortableExec]: "",
+      });
+
+      let linkTarget = "";
+      sandbox.stub(fileHelper, "createSymlink").callsFake(async (target, _linkFilePath) => {
+        linkTarget = target;
+      });
+      sandbox
+        .stub(cpUtils, "executeCommand")
+        .callsFake(async (_cwd, _logger, _options, command, ...args) => {
+          command = command.replace(/^"|'/, "").replace(/"|'$/, ""); // trim quotes
+          if (args.includes("--version")) {
+            if (command.includes(projectPath)) {
+              throw new Error("not installed");
+            } else if (isAncesterDir(homePortableDir, command)) {
+              return "1.2.3";
+            }
+          } else if (args.includes("install")) {
+            npmInstalled = true;
+          }
+          return "";
+        });
+
+      // Act
+      const status = await checker.resolve({ projectPath, symlinkDir, versionRange });
+
+      // Assert
+      expect(status.isInstalled).to.be.true;
+      expect(status.details.binFolders).not.empty;
+      expect(status.error).to.be.undefined;
+      expect(npmInstalled).to.be.false;
+      expect(path.resolve(linkTarget)).to.equal(path.resolve(homePortableDir));
+    });
+
+    it("Already installed in home multiple versions, should use more recent version", async () => {
+      const checker = new TestToolChecker();
+      const symlinkDir = "symlinkDir";
+      const versionRange = "~1.2.3";
+      const homePortableDir123 = path.join(homePortablesDir, "1.2.3");
+      const homePortableExec123 = path.join(
+        homePortableDir123,
+        "node_modules",
+        ".bin",
+        "teamsapptester"
+      );
+      const homePortableDir124 = path.join(homePortablesDir, "1.2.4");
+      const homePortableExec124 = path.join(
+        homePortableDir124,
+        "node_modules",
+        ".bin",
+        "teamsapptester"
+      );
+      mockfs({
+        [homePortableExec123]: "",
+        [homePortableExec124]: "",
+      });
+
+      let linkTarget = "";
+      sandbox.stub(fileHelper, "createSymlink").callsFake(async (target, _linkFilePath) => {
+        linkTarget = target;
+      });
+      sandbox
+        .stub(cpUtils, "executeCommand")
+        .callsFake(async (_cwd, _logger, _options, command, ...args) => {
+          command = command.replace(/^"|'/, "").replace(/"|'$/, ""); // trim quotes
+          if (args.includes("--version")) {
+            if (command.includes(projectPath)) {
+              throw new Error("not installed");
+            } else if (isAncesterDir(homePortablesDir, command)) {
+              const relPath = path.relative(homePortablesDir, command);
+              const dirNames = pathSplit(relPath);
+              const version = dirNames[0];
+              return version;
+            }
+          } else if (args.includes("install")) {
+            throw new Error("Should not install");
+          }
+          return "";
+        });
+
+      // Act
+      const status = await checker.resolve({ projectPath, symlinkDir, versionRange });
+
+      // Assert
+      expect(status.isInstalled).to.be.true;
+      expect(status.details.binFolders).not.empty;
+      expect(status.error).to.be.undefined;
+      expect(path.resolve(linkTarget)).to.equal(path.resolve(homePortableDir124));
+    });
+
+    it("Already installed globally", async () => {
+      const checker = new TestToolChecker();
+      const versionRange = "~1.2.3";
+      const symlinkDir = "symlinkDir";
+
+      const createSymlinkStub = sandbox.stub(fileHelper, "createSymlink");
+      sandbox
+        .stub(cpUtils, "executeCommand")
+        .callsFake(async (_cwd, _logger, _options, command, ...args) => {
+          command = command.replace(/^"|'/, "").replace(/"|'$/, ""); // trim quotes
+          if (args.includes("--version")) {
+            if (command.includes(projectPath)) {
+              throw new Error("not installed");
+            } else if (isAncesterDir(homePortablesDir, command)) {
+              const relPath = path.relative(homePortablesDir, command);
+              const dirNames = pathSplit(relPath);
+              const version = dirNames[0];
+              return version;
+            } else if (command.startsWith("teamsapptester")) {
+              // global check
+              return "1.2.3";
+            }
+          } else if (args.includes("install")) {
+            throw new Error("Should not install");
+          }
+          return "";
+        });
+
+      // Act
+      const status = await checker.resolve({ projectPath, symlinkDir, versionRange });
+
+      // Assert
+      expect(status.isInstalled).to.be.true;
+      expect(status.details.binFolders).to.be.empty;
+      expect(status.error).to.be.undefined;
+      expect(createSymlinkStub.notCalled);
+    });
+  });
+
+  describe("Installed but version not match", () => {
+    it("Installed and symlink created but version not match", async () => {
+      const checker = new TestToolChecker();
+      const symlinkDir = "symlinkDir";
+      const versionRange = "~1.2.3";
+      let npmInstalled = false;
+      sandbox.stub(fileHelper, "rename").resolves();
+      sandbox.stub(fileHelper, "createSymlink").resolves();
+      sandbox
+        .stub(cpUtils, "executeCommand")
+        .callsFake(async (_cwd, _logger, _options, command, ...args) => {
+          if (args.includes("--version")) {
+            if (npmInstalled) {
+              return "1.2.3";
+            } else {
+              return "1.2.2";
+            }
+          } else if (args.includes("install")) {
+            npmInstalled = true;
+          }
+          return "";
+        });
+
+      // Act
+      const status = await checker.resolve({ projectPath, symlinkDir, versionRange });
+
+      // Assert
+      expect(status.isInstalled).to.be.true;
+      expect(status.details.binFolders).not.empty;
+      expect(status.error).to.be.undefined;
+      expect(npmInstalled).to.be.true;
+    });
+    it("Already installed in home, but version not match", async () => {
+      const checker = new TestToolChecker();
+      const symlinkDir = "symlinkDir";
+      const versionRange = "~1.2.4";
+      let npmInstalled = false;
+      const homePortableDir123 = path.join(homePortablesDir, "1.2.3");
+      const homePortableExec123 = path.join(
+        homePortableDir123,
+        "node_modules",
+        ".bin",
+        "teamsapptester"
+      );
+      const homePortableDir124 = path.join(homePortablesDir, "1.2.4");
+      mockfs({
+        [homePortableExec123]: "",
+      });
+
+      let linkTarget = "";
+      sandbox.stub(fileHelper, "createSymlink").callsFake(async (target, _linkFilePath) => {
+        linkTarget = target;
+      });
+      sandbox.stub(fileHelper, "rename").resolves();
+      sandbox
+        .stub(cpUtils, "executeCommand")
+        .callsFake(async (_cwd, _logger, _options, command, ...args) => {
+          command = command.replace(/^"|'/, "").replace(/"|'$/, ""); // trim quotes
+          if (args.includes("--version")) {
+            if (command.includes(projectPath)) {
+              if (npmInstalled) {
+                return "1.2.4";
+              }
+              throw new Error("not installed");
+            } else if (isAncesterDir(homePortablesDir, command)) {
+              const relPath = path.relative(homePortablesDir, command);
+              const dirNames = pathSplit(relPath);
+              const version = dirNames[0];
+              if (version.startsWith("tmp")) {
+                return "1.2.4";
+              }
+              return version;
+            }
+          } else if (args.includes("install")) {
+            npmInstalled = true;
+          }
+          return "";
+        });
+
+      // Act
+      const status = await checker.resolve({ projectPath, symlinkDir, versionRange });
+
+      // Assert
+      expect(status.isInstalled).to.be.true;
+      expect(status.details.binFolders).not.empty;
+      expect(status.error).to.be.undefined;
+      expect(path.resolve(linkTarget)).to.equal(path.resolve(homePortableDir124));
+    });
+  });
+
+  describe("Corner cases", () => {
+    it("Failed to install", async () => {
+      const checker = new TestToolChecker();
+      const symlinkDir = "symlinkDir";
+      const versionRange = "~1.2.3";
+      sandbox.stub(fileHelper, "rename").resolves();
+      sandbox.stub(fileHelper, "createSymlink").resolves();
+      sandbox
+        .stub(cpUtils, "executeCommand")
+        .callsFake(async (_cwd, _logger, _options, command, ...args) => {
+          if (args.includes("--version")) {
             throw new Error("not installed");
+          } else if (args.includes("install")) {
+            throw new Error("install error");
           }
-        } else if (args.includes("install")) {
-          npmInstalled = true;
-        }
-        return "";
-      });
+          return "";
+        });
 
-    // Act
-    const status = await checker.resolve({ projectPath, symlinkDir, versionRange });
+      // Act
+      const status = await checker.resolve({ projectPath, symlinkDir, versionRange });
 
-    // Assert
-    expect(status.isInstalled).to.be.true;
-    expect(status.details.binFolders).not.empty;
-    expect(status.error).to.be.undefined;
-    expect(npmInstalled).to.be.true;
-  });
-
-  it("Failed to install", async () => {
-    const checker = new TestToolChecker();
-    const symlinkDir = "symlinkDir";
-    const versionRange = "~1.2.3";
-    sandbox.stub(fileHelper, "rename").resolves();
-    sandbox.stub(fileHelper, "createSymlink").resolves();
-    sandbox
-      .stub(cpUtils, "executeCommand")
-      .callsFake(async (_cwd, _logger, _options, command, ...args) => {
-        if (args.includes("--version")) {
-          throw new Error("not installed");
-        } else if (args.includes("install")) {
-          throw new Error("install error");
-        }
-        return "";
-      });
-
-    // Act
-    const status = await checker.resolve({ projectPath, symlinkDir, versionRange });
-
-    // Assert
-    expect(status.isInstalled).to.be.false;
-    expect(status.details.binFolders).to.be.empty;
-    expect(status.error).instanceOf(DepsCheckerError);
-  });
-
-  it("Special characters in tgz path", async () => {
-    const checker = new TestToolChecker();
-    const symlinkDir = "symlinkDir";
-    const versionRange = "~1.2.3";
-    const mockProjectPath = "./projectPath";
-    mockfs({
-      [path.join(mockProjectPath, "microsoft-teams-app-test-tool-cli-1.2.3.tgz")]: "",
+      // Assert
+      expect(status.isInstalled).to.be.false;
+      expect(status.details.binFolders).to.be.empty;
+      expect(status.error).instanceOf(DepsCheckerError);
     });
-    let installArgs: string[] = [];
-    sandbox.stub(fileHelper, "rename").resolves();
-    sandbox.stub(fileHelper, "createSymlink").resolves();
-    sandbox
-      .stub(cpUtils, "executeCommand")
-      .callsFake(async (_cwd, _logger, _options, command, ...args) => {
-        if (args.includes("--version")) {
-          throw new Error("not installed");
-        } else if (args.includes("install")) {
-          installArgs = args;
-        }
-        return "";
+
+    it("Special characters in tgz path", async () => {
+      const checker = new TestToolChecker();
+      const symlinkDir = "symlinkDir";
+      const versionRange = "~1.2.3";
+      const mockProjectPath = "./projectPath";
+      mockfs({
+        [path.join(mockProjectPath, "microsoft-teams-app-test-tool-cli-1.2.3.tgz")]: "",
       });
+      let installArgs: string[] = [];
+      sandbox.stub(fileHelper, "rename").resolves();
+      sandbox.stub(fileHelper, "createSymlink").resolves();
+      sandbox
+        .stub(cpUtils, "executeCommand")
+        .callsFake(async (_cwd, _logger, _options, command, ...args) => {
+          if (args.includes("--version")) {
+            throw new Error("not installed");
+          } else if (args.includes("install")) {
+            installArgs = args;
+          }
+          return "";
+        });
 
-    // Act
-    await checker.resolve({ projectPath, symlinkDir, versionRange });
+      // Act
+      await checker.resolve({ projectPath, symlinkDir, versionRange });
 
-    // Assert
-    const fileArg = installArgs.filter((arg) =>
-      arg.includes("microsoft-teams-app-test-tool-cli")
-    )[0];
-    expect(fileArg).not.empty;
-    let parsed: url.URL | undefined;
-    expect(() => {
-      parsed = new url.URL(fileArg);
-    }).not.throw();
-    expect(parsed).not.undefined;
-    expect(parsed?.protocol).equals("file:");
-  });
-
-  it("Install timeout", async () => {
-    const clock = sinon.useFakeTimers();
-    after(() => clock.restore());
-    const checker = new TestToolChecker();
-
-    const symlinkDir = "symlinkDir";
-    const versionRange = "~1.2.3";
-    sandbox.stub(fileHelper, "rename").resolves();
-    sandbox.stub(fileHelper, "createSymlink").resolves();
-    const oldExecuteCommand = cpUtils.executeCommand;
-    sandbox.stub(cp, "spawn").callsFake(() => {
-      const events: { [key: string]: any } = {};
-      // return a stub for ChildProcess
-      return {
-        kill: () => {
-          events["error"]?.(new Error("timeout"));
-          return true;
-        },
-        on: (event: string, cb: unknown) => {
-          events[event] = cb;
-        },
-      } as any as cp.ChildProcess;
+      // Assert
+      const fileArg = installArgs.filter((arg) =>
+        arg.includes("microsoft-teams-app-test-tool-cli")
+      )[0];
+      expect(fileArg).not.empty;
+      let parsed: url.URL | undefined;
+      expect(() => {
+        parsed = new url.URL(fileArg);
+      }).not.throw();
+      expect(parsed).not.undefined;
+      expect(parsed?.protocol).equals("file:");
     });
-    sandbox
-      .stub(cpUtils, "executeCommand")
-      .callsFake(async (_cwd, _logger, _options, command, ...args) => {
-        if (args.includes("--version")) {
-          throw new Error("not installed");
-        } else if (args.includes("install")) {
-          const promise = oldExecuteCommand(_cwd, _logger, _options, command, ...args);
-          // tick the clock before execute command
-          clock.tick(5 * 60 * 1000 + 10);
-          return await promise;
-        }
-        return "";
+
+    it("Install timeout", async () => {
+      const clock = sinon.useFakeTimers();
+      after(() => clock.restore());
+      const checker = new TestToolChecker();
+
+      const symlinkDir = "symlinkDir";
+      const versionRange = "~1.2.3";
+      sandbox.stub(fileHelper, "rename").resolves();
+      sandbox.stub(fileHelper, "createSymlink").resolves();
+      const oldExecuteCommand = cpUtils.executeCommand;
+      sandbox.stub(cp, "spawn").callsFake(() => {
+        const events: { [key: string]: any } = {};
+        // return a stub for ChildProcess
+        return {
+          kill: () => {
+            events["error"]?.(new Error("timeout"));
+            return true;
+          },
+          on: (event: string, cb: unknown) => {
+            events[event] = cb;
+          },
+        } as any as cp.ChildProcess;
       });
+      sandbox
+        .stub(cpUtils, "executeCommand")
+        .callsFake(async (_cwd, _logger, _options, command, ...args) => {
+          if (args.includes("--version")) {
+            throw new Error("not installed");
+          } else if (args.includes("install")) {
+            const promise = oldExecuteCommand(_cwd, _logger, _options, command, ...args);
+            // tick the clock before execute command
+            clock.tick(5 * 60 * 1000 + 10);
+            return await promise;
+          }
+          return "";
+        });
 
-    // Act
-    const status = await checker.resolve({ projectPath, symlinkDir, versionRange });
+      // Act
+      const status = await checker.resolve({ projectPath, symlinkDir, versionRange });
 
-    // Assert
-    expect(status.isInstalled).to.be.false;
-    expect(status.details.binFolders).to.be.empty;
-    expect(status.error).instanceOf(DepsCheckerError);
+      // Assert
+      expect(status.isInstalled).to.be.false;
+      expect(status.details.binFolders).to.be.empty;
+      expect(status.error).instanceOf(DepsCheckerError);
+    });
   });
 });


### PR DESCRIPTION
- if portable versions are installed in home, reuse the latest working version
- if globally installed, use global version
- change symbol link path from  `.fx/bin/testTool/1.2.3/node_modules/.bin` to `.fx/bin/testTool/1.2.3` to solve npm link issue on Windows

TODO: update PATH env variable for sample apps in TeamsAppTestTool repo.

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/16357625