### PR TITLE
fix: make import work when no appPackage folder exists

### DIFF
--- a/packages/fx-core/src/component/generator/officeAddin/helperMethods.ts
+++ b/packages/fx-core/src/component/generator/officeAddin/helperMethods.ts
@@ -6,7 +6,7 @@
  */
 import axios from "axios";
 import fs from "fs";
-import * as fse from "fs-extra";
+import fse from "fs-extra";
 import * as path from "path";
 import * as unzip from "unzipper";
 import { ManifestUtil, devPreview } from "@microsoft/teamsfx-api";
@@ -98,6 +98,9 @@ export class HelperMethods {
 
     // Open project manifest file
     const manifestTemplatePath = manifestUtils.getTeamsAppManifestPath(projectRoot);
+    if (!(await fse.pathExists(manifestTemplatePath))) {
+      return;
+    }
     const manifest: devPreview.DevPreviewSchema = await ManifestUtil.loadFromPath(
       manifestTemplatePath
     );

--- a/packages/fx-core/tests/component/generator/officeAddinGenerator.test.ts
+++ b/packages/fx-core/tests/component/generator/officeAddinGenerator.test.ts
@@ -20,7 +20,7 @@ import * as chai from "chai";
 import * as childProcess from "child_process";
 import EventEmitter from "events";
 import fs from "fs";
-import * as fse from "fs-extra";
+import fse from "fs-extra";
 import "mocha";
 import mockfs from "mock-fs";
 import mockedEnv, { RestoreFn } from "mocked-env";
@@ -350,14 +350,23 @@ describe("helperMethods", async () => {
 
     afterEach(() => {
       sandbox.restore();
+      writePathResult = undefined;
     });
 
     it("should update manifest's extenstions and authorization", async () => {
+      sandbox.stub(fse, "pathExists").resolves(true);
       await HelperMethods.updateManifest("", manifestPath);
 
       chai.assert.isDefined(writePathResult);
       chai.assert.equal(writePathResult?.extensions?.length, 0);
       chai.assert.equal(writePathResult?.authorization?.permissions?.resourceSpecific?.length, 0);
+    });
+
+    it("should early return if there's no appPackage folder", async () => {
+      sandbox.stub(fse, "pathExists").resolves(false);
+      await HelperMethods.updateManifest("", manifestPath);
+
+      chai.assert.isUndefined(writePathResult, "writeToPath should not be called");
     });
   });
 


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/25239204