### PR TITLE
docs(vsc-templates): rebrand aad to Microsoft Entra

### DIFF
--- a/templates/constraints/yml/actions/aadAppCreate.mustache
+++ b/templates/constraints/yml/actions/aadAppCreate.mustache
@@ -1,4 +1,4 @@
-  # Creates a new Azure Active Directory (AAD) app to authenticate users if
+  # Creates a new Microsoft Entra app to authenticate users if
   # the environment variable that stores clientId is empty
   - uses: aadApp/create
     with:
@@ -10,7 +10,7 @@
       # If the value is false, the action will not generate client secret for you
       generateClientSecret: true
       # Authenticate users with a Microsoft work or school account in your
-      # organization's Azure AD tenant (for example, single tenant).
+      # organization's Microsoft Entra tenant (for example, single tenant).
       signInAudience: AzureADMyOrg
     # Write the information of created resources into environment file for the
     # specified environment variable(s).

--- a/templates/constraints/yml/actions/botAadAppCreate.mustache
+++ b/templates/constraints/yml/actions/botAadAppCreate.mustache
@@ -1,10 +1,10 @@
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD

--- a/templates/js/ai-bot/teamsapp.local.yml.tpl
+++ b/templates/js/ai-bot/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   # Create or update the bot registration on dev.botframework.com

--- a/templates/js/ai-bot/teamsapp.yml.tpl
+++ b/templates/js/ai-bot/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   - uses: arm/deploy # Deploy given ARM templates parallelly.

--- a/templates/js/command-and-response/teamsapp.local.yml.tpl
+++ b/templates/js/command-and-response/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   # Create or update the bot registration on dev.botframework.com

--- a/templates/js/command-and-response/teamsapp.yml.tpl
+++ b/templates/js/command-and-response/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   - uses: arm/deploy  # Deploy given ARM templates parallelly.

--- a/templates/js/default-bot-message-extension/teamsapp.local.yml.tpl
+++ b/templates/js/default-bot-message-extension/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   # Create or update the bot registration on dev.botframework.com

--- a/templates/js/default-bot-message-extension/teamsapp.yml.tpl
+++ b/templates/js/default-bot-message-extension/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   - uses: arm/deploy  # Deploy given ARM templates parallelly.

