### PR TITLE
feat(vsc): persist layout data in sample gallery

### DIFF
--- a/packages/vscode-extension/src/constants.ts
+++ b/packages/vscode-extension/src/constants.ts
@@ -26,6 +26,7 @@ export enum GlobalKey {
   OpenSampleReadMe = "fx-extension.openSampleReadMe",
   ShowLocalDebugMessage = "ShowLocalDebugMessage",
   CreateWarnings = "CreateWarnings",
+  SampleGalleryLayout = "teamsToolkit:sampleGallery:layout",
 }
 
 export const environmentVariableRegex = /\${{[a-zA-Z-_]+}}/g;

--- a/packages/vscode-extension/src/controls/Commands.ts
+++ b/packages/vscode-extension/src/controls/Commands.ts
@@ -11,4 +11,6 @@ export enum Commands {
   ExecuteCommand = "execute-command",
   LoadSampleCollection = "get-sample-collection",
   UpgradeToolkit = "upgrade-toolkit",
+  StoreData = "store-data",
+  GetData = "get-data",
 }

--- a/packages/vscode-extension/src/controls/sampleGallery/ISamples.ts
+++ b/packages/vscode-extension/src/controls/sampleGallery/ISamples.ts
@@ -1,16 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import Fuse from "fuse.js";
-
 export type SampleGalleryState = {
   loading: boolean;
-  samples: Array<SampleInfo>;
+  layout: "grid" | "list";
+  filteredSamples?: Array<SampleInfo>;
   error?: Error;
   selectedSampleId?: string;
-  query: string;
-  fuse: Fuse<SampleInfo>;
-  layout: "grid" | "list";
 };
 
 export interface SampleInfo {
@@ -37,8 +33,13 @@ export type SampleProps = {
 };
 
 export type SampleFilterProps = {
-  query: string;
+  samples: Array<SampleInfo>;
   layout: "grid" | "list";
-  onQueryChange: (query: string) => void;
+
+  onFilteredSamplesChange: (samples: SampleInfo[]) => void;
   onLayoutChange: (layout: "grid" | "list") => void;
+};
+
+export type SampleFilterState = {
+  query: string;
 };

--- a/packages/vscode-extension/src/controls/sampleGallery/SampleGallery.tsx
+++ b/packages/vscode-extension/src/controls/sampleGallery/SampleGallery.tsx
@@ -3,11 +3,16 @@
 
 import "./SampleGallery.scss";
 
-import Fuse from "fuse.js";
 import * as React from "react";
 
 import { Icon } from "@fluentui/react";
 
+import { GlobalKey } from "../../constants";
+import {
+  TelemetryEvent,
+  TelemetryProperty,
+  TelemetryTriggerFrom,
+} from "../../telemetry/extTelemetryEvents";
 import { Commands } from "../Commands";
 import { SampleGalleryState, SampleInfo } from "./ISamples";
 import OfflinePage from "./offlinePage";
@@ -17,13 +22,12 @@ import SampleFilter from "./sampleFilter";
 import SampleListItem from "./sampleListItem";
 
 export default class SampleGallery extends React.Component<unknown, SampleGalleryState> {
+  private samples: SampleInfo[] = [];
+
   constructor(props: unknown) {
     super(props);
     this.state = {
-      samples: [],
       loading: true,
-      query: "",
-      fuse: new Fuse([]),
       layout: "grid",
     };
   }
@@ -32,6 +36,12 @@ export default class SampleGallery extends React.Component<unknown, SampleGaller
     window.addEventListener("message", this.receiveMessage, false);
     vscode.postMessage({
       command: Commands.LoadSampleCollection,
+    });
+    vscode.postMessage({
+      command: Commands.GetData,
+      data: {
+        key: GlobalKey.SampleGalleryLayout,
+      },
     });
   }
 
@@ -53,16 +63,11 @@ export default class SampleGallery extends React.Component<unknown, SampleGaller
     if (this.state.loading) {
       return <div className="sample-gallery">{titleSection}</div>;
     } else if (this.state.selectedSampleId) {
-      const selectedSample = this.state.samples.filter(
+      const selectedSample = this.samples.filter(
         (sample: SampleInfo) => sample.id == this.state.selectedSampleId
       )[0];
       return <SampleDetailPage sample={selectedSample} selectSample={this.selectSample} />;
     } else {
-      const query = this.state.query.trim();
-      const filteredSamples =
-        query === ""
-          ? this.state.samples
-          : this.state.fuse.search(query).map((result: { item: SampleInfo }) => result.item);
       return (
         <div className="sample-gallery">
           {titleSection}
@@ -71,19 +76,16 @@ export default class SampleGallery extends React.Component<unknown, SampleGaller
           ) : (
             <>
               <SampleFilter
-                query={this.state.query}
                 layout={this.state.layout}
-                onQueryChange={(newQuery: string) => {
-                  this.setState({ query: newQuery });
+                samples={this.samples}
+                onFilteredSamplesChange={(filteredSamples: SampleInfo[]) => {
+                  this.setState({ filteredSamples });
                 }}
-                onLayoutChange={(newLayout: "grid" | "list") => {
-                  console.log(newLayout);
-                  this.setState({ layout: newLayout });
-                }}
+                onLayoutChange={this.onLayoutChanged}
               ></SampleFilter>
               {this.state.layout === "grid" ? (
                 <div className="sample-stack">
-                  {filteredSamples.map((sample: SampleInfo) => {
+                  {(this.state.filteredSamples ?? this.samples).map((sample: SampleInfo) => {
                     return (
                       <SampleCard
                         key={sample.id}
@@ -95,7 +97,7 @@ export default class SampleGallery extends React.Component<unknown, SampleGaller
                 </div>
               ) : (
                 <div className="sample-list">
-                  {filteredSamples.map((sample: SampleInfo) => {
+                  {(this.state.filteredSamples ?? this.samples).map((sample: SampleInfo) => {
                     return (
                       <SampleListItem
                         key={sample.id}
@@ -118,15 +120,20 @@ export default class SampleGallery extends React.Component<unknown, SampleGaller
     switch (message) {
       case Commands.LoadSampleCollection:
         const error = event.data.error;
-        const samples = event.data.data as SampleInfo[];
+        this.samples = event.data.data as SampleInfo[];
         this.setState({
           loading: false,
-          samples,
           error,
-          fuse: new Fuse(samples, {
-            keys: ["title", "shortDescription", "fullDescription", "tags"],
-          }),
         });
+        break;
+      case Commands.GetData:
+        const key = event.data.data.key;
+        const value = event.data.data.value;
+        if (key === GlobalKey.SampleGalleryLayout) {
+          this.setState({
+            layout: value,
+          });
+        }
         break;
       default:
         break;
@@ -137,5 +144,26 @@ export default class SampleGallery extends React.Component<unknown, SampleGaller
     this.setState({
       selectedSampleId: id,
     });
+  };
+
+  private onLayoutChanged = (newLayout: "grid" | "list") => {
+    vscode.postMessage({
+      command: Commands.SendTelemetryEvent,
+      data: {
+        eventName: TelemetryEvent.SearchSample,
+        properties: {
+          [TelemetryProperty.TriggerFrom]: TelemetryTriggerFrom.Webview,
+          [TelemetryProperty.Layout]: newLayout,
+        },
+      },
+    });
+    vscode.postMessage({
+      command: Commands.StoreData,
+      data: {
+        key: GlobalKey.SampleGalleryLayout,
+        value: newLayout,
+      },
+    });
+    this.setState({ layout: newLayout });
   };
 }

--- a/packages/vscode-extension/src/controls/sampleGallery/sampleCard.tsx
+++ b/packages/vscode-extension/src/controls/sampleGallery/sampleCard.tsx
@@ -15,7 +15,6 @@ import {
   TelemetryTriggerFrom,
 } from "../../telemetry/extTelemetryEvents";
 import { Commands } from "../Commands";
-import { Setting } from "../resources";
 import { SampleProps } from "./ISamples";
 
 export default class SampleCard extends React.Component<SampleProps, unknown> {

--- a/packages/vscode-extension/src/controls/sampleGallery/sampleFilter.scss
+++ b/packages/vscode-extension/src/controls/sampleGallery/sampleFilter.scss
@@ -38,7 +38,7 @@
     z-index: 2;
   }
 
-  .selected {
+  .view-selected {
     border-radius: 4px;
     background: var(--vscode-checkbox-border, #3c3c3c);
   }

--- a/packages/vscode-extension/src/controls/sampleGallery/sampleFilter.tsx
+++ b/packages/vscode-extension/src/controls/sampleGallery/sampleFilter.tsx
@@ -3,17 +3,27 @@
 
 import "./sampleFilter.scss";
 
+import Fuse from "fuse.js";
 import { debounce } from "lodash";
 import * as React from "react";
 
 import { VSCodeButton, VSCodeTextField } from "@vscode/webview-ui-toolkit/react";
 
+import {
+  TelemetryEvent,
+  TelemetryProperty,
+  TelemetryTriggerFrom,
+} from "../../telemetry/extTelemetryEvents";
+import { Commands } from "../Commands";
 import { Grid } from "../resources";
-import { SampleFilterProps } from "./ISamples";
+import { SampleFilterProps, SampleFilterState, SampleInfo } from "./ISamples";
 
-export default class SampleFilter extends React.Component<SampleFilterProps, unknown> {
+export default class SampleFilter extends React.Component<SampleFilterProps, SampleFilterState> {
   constructor(props: SampleFilterProps) {
     super(props);
+    this.state = {
+      query: "",
+    };
   }
 
   render() {
@@ -22,16 +32,14 @@ export default class SampleFilter extends React.Component<SampleFilterProps, unk
         <VSCodeTextField
           className="search-box"
           placeholder="Search samples"
-          value={this.props.query}
-          onInput={(e: { target: { value: string } }) => {
-            debounce(() => this.props.onQueryChange(e.target.value), 500)();
-          }}
+          value={this.state.query}
+          onInput={this.onSearchTextChanged}
         >
           <span slot="start" className="codicon codicon-search"></span>
           <span
             slot="end"
-            className={`codicon codicon-close ${this.props.query === "" ? "hide" : ""}`}
-            onClick={() => this.props.onQueryChange("")}
+            className={`codicon codicon-close ${this.state.query === "" ? "hide" : ""}`}
+            onClick={() => this.setState({ query: "" })}
           ></span>
         </VSCodeTextField>
         <div className="filter-bar"></div>
@@ -39,7 +47,7 @@ export default class SampleFilter extends React.Component<SampleFilterProps, unk
           onClick={() => this.props.onLayoutChange("grid")}
           appearance="icon"
           aria-label="gallary view"
-          className={`view-button ${this.props.layout === "grid" ? "selected" : ""}`}
+          className={`view-button ${this.props.layout === "grid" ? "view-selected" : ""}`}
         >
           <Grid />
         </VSCodeButton>
@@ -47,11 +55,41 @@ export default class SampleFilter extends React.Component<SampleFilterProps, unk
           onClick={() => this.props.onLayoutChange("list")}
           appearance="icon"
           aria-label="list view"
-          className={`view-button ${this.props.layout === "list" ? "selected" : ""}`}
+          className={`view-button ${this.props.layout === "list" ? "view-selected" : ""}`}
         >
           <span className="codicon codicon-list-unordered"></span>
         </VSCodeButton>
       </div>
     );
+  }
+
+  private onSearchTextChanged = (e: { target: { value: string } }) => {
+    debounce(() => {
+      vscode.postMessage({
+        command: Commands.SendTelemetryEvent,
+        data: {
+          eventName: TelemetryEvent.SearchSample,
+          properties: {
+            [TelemetryProperty.TriggerFrom]: TelemetryTriggerFrom.Webview,
+            [TelemetryProperty.SearchText]: e.target.value,
+          },
+        },
+      });
+      this.setState({ query: e.target.value });
+      this.filterSamples();
+    }, 500)();
+  };
+
+  private filterSamples(): void {
+    let filteredSamples = this.props.samples;
+    if (this.state.query !== "") {
+      const fuse = new Fuse(filteredSamples, {
+        keys: ["title", "shortDescription", "fullDescription", "tags"],
+      });
+      filteredSamples = fuse
+        .search(this.state.query)
+        .map((result: { item: SampleInfo }) => result.item);
+    }
+    this.props.onFilteredSamplesChange(filteredSamples);
   }
 }

--- a/packages/vscode-extension/src/controls/webviewPanel.ts
+++ b/packages/vscode-extension/src/controls/webviewPanel.ts
@@ -141,6 +141,18 @@ export class WebviewPanel {
           case Commands.UpgradeToolkit:
             await this.OpenToolkitInExtensionView(msg.data.version);
             break;
+          case Commands.StoreData:
+            await globalVariables.context.globalState.update(msg.data.key, msg.data.value);
+            break;
+          case Commands.GetData:
+            await this.panel.webview.postMessage({
+              message: Commands.GetData,
+              data: {
+                key: msg.data.key,
+                value: globalVariables.context.globalState.get(msg.data.key),
+              },
+            });
+            break;
           default:
             break;
         }

--- a/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
@@ -86,6 +86,7 @@ export enum TelemetryEvent {
 
   ViewSampleInGitHub = "view-sample-in-github",
   UpgradeToolkitForSample = "upgrade-toolkit-for-sample",
+  SearchSample = "search-sample",
 
   WatchVideo = "watch-video",
   PauseVideo = "pause-video",
@@ -339,6 +340,9 @@ export enum TelemetryProperty {
   Interaction = "interaction",
   Identifier = "identifier",
   ValidateMethod = "validate-method",
+  // Used in Sample Gallery
+  SearchText = "search-text",
+  Layout = "layout",
 }
 
 export enum TelemetryMeasurements {


### PR DESCRIPTION
Task: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/25415409

- Refactor filter logic.
- Store layout data in VS Code global state.