### PR TITLE
fix: the task of watch backend not termintated

### DIFF
--- a/templates/ts/copilot-plugin-from-scratch/.vscode/tasks.json
+++ b/templates/ts/copilot-plugin-from-scratch/.vscode/tasks.json
@@ -116,7 +116,7 @@
         {
             "label": "Watch backend",
             "type": "shell",
-            "command": "npm run watch",
+            "command": "npm run watch:teamsfx",
             "isBackground": true,
             "options": {
                 "cwd": "${workspaceFolder}"

--- a/templates/ts/copilot-plugin-from-scratch/package.json.tpl
+++ b/templates/ts/copilot-plugin-from-scratch/package.json.tpl
@@ -5,6 +5,7 @@
         "dev:teamsfx": "env-cmd --silent -f .localConfigs npm run dev",
         "dev": "func start --typescript --language-worker=\"--inspect=9229\" --port \"7071\" --cors \"*\"",
         "build": "tsc",
+        "watch:teamsfx": "tsc --watch",
         "watch": "tsc -w",
         "prestart": "npm run build",
         "start": "npx func start",


### PR DESCRIPTION
Fix the issue of the task of watch backend not terminated after stopping local debug.
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/25411618