### PR TITLE
refactor: revert yaml change

### DIFF
--- a/templates/common/copilot-plugin-existing-api/teamsapp.yml.tpl
+++ b/templates/common/copilot-plugin-existing-api/teamsapp.yml.tpl
@@ -17,6 +17,11 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
+  # Validate using manifest schema
+  - uses: teamsApp/validateManifest
+    with:
+      # Path to manifest template
+      manifestPath: ./appPackage/manifest.json
   # Build Teams app package with latest env value
   - uses: teamsApp/zipAppPackage
     with:
@@ -49,6 +54,11 @@ provision:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
+  # Validate using manifest schema
+  - uses: teamsApp/validateManifest
+    with:
+      # Path to manifest template
+      manifestPath: ./appPackage/manifest.json
   # Build Teams app package with latest env value
   - uses: teamsApp/zipAppPackage
     with:

--- a/templates/common/copilot-plugin-from-oai-plugin/teamsapp.yml.tpl
+++ b/templates/common/copilot-plugin-from-oai-plugin/teamsapp.yml.tpl
@@ -17,6 +17,11 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
+  # Validate using manifest schema
+  - uses: teamsApp/validateManifest
+    with:
+      # Path to manifest template
+      manifestPath: ./appPackage/manifest.json
   # Build Teams app package with latest env value
   - uses: teamsApp/zipAppPackage
     with:
@@ -49,6 +54,11 @@ provision:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
+  # Validate using manifest schema
+  - uses: teamsApp/validateManifest
+    with:
+      # Path to manifest template
+      manifestPath: ./appPackage/manifest.json
   # Build Teams app package with latest env value
   - uses: teamsApp/zipAppPackage
     with:

--- a/templates/constraints/yml/templates/common/copilot-plugin-existing-api/teamsapp.yml.tpl.mustache
+++ b/templates/constraints/yml/templates/common/copilot-plugin-existing-api/teamsapp.yml.tpl.mustache
@@ -6,6 +6,7 @@ environmentFolderPath: ./env
 provision:
 {{#teamsAppCreate}} {{/teamsAppCreate}}
 
+{{#teamsAppValidateManifest}} {{/teamsAppValidateManifest}}
 {{#teamsAppZipAppPackage}} {{/teamsAppZipAppPackage}}
 {{#teamsAppValidateAppPackage}} {{/teamsAppValidateAppPackage}}
 {{#teamsAppUpdate}} {{/teamsAppUpdate}}
@@ -13,6 +14,7 @@ provision:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
+{{#teamsAppValidateManifest}} {{/teamsAppValidateManifest}}
 {{#teamsAppZipAppPackage}} {{/teamsAppZipAppPackage}}
 {{#teamsAppValidateAppPackage}} {{/teamsAppValidateAppPackage}}
 {{#teamsAppUpdate}} {{/teamsAppUpdate}}

--- a/templates/constraints/yml/templates/common/copilot-plugin-from-oai-plugin/teamsapp.yml.tpl.mustache
+++ b/templates/constraints/yml/templates/common/copilot-plugin-from-oai-plugin/teamsapp.yml.tpl.mustache
@@ -6,6 +6,7 @@ environmentFolderPath: ./env
 provision:
 {{#teamsAppCreate}} {{/teamsAppCreate}}
 
+{{#teamsAppValidateManifest}} {{/teamsAppValidateManifest}}
 {{#teamsAppZipAppPackage}} {{/teamsAppZipAppPackage}}
 {{#teamsAppValidateAppPackage}} {{/teamsAppValidateAppPackage}}
 {{#teamsAppUpdate}} {{/teamsAppUpdate}}
@@ -13,6 +14,7 @@ provision:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
+{{#teamsAppValidateManifest}} {{/teamsAppValidateManifest}}
 {{#teamsAppZipAppPackage}} {{/teamsAppZipAppPackage}}
 {{#teamsAppValidateAppPackage}} {{/teamsAppValidateAppPackage}}
 {{#teamsAppUpdate}} {{/teamsAppUpdate}}

--- a/templates/constraints/yml/templates/csharp/copilot-plugin-existing-api/teamsapp.yml.tpl.mustache
+++ b/templates/constraints/yml/templates/csharp/copilot-plugin-existing-api/teamsapp.yml.tpl.mustache
@@ -6,6 +6,8 @@ environmentFolderPath: ./env
 provision:
 {{#teamsAppCreate}}  {{/teamsAppCreate}}
 
+{{#teamsAppValidateManifest}}  {{/teamsAppValidateManifest}}
+
 {{#teamsAppZipAppPackage}}  {{/teamsAppZipAppPackage}}
 
 {{#teamsAppValidateAppPackage}}  {{/teamsAppValidateAppPackage}}

--- a/templates/constraints/yml/templates/csharp/copilot-plugin-from-oai-plugin/teamsapp.yml.tpl.mustache
+++ b/templates/constraints/yml/templates/csharp/copilot-plugin-from-oai-plugin/teamsapp.yml.tpl.mustache
@@ -6,6 +6,8 @@ environmentFolderPath: ./env
 provision:
 {{#teamsAppCreate}}  {{/teamsAppCreate}}
 
+{{#teamsAppValidateManifest}}  {{/teamsAppValidateManifest}}
+
 {{#teamsAppZipAppPackage}}  {{/teamsAppZipAppPackage}}
 
 {{#teamsAppValidateAppPackage}}  {{/teamsAppValidateAppPackage}}

--- a/templates/constraints/yml/templates/csharp/copilot-plugin-from-scratch/teamsapp.local.yml.tpl.mustache
+++ b/templates/constraints/yml/templates/csharp/copilot-plugin-from-scratch/teamsapp.local.yml.tpl.mustache
@@ -5,6 +5,8 @@ provision:
 
 {{#script}} COPILOT {{/script}}
 
+{{#teamsAppValidateManifest}} {{/teamsAppValidateManifest}}
+
 {{#teamsAppZipAppPackage}} {{/teamsAppZipAppPackage}}
 
 {{#teamsAppValidateAppPackage}} {{/teamsAppValidateAppPackage}}

--- a/templates/constraints/yml/templates/csharp/copilot-plugin-from-scratch/teamsapp.yml.tpl.mustache
+++ b/templates/constraints/yml/templates/csharp/copilot-plugin-from-scratch/teamsapp.yml.tpl.mustache
@@ -8,6 +8,8 @@ provision:
 
 {{#armDeploy}} deploymentName: Create-resources-for-sme {{/armDeploy}}
 
+{{#teamsAppValidateManifest}} {{/teamsAppValidateManifest}}
+
 {{#teamsAppZipAppPackage}} {{/teamsAppZipAppPackage}}
 
 {{#teamsAppValidateAppPackage}} {{/teamsAppValidateAppPackage}}

--- a/templates/constraints/yml/templates/js/copilot-plugin-from-scratch/teamsapp.local.yml.tpl.mustache
+++ b/templates/constraints/yml/templates/js/copilot-plugin-from-scratch/teamsapp.local.yml.tpl.mustache
@@ -5,6 +5,8 @@ provision:
 
 {{#script}} FUNC, FUNC_NAME: repair {{/script}}
 
+{{#teamsAppValidateManifest}} {{/teamsAppValidateManifest}}
+
 {{#teamsAppZipAppPackage}} {{/teamsAppZipAppPackage}}
 
 {{#teamsAppValidateAppPackage}} {{/teamsAppValidateAppPackage}}

--- a/templates/constraints/yml/templates/js/copilot-plugin-from-scratch/teamsapp.yml.tpl.mustache
+++ b/templates/constraints/yml/templates/js/copilot-plugin-from-scratch/teamsapp.yml.tpl.mustache
@@ -8,6 +8,8 @@ provision:
 
 {{#armDeploy}} deploymentName: Create-resources-for-sme {{/armDeploy}}
 
+{{#teamsAppValidateManifest}} {{/teamsAppValidateManifest}}
+
 {{#teamsAppZipAppPackage}} {{/teamsAppZipAppPackage}}
 
 {{#teamsAppValidateAppPackage}} {{/teamsAppValidateAppPackage}}
@@ -24,6 +26,7 @@ deploy:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
+{{#teamsAppValidateManifest}} {{/teamsAppValidateManifest}}
 {{#teamsAppZipAppPackage}} {{/teamsAppZipAppPackage}}
 {{#teamsAppValidateAppPackage}} {{/teamsAppValidateAppPackage}}
 {{#teamsAppUpdate}} {{/teamsAppUpdate}}

--- a/templates/constraints/yml/templates/ts/copilot-plugin-from-scratch/teamsapp.local.yml.tpl.mustache
+++ b/templates/constraints/yml/templates/ts/copilot-plugin-from-scratch/teamsapp.local.yml.tpl.mustache
@@ -5,6 +5,8 @@ provision:
 
 {{#script}} FUNC, FUNC_NAME: repair {{/script}}
 
+{{#teamsAppValidateManifest}} {{/teamsAppValidateManifest}}
+
 {{#teamsAppZipAppPackage}} {{/teamsAppZipAppPackage}}
 
 {{#teamsAppValidateAppPackage}} {{/teamsAppValidateAppPackage}}

--- a/templates/constraints/yml/templates/ts/copilot-plugin-from-scratch/teamsapp.yml.tpl.mustache
+++ b/templates/constraints/yml/templates/ts/copilot-plugin-from-scratch/teamsapp.yml.tpl.mustache
@@ -8,6 +8,8 @@ provision:
 
 {{#armDeploy}} deploymentName: Create-resources-for-sme {{/armDeploy}}
 
+{{#teamsAppValidateManifest}} {{/teamsAppValidateManifest}}
+
 {{#teamsAppZipAppPackage}} {{/teamsAppZipAppPackage}}
 
 {{#teamsAppValidateAppPackage}} {{/teamsAppValidateAppPackage}}
@@ -26,6 +28,7 @@ deploy:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
+{{#teamsAppValidateManifest}} {{/teamsAppValidateManifest}}
 {{#teamsAppZipAppPackage}} {{/teamsAppZipAppPackage}}
 {{#teamsAppValidateAppPackage}} {{/teamsAppValidateAppPackage}}
 {{#teamsAppUpdate}} {{/teamsAppUpdate}}

--- a/templates/csharp/copilot-plugin-existing-api/teamsapp.yml.tpl
+++ b/templates/csharp/copilot-plugin-existing-api/teamsapp.yml.tpl
@@ -17,6 +17,12 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
+  # Validate using manifest schema
+  - uses: teamsApp/validateManifest
+    with:
+      # Path to manifest template
+      manifestPath: ./appPackage/manifest.json
+
   # Build Teams app package with latest env value
   - uses: teamsApp/zipAppPackage
     with:

--- a/templates/csharp/copilot-plugin-from-oai-plugin/teamsapp.yml.tpl
+++ b/templates/csharp/copilot-plugin-from-oai-plugin/teamsapp.yml.tpl
@@ -17,6 +17,12 @@ provision:
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
 
+  # Validate using manifest schema
+  - uses: teamsApp/validateManifest
+    with:
+      # Path to manifest template
+      manifestPath: ./appPackage/manifest.json
+
   # Build Teams app package with latest env value
   - uses: teamsApp/zipAppPackage
     with:

--- a/templates/csharp/copilot-plugin-from-scratch/teamsapp.local.yml.tpl
+++ b/templates/csharp/copilot-plugin-from-scratch/teamsapp.local.yml.tpl
@@ -20,6 +20,12 @@ provision:
       run:
         echo "::set-teamsfx-env OPENAPI_SERVER_URL=https://${{DEV_TUNNEL_URL}}";
 
+  # Validate using manifest schema
+  - uses: teamsApp/validateManifest
+    with:
+      # Path to manifest template
+      manifestPath: ./appPackage/manifest.json
+
   # Build Teams app package with latest env value
   - uses: teamsApp/zipAppPackage
     with:

--- a/templates/csharp/copilot-plugin-from-scratch/teamsapp.yml.tpl
+++ b/templates/csharp/copilot-plugin-from-scratch/teamsapp.yml.tpl
@@ -42,6 +42,12 @@ provision:
       # will use bicep CLI in PATH if you remove this config.
       bicepCliVersion: v0.9.1
 
+  # Validate using manifest schema
+  - uses: teamsApp/validateManifest
+    with:
+      # Path to manifest template
+      manifestPath: ./appPackage/manifest.json
+
   # Build Teams app package with latest env value
   - uses: teamsApp/zipAppPackage
     with:

--- a/templates/js/copilot-plugin-from-scratch/teamsapp.local.yml.tpl
+++ b/templates/js/copilot-plugin-from-scratch/teamsapp.local.yml.tpl
@@ -21,6 +21,12 @@ provision:
         echo "::set-teamsfx-env FUNC_NAME=repair";
         echo "::set-teamsfx-env FUNC_ENDPOINT=http://localhost:7071";
 
+  # Validate using manifest schema
+  - uses: teamsApp/validateManifest
+    with:
+      # Path to manifest template
+      manifestPath: ./appPackage/manifest.json
+
   # Build Teams app package with latest env value
   - uses: teamsApp/zipAppPackage
     with:

--- a/templates/js/copilot-plugin-from-scratch/teamsapp.yml.tpl
+++ b/templates/js/copilot-plugin-from-scratch/teamsapp.yml.tpl
@@ -42,6 +42,12 @@ provision:
       # will use bicep CLI in PATH if you remove this config.
       bicepCliVersion: v0.9.1
 
+  # Validate using manifest schema
+  - uses: teamsApp/validateManifest
+    with:
+      # Path to manifest template
+      manifestPath: ./appPackage/manifest.json
+
   # Build Teams app package with latest env value
   - uses: teamsApp/zipAppPackage
     with:
@@ -99,6 +105,11 @@ deploy:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
+  # Validate using manifest schema
+  - uses: teamsApp/validateManifest
+    with:
+      # Path to manifest template
+      manifestPath: ./appPackage/manifest.json
   # Build Teams app package with latest env value
   - uses: teamsApp/zipAppPackage
     with:

--- a/templates/ts/copilot-plugin-from-scratch/teamsapp.local.yml.tpl
+++ b/templates/ts/copilot-plugin-from-scratch/teamsapp.local.yml.tpl
@@ -21,6 +21,12 @@ provision:
         echo "::set-teamsfx-env FUNC_NAME=repair";
         echo "::set-teamsfx-env FUNC_ENDPOINT=http://localhost:7071";
 
+  # Validate using manifest schema
+  - uses: teamsApp/validateManifest
+    with:
+      # Path to manifest template
+      manifestPath: ./appPackage/manifest.json
+
   # Build Teams app package with latest env value
   - uses: teamsApp/zipAppPackage
     with:

--- a/templates/ts/copilot-plugin-from-scratch/teamsapp.yml.tpl
+++ b/templates/ts/copilot-plugin-from-scratch/teamsapp.yml.tpl
@@ -42,6 +42,12 @@ provision:
       # will use bicep CLI in PATH if you remove this config.
       bicepCliVersion: v0.9.1
 
+  # Validate using manifest schema
+  - uses: teamsApp/validateManifest
+    with:
+      # Path to manifest template
+      manifestPath: ./appPackage/manifest.json
+
   # Build Teams app package with latest env value
   - uses: teamsApp/zipAppPackage
     with:
@@ -104,6 +110,11 @@ deploy:
 
 # Triggered when 'teamsfx publish' is executed
 publish:
+  # Validate using manifest schema
+  - uses: teamsApp/validateManifest
+    with:
+      # Path to manifest template
+      manifestPath: ./appPackage/manifest.json
   # Build Teams app package with latest env value
   - uses: teamsApp/zipAppPackage
     with:


### PR DESCRIPTION
Reverting change in PR: https://github.com/OfficeDev/TeamsFx/pull/10007

The manifest schema has been fixed, and teamsApp/validateManifest action can be added back.

Related work item: [25124059](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/25124059)