### PR TITLE
fix: vulnerability in Azure.Identity dependency

### DIFF
--- a/packages/simpleauth/src/TeamsFxSimpleAuth.Tests/Microsoft.TeamsFx.SimpleAuth.Tests.csproj
+++ b/packages/simpleauth/src/TeamsFxSimpleAuth.Tests/Microsoft.TeamsFx.SimpleAuth.Tests.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.5.0" />
+    <PackageReference Include="Azure.Identity" Version="1.10.3" />
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.7" />


### PR DESCRIPTION
CVE-2023-36414
Bumping to Azure.Identity >= 1.10.2 to fix the vulnerability