### PR TITLE
refactor(vs-templates): rebrand aad name to Microsoft Entra

### DIFF
--- a/templates/csharp/ai-bot/teamsapp.local.yml.tpl
+++ b/templates/csharp/ai-bot/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   # Generate runtime appsettings to JSON file

--- a/templates/csharp/ai-bot/teamsapp.yml.tpl
+++ b/templates/csharp/ai-bot/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   - uses: arm/deploy  # Deploy given ARM templates parallelly.

--- a/templates/csharp/command-and-response/teamsapp.local.yml.tpl
+++ b/templates/csharp/command-and-response/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   # Generate runtime appsettings to JSON file

--- a/templates/csharp/command-and-response/teamsapp.yml.tpl
+++ b/templates/csharp/command-and-response/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   - uses: arm/deploy  # Deploy given ARM templates parallelly.

--- a/templates/csharp/default-bot/teamsapp.local.yml.tpl
+++ b/templates/csharp/default-bot/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   # Generate runtime appsettings to JSON file

--- a/templates/csharp/default-bot/teamsapp.yml.tpl
+++ b/templates/csharp/default-bot/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   - uses: arm/deploy  # Deploy given ARM templates parallelly.

--- a/templates/csharp/link-unfurling/teamsapp.local.yml.tpl
+++ b/templates/csharp/link-unfurling/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   # Generate runtime appsettings to JSON file

--- a/templates/csharp/link-unfurling/teamsapp.yml.tpl
+++ b/templates/csharp/link-unfurling/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   - uses: arm/deploy  # Deploy given ARM templates parallelly.

--- a/templates/csharp/message-extension-action/teamsapp.local.yml.tpl
+++ b/templates/csharp/message-extension-action/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile: 
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD 
 
   # Generate runtime appsettings to JSON file

--- a/templates/csharp/message-extension-action/teamsapp.yml.tpl
+++ b/templates/csharp/message-extension-action/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile: 
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD 
 
   - uses: arm/deploy  # Deploy given ARM templates parallelly.

--- a/templates/csharp/message-extension-copilot/teamsapp.local.yml.tpl
+++ b/templates/csharp/message-extension-copilot/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   # Generate runtime appsettings to JSON file

--- a/templates/csharp/message-extension-copilot/teamsapp.yml.tpl
+++ b/templates/csharp/message-extension-copilot/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   - uses: arm/deploy  # Deploy given ARM templates parallelly.

--- a/templates/csharp/message-extension-search/teamsapp.local.yml.tpl
+++ b/templates/csharp/message-extension-search/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile: 
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD 
 
   # Generate runtime appsettings to JSON file

--- a/templates/csharp/message-extension-search/teamsapp.yml.tpl
+++ b/templates/csharp/message-extension-search/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile: 
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD 
 
   - uses: arm/deploy  # Deploy given ARM templates parallelly.

--- a/templates/csharp/message-extension/teamsapp.local.yml.tpl
+++ b/templates/csharp/message-extension/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   # Generate runtime appsettings to JSON file

--- a/templates/csharp/message-extension/teamsapp.yml.tpl
+++ b/templates/csharp/message-extension/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   - uses: arm/deploy  # Deploy given ARM templates parallelly.

--- a/templates/csharp/non-sso-tab/Interop/TeamsSDK/TeamsContext.cs.tpl
+++ b/templates/csharp/non-sso-tab/Interop/TeamsSDK/TeamsContext.cs.tpl
@@ -175,7 +175,7 @@ public class TeamsUserContext
     public bool? IsPSTNCallingAllowed { get; set; }
 
     /// <summary>
-    /// A value suitable for use as a login_hint when authenticating with Azure AD. Because a malicious party can run your
+    /// A value suitable for use as a login_hint when authenticating with Microsoft Entra. Because a malicious party can run your
     /// content in a browser, this value should be used only as a hint as to who the user is and never as proof of identity.
     /// This field is available only when the identity permission is requested in the manifest.
     /// </summary>
@@ -189,7 +189,7 @@ public class TeamsUserContext
     public string LicenseType { get; set; }
 
     /// <summary>
-    /// The Azure AD object id of the current user. Because a malicious party run your content in a browser,
+    /// The Microsoft Entra object id of the current user. Because a malicious party run your content in a browser,
     /// this value should be used only as a hint as to who the user is and never as proof of identity. This field
     /// is available only when the identity permission is requested in the manifest.
     /// </summary>
@@ -254,7 +254,7 @@ public class TeamsUserTenantContext
     public string TeamsSKU { get; set; }
 
     /// <summary>
-    /// The Azure AD tenant ID of the current user. Because a malicious party can run your content in a browser,
+    /// The Microsoft Entra tenant ID of the current user. Because a malicious party can run your content in a browser,
     /// this value should be used only as a hint as to who the user is and never as proof of identity. This field
     /// is available only when the identity permission is requested in the manifest.
     /// </summary>

