### PR TITLE
fix: add capability to templates

### DIFF
--- a/templates/csharp/copilot-plugin-existing-api/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/copilot-plugin-existing-api/{{ProjectName}}.csproj.tpl
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <ProjectCapability Include="TeamsFx" />
+    <ProjectCapability Include="CopilotPlugin" />
   </ItemGroup>
 
   <ItemGroup>

--- a/templates/csharp/copilot-plugin-from-oai-plugin/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/copilot-plugin-from-oai-plugin/{{ProjectName}}.csproj.tpl
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <ProjectCapability Include="TeamsFx" />
+    <ProjectCapability Include="CopilotPlugin" />
   </ItemGroup>
 
   <ItemGroup>

--- a/templates/csharp/copilot-plugin-from-scratch/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/copilot-plugin-from-scratch/{{ProjectName}}.csproj.tpl
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <ProjectCapability Include="TeamsFx" />
+    <ProjectCapability Include="CopilotPlugin" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
For API ME projects, add capability as the feature flag for "Add API".

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/25177849