### PR TITLE
feat(sdk): support set notification localstore file name with env variable

### DIFF
--- a/packages/sdk/src/conversation/storage.ts
+++ b/packages/sdk/src/conversation/storage.ts
@@ -15,7 +15,8 @@ import {
  * @internal
  */
 export class LocalFileStorage implements NotificationTargetStorage {
-  private readonly localFileName = ".notification.localstore.json";
+  private readonly localFileName =
+    process.env.TEAMSFX_NOTIFICATION_STORE_FILENAME ?? ".notification.localstore.json";
   private readonly filePath: string;
 
   constructor(fileDir: string) {

--- a/packages/sdk/test/unit/node/conversation/storage.spec.ts
+++ b/packages/sdk/test/unit/node/conversation/storage.spec.ts
@@ -11,6 +11,7 @@ import {
   LocalFileStorage,
 } from "../../../../src/conversation/storage";
 import { TestStorage } from "./testUtils";
+import * as path from "path";
 
 chaiUse(chaiPromises);
 
@@ -19,10 +20,12 @@ describe("Notification.Storage Tests - Node", () => {
     const sandbox = sinon.createSandbox();
     let fileContent = "";
     let fileExists = true;
+    let filePath = "";
     let localFileStorage: LocalFileStorage;
 
     beforeEach(() => {
       sandbox.stub(fs, "access").callsFake((path, cb) => {
+        filePath = path.toString();
         if (fileExists) {
           cb(null);
         } else {
@@ -64,6 +67,19 @@ describe("Notification.Storage Tests - Node", () => {
       fileExists = false;
       const data = await localFileStorage.read("key");
       assert.isUndefined(data);
+      assert.strictEqual(path.basename(filePath), ".notification.localstore.json");
+    });
+
+    it("read should load file name from env", async () => {
+      const oldEnv = process.env.TEAMSFX_NOTIFICATION_STORE_FILENAME;
+      process.env.TEAMSFX_NOTIFICATION_STORE_FILENAME = ".notification.testtool.json";
+      fileExists = false;
+
+      const data = await localFileStorage.read("key");
+      assert.isUndefined(data);
+      assert.strictEqual(path.basename(filePath), ".notification.testtool.json");
+
+      process.env.TEAMSFX_NOTIFICATION_STORE_FILENAME = oldEnv;
     });
 
     it("read should return correct data", async () => {


### PR DESCRIPTION
Support to set notification local store via environment variable, so Test Tool can save conversation reference in a separated file.

work item: [24320317](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/24320317)