### PR TITLE
fix(cli): disable telemetry when the global option is turned off

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,6 +21,7 @@
     "test:helper": "nyc --no-clean mocha \"tests/unit/helper.tests.ts\" ",
     "test:engine": "nyc --no-clean mocha \"tests/unit/engine.tests.ts\" ",
     "test:commands": "nyc --no-clean mocha \"tests/unit/commands.tests.ts\" ",
+    "test:telemetry": "nyc --no-clean mocha \"tests/unit/telemetry.tests.ts\" ",
     "check-format": "prettier --list-different --config .prettierrc.json --ignore-path .prettierignore \"{src,tests}/**/*.ts\" \"*.{js,json}\"",
     "format": "prettier --write --config .prettierrc.json --ignore-path .prettierignore \"{src,tests}/**/*.ts\" \"*.{js,json}\"",
     "lint:fix": "eslint \"src/**/*.ts\" \"tests/**/*.ts\" --fix",

--- a/packages/cli/src/commands/engine.ts
+++ b/packages/cli/src/commands/engine.ts
@@ -142,10 +142,8 @@ class CLIEngine {
       )}`
     );
 
-    const telemetryEnabled = this.isTelemetryEnabled(context);
-
     // send start event
-    if (telemetryEnabled && context.command.telemetry) {
+    if (context.command.telemetry) {
       CliTelemetry.sendTelemetryEvent(
         context.command.telemetry.event + "-start",
         context.telemetryProperties
@@ -464,6 +462,10 @@ class CLIEngine {
     }
     this.debugLogs = [];
 
+    // disable telemetry of turned off
+    const telemetryEnabled = this.isTelemetryEnabled(context);
+    CliTelemetry.enable = telemetryEnabled;
+
     // special process for global options
     // interactive
     // if user not input "--interactive" option value explicitly, toolkit will use default value defined by `defaultInteractiveOption`
@@ -580,8 +582,7 @@ class CLIEngine {
     return ok(undefined);
   }
   processResult(context?: CLIContext, fxError?: FxError): void {
-    const telemetryEnabled = this.isTelemetryEnabled(context);
-    if (context && context.command.telemetry && telemetryEnabled) {
+    if (context && context.command.telemetry) {
       if (context.optionValues.env) {
         context.telemetryProperties[TelemetryProperty.Env] = getHashedEnv(
           context.optionValues.env as string

--- a/packages/cli/src/commands/engine.ts
+++ b/packages/cli/src/commands/engine.ts
@@ -100,7 +100,7 @@ class CLIEngine {
     } else {
       this.processResult(context);
     }
-    if (context.command.name !== "preview") {
+    if (context.command.name !== "preview" || context.globalOptionValues.help) {
       // TODO: consider to remove the hardcode
       process.exit();
     }

--- a/packages/cli/src/commonlib/telemetry.ts
+++ b/packages/cli/src/commonlib/telemetry.ts
@@ -20,6 +20,7 @@ import { logger } from "./logger";
  *    extensionId = '<your extension unique name>', all events will be prefixed with this event name. eg: 'extensionId/eventname'
  */
 export class CliTelemetryReporter implements TelemetryReporter {
+  enable = true;
   private readonly reporter: Reporter;
   private rootFolder: string | undefined;
   private sharedProperties: { [key: string]: string } = {};
@@ -50,6 +51,7 @@ export class CliTelemetryReporter implements TelemetryReporter {
     measurements?: { [p: string]: number },
     errorProps?: string[]
   ): void {
+    if (!this.enable) return;
     if (!properties) {
       properties = { ...this.sharedProperties };
     } else {
@@ -73,6 +75,7 @@ export class CliTelemetryReporter implements TelemetryReporter {
     properties?: { [p: string]: string },
     measurements?: { [p: string]: number }
   ): void {
+    if (!this.enable) return;
     if (!properties) {
       properties = { ...this.sharedProperties };
     } else {
@@ -96,6 +99,7 @@ export class CliTelemetryReporter implements TelemetryReporter {
     properties?: { [p: string]: string },
     measurements?: { [p: string]: number }
   ): void {
+    if (!this.enable) return;
     if (!properties) {
       properties = { ...this.sharedProperties };
     } else {
@@ -111,6 +115,7 @@ export class CliTelemetryReporter implements TelemetryReporter {
   }
 
   async flush(): Promise<void> {
+    if (!this.enable) return;
     await this.reporter.flush();
   }
 

--- a/packages/cli/src/commonlib/telemetry.ts
+++ b/packages/cli/src/commonlib/telemetry.ts
@@ -21,7 +21,7 @@ import { logger } from "./logger";
  */
 export class CliTelemetryReporter implements TelemetryReporter {
   enable = true;
-  private readonly reporter: Reporter;
+  readonly reporter: Reporter;
   private rootFolder: string | undefined;
   private sharedProperties: { [key: string]: string } = {};
 

--- a/packages/cli/src/error.ts
+++ b/packages/cli/src/error.ts
@@ -18,7 +18,7 @@ export class MissingRequiredOptionError extends UserError {
     super({
       source: constants.cliSource,
       message: util.format(
-        strings["error.MissingRequiredArgumentError"],
+        strings["error.MissingRequiredOptionError"],
         command,
         typeof option === "string" ? option : option.name,
         typeof option === "string" ? option : helper.formatOptionName(option, false)

--- a/packages/cli/src/telemetry/cliTelemetry.ts
+++ b/packages/cli/src/telemetry/cliTelemetry.ts
@@ -4,7 +4,6 @@
 import { FxError, Inputs } from "@microsoft/teamsfx-api";
 import { fillInTelemetryPropsForFxError, getHashedEnv } from "@microsoft/teamsfx-core";
 import { CliTelemetryReporter } from "../commonlib/telemetry";
-import CLIUIInstance from "../userInteraction";
 import { getSettingsVersion } from "../utils";
 import { TelemetryComponentType, TelemetryProperty, TelemetrySuccess } from "./cliTelemetryEvents";
 

--- a/packages/cli/src/telemetry/cliTelemetry.ts
+++ b/packages/cli/src/telemetry/cliTelemetry.ts
@@ -24,6 +24,12 @@ class CliTelemetry {
   reporter: CliTelemetryReporter | undefined;
   rootFolder: string | undefined;
 
+  set enable(value: boolean) {
+    if (this.reporter) {
+      this.reporter.enable = value;
+    }
+  }
+
   public withRootFolder(rootFolder: string | undefined): CliTelemetry {
     this.rootFolder = rootFolder;
     this.reporter?.withRootFolder(rootFolder);

--- a/packages/cli/tests/unit/commands.tests.ts
+++ b/packages/cli/tests/unit/commands.tests.ts
@@ -342,16 +342,15 @@ describe("CLI commands", () => {
       assert.isTrue(res.isOk());
     });
     it("isWorkspaceSupported: false", async () => {
-      sandbox.stub(FxCore.prototype, "createEnv").resolves(ok(undefined));
       sandbox.stub(utils, "isWorkspaceSupported").returns(false);
       const ctx: CLIContext = {
-        command: { ...envAddCommand, fullName: "teamsfx" },
+        command: { ...envListCommand, fullName: "teamsfx" },
         optionValues: { projectPath: "." },
         globalOptionValues: {},
         argumentValues: [],
         telemetryProperties: {},
       };
-      const res = await envAddCommand.handler!(ctx);
+      const res = await envListCommand.handler!(ctx);
       assert.isTrue(res.isErr());
     });
     it("listEnv error", async () => {

--- a/packages/cli/tests/unit/engine.tests.ts
+++ b/packages/cli/tests/unit/engine.tests.ts
@@ -1,4 +1,5 @@
 import {
+  CLICommand,
   CLICommandOption,
   CLIContext,
   CLIFoundCommand,
@@ -323,12 +324,37 @@ describe("CLI Engine", () => {
       engine.processResult(ctx, undefined);
       assert.isTrue(sendTelemetryEventStub.calledOnce);
     });
-    it("skip telemetry", async () => {
+    it("skip telemetry when reporter is disabled", async () => {
       CliTelemetry.reporter = new CliTelemetryReporter("real", "real", "real", "real");
       CliTelemetry.enable = false;
       const spy = sandbox.spy(CliTelemetry.reporter.reporter, "sendTelemetryEvent");
       const ctx: CLIContext = {
         command: { ...getCreateCommand(), fullName: "abc" },
+        optionValues: {},
+        globalOptionValues: { telemetry: false },
+        argumentValues: [],
+        telemetryProperties: {},
+      };
+      engine.processResult(ctx, undefined);
+      assert.isTrue(spy.notCalled);
+    });
+    it("skip telemetry when context is undefined", async () => {
+      CliTelemetry.reporter = new CliTelemetryReporter("real", "real", "real", "real");
+      CliTelemetry.enable = false;
+      const spy = sandbox.spy(CliTelemetry.reporter.reporter, "sendTelemetryEvent");
+      engine.processResult(undefined, undefined);
+      assert.isTrue(spy.notCalled);
+    });
+    it("skip telemetry when command telemetry is undefined", async () => {
+      CliTelemetry.reporter = new CliTelemetryReporter("real", "real", "real", "real");
+      CliTelemetry.enable = false;
+      const spy = sandbox.spy(CliTelemetry.reporter.reporter, "sendTelemetryEvent");
+      const command: CLICommand = {
+        name: "test",
+        description: "test",
+      };
+      const ctx: CLIContext = {
+        command: { ...command, fullName: "test" },
         optionValues: {},
         globalOptionValues: { telemetry: false },
         argumentValues: [],

--- a/packages/cli/tests/unit/engine.tests.ts
+++ b/packages/cli/tests/unit/engine.tests.ts
@@ -37,6 +37,7 @@ import * as main from "../../src/index";
 import CliTelemetry from "../../src/telemetry/cliTelemetry";
 import { getVersion } from "../../src/utils";
 import { UserSettings } from "../../src/userSetttings";
+import { CliTelemetryReporter } from "../../src/commonlib/telemetry";
 
 describe("CLI Engine", () => {
   const sandbox = sinon.createSandbox();
@@ -323,7 +324,9 @@ describe("CLI Engine", () => {
       assert.isTrue(sendTelemetryEventStub.calledOnce);
     });
     it("skip telemetry", async () => {
-      const sendTelemetryEventStub = sandbox.stub(CliTelemetry, "sendTelemetryEvent").returns();
+      CliTelemetry.reporter = new CliTelemetryReporter("real", "real", "real", "real");
+      CliTelemetry.enable = false;
+      const spy = sandbox.spy(CliTelemetry.reporter.reporter, "sendTelemetryEvent");
       const ctx: CLIContext = {
         command: { ...getCreateCommand(), fullName: "abc" },
         optionValues: {},
@@ -332,7 +335,7 @@ describe("CLI Engine", () => {
         telemetryProperties: {},
       };
       engine.processResult(ctx, undefined);
-      assert.isTrue(sendTelemetryEventStub.callCount === 0);
+      assert.isTrue(spy.notCalled);
     });
   });
   describe("start", async () => {

--- a/packages/cli/tests/unit/telemetry.tests.ts
+++ b/packages/cli/tests/unit/telemetry.tests.ts
@@ -14,6 +14,9 @@ describe("CLI Telemetry", function () {
     sandbox.restore();
   });
   describe("disable", () => {
+    it("no reporter", () => {
+      cliTelemetry.enable = false;
+    });
     it("sendTelemetryEvent", () => {
       cliTelemetry.reporter = new CliTelemetryReporter("real", "real", "real", "real");
       const spy = sandbox.spy(cliTelemetry.reporter.reporter, "sendTelemetryEvent");

--- a/packages/cli/tests/unit/telemetry.tests.ts
+++ b/packages/cli/tests/unit/telemetry.tests.ts
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { assert } from "chai";
+import "mocha";
+import sinon from "sinon";
+import cliTelemetry from "../../src/telemetry/cliTelemetry";
+import { CliTelemetryReporter } from "../../src/commonlib/telemetry";
+import { UserCancelError } from "@microsoft/teamsfx-core";
+
+describe("CLI Telemetry", function () {
+  const sandbox = sinon.createSandbox();
+  afterEach(() => {
+    sandbox.restore();
+  });
+  describe("disable", () => {
+    it("sendTelemetryEvent", () => {
+      cliTelemetry.reporter = new CliTelemetryReporter("real", "real", "real", "real");
+      const spy = sandbox.spy(cliTelemetry.reporter.reporter, "sendTelemetryEvent");
+      cliTelemetry.enable = false;
+      cliTelemetry.sendTelemetryEvent("eventName");
+      assert.isTrue(spy.notCalled);
+    });
+    it("sendTelemetryErrorEvent", () => {
+      cliTelemetry.reporter = new CliTelemetryReporter("real", "real", "real", "real");
+      const spy = sandbox.spy(cliTelemetry.reporter.reporter, "sendTelemetryErrorEvent");
+      cliTelemetry.enable = false;
+      cliTelemetry.sendTelemetryErrorEvent("eventName", new UserCancelError());
+      assert.isTrue(spy.notCalled);
+    });
+    it("sendTelemetryException", () => {
+      cliTelemetry.reporter = new CliTelemetryReporter("real", "real", "real", "real");
+      const spy = sandbox.spy(cliTelemetry.reporter.reporter, "sendTelemetryException");
+      cliTelemetry.enable = false;
+      cliTelemetry.sendTelemetryException(new Error());
+      assert.isTrue(spy.notCalled);
+    });
+  });
+});


### PR DESCRIPTION
fix: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/25186195