### PR TITLE
fix: typo in tab detail description

### DIFF
--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -275,7 +275,7 @@
   "core.createProjectQuestion.projectType.outlookAddin.detail": "Customize the ribbon and Task Pane with your web content",
   "core.createProjectQuestion.projectType.outlookAddin.label": "Outlook Add-in",
   "core.createProjectQuestion.projectType.outlookAddin.title": "App Features Using an Outlook Add-in",
-  "core.createProjectQuestion.projectType.tab.detail": "Embed your own web content in Teams, Outlook, and the Micosoft 365 app",
+  "core.createProjectQuestion.projectType.tab.detail": "Embed your own web content in Teams, Outlook, and the Microsoft 365 app",
   "core.createProjectQuestion.projectType.tab.title": "App Features Using a Tab",
   "core.createProjectQuestion.projectType.copilotPlugin.detail": "Create a plugin to extend Microsoft 365 Copilot using your APIs",
   "core.createProjectQuestion.projectType.copilotPlugin.label": "Plugin",


### PR DESCRIPTION
Related bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/25526040