### PR TITLE
perf(spec-parser): add browser api, truncate string

### DIFF
--- a/packages/fx-core/src/common/spec-parser/adaptiveCardGenerator.ts
+++ b/packages/fx-core/src/common/spec-parser/adaptiveCardGenerator.ts
@@ -3,8 +3,7 @@
 "use strict";
 
 import { OpenAPIV3 } from "openapi-types";
-import * as util from "util";
-import { getResponseJson, isWellKnownName } from "./utils";
+import { getResponseJson, isWellKnownName, format } from "./utils";
 import {
   AdaptiveCard,
   ArrayElement,
@@ -166,10 +165,10 @@ export function generateCardFromResponse(
   }
 
   if (schema.oneOf || schema.anyOf || schema.not || schema.allOf) {
-    throw new Error(util.format(ConstantString.SchemaNotSupported, JSON.stringify(schema)));
+    throw new Error(format(ConstantString.SchemaNotSupported, JSON.stringify(schema)));
   }
 
-  throw new Error(util.format(ConstantString.UnknownSchema, JSON.stringify(schema)));
+  throw new Error(format(ConstantString.UnknownSchema, JSON.stringify(schema)));
 }
 
 // Find the first array property in the response schema object with the well-known name

--- a/packages/fx-core/src/common/spec-parser/constants.ts
+++ b/packages/fx-core/src/common/spec-parser/constants.ts
@@ -97,4 +97,11 @@ export class ConstantString {
     "thumbnail",
     "img",
   ];
+
+  static readonly ShortDescriptionMaxLens = 80;
+  static readonly FullDescriptionMaxLens = 4000;
+  static readonly CommandDescriptionMaxLens = 128;
+  static readonly ParameterDescriptionMaxLens = 128;
+  static readonly CommandTitleMaxLens = 32;
+  static readonly ParameterTitleMaxLens = 32;
 }

--- a/packages/fx-core/src/common/spec-parser/index.browser.ts
+++ b/packages/fx-core/src/common/spec-parser/index.browser.ts
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+"use strict";
+
+export { SpecParser } from "./specParser.browser";
+export { SpecParserError } from "./specParserError";
+export { ValidationStatus, WarningType, ErrorType, WarningResult } from "./interfaces";
+export { ConstantString } from "./constants";

