### PR TITLE
perf(spec-parser): treat required + default parameter as optional parameter

### DIFF
--- a/packages/fx-core/src/common/spec-parser/manifestUpdater.ts
+++ b/packages/fx-core/src/common/spec-parser/manifestUpdater.ts
@@ -67,7 +67,7 @@ export function generateParametersFromSchema(
       title: updateFirstLetter(name),
       description: schema.description ?? "",
     };
-    if (isRequired) {
+    if (isRequired && schema.default === undefined) {
       requiredParams.push(parameter);
     } else {
       optionalParams.push(parameter);
@@ -123,10 +123,14 @@ export async function generateCommands(
                     title: updateFirstLetter(param.name),
                     description: param.description ?? "",
                   };
-                  if (param.required) {
-                    requiredParams.push(parameter);
-                  } else {
-                    optionalParams.push(parameter);
+
+                  const schema = param.schema as OpenAPIV3.SchemaObject;
+                  if (param.in !== "header" && param.in !== "cookie") {
+                    if (param.required && schema?.default === undefined) {
+                      requiredParams.push(parameter);
+                    } else {
+                      optionalParams.push(parameter);
+                    }
                   }
                 });
               }

--- a/packages/fx-core/src/common/spec-parser/utils.ts
+++ b/packages/fx-core/src/common/spec-parser/utils.ts
@@ -46,7 +46,7 @@ export function checkParameters(paramObject: OpenAPIV3.ParameterObject[]): Check
     const schema = param.schema as OpenAPIV3.SchemaObject;
 
     if (param.in === "header" || param.in === "cookie") {
-      if (param.required && schema.default === undefined) {
+      if (isRequiredDefaultParam(param, schema)) {
         paramResult.isValid = false;
       }
       continue;
@@ -58,14 +58,14 @@ export function checkParameters(paramObject: OpenAPIV3.ParameterObject[]): Check
       schema.type !== "number" &&
       schema.type !== "integer"
     ) {
-      if (param.required && schema.default === undefined) {
+      if (isRequiredDefaultParam(param, schema)) {
         paramResult.isValid = false;
       }
       continue;
     }
 
     if (param.in === "query" || param.in === "path") {
-      if (param.required && schema.default === undefined) {
+      if (isRequiredDefaultParam(param, schema)) {
         paramResult.requiredNum = paramResult.requiredNum + 1;
       } else {
         paramResult.optionalNum = paramResult.optionalNum + 1;
@@ -74,6 +74,13 @@ export function checkParameters(paramObject: OpenAPIV3.ParameterObject[]): Check
   }
 
   return paramResult;
+}
+
+export function isRequiredDefaultParam(
+  param: OpenAPIV3.ParameterObject,
+  schema: OpenAPIV3.SchemaObject
+): boolean | undefined {
+  return param.required && schema.default === undefined;
 }
 
 export function checkPostBody(

--- a/packages/fx-core/src/common/spec-parser/utils.ts
+++ b/packages/fx-core/src/common/spec-parser/utils.ts
@@ -44,9 +44,10 @@ export function checkParameters(paramObject: OpenAPIV3.ParameterObject[]): Check
   for (let i = 0; i < paramObject.length; i++) {
     const param = paramObject[i];
     const schema = param.schema as OpenAPIV3.SchemaObject;
+    const isRequiredWithoutDefault = param.required && schema.default === undefined;
 
     if (param.in === "header" || param.in === "cookie") {
-      if (isRequiredDefaultParam(param, schema)) {
+      if (isRequiredWithoutDefault) {
         paramResult.isValid = false;
       }
       continue;
@@ -58,14 +59,14 @@ export function checkParameters(paramObject: OpenAPIV3.ParameterObject[]): Check
       schema.type !== "number" &&
       schema.type !== "integer"
     ) {
-      if (isRequiredDefaultParam(param, schema)) {
+      if (isRequiredWithoutDefault) {
         paramResult.isValid = false;
       }
       continue;
     }
 
     if (param.in === "query" || param.in === "path") {
-      if (isRequiredDefaultParam(param, schema)) {
+      if (isRequiredWithoutDefault) {
         paramResult.requiredNum = paramResult.requiredNum + 1;
       } else {
         paramResult.optionalNum = paramResult.optionalNum + 1;
@@ -74,13 +75,6 @@ export function checkParameters(paramObject: OpenAPIV3.ParameterObject[]): Check
   }
 
   return paramResult;
-}
-
-export function isRequiredDefaultParam(
-  param: OpenAPIV3.ParameterObject,
-  schema: OpenAPIV3.SchemaObject
-): boolean | undefined {
-  return param.required && schema.default === undefined;
 }
 
 export function checkPostBody(
@@ -97,13 +91,15 @@ export function checkPostBody(
     return paramResult;
   }
 
+  const isRequiredWithoutDefault = isRequired && schema.default === undefined;
+
   if (
     schema.type === "string" ||
     schema.type === "integer" ||
     schema.type === "boolean" ||
     schema.type === "number"
   ) {
-    if (isRequired && schema.default === undefined) {
+    if (isRequiredWithoutDefault) {
       paramResult.requiredNum = paramResult.requiredNum + 1;
     } else {
       paramResult.optionalNum = paramResult.optionalNum + 1;
@@ -121,7 +117,7 @@ export function checkPostBody(
       paramResult.isValid = paramResult.isValid && result.isValid;
     }
   } else {
-    if (isRequired && schema.default === undefined) {
+    if (isRequiredWithoutDefault) {
       paramResult.isValid = false;
     }
   }

--- a/packages/fx-core/src/common/spec-parser/utils.ts
+++ b/packages/fx-core/src/common/spec-parser/utils.ts
@@ -43,28 +43,29 @@ export function checkParameters(paramObject: OpenAPIV3.ParameterObject[]): Check
 
   for (let i = 0; i < paramObject.length; i++) {
     const param = paramObject[i];
+    const schema = param.schema as OpenAPIV3.SchemaObject;
+
     if (param.in === "header" || param.in === "cookie") {
-      if (param.required) {
+      if (param.required && schema.default === undefined) {
         paramResult.isValid = false;
       }
       continue;
     }
 
-    const schema = param.schema as OpenAPIV3.SchemaObject;
     if (
       schema.type !== "boolean" &&
       schema.type !== "string" &&
       schema.type !== "number" &&
       schema.type !== "integer"
     ) {
-      if (param.required) {
+      if (param.required && schema.default === undefined) {
         paramResult.isValid = false;
       }
       continue;
     }
 
     if (param.in === "query" || param.in === "path") {
-      if (param.required) {
+      if (param.required && schema.default === undefined) {
         paramResult.requiredNum = paramResult.requiredNum + 1;
       } else {
         paramResult.optionalNum = paramResult.optionalNum + 1;
@@ -95,7 +96,7 @@ export function checkPostBody(
     schema.type === "boolean" ||
     schema.type === "number"
   ) {
-    if (isRequired) {
+    if (isRequired && schema.default === undefined) {
       paramResult.requiredNum = paramResult.requiredNum + 1;
     } else {
       paramResult.optionalNum = paramResult.optionalNum + 1;
@@ -113,7 +114,7 @@ export function checkPostBody(
       paramResult.isValid = paramResult.isValid && result.isValid;
     }
   } else {
-    if (isRequired) {
+    if (isRequired && schema.default === undefined) {
       paramResult.isValid = false;
     }
   }


### PR DESCRIPTION
[Bug 25203352](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/25203352): [API ME] Treat required + default parameter as optional when list supported apis