### PR TITLE
fix: install prerelease acp

### DIFF
--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -1969,7 +1969,9 @@ export async function installAdaptiveCardExt(
         TelemetryEvent.AdaptiveCardPreviewerInstallConfirm,
         getTriggerFromProperty(args)
       );
-      await vscode.commands.executeCommand("workbench.extensions.installExtension", acExtId);
+      await vscode.commands.executeCommand("workbench.extensions.installExtension", acExtId, {
+        installPreReleaseVersion: true,
+      });
     } else {
       ExtTelemetry.sendTelemetryEvent(
         TelemetryEvent.AdaptiveCardPreviewerInstallCancel,


### PR DESCRIPTION
- fix the bug that prerelease version cannot be installed when clicking "Install"
- after ACP releases stable version, this can be reverted

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/21975747/