--- a/packages/fx-core/src/common/spec-parser/interfaces.ts
+++ b/packages/fx-core/src/common/spec-parser/interfaces.ts
@@ -83,6 +83,7 @@ export enum ErrorType {
 
   ListFailed = "list-failed",
   ListOperationMapFailed = "list-operation-map-failed",
+  listSupportedAPIInfoFailed = "list-supported-api-info-failed",
   FilterSpecFailed = "filter-spec-failed",
   UpdateManifestFailed = "update-manifest-failed",
   GenerateAdaptiveCardFailed = "generate-adaptive-card-failed",
@@ -181,4 +182,5 @@ export interface APIInfo {
   id: string;
   parameters: Parameter[];
   description: string;
+  warning?: WarningResult;
 }

--- a/packages/fx-core/src/common/spec-parser/manifestUpdater.ts
+++ b/packages/fx-core/src/common/spec-parser/manifestUpdater.ts
@@ -6,7 +6,7 @@ import { OpenAPIV3 } from "openapi-types";
 import fs from "fs-extra";
 import path from "path";
 import { ErrorType, WarningResult } from "./interfaces";
-import { getRelativePath, parseApiInfo } from "./utils";
+import { parseApiInfo } from "./utils";
 import { SpecParserError } from "./specParserError";
 import { ConstantString } from "./constants";
 import {
@@ -33,8 +33,11 @@ export async function updateManifest(
 
     const updatedPart = {
       description: {
-        short: spec.info.title,
-        full: spec.info.description ?? originalManifest.description.full,
+        short: spec.info.title.slice(0, ConstantString.ShortDescriptionMaxLens),
+        full: (spec.info.description ?? originalManifest.description.full)?.slice(
+          0,
+          ConstantString.FullDescriptionMaxLens
+        ),
       },
       composeExtensions: [ComposeExtension],
     };
@@ -86,4 +89,9 @@ export async function generateCommands(
   }
 
   return [commands, warnings];
+}
+
+export function getRelativePath(from: string, to: string): string {
+  const relativePath = path.relative(path.dirname(from), to);
+  return path.normalize(relativePath).replace(/\\/g, "/");
 }

--- a/packages/fx-core/src/common/spec-parser/specParser.browser.ts
+++ b/packages/fx-core/src/common/spec-parser/specParser.browser.ts
@@ -1,0 +1,184 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+"use strict";
+
+import SwaggerParser from "@apidevtools/swagger-parser";
+import { OpenAPIV3 } from "openapi-types";
+import {
+  APIInfo,
+  ErrorType,
+  GenerateResult,
+  ParseOptions,
+  ValidateResult,
+  ValidationStatus,
+  Parameter,
+} from "./interfaces";
+import { SpecParserError } from "./specParserError";
+import { isSupportedApi, listSupportedAPIs, parseApiInfo, validateSpec } from "./utils";
+import { ConstantString } from "./constants";
+
+/**
+ * A class that parses an OpenAPI specification file and provides methods to validate, list, and generate artifacts.
+ */
+export class SpecParser {
+  public readonly pathOrSpec: string | OpenAPIV3.Document;
+  public readonly parser: SwaggerParser;
+  public readonly options: ParseOptions;
+
+  private apiMap: { [key: string]: OpenAPIV3.PathItemObject } | undefined;
+  private spec: OpenAPIV3.Document | undefined;
+  private unResolveSpec: OpenAPIV3.Document | undefined;
+  private isSwaggerFile: boolean | undefined;
+
+  private defaultOptions: ParseOptions = {
+    allowMissingId: true,
+    allowSwagger: true,
+  };
+
+  /**
+   * Creates a new instance of the SpecParser class.
+   * @param pathOrDoc The path to the OpenAPI specification file or the OpenAPI specification object.
+   * @param options The options for parsing the OpenAPI specification file.
+   */
+  constructor(pathOrDoc: string | OpenAPIV3.Document, options?: ParseOptions) {
+    this.pathOrSpec = pathOrDoc;
+    this.parser = new SwaggerParser();
+    this.options = {
+      ...this.defaultOptions,
+      ...(options ?? {}),
+    };
+  }
+
+  /**
+   * Validates the OpenAPI specification file and returns a validation result.
+   *
+   * @returns A validation result object that contains information about any errors or warnings in the specification file.
+   */
+  async validate(): Promise<ValidateResult> {
+    try {
+      try {
+        await this.loadSpec();
+        await this.parser.validate(this.spec!);
+      } catch (e) {
+        return {
+          status: ValidationStatus.Error,
+          warnings: [],
+          errors: [{ type: ErrorType.SpecNotValid, content: (e as Error).toString() }],
+        };
+      }
+
+      if (!this.options.allowSwagger && this.isSwaggerFile) {
+        return {
+          status: ValidationStatus.Error,
+          warnings: [],
+          errors: [
+            { type: ErrorType.SwaggerNotSupported, content: ConstantString.SwaggerNotSupported },
+          ],
+        };
+      }
+
+      return validateSpec(this.spec!, this.parser, !!this.isSwaggerFile);
+    } catch (err) {
+      throw new SpecParserError((err as Error).toString(), ErrorType.ValidateFailed);
+    }
+  }
+
+  async listSupportedAPIInfo(): Promise<APIInfo[]> {
+    try {
+      await this.loadSpec();
+      const apiMap = this.getAllSupportedAPIs(this.spec!);
+      const apiInfos: APIInfo[] = [];
+      for (const key in apiMap) {
+        const pathObjectItem = apiMap[key];
+        const [method, path] = key.split(" ");
+        if (isSupportedApi(method, path, this.spec!, this.options.allowMissingId!)) {
+          const operationId = pathObjectItem.operationId;
+          if (!operationId) {
+            continue;
+          }
+
+          const [command, warning] = parseApiInfo(pathObjectItem);
+
+          const apiInfo: APIInfo = {
+            method: method,
+            path: path,
+            title: command.title,
+            id: operationId,
+            parameters: command.parameters! as Parameter[],
+            description: command.description!,
+          };
+
+          if (warning) {
+            apiInfo.warning = warning;
+          }
+
+          apiInfos.push(apiInfo);
+        }
+      }
+
+      return apiInfos;
+    } catch (err) {
+      throw new SpecParserError((err as Error).toString(), ErrorType.listSupportedAPIInfoFailed);
+    }
+  }
+
+  /**
+   * Lists all the OpenAPI operations in the specification file.
+   * @returns A string array that represents the HTTP method and path of each operation, such as ['GET /pets/{petId}', 'GET /user/{userId}']
+   * according to copilot plugin spec, only list get and post method without auth
+   */
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async list(): Promise<string[]> {
+    throw new Error("Method not implemented.");
+  }
+
+  /**
+   * List all the OpenAPI operations in the specification file and return a map of operationId and operation path.
+   * @returns A map of operationId and operation path, such as [{'getPetById': 'GET /pets/{petId}'}, {'getUser': 'GET /user/{userId}'}]
+   */
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async listOperationMap(): Promise<Map<string, string>> {
+    throw new Error("Method not implemented.");
+  }
+
+  /**
+   * Generates and update artifacts from the OpenAPI specification file. Generate Adaptive Cards, update Teams app manifest, and generate a new OpenAPI specification file.
+   * @param manifestPath A file path of the Teams app manifest file to update.
+   * @param filter An array of strings that represent the filters to apply when generating the artifacts. If filter is empty, it would process nothing.
+   * @param outputSpecPath File path of the new OpenAPI specification file to generate. If not specified or empty, no spec file will be generated.
+   * @param adaptiveCardFolder Folder path where the Adaptive Card files will be generated. If not specified or empty, Adaptive Card files will not be generated.
+   */
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async generate(
+    manifestPath: string,
+    filter: string[],
+    outputSpecPath: string,
+    adaptiveCardFolder: string,
+    signal?: AbortSignal
+  ): Promise<GenerateResult> {
+    throw new Error("Method not implemented.");
+  }
+
+  private async loadSpec(): Promise<void> {
+    if (!this.spec) {
+      this.unResolveSpec = (await this.parser.parse(this.pathOrSpec)) as OpenAPIV3.Document;
+      if (!this.unResolveSpec.openapi && (this.unResolveSpec as any).swagger === "2.0") {
+        this.isSwaggerFile = true;
+      }
+
+      const clonedUnResolveSpec = JSON.parse(JSON.stringify(this.unResolveSpec));
+      this.spec = (await this.parser.dereference(clonedUnResolveSpec)) as OpenAPIV3.Document;
+    }
+  }
+
+  private getAllSupportedAPIs(spec: OpenAPIV3.Document): {
+    [key: string]: OpenAPIV3.OperationObject;
+  } {
+    if (this.apiMap !== undefined) {
+      return this.apiMap;
+    }
+    const result = listSupportedAPIs(spec, true);
+    this.apiMap = result;
+    return result;
+  }
+}

--- a/packages/fx-core/tests/common/spec-parser/adaptiveCardGenerator.test.ts
+++ b/packages/fx-core/tests/common/spec-parser/adaptiveCardGenerator.test.ts
@@ -1,5 +1,4 @@
 import { expect } from "chai";
-import * as util from "util";
 import "mocha";
 import sinon from "sinon";
 import {
@@ -855,7 +854,7 @@ describe("adaptiveCardGenerator", () => {
       const parentArrayName = "";
 
       expect(() => generateCardFromResponse(schema as any, name, parentArrayName)).to.throw(
-        util.format(ConstantString.SchemaNotSupported, JSON.stringify(schema))
+        utils.format(ConstantString.SchemaNotSupported, JSON.stringify(schema))
       );
     });
 
@@ -867,7 +866,7 @@ describe("adaptiveCardGenerator", () => {
       const parentArrayName = "";
 
       expect(() => generateCardFromResponse(schema as any, name, parentArrayName)).to.throw(
-        util.format(ConstantString.UnknownSchema, JSON.stringify(schema))
+        utils.format(ConstantString.UnknownSchema, JSON.stringify(schema))
       );
     });
 

--- a/packages/fx-core/tests/common/spec-parser/specParser.browser.test.ts
+++ b/packages/fx-core/tests/common/spec-parser/specParser.browser.test.ts
@@ -1,0 +1,645 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import "mocha";
+import { expect } from "chai";
+import sinon from "sinon";
+import { SpecParser } from "../../../src/common/spec-parser/specParser.browser";
+import {
+  ErrorType,
+  ValidationStatus,
+  WarningType,
+} from "../../../src/common/spec-parser/interfaces";
+import { SpecParserError } from "../../../src/common/spec-parser/specParserError";
+import { ConstantString } from "../../../src/common/spec-parser/constants";
+import { OpenAPIV3 } from "openapi-types";
+import * as utils from "../../../src/common/spec-parser/utils";
+import SwaggerParser from "@apidevtools/swagger-parser";
+
+// TODO: After SpecParser lib become a npm package, these tests should be running in browser environment
+describe("SpecParser in Browser", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("listSupportedAPIInfo", () => {
+    it("should return a list of HTTP methods and paths for all GET with 1 parameter and without security", async () => {
+      const specPath = "valid-spec.yaml";
+      const specParser = new SpecParser(specPath, { allowMissingId: false });
+      const spec = {
+        paths: {
+          "/pets": {
+            get: {
+              operationId: "getPetById",
+              security: [{ api_key: [] }],
+            },
+          },
+          "/user/{userId}": {
+            get: {
+              operationId: "getUserById",
+              description: "Get user by user id, balabala",
+              summary: "Get user by user id",
+              parameters: [
+                {
+                  name: "userId",
+                  in: "path",
+                  description: "User Id",
+                  schema: {
+                    type: "string",
+                  },
+                },
+              ],
+              responses: {
+                200: {
+                  content: {
+                    "application/json": {
+                      schema: {
+                        type: "object",
+                        properties: {
+                          name: {
+                            type: "string",
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            post: {
+              operationId: "createUser",
+              security: [{ api_key: [] }],
+            },
+          },
+          "/store/order": {
+            post: {
+              operationId: "placeOrder",
+            },
+          },
+        },
+      };
+
+      const parseStub = sinon.stub(specParser.parser, "parse").resolves(spec as any);
+      const dereferenceStub = sinon.stub(specParser.parser, "dereference").resolves(spec as any);
+
+      const result = await specParser.listSupportedAPIInfo();
+      expect(result).to.deep.equal([
+        {
+          method: "GET",
+          path: "/user/{userId}",
+          title: "Get user by user id",
+          id: "getUserById",
+          parameters: [
+            {
+              name: "userId",
+              title: "UserId",
+              description: "User Id",
+            },
+          ],
+          description: "Get user by user id, balabala",
+        },
+      ]);
+    });
+
+    it("should not list api without operationId with allowMissingId is false", async () => {
+      const specPath = "valid-spec.yaml";
+      const specParser = new SpecParser(specPath, { allowMissingId: false });
+      const spec = {
+        paths: {
+          "/pets": {
+            get: {
+              operationId: "getPetById",
+              security: [{ api_key: [] }],
+            },
+          },
+          "/user/{userId}": {
+            get: {
+              parameters: [
+                {
+                  name: "userId",
+                  in: "path",
+                  schema: {
+                    type: "string",
+                  },
+                },
+              ],
+              responses: {
+                200: {
+                  content: {
+                    "application/json": {
+                      schema: {
+                        type: "object",
+                        properties: {
+                          name: {
+                            type: "string",
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            post: {
+              operationId: "createUser",
+              security: [{ api_key: [] }],
+            },
+          },
+          "/store/order": {
+            post: {
+              operationId: "placeOrder",
+            },
+          },
+        },
+      };
+
+      const parseStub = sinon.stub(specParser.parser, "parse").resolves(spec as any);
+      const dereferenceStub = sinon.stub(specParser.parser, "dereference").resolves(spec as any);
+
+      const result = await specParser.listSupportedAPIInfo();
+
+      expect(result).to.deep.equal([]);
+    });
+
+    it("should throw an error when the SwaggerParser library throws an error", async () => {
+      const specPath = "invalid-spec.yaml";
+      const specParser = new SpecParser(specPath);
+      sinon.stub(SwaggerParser, "validate").rejects(new Error("Invalid specification"));
+      const parseStub = sinon
+        .stub(specParser.parser, "parse")
+        .rejects(new Error("Invalid specification"));
+      try {
+        await specParser.listSupportedAPIInfo();
+        expect.fail("Expected an error to be thrown");
+      } catch (err) {
+        expect((err as SpecParserError).message).contain("Invalid specification");
+        expect((err as SpecParserError).errorType).to.equal(ErrorType.listSupportedAPIInfoFailed);
+      }
+    });
+  });
+
+  describe("validate", () => {
+    it("should return an error result when the spec is not valid", async () => {
+      const specParser = new SpecParser("/path/to/spec.yaml");
+      const spec = { openapi: "3.0.0" };
+      sinon.stub(specParser.parser, "parse").resolves(spec as any);
+      sinon.stub(specParser.parser, "dereference").resolves(spec as any);
+      const parseStub = sinon
+        .stub(specParser.parser, "validate")
+        .rejects(new Error("Invalid spec"));
+
+      const result = await specParser.validate();
+
+      expect(result.status).to.equal(ValidationStatus.Error);
+      expect(result.warnings).to.be.an("array").that.is.empty;
+      expect(result.errors).to.be.an("array").that.has.lengthOf(1);
+      expect(result.errors[0].type).to.equal(ErrorType.SpecNotValid);
+      expect(result.errors[0].content).to.equal("Error: Invalid spec");
+      sinon.assert.calledOnce(parseStub);
+    });
+
+    it("should return error object if the spec version is 2.0 with allowSwagger is false", async function () {
+      const specPath = "path/to/spec";
+      const spec = {
+        swagger: "2.0",
+        info: {
+          version: "1.0.0",
+          title: "Swagger Petstore",
+          description:
+            "A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification",
+        },
+        host: "petstore.swagger.io",
+        basePath: "/v2",
+        schemes: ["https"],
+        paths: {
+          "/pet": {
+            post: {
+              summary: "Add a new pet to the store",
+              operationId: "addPet",
+              consumes: ["application/json"],
+              produces: ["application/json"],
+              parameters: [
+                {
+                  in: "body",
+                  name: "body",
+                  schema: {
+                    type: "object",
+                    required: ["name"],
+                    properties: {
+                      id: {
+                        type: "integer",
+                        format: "int64",
+                      },
+                      name: {
+                        type: "string",
+                      },
+                    },
+                  },
+                },
+              ],
+              responses: {
+                "200": {
+                  description: "Pet added to the store",
+                  schema: {
+                    type: "object",
+                    required: ["id", "name"],
+                    properties: {
+                      id: {
+                        type: "integer",
+                        format: "int64",
+                      },
+                      name: {
+                        type: "string",
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      const specParser = new SpecParser(specPath, { allowSwagger: false });
+
+      const parseStub = sinon.stub(specParser.parser, "parse").resolves(spec as any);
+
+      const dereferenceStub = sinon.stub(specParser.parser, "dereference").resolves(spec);
+      const validateStub = sinon.stub(specParser.parser, "validate").resolves(spec);
+
+      const result = await specParser.validate();
+
+      expect(result).to.deep.equal({
+        status: ValidationStatus.Error,
+        errors: [
+          {
+            type: ErrorType.SwaggerNotSupported,
+            content: ConstantString.SwaggerNotSupported,
+          },
+        ],
+        warnings: [],
+      });
+    });
+
+    it("should return an error result object if no server information", async function () {
+      const specPath = "path/to/spec";
+      const spec = { openapi: "3.0.0" };
+
+      const specParser = new SpecParser(specPath);
+      const parseStub = sinon.stub(specParser.parser, "parse").resolves(spec as any);
+      const dereferenceStub = sinon.stub(specParser.parser, "dereference").resolves(spec as any);
+      const validateStub = sinon.stub(specParser.parser, "validate").resolves(spec as any);
+      const result = await specParser.validate();
+
+      expect(result).to.deep.equal({
+        status: ValidationStatus.Error,
+        warnings: [],
+        errors: [
+          { type: ErrorType.NoServerInformation, content: ConstantString.NoServerInformation },
+          { type: ErrorType.NoSupportedApi, content: ConstantString.NoSupportedApi },
+        ],
+      });
+      sinon.assert.calledOnce(dereferenceStub);
+    });
+
+    it("should return an error result object if server url is http", async function () {
+      const specPath = "path/to/spec";
+      const spec = { openapi: "3.0.0", servers: [{ url: "http://server1" }] };
+
+      const specParser = new SpecParser(specPath);
+      const parseStub = sinon.stub(specParser.parser, "parse").resolves(spec as any);
+      const dereferenceStub = sinon.stub(specParser.parser, "dereference").resolves(spec as any);
+      const validateStub = sinon.stub(specParser.parser, "validate").resolves(spec as any);
+      const result = await specParser.validate();
+
+      expect(result).to.deep.equal({
+        status: ValidationStatus.Error,
+        warnings: [],
+        errors: [
+          {
+            type: ErrorType.UrlProtocolNotSupported,
+            content: utils.format(ConstantString.UrlProtocolNotSupported, "http"),
+            data: "http",
+          },
+          { type: ErrorType.NoSupportedApi, content: ConstantString.NoSupportedApi },
+        ],
+      });
+      sinon.assert.calledOnce(dereferenceStub);
+    });
+
+    it("should return an error result object if server url is relative path", async function () {
+      const specPath = "path/to/spec";
+      const spec = { openapi: "3.0.0", servers: [{ url: "path/to/server1" }] };
+
+      const specParser = new SpecParser(specPath);
+      const parseStub = sinon.stub(specParser.parser, "parse").resolves(spec as any);
+      const dereferenceStub = sinon.stub(specParser.parser, "dereference").resolves(spec as any);
+      const validateStub = sinon.stub(specParser.parser, "validate").resolves(spec as any);
+      const result = await specParser.validate();
+
+      expect(result).to.deep.equal({
+        status: ValidationStatus.Error,
+        warnings: [],
+        errors: [
+          {
+            type: ErrorType.RelativeServerUrlNotSupported,
+            content: ConstantString.RelativeServerUrlNotSupported,
+            data: [
+              {
+                url: "path/to/server1",
+              },
+            ],
+          },
+          { type: ErrorType.NoSupportedApi, content: ConstantString.NoSupportedApi },
+        ],
+      });
+      sinon.assert.calledOnce(dereferenceStub);
+    });
+
+    it("should return an error result object if no supported apis", async function () {
+      const specPath = "path/to/spec";
+      const spec = { openapi: "3.0.0", servers: [{ url: "https://server1" }] };
+
+      const specParser = new SpecParser(specPath);
+      const parseStub = sinon.stub(specParser.parser, "parse").resolves(spec as any);
+      const dereferenceStub = sinon.stub(specParser.parser, "dereference").resolves(spec as any);
+      const validateStub = sinon.stub(specParser.parser, "validate").resolves(spec as any);
+      const result = await specParser.validate();
+
+      expect(result).to.deep.equal({
+        status: ValidationStatus.Error,
+        warnings: [],
+        errors: [{ type: ErrorType.NoSupportedApi, content: ConstantString.NoSupportedApi }],
+      });
+      sinon.assert.calledOnce(dereferenceStub);
+    });
+
+    it("should return an error result object if contain remote reference", async function () {
+      const spec = {
+        openapi: "3.0.3",
+        info: {
+          title: "Swagger Petstore - OpenAPI 3.",
+          version: "1.0.11",
+        },
+        servers: [
+          {
+            url: "https://petstore3.swagger.io/api/v3",
+          },
+        ],
+        paths: {
+          "/pet": {
+            get: {
+              tags: ["pet"],
+              operationId: "updatePet",
+              responses: {
+                "200": {
+                  description: "Successful operation",
+                  content: {
+                    "application/json": {
+                      schema: {
+                        $ref: "https://petstore3.swagger.io/api/v3/openapi.json#/components/schemas/Pet",
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        components: {
+          schemas: {
+            Pet: {
+              type: "object",
+              properties: {
+                name: {
+                  type: "string",
+                  example: "doggie",
+                },
+              },
+            },
+          },
+        },
+      } as OpenAPIV3.Document;
+      const specPath = "path/to/spec";
+      const specParser = new SpecParser(spec as any);
+      const validateStub = sinon.stub(specParser.parser, "validate").resolves(spec as any);
+      const result = await specParser.validate();
+
+      expect(result.errors[0].type).equal(ErrorType.RemoteRefNotSupported);
+      expect(result.status).equal(ValidationStatus.Error);
+    });
+
+    it("should return an warning result object if missing operation id", async function () {
+      const specPath = "path/to/spec";
+      const spec = {
+        openapi: "3.0.2",
+        servers: [
+          {
+            url: "https://servers1",
+          },
+        ],
+        paths: {
+          "/pet": {
+            get: {
+              tags: ["pet"],
+              summary: "Get pet information from the store",
+              parameters: [
+                {
+                  name: "tags",
+                  in: "query",
+                  description: "Tags to filter by",
+                  schema: {
+                    type: "string",
+                  },
+                },
+              ],
+              responses: {
+                "200": {
+                  content: {
+                    "application/json": {
+                      schema: {
+                        $ref: "#/components/schemas/Pet",
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const specParser = new SpecParser(specPath);
+      const parseStub = sinon.stub(specParser.parser, "parse").resolves(spec as any);
+      const dereferenceStub = sinon.stub(specParser.parser, "dereference").resolves(spec as any);
+      const validateStub = sinon.stub(specParser.parser, "validate").resolves(spec as any);
+      const result = await specParser.validate();
+
+      expect(result).to.deep.equal({
+        status: ValidationStatus.Warning,
+        warnings: [
+          {
+            type: WarningType.OperationIdMissing,
+            content: utils.format(ConstantString.MissingOperationId, "GET /pet"),
+            data: ["GET /pet"],
+          },
+        ],
+        errors: [],
+      });
+      sinon.assert.calledOnce(dereferenceStub);
+    });
+
+    it("should return a valid result when the spec is valid", async () => {
+      const specPath = "path/to/spec";
+      const spec = {
+        openapi: "3.0.2",
+        servers: [
+          {
+            url: "https://server1",
+          },
+        ],
+        paths: {
+          "/pet": {
+            get: {
+              tags: ["pet"],
+              operationId: "getPet",
+              summary: "Get pet information from the store",
+              parameters: [
+                {
+                  name: "tags",
+                  in: "query",
+                  description: "Tags to filter by",
+                  schema: {
+                    type: "string",
+                  },
+                },
+              ],
+              responses: {
+                "200": {
+                  content: {
+                    "application/json": {
+                      schema: {
+                        $ref: "#/components/schemas/Pet",
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      const specParser = new SpecParser(specPath);
+      const parseStub = sinon.stub(specParser.parser, "parse").resolves(spec as any);
+      const dereferenceStub = sinon.stub(specParser.parser, "dereference").resolves(spec as any);
+      const validateStub = sinon.stub(specParser.parser, "validate").resolves(spec as any);
+      const result = await specParser.validate();
+      expect(result.status).to.equal(ValidationStatus.Valid);
+      expect(result.warnings).to.be.an("array").that.is.empty;
+      expect(result.errors).to.be.an("array").that.is.empty;
+      sinon.assert.calledOnce(dereferenceStub);
+    });
+
+    it("should throw a SpecParserError when an error occurs", async () => {
+      const specPath = "path/to/spec";
+      const spec = {
+        openapi: "3.0.2",
+        servers: [
+          {
+            url: "https://server1",
+          },
+        ],
+        paths: {
+          "/pet": {
+            get: {
+              tags: ["pet"],
+              operationId: "getPet",
+              summary: "Get pet information from the store",
+              parameters: [
+                {
+                  name: "tags",
+                  in: "query",
+                  description: "Tags to filter by",
+                  schema: {
+                    type: "string",
+                  },
+                },
+              ],
+              responses: {
+                "200": {
+                  content: {
+                    "application/xml": {
+                      schema: {
+                        $ref: "#/components/schemas/Pet",
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      try {
+        const specParser = new SpecParser(specPath);
+        const parseStub = sinon.stub(specParser.parser, "parse").resolves(spec as any);
+        const dereferenceStub = sinon.stub(specParser.parser, "dereference").resolves(spec as any);
+        const validateStub = sinon.stub(specParser.parser, "validate").resolves(spec as any);
+        sinon.stub(utils as any, "validateSpec").throws(new Error("validateSpec error"));
+
+        const result = await specParser.validate();
+        expect.fail("Expected SpecParserError to be thrown");
+      } catch (err) {
+        expect(err).to.be.instanceOf(SpecParserError);
+        expect(err.errorType).to.equal(ErrorType.ValidateFailed);
+        expect(err.message).to.equal("Error: validateSpec error");
+      }
+    });
+  });
+
+  describe("generate", () => {
+    it("should throw not implemented error", async () => {
+      try {
+        const specParser = new SpecParser("path/to/spec.yaml");
+        const filter = ["get /hello"];
+        const outputSpecPath = "path/to/output.yaml";
+        const result = await specParser.generate(
+          "path/to/manifest.json",
+          filter,
+          outputSpecPath,
+          "path/to/adaptiveCardFolder"
+        );
+        expect.fail("Should throw not implemented error");
+      } catch (error) {
+        expect(error.message).to.equal("Method not implemented.");
+      }
+    });
+  });
+
+  describe("listOperationMap", async () => {
+    it("should throw an error if loading the spec fails", async () => {
+      try {
+        const specPath = "valid-spec.yaml";
+        const specParser = new SpecParser(specPath);
+        await specParser.listOperationMap();
+        expect.fail("Should throw not implemented error");
+      } catch (error) {
+        expect(error.message).to.equal("Method not implemented.");
+      }
+    });
+  });
+
+  describe("list", () => {
+    it("should throw an error when the SwaggerParser library throws an error", async () => {
+      try {
+        const specPath = "valid-spec.yaml";
+        const specParser = new SpecParser(specPath);
+        await specParser.list();
+        expect.fail("Should throw not implemented error");
+      } catch (error) {
+        expect(error.message).to.equal("Method not implemented.");
+      }
+    });
+  });
+});

--- a/packages/fx-core/tests/common/spec-parser/specParser.test.ts
+++ b/packages/fx-core/tests/common/spec-parser/specParser.test.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as util from "util";
 import fs from "fs-extra";
 import "mocha";
 import { expect } from "chai";
@@ -22,6 +21,7 @@ import * as ManifestUpdater from "../../../src/common/spec-parser/manifestUpdate
 import * as AdaptiveCardGenerator from "../../../src/common/spec-parser/adaptiveCardGenerator";
 import * as utils from "../../../src/common/spec-parser/utils";
 import jsyaml from "js-yaml";
+import { format } from "../../../src/common/spec-parser/utils";
 
 describe("SpecParser", () => {
   afterEach(() => {
@@ -272,7 +272,7 @@ describe("SpecParser", () => {
         errors: [
           {
             type: ErrorType.UrlProtocolNotSupported,
-            content: util.format(ConstantString.UrlProtocolNotSupported, "http"),
+            content: format(ConstantString.UrlProtocolNotSupported, "http"),
             data: "http",
           },
           { type: ErrorType.NoSupportedApi, content: ConstantString.NoSupportedApi },
@@ -434,7 +434,7 @@ describe("SpecParser", () => {
         warnings: [
           {
             type: WarningType.OperationIdMissing,
-            content: util.format(ConstantString.MissingOperationId, "GET /pet"),
+            content: format(ConstantString.MissingOperationId, "GET /pet"),
             data: ["GET /pet"],
           },
         ],

--- a/packages/fx-core/tests/common/spec-parser/utils.test.ts
+++ b/packages/fx-core/tests/common/spec-parser/utils.test.ts
@@ -2,15 +2,12 @@
 // Licensed under the MIT license.
 
 import { assert, expect } from "chai";
-import os from "os";
-import * as util from "util";
 import "mocha";
 import {
   checkPostBody,
   checkParameters,
   checkServerUrl,
   convertPathToCamelCase,
-  getRelativePath,
   getResponseJson,
   getUrlProtocol,
   isSupportedApi,
@@ -18,11 +15,11 @@ import {
   validateServer,
   resolveServerUrl,
   isWellKnownName,
+  format,
 } from "../../../src/common/spec-parser/utils";
 import { OpenAPIV3 } from "openapi-types";
 import { ConstantString } from "../../../src/common/spec-parser/constants";
 import { ErrorType } from "../../../src/common/spec-parser/interfaces";
-import { format } from "util";
 
 describe("utils", () => {
   describe("updateFirstLetter", () => {
@@ -34,31 +31,6 @@ describe("utils", () => {
     it("should return an empty string if the input is empty", () => {
       const result = updateFirstLetter("");
       expect(result).to.equal("");
-    });
-  });
-
-  describe("getRelativePath", () => {
-    it("should return the correct relative path", () => {
-      const from = "/path/to/from";
-      const to = "/path/to/file.txt";
-      const result = getRelativePath(from, to);
-      expect(result).to.equal("file.txt");
-    });
-
-    it("should get relative path with subfolder", () => {
-      const from = "/path/to/from";
-      const to = "/path/to/subfolder/file.txt";
-      const result = getRelativePath(from, to);
-      expect(result).to.equal("subfolder/file.txt");
-    });
-
-    it("should replace backslashes with forward slashes on Windows", () => {
-      if (os.platform() === "win32") {
-        const from = "c:\\path\\to\\from";
-        const to = "c:\\path\\to\\subfolder\\file.txt";
-        const result = getRelativePath(from, to);
-        expect(result).to.equal("subfolder/file.txt");
-      }
     });
   });
 
@@ -1087,7 +1059,7 @@ describe("utils", () => {
       assert.deepStrictEqual(errors, [
         {
           type: ErrorType.UrlProtocolNotSupported,
-          content: util.format(ConstantString.UrlProtocolNotSupported, "http"),
+          content: format(ConstantString.UrlProtocolNotSupported, "http"),
           data: "http",
         },
       ]);
@@ -1251,12 +1223,12 @@ describe("utils", () => {
         },
         {
           type: ErrorType.UrlProtocolNotSupported,
-          content: util.format(ConstantString.UrlProtocolNotSupported, "http"),
+          content: format(ConstantString.UrlProtocolNotSupported, "http"),
           data: "http",
         },
         {
           type: ErrorType.UrlProtocolNotSupported,
-          content: util.format(ConstantString.UrlProtocolNotSupported, "ftp"),
+          content: format(ConstantString.UrlProtocolNotSupported, "ftp"),
           data: "ftp",
         },
       ]);
@@ -1510,6 +1482,33 @@ describe("utils", () => {
       expect(isWellKnownName("bar", ConstantString.WellknownResultNames)).to.be.false;
       expect(isWellKnownName("baz", ConstantString.WellknownResultNames)).to.be.false;
       expect(isWellKnownName("qux", ConstantString.WellknownResultNames)).to.be.false;
+    });
+  });
+
+  describe("format", () => {
+    it("should replace %s placeholders with arguments", () => {
+      const result = format("Hello, %s!", "world");
+      expect(result).to.equal("Hello, world!");
+    });
+
+    it("should handle multiple placeholders and arguments", () => {
+      const result = format("The %s is %s.", "answer", "42");
+      expect(result).to.equal("The answer is 42.");
+    });
+
+    it("should handle missing arguments", () => {
+      const result = format("Hello, %s!", "");
+      expect(result).to.equal("Hello, !");
+    });
+
+    it("should handle extra arguments", () => {
+      const result = format("Hello, %s!", "world", "extra");
+      expect(result).to.equal("Hello, world!");
+    });
+
+    it("should handle no placeholders", () => {
+      const result = format("Hello, world!");
+      expect(result).to.equal("Hello, world!");
     });
   });
 });


### PR DESCRIPTION
- add browser api in specParser.browser.ts file
- replace node js api such as "path" and "util"
- truncate string
- test cases update

How to use browser api:

- Copy related files to your project: 
  - specParser.browser.ts
  - index.browser.ts
  - constants.ts
  - interfaces.ts
  - utils.ts

- Install packages
  - @apidevtools/swagger-parser
  - "openapi-types"
  - @microsoft/teams-manifest

- change below import in utils file
  - import { IMessagingExtensionCommand } from "@microsoft/teamsfx-api"; 
  ->
  - import { IMessagingExtensionCommand } from "@microsoft/teams-manifest"; 
- referece api from index.browser.ts file

