### PR TITLE
fix: add app name suffix in templates

### DIFF
--- a/docs/vscode-extension/5.0-multi-capability-sample/tab-and-api-with-sso/env/.env.dev
+++ b/docs/vscode-extension/5.0-multi-capability-sample/tab-and-api-with-sso/env/.env.dev
@@ -1,2 +1,3 @@
 # This file includes environment variables that will be committed to git by default.
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev

--- a/docs/vscode-extension/5.0-multi-capability-sample/tab-and-bot-with-sso/env/.env.dev
+++ b/docs/vscode-extension/5.0-multi-capability-sample/tab-and-bot-with-sso/env/.env.dev
@@ -1,2 +1,3 @@
 # This file includes environment variables that will be committed to git by default.
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev

--- a/docs/vscode-extension/5.0-multi-capability-sample/tab-and-bot/env/.env.dev
+++ b/docs/vscode-extension/5.0-multi-capability-sample/tab-and-bot/env/.env.dev
@@ -1,2 +1,3 @@
 # This file includes environment variables that will be committed to git by default.
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev

--- a/docs/vscode-extension/5.0-multi-capability-sample/tab-api-and-bot-with-sso/env/.env.dev
+++ b/docs/vscode-extension/5.0-multi-capability-sample/tab-api-and-bot-with-sso/env/.env.dev
@@ -1,2 +1,3 @@
 # This file includes environment variables that will be committed to git by default.
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev

--- a/packages/fx-core/package.json
+++ b/packages/fx-core/package.json
@@ -58,6 +58,7 @@
     "test:error": "nyc mocha \"tests/error/*.test.ts\"",
     "test:cutils": "nyc mocha \"tests/component/utils.test.ts\"",
     "test:globalVars": "nyc mocha \"tests/core/globalVars.test.ts\"",
+    "test:migration": "nyc mocha \"tests/core/middleware/migration/projectMigrationV3.test.ts\"",
     "clean": "rm -rf build",
     "build": "rimraf build && npx tsc -p ./",
     "lint:fix": "eslint --fix \"src/**/*.ts\" \"tests/**/*.ts\"",

--- a/packages/fx-core/src/core/middleware/projectMigratorV3.ts
+++ b/packages/fx-core/src/core/middleware/projectMigratorV3.ts
@@ -696,7 +696,7 @@ export async function configsMigration(context: MigrationContext): Promise<void>
               .toString()
               .includes("TEAMSFX_ENV=")
               ? ""
-              : "TEAMSFX_ENV=" + envName + EOL;
+              : "TEAMSFX_ENV=" + envName + EOL + "APP_NAME_SUFFIX=" + envName + EOL;
             // convert every name and add the env name at the first line
             const envData =
               teamsfx_env +

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/happyPath/testCaseFiles/.env.all.dev
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/happyPath/testCaseFiles/.env.all.dev
@@ -1,5 +1,6 @@
 # This file includes environment variables that will be committed to git by default.
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 CONFIG__MANIFEST__APPNAME__SHORT=testApp
 CONFIG__MANIFEST__APPNAME__FULL=Full name for testApp
 CONFIG__MANIFEST__DESCRIPTION__SHORT=Short description of testApp

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/happyPath/testCaseFiles/.env.all.local
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/happyPath/testCaseFiles/.env.all.local
@@ -1,5 +1,6 @@
 # This file includes environment variables that can be committed to git. It's gitignored by default because it represents your local development environment.
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 CONFIG__MANIFEST__APPNAME__SHORT=testApp-local
 CONFIG__MANIFEST__APPNAME__FULL=Full name for testApp-local
 CONFIG__MANIFEST__DESCRIPTION__SHORT=Short description of testApp-local

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/happyPath/testCaseFiles/.env.config.dev
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/happyPath/testCaseFiles/.env.config.dev
@@ -1,5 +1,6 @@
 # This file includes environment variables that will be committed to git by default.
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 CONFIG__MANIFEST__APPNAME__SHORT=testApp
 CONFIG__MANIFEST__APPNAME__FULL=Full name for testApp
 CONFIG__MANIFEST__DESCRIPTION__SHORT=Short description of testApp

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/happyPath/testCaseFiles/.env.config.local
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/happyPath/testCaseFiles/.env.config.local
@@ -1,5 +1,6 @@
 # This file includes environment variables that can be committed to git. It's gitignored by default because it represents your local development environment.
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 CONFIG__MANIFEST__APPNAME__SHORT=testApp-local
 CONFIG__MANIFEST__APPNAME__FULL=Full name for testApp-local
 CONFIG__MANIFEST__DESCRIPTION__SHORT=Short description of testApp-local

