### PR TITLE
refactor: disable validate manifest action for unreleased dev preview schema

### DIFF
--- a/templates/common/copilot-plugin-existing-api/teamsapp.yml.tpl
+++ b/templates/common/copilot-plugin-existing-api/teamsapp.yml.tpl
@@ -17,11 +17,6 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Validate using manifest schema
-  - uses: teamsApp/validateManifest
-    with:
-      # Path to manifest template
-      manifestPath: ./appPackage/manifest.json
   # Build Teams app package with latest env value
   - uses: teamsApp/zipAppPackage
     with:
@@ -54,11 +49,6 @@ provision:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-  # Validate using manifest schema
-  - uses: teamsApp/validateManifest
-    with:
-      # Path to manifest template
-      manifestPath: ./appPackage/manifest.json
   # Build Teams app package with latest env value
   - uses: teamsApp/zipAppPackage
     with:

--- a/templates/common/copilot-plugin-from-oai-plugin/teamsapp.yml.tpl
+++ b/templates/common/copilot-plugin-from-oai-plugin/teamsapp.yml.tpl
@@ -17,11 +17,6 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Validate using manifest schema
-  - uses: teamsApp/validateManifest
-    with:
-      # Path to manifest template
-      manifestPath: ./appPackage/manifest.json
   # Build Teams app package with latest env value
   - uses: teamsApp/zipAppPackage
     with:
@@ -54,11 +49,6 @@ provision:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-  # Validate using manifest schema
-  - uses: teamsApp/validateManifest
-    with:
-      # Path to manifest template
-      manifestPath: ./appPackage/manifest.json
   # Build Teams app package with latest env value
   - uses: teamsApp/zipAppPackage
     with:

