### PR TITLE
fix: avoid set process.env to local when env.local doesn't exist

### DIFF
--- a/packages/fx-core/src/component/utils/envUtil.ts
+++ b/packages/fx-core/src/component/utils/envUtil.ts
@@ -61,7 +61,9 @@ class EnvUtil {
     if (!dotEnvFilePath || !(await fs.pathExists(dotEnvFilePath))) {
       if (silent) {
         // .env file does not exist, just ignore
-        process.env.TEAMSFX_ENV = env;
+        if (loadToProcessEnv) {
+          process.env.TEAMSFX_ENV = env;
+        }
         return ok({ TEAMSFX_ENV: env });
       } else {
         return err(new FileNotFoundError("core", dotEnvFilePath || `.env.${env}`));


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/25150410