--- a/templates/common/copilot-plugin-existing-api/appPackage/manifest.json.tpl
+++ b/templates/common/copilot-plugin-existing-api/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "Full name for {{appName}}"
     },
     "description": {

--- a/templates/common/copilot-plugin-existing-api/env/.env.dev
+++ b/templates/common/copilot-plugin-existing-api/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Generated during provision, you can also add your own variables.
 TEAMS_APP_ID=

--- a/templates/common/copilot-plugin-existing-api/teamsapp.yml.tpl
+++ b/templates/common/copilot-plugin-existing-api/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:

--- a/templates/common/copilot-plugin-from-oai-plugin/appPackage/manifest.json.tpl
+++ b/templates/common/copilot-plugin-from-oai-plugin/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "Full name for {{appName}}"
     },
     "description": {

--- a/templates/common/copilot-plugin-from-oai-plugin/env/.env.dev
+++ b/templates/common/copilot-plugin-from-oai-plugin/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Generated during provision, you can also add your own variables.
 TEAMS_APP_ID=

--- a/templates/common/copilot-plugin-from-oai-plugin/teamsapp.yml.tpl
+++ b/templates/common/copilot-plugin-from-oai-plugin/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:

--- a/templates/common/office-addin/env/.env.dev
+++ b/templates/common/office-addin/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/constraints/yml/actions/botAadAppCreate.mustache
+++ b/templates/constraints/yml/actions/botAadAppCreate.mustache
@@ -2,7 +2,7 @@
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/constraints/yml/actions/teamsAppCreate.mustache
+++ b/templates/constraints/yml/actions/teamsAppCreate.mustache
@@ -2,7 +2,7 @@
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:

--- a/templates/csharp/ai-bot/appPackage/manifest.json.tpl
+++ b/templates/csharp/ai-bot/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "full name for {{appName}}"
     },
     "description": {

--- a/templates/csharp/ai-bot/env/.env.dev
+++ b/templates/csharp/ai-bot/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/csharp/ai-bot/env/.env.local
+++ b/templates/csharp/ai-bot/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables. 
 BOT_ID=

--- a/templates/csharp/ai-bot/teamsapp.local.yml.tpl
+++ b/templates/csharp/ai-bot/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/csharp/ai-bot/teamsapp.yml.tpl
+++ b/templates/csharp/ai-bot/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/csharp/command-and-response/appPackage/manifest.json.tpl
+++ b/templates/csharp/command-and-response/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "Full name for {{appName}}"
     },
     "description": {

--- a/templates/csharp/command-and-response/env/.env.dev
+++ b/templates/csharp/command-and-response/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/csharp/command-and-response/env/.env.local
+++ b/templates/csharp/command-and-response/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables. 
 BOT_ID=

--- a/templates/csharp/command-and-response/teamsapp.local.yml.tpl
+++ b/templates/csharp/command-and-response/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/csharp/command-and-response/teamsapp.yml.tpl
+++ b/templates/csharp/command-and-response/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/csharp/copilot-plugin-existing-api/appPackage/manifest.json.tpl
+++ b/templates/csharp/copilot-plugin-existing-api/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "Full name for {{appName}}"
     },
     "description": {

--- a/templates/csharp/copilot-plugin-existing-api/env/.env.dev
+++ b/templates/csharp/copilot-plugin-existing-api/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Generated during provision, you can also add your own variables.
 TEAMS_APP_ID=

--- a/templates/csharp/copilot-plugin-existing-api/teamsapp.yml.tpl
+++ b/templates/csharp/copilot-plugin-existing-api/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:

--- a/templates/csharp/copilot-plugin-from-oai-plugin/appPackage/manifest.json.tpl
+++ b/templates/csharp/copilot-plugin-from-oai-plugin/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "Full name for {{appName}}"
     },
     "description": {

--- a/templates/csharp/copilot-plugin-from-oai-plugin/env/.env.dev
+++ b/templates/csharp/copilot-plugin-from-oai-plugin/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Generated during provision, you can also add your own variables.
 TEAMS_APP_ID=

--- a/templates/csharp/copilot-plugin-from-oai-plugin/teamsapp.yml.tpl
+++ b/templates/csharp/copilot-plugin-from-oai-plugin/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:

--- a/templates/csharp/copilot-plugin-from-scratch/appPackage/manifest.json.tpl
+++ b/templates/csharp/copilot-plugin-from-scratch/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "Full name for {{appName}}"
     },
     "description": {

--- a/templates/csharp/copilot-plugin-from-scratch/env/.env.dev
+++ b/templates/csharp/copilot-plugin-from-scratch/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/csharp/copilot-plugin-from-scratch/env/.env.local
+++ b/templates/csharp/copilot-plugin-from-scratch/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables. 
 TEAMS_APP_ID=

--- a/templates/csharp/copilot-plugin-from-scratch/teamsapp.local.yml.tpl
+++ b/templates/csharp/copilot-plugin-from-scratch/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:

--- a/templates/csharp/copilot-plugin-from-scratch/teamsapp.yml.tpl
+++ b/templates/csharp/copilot-plugin-from-scratch/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:

--- a/templates/csharp/default-bot/appPackage/manifest.json.tpl
+++ b/templates/csharp/default-bot/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "full name for {{appName}}"
     },
     "description": {

--- a/templates/csharp/default-bot/env/.env.dev
+++ b/templates/csharp/default-bot/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/csharp/default-bot/env/.env.local
+++ b/templates/csharp/default-bot/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables. 
 BOT_ID=

--- a/templates/csharp/default-bot/teamsapp.local.yml.tpl
+++ b/templates/csharp/default-bot/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/csharp/default-bot/teamsapp.yml.tpl
+++ b/templates/csharp/default-bot/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/csharp/link-unfurling/appPackage/manifest.json.tpl
+++ b/templates/csharp/link-unfurling/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "full name for {{appName}}"
     },
     "description": {

--- a/templates/csharp/link-unfurling/env/.env.dev
+++ b/templates/csharp/link-unfurling/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/csharp/link-unfurling/env/.env.local
+++ b/templates/csharp/link-unfurling/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables. 
 BOT_ID=

--- a/templates/csharp/link-unfurling/teamsapp.local.yml.tpl
+++ b/templates/csharp/link-unfurling/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/csharp/link-unfurling/teamsapp.yml.tpl
+++ b/templates/csharp/link-unfurling/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/csharp/message-extension-action/appPackage/manifest.json.tpl
+++ b/templates/csharp/message-extension-action/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "full name for {{appName}}"
     },
     "description": {

--- a/templates/csharp/message-extension-action/env/.env.dev
+++ b/templates/csharp/message-extension-action/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/csharp/message-extension-action/env/.env.local
+++ b/templates/csharp/message-extension-action/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables. 
 BOT_ID=

--- a/templates/csharp/message-extension-action/teamsapp.local.yml.tpl
+++ b/templates/csharp/message-extension-action/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile: 
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/csharp/message-extension-action/teamsapp.yml.tpl
+++ b/templates/csharp/message-extension-action/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile: 
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/csharp/message-extension-copilot/appPackage/manifest.json.tpl
+++ b/templates/csharp/message-extension-copilot/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "full name for {{appName}}"
     },
     "description": {

--- a/templates/csharp/message-extension-copilot/env/.env.dev
+++ b/templates/csharp/message-extension-copilot/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/csharp/message-extension-copilot/env/.env.local
+++ b/templates/csharp/message-extension-copilot/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables. 
 BOT_ID=

--- a/templates/csharp/message-extension-copilot/teamsapp.local.yml.tpl
+++ b/templates/csharp/message-extension-copilot/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/csharp/message-extension-copilot/teamsapp.yml.tpl
+++ b/templates/csharp/message-extension-copilot/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/csharp/message-extension-search/appPackage/manifest.json.tpl
+++ b/templates/csharp/message-extension-search/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "full name for {{appName}}"
     },
     "description": {

--- a/templates/csharp/message-extension-search/env/.env.dev
+++ b/templates/csharp/message-extension-search/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/csharp/message-extension-search/env/.env.local
+++ b/templates/csharp/message-extension-search/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables. 
 BOT_ID=

--- a/templates/csharp/message-extension-search/teamsapp.local.yml.tpl
+++ b/templates/csharp/message-extension-search/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile: 
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/csharp/message-extension-search/teamsapp.yml.tpl
+++ b/templates/csharp/message-extension-search/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile: 
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/csharp/message-extension/appPackage/manifest.json.tpl
+++ b/templates/csharp/message-extension/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "full name for {{appName}}"
     },
     "description": {

--- a/templates/csharp/message-extension/env/.env.dev
+++ b/templates/csharp/message-extension/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/csharp/message-extension/env/.env.local
+++ b/templates/csharp/message-extension/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables. 
 BOT_ID=

--- a/templates/csharp/message-extension/teamsapp.local.yml.tpl
+++ b/templates/csharp/message-extension/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/csharp/message-extension/teamsapp.yml.tpl
+++ b/templates/csharp/message-extension/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/csharp/non-sso-tab/appPackage/manifest.json.tpl
+++ b/templates/csharp/non-sso-tab/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "Full name for {{appName}}"
     },
     "description": {

--- a/templates/csharp/non-sso-tab/env/.env.dev
+++ b/templates/csharp/non-sso-tab/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/csharp/non-sso-tab/env/.env.local
+++ b/templates/csharp/non-sso-tab/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables. 
 TEAMS_APP_ID=

--- a/templates/csharp/non-sso-tab/teamsapp.local.yml.tpl
+++ b/templates/csharp/non-sso-tab/teamsapp.local.yml.tpl
@@ -14,7 +14,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:

--- a/templates/csharp/non-sso-tab/teamsapp.yml.tpl
+++ b/templates/csharp/non-sso-tab/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:

--- a/templates/csharp/notification-http-timer-trigger/appPackage/manifest.json.tpl
+++ b/templates/csharp/notification-http-timer-trigger/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "Full name for {{appName}}"
     },
     "description": {

--- a/templates/csharp/notification-http-timer-trigger/env/.env.dev
+++ b/templates/csharp/notification-http-timer-trigger/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/csharp/notification-http-timer-trigger/env/.env.local
+++ b/templates/csharp/notification-http-timer-trigger/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 
 # Generated during provision, you can also add your own variables.

--- a/templates/csharp/notification-http-timer-trigger/teamsapp.local.yml.tpl
+++ b/templates/csharp/notification-http-timer-trigger/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/csharp/notification-http-timer-trigger/teamsapp.yml.tpl
+++ b/templates/csharp/notification-http-timer-trigger/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/csharp/notification-http-trigger/appPackage/manifest.json.tpl
+++ b/templates/csharp/notification-http-trigger/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "Full name for {{appName}}"
     },
     "description": {

--- a/templates/csharp/notification-http-trigger/env/.env.dev
+++ b/templates/csharp/notification-http-trigger/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/csharp/notification-http-trigger/env/.env.local
+++ b/templates/csharp/notification-http-trigger/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables. 
 BOT_ID=

--- a/templates/csharp/notification-http-trigger/teamsapp.local.yml.tpl
+++ b/templates/csharp/notification-http-trigger/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/csharp/notification-http-trigger/teamsapp.yml.tpl
+++ b/templates/csharp/notification-http-trigger/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/csharp/notification-timer-trigger/appPackage/manifest.json.tpl
+++ b/templates/csharp/notification-timer-trigger/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "Full name for {{appName}}"
     },
     "description": {

--- a/templates/csharp/notification-timer-trigger/env/.env.dev
+++ b/templates/csharp/notification-timer-trigger/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/csharp/notification-timer-trigger/env/.env.local
+++ b/templates/csharp/notification-timer-trigger/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables.
 BOT_ID=

--- a/templates/csharp/notification-timer-trigger/teamsapp.local.yml.tpl
+++ b/templates/csharp/notification-timer-trigger/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/csharp/notification-timer-trigger/teamsapp.yml.tpl
+++ b/templates/csharp/notification-timer-trigger/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/csharp/notification-webapi/appPackage/manifest.json.tpl
+++ b/templates/csharp/notification-webapi/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "Full name for {{appName}}"
     },
     "description": {

--- a/templates/csharp/notification-webapi/env/.env.dev
+++ b/templates/csharp/notification-webapi/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/csharp/notification-webapi/env/.env.local
+++ b/templates/csharp/notification-webapi/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables.
 BOT_ID=

--- a/templates/csharp/notification-webapi/teamsapp.local.yml.tpl
+++ b/templates/csharp/notification-webapi/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/csharp/notification-webapi/teamsapp.yml.tpl
+++ b/templates/csharp/notification-webapi/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/csharp/sso-tab/appPackage/manifest.json.tpl
+++ b/templates/csharp/sso-tab/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "Full name for {{appName}}"
     },
     "description": {

--- a/templates/csharp/sso-tab/env/.env.dev
+++ b/templates/csharp/sso-tab/env/.env.dev
@@ -1,5 +1,6 @@
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/csharp/sso-tab/env/.env.local
+++ b/templates/csharp/sso-tab/env/.env.local
@@ -1,5 +1,6 @@
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables. 
 TEAMS_APP_ID=

--- a/templates/csharp/sso-tab/teamsapp.local.yml.tpl
+++ b/templates/csharp/sso-tab/teamsapp.local.yml.tpl
@@ -34,7 +34,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:

--- a/templates/csharp/sso-tab/teamsapp.yml.tpl
+++ b/templates/csharp/sso-tab/teamsapp.yml.tpl
@@ -37,7 +37,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:

--- a/templates/csharp/workflow/appPackage/manifest.json.tpl
+++ b/templates/csharp/workflow/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "Full name for {{appName}}"
     },
     "description": {

--- a/templates/csharp/workflow/env/.env.dev
+++ b/templates/csharp/workflow/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/csharp/workflow/env/.env.local
+++ b/templates/csharp/workflow/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables.
 BOT_ID=

--- a/templates/csharp/workflow/teamsapp.local.yml.tpl
+++ b/templates/csharp/workflow/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/csharp/workflow/teamsapp.yml.tpl
+++ b/templates/csharp/workflow/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/js/ai-bot/appPackage/manifest.json.tpl
+++ b/templates/js/ai-bot/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "full name for {{appName}}"
     },
     "description": {

--- a/templates/js/ai-bot/env/.env.dev
+++ b/templates/js/ai-bot/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/js/ai-bot/env/.env.local
+++ b/templates/js/ai-bot/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables.
 BOT_ID=

--- a/templates/js/ai-bot/teamsapp.local.yml.tpl
+++ b/templates/js/ai-bot/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/js/ai-bot/teamsapp.yml.tpl
+++ b/templates/js/ai-bot/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/js/command-and-response/appPackage/manifest.json.tpl
+++ b/templates/js/command-and-response/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "Full name for {{appName}}"
     },
     "description": {

--- a/templates/js/command-and-response/env/.env.dev
+++ b/templates/js/command-and-response/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/js/command-and-response/env/.env.local
+++ b/templates/js/command-and-response/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables.
 BOT_ID=

--- a/templates/js/command-and-response/teamsapp.local.yml.tpl
+++ b/templates/js/command-and-response/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/js/command-and-response/teamsapp.yml.tpl
+++ b/templates/js/command-and-response/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/js/copilot-plugin-from-scratch/appPackage/manifest.json.tpl
+++ b/templates/js/copilot-plugin-from-scratch/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "Full name for {{appName}}"
     },
     "description": {

--- a/templates/js/copilot-plugin-from-scratch/env/.env.dev
+++ b/templates/js/copilot-plugin-from-scratch/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/js/copilot-plugin-from-scratch/env/.env.local
+++ b/templates/js/copilot-plugin-from-scratch/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables.
 TEAMS_APP_ID=

--- a/templates/js/copilot-plugin-from-scratch/teamsapp.local.yml.tpl
+++ b/templates/js/copilot-plugin-from-scratch/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:

--- a/templates/js/copilot-plugin-from-scratch/teamsapp.yml.tpl
+++ b/templates/js/copilot-plugin-from-scratch/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:

--- a/templates/js/dashboard-tab/appPackage/manifest.json.tpl
+++ b/templates/js/dashboard-tab/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "Full name for {{appName}}"
     },
     "description": {

--- a/templates/js/dashboard-tab/env/.env.dev
+++ b/templates/js/dashboard-tab/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/js/dashboard-tab/env/.env.local
+++ b/templates/js/dashboard-tab/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables.
 TAB_DOMAIN=

--- a/templates/js/dashboard-tab/teamsapp.local.yml.tpl
+++ b/templates/js/dashboard-tab/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:

--- a/templates/js/dashboard-tab/teamsapp.yml.tpl
+++ b/templates/js/dashboard-tab/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:

--- a/templates/js/default-bot-message-extension/appPackage/manifest.json.tpl
+++ b/templates/js/default-bot-message-extension/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "full name for {{appName}}"
     },
     "description": {

--- a/templates/js/default-bot-message-extension/env/.env.dev
+++ b/templates/js/default-bot-message-extension/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/js/default-bot-message-extension/env/.env.local
+++ b/templates/js/default-bot-message-extension/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables.
 BOT_ID=

--- a/templates/js/default-bot-message-extension/teamsapp.local.yml.tpl
+++ b/templates/js/default-bot-message-extension/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/js/default-bot-message-extension/teamsapp.yml.tpl
+++ b/templates/js/default-bot-message-extension/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/js/default-bot/appPackage/manifest.json.tpl
+++ b/templates/js/default-bot/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "full name for {{appName}}"
     },
     "description": {

--- a/templates/js/default-bot/env/.env.dev
+++ b/templates/js/default-bot/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/js/default-bot/env/.env.local
+++ b/templates/js/default-bot/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables.
 BOT_ID=

--- a/templates/js/default-bot/teamsapp.local.yml.tpl
+++ b/templates/js/default-bot/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/js/default-bot/teamsapp.yml.tpl
+++ b/templates/js/default-bot/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/js/link-unfurling/appPackage/manifest.json.tpl
+++ b/templates/js/link-unfurling/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "full name for {{appName}}"
     },
     "description": {

--- a/templates/js/link-unfurling/env/.env.dev
+++ b/templates/js/link-unfurling/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/js/link-unfurling/env/.env.local
+++ b/templates/js/link-unfurling/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables.
 BOT_ID=

--- a/templates/js/link-unfurling/teamsapp.local.yml.tpl
+++ b/templates/js/link-unfurling/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/js/link-unfurling/teamsapp.yml.tpl
+++ b/templates/js/link-unfurling/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/js/m365-message-extension/appPackage/manifest.json.tpl
+++ b/templates/js/m365-message-extension/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "full name for {{appName}}"
     },
     "description": {

--- a/templates/js/m365-message-extension/env/.env.dev
+++ b/templates/js/m365-message-extension/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/js/m365-message-extension/env/.env.local
+++ b/templates/js/m365-message-extension/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables.
 BOT_ID=

--- a/templates/js/m365-message-extension/teamsapp.local.yml.tpl
+++ b/templates/js/m365-message-extension/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/js/m365-message-extension/teamsapp.yml.tpl
+++ b/templates/js/m365-message-extension/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/js/m365-tab/appPackage/manifest.json.tpl
+++ b/templates/js/m365-tab/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "Full name for {{appName}}"
     },
     "description": {

--- a/templates/js/m365-tab/env/.env.dev
+++ b/templates/js/m365-tab/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/js/m365-tab/env/.env.local
+++ b/templates/js/m365-tab/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables.
 TAB_DOMAIN=

--- a/templates/js/m365-tab/teamsapp.local.yml.tpl
+++ b/templates/js/m365-tab/teamsapp.local.yml.tpl
@@ -34,7 +34,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile: 

--- a/templates/js/m365-tab/teamsapp.yml.tpl
+++ b/templates/js/m365-tab/teamsapp.yml.tpl
@@ -37,7 +37,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile: 

--- a/templates/js/message-extension-action/appPackage/manifest.json.tpl
+++ b/templates/js/message-extension-action/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "full name for {{appName}}"
     },
     "description": {

--- a/templates/js/message-extension-action/env/.env.dev
+++ b/templates/js/message-extension-action/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/js/message-extension-action/env/.env.local
+++ b/templates/js/message-extension-action/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables. 
 BOT_ID=

--- a/templates/js/message-extension-action/teamsapp.local.yml.tpl
+++ b/templates/js/message-extension-action/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile: 
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/js/message-extension-action/teamsapp.yml.tpl
+++ b/templates/js/message-extension-action/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile: 
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/js/message-extension-copilot/appPackage/manifest.json.tpl
+++ b/templates/js/message-extension-copilot/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "full name for {{appName}}"
     },
     "description": {

--- a/templates/js/message-extension-copilot/env/.env.dev
+++ b/templates/js/message-extension-copilot/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/js/message-extension-copilot/env/.env.local
+++ b/templates/js/message-extension-copilot/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables.
 BOT_ID=

--- a/templates/js/message-extension-copilot/teamsapp.local.yml.tpl
+++ b/templates/js/message-extension-copilot/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/js/message-extension-copilot/teamsapp.yml.tpl
+++ b/templates/js/message-extension-copilot/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/js/message-extension/appPackage/manifest.json.tpl
+++ b/templates/js/message-extension/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "full name for {{appName}}"
     },
     "description": {

--- a/templates/js/message-extension/env/.env.dev
+++ b/templates/js/message-extension/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/js/message-extension/env/.env.local
+++ b/templates/js/message-extension/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 
 # Generated during provision, you can also add your own variables.

--- a/templates/js/message-extension/teamsapp.local.yml.tpl
+++ b/templates/js/message-extension/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/js/message-extension/teamsapp.yml.tpl
+++ b/templates/js/message-extension/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/js/non-sso-tab-default-bot/appPackage/manifest.json.tpl
+++ b/templates/js/non-sso-tab-default-bot/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "Full name for {{appName}}"
     },
     "description": {

--- a/templates/js/non-sso-tab-default-bot/env/.env.dev
+++ b/templates/js/non-sso-tab-default-bot/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/js/non-sso-tab-default-bot/env/.env.local
+++ b/templates/js/non-sso-tab-default-bot/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables.
 TAB_DOMAIN=

--- a/templates/js/non-sso-tab-default-bot/teamsapp.local.yml.tpl
+++ b/templates/js/non-sso-tab-default-bot/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/js/non-sso-tab-default-bot/teamsapp.yml.tpl
+++ b/templates/js/non-sso-tab-default-bot/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/js/non-sso-tab/appPackage/manifest.json.tpl
+++ b/templates/js/non-sso-tab/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "Full name for {{appName}}"
     },
     "description": {

--- a/templates/js/non-sso-tab/env/.env.dev
+++ b/templates/js/non-sso-tab/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/js/non-sso-tab/env/.env.local
+++ b/templates/js/non-sso-tab/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 
 # Generated during provision, you can also add your own variables.

--- a/templates/js/non-sso-tab/teamsapp.local.yml.tpl
+++ b/templates/js/non-sso-tab/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:

--- a/templates/js/non-sso-tab/teamsapp.yml.tpl
+++ b/templates/js/non-sso-tab/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:

--- a/templates/js/notification-http-timer-trigger/appPackage/manifest.json.tpl
+++ b/templates/js/notification-http-timer-trigger/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "ful name for {{appName}}"
     },
     "description": {

--- a/templates/js/notification-http-timer-trigger/env/.env.dev
+++ b/templates/js/notification-http-timer-trigger/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/js/notification-http-timer-trigger/env/.env.local
+++ b/templates/js/notification-http-timer-trigger/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables.
 BOT_ID=

--- a/templates/js/notification-http-timer-trigger/teamsapp.local.yml.tpl
+++ b/templates/js/notification-http-timer-trigger/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/js/notification-http-timer-trigger/teamsapp.yml.tpl
+++ b/templates/js/notification-http-timer-trigger/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/js/notification-http-trigger/appPackage/manifest.json.tpl
+++ b/templates/js/notification-http-trigger/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "ful name for {{appName}}"
     },
     "description": {

--- a/templates/js/notification-http-trigger/env/.env.dev
+++ b/templates/js/notification-http-trigger/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/js/notification-http-trigger/env/.env.local
+++ b/templates/js/notification-http-trigger/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables.
 BOT_ID=

--- a/templates/js/notification-http-trigger/teamsapp.local.yml.tpl
+++ b/templates/js/notification-http-trigger/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/js/notification-http-trigger/teamsapp.yml.tpl
+++ b/templates/js/notification-http-trigger/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/js/notification-restify/appPackage/manifest.json.tpl
+++ b/templates/js/notification-restify/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "Full name for {{appName}}"
     },
     "description": {

--- a/templates/js/notification-restify/env/.env.dev
+++ b/templates/js/notification-restify/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/js/notification-restify/env/.env.local
+++ b/templates/js/notification-restify/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables.
 BOT_ID=

--- a/templates/js/notification-restify/teamsapp.local.yml.tpl
+++ b/templates/js/notification-restify/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/js/notification-restify/teamsapp.yml.tpl
+++ b/templates/js/notification-restify/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/js/notification-timer-trigger/appPackage/manifest.json.tpl
+++ b/templates/js/notification-timer-trigger/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "ful name for {{appName}}"
     },
     "description": {

--- a/templates/js/notification-timer-trigger/env/.env.dev
+++ b/templates/js/notification-timer-trigger/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/js/notification-timer-trigger/env/.env.local
+++ b/templates/js/notification-timer-trigger/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables.
 BOT_ID=

--- a/templates/js/notification-timer-trigger/teamsapp.local.yml.tpl
+++ b/templates/js/notification-timer-trigger/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/js/notification-timer-trigger/teamsapp.yml.tpl
+++ b/templates/js/notification-timer-trigger/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/js/sso-tab-with-obo-flow/appPackage/manifest.json.tpl
+++ b/templates/js/sso-tab-with-obo-flow/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "Full name for {{appName}}"
     },
     "description": {

--- a/templates/js/sso-tab-with-obo-flow/env/.env.dev
+++ b/templates/js/sso-tab-with-obo-flow/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=
 AZURE_RESOURCE_GROUP_NAME=

--- a/templates/js/sso-tab-with-obo-flow/env/.env.local
+++ b/templates/js/sso-tab-with-obo-flow/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables. If you're adding a secret value, add SECRET_ prefix to the name so Teams Toolkit can handle them properly
 TAB_DOMAIN=

--- a/templates/js/sso-tab-with-obo-flow/teamsapp.local.yml.tpl
+++ b/templates/js/sso-tab-with-obo-flow/teamsapp.local.yml.tpl
@@ -34,7 +34,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:

--- a/templates/js/sso-tab-with-obo-flow/teamsapp.yml.tpl
+++ b/templates/js/sso-tab-with-obo-flow/teamsapp.yml.tpl
@@ -37,7 +37,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:

--- a/templates/js/workflow/appPackage/manifest.json.tpl
+++ b/templates/js/workflow/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "Full name for {{appName}}"
     },
     "description": {

--- a/templates/js/workflow/env/.env.dev
+++ b/templates/js/workflow/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/js/workflow/env/.env.local
+++ b/templates/js/workflow/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables.
 BOT_ID=

--- a/templates/js/workflow/teamsapp.local.yml.tpl
+++ b/templates/js/workflow/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/js/workflow/teamsapp.yml.tpl
+++ b/templates/js/workflow/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/ts/ai-bot/appPackage/manifest.json.tpl
+++ b/templates/ts/ai-bot/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "full name for {{appName}}"
     },
     "description": {

--- a/templates/ts/ai-bot/env/.env.dev
+++ b/templates/ts/ai-bot/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/ts/ai-bot/env/.env.local
+++ b/templates/ts/ai-bot/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables.
 BOT_ID=

--- a/templates/ts/ai-bot/teamsapp.local.yml.tpl
+++ b/templates/ts/ai-bot/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/ts/ai-bot/teamsapp.yml.tpl
+++ b/templates/ts/ai-bot/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/ts/command-and-response/appPackage/manifest.json.tpl
+++ b/templates/ts/command-and-response/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "Full name for {{appName}}"
     },
     "description": {

--- a/templates/ts/command-and-response/env/.env.dev
+++ b/templates/ts/command-and-response/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/ts/command-and-response/env/.env.local
+++ b/templates/ts/command-and-response/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables.
 BOT_ID=

--- a/templates/ts/command-and-response/teamsapp.local.yml.tpl
+++ b/templates/ts/command-and-response/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/ts/command-and-response/teamsapp.yml.tpl
+++ b/templates/ts/command-and-response/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/ts/copilot-plugin-from-scratch/appPackage/manifest.json.tpl
+++ b/templates/ts/copilot-plugin-from-scratch/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "Full name for {{appName}}"
     },
     "description": {

--- a/templates/ts/copilot-plugin-from-scratch/env/.env.dev
+++ b/templates/ts/copilot-plugin-from-scratch/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/ts/copilot-plugin-from-scratch/env/.env.local
+++ b/templates/ts/copilot-plugin-from-scratch/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables.
 TEAMS_APP_ID=

--- a/templates/ts/copilot-plugin-from-scratch/teamsapp.local.yml.tpl
+++ b/templates/ts/copilot-plugin-from-scratch/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:

--- a/templates/ts/copilot-plugin-from-scratch/teamsapp.yml.tpl
+++ b/templates/ts/copilot-plugin-from-scratch/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:

--- a/templates/ts/dashboard-tab/appPackage/manifest.json.tpl
+++ b/templates/ts/dashboard-tab/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "Full name for {{appName}}"
     },
     "description": {

--- a/templates/ts/dashboard-tab/env/.env.dev
+++ b/templates/ts/dashboard-tab/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/ts/dashboard-tab/env/.env.local
+++ b/templates/ts/dashboard-tab/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables.
 TAB_DOMAIN=

--- a/templates/ts/dashboard-tab/teamsapp.local.yml.tpl
+++ b/templates/ts/dashboard-tab/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:

--- a/templates/ts/dashboard-tab/teamsapp.yml.tpl
+++ b/templates/ts/dashboard-tab/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:

--- a/templates/ts/default-bot-message-extension/appPackage/manifest.json.tpl
+++ b/templates/ts/default-bot-message-extension/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "full name for {{appName}}"
     },
     "description": {

--- a/templates/ts/default-bot-message-extension/env/.env.dev
+++ b/templates/ts/default-bot-message-extension/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/ts/default-bot-message-extension/env/.env.local
+++ b/templates/ts/default-bot-message-extension/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables.
 BOT_ID=

--- a/templates/ts/default-bot-message-extension/teamsapp.local.yml.tpl
+++ b/templates/ts/default-bot-message-extension/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/ts/default-bot-message-extension/teamsapp.yml.tpl
+++ b/templates/ts/default-bot-message-extension/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/ts/default-bot/appPackage/manifest.json.tpl
+++ b/templates/ts/default-bot/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "full name for {{appName}}"
     },
     "description": {

--- a/templates/ts/default-bot/env/.env.dev
+++ b/templates/ts/default-bot/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/ts/default-bot/env/.env.local
+++ b/templates/ts/default-bot/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables.
 BOT_ID=

--- a/templates/ts/default-bot/teamsapp.local.yml.tpl
+++ b/templates/ts/default-bot/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/ts/default-bot/teamsapp.yml.tpl
+++ b/templates/ts/default-bot/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/ts/link-unfurling/appPackage/manifest.json.tpl
+++ b/templates/ts/link-unfurling/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "full name for {{appName}}"
     },
     "description": {

--- a/templates/ts/link-unfurling/env/.env.dev
+++ b/templates/ts/link-unfurling/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/ts/link-unfurling/env/.env.local
+++ b/templates/ts/link-unfurling/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables.
 BOT_ID=

--- a/templates/ts/link-unfurling/teamsapp.local.yml.tpl
+++ b/templates/ts/link-unfurling/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/ts/link-unfurling/teamsapp.yml.tpl
+++ b/templates/ts/link-unfurling/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/ts/m365-message-extension/appPackage/manifest.json.tpl
+++ b/templates/ts/m365-message-extension/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "full name for {{appName}}"
     },
     "description": {

--- a/templates/ts/m365-message-extension/env/.env.dev
+++ b/templates/ts/m365-message-extension/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/ts/m365-message-extension/env/.env.local
+++ b/templates/ts/m365-message-extension/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables.
 BOT_ID=

--- a/templates/ts/m365-message-extension/teamsapp.local.yml.tpl
+++ b/templates/ts/m365-message-extension/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/ts/m365-message-extension/teamsapp.yml.tpl
+++ b/templates/ts/m365-message-extension/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/ts/m365-tab/appPackage/manifest.json.tpl
+++ b/templates/ts/m365-tab/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "Full name for {{appName}}"
     },
     "description": {

--- a/templates/ts/m365-tab/env/.env.dev
+++ b/templates/ts/m365-tab/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/ts/m365-tab/env/.env.local
+++ b/templates/ts/m365-tab/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables.
 TAB_DOMAIN=

--- a/templates/ts/m365-tab/teamsapp.local.yml.tpl
+++ b/templates/ts/m365-tab/teamsapp.local.yml.tpl
@@ -34,7 +34,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile: 

--- a/templates/ts/m365-tab/teamsapp.yml.tpl
+++ b/templates/ts/m365-tab/teamsapp.yml.tpl
@@ -37,7 +37,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile: 

--- a/templates/ts/message-extension-action/appPackage/manifest.json.tpl
+++ b/templates/ts/message-extension-action/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "full name for {{appName}}"
     },
     "description": {

--- a/templates/ts/message-extension-action/env/.env.dev
+++ b/templates/ts/message-extension-action/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/ts/message-extension-action/env/.env.local
+++ b/templates/ts/message-extension-action/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables. 
 BOT_ID=

--- a/templates/ts/message-extension-action/teamsapp.local.yml.tpl
+++ b/templates/ts/message-extension-action/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile: 
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/ts/message-extension-action/teamsapp.yml.tpl
+++ b/templates/ts/message-extension-action/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile: 
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/ts/message-extension-copilot/appPackage/manifest.json.tpl
+++ b/templates/ts/message-extension-copilot/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "full name for {{appName}}"
     },
     "description": {

--- a/templates/ts/message-extension-copilot/env/.env.dev
+++ b/templates/ts/message-extension-copilot/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/ts/message-extension-copilot/env/.env.local
+++ b/templates/ts/message-extension-copilot/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables.
 BOT_ID=

--- a/templates/ts/message-extension-copilot/teamsapp.local.yml.tpl
+++ b/templates/ts/message-extension-copilot/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/ts/message-extension-copilot/teamsapp.yml.tpl
+++ b/templates/ts/message-extension-copilot/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/ts/message-extension/appPackage/manifest.json.tpl
+++ b/templates/ts/message-extension/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "full name for {{appName}}"
     },
     "description": {

--- a/templates/ts/message-extension/env/.env.dev
+++ b/templates/ts/message-extension/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/ts/message-extension/env/.env.local
+++ b/templates/ts/message-extension/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables.
 BOT_ID=

--- a/templates/ts/message-extension/teamsapp.local.yml.tpl
+++ b/templates/ts/message-extension/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/ts/message-extension/teamsapp.yml.tpl
+++ b/templates/ts/message-extension/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/ts/non-sso-tab-default-bot/appPackage/manifest.json.tpl
+++ b/templates/ts/non-sso-tab-default-bot/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "Full name for {{appName}}"
     },
     "description": {

--- a/templates/ts/non-sso-tab-default-bot/env/.env.dev
+++ b/templates/ts/non-sso-tab-default-bot/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/ts/non-sso-tab-default-bot/env/.env.local
+++ b/templates/ts/non-sso-tab-default-bot/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 
 # Generated during provision, you can also add your own variables.

--- a/templates/ts/non-sso-tab-default-bot/teamsapp.local.yml.tpl
+++ b/templates/ts/non-sso-tab-default-bot/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/ts/non-sso-tab-default-bot/teamsapp.yml.tpl
+++ b/templates/ts/non-sso-tab-default-bot/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/ts/non-sso-tab/appPackage/manifest.json.tpl
+++ b/templates/ts/non-sso-tab/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "Full name for {{appName}}"
     },
     "description": {

--- a/templates/ts/non-sso-tab/env/.env.dev
+++ b/templates/ts/non-sso-tab/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/ts/non-sso-tab/env/.env.local
+++ b/templates/ts/non-sso-tab/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 
 # Generated during provision, you can also add your own variables.

--- a/templates/ts/non-sso-tab/teamsapp.local.yml.tpl
+++ b/templates/ts/non-sso-tab/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:

--- a/templates/ts/non-sso-tab/teamsapp.yml.tpl
+++ b/templates/ts/non-sso-tab/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:

--- a/templates/ts/notification-http-timer-trigger/appPackage/manifest.json.tpl
+++ b/templates/ts/notification-http-timer-trigger/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "ful name for {{appName}}"
     },
     "description": {

--- a/templates/ts/notification-http-timer-trigger/env/.env.dev
+++ b/templates/ts/notification-http-timer-trigger/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/ts/notification-http-timer-trigger/env/.env.local
+++ b/templates/ts/notification-http-timer-trigger/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables.
 BOT_ID=

--- a/templates/ts/notification-http-timer-trigger/teamsapp.local.yml.tpl
+++ b/templates/ts/notification-http-timer-trigger/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/ts/notification-http-timer-trigger/teamsapp.yml.tpl
+++ b/templates/ts/notification-http-timer-trigger/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/ts/notification-http-trigger/appPackage/manifest.json.tpl
+++ b/templates/ts/notification-http-trigger/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "ful name for {{appName}}"
     },
     "description": {

--- a/templates/ts/notification-http-trigger/env/.env.dev
+++ b/templates/ts/notification-http-trigger/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/ts/notification-http-trigger/env/.env.local
+++ b/templates/ts/notification-http-trigger/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables.
 BOT_ID=

--- a/templates/ts/notification-http-trigger/teamsapp.local.yml.tpl
+++ b/templates/ts/notification-http-trigger/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/ts/notification-http-trigger/teamsapp.yml.tpl
+++ b/templates/ts/notification-http-trigger/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/ts/notification-restify/appPackage/manifest.json.tpl
+++ b/templates/ts/notification-restify/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "Full name for {{appName}}"
     },
     "description": {

--- a/templates/ts/notification-restify/env/.env.dev
+++ b/templates/ts/notification-restify/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/ts/notification-restify/env/.env.local
+++ b/templates/ts/notification-restify/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables.
 BOT_ID=

--- a/templates/ts/notification-restify/teamsapp.local.yml.tpl
+++ b/templates/ts/notification-restify/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/ts/notification-restify/teamsapp.yml.tpl
+++ b/templates/ts/notification-restify/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/ts/notification-timer-trigger/appPackage/manifest.json.tpl
+++ b/templates/ts/notification-timer-trigger/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "ful name for {{appName}}"
     },
     "description": {

--- a/templates/ts/notification-timer-trigger/env/.env.dev
+++ b/templates/ts/notification-timer-trigger/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/ts/notification-timer-trigger/env/.env.local
+++ b/templates/ts/notification-timer-trigger/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables.
 BOT_ID=

--- a/templates/ts/notification-timer-trigger/teamsapp.local.yml.tpl
+++ b/templates/ts/notification-timer-trigger/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/ts/notification-timer-trigger/teamsapp.yml.tpl
+++ b/templates/ts/notification-timer-trigger/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/ts/office-addin/env/.env.dev
+++ b/templates/ts/office-addin/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/ts/spfx-tab/appPackage/manifest.json.tpl
+++ b/templates/ts/spfx-tab/appPackage/manifest.json.tpl
@@ -11,7 +11,7 @@
         "termsOfUseUrl": "https://www.microsoft.com/en-us/servicesagreement"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "Full name for {{appName}}"
     },
     "description": {

--- a/templates/ts/spfx-tab/appPackage/manifest.local.json.tpl
+++ b/templates/ts/spfx-tab/appPackage/manifest.local.json.tpl
@@ -11,7 +11,7 @@
         "termsOfUseUrl": "https://www.microsoft.com/en-us/servicesagreement"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "Full name for {{appName}}"
     },
     "description": {

--- a/templates/ts/spfx-tab/env/.env.dev
+++ b/templates/ts/spfx-tab/env/.env.dev
@@ -1,5 +1,6 @@
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Generated during provision, you can also add your own variables.
 TEAMS_APP_ID=

--- a/templates/ts/spfx-tab/env/.env.local
+++ b/templates/ts/spfx-tab/env/.env.local
@@ -1,5 +1,6 @@
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables.
 TEAMS_APP_ID=

--- a/templates/ts/spfx-tab/teamsapp.local.yml.tpl
+++ b/templates/ts/spfx-tab/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:

--- a/templates/ts/spfx-tab/teamsapp.yml.tpl
+++ b/templates/ts/spfx-tab/teamsapp.yml.tpl
@@ -32,7 +32,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:

--- a/templates/ts/sso-tab-with-obo-flow/appPackage/manifest.json.tpl
+++ b/templates/ts/sso-tab-with-obo-flow/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "Full name for {{appName}}"
     },
     "description": {

--- a/templates/ts/sso-tab-with-obo-flow/env/.env.dev
+++ b/templates/ts/sso-tab-with-obo-flow/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=
 AZURE_RESOURCE_GROUP_NAME=

--- a/templates/ts/sso-tab-with-obo-flow/env/.env.local
+++ b/templates/ts/sso-tab-with-obo-flow/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables. If you're adding a secret value, add SECRET_ prefix to the name so Teams Toolkit can handle them properly
 TAB_DOMAIN=

--- a/templates/ts/sso-tab-with-obo-flow/teamsapp.local.yml.tpl
+++ b/templates/ts/sso-tab-with-obo-flow/teamsapp.local.yml.tpl
@@ -34,7 +34,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:

--- a/templates/ts/sso-tab-with-obo-flow/teamsapp.yml.tpl
+++ b/templates/ts/sso-tab-with-obo-flow/teamsapp.yml.tpl
@@ -37,7 +37,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:

--- a/templates/ts/workflow/appPackage/manifest.json.tpl
+++ b/templates/ts/workflow/appPackage/manifest.json.tpl
@@ -15,7 +15,7 @@
         "outline": "outline.png"
     },
     "name": {
-        "short": "{{appName}}-${{TEAMSFX_ENV}}",
+        "short": "{{appName}}${{APP_NAME_SUFFIX}}",
         "full": "Full name for {{appName}}"
     },
     "description": {

--- a/templates/ts/workflow/env/.env.dev
+++ b/templates/ts/workflow/env/.env.dev
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=dev
+APP_NAME_SUFFIX=dev
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/ts/workflow/env/.env.local
+++ b/templates/ts/workflow/env/.env.local
@@ -2,6 +2,7 @@
 
 # Built-in environment variables
 TEAMSFX_ENV=local
+APP_NAME_SUFFIX=local
 
 # Generated during provision, you can also add your own variables.
 BOT_ID=

--- a/templates/ts/workflow/teamsapp.local.yml.tpl
+++ b/templates/ts/workflow/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -18,7 +18,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID

--- a/templates/ts/workflow/teamsapp.yml.tpl
+++ b/templates/ts/workflow/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:
@@ -21,7 +21,7 @@ provision:
   - uses: botAadApp/create
     with:
       # The Azure Active Directory application's display name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       # The Azure Active Directory application's client id created for bot.
       botId: BOT_ID


### PR DESCRIPTION
fix: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/25437765

Add a new env variable name `APP_NAME_SUFFIX` that user can keep it empty for production environment.

Decouple the relationship between teams app name and TEAMSFX_ENV 