--- a/templates/constraints/yml/templates/common/copilot-plugin-existing-api/teamsapp.yml.tpl.mustache
+++ b/templates/constraints/yml/templates/common/copilot-plugin-existing-api/teamsapp.yml.tpl.mustache
@@ -6,7 +6,6 @@ environmentFolderPath: ./env
 provision:
 {{#teamsAppCreate}} {{/teamsAppCreate}}
 
-{{#teamsAppValidateManifest}} {{/teamsAppValidateManifest}}
 {{#teamsAppZipAppPackage}} {{/teamsAppZipAppPackage}}
 {{#teamsAppValidateAppPackage}} {{/teamsAppValidateAppPackage}}
 {{#teamsAppUpdate}} {{/teamsAppUpdate}}
@@ -14,7 +13,6 @@ provision:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-{{#teamsAppValidateManifest}} {{/teamsAppValidateManifest}}
 {{#teamsAppZipAppPackage}} {{/teamsAppZipAppPackage}}
 {{#teamsAppValidateAppPackage}} {{/teamsAppValidateAppPackage}}
 {{#teamsAppUpdate}} {{/teamsAppUpdate}}

--- a/templates/constraints/yml/templates/common/copilot-plugin-from-oai-plugin/teamsapp.yml.tpl.mustache
+++ b/templates/constraints/yml/templates/common/copilot-plugin-from-oai-plugin/teamsapp.yml.tpl.mustache
@@ -6,7 +6,6 @@ environmentFolderPath: ./env
 provision:
 {{#teamsAppCreate}} {{/teamsAppCreate}}
 
-{{#teamsAppValidateManifest}} {{/teamsAppValidateManifest}}
 {{#teamsAppZipAppPackage}} {{/teamsAppZipAppPackage}}
 {{#teamsAppValidateAppPackage}} {{/teamsAppValidateAppPackage}}
 {{#teamsAppUpdate}} {{/teamsAppUpdate}}
@@ -14,7 +13,6 @@ provision:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-{{#teamsAppValidateManifest}} {{/teamsAppValidateManifest}}
 {{#teamsAppZipAppPackage}} {{/teamsAppZipAppPackage}}
 {{#teamsAppValidateAppPackage}} {{/teamsAppValidateAppPackage}}
 {{#teamsAppUpdate}} {{/teamsAppUpdate}}

--- a/templates/constraints/yml/templates/csharp/copilot-plugin-existing-api/teamsapp.yml.tpl.mustache
+++ b/templates/constraints/yml/templates/csharp/copilot-plugin-existing-api/teamsapp.yml.tpl.mustache
@@ -6,8 +6,6 @@ environmentFolderPath: ./env
 provision:
 {{#teamsAppCreate}}  {{/teamsAppCreate}}
 
-{{#teamsAppValidateManifest}}  {{/teamsAppValidateManifest}}
-
 {{#teamsAppZipAppPackage}}  {{/teamsAppZipAppPackage}}
 
 {{#teamsAppValidateAppPackage}}  {{/teamsAppValidateAppPackage}}

--- a/templates/constraints/yml/templates/csharp/copilot-plugin-from-oai-plugin/teamsapp.yml.tpl.mustache
+++ b/templates/constraints/yml/templates/csharp/copilot-plugin-from-oai-plugin/teamsapp.yml.tpl.mustache
@@ -6,8 +6,6 @@ environmentFolderPath: ./env
 provision:
 {{#teamsAppCreate}}  {{/teamsAppCreate}}
 
-{{#teamsAppValidateManifest}}  {{/teamsAppValidateManifest}}
-
 {{#teamsAppZipAppPackage}}  {{/teamsAppZipAppPackage}}
 
 {{#teamsAppValidateAppPackage}}  {{/teamsAppValidateAppPackage}}

--- a/templates/constraints/yml/templates/csharp/copilot-plugin-from-scratch/teamsapp.local.yml.tpl.mustache
+++ b/templates/constraints/yml/templates/csharp/copilot-plugin-from-scratch/teamsapp.local.yml.tpl.mustache
@@ -3,8 +3,6 @@
 provision:
 {{#teamsAppCreate}} {{/teamsAppCreate}}
 
-{{#teamsAppValidateManifest}} {{/teamsAppValidateManifest}}
-
 {{#teamsAppZipAppPackage}} {{/teamsAppZipAppPackage}}
 
 {{#teamsAppValidateAppPackage}} {{/teamsAppValidateAppPackage}}

--- a/templates/constraints/yml/templates/csharp/copilot-plugin-from-scratch/teamsapp.yml.tpl.mustache
+++ b/templates/constraints/yml/templates/csharp/copilot-plugin-from-scratch/teamsapp.yml.tpl.mustache
@@ -8,8 +8,6 @@ provision:
 
 {{#armDeploy}} deploymentName: Create-resources-for-sme {{/armDeploy}}
 
-{{#teamsAppValidateManifest}} {{/teamsAppValidateManifest}}
-
 {{#teamsAppZipAppPackage}} {{/teamsAppZipAppPackage}}
 
 {{#teamsAppValidateAppPackage}} {{/teamsAppValidateAppPackage}}

--- a/templates/constraints/yml/templates/js/copilot-plugin-from-scratch/teamsapp.local.yml.tpl.mustache
+++ b/templates/constraints/yml/templates/js/copilot-plugin-from-scratch/teamsapp.local.yml.tpl.mustache
@@ -5,8 +5,6 @@ provision:
 
 {{#script}} FUNC, FUNC_NAME: repair {{/script}}
 
-{{#teamsAppValidateManifest}} {{/teamsAppValidateManifest}}
-
 {{#teamsAppZipAppPackage}} {{/teamsAppZipAppPackage}}
 
 {{#teamsAppValidateAppPackage}} {{/teamsAppValidateAppPackage}}

--- a/templates/constraints/yml/templates/js/copilot-plugin-from-scratch/teamsapp.yml.tpl.mustache
+++ b/templates/constraints/yml/templates/js/copilot-plugin-from-scratch/teamsapp.yml.tpl.mustache
@@ -8,8 +8,6 @@ provision:
 
 {{#armDeploy}} deploymentName: Create-resources-for-sme {{/armDeploy}}
 
-{{#teamsAppValidateManifest}} {{/teamsAppValidateManifest}}
-
 {{#teamsAppZipAppPackage}} {{/teamsAppZipAppPackage}}
 
 {{#teamsAppValidateAppPackage}} {{/teamsAppValidateAppPackage}}
@@ -26,7 +24,6 @@ deploy:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-{{#teamsAppValidateManifest}} {{/teamsAppValidateManifest}}
 {{#teamsAppZipAppPackage}} {{/teamsAppZipAppPackage}}
 {{#teamsAppValidateAppPackage}} {{/teamsAppValidateAppPackage}}
 {{#teamsAppUpdate}} {{/teamsAppUpdate}}

--- a/templates/constraints/yml/templates/ts/copilot-plugin-from-scratch/teamsapp.local.yml.tpl.mustache
+++ b/templates/constraints/yml/templates/ts/copilot-plugin-from-scratch/teamsapp.local.yml.tpl.mustache
@@ -5,8 +5,6 @@ provision:
 
 {{#script}} FUNC, FUNC_NAME: repair {{/script}}
 
-{{#teamsAppValidateManifest}} {{/teamsAppValidateManifest}}
-
 {{#teamsAppZipAppPackage}} {{/teamsAppZipAppPackage}}
 
 {{#teamsAppValidateAppPackage}} {{/teamsAppValidateAppPackage}}

--- a/templates/constraints/yml/templates/ts/copilot-plugin-from-scratch/teamsapp.yml.tpl.mustache
+++ b/templates/constraints/yml/templates/ts/copilot-plugin-from-scratch/teamsapp.yml.tpl.mustache
@@ -8,8 +8,6 @@ provision:
 
 {{#armDeploy}} deploymentName: Create-resources-for-sme {{/armDeploy}}
 
-{{#teamsAppValidateManifest}} {{/teamsAppValidateManifest}}
-
 {{#teamsAppZipAppPackage}} {{/teamsAppZipAppPackage}}
 
 {{#teamsAppValidateAppPackage}} {{/teamsAppValidateAppPackage}}
@@ -28,7 +26,6 @@ deploy:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-{{#teamsAppValidateManifest}} {{/teamsAppValidateManifest}}
 {{#teamsAppZipAppPackage}} {{/teamsAppZipAppPackage}}
 {{#teamsAppValidateAppPackage}} {{/teamsAppValidateAppPackage}}
 {{#teamsAppUpdate}} {{/teamsAppUpdate}}

--- a/templates/csharp/copilot-plugin-existing-api/teamsapp.yml.tpl
+++ b/templates/csharp/copilot-plugin-existing-api/teamsapp.yml.tpl
@@ -17,12 +17,6 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Validate using manifest schema
-  - uses: teamsApp/validateManifest
-    with:
-      # Path to manifest template
-      manifestPath: ./appPackage/manifest.json
-
   # Build Teams app package with latest env value
   - uses: teamsApp/zipAppPackage
     with:

--- a/templates/csharp/copilot-plugin-from-oai-plugin/teamsapp.yml.tpl
+++ b/templates/csharp/copilot-plugin-from-oai-plugin/teamsapp.yml.tpl
@@ -17,12 +17,6 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Validate using manifest schema
-  - uses: teamsApp/validateManifest
-    with:
-      # Path to manifest template
-      manifestPath: ./appPackage/manifest.json
-
   # Build Teams app package with latest env value
   - uses: teamsApp/zipAppPackage
     with:

--- a/templates/csharp/copilot-plugin-from-scratch/teamsapp.local.yml.tpl
+++ b/templates/csharp/copilot-plugin-from-scratch/teamsapp.local.yml.tpl
@@ -14,12 +14,6 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Validate using manifest schema
-  - uses: teamsApp/validateManifest
-    with:
-      # Path to manifest template
-      manifestPath: ./appPackage/manifest.json
-
   # Build Teams app package with latest env value
   - uses: teamsApp/zipAppPackage
     with:

--- a/templates/csharp/copilot-plugin-from-scratch/teamsapp.yml.tpl
+++ b/templates/csharp/copilot-plugin-from-scratch/teamsapp.yml.tpl
@@ -42,12 +42,6 @@ provision:
       # will use bicep CLI in PATH if you remove this config.
       bicepCliVersion: v0.9.1
 
-  # Validate using manifest schema
-  - uses: teamsApp/validateManifest
-    with:
-      # Path to manifest template
-      manifestPath: ./appPackage/manifest.json
-
   # Build Teams app package with latest env value
   - uses: teamsApp/zipAppPackage
     with:

--- a/templates/js/copilot-plugin-from-scratch/teamsapp.local.yml.tpl
+++ b/templates/js/copilot-plugin-from-scratch/teamsapp.local.yml.tpl
@@ -21,12 +21,6 @@ provision:
         echo "::set-teamsfx-env FUNC_NAME=repair";
         echo "::set-teamsfx-env FUNC_ENDPOINT=http://localhost:7071";
 
-  # Validate using manifest schema
-  - uses: teamsApp/validateManifest
-    with:
-      # Path to manifest template
-      manifestPath: ./appPackage/manifest.json
-
   # Build Teams app package with latest env value
   - uses: teamsApp/zipAppPackage
     with:

--- a/templates/js/copilot-plugin-from-scratch/teamsapp.yml.tpl
+++ b/templates/js/copilot-plugin-from-scratch/teamsapp.yml.tpl
@@ -42,12 +42,6 @@ provision:
       # will use bicep CLI in PATH if you remove this config.
       bicepCliVersion: v0.9.1
 
-  # Validate using manifest schema
-  - uses: teamsApp/validateManifest
-    with:
-      # Path to manifest template
-      manifestPath: ./appPackage/manifest.json
-
   # Build Teams app package with latest env value
   - uses: teamsApp/zipAppPackage
     with:
@@ -105,11 +99,6 @@ deploy:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-  # Validate using manifest schema
-  - uses: teamsApp/validateManifest
-    with:
-      # Path to manifest template
-      manifestPath: ./appPackage/manifest.json
   # Build Teams app package with latest env value
   - uses: teamsApp/zipAppPackage
     with:

--- a/templates/ts/copilot-plugin-from-scratch/teamsapp.local.yml.tpl
+++ b/templates/ts/copilot-plugin-from-scratch/teamsapp.local.yml.tpl
@@ -21,12 +21,6 @@ provision:
         echo "::set-teamsfx-env FUNC_NAME=repair";
         echo "::set-teamsfx-env FUNC_ENDPOINT=http://localhost:7071";
 
-  # Validate using manifest schema
-  - uses: teamsApp/validateManifest
-    with:
-      # Path to manifest template
-      manifestPath: ./appPackage/manifest.json
-
   # Build Teams app package with latest env value
   - uses: teamsApp/zipAppPackage
     with:

--- a/templates/ts/copilot-plugin-from-scratch/teamsapp.yml.tpl
+++ b/templates/ts/copilot-plugin-from-scratch/teamsapp.yml.tpl
@@ -42,12 +42,6 @@ provision:
       # will use bicep CLI in PATH if you remove this config.
       bicepCliVersion: v0.9.1
 
-  # Validate using manifest schema
-  - uses: teamsApp/validateManifest
-    with:
-      # Path to manifest template
-      manifestPath: ./appPackage/manifest.json
-
   # Build Teams app package with latest env value
   - uses: teamsApp/zipAppPackage
     with:
@@ -110,11 +104,6 @@ deploy:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
-  # Validate using manifest schema
-  - uses: teamsApp/validateManifest
-    with:
-      # Path to manifest template
-      manifestPath: ./appPackage/manifest.json
   # Build Teams app package with latest env value
   - uses: teamsApp/zipAppPackage
     with:


### PR DESCRIPTION
Temporarily disable this action due to dev preview schema not released. Will bring it back when schema ready.

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/25124059