### PR TITLE
fix: corner cases for npm view command

### DIFF
--- a/packages/fx-core/src/common/deps-checker/internal/testToolChecker.ts
+++ b/packages/fx-core/src/common/deps-checker/internal/testToolChecker.ts
@@ -172,8 +172,14 @@ export class TestToolChecker implements DepsChecker {
         "version",
         "--json"
       );
-      const versionList: string[] = JSON.parse(result);
+      // when there are one result, it will return string
+      // when there are multiple results, it will return array of strings
+      let versionList: string[] | string = JSON.parse(result);
+      if (typeof versionList === "string") {
+        versionList = [versionList];
+      }
       if (!Array.isArray(versionList)) {
+        // do update if npm returned invalid result
         return true;
       }
       return versionList.filter((v) => semver.gt(v, latestInstalledVersion)).length > 0;


### PR DESCRIPTION
Fix the bug: if there is only one version released on npm, every F5 will cause reinstall of test tool.

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/16357625