### PR TITLE
perf(spec-parser): show N/A when value in AC is missing

### DIFF
--- a/packages/fx-core/src/common/spec-parser/adaptiveCardGenerator.ts
+++ b/packages/fx-core/src/common/spec-parser/adaptiveCardGenerator.ts
@@ -112,7 +112,7 @@ export function generateCardFromResponse(
     let text = "result: ${$root}";
     if (name) {
       // object { id: "1" }
-      text = `${name}: \${${name}}`;
+      text = `${name}: \${if(${name}, ${name}, 'N/A')}`;
       if (parentArrayName) {
         // object types inside array: { tags: ["id": 1, "name": "name"] }
         text = `${parentArrayName}.${text}`;

--- a/packages/fx-core/tests/common/spec-parser/adaptiveCardGenerator.test.ts
+++ b/packages/fx-core/tests/common/spec-parser/adaptiveCardGenerator.test.ts
@@ -46,12 +46,12 @@ describe("adaptiveCardGenerator", () => {
         body: [
           {
             type: "TextBlock",
-            text: "name: ${name}",
+            text: "name: ${if(name, name, 'N/A')}",
             wrap: true,
           },
           {
             type: "TextBlock",
-            text: "age: ${age}",
+            text: "age: ${if(age, age, 'N/A')}",
             wrap: true,
           },
         ],
@@ -190,12 +190,12 @@ describe("adaptiveCardGenerator", () => {
       const expected = [
         {
           type: "TextBlock",
-          text: "person.name: ${person.name}",
+          text: "person.name: ${if(person.name, person.name, 'N/A')}",
           wrap: true,
         },
         {
           type: "TextBlock",
-          text: "person.age: ${person.age}",
+          text: "person.age: ${if(person.age, person.age, 'N/A')}",
           wrap: true,
         },
       ];
@@ -262,7 +262,7 @@ describe("adaptiveCardGenerator", () => {
       const expected = [
         {
           type: "TextBlock",
-          text: "person: ${person}",
+          text: "person: ${if(person, person, 'N/A')}",
           wrap: true,
         },
       ];
@@ -297,17 +297,17 @@ describe("adaptiveCardGenerator", () => {
       const expected = [
         {
           type: "TextBlock",
-          text: "person.name: ${person.name}",
+          text: "person.name: ${if(person.name, person.name, 'N/A')}",
           wrap: true,
         },
         {
           type: "TextBlock",
-          text: "person.address.street: ${person.address.street}",
+          text: "person.address.street: ${if(person.address.street, person.address.street, 'N/A')}",
           wrap: true,
         },
         {
           type: "TextBlock",
-          text: "person.address.city: ${person.address.city}",
+          text: "person.address.city: ${if(person.address.city, person.address.city, 'N/A')}",
           wrap: true,
         },
       ];
@@ -342,17 +342,17 @@ describe("adaptiveCardGenerator", () => {
       const expected = [
         {
           type: "TextBlock",
-          text: "name: ${name}",
+          text: "name: ${if(name, name, 'N/A')}",
           wrap: true,
         },
         {
           type: "TextBlock",
-          text: "address.street: ${address.street}",
+          text: "address.street: ${if(address.street, address.street, 'N/A')}",
           wrap: true,
         },
         {
           type: "TextBlock",
-          text: "address.city: ${address.city}",
+          text: "address.city: ${if(address.city, address.city, 'N/A')}",
           wrap: true,
         },
       ];
@@ -397,7 +397,7 @@ describe("adaptiveCardGenerator", () => {
           items: [
             {
               type: "TextBlock",
-              text: "company.name: ${name}",
+              text: "company.name: ${if(name, name, 'N/A')}",
               wrap: true,
             },
             {
@@ -406,12 +406,12 @@ describe("adaptiveCardGenerator", () => {
               items: [
                 {
                   type: "TextBlock",
-                  text: "people.name: ${name}",
+                  text: "people.name: ${if(name, name, 'N/A')}",
                   wrap: true,
                 },
                 {
                   type: "TextBlock",
-                  text: "people.age: ${age}",
+                  text: "people.age: ${if(age, age, 'N/A')}",
                   wrap: true,
                 },
               ],
@@ -460,7 +460,7 @@ describe("adaptiveCardGenerator", () => {
           items: [
             {
               type: "TextBlock",
-              text: "name: ${name}",
+              text: "name: ${if(name, name, 'N/A')}",
               wrap: true,
             },
             {
@@ -469,12 +469,12 @@ describe("adaptiveCardGenerator", () => {
               items: [
                 {
                   type: "TextBlock",
-                  text: "people.name: ${name}",
+                  text: "people.name: ${if(name, name, 'N/A')}",
                   wrap: true,
                 },
                 {
                   type: "TextBlock",
-                  text: "people.age: ${age}",
+                  text: "people.age: ${if(age, age, 'N/A')}",
                   wrap: true,
                 },
               ],
@@ -516,7 +516,7 @@ describe("adaptiveCardGenerator", () => {
       const expected = [
         {
           type: "TextBlock",
-          text: "company.name: ${company.name}",
+          text: "company.name: ${if(company.name, company.name, 'N/A')}",
           wrap: true,
         },
         {
@@ -525,12 +525,12 @@ describe("adaptiveCardGenerator", () => {
           items: [
             {
               type: "TextBlock",
-              text: "company.people.name: ${name}",
+              text: "company.people.name: ${if(name, name, 'N/A')}",
               wrap: true,
             },
             {
               type: "TextBlock",
-              text: "company.people.age: ${age}",
+              text: "company.people.age: ${if(age, age, 'N/A')}",
               wrap: true,
             },
           ],
@@ -588,7 +588,7 @@ describe("adaptiveCardGenerator", () => {
       const expected = [
         {
           type: "TextBlock",
-          text: "person.name: ${person.name}",
+          text: "person.name: ${if(person.name, person.name, 'N/A')}",
           wrap: true,
         },
       ];


### PR DESCRIPTION
[Bug 25150444](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/25150444): [API ME] Better way to show value in the adaptive card when the value is missing in the response

For previewCardTemplate, we need further discussion before making changes