--- a/templates/csharp/notification-http-timer-trigger/teamsapp.local.yml.tpl
+++ b/templates/csharp/notification-http-timer-trigger/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   # Generate runtime appsettings to JSON file

--- a/templates/csharp/notification-http-timer-trigger/teamsapp.yml.tpl
+++ b/templates/csharp/notification-http-timer-trigger/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   - uses: arm/deploy  # Deploy given ARM templates parallelly.

--- a/templates/csharp/notification-http-trigger/teamsapp.local.yml.tpl
+++ b/templates/csharp/notification-http-trigger/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   # Generate runtime appsettings to JSON file

--- a/templates/csharp/notification-http-trigger/teamsapp.yml.tpl
+++ b/templates/csharp/notification-http-trigger/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   - uses: arm/deploy  # Deploy given ARM templates parallelly.

--- a/templates/csharp/notification-timer-trigger/teamsapp.local.yml.tpl
+++ b/templates/csharp/notification-timer-trigger/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   # Generate runtime appsettings to JSON file

--- a/templates/csharp/notification-timer-trigger/teamsapp.yml.tpl
+++ b/templates/csharp/notification-timer-trigger/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   - uses: arm/deploy  # Deploy given ARM templates parallelly.

--- a/templates/csharp/notification-webapi/teamsapp.local.yml.tpl
+++ b/templates/csharp/notification-webapi/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   # Generate runtime appsettings to JSON file

--- a/templates/csharp/notification-webapi/teamsapp.yml.tpl
+++ b/templates/csharp/notification-webapi/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   - uses: arm/deploy  # Deploy given ARM templates parallelly.

--- a/templates/csharp/sso-tab/GettingStarted.md
+++ b/templates/csharp/sso-tab/GettingStarted.md
@@ -14,7 +14,7 @@ New to Teams app development or Teams Toolkit? Learn more about
 Teams app manifests, deploying to the cloud, and more in the documentation 
 at https://aka.ms/teams-toolkit-vs-docs
 
-Note: This sample will only provision single tenant Azure Active Directory app.
+Note: This sample will only provision single tenant Microsoft Entra app.
 For multi-tenant support, please refer to https://aka.ms/teamsfx-multi-tenant.
 
 ## Report an issue

--- a/templates/csharp/sso-tab/Interop/TeamsSDK/TeamsContext.cs.tpl
+++ b/templates/csharp/sso-tab/Interop/TeamsSDK/TeamsContext.cs.tpl
@@ -175,7 +175,7 @@ public class TeamsUserContext
     public bool? IsPSTNCallingAllowed { get; set; }
 
     /// <summary>
-    /// A value suitable for use as a login_hint when authenticating with Azure AD. Because a malicious party can run your
+    /// A value suitable for use as a login_hint when authenticating with Microsoft Entra. Because a malicious party can run your
     /// content in a browser, this value should be used only as a hint as to who the user is and never as proof of identity.
     /// This field is available only when the identity permission is requested in the manifest.
     /// </summary>
@@ -189,7 +189,7 @@ public class TeamsUserContext
     public string LicenseType { get; set; }
 
     /// <summary>
-    /// The Azure AD object id of the current user. Because a malicious party run your content in a browser,
+    /// The Microsoft Entra object id of the current user. Because a malicious party run your content in a browser,
     /// this value should be used only as a hint as to who the user is and never as proof of identity. This field
     /// is available only when the identity permission is requested in the manifest.
     /// </summary>
@@ -249,7 +249,7 @@ public class TeamsUserTenantContext
     public string TeamsSKU { get; set; }
 
     /// <summary>
-    /// The Azure AD tenant ID of the current user. Because a malicious party can run your content in a browser,
+    /// The Microsoft Entra tenant ID of the current user. Because a malicious party can run your content in a browser,
     /// this value should be used only as a hint as to who the user is and never as proof of identity. This field
     /// is available only when the identity permission is requested in the manifest.
     /// </summary>

--- a/templates/csharp/sso-tab/teamsapp.local.yml.tpl
+++ b/templates/csharp/sso-tab/teamsapp.local.yml.tpl
@@ -4,19 +4,19 @@
 version: 1.1.0
 
 provision:
-  # Creates a new Azure Active Directory (AAD) app to authenticate users if
+  # Creates a new Microsoft Entra app to authenticate users if
   # the environment variable that stores clientId is empty
   - uses: aadApp/create
     with:
-      # Note: when you run aadApp/update, the AAD app name will be updated
+      # Note: when you run aadApp/update, the Microsoft Entra app name will be updated
       # based on the definition in manifest. If you don't want to change the