--- a/templates/js/default-bot/README.md
+++ b/templates/js/default-bot/README.md
@@ -59,7 +59,7 @@ Following documentation will help you to extend the Basic Bot template.
 - [Create multi-capability app](https://learn.microsoft.com/microsoftteams/platform/toolkit/add-capability)
 - [Add single sign on to your app](https://learn.microsoft.com/microsoftteams/platform/toolkit/add-single-sign-on)
 - [Access data in Microsoft Graph](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-sdk#microsoft-graph-scenarios)
-- [Use an existing Azure Active Directory application](https://learn.microsoft.com/microsoftteams/platform/toolkit/use-existing-aad-app)
+- [Use an existing Microsoft Entra application](https://learn.microsoft.com/microsoftteams/platform/toolkit/use-existing-aad-app)
 - [Customize the Teams app manifest](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-preview-and-customize-app-manifest)
 - Host your app in Azure by [provision cloud resources](https://learn.microsoft.com/microsoftteams/platform/toolkit/provision) and [deploy the code to cloud](https://learn.microsoft.com/microsoftteams/platform/toolkit/deploy)
 - [Collaborate on app development](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-collaboration)

--- a/templates/js/default-bot/teamsapp.local.yml.tpl
+++ b/templates/js/default-bot/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   # Create or update the bot registration on dev.botframework.com

--- a/templates/js/default-bot/teamsapp.yml.tpl
+++ b/templates/js/default-bot/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   - uses: arm/deploy  # Deploy given ARM templates parallelly.

--- a/templates/js/link-unfurling/teamsapp.local.yml.tpl
+++ b/templates/js/link-unfurling/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   # Create or update the bot registration on dev.botframework.com

--- a/templates/js/link-unfurling/teamsapp.yml.tpl
+++ b/templates/js/link-unfurling/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   - uses: arm/deploy  # Deploy given ARM templates parallelly.

--- a/templates/js/m365-message-extension/README.md
+++ b/templates/js/m365-message-extension/README.md
@@ -58,7 +58,7 @@ Following documentation will help you to extend the template.
 - [Create multi-capability app](https://learn.microsoft.com/microsoftteams/platform/toolkit/add-capability)
 - [Add single sign on to your app](https://learn.microsoft.com/microsoftteams/platform/toolkit/add-single-sign-on)
 - [Access data in Microsoft Graph](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-sdk#microsoft-graph-scenarios)
-- [Use an existing Azure Active Directory application](https://learn.microsoft.com/microsoftteams/platform/toolkit/use-existing-aad-app)
+- [Use an existing Microsoft Entra application](https://learn.microsoft.com/microsoftteams/platform/toolkit/use-existing-aad-app)
 - [Customize the Teams app manifest](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-preview-and-customize-app-manifest)
 - Host your app in Azure by [provision cloud resources](https://learn.microsoft.com/microsoftteams/platform/toolkit/provision) and [deploy the code to cloud](https://learn.microsoft.com/microsoftteams/platform/toolkit/deploy)
 - [Collaborate on app development](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-collaboration)

--- a/templates/js/m365-message-extension/teamsapp.local.yml.tpl
+++ b/templates/js/m365-message-extension/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   # Create or update the bot registration on dev.botframework.com

--- a/templates/js/m365-message-extension/teamsapp.yml.tpl
+++ b/templates/js/m365-message-extension/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   - uses: arm/deploy  # Deploy given ARM templates parallelly.

--- a/templates/js/m365-tab/README.md
+++ b/templates/js/m365-tab/README.md
@@ -39,7 +39,7 @@ The following are Teams Toolkit specific project files. You can [visit a complet
 | - | - |
 |`teamsapp.yml`|This is the main Teams Toolkit project file. The project file defines two primary things:  Properties and configuration Stage definitions.|
 |`teamsapp.local.yml`|This overrides `teamsapp.yml` with actions that enable local execution and debugging.|
-|`aad.manifest.json`|This file defines the configuration of Azure Active Directory app. This template will only provision [single tenant](https://learn.microsoft.com/azure/active-directory/develop/single-and-multi-tenant-apps#who-can-sign-in-to-your-app) Azure Active Directory app.|
+|`aad.manifest.json`|This file defines the configuration of Microsoft Entra app. This template will only provision [single tenant](https://learn.microsoft.com/azure/active-directory/develop/single-and-multi-tenant-apps#who-can-sign-in-to-your-app) Microsoft Entra app.|
 
 ## Extend the React with Fluent UI template
 
@@ -47,7 +47,7 @@ Following documentation will help you to extend the React with Fluent UI templat
 
 - [Add or manage the environment](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-multi-env)
 - [Create multi-capability app](https://learn.microsoft.com/microsoftteams/platform/toolkit/add-capability)
-- [Use an existing Azure Active Directory application](https://learn.microsoft.com/microsoftteams/platform/toolkit/use-existing-aad-app)
+- [Use an existing Microsoft Entra application](https://learn.microsoft.com/microsoftteams/platform/toolkit/use-existing-aad-app)
 - [Customize the Teams app manifest](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-preview-and-customize-app-manifest)
 - Host your app in Azure by [provision cloud resources](https://learn.microsoft.com/microsoftteams/platform/toolkit/provision) and [deploy the code to cloud](https://learn.microsoft.com/microsoftteams/platform/toolkit/deploy)
 - [Collaborate on app development](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-collaboration)

--- a/templates/js/m365-tab/teamsapp.local.yml.tpl
+++ b/templates/js/m365-tab/teamsapp.local.yml.tpl
@@ -4,19 +4,19 @@
 version: 1.0.0
 
 provision:
-  # Creates a new Azure Active Directory (AAD) app to authenticate users if
+  # Creates a new Microsoft Entra app to authenticate users if
   # the environment variable that stores clientId is empty
   - uses: aadApp/create
     with:
-      # Note: when you run aadApp/update, the AAD app name will be updated
+      # Note: when you run aadApp/update, the Microsoft Entra app name will be updated
       # based on the definition in manifest. If you don't want to change the
-      # name, make sure the name in AAD manifest is the same with the name
+      # name, make sure the name in Microsoft Entra manifest is the same with the name
       # defined here.
       name: {{appName}}
       # If the value is false, the action will not generate client secret for you
       generateClientSecret: true
       # Authenticate users with a Microsoft work or school account in your
-      # organization's Azure AD tenant (for example, single tenant).
+      # organization's Microsoft Entra tenant (for example, single tenant).
       signInAudience: AzureADMyOrg
     # Write the information of created resources into environment file for the
     # specified environment variable(s).
@@ -47,12 +47,12 @@ provision:
         echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000";
         echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000";
 
-  # Apply the AAD manifest to an existing AAD app. Will use the object id in
-  # manifest file to determine which AAD app to update.
+  # Apply the Microsoft Entra manifest to an existing Microsoft Entra app. Will use the object id in
+  # manifest file to determine which Microsoft Entra app to update.
   - uses: aadApp/update
     with:
       # Relative path to this file. Environment variables in manifest will
-      # be replaced before apply to AAD app
+      # be replaced before apply to Microsoft Entra app
       manifestPath: ./aad.manifest.json
       outputFilePath: ./build/aad.manifest.${{TEAMSFX_ENV}}.json
 

--- a/templates/js/m365-tab/teamsapp.yml.tpl
+++ b/templates/js/m365-tab/teamsapp.yml.tpl
@@ -7,19 +7,19 @@ environmentFolderPath: ./env
 
 # Triggered when 'teamsfx provision' is executed
 provision:
-  # Creates a new Azure Active Directory (AAD) app to authenticate users if
+  # Creates a new Microsoft Entra app to authenticate users if
   # the environment variable that stores clientId is empty
   - uses: aadApp/create
     with:
-      # Note: when you run aadApp/update, the AAD app name will be updated
+      # Note: when you run aadApp/update, the Microsoft Entra app name will be updated
       # based on the definition in manifest. If you don't want to change the
-      # name, make sure the name in AAD manifest is the same with the name
+      # name, make sure the name in Microsoft Entra manifest is the same with the name
       # defined here.
       name: {{appName}}
       # If the value is false, the action will not generate client secret for you
       generateClientSecret: true
       # Authenticate users with a Microsoft work or school account in your
-      # organization's Azure AD tenant (for example, single tenant).
+      # organization's Microsoft Entra tenant (for example, single tenant).
       signInAudience: AzureADMyOrg
     # Write the information of created resources into environment file for the
     # specified environment variable(s).
@@ -74,12 +74,12 @@ provision:
       indexPage: index.html
       errorPage: error.html
 
-  # Apply the AAD manifest to an existing AAD app. Will use the object id in
-  # manifest file to determine which AAD app to update.
+  # Apply the Microsoft Entra manifest to an existing Microsoft Entra app. Will use the object id in
+  # manifest file to determine which Microsoft Entra app to update.
   - uses: aadApp/update
     with:
       # Relative path to this file. Environment variables in manifest will
-      # be replaced before apply to AAD app
+      # be replaced before apply to Microsoft Entra app
       manifestPath: ./aad.manifest.json
       outputFilePath : ./build/aad.manifest.${{TEAMSFX_ENV}}.json
 

--- a/templates/js/message-extension-action/README.md
+++ b/templates/js/message-extension-action/README.md
@@ -56,7 +56,7 @@ Following documentation will help you to extend the template.
 - [Create multi-capability app](https://learn.microsoft.com/microsoftteams/platform/toolkit/add-capability)
 - [Add single sign on to your app](https://learn.microsoft.com/microsoftteams/platform/toolkit/add-single-sign-on)
 - [Access data in Microsoft Graph](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-sdk#microsoft-graph-scenarios)
-- [Use an existing Azure Active Directory application](https://learn.microsoft.com/microsoftteams/platform/toolkit/use-existing-aad-app)
+- [Use an existing Microsoft Entra application](https://learn.microsoft.com/microsoftteams/platform/toolkit/use-existing-aad-app)
 - [Customize the Teams app manifest](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-preview-and-customize-app-manifest)
 - Host your app in Azure by [provision cloud resources](https://learn.microsoft.com/microsoftteams/platform/toolkit/provision) and [deploy the code to cloud](https://learn.microsoft.com/microsoftteams/platform/toolkit/deploy)
 - [Collaborate on app development](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-collaboration)

--- a/templates/js/message-extension-action/teamsapp.local.yml.tpl
+++ b/templates/js/message-extension-action/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile: 
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD  
 
   # Create or update the bot registration on dev.botframework.com

--- a/templates/js/message-extension-action/teamsapp.yml.tpl
+++ b/templates/js/message-extension-action/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile: 
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD  
 
   - uses: arm/deploy  # Deploy given ARM templates parallelly.

--- a/templates/js/message-extension-copilot/README.md
+++ b/templates/js/message-extension-copilot/README.md
@@ -64,7 +64,7 @@ Following documentation will help you to extend the template.
 - [Create multi-capability app](https://learn.microsoft.com/microsoftteams/platform/toolkit/add-capability)
 - [Add single sign on to your app](https://learn.microsoft.com/microsoftteams/platform/toolkit/add-single-sign-on)
 - [Access data in Microsoft Graph](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-sdk#microsoft-graph-scenarios)
-- [Use an existing Azure Active Directory application](https://learn.microsoft.com/microsoftteams/platform/toolkit/use-existing-aad-app)
+- [Use an existing Microsoft Entra application](https://learn.microsoft.com/microsoftteams/platform/toolkit/use-existing-aad-app)
 - [Customize the Teams app manifest](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-preview-and-customize-app-manifest)
 - Host your app in Azure by [provision cloud resources](https://learn.microsoft.com/microsoftteams/platform/toolkit/provision) and [deploy the code to cloud](https://learn.microsoft.com/microsoftteams/platform/toolkit/deploy)
 - [Collaborate on app development](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-collaboration)

--- a/templates/js/message-extension-copilot/teamsapp.local.yml.tpl
+++ b/templates/js/message-extension-copilot/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   # Create or update the bot registration on dev.botframework.com

--- a/templates/js/message-extension-copilot/teamsapp.yml.tpl
+++ b/templates/js/message-extension-copilot/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   - uses: arm/deploy  # Deploy given ARM templates parallelly.

--- a/templates/js/message-extension/README.md
+++ b/templates/js/message-extension/README.md
@@ -55,7 +55,7 @@ Following documentation will help you to extend the template.
 - [Create multi-capability app](https://learn.microsoft.com/microsoftteams/platform/toolkit/add-capability)
 - [Add single sign on to your app](https://learn.microsoft.com/microsoftteams/platform/toolkit/add-single-sign-on)
 - [Access data in Microsoft Graph](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-sdk#microsoft-graph-scenarios)
-- [Use an existing Azure Active Directory application](https://learn.microsoft.com/microsoftteams/platform/toolkit/use-existing-aad-app)
+- [Use an existing Microsoft Entra application](https://learn.microsoft.com/microsoftteams/platform/toolkit/use-existing-aad-app)
 - [Customize the Teams app manifest](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-preview-and-customize-app-manifest)
 - Host your app in Azure by [provision cloud resources](https://learn.microsoft.com/microsoftteams/platform/toolkit/provision) and [deploy the code to cloud](https://learn.microsoft.com/microsoftteams/platform/toolkit/deploy)
 - [Collaborate on app development](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-collaboration)

--- a/templates/js/message-extension/teamsapp.local.yml.tpl
+++ b/templates/js/message-extension/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   # Create or update the bot registration on dev.botframework.com

--- a/templates/js/message-extension/teamsapp.yml.tpl
+++ b/templates/js/message-extension/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   - uses: arm/deploy  # Deploy given ARM templates parallelly.

--- a/templates/js/non-sso-tab-default-bot/tab/README.md
+++ b/templates/js/non-sso-tab-default-bot/tab/README.md
@@ -67,6 +67,6 @@ Once deployed, you may want to distribute your application to your organization'
 
 ## Add Single Sign On feature
 
-Microsoft Teams provides a mechanism by which an application can obtain the signed-in Teams user token to access Microsoft Graph (and other APIs). Teams Toolkit facilitates this interaction by abstracting some of the Azure Active Directory (AAD) flows and integrations behind some simple, high-level APIs. This enables you to add single sign-on (SSO) features easily to your Teams application.
+Microsoft Teams provides a mechanism by which an application can obtain the signed-in Teams user token to access Microsoft Graph (and other APIs). Teams Toolkit facilitates this interaction by abstracting some of the Microsoft Entra flows and integrations behind some simple, high-level APIs. This enables you to add single sign-on (SSO) features easily to your Teams application.
 
 Please follow this [document](https://aka.ms/teamsfx-add-sso-new) to add single sign on for your project.

--- a/templates/js/non-sso-tab-default-bot/teamsapp.local.yml.tpl
+++ b/templates/js/non-sso-tab-default-bot/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   # Create or update the bot registration on dev.botframework.com

--- a/templates/js/non-sso-tab-default-bot/teamsapp.yml.tpl
+++ b/templates/js/non-sso-tab-default-bot/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   - uses: arm/deploy  # Deploy given ARM templates parallelly.

--- a/templates/js/non-sso-tab/README.md
+++ b/templates/js/non-sso-tab/README.md
@@ -57,7 +57,7 @@ Following documentation will help you to extend the Basic Tab template.
 - [Create multi-capability app](https://learn.microsoft.com/microsoftteams/platform/toolkit/add-capability)
 - [Add single sign on to your app](https://learn.microsoft.com/microsoftteams/platform/toolkit/add-single-sign-on)
 - [Access data in Microsoft Graph](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-sdk#microsoft-graph-scenarios)
-- [Use an existing Azure Active Directory application](https://learn.microsoft.com/microsoftteams/platform/toolkit/use-existing-aad-app)
+- [Use an existing Microsoft Entra application](https://learn.microsoft.com/microsoftteams/platform/toolkit/use-existing-aad-app)
 - [Customize the Teams app manifest](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-preview-and-customize-app-manifest)
 - Host your app in Azure by [provision cloud resources](https://learn.microsoft.com/microsoftteams/platform/toolkit/provision) and [deploy the code to cloud](https://learn.microsoft.com/microsoftteams/platform/toolkit/deploy)
 - [Collaborate on app development](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-collaboration)

--- a/templates/js/notification-http-timer-trigger/teamsapp.local.yml.tpl
+++ b/templates/js/notification-http-timer-trigger/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   # Create or update the bot registration on dev.botframework.com

--- a/templates/js/notification-http-timer-trigger/teamsapp.yml.tpl
+++ b/templates/js/notification-http-timer-trigger/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   - uses: arm/deploy  # Deploy given ARM templates parallelly.

--- a/templates/js/notification-http-trigger/teamsapp.local.yml.tpl
+++ b/templates/js/notification-http-trigger/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   # Create or update the bot registration on dev.botframework.com

--- a/templates/js/notification-http-trigger/teamsapp.yml.tpl
+++ b/templates/js/notification-http-trigger/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   - uses: arm/deploy  # Deploy given ARM templates parallelly.

--- a/templates/js/notification-restify/teamsapp.local.yml.tpl
+++ b/templates/js/notification-restify/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   # Create or update the bot registration on dev.botframework.com

--- a/templates/js/notification-restify/teamsapp.yml.tpl
+++ b/templates/js/notification-restify/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   - uses: arm/deploy  # Deploy given ARM templates parallelly.

--- a/templates/js/notification-timer-trigger/teamsapp.local.yml.tpl
+++ b/templates/js/notification-timer-trigger/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   # Create or update the bot registration on dev.botframework.com

--- a/templates/js/notification-timer-trigger/teamsapp.yml.tpl
+++ b/templates/js/notification-timer-trigger/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   - uses: arm/deploy  # Deploy given ARM templates parallelly.

--- a/templates/js/sso-tab-with-obo-flow/README.md
+++ b/templates/js/sso-tab-with-obo-flow/README.md
@@ -41,7 +41,7 @@ The following are Teams Toolkit specific project files. You can [visit a complet
 | - | - |
 |`teamsapp.yml`|This is the main Teams Toolkit project file. The project file defines two primary things:  Properties and configuration Stage definitions.|
 |`teamsapp.local.yml`|This overrides `teamsapp.yml` with actions that enable local execution and debugging.|
-|`aad.manifest.json`|This file defines the configuration of Azure Active Directory app. This template will only provision [single tenant](https://learn.microsoft.com/azure/active-directory/develop/single-and-multi-tenant-apps#who-can-sign-in-to-your-app) Azure Active Directory app.|
+|`aad.manifest.json`|This file defines the configuration of Microsoft Entra app. This template will only provision [single tenant](https://learn.microsoft.com/azure/active-directory/develop/single-and-multi-tenant-apps#who-can-sign-in-to-your-app) Microsoft Entra app.|
 
 ## Extend the React with Fluent UI template
 
@@ -49,7 +49,7 @@ Following documentation will help you to extend the React with Fluent UI templat
 
 - [Add or manage the environment](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-multi-env)
 - [Create multi-capability app](https://learn.microsoft.com/microsoftteams/platform/toolkit/add-capability)
-- [Use an existing Azure Active Directory application](https://learn.microsoft.com/microsoftteams/platform/toolkit/use-existing-aad-app)
+- [Use an existing Microsoft Entra application](https://learn.microsoft.com/microsoftteams/platform/toolkit/use-existing-aad-app)
 - [Customize the Teams app manifest](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-preview-and-customize-app-manifest)
 - Host your app in Azure by [provision cloud resources](https://learn.microsoft.com/microsoftteams/platform/toolkit/provision) and [deploy the code to cloud](https://learn.microsoft.com/microsoftteams/platform/toolkit/deploy)
 - [Collaborate on app development](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-collaboration)

--- a/templates/js/sso-tab-with-obo-flow/teamsapp.local.yml.tpl
+++ b/templates/js/sso-tab-with-obo-flow/teamsapp.local.yml.tpl
@@ -4,19 +4,19 @@
 version: 1.0.0
 
 provision:
-  # Creates a new Azure Active Directory (AAD) app to authenticate users if
+  # Creates a new Microsoft Entra app to authenticate users if
   # the environment variable that stores clientId is empty
   - uses: aadApp/create
     with:
-      # Note: when you run aadApp/update, the AAD app name will be updated
+      # Note: when you run aadApp/update, the Microsoft Entra app name will be updated
       # based on the definition in manifest. If you don't want to change the
-      # name, make sure the name in AAD manifest is the same with the name
+      # name, make sure the name in Microsoft Entra manifest is the same with the name
       # defined here.
       name: {{appName}}
       # If the value is false, the action will not generate client secret for you
       generateClientSecret: true
       # Authenticate users with a Microsoft work or school account in your
-      # organization's Azure AD tenant (for example, single tenant).
+      # organization's Microsoft Entra tenant (for example, single tenant).
       signInAudience: AzureADMyOrg
     # Write the information of created resources into environment file for the
     # specified environment variable(s).
@@ -49,12 +49,12 @@ provision:
         echo "::set-teamsfx-env FUNC_NAME=getUserProfile";
         echo "::set-teamsfx-env FUNC_ENDPOINT=http://localhost:7071";
 
-  # Apply the AAD manifest to an existing AAD app. Will use the object id in
-  # manifest file to determine which AAD app to update.
+  # Apply the Microsoft Entra manifest to an existing Microsoft Entra app. Will use the object id in
+  # manifest file to determine which Microsoft Entra app to update.
   - uses: aadApp/update
     with:
       # Relative path to this file. Environment variables in manifest will
-      # be replaced before apply to AAD app
+      # be replaced before apply to Microsoft Entra app
       manifestPath: ./aad.manifest.json
       outputFilePath: ./build/aad.manifest.${{TEAMSFX_ENV}}.json
 

--- a/templates/js/sso-tab-with-obo-flow/teamsapp.yml.tpl
+++ b/templates/js/sso-tab-with-obo-flow/teamsapp.yml.tpl
@@ -7,19 +7,19 @@ environmentFolderPath: ./env
 
 # Triggered when 'teamsfx provision' is executed
 provision:
-  # Creates a new Azure Active Directory (AAD) app to authenticate users if
+  # Creates a new Microsoft Entra app to authenticate users if
   # the environment variable that stores clientId is empty
   - uses: aadApp/create
     with:
-      # Note: when you run aadApp/update, the AAD app name will be updated
+      # Note: when you run aadApp/update, the Microsoft Entra app name will be updated
       # based on the definition in manifest. If you don't want to change the
-      # name, make sure the name in AAD manifest is the same with the name
+      # name, make sure the name in Microsoft Entra manifest is the same with the name
       # defined here.
       name: {{appName}}
       # If the value is false, the action will not generate client secret for you
       generateClientSecret: true
       # Authenticate users with a Microsoft work or school account in your
-      # organization's Azure AD tenant (for example, single tenant).
+      # organization's Microsoft Entra tenant (for example, single tenant).
       signInAudience: AzureADMyOrg
     # Write the information of created resources into environment file for the
     # specified environment variable(s).
@@ -74,12 +74,12 @@ provision:
       indexPage: index.html
       errorPage: error.html
 
-  # Apply the AAD manifest to an existing AAD app. Will use the object id in
-  # manifest file to determine which AAD app to update.
+  # Apply the Microsoft Entra manifest to an existing Microsoft Entra app. Will use the object id in
+  # manifest file to determine which Microsoft Entra app to update.
   - uses: aadApp/update
     with:
       # Relative path to this file. Environment variables in manifest will
-      # be replaced before apply to AAD app
+      # be replaced before apply to Microsoft Entra app
       manifestPath: ./aad.manifest.json
       outputFilePath: ./build/aad.manifest.${{TEAMSFX_ENV}}.json
 
@@ -137,7 +137,7 @@ deploy:
   # Deploy bits to Azure Storage Static Website
   - uses: azureStorage/deploy
     with:
-      # Deploy base folder. This folder includes manifest files for AAD app and Teams app that should be ignored using the ignoreFile.
+      # Deploy base folder. This folder includes manifest files for Microsoft Entra app and Teams app that should be ignored using the ignoreFile.
       artifactFolder: build
       ignoreFile: .storageignore
       # The resource id of the cloud resource to be deployed to.

--- a/templates/js/workflow/teamsapp.local.yml.tpl
+++ b/templates/js/workflow/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   # Create or update the bot registration on dev.botframework.com

--- a/templates/js/workflow/teamsapp.yml.tpl
+++ b/templates/js/workflow/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   - uses: arm/deploy  # Deploy given ARM templates parallelly.

--- a/templates/ts/ai-bot/teamsapp.local.yml.tpl
+++ b/templates/ts/ai-bot/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   # Create or update the bot registration on dev.botframework.com

--- a/templates/ts/ai-bot/teamsapp.yml.tpl
+++ b/templates/ts/ai-bot/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   - uses: arm/deploy # Deploy given ARM templates parallelly.

--- a/templates/ts/command-and-response/teamsapp.local.yml.tpl
+++ b/templates/ts/command-and-response/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   # Create or update the bot registration on dev.botframework.com

--- a/templates/ts/command-and-response/teamsapp.yml.tpl
+++ b/templates/ts/command-and-response/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   - uses: arm/deploy  # Deploy given ARM templates parallelly.

--- a/templates/ts/default-bot-message-extension/teamsapp.local.yml.tpl
+++ b/templates/ts/default-bot-message-extension/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   # Create or update the bot registration on dev.botframework.com

--- a/templates/ts/default-bot-message-extension/teamsapp.yml.tpl
+++ b/templates/ts/default-bot-message-extension/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   - uses: arm/deploy  # Deploy given ARM templates parallelly.

--- a/templates/ts/default-bot/README.md
+++ b/templates/ts/default-bot/README.md
@@ -59,7 +59,7 @@ Following documentation will help you to extend the Basic Bot template.
 - [Create multi-capability app](https://learn.microsoft.com/microsoftteams/platform/toolkit/add-capability)
 - [Add single sign on to your app](https://learn.microsoft.com/microsoftteams/platform/toolkit/add-single-sign-on)
 - [Access data in Microsoft Graph](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-sdk#microsoft-graph-scenarios)
-- [Use an existing Azure Active Directory application](https://learn.microsoft.com/microsoftteams/platform/toolkit/use-existing-aad-app)
+- [Use an existing Microsoft Entra application](https://learn.microsoft.com/microsoftteams/platform/toolkit/use-existing-aad-app)
 - [Customize the Teams app manifest](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-preview-and-customize-app-manifest)
 - Host your app in Azure by [provision cloud resources](https://learn.microsoft.com/microsoftteams/platform/toolkit/provision) and [deploy the code to cloud](https://learn.microsoft.com/microsoftteams/platform/toolkit/deploy)
 - [Collaborate on app development](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-collaboration)

--- a/templates/ts/default-bot/teamsapp.local.yml.tpl
+++ b/templates/ts/default-bot/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   # Create or update the bot registration on dev.botframework.com

--- a/templates/ts/default-bot/teamsapp.yml.tpl
+++ b/templates/ts/default-bot/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   - uses: arm/deploy  # Deploy given ARM templates parallelly.

--- a/templates/ts/link-unfurling/teamsapp.local.yml.tpl
+++ b/templates/ts/link-unfurling/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   # Create or update the bot registration on dev.botframework.com

--- a/templates/ts/link-unfurling/teamsapp.yml.tpl
+++ b/templates/ts/link-unfurling/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   - uses: arm/deploy  # Deploy given ARM templates parallelly.

--- a/templates/ts/m365-message-extension/README.md
+++ b/templates/ts/m365-message-extension/README.md
@@ -58,7 +58,7 @@ Following documentation will help you to extend the template.
 - [Create multi-capability app](https://learn.microsoft.com/microsoftteams/platform/toolkit/add-capability)
 - [Add single sign on to your app](https://learn.microsoft.com/microsoftteams/platform/toolkit/add-single-sign-on)
 - [Access data in Microsoft Graph](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-sdk#microsoft-graph-scenarios)
-- [Use an existing Azure Active Directory application](https://learn.microsoft.com/microsoftteams/platform/toolkit/use-existing-aad-app)
+- [Use an existing Microsoft Entra application](https://learn.microsoft.com/microsoftteams/platform/toolkit/use-existing-aad-app)
 - [Customize the Teams app manifest](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-preview-and-customize-app-manifest)
 - Host your app in Azure by [provision cloud resources](https://learn.microsoft.com/microsoftteams/platform/toolkit/provision) and [deploy the code to cloud](https://learn.microsoft.com/microsoftteams/platform/toolkit/deploy)
 - [Collaborate on app development](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-collaboration)

--- a/templates/ts/m365-message-extension/teamsapp.local.yml.tpl
+++ b/templates/ts/m365-message-extension/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   # Create or update the bot registration on dev.botframework.com

--- a/templates/ts/m365-message-extension/teamsapp.yml.tpl
+++ b/templates/ts/m365-message-extension/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   - uses: arm/deploy  # Deploy given ARM templates parallelly.

--- a/templates/ts/m365-tab/README.md
+++ b/templates/ts/m365-tab/README.md
@@ -39,7 +39,7 @@ The following are Teams Toolkit specific project files. You can [visit a complet
 | - | - |
 |`teamsapp.yml`|This is the main Teams Toolkit project file. The project file defines two primary things:  Properties and configuration Stage definitions.|
 |`teamsapp.local.yml`|This overrides `teamsapp.yml` with actions that enable local execution and debugging.|
-|`aad.manifest.json`|This file defines the configuration of Azure Active Directory app. This template will only provision [single tenant](https://learn.microsoft.com/azure/active-directory/develop/single-and-multi-tenant-apps#who-can-sign-in-to-your-app) Azure Active Directory app.|
+|`aad.manifest.json`|This file defines the configuration of Microsoft Entra app. This template will only provision [single tenant](https://learn.microsoft.com/azure/active-directory/develop/single-and-multi-tenant-apps#who-can-sign-in-to-your-app) Microsoft Entra app.|
 
 ## Extend the React with Fluent UI template
 
@@ -47,7 +47,7 @@ Following documentation will help you to extend the React with Fluent UI templat
 
 - [Add or manage the environment](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-multi-env)
 - [Create multi-capability app](https://learn.microsoft.com/microsoftteams/platform/toolkit/add-capability)
-- [Use an existing Azure Active Directory application](https://learn.microsoft.com/microsoftteams/platform/toolkit/use-existing-aad-app)
+- [Use an existing Microsoft Entra application](https://learn.microsoft.com/microsoftteams/platform/toolkit/use-existing-aad-app)
 - [Customize the Teams app manifest](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-preview-and-customize-app-manifest)
 - Host your app in Azure by [provision cloud resources](https://learn.microsoft.com/microsoftteams/platform/toolkit/provision) and [deploy the code to cloud](https://learn.microsoft.com/microsoftteams/platform/toolkit/deploy)
 - [Collaborate on app development](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-collaboration)

--- a/templates/ts/m365-tab/teamsapp.local.yml.tpl
+++ b/templates/ts/m365-tab/teamsapp.local.yml.tpl
@@ -4,19 +4,19 @@
 version: 1.0.0
 
 provision:
-  # Creates a new Azure Active Directory (AAD) app to authenticate users if
+  # Creates a new Microsoft Entra app to authenticate users if
   # the environment variable that stores clientId is empty
   - uses: aadApp/create
     with:
-      # Note: when you run aadApp/update, the AAD app name will be updated
+      # Note: when you run aadApp/update, the Microsoft Entra app name will be updated
       # based on the definition in manifest. If you don't want to change the
-      # name, make sure the name in AAD manifest is the same with the name
+      # name, make sure the name in Microsoft Entra manifest is the same with the name
       # defined here.
       name: {{appName}}
       # If the value is false, the driver will not generate client secret for you
       generateClientSecret: true
       # Authenticate users with a Microsoft work or school account in your
-      # organization's Azure AD tenant (for example, single tenant).
+      # organization's Microsoft Entra tenant (for example, single tenant).
       signInAudience: AzureADMyOrg
     # Write the information of created resources into environment file for the
     # specified environment variable(s).
@@ -47,12 +47,12 @@ provision:
         echo "::set-teamsfx-env TAB_DOMAIN=localhost:53000";
         echo "::set-teamsfx-env TAB_ENDPOINT=https://localhost:53000";
 
-  # Apply the AAD manifest to an existing AAD app. Will use the object id in
-  # manifest file to determine which AAD app to update.
+  # Apply the Microsoft Entra manifest to an existing Microsoft Entra app. Will use the object id in
+  # manifest file to determine which Microsoft Entra app to update.
   - uses: aadApp/update
     with:
       # Relative path to this file. Environment variables in manifest will
-      # be replaced before apply to AAD app
+      # be replaced before apply to Microsoft Entra app
       manifestPath: ./aad.manifest.json
       outputFilePath: ./build/aad.manifest.${{TEAMSFX_ENV}}.json
 

--- a/templates/ts/m365-tab/teamsapp.yml.tpl
+++ b/templates/ts/m365-tab/teamsapp.yml.tpl
@@ -7,19 +7,19 @@ environmentFolderPath: ./env
 
 # Triggered when 'teamsfx provision' is executed
 provision:
-  # Creates a new Azure Active Directory (AAD) app to authenticate users if
+  # Creates a new Microsoft Entra app to authenticate users if
   # the environment variable that stores clientId is empty
   - uses: aadApp/create
     with:
-      # Note: when you run aadApp/update, the AAD app name will be updated
+      # Note: when you run aadApp/update, the Microsoft Entra app name will be updated
       # based on the definition in manifest. If you don't want to change the
-      # name, make sure the name in AAD manifest is the same with the name
+      # name, make sure the name in Microsoft Entra manifest is the same with the name
       # defined here.
       name: {{appName}}
       # If the value is false, the action will not generate client secret for you
       generateClientSecret: true
       # Authenticate users with a Microsoft work or school account in your
-      # organization's Azure AD tenant (for example, single tenant).
+      # organization's Microsoft Entra tenant (for example, single tenant).
       signInAudience: AzureADMyOrg
     # Write the information of created resources into environment file for the
     # specified environment variable(s).
@@ -74,12 +74,12 @@ provision:
       indexPage: index.html
       errorPage: error.html
 
-  # Apply the AAD manifest to an existing AAD app. Will use the object id in
-  # manifest file to determine which AAD app to update.
+  # Apply the Microsoft Entra manifest to an existing Microsoft Entra app. Will use the object id in
+  # manifest file to determine which Microsoft Entra app to update.
   - uses: aadApp/update
     with:
       # Relative path to this file. Environment variables in manifest will
-      # be replaced before apply to AAD app
+      # be replaced before apply to Microsoft Entra app
       manifestPath: ./aad.manifest.json
       outputFilePath : ./build/aad.manifest.${{TEAMSFX_ENV}}.json
 

--- a/templates/ts/message-extension-action/README.md
+++ b/templates/ts/message-extension-action/README.md
@@ -56,7 +56,7 @@ Following documentation will help you to extend the template.
 - [Create multi-capability app](https://learn.microsoft.com/microsoftteams/platform/toolkit/add-capability)
 - [Add single sign on to your app](https://learn.microsoft.com/microsoftteams/platform/toolkit/add-single-sign-on)
 - [Access data in Microsoft Graph](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-sdk#microsoft-graph-scenarios)
-- [Use an existing Azure Active Directory application](https://learn.microsoft.com/microsoftteams/platform/toolkit/use-existing-aad-app)
+- [Use an existing Microsoft Entra application](https://learn.microsoft.com/microsoftteams/platform/toolkit/use-existing-aad-app)
 - [Customize the Teams app manifest](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-preview-and-customize-app-manifest)
 - Host your app in Azure by [provision cloud resources](https://learn.microsoft.com/microsoftteams/platform/toolkit/provision) and [deploy the code to cloud](https://learn.microsoft.com/microsoftteams/platform/toolkit/deploy)
 - [Collaborate on app development](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-collaboration)

--- a/templates/ts/message-extension-action/teamsapp.local.yml.tpl
+++ b/templates/ts/message-extension-action/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile: 
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD  
 
   # Create or update the bot registration on dev.botframework.com

--- a/templates/ts/message-extension-action/teamsapp.yml.tpl
+++ b/templates/ts/message-extension-action/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile: 
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD  
 
   - uses: arm/deploy  # Deploy given ARM templates parallelly.

--- a/templates/ts/message-extension-copilot/README.md
+++ b/templates/ts/message-extension-copilot/README.md
@@ -64,7 +64,7 @@ Following documentation will help you to extend the template.
 - [Create multi-capability app](https://learn.microsoft.com/microsoftteams/platform/toolkit/add-capability)
 - [Add single sign on to your app](https://learn.microsoft.com/microsoftteams/platform/toolkit/add-single-sign-on)
 - [Access data in Microsoft Graph](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-sdk#microsoft-graph-scenarios)
-- [Use an existing Azure Active Directory application](https://learn.microsoft.com/microsoftteams/platform/toolkit/use-existing-aad-app)
+- [Use an existing Microsoft Entra application](https://learn.microsoft.com/microsoftteams/platform/toolkit/use-existing-aad-app)
 - [Customize the Teams app manifest](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-preview-and-customize-app-manifest)
 - Host your app in Azure by [provision cloud resources](https://learn.microsoft.com/microsoftteams/platform/toolkit/provision) and [deploy the code to cloud](https://learn.microsoft.com/microsoftteams/platform/toolkit/deploy)
 - [Collaborate on app development](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-collaboration)

--- a/templates/ts/message-extension-copilot/teamsapp.local.yml.tpl
+++ b/templates/ts/message-extension-copilot/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   # Create or update the bot registration on dev.botframework.com

--- a/templates/ts/message-extension-copilot/teamsapp.yml.tpl
+++ b/templates/ts/message-extension-copilot/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   - uses: arm/deploy  # Deploy given ARM templates parallelly.

--- a/templates/ts/message-extension/README.md
+++ b/templates/ts/message-extension/README.md
@@ -55,7 +55,7 @@ Following documentation will help you to extend the template.
 - [Create multi-capability app](https://learn.microsoft.com/microsoftteams/platform/toolkit/add-capability)
 - [Add single sign on to your app](https://learn.microsoft.com/microsoftteams/platform/toolkit/add-single-sign-on)
 - [Access data in Microsoft Graph](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-sdk#microsoft-graph-scenarios)
-- [Use an existing Azure Active Directory application](https://learn.microsoft.com/microsoftteams/platform/toolkit/use-existing-aad-app)
+- [Use an existing Microsoft Entra application](https://learn.microsoft.com/microsoftteams/platform/toolkit/use-existing-aad-app)
 - [Customize the Teams app manifest](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-preview-and-customize-app-manifest)
 - Host your app in Azure by [provision cloud resources](https://learn.microsoft.com/microsoftteams/platform/toolkit/provision) and [deploy the code to cloud](https://learn.microsoft.com/microsoftteams/platform/toolkit/deploy)
 - [Collaborate on app development](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-collaboration)

--- a/templates/ts/message-extension/teamsapp.local.yml.tpl
+++ b/templates/ts/message-extension/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   # Create or update the bot registration on dev.botframework.com

--- a/templates/ts/message-extension/teamsapp.yml.tpl
+++ b/templates/ts/message-extension/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   - uses: arm/deploy  # Deploy given ARM templates parallelly.

--- a/templates/ts/non-sso-tab-default-bot/tab/README.md
+++ b/templates/ts/non-sso-tab-default-bot/tab/README.md
@@ -67,6 +67,6 @@ Once deployed, you may want to distribute your application to your organization'
 
 ## Add Single Sign On feature
 
-Microsoft Teams provides a mechanism by which an application can obtain the signed-in Teams user token to access Microsoft Graph (and other APIs). Teams Toolkit facilitates this interaction by abstracting some of the Azure Active Directory (AAD) flows and integrations behind some simple, high-level APIs. This enables you to add single sign-on (SSO) features easily to your Teams application.
+Microsoft Teams provides a mechanism by which an application can obtain the signed-in Teams user token to access Microsoft Graph (and other APIs). Teams Toolkit facilitates this interaction by abstracting some of the Microsoft Entra flows and integrations behind some simple, high-level APIs. This enables you to add single sign-on (SSO) features easily to your Teams application.
 
 Please follow this [document](https://aka.ms/teamsfx-add-sso-new) to add single sign on for your project.

--- a/templates/ts/non-sso-tab-default-bot/tab/src/components/sample/AddSSO.tsx
+++ b/templates/ts/non-sso-tab-default-bot/tab/src/components/sample/AddSSO.tsx
@@ -18,8 +18,8 @@ export function AddSSO(props: Record<string, unknown>) {
           SSO support
         </a>
         ) and interact with Microsoft Graph for building rich and seamless user experience. With
-        Teams Toolkit, authentication is further simplified by automatic AAD app registration and
-        configuration.
+        Teams Toolkit, authentication is further simplified by automatic Microsoft Entra app
+        registration and configuration.
       </p>
       <p>
         Starting with this simple static tab app, you can follow few steps to add SSO logics to

--- a/templates/ts/non-sso-tab-default-bot/teamsapp.local.yml.tpl
+++ b/templates/ts/non-sso-tab-default-bot/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   # Create or update the bot registration on dev.botframework.com

--- a/templates/ts/non-sso-tab-default-bot/teamsapp.yml.tpl
+++ b/templates/ts/non-sso-tab-default-bot/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   - uses: arm/deploy  # Deploy given ARM templates parallelly.

--- a/templates/ts/non-sso-tab/README.md
+++ b/templates/ts/non-sso-tab/README.md
@@ -57,7 +57,7 @@ Following documentation will help you to extend the Basic Tab template.
 - [Create multi-capability app](https://learn.microsoft.com/microsoftteams/platform/toolkit/add-capability)
 - [Add single sign on to your app](https://learn.microsoft.com/microsoftteams/platform/toolkit/add-single-sign-on)
 - [Access data in Microsoft Graph](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-sdk#microsoft-graph-scenarios)
-- [Use an existing Azure Active Directory application](https://learn.microsoft.com/microsoftteams/platform/toolkit/use-existing-aad-app)
+- [Use an existing Microsoft Entra application](https://learn.microsoft.com/microsoftteams/platform/toolkit/use-existing-aad-app)
 - [Customize the Teams app manifest](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-preview-and-customize-app-manifest)
 - Host your app in Azure by [provision cloud resources](https://learn.microsoft.com/microsoftteams/platform/toolkit/provision) and [deploy the code to cloud](https://learn.microsoft.com/microsoftteams/platform/toolkit/deploy)
 - [Collaborate on app development](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-collaboration)

--- a/templates/ts/notification-http-timer-trigger/teamsapp.local.yml.tpl
+++ b/templates/ts/notification-http-timer-trigger/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   # Create or update the bot registration on dev.botframework.com

--- a/templates/ts/notification-http-timer-trigger/teamsapp.yml.tpl
+++ b/templates/ts/notification-http-timer-trigger/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   - uses: arm/deploy  # Deploy given ARM templates parallelly.

--- a/templates/ts/notification-http-trigger/teamsapp.local.yml.tpl
+++ b/templates/ts/notification-http-trigger/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   # Create or update the bot registration on dev.botframework.com

--- a/templates/ts/notification-http-trigger/teamsapp.yml.tpl
+++ b/templates/ts/notification-http-trigger/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   - uses: arm/deploy  # Deploy given ARM templates parallelly.

--- a/templates/ts/notification-restify/teamsapp.local.yml.tpl
+++ b/templates/ts/notification-restify/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   # Create or update the bot registration on dev.botframework.com

--- a/templates/ts/notification-restify/teamsapp.yml.tpl
+++ b/templates/ts/notification-restify/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   - uses: arm/deploy  # Deploy given ARM templates parallelly.

--- a/templates/ts/notification-timer-trigger/teamsapp.local.yml.tpl
+++ b/templates/ts/notification-timer-trigger/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   # Create or update the bot registration on dev.botframework.com

--- a/templates/ts/notification-timer-trigger/teamsapp.yml.tpl
+++ b/templates/ts/notification-timer-trigger/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   - uses: arm/deploy  # Deploy given ARM templates parallelly.

--- a/templates/ts/sso-tab-with-obo-flow/README.md
+++ b/templates/ts/sso-tab-with-obo-flow/README.md
@@ -41,7 +41,7 @@ The following are Teams Toolkit specific project files. You can [visit a complet
 | - | - |
 |`teamsapp.yml`|This is the main Teams Toolkit project file. The project file defines two primary things:  Properties and configuration Stage definitions.|
 |`teamsapp.local.yml`|This overrides `teamsapp.yml` with actions that enable local execution and debugging.|
-|`aad.manifest.json`|This file defines the configuration of Azure Active Directory app. This template will only provision [single tenant](https://learn.microsoft.com/azure/active-directory/develop/single-and-multi-tenant-apps#who-can-sign-in-to-your-app) Azure Active Directory app.|
+|`aad.manifest.json`|This file defines the configuration of Microsoft Entra app. This template will only provision [single tenant](https://learn.microsoft.com/azure/active-directory/develop/single-and-multi-tenant-apps#who-can-sign-in-to-your-app) Microsoft Entra app.|
 
 ## Extend the React with Fluent UI template
 
@@ -49,7 +49,7 @@ Following documentation will help you to extend the React with Fluent UI templat
 
 - [Add or manage the environment](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-multi-env)
 - [Create multi-capability app](https://learn.microsoft.com/microsoftteams/platform/toolkit/add-capability)
-- [Use an existing Azure Active Directory application](https://learn.microsoft.com/microsoftteams/platform/toolkit/use-existing-aad-app)
+- [Use an existing Microsoft Entra application](https://learn.microsoft.com/microsoftteams/platform/toolkit/use-existing-aad-app)
 - [Customize the Teams app manifest](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-preview-and-customize-app-manifest)
 - Host your app in Azure by [provision cloud resources](https://learn.microsoft.com/microsoftteams/platform/toolkit/provision) and [deploy the code to cloud](https://learn.microsoft.com/microsoftteams/platform/toolkit/deploy)
 - [Collaborate on app development](https://learn.microsoft.com/microsoftteams/platform/toolkit/teamsfx-collaboration)

--- a/templates/ts/sso-tab-with-obo-flow/api/getUserProfile/index.ts
+++ b/templates/ts/sso-tab-with-obo-flow/api/getUserProfile/index.ts
@@ -84,7 +84,7 @@ export default async function run(
       body: {
         error:
           "Failed to construct OnBehalfOfUserCredential using your accessToken. " +
-          "Ensure your function app is configured with the right Azure AD App registration.",
+          "Ensure your function app is configured with the right Microsoft Entra App registration.",
       },
     };
   }
@@ -177,7 +177,7 @@ export default async function run(
         error:
           "App credential error:" +
           "Failed to construct TeamsFx using your accessToken. " +
-          "Ensure your function app is configured with the right Azure AD App registration.",
+          "Ensure your function app is configured with the right Microsoft Entra App registration.",
       },
     };
   }

--- a/templates/ts/sso-tab-with-obo-flow/teamsapp.local.yml.tpl
+++ b/templates/ts/sso-tab-with-obo-flow/teamsapp.local.yml.tpl
@@ -4,19 +4,19 @@
 version: 1.0.0
 
 provision:
-  # Creates a new Azure Active Directory (AAD) app to authenticate users if
+  # Creates a new Microsoft Entra app to authenticate users if
   # the environment variable that stores clientId is empty
   - uses: aadApp/create
     with:
-      # Note: when you run aadApp/update, the AAD app name will be updated
+      # Note: when you run aadApp/update, the Microsoft Entra app name will be updated
       # based on the definition in manifest. If you don't want to change the
-      # name, make sure the name in AAD manifest is the same with the name
+      # name, make sure the name in Microsoft Entra manifest is the same with the name
       # defined here.
       name: {{appName}}
       # If the value is false, the action will not generate client secret for you
       generateClientSecret: true
       # Authenticate users with a Microsoft work or school account in your
-      # organization's Azure AD tenant (for example, single tenant).
+      # organization's Microsoft Entra tenant (for example, single tenant).
       signInAudience: AzureADMyOrg
     # Write the information of created resources into environment file for the
     # specified environment variable(s).
@@ -49,12 +49,12 @@ provision:
         echo "::set-teamsfx-env FUNC_NAME=getUserProfile";
         echo "::set-teamsfx-env FUNC_ENDPOINT=http://localhost:7071";
 
-  # Apply the AAD manifest to an existing AAD app. Will use the object id in
-  # manifest file to determine which AAD app to update.
+  # Apply the Microsoft Entra manifest to an existing Microsoft Entra app. Will use the object id in
+  # manifest file to determine which Microsoft Entra app to update.
   - uses: aadApp/update
     with:
       # Relative path to this file. Environment variables in manifest will
-      # be replaced before apply to AAD app
+      # be replaced before apply to Microsoft Entra app
       manifestPath: ./aad.manifest.json
       outputFilePath: ./build/aad.manifest.${{TEAMSFX_ENV}}.json
 

--- a/templates/ts/sso-tab-with-obo-flow/teamsapp.yml.tpl
+++ b/templates/ts/sso-tab-with-obo-flow/teamsapp.yml.tpl
@@ -7,19 +7,19 @@ environmentFolderPath: ./env
 
 # Triggered when 'teamsfx provision' is executed
 provision:
-  # Creates a new Azure Active Directory (AAD) app to authenticate users if
+  # Creates a new Microsoft Entra app to authenticate users if
   # the environment variable that stores clientId is empty
   - uses: aadApp/create
     with:
-      # Note: when you run aadApp/update, the AAD app name will be updated
+      # Note: when you run aadApp/update, the Microsoft Entra app name will be updated
       # based on the definition in manifest. If you don't want to change the
-      # name, make sure the name in AAD manifest is the same with the name
+      # name, make sure the name in Microsoft Entra manifest is the same with the name
       # defined here.
       name: {{appName}}
       # If the value is false, the action will not generate client secret for you
       generateClientSecret: true
       # Authenticate users with a Microsoft work or school account in your
-      # organization's Azure AD tenant (for example, single tenant).
+      # organization's Microsoft Entra tenant (for example, single tenant).
       signInAudience: AzureADMyOrg
     # Write the information of created resources into environment file for the
     # specified environment variable(s).
@@ -74,12 +74,12 @@ provision:
       indexPage: index.html
       errorPage: error.html
 
-  # Apply the AAD manifest to an existing AAD app. Will use the object id in
-  # manifest file to determine which AAD app to update.
+  # Apply the Microsoft Entra manifest to an existing Microsoft Entra app. Will use the object id in
+  # manifest file to determine which Microsoft Entra app to update.
   - uses: aadApp/update
     with:
       # Relative path to this file. Environment variables in manifest will
-      # be replaced before apply to AAD app
+      # be replaced before apply to Microsoft Entra app
       manifestPath: ./aad.manifest.json
       outputFilePath: ./build/aad.manifest.${{TEAMSFX_ENV}}.json
 
@@ -137,7 +137,7 @@ deploy:
   # Deploy bits to Azure Storage Static Website
   - uses: azureStorage/deploy
     with:
-      # Deploy base folder. This folder includes manifest files for AAD app and Teams app that should be ignored using the ignoreFile.
+      # Deploy base folder. This folder includes manifest files for Microsoft Entra app and Teams app that should be ignored using the ignoreFile.
       artifactFolder: build
       ignoreFile: .storageignore
       # The resource id of the cloud resource to be deployed to.

--- a/templates/ts/workflow/teamsapp.local.yml.tpl
+++ b/templates/ts/workflow/teamsapp.local.yml.tpl
@@ -14,15 +14,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   # Create or update the bot registration on dev.botframework.com

--- a/templates/ts/workflow/teamsapp.yml.tpl
+++ b/templates/ts/workflow/teamsapp.yml.tpl
@@ -17,15 +17,15 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
-  # Create or reuse an existing Azure Active Directory application for bot.
+  # Create or reuse an existing Microsoft Entra application for bot.
   - uses: botAadApp/create
     with:
-      # The Azure Active Directory application's display name
+      # The Microsoft Entra application's display name
       name: {{appName}}${{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
-      # The Azure Active Directory application's client id created for bot.
+      # The Microsoft Entra application's client id created for bot.
       botId: BOT_ID
-      # The Azure Active Directory application's client secret created for bot.
+      # The Microsoft Entra application's client secret created for bot.
       botPassword: SECRET_BOT_PASSWORD
 
   - uses: arm/deploy  # Deploy given ARM templates parallelly.


### PR DESCRIPTION
Task: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/25532638
Related PR: https://github.com/OfficeDev/TeamsFx/pull/10170
Feature: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/25518522

Description: Rename Azure Active Directory, Azure AD, AAD to Microsoft Entra in all our toolkit UI in VSC/VS/CLI, app templates and documents. We also need to close this work item [User Story 1869234](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1869234): [VS (x64 & arm64) M365 Developer Experience] Rebrand Azure Active Directory, Azure AD, AAD to Microsoft Entra as part of the overall DevDiv efforts.