### PR TITLE
perf(spec-parser): wrap adaptive card

### DIFF
--- a/packages/fx-core/src/common/spec-parser/adaptiveCardWrapper.ts
+++ b/packages/fx-core/src/common/spec-parser/adaptiveCardWrapper.ts
@@ -11,8 +11,8 @@ export function wrapAdaptiveCard(
   subtitle: string
 ): WrappedAdaptiveCard {
   const result: WrappedAdaptiveCard = {
-    version: ConstantString.AdaptiveCardVersion,
-    $schema: ConstantString.AdaptiveCardSchema,
+    version: ConstantString.WrappedCardVersion,
+    $schema: ConstantString.WrappedCardSchema,
     responseLayout: ConstantString.WrappedCardResponseLayout,
     responseCardTemplate: card,
     previewCardTemplate: {

--- a/packages/fx-core/src/common/spec-parser/adaptiveCardWrapper.ts
+++ b/packages/fx-core/src/common/spec-parser/adaptiveCardWrapper.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 "use strict";
 
+import { ConstantString } from "./constants";
 import { AdaptiveCard, WrappedAdaptiveCard } from "./interfaces";
 
 export function wrapAdaptiveCard(
@@ -10,9 +11,9 @@ export function wrapAdaptiveCard(
   subtitle: string
 ): WrappedAdaptiveCard {
   const result: WrappedAdaptiveCard = {
-    version: "devPreview",
-    $schema: "<URL_REFERENCE_TO_SCHEMA>",
-    responseLayout: "list",
+    version: ConstantString.AdaptiveCardVersion,
+    $schema: ConstantString.AdaptiveCardSchema,
+    responseLayout: ConstantString.WrappedCardResponseLayout,
     responseCardTemplate: card,
     previewCardTemplate: {
       title: title,

--- a/packages/fx-core/src/common/spec-parser/adaptiveCardWrapper.ts
+++ b/packages/fx-core/src/common/spec-parser/adaptiveCardWrapper.ts
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+"use strict";
+
+import { AdaptiveCard, WrappedAdaptiveCard } from "./interfaces";
+
+export function wrapAdaptiveCard(
+  card: AdaptiveCard,
+  title: string,
+  subtitle: string
+): WrappedAdaptiveCard {
+  const result: WrappedAdaptiveCard = {
+    version: "devPreview",
+    $schema: "<URL_REFERENCE_TO_SCHEMA>",
+    responseLayout: "list",
+    responseCardTemplate: card,
+    previewCardTemplate: {
+      title: title,
+      subtitle: subtitle,
+    },
+  };
+
+  return result;
+}

--- a/packages/fx-core/src/common/spec-parser/constants.ts
+++ b/packages/fx-core/src/common/spec-parser/constants.ts
@@ -30,6 +30,10 @@ export class ConstantString {
     "core.common.ConvertSwaggerToOpenAPI"
   );
 
+  static readonly WrappedCardVersion = "devPreview";
+  static readonly WrappedCardSchema = "<URL_REFERENCE_TO_SCHEMA>";
+  static readonly WrappedCardResponseLayout = "list";
+
   static readonly GetMethod = "get";
   static readonly PostMethod = "post";
   static readonly AdaptiveCardVersion = "1.5";

--- a/packages/fx-core/src/common/spec-parser/interfaces.ts
+++ b/packages/fx-core/src/common/spec-parser/interfaces.ts
@@ -133,6 +133,22 @@ export interface AdaptiveCard {
   body: Array<TextBlockElement | ArrayElement>;
 }
 
+export interface WrappedAdaptiveCard {
+  version: string;
+  $schema?: string;
+  jsonPath?: string;
+  responseLayout: string;
+  responseCardTemplate: AdaptiveCard;
+  previewCardTemplate: {
+    title: string;
+    subtitle?: string;
+    image?: {
+      url: string;
+      alt?: string;
+    };
+  };
+}
+
 export interface Parameter {
   name: string;
   title: string;

--- a/packages/fx-core/src/common/spec-parser/specParser.ts
+++ b/packages/fx-core/src/common/spec-parser/specParser.ts
@@ -25,6 +25,7 @@ import { convertPathToCamelCase, isSupportedApi, validateServer } from "./utils"
 import { updateManifest } from "./manifestUpdater";
 import { generateAdaptiveCard } from "./adaptiveCardGenerator";
 import path from "path";
+import { wrapAdaptiveCard } from "./adaptiveCardWrapper";
 
 /**
  * A class that parses an OpenAPI specification file and provides methods to validate, list, and generate artifacts.
@@ -228,7 +229,12 @@ export class SpecParser {
             try {
               const card: AdaptiveCard = generateAdaptiveCard(operation);
               const fileName = path.join(adaptiveCardFolder, `${operation.operationId!}.json`);
-              await fs.outputJSON(fileName, card, { spaces: 2 });
+              const wrappedCard = wrapAdaptiveCard(
+                card,
+                operation.operationId!,
+                method.toUpperCase() + " " + url
+              );
+              await fs.outputJSON(fileName, wrappedCard, { spaces: 2 });
             } catch (err) {
               result.allSuccess = false;
               result.warnings.push({

--- a/packages/fx-core/tests/common/spec-parser/adaptiveCardWrapper.test.ts
+++ b/packages/fx-core/tests/common/spec-parser/adaptiveCardWrapper.test.ts
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { expect } from "chai";
+import * as util from "util";
+import "mocha";
+import sinon from "sinon";
+import { wrapAdaptiveCard } from "../../../src/common/spec-parser/adaptiveCardWrapper";
+import { AdaptiveCard } from "../../../src/common/spec-parser/interfaces";
+
+describe("adaptiveCardWrapper", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("wrapAdaptiveCard", () => {
+    it("should generate wrapped card correctly", () => {
+      const card: AdaptiveCard = {
+        type: "AdaptiveCard",
+        version: "1.5",
+        body: [
+          {
+            type: "TextBlock",
+            text: "id: ${id}",
+            wrap: true,
+          },
+          {
+            type: "TextBlock",
+            text: "petId: ${petId}",
+            wrap: true,
+          },
+        ],
+        $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+      };
+
+      const expectedWrappedCard = {
+        version: "devPreview",
+        $schema: "<URL_REFERENCE_TO_SCHEMA>",
+        responseLayout: "list",
+        responseCardTemplate: card,
+        previewCardTemplate: {
+          title: "title",
+          subtitle: "subtitle",
+        },
+      };
+
+      const wrappedCard = wrapAdaptiveCard(card, "title", "subtitle");
+
+      expect(util.isDeepStrictEqual(wrappedCard, expectedWrappedCard)).to.be.true;
+    });
+  });
+});

--- a/packages/fx-core/tests/common/spec-parser/adaptiveCardWrapper.test.ts
+++ b/packages/fx-core/tests/common/spec-parser/adaptiveCardWrapper.test.ts
@@ -7,6 +7,7 @@ import "mocha";
 import sinon from "sinon";
 import { wrapAdaptiveCard } from "../../../src/common/spec-parser/adaptiveCardWrapper";
 import { AdaptiveCard } from "../../../src/common/spec-parser/interfaces";
+import { ConstantString } from "../../../src/common/spec-parser/constants";
 
 describe("adaptiveCardWrapper", () => {
   afterEach(() => {
@@ -34,9 +35,9 @@ describe("adaptiveCardWrapper", () => {
       };
 
       const expectedWrappedCard = {
-        version: "devPreview",
-        $schema: "<URL_REFERENCE_TO_SCHEMA>",
-        responseLayout: "list",
+        version: ConstantString.AdaptiveCardVersion,
+        $schema: ConstantString.AdaptiveCardSchema,
+        responseLayout: ConstantString.WrappedCardResponseLayout,
         responseCardTemplate: card,
         previewCardTemplate: {
           title: "title",

--- a/packages/fx-core/tests/common/spec-parser/adaptiveCardWrapper.test.ts
+++ b/packages/fx-core/tests/common/spec-parser/adaptiveCardWrapper.test.ts
@@ -35,8 +35,8 @@ describe("adaptiveCardWrapper", () => {
       };
 
       const expectedWrappedCard = {
-        version: ConstantString.AdaptiveCardVersion,
-        $schema: ConstantString.AdaptiveCardSchema,
+        version: ConstantString.WrappedCardVersion,
+        $schema: ConstantString.WrappedCardSchema,
         responseLayout: ConstantString.WrappedCardResponseLayout,
         responseCardTemplate: card,
         previewCardTemplate: {


### PR DESCRIPTION
Wrap adaptive card as below for SME:
```
 {
    version: "devPreview",
    $schema: "<URL_REFERENCE_TO_SCHEMA>",
    responseLayout: "list",
    responseCardTemplate: card,
    previewCardTemplate: {
      title: title,
      subtitle: subtitle,
    },
  };
```