-      # name, make sure the name in AAD manifest is the same with the name
+      # name, make sure the name in Microsoft Entra manifest is the same with the name
       # defined here.
       name: {{appName}}
       # If the value is false, the action will not generate client secret for you
       generateClientSecret: true
       # Authenticate users with a Microsoft work or school account in your
-      # organization's Azure AD tenant (for example, single tenant).
+      # organization's Microsoft Entra tenant (for example, single tenant).
       signInAudience: AzureADMyOrg
     # Write the information of created resources into environment file for the
     # specified environment variable(s).
@@ -59,12 +59,12 @@ provision:
             InitiateLoginEndpoint: ${{TAB_ENDPOINT}}/auth-start.html
             OAuthAuthority: ${{AAD_APP_OAUTH_AUTHORITY}}
 
-  # Apply the AAD manifest to an existing AAD app. Will use the object id in
-  # manifest file to determine which AAD app to update.
+  # Apply the Microsoft Entra manifest to an existing Microsoft Entra app. Will use the object id in
+  # manifest file to determine which Microsoft Entra app to update.
   - uses: aadApp/update
     with:
       # Relative path to this file. Environment variables in manifest will
-      # be replaced before apply to AAD app
+      # be replaced before apply to Microsoft Entra app
       manifestPath: ./aad.manifest.json
       outputFilePath: ./build/aad.manifest.${{TEAMSFX_ENV}}.json
 

--- a/templates/csharp/sso-tab/teamsapp.yml.tpl
+++ b/templates/csharp/sso-tab/teamsapp.yml.tpl
@@ -7,19 +7,19 @@ environmentFolderPath: ./env
 
 # Triggered when 'teamsfx provision' is executed
 provision:
-  # Creates a new Azure Active Directory (AAD) app to authenticate users if
+  # Creates a new Microsoft Entra app to authenticate users if
   # the environment variable that stores clientId is empty
   - uses: aadApp/create
     with:
-      # Note: when you run aadApp/update, the AAD app name will be updated
+      # Note: when you run aadApp/update, the Microsoft Entra app name will be updated
       # based on the definition in manifest. If you don't want to change the
-      # name, make sure the name in AAD manifest is the same with the name
+      # name, make sure the name in Microsoft Entra manifest is the same with the name
       # defined here.
       name: {{appName}}
       # If the value is false, the action will not generate client secret for you
       generateClientSecret: true
       # Authenticate users with a Microsoft work or school account in your
-      # organization's Azure AD tenant (for example, single tenant).
+      # organization's Microsoft Entra tenant (for example, single tenant).
       signInAudience: AzureADMyOrg
     # Write the information of created resources into environment file for the
     # specified environment variable(s).
@@ -68,12 +68,12 @@ provision:
       # will use bicep CLI in PATH if you remove this config.
       bicepCliVersion: v0.9.1
 
-  # Apply the AAD manifest to an existing AAD app. Will use the object id in
-  # manifest file to determine which AAD app to update.
+  # Apply the Microsoft Entra manifest to an existing Microsoft Entra app. Will use the object id in
+  # manifest file to determine which Microsoft Entra app to update.
   - uses: aadApp/update
     with:
       # Relative path to this file. Environment variables in manifest will
-      # be replaced before apply to AAD app
+      # be replaced before apply to Microsoft Entra app
       manifestPath: ./aad.manifest.json
       outputFilePath: ./build/aad.manifest.${{TEAMSFX_ENV}}.json
 

--- a/templates/csharp/sso-tab/wwwroot/auth-start.html
+++ b/templates/csharp/sso-tab/wwwroot/auth-start.html
@@ -16,7 +16,7 @@
     ></script>
     <script type="text/javascript">
       microsoftTeams.app.initialize().then(() => {
-        // Get the tab context, and use the information to navigate to Azure AD login page
+        // Get the tab context, and use the information to navigate to Microsoft Entra login page
         microsoftTeams.app.getContext().then(async function (context) {
           // Generate random state string and store it, so we can verify it in the callback
           let state = _guid();

--- a/templates/csharp/workflow/teamsapp.local.yml.tpl
+++ b/templates/csharp/workflow/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   # Generate runtime appsettings to JSON file

--- a/templates/csharp/workflow/teamsapp.yml.tpl
+++ b/templates/csharp/workflow/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   - uses: arm/deploy  # Deploy given ARM templates parallelly.


### PR DESCRIPTION
Task: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/25531550
Feature: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/25518522

Description: Rename Azure Active Directory, Azure AD, AAD to Microsoft Entra in all our toolkit UI in VSC/VS/CLI, app templates and documents. We also need to close this work item [User Story 1869234](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1869234): [VS (x64 & arm64) M365 Developer Experience] Rebrand Azure Active Directory, Azure AD, AAD to Microsoft Entra as part of the overall DevDiv efforts.