### PR TITLE
fix(dotnet-sdk): correct notification key generation

### DIFF
--- a/packages/dotnet-sdk/CHANGELOG.md
+++ b/packages/dotnet-sdk/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.2.1-rc
+
+- Fix `NotificationMiddleware` reference key generation when bot is added to a Team.
+
 # 2.2.0
 
 - Add `validationEnabled` to `GetPagedInstallationsAsync()` to enable or disable installation validation.

--- a/packages/dotnet-sdk/src/TeamsFx.Test/Conversation/NotificationMiddlewareTest.cs
+++ b/packages/dotnet-sdk/src/TeamsFx.Test/Conversation/NotificationMiddlewareTest.cs
@@ -187,12 +187,12 @@
             await _middleware.OnTurnAsync(mockContext.Object, (ctx) => Task.CompletedTask, CancellationToken.None);
 
             Assert.AreEqual(1, _storage.Items.Count);
-            var reference = _storage.Items.GetValueOrDefault($"_a_{conversationId}", null);
+            var reference = _storage.Items.GetValueOrDefault($"_a_{teamId}", null);
             Assert.IsNotNull(reference);
             Assert.AreEqual(activityId, reference.ActivityId);
             Assert.AreEqual("x", reference.ChannelId);
             Assert.AreEqual("a", reference.Conversation.TenantId);
-            Assert.AreEqual(conversationId, reference.Conversation.Id);
+            Assert.AreEqual(teamId, reference.Conversation.Id);
         }
 
         [TestMethod]

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/NotificationMiddleware.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/NotificationMiddleware.cs
@@ -110,7 +110,7 @@ namespace Microsoft.TeamsFx.Conversation
                     var options = new ConversationReferenceStoreAddOptions {
                         Overwrite = false
                     };
-                    var isUpdated = await _store.Add(reference.GetKey(), reference, options, cancellationToken).ConfigureAwait(false);
+                    var isUpdated = await _store.Add(channelReference.GetKey(), channelReference, options, cancellationToken).ConfigureAwait(false);
                     return isUpdated;
                 }
                 else

--- a/packages/dotnet-sdk/src/TeamsFx/Microsoft.TeamsFx.csproj
+++ b/packages/dotnet-sdk/src/TeamsFx/Microsoft.TeamsFx.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Microsoft.TeamsFx</AssemblyName>
     <RootNamespace>Microsoft.TeamsFx</RootNamespace>
-    <Version>2.2.0</Version>
+    <Version>2.2.1-rc</Version>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
     <RepositoryUrl>https://github.com/OfficeDev/TeamsFx</RepositoryUrl>


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/25397717/
https://github.com/OfficeDev/TeamsFx/issues/10081

When adding to a Team, conversation reference key should use team id instead of conversation id.

E2E Test: N/A