### PR TITLE
feat(vsc): update sample gallery UI

### DIFF
--- a/packages/vscode-extension/src/controls/sampleGallery/sampleCard.scss
+++ b/packages/vscode-extension/src/controls/sampleGallery/sampleCard.scss
@@ -106,34 +106,6 @@
       margin: 4px 8px 0px 0px;
     }
 
-    .configuration {
-      padding-left: 10px;
-      color: var(--vscode-debugConsoleInputIcon-foreground);
-      display: flex;
-      font-size: 11px;
-      height: 24px;
-      margin-top: 4px;
-
-      .setting {
-        width: 16px;
-        height: 16px;
-        margin-top: auto;
-        margin-bottom: auto;
-      }
-
-      .ms-Image {
-        margin-top: auto;
-        margin-bottom: auto;
-      }
-
-      label {
-        width: 242px;
-        margin-top: auto;
-        margin-bottom: auto;
-        cursor: pointer;
-      }
-    }
-
     h3 {
       font-size: 13px;
       text-align: center;
@@ -171,12 +143,6 @@
   }
 
   .sample-card.unavailable {
-    cursor: default;
-
-    .infoBox {
-      opacity: 0.3;
-    }
-
     .tooltip {
       visibility: hidden;
       width: 90px;

--- a/packages/vscode-extension/src/controls/sampleGallery/sampleCard.tsx
+++ b/packages/vscode-extension/src/controls/sampleGallery/sampleCard.tsx
@@ -67,14 +67,6 @@ export default class SampleCard extends React.Component<SampleProps, unknown> {
               );
             })}
         </div>
-        {sample.configuration != "Ready for debug" && (
-          <div className="configuration">
-            <div className="setting">
-              <Setting></Setting>
-            </div>
-            <label style={{ paddingLeft: 4 }}>{sample.configuration}</label>
-          </div>
-        )}
       </div>
     );
     let sampleImage = previewImage;

--- a/packages/vscode-extension/src/controls/sampleGallery/sampleFilter.scss
+++ b/packages/vscode-extension/src/controls/sampleGallery/sampleFilter.scss
@@ -5,8 +5,22 @@
   margin-bottom: 24px;
 
   .search-box {
-    width: 426px;
+    width: 200px;
     margin-bottom: 16px;
+
+    .codicon-close {
+      width: 20px;
+      height: 20px;
+      font-size: 20px;
+    }
+
+    .hide {
+      display: none;
+    }
+  }
+
+  .search-box::part(root) {
+    border-radius: 2px;
   }
 
   .filter-bar {

--- a/packages/vscode-extension/src/controls/sampleGallery/sampleFilter.tsx
+++ b/packages/vscode-extension/src/controls/sampleGallery/sampleFilter.tsx
@@ -28,6 +28,11 @@ export default class SampleFilter extends React.Component<SampleFilterProps, unk
           }}
         >
           <span slot="start" className="codicon codicon-search"></span>
+          <span
+            slot="end"
+            className={`codicon codicon-close ${this.props.query === "" ? "hide" : ""}`}
+            onClick={() => this.setState({ query: "" })}
+          ></span>
         </VSCodeTextField>
         <div className="filter-bar"></div>
         <VSCodeButton

--- a/packages/vscode-extension/src/controls/sampleGallery/sampleFilter.tsx
+++ b/packages/vscode-extension/src/controls/sampleGallery/sampleFilter.tsx
@@ -31,7 +31,7 @@ export default class SampleFilter extends React.Component<SampleFilterProps, unk
           <span
             slot="end"
             className={`codicon codicon-close ${this.props.query === "" ? "hide" : ""}`}
-            onClick={() => this.setState({ query: "" })}
+            onClick={() => this.props.onQueryChange("")}
           ></span>
         </VSCodeTextField>
         <div className="filter-bar"></div>

--- a/packages/vscode-extension/src/controls/sampleGallery/sampleListItem.scss
+++ b/packages/vscode-extension/src/controls/sampleGallery/sampleListItem.scss
@@ -1,6 +1,11 @@
 .sample-gallery {
+  .sample-list-item:first-child {
+    border-top: 1px solid;
+    border-color: #454545;
+  }
+
   .sample-list-item {
-    height: auto;
+    height: 44px;
     display: flex;
     flex-direction: row;
     align-items: center;
@@ -23,20 +28,39 @@
       text-align: left;
       line-height: 18px;
       cursor: pointer;
+      margin: 0;
+      min-width: 50px;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      overflow: hidden;
+    }
+
+    h3:hover {
+      flex-shrink: 0;
+    }
+
+    h3:hover ~ .tagSection {
+      flex-shrink: 1;
+      overflow: hidden;
+      flex-wrap: nowrap;
     }
 
     .padding {
       flex-grow: 1;
+      flex-shrink: 2;
+      min-width: 4.5px;
     }
 
     .tagSection {
       display: flex;
       flex-wrap: wrap;
       align-items: center;
-      margin-left: 22px;
+      flex-shrink: 0;
+      margin-left: 4px;
 
       .tag {
         margin-left: 8px;
+        flex-shrink: 0;
       }
     }
 
@@ -49,23 +73,18 @@
       border-radius: 4px;
       padding: 1px 4px;
       margin-left: 10px;
-      margin-top: 10px;
 
       position: absolute;
       z-index: 1;
     }
 
-    .setting {
-      height: 16px;
-      margin-left: 13px;
-    }
+    .info {
+      flex-shrink: 0;
 
-    .setting:hover .tooltip {
-      display: block;
-    }
-
-    .info .codicon {
-      color: var(--vscode-symbolIcon-interfaceForeground);
+      .codicon {
+        margin-left: 7.5px;
+        color: var(--vscode-symbolIcon-interfaceForeground);
+      }
     }
 
     .info:hover .tooltip {
@@ -73,8 +92,10 @@
     }
 
     vscode-button {
+      flex-shrink: 0;
       border-radius: 0;
       margin-left: 7.5px;
+      height: 28px;
     }
   }
 }

--- a/packages/vscode-extension/src/controls/sampleGallery/sampleListItem.tsx
+++ b/packages/vscode-extension/src/controls/sampleGallery/sampleListItem.tsx
@@ -59,12 +59,6 @@ export default class SampleListItem extends React.Component<SampleProps, unknown
               );
             })}
         </div>
-        {sample.configuration != "Ready for debug" && (
-          <div className="setting">
-            <Setting></Setting>
-            <span className="tooltip">{sample.configuration}</span>
-          </div>
-        )}
         <div className="padding" />
         {sample.versionComparisonResult != 0 && (
           <div className="info">


### PR DESCRIPTION
Related task: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/25297871

- Use normal font size on unavailable sample card.
- Remove 'manual configuration required'.
- Refine search bar UI
- Support responsive sample list.

Effect:
![image](https://github.com/OfficeDev/TeamsFx/assets/886116/ae45e34f-76d6-46b3-83ce-de21b1fc1029)
![image](https://github.com/OfficeDev/TeamsFx/assets/886116/875a1748-022d-4512-b2e3-cc5f5b18a00a)
![image](https://github.com/OfficeDev/TeamsFx/assets/886116/aaf80ac0-7aa5-47d4-a488-4cf2cb49ce0a)
![image](https://github.com/OfficeDev/TeamsFx/assets/886116/08e867da-d1b1-4b56-bb51-82c414f0c3d3)
