### PR TITLE
fix: update warning message for old cli name

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -41,11 +41,7 @@ export async function start(binName: "teamsfx" | "teamsapp"): Promise<void> {
   initTelemetryReporter();
   if (binName === "teamsfx") {
     logger.warning(
-      `
-  **********************************************************************************
-  * Warning: command 'teamsfx' is deprecated and will be replaced with 'teamsapp'. *
-  **********************************************************************************/
-  `
+      "Warning: We are planning to depreate 'teamsfx' as command signagure and move to 'teamsapp' instead in the next major version of Teams Toolkit CLI."
     );
   }
   cliTelemetry.reporter?.addSharedProperty(TelemetryProperty.BinName, binName); // trigger binary name for telemetry


### PR DESCRIPTION
fix: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/25096039