### PR TITLE
ci: bump template version due to temporary spfx-import template removal

### DIFF
--- a/packages/fx-core/src/common/templates-config.json
+++ b/packages/fx-core/src/common/templates-config.json
@@ -1,5 +1,5 @@
 {
-    "version": "4.1.x",
+    "version": "4.0.x",
     "tagPrefix": "templates@",
     "tagListURL": "https://github.com/OfficeDev/TeamsFx/releases/download/template-tag-list/template-tags.txt",
     "templateDownloadBaseURL": "https://github.com/OfficeDev/TeamsFx/releases/download",

--- a/packages/fx-core/src/common/templates-config.json
+++ b/packages/fx-core/src/common/templates-config.json
@@ -1,5 +1,5 @@
 {
-    "version": "4.0.x",
+    "version": "4.1.x",
     "tagPrefix": "templates@",
     "tagListURL": "https://github.com/OfficeDev/TeamsFx/releases/download/template-tag-list/template-tags.txt",
     "templateDownloadBaseURL": "https://github.com/OfficeDev/TeamsFx/releases/download",

--- a/templates/package.json
+++ b/templates/package.json
@@ -1,6 +1,6 @@
 {
     "name": "templates",
-    "version": "4.0.1",
+    "version": "4.1.0",
     "private": "true",
     "license": "MIT",
     "scripts": {


### PR DESCRIPTION
As a temporary solution to [this bug](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/24527017/?view=edit), we added a spfx-import template in [this PR](https://github.com/OfficeDev/TeamsFx/pull/9319).  Now SPFx v1.18 has been released and the outline icon is updated, so we removed the template in https://github.com/OfficeDev/TeamsFx/pull/10056 and bump template version here.