### PR TITLE
feat: treat testtool env as a local env in treeview

### DIFF
--- a/packages/fx-core/src/core/environment.ts
+++ b/packages/fx-core/src/core/environment.ts
@@ -53,10 +53,10 @@ class EnvironmentManager {
 
   public async getExistingNonRemoteEnvs(projectPath: string): Promise<string[]> {
     return [
-      environmentNameManager.getLocalEnvName(),
       ...((await this.hasTestToolEnv(projectPath))
         ? [environmentNameManager.getTestToolEnvName()]
         : []),
+      environmentNameManager.getLocalEnvName(),
     ];
   }
 }

--- a/packages/fx-core/tests/component/envUtil.test.ts
+++ b/packages/fx-core/tests/component/envUtil.test.ts
@@ -402,7 +402,7 @@ describe("envUtils", () => {
         .stub(fs, "readdir")
         .resolves([".env.dev", ".env.prod", ".env.local", ".env.testtool"] as any);
       const res = await environmentManager.getExistingNonRemoteEnvs(".");
-      assert.deepEqual(res, ["local", "testtool"]);
+      assert.deepEqual(res, ["testtool", "local"]);
     });
     it("environmentManager.getExistingNonRemoteEnvs without testtool env", async () => {
       sandbox.stub(pathUtils, "getEnvFolderPath").resolves(ok("teamsfx"));

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -288,6 +288,11 @@
           "group": "inline@3"
         },
         {
+          "command": "fx-extension.debugInTestToolWithIcon",
+          "when": "view == teamsfx-environment && viewItem =~ /^testtool$/",
+          "group": "inline@3"
+        },
+        {
           "command": "fx-extension.manageCollaborator",
           "when": "view == teamsfx-environment && viewItem =~ /environment/",
           "group": "inline@3"
@@ -367,6 +372,10 @@
         },
         {
           "command": "fx-extension.localdebugWithIcon",
+          "when": "false"
+        },
+        {
+          "command": "fx-extension.debugInTestToolWithIcon",
           "when": "false"
         },
         {
@@ -639,6 +648,11 @@
       {
         "command": "fx-extension.localdebugWithIcon",
         "title": "%teamstoolkit.commands.localDebug.title%",
+        "icon": "$(debug-alt)"
+      },
+      {
+        "command": "fx-extension.debugInTestToolWithIcon",
+        "title": "%teamstoolkit.commands.debugInTestTool.title%",
         "icon": "$(debug-alt)"
       },
       {

--- a/packages/vscode-extension/package.nls.json
+++ b/packages/vscode-extension/package.nls.json
@@ -64,6 +64,7 @@
     "teamstoolkit.commands.listAppOwner.title": "List Microsoft 365 Teams App (with AAD App) Owners",
     "teamstoolkit.commands.manageCollaborator.title": "Manage M365 Teams App (with AAD app) Collaborators",
     "teamstoolkit.commands.localDebug.title": "Debug",
+    "teamstoolkit.commands.debugInTestTool.title": "Debug in Test Tool",
     "teamstoolkit.commands.m365AccountSettings.title": "Microsoft 365 Portal",
     "teamstoolkit.commands.migrateApp.title": "Upgrade Teams JS SDK and Code References",
     "teamstoolkit.commands.migrateManifest.title": "Upgrade Teams Manifest",

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -519,6 +519,12 @@ function registerMenuCommands(context: vscode.ExtensionContext) {
   );
   context.subscriptions.push(localDebugWithIcon);
 
+  const debugInTestToolWithIcon = vscode.commands.registerCommand(
+    "fx-extension.debugInTestToolWithIcon",
+    () => Correlator.run(handlers.treeViewDebugInTestToolHandler)
+  );
+  context.subscriptions.push(debugInTestToolWithIcon);
+
   const m365AccountSettingsCmd = vscode.commands.registerCommand(
     "fx-extension.m365AccountSettings",
     () => Correlator.run(handlers.openM365AccountHandler)

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -430,6 +430,13 @@ export async function treeViewLocalDebugHandler(args?: any[]): Promise<Result<nu
   return ok(null);
 }
 
+export async function treeViewDebugInTestToolHandler(args?: any[]): Promise<Result<null, FxError>> {
+  ExtTelemetry.sendTelemetryEvent(TelemetryEvent.TreeViewDebugInTestTool);
+  await vscode.commands.executeCommand("workbench.action.quickOpen", "debug in Test Tool");
+
+  return ok(null);
+}
+
 export async function treeViewPreviewHandler(env: string): Promise<Result<null, FxError>> {
   ExtTelemetry.sendTelemetryEvent(TelemetryEvent.TreeViewPreviewStart);
   const properties: { [key: string]: string } = {};

--- a/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
@@ -199,6 +199,7 @@ export enum TelemetryEvent {
   MigrateTeamsManifest = "migrate-teams-manifest",
 
   TreeViewLocalDebug = "treeview-localdebug",
+  TreeViewDebugInTestTool = "treeview-debugintesttool",
 
   TreeViewPreviewStart = "treeview-preview-start",
   TreeViewPreview = "treeview-preview",

--- a/packages/vscode-extension/src/treeview/environmentTreeItem.ts
+++ b/packages/vscode-extension/src/treeview/environmentTreeItem.ts
@@ -22,6 +22,7 @@ import { AppStudioScopes, environmentNameManager } from "@microsoft/teamsfx-core
 
 enum EnvInfo {
   Local = "local",
+  TestTool = "testtool",
   LocalForExistingApp = "local-existing-app",
   RemoteEnv = "environment",
   ProvisionedRemoteEnv = "environment-provisioned",
@@ -153,6 +154,8 @@ export class EnvironmentNode extends DynamicNode {
   private async getCurrentEnvInfo(envName: string): Promise<EnvInfo> {
     if (envName === environmentNameManager.getLocalEnvName()) {
       return EnvInfo.Local;
+    } else if (envName === environmentNameManager.getTestToolEnvName()) {
+      return EnvInfo.TestTool;
     } else {
       const provisionSucceeded = await getProvisionSucceedFromEnv(envName);
       return provisionSucceeded ? EnvInfo.ProvisionedRemoteEnv : EnvInfo.RemoteEnv;

--- a/packages/vscode-extension/test/extension/handlers.test.ts
+++ b/packages/vscode-extension/test/extension/handlers.test.ts
@@ -2574,4 +2574,17 @@ describe("autoOpenProjectHandler", () => {
 
     chai.assert.isTrue(executeCommandStub.calledWith("workbench.view.extension.teamsfx"));
   });
+
+  it("treeViewDebugInTestToolHandler", async () => {
+    sinon.stub(handlers, "core").value(new MockCore());
+    sinon.stub(ExtTelemetry, "sendTelemetryEvent");
+    const executeCommandStub = sinon.stub(vscode.commands, "executeCommand");
+
+    await handlers.treeViewDebugInTestToolHandler();
+
+    chai.assert.isTrue(
+      executeCommandStub.calledOnceWith("workbench.action.quickOpen", "debug in Test Tool")
+    );
+    sinon.restore();
+  });
 });

--- a/packages/vscode-extension/test/extension/treeview/environmentTreeItem.test.ts
+++ b/packages/vscode-extension/test/extension/treeview/environmentTreeItem.test.ts
@@ -30,6 +30,17 @@ describe("EnvironmentNode", () => {
     chai.assert.equal(treeItem.contextValue, "local");
   });
 
+  it("getTreeItem for local", async () => {
+    const environmentNode = new EnvironmentNode("testtool");
+    sandbox.stub(environmentNode, "getChildren").returns(Promise.resolve([]));
+
+    const treeItem = await environmentNode.getTreeItem();
+
+    chai.assert.deepEqual(treeItem.iconPath, new vscode.ThemeIcon("symbol-folder"));
+    chai.assert.equal(treeItem.collapsibleState, vscode.TreeItemCollapsibleState.None);
+    chai.assert.equal(treeItem.contextValue, "testtool");
+  });
+
   it("getChildren returns warning for SPFx project", async () => {
     const environmentNode = new EnvironmentNode("test");
     sandbox.stub(M365Login.getInstance(), "getStatus").returns(


### PR DESCRIPTION
![image](https://github.com/OfficeDev/TeamsFx/assets/9698542/86ecb5a8-ce7d-4397-bb8d-988309e86468)

Make testtool env similar to local env.

Only affects projects that have "testtool" env.

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/16357625