### PR TITLE
fix: command alias

### DIFF
--- a/packages/api/review/teamsfx-api.api.md
+++ b/packages/api/review/teamsfx-api.api.md
@@ -118,6 +118,7 @@ export interface CLIBooleanOption extends CLICommandOptionBase {
 
 // @public (undocumented)
 export interface CLICommand {
+    aliases?: string[];
     arguments?: CLICommandArgument[];
     commands?: CLICommand[];
     defaultInteractiveOption?: boolean;

--- a/packages/api/src/cli.ts
+++ b/packages/api/src/cli.ts
@@ -13,6 +13,10 @@ export interface CLICommand {
    */
   name: string;
   /**
+   * @description command aliases
+   */
+  aliases?: string[];
+  /**
    * @description command full name, like "teamsfx new sample", only available after command finding
    */
   fullName?: string;

--- a/packages/cli/src/commands/engine.ts
+++ b/packages/cli/src/commands/engine.ts
@@ -255,7 +255,9 @@ class CLIEngine {
     let token: string | undefined;
     for (; i < args.length; i++) {
       token = args[i];
-      const command = cmd.commands?.find((c) => c.name === token);
+      const command = cmd.commands?.find(
+        (c) => c.name === token || (token && c.aliases?.includes(token))
+      );
       if (command) {
         cmd = command;
       } else {

--- a/packages/cli/src/commands/models/m365Sideloading.ts
+++ b/packages/cli/src/commands/models/m365Sideloading.ts
@@ -11,6 +11,7 @@ export const sideloadingServiceEndpoint =
 
 export const m365SideloadingCommand: CLICommand = {
   name: "install",
+  aliases: ["sideloading"],
   description:
     "Sideloading an M365 App with corresponding information specified in the given manifest package.",
   options: [

--- a/packages/cli/src/commands/models/m365Unacquire.ts
+++ b/packages/cli/src/commands/models/m365Unacquire.ts
@@ -10,6 +10,7 @@ import { sideloadingServiceEndpoint } from "./m365Sideloading";
 
 export const m365UnacquireCommand: CLICommand = {
   name: "uninstall",
+  aliases: ["unacquire"],
   description: "Remove an acquired M365 App.",
   options: [
     {

--- a/packages/cli/src/commands/models/permission.ts
+++ b/packages/cli/src/commands/models/permission.ts
@@ -6,6 +6,7 @@ import { permissionStatusCommand } from "./permissionStatus";
 
 export const permissionCommand: CLICommand = {
   name: "collaborator",
+  aliases: ["permission"],
   description:
     "Check, grant and list permissions for who can access and manage Microsoft Teams application and Azure Active Directory application.",
   commands: [permissionStatusCommand, permissionGrantCommand],

--- a/packages/cli/tests/unit/engine.tests.ts
+++ b/packages/cli/tests/unit/engine.tests.ts
@@ -23,7 +23,11 @@ import * as activate from "../../src/activate";
 import { getFxCore, resetFxCore } from "../../src/activate";
 import { engine } from "../../src/commands/engine";
 import { start } from "../../src/commands/index";
-import { listTemplatesCommand, listSamplesCommand } from "../../src/commands/models";
+import {
+  listTemplatesCommand,
+  listSamplesCommand,
+  m365SideloadingCommand,
+} from "../../src/commands/models";
 import { getCreateCommand } from "../../src/commands/models/create";
 import { createSampleCommand } from "../../src/commands/models/createSample";
 import { rootCommand } from "../../src/commands/models/root";
@@ -53,9 +57,14 @@ describe("CLI Engine", () => {
   });
 
   describe("findCommand", async () => {
-    it("should find new template command", async () => {
+    it("should find new sample command", async () => {
       const result = engine.findCommand(rootCommand, ["new", "sample"]);
       assert.equal(result.cmd.name, createSampleCommand.name);
+      assert.deepEqual(result.remainingArgs, []);
+    });
+    it("should find m365 command alias", async () => {
+      const result = engine.findCommand(rootCommand, ["m365", "sideloading"]);
+      assert.equal(result.cmd.name, m365SideloadingCommand.name);
       assert.deepEqual(result.remainingArgs, []);
     });
   });


### PR DESCRIPTION
fix: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/25239178

1. command alias for m365 sideloading/install and unacuire/uninstall
2. command alias for permission/collaborator