### PR TITLE
feat: add telemetry for debug in test tool

### DIFF
--- a/packages/fx-core/src/common/local/constants.ts
+++ b/packages/fx-core/src/common/local/constants.ts
@@ -104,17 +104,25 @@ export const TaskCommand = Object.freeze({
   migrate: "migrate",
 });
 
+export const TeamsFxNpmCommands = Object.freeze({
+  startApplication: "npm run dev:teamsfx",
+  startApplicationForTestTool: "npm run dev:teamsfx:testtool",
+  startTestTool: "npm run dev:teamsfx:launch-testtool",
+});
+
 export const TaskOverallLabel = Object.freeze({
   NextDefault: "Pre Debug Check & Start All",
   NextM365: "Pre Debug Check & Start All & Install App",
   NextSPFx: "prepare dev env",
   TransparentDefault: "Start Teams App Locally",
   TransparentM365: "Start Teams App Locally & Install App",
+  TestToolDefault: "Start Teams App (Test Tool)",
 });
 
 export const TaskLabel = Object.freeze({
   PrerequisiteCheck: "Validate & install prerequisites",
   PrerequisiteCheckV3: "Validate prerequisites",
+  PrerequisiteCheckV3TestTool: "Validate prerequisites (Test Tool)",
   InstallNpmPackages: "Install npm packages",
   StartLocalTunnel: "Start local tunnel",
   SetUpTab: "Set up tab",
@@ -124,6 +132,8 @@ export const TaskLabel = Object.freeze({
   InstallAzureFuncBindingExt: "Install Azure Functions binding extensions",
   StartServices: "Start services",
   StartApplication: "Start application", // V3
+  StartApplicationTestTool: "Start application for Test Tool", // V3
+  StartTestTool: "Start Test Tool", // V3
   StartFrontend: "Start frontend",
   StartBackend: "Start backend",
   WatchBackend: "Watch backend",
@@ -135,6 +145,7 @@ export const TaskLabel = Object.freeze({
   GulpServe: "gulp serve",
   Provision: "Provision", // V3
   Deploy: "Deploy", // V3
+  DeployTestTool: "Deploy (Test Tool)", // V3
 });
 
 export const TaskDefaultValue = Object.freeze({

--- a/packages/vscode-extension/src/debug/localTelemetryReporter.ts
+++ b/packages/vscode-extension/src/debug/localTelemetryReporter.ts
@@ -22,6 +22,7 @@ import {
 } from "../telemetry/extTelemetryEvents";
 import { getLocalDebugSession } from "./commonUtils";
 import { TeamsfxTaskProvider } from "./teamsfxTaskProvider";
+import { TeamsFxNpmCommands } from "@microsoft/teamsfx-core";
 
 function saveEventTime(eventName: string, time: number) {
   const session = getLocalDebugSession();
@@ -52,7 +53,7 @@ export const localTelemetryReporter = new LocalTelemetryReporter(
   saveEventTime
 );
 
-export function sendDebugAllStartEvent(additionalProperties: {
+export async function sendDebugAllStartEvent(additionalProperties: {
   [key: string]: string;
 }): Promise<void> {
   const session = getLocalDebugSession();
@@ -62,6 +63,20 @@ export function sendDebugAllStartEvent(additionalProperties: {
     { [TelemetryProperty.CorrelationId]: session.id },
     session.properties
   );
+
+  // Transparent task properties
+  const taskInfo = await getTaskInfo();
+  if (taskInfo && taskInfo.IsTransparentTask) {
+    properties[TelemetryProperty.DebugPrelaunchTaskInfo] = JSON.stringify(
+      taskInfo.PreLaunchTaskInfo
+    );
+    properties[TelemetryProperty.DebugIsTransparentTask] =
+      properties[TelemetryProperty.DebugIsTransparentTask] ?? "true";
+  } else {
+    properties[TelemetryProperty.DebugIsTransparentTask] =
+      properties[TelemetryProperty.DebugIsTransparentTask] ?? "false";
+  }
+
   localTelemetryReporter.sendTelemetryEvent(TelemetryEvent.DebugAllStart, properties);
   return Promise.resolve();
 }
@@ -226,7 +241,11 @@ export async function getTaskInfo(): Promise<TaskInfo | undefined> {
 
       for (const label of labelList) {
         const task = findTask(taskJson, label);
-        const isTeamsFxTask = task?.type === TeamsfxTaskProvider.type;
+        const isTeamsFxTask =
+          task?.type === TeamsfxTaskProvider.type ||
+          (task?.type === "shell" &&
+            task?.command &&
+            Object.values(TeamsFxNpmCommands).includes(task?.command));
 
         // Only send the info scaffold by Teams Toolkit. If user changed some property, the value will be "unknown".
         dependsOnArr.push({
@@ -236,7 +255,10 @@ export async function getTaskInfo(): Promise<TaskInfo | undefined> {
             ? task?.command
               ? UnknownPlaceholder
               : UndefinedPlaceholder
-            : maskValue(task?.command, Object.values(TaskCommand)),
+            : maskValue(task?.command, [
+                ...Object.values(TaskCommand),
+                ...Object.values(TeamsFxNpmCommands),
+              ]),
         });
       }
       return dependsOnArr;

--- a/packages/vscode-extension/src/error.ts
+++ b/packages/vscode-extension/src/error.ts
@@ -17,6 +17,7 @@ export enum ExtensionErrors {
   PrerequisitesSideloadingDisabledError = "PrerequisitesSideloadingDisabledError",
   PrerequisitesInstallPackagesError = "PrerequisitesPackageInstallError",
   DebugServiceFailedBeforeStartError = "DebugServiceFailedBeforeStartError",
+  DebugTestToolFailedToStartError = "DebugTestToolFailedToStartError",
   DebugNpmInstallError = "DebugNpmInstallError",
   OpenExternalFailed = "OpenExternalFailed",
   FolderAlreadyExist = "FolderAlreadyExist",

--- a/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
@@ -296,6 +296,7 @@ export enum TelemetryProperty {
   DebugNgrokLog = "debug-ngrok-log",
   DebugConfigName = "debug-config-name",
   DebugDevTunnelNum = "debug-dev-tunnel-num",
+  DebugTestTool = "debug-test-tool",
   Internal = "internal",
   InternalAlias = "internal-alias",
   OSArch = "os-arch",


### PR DESCRIPTION
- Test tool won't use vscode launch.json to launch browser, so old telemetry logic to send "debug-all" doesn't work
- Change to send "debug-all" in the "Launch Test Tool" task which is the final task for "Debug in Test Tool"

TODO: send test tool logs in telemetry
