### PR TITLE
fix: show framwork question node in cli for non-interactive mode and …

### DIFF
--- a/packages/fx-core/src/question/inputs/SPFxAddWebpartInputs.ts
+++ b/packages/fx-core/src/question/inputs/SPFxAddWebpartInputs.ts
@@ -15,6 +15,8 @@ export interface SPFxAddWebpartInputs extends Inputs {
   "spfx-folder"?: string;
   /** @description Name for SharePoint Framework Web Part */
   "spfx-webpart-name"?: string;
+  /** @description Framework */
+  "spfx-framework-type"?: "react" | "minimal" | "none";
   /** @description Select Teams manifest.json file */
   "manifest-path"?: string;
   /** @description Select local Teams manifest.json file */

--- a/packages/fx-core/src/question/options/SPFxAddWebpartOptions.ts
+++ b/packages/fx-core/src/question/options/SPFxAddWebpartOptions.ts
@@ -26,6 +26,15 @@ export const SPFxAddWebpartOptions: CLICommandOption[] = [
     default: "helloworld",
   },
   {
+    name: "spfx-framework-type",
+    type: "string",
+    shortName: "k",
+    description: "Framework.",
+    required: true,
+    default: "react",
+    choices: ["react", "minimal", "none"],
+  },
+  {
     name: "teams-manifest-file",
     questionName: "manifest-path",
     type: "string",

--- a/packages/fx-core/src/question/other.ts
+++ b/packages/fx-core/src/question/other.ts
@@ -198,6 +198,10 @@ function confirmCondition(inputs: Inputs, isLocal: boolean): boolean {
 }
 
 async function spfxFrameworkExist(inputs: Inputs): Promise<boolean> {
+  if (inputs.platform === Platform.CLI_HELP) {
+    return false;
+  }
+
   const yorcPath = path.join(inputs[QuestionNames.SPFxFolder], Constants.YO_RC_FILE);
   if (!(await fs.pathExists(yorcPath))) {
     return false;

--- a/packages/fx-core/tests/core/FxCore.test.ts
+++ b/packages/fx-core/tests/core/FxCore.test.ts
@@ -141,6 +141,29 @@ describe("Core basic APIs", () => {
     runSpy.restore();
   });
 
+  it("add web part to SPFx - CLI help", async () => {
+    const core = new FxCore(tools);
+    const appName = await mockV3Project();
+    const appPath = path.join(os.tmpdir(), appName);
+    const inputs: Inputs = {
+      platform: Platform.CLI_HELP,
+      [QuestionNames.Folder]: os.tmpdir(),
+      "spfx-folder": ".\\src",
+      "manifest-path": path.join(appPath, "appPackage\\manifest.json"),
+      "local-manifest-path": path.join(appPath, "appPackage\\manifest.local.json"),
+      "spfx-webpart-name": "helloworld",
+      "spfx-install-latest-package": "true",
+      "spfx-load-package-version": "loaded",
+      stage: Stage.addWebpart,
+      projectPath: appPath,
+    };
+
+    const runSpy = sandbox.spy(AddWebPartDriver.prototype, "run");
+    await core.addWebpart(inputs);
+    sandbox.assert.calledOnce(runSpy);
+    runSpy.restore();
+  });
+
   it("add web part to SPFx with empty .yo-rc.json", async () => {
     const core = new FxCore(tools);
     const appName = await mockV3Project();


### PR DESCRIPTION
…help mode

ADO:
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/25392352
Screenshot:
CLI help:
![image](https://github.com/OfficeDev/TeamsFx/assets/73154171/ea4fb812-d0d3-4cad-8695-290891facd33)
CLI non-interactive mode:
![image](https://github.com/OfficeDev/TeamsFx/assets/73154171/d566fe81-ff72-4b77-9cf1-509e507178ee)
