### PR TITLE
feat: test tool install schema for 1.3

### DIFF
--- a/packages/fx-core/resource/yaml-schema/v1.3/yaml.schema.json
+++ b/packages/fx-core/resource/yaml-schema/v1.3/yaml.schema.json
@@ -1221,10 +1221,7 @@
               "type": "object",
               "description": "Install Teams App Test Tool. This will output environment variables specified by `testToolPath` to current environment's .env file.",
               "additionalProperties": false,
-              "required": [
-                "version",
-                "symlinkDir"
-              ],
+              "required": ["version"],
               "properties": {
                 "version": {
                   "oneOf": [

--- a/packages/fx-core/src/component/configManager/validator.ts
+++ b/packages/fx-core/src/component/configManager/validator.ts
@@ -5,10 +5,9 @@ import Ajv, { ValidateFunction } from "ajv";
 import fs from "fs-extra";
 import path from "path";
 import { getResourceFolder } from "../../folder";
-import { isTestToolEnabled } from "../../common/featureFlags";
 
 type Version = string;
-const supportedVersions = ["1.0.0", "1.1.0", "v1.2"];
+const supportedVersions = ["1.0.0", "1.1.0", "v1.2", "v1.3"];
 
 export class Validator {
   impl: Map<Version, { validator: ValidateFunction }>;
@@ -36,7 +35,7 @@ export class Validator {
   }
 
   supportedVersions(): string[] {
-    return [...supportedVersions, ...(isTestToolEnabled() ? ["v1.3"] : [])];
+    return supportedVersions;
   }
 
   private latestSupportedVersion(): string {

--- a/packages/fx-core/src/component/driver/devTool/installDriver.ts
+++ b/packages/fx-core/src/component/driver/devTool/installDriver.ts
@@ -128,7 +128,8 @@ export class ToolsInstallDriverImpl {
     }
 
     if (args.testTool) {
-      await this.resolveTestTool(`${args.testTool.version}`, args.testTool.symlinkDir);
+      // Disable test tool until test tool npm package is published to prevent blocking users who accidentally add this action by intellisense.
+      // await this.resolveTestTool(`${args.testTool.version}`, args.testTool.symlinkDir);
     }
 
     return res;

--- a/packages/fx-core/src/component/driver/devTool/interfaces/InstallToolArgs.ts
+++ b/packages/fx-core/src/component/driver/devTool/interfaces/InstallToolArgs.ts
@@ -34,5 +34,5 @@ interface FuncArgs {
 
 interface TestToolArgs {
   version: string | number;
-  symlinkDir: string;
+  symlinkDir?: string;
 }

--- a/packages/fx-core/tests/component/configManager/validator.test.ts
+++ b/packages/fx-core/tests/component/configManager/validator.test.ts
@@ -9,8 +9,6 @@ import chai from "chai";
 import { describe, it } from "mocha";
 import { Validator } from "../../../src/component/configManager/validator";
 import * as sinon from "sinon";
-import * as featureFlags from "../../../src/common/featureFlags";
-
 describe("yaml validator", () => {
   const validator = new Validator();
   afterEach(() => {
@@ -26,11 +24,7 @@ describe("yaml validator", () => {
       .expect(validator.supportedVersions())
       .contains("1.0.0")
       .and.contains("1.1.0")
-      .and.contains("v1.2");
-  });
-
-  it("should support v1.3 for test tool", () => {
-    sinon.stub(featureFlags, "isTestToolEnabled").resolves(true);
-    chai.expect(validator.supportedVersions()).contain("v1.3");
+      .and.contains("v1.2")
+      .and.contains("v1.3");
   });
 });

--- a/packages/fx-core/tests/component/driver/devTool/installDriver.test.ts
+++ b/packages/fx-core/tests/component/driver/devTool/installDriver.test.ts
@@ -343,45 +343,45 @@ describe("Tools Install Driver test", () => {
       }
     });
 
-    it("Install test tool failed without error", async () => {
-      sandbox.stub(TestToolChecker.prototype, "resolve").resolves({
-        name: "Teams App Test Tool",
-        type: DepsType.TestTool,
-        isInstalled: false,
-        command: "teamsapptester",
-        details: {
-          isLinuxSupported: true,
-          supportedVersions: [],
-          installVersion: "0.1.0",
-          binFolders: ["./devTools/testTool"],
-        },
-      });
-      const res = await toolsInstallDriver.run(
-        { testTool: { version: "~0.1.0", symlinkDir: "./devTools/testTool" } },
-        mockedDriverContext
-      );
-      chai.assert.isTrue(res.isErr());
-    });
-    it("Install test tool failed with error", async () => {
-      sandbox.stub(TestToolChecker.prototype, "resolve").resolves({
-        name: "Teams App Test Tool",
-        type: DepsType.TestTool,
-        isInstalled: false,
-        command: "teamsapptester",
-        details: {
-          isLinuxSupported: true,
-          supportedVersions: [],
-          installVersion: "0.1.0",
-          binFolders: ["./devTools/testTool"],
-        },
-        error: new DepsCheckerError("failed", "help link"),
-      });
-      const res = await toolsInstallDriver.run(
-        { testTool: { version: "~0.1.0", symlinkDir: "./devTools/testTool" } },
-        mockedDriverContext
-      );
-      chai.assert.isTrue(res.isErr());
-    });
+    // it("Install test tool failed without error", async () => {
+    //   sandbox.stub(TestToolChecker.prototype, "resolve").resolves({
+    //     name: "Teams App Test Tool",
+    //     type: DepsType.TestTool,
+    //     isInstalled: false,
+    //     command: "teamsapptester",
+    //     details: {
+    //       isLinuxSupported: true,
+    //       supportedVersions: [],
+    //       installVersion: "0.1.0",
+    //       binFolders: ["./devTools/testTool"],
+    //     },
+    //   });
+    //   const res = await toolsInstallDriver.run(
+    //     { testTool: { version: "~0.1.0", symlinkDir: "./devTools/testTool" } },
+    //     mockedDriverContext
+    //   );
+    //   chai.assert.isTrue(res.isErr());
+    // });
+    // it("Install test tool failed with error", async () => {
+    //   sandbox.stub(TestToolChecker.prototype, "resolve").resolves({
+    //     name: "Teams App Test Tool",
+    //     type: DepsType.TestTool,
+    //     isInstalled: false,
+    //     command: "teamsapptester",
+    //     details: {
+    //       isLinuxSupported: true,
+    //       supportedVersions: [],
+    //       installVersion: "0.1.0",
+    //       binFolders: ["./devTools/testTool"],
+    //     },
+    //     error: new DepsCheckerError("failed", "help link"),
+    //   });
+    //   const res = await toolsInstallDriver.run(
+    //     { testTool: { version: "~0.1.0", symlinkDir: "./devTools/testTool" } },
+    //     mockedDriverContext
+    //   );
+    //   chai.assert.isTrue(res.isErr());
+    // });
     const cases: { name: string; args: unknown; expected: boolean }[] = [
       {
         name: "happy path",


### PR DESCRIPTION
- Disable test tool install logic because YAML 1.3 release is before test tool release. This is to prevent from accidentally using test tool driver between 1.3 schema release and test tool release
- remove feature flag

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/16357625/