### PR TITLE
fix: relative path check

### DIFF
--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -600,6 +600,7 @@
   "error.teamsApp.validate.details": "File path: %s, title: %s",
   "error.teamsApp.AppIdNotExistError": "Teams app with ID %s does not exist in Teams Developer Portal.",
   "error.teamsApp.InvalidAppIdError": "Teams app ID %s is invalid, must be a GUID.",
+  "error.teamsApp.createAppPackage.invalidFile": "%s is invalid, it should be in the same or subdirectory of manifest.json",
   "driver.botFramework.description": "creates or updates the bot registration on dev.botframework.com",
   "driver.botFramework.summary.create": "The bot registration has been created successfully (%s).",
   "driver.botFramework.summary.update": "The bot registration has been updated successfully (%s).",

--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -600,7 +600,7 @@
   "error.teamsApp.validate.details": "File path: %s, title: %s",
   "error.teamsApp.AppIdNotExistError": "Teams app with ID %s does not exist in Teams Developer Portal.",
   "error.teamsApp.InvalidAppIdError": "Teams app ID %s is invalid, must be a GUID.",
-  "error.teamsApp.createAppPackage.invalidFile": "%s is invalid, it should be in the same or subdirectory of manifest.json",
+  "error.teamsApp.createAppPackage.invalidFile": "%s is invalid, it should be in the same directory as manifest.json or a subdirectory of it.",
   "driver.botFramework.description": "creates or updates the bot registration on dev.botframework.com",
   "driver.botFramework.summary.create": "The bot registration has been created successfully (%s).",
   "driver.botFramework.summary.update": "The bot registration has been updated successfully (%s).",

--- a/packages/fx-core/src/component/driver/teamsApp/createAppPackage.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/createAppPackage.ts
@@ -98,6 +98,7 @@ export class CreateAppPackageDriver implements StepDriver {
       return err(error);
     }
     const colorFileRelativePath = path.relative(appDirectory, colorFile);
+    console.log(`My test: ${colorFileRelativePath}`);
     if (colorFileRelativePath.startsWith("..\\")) {
       return err(new InvalidFileOutsideOfTheDirectotryError(colorFile));
     }

--- a/packages/fx-core/src/component/driver/teamsApp/createAppPackage.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/createAppPackage.ts
@@ -98,7 +98,6 @@ export class CreateAppPackageDriver implements StepDriver {
       return err(error);
     }
     const colorFileRelativePath = path.relative(appDirectory, colorFile);
-    console.log(`My test: ${colorFileRelativePath}`);
     if (colorFileRelativePath.startsWith("..")) {
       return err(new InvalidFileOutsideOfTheDirectotryError(colorFile));
     }

--- a/packages/fx-core/src/component/driver/teamsApp/createAppPackage.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/createAppPackage.ts
@@ -23,6 +23,7 @@ import { CreateAppPackageArgs } from "./interfaces/CreateAppPackageArgs";
 import { manifestUtils } from "./utils/ManifestUtils";
 import { expandEnvironmentVariable, getEnvironmentVariables } from "../../utils/common";
 import { TelemetryPropertyKey } from "./utils/telemetry";
+import { InvalidFileOutsideOfTheDirectotryError } from "../../../error/teamsApp";
 
 export const actionName = "teamsApp/zipAppPackage";
 
@@ -87,7 +88,7 @@ export class CreateAppPackageDriver implements StepDriver {
 
     const appDirectory = path.dirname(manifestPath);
 
-    const colorFile = path.join(appDirectory, manifest.icons.color);
+    const colorFile = path.resolve(appDirectory, manifest.icons.color);
     if (!(await fs.pathExists(colorFile))) {
       const error = new FileNotFoundError(
         actionName,
@@ -96,8 +97,12 @@ export class CreateAppPackageDriver implements StepDriver {
       );
       return err(error);
     }
+    const colorFileRelativePath = path.relative(appDirectory, colorFile);
+    if (colorFileRelativePath.startsWith("..\\")) {
+      return err(new InvalidFileOutsideOfTheDirectotryError(colorFile));
+    }
 
-    const outlineFile = path.join(appDirectory, manifest.icons.outline);
+    const outlineFile = path.resolve(appDirectory, manifest.icons.outline);
     if (!(await fs.pathExists(outlineFile))) {
       const error = new FileNotFoundError(
         actionName,
@@ -105,6 +110,10 @@ export class CreateAppPackageDriver implements StepDriver {
         "https://aka.ms/teamsfx-actions/teamsapp-zipAppPackage"
       );
       return err(error);
+    }
+    const outlineFileRelativePath = path.relative(appDirectory, outlineFile);
+    if (outlineFileRelativePath.startsWith("..\\")) {
+      return err(new InvalidFileOutsideOfTheDirectotryError(outlineFile));
     }
 
     // pre-check existence
@@ -132,10 +141,8 @@ export class CreateAppPackageDriver implements StepDriver {
     zip.addFile(Constants.MANIFEST_FILE, Buffer.from(JSON.stringify(manifest, null, 4)));
 
     // outline.png & color.png, relative path
-    let dir = path.dirname(manifest.icons.color);
-    zip.addLocalFile(colorFile, dir === "." ? "" : dir);
-    dir = path.dirname(manifest.icons.outline);
-    zip.addLocalFile(outlineFile, dir === "." ? "" : dir);
+    zip.addFile(colorFileRelativePath, Buffer.from(colorFile));
+    zip.addFile(outlineFileRelativePath, Buffer.from(outlineFile));
 
     // localization file
     if (
@@ -145,9 +152,12 @@ export class CreateAppPackageDriver implements StepDriver {
     ) {
       for (const language of manifest.localizationInfo.additionalLanguages) {
         const file = language.file;
-        const fileName = `${appDirectory}/${file}`;
-        const dir = path.dirname(file);
-        zip.addLocalFile(fileName, dir === "." ? "" : dir);
+        const fileName = path.resolve(appDirectory, file);
+        const relativePath = path.relative(appDirectory, fileName);
+        if (relativePath.startsWith("..\\")) {
+          return err(new InvalidFileOutsideOfTheDirectotryError(fileName));
+        }
+        zip.addFile(relativePath, Buffer.from(fileName));
       }
     }
 
@@ -158,7 +168,10 @@ export class CreateAppPackageDriver implements StepDriver {
       manifest.composeExtensions[0].composeExtensionType == "apiBased" &&
       manifest.composeExtensions[0].apiSpecificationFile
     ) {
-      const apiSpecificationFile = `${appDirectory}/${manifest.composeExtensions[0].apiSpecificationFile}`;
+      const apiSpecificationFile = path.resolve(
+        appDirectory,
+        manifest.composeExtensions[0].apiSpecificationFile
+      );
       if (!(await fs.pathExists(apiSpecificationFile))) {
         return err(
           new FileNotFoundError(
@@ -167,6 +180,10 @@ export class CreateAppPackageDriver implements StepDriver {
             "https://aka.ms/teamsfx-actions/teamsapp-zipAppPackage"
           )
         );
+      }
+      const relativePath = path.relative(appDirectory, apiSpecificationFile);
+      if (relativePath.startsWith("..\\")) {
+        return err(new InvalidFileOutsideOfTheDirectotryError(apiSpecificationFile));
       }
       const expandedEnvVarResult = await CreateAppPackageDriver.expandOpenAPIEnvVars(
         apiSpecificationFile,
@@ -177,18 +194,15 @@ export class CreateAppPackageDriver implements StepDriver {
       }
       const openAPIContent = expandedEnvVarResult.value;
       const attr = await fs.stat(apiSpecificationFile);
-      zip.addFile(
-        manifest.composeExtensions[0].apiSpecificationFile,
-        Buffer.from(openAPIContent),
-        "",
-        attr.mode
-      );
-      // zip.addLocalFile(apiSpecificationFile, dir === "." ? "" : dir);
+      zip.addFile(relativePath, Buffer.from(openAPIContent), "", attr.mode);
 
       if (manifest.composeExtensions[0].commands.length > 0) {
         for (const command of manifest.composeExtensions[0].commands) {
           if (command.apiResponseRenderingTemplateFile) {
-            const adaptiveCardFile = `${appDirectory}/${command.apiResponseRenderingTemplateFile}`;
+            const adaptiveCardFile = path.resolve(
+              appDirectory,
+              command.apiResponseRenderingTemplateFile
+            );
             if (!(await fs.pathExists(adaptiveCardFile))) {
               return err(
                 new FileNotFoundError(
@@ -198,8 +212,11 @@ export class CreateAppPackageDriver implements StepDriver {
                 )
               );
             }
-            const dir = path.dirname(command.apiResponseRenderingTemplateFile);
-            zip.addLocalFile(adaptiveCardFile, dir === "." ? "" : dir);
+            const relativePath = path.relative(appDirectory, adaptiveCardFile);
+            if (relativePath.startsWith("..\\")) {
+              return err(new InvalidFileOutsideOfTheDirectotryError(adaptiveCardFile));
+            }
+            zip.addFile(relativePath, Buffer.from(openAPIContent), "");
           }
         }
       }

--- a/packages/fx-core/src/component/driver/teamsApp/createAppPackage.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/createAppPackage.ts
@@ -99,7 +99,7 @@ export class CreateAppPackageDriver implements StepDriver {
     }
     const colorFileRelativePath = path.relative(appDirectory, colorFile);
     console.log(`My test: ${colorFileRelativePath}`);
-    if (colorFileRelativePath.startsWith("..\\")) {
+    if (colorFileRelativePath.startsWith("..")) {
       return err(new InvalidFileOutsideOfTheDirectotryError(colorFile));
     }
 
@@ -113,7 +113,7 @@ export class CreateAppPackageDriver implements StepDriver {
       return err(error);
     }
     const outlineFileRelativePath = path.relative(appDirectory, outlineFile);
-    if (outlineFileRelativePath.startsWith("..\\")) {
+    if (outlineFileRelativePath.startsWith("..")) {
       return err(new InvalidFileOutsideOfTheDirectotryError(outlineFile));
     }
 
@@ -155,7 +155,7 @@ export class CreateAppPackageDriver implements StepDriver {
         const file = language.file;
         const fileName = path.resolve(appDirectory, file);
         const relativePath = path.relative(appDirectory, fileName);
-        if (relativePath.startsWith("..\\")) {
+        if (relativePath.startsWith("..")) {
           return err(new InvalidFileOutsideOfTheDirectotryError(fileName));
         }
         zip.addFile(relativePath, Buffer.from(fileName));
@@ -183,7 +183,7 @@ export class CreateAppPackageDriver implements StepDriver {
         );
       }
       const relativePath = path.relative(appDirectory, apiSpecificationFile);
-      if (relativePath.startsWith("..\\")) {
+      if (relativePath.startsWith("..")) {
         return err(new InvalidFileOutsideOfTheDirectotryError(apiSpecificationFile));
       }
       const expandedEnvVarResult = await CreateAppPackageDriver.expandOpenAPIEnvVars(
@@ -214,7 +214,7 @@ export class CreateAppPackageDriver implements StepDriver {
               );
             }
             const relativePath = path.relative(appDirectory, adaptiveCardFile);
-            if (relativePath.startsWith("..\\")) {
+            if (relativePath.startsWith("..")) {
               return err(new InvalidFileOutsideOfTheDirectotryError(adaptiveCardFile));
             }
             zip.addFile(relativePath, Buffer.from(openAPIContent), "");

--- a/packages/fx-core/src/component/driver/teamsApp/createAppPackage.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/createAppPackage.ts
@@ -141,8 +141,10 @@ export class CreateAppPackageDriver implements StepDriver {
     zip.addFile(Constants.MANIFEST_FILE, Buffer.from(JSON.stringify(manifest, null, 4)));
 
     // outline.png & color.png, relative path
-    zip.addFile(colorFileRelativePath, Buffer.from(colorFile));
-    zip.addFile(outlineFileRelativePath, Buffer.from(outlineFile));
+    let dir = path.dirname(manifest.icons.color);
+    zip.addLocalFile(colorFile, dir === "." ? "" : dir);
+    dir = path.dirname(manifest.icons.outline);
+    zip.addLocalFile(outlineFile, dir === "." ? "" : dir);
 
     // localization file
     if (
@@ -157,7 +159,8 @@ export class CreateAppPackageDriver implements StepDriver {
         if (relativePath.startsWith("..")) {
           return err(new InvalidFileOutsideOfTheDirectotryError(fileName));
         }
-        zip.addFile(relativePath, Buffer.from(fileName));
+        const dir = path.dirname(file);
+        zip.addLocalFile(fileName, dir === "." ? "" : dir);
       }
     }
 
@@ -194,7 +197,12 @@ export class CreateAppPackageDriver implements StepDriver {
       }
       const openAPIContent = expandedEnvVarResult.value;
       const attr = await fs.stat(apiSpecificationFile);
-      zip.addFile(relativePath, Buffer.from(openAPIContent), "", attr.mode);
+      zip.addFile(
+        manifest.composeExtensions[0].apiSpecificationFile,
+        Buffer.from(openAPIContent),
+        "",
+        attr.mode
+      );
 
       if (manifest.composeExtensions[0].commands.length > 0) {
         for (const command of manifest.composeExtensions[0].commands) {
@@ -216,7 +224,8 @@ export class CreateAppPackageDriver implements StepDriver {
             if (relativePath.startsWith("..")) {
               return err(new InvalidFileOutsideOfTheDirectotryError(adaptiveCardFile));
             }
-            zip.addFile(relativePath, Buffer.from(openAPIContent), "");
+            const dir = path.dirname(command.apiResponseRenderingTemplateFile);
+            zip.addLocalFile(adaptiveCardFile, dir === "." ? "" : dir);
           }
         }
       }

--- a/packages/fx-core/src/error/teamsApp.ts
+++ b/packages/fx-core/src/error/teamsApp.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { SystemError, SystemErrorOptions } from "@microsoft/teamsfx-api";
+import {
+  SystemError,
+  SystemErrorOptions,
+  UserError,
+  UserErrorOptions,
+} from "@microsoft/teamsfx-api";
 import { getDefaultString, getLocalizedString } from "../common/localizeUtils";
 import { ErrorCategory } from "./types";
 import { Constants } from "../component/driver/teamsApp/constants";
@@ -39,6 +44,18 @@ export class CheckSideloadingPermissionFailedError extends SystemError {
         correlationId,
         extraData
       ),
+      categories: [ErrorCategory.External],
+    };
+    super(errorOptions);
+  }
+}
+
+export class InvalidFileOutsideOfTheDirectotryError extends UserError {
+  constructor(filePath: string) {
+    const errorOptions: UserErrorOptions = {
+      source: Constants.PLUGIN_NAME,
+      message: getDefaultString("error.teamsApp.createAppPackage.invalidFile", filePath),
+      displayMessage: getLocalizedString("error.teamsApp.createAppPackage.invalidFile", filePath),
       categories: [ErrorCategory.External],
     };
     super(errorOptions);

--- a/packages/fx-core/tests/component/driver/teamsApp/createAppPackage.test.ts
+++ b/packages/fx-core/tests/component/driver/teamsApp/createAppPackage.test.ts
@@ -499,4 +499,112 @@ describe("teamsApp/createAppPackage", async () => {
       chai.assert.isTrue(result.error instanceof InvalidFileOutsideOfTheDirectotryError);
     }
   });
+
+  it("invalid outline file", async () => {
+    const args: CreateAppPackageArgs = {
+      manifestPath:
+        "./tests/plugins/resource/appstudio/resources-multi-env/templates/appPackage/v3.manifest.template.json",
+      outputZipPath:
+        "./tests/plugins/resource/appstudio/resources-multi-env/build/appPackage/appPackage.dev.zip",
+      outputJsonPath:
+        "./tests/plugins/resource/appstudio/resources-multi-env/build/appPackage/manifest.dev.json",
+    };
+
+    const manifest = new TeamsAppManifest();
+    manifest.icons = {
+      color: "resources/color.png",
+      outline: "../outline.png",
+    };
+    sinon.stub(manifestUtils, "getManifestV3").resolves(ok(manifest));
+    sinon.stub(fs, "pathExists").callsFake((filePath) => {
+      return true;
+    });
+    const result = (await teamsAppDriver.execute(args, mockedDriverContext)).result;
+    chai.assert(result.isErr());
+    if (result.isErr()) {
+      chai.assert.isTrue(result.error instanceof InvalidFileOutsideOfTheDirectotryError);
+    }
+  });
+
+  it("invalid api spec file", async () => {
+    const args: CreateAppPackageArgs = {
+      manifestPath:
+        "./tests/plugins/resource/appstudio/resources-multi-env/templates/appPackage/v3.manifest.template.json",
+      outputZipPath:
+        "./tests/plugins/resource/appstudio/resources-multi-env/build/appPackage/appPackage.dev.zip",
+      outputJsonPath:
+        "./tests/plugins/resource/appstudio/resources-multi-env/build/appPackage/manifest.dev.json",
+    };
+
+    const manifest = new TeamsAppManifest();
+    manifest.composeExtensions = [
+      {
+        composeExtensionType: "apiBased",
+        apiSpecificationFile: "../openai.yml",
+        commands: [
+          {
+            id: "GET /repairs",
+            apiResponseRenderingTemplateFile: "resources/repairs.json",
+            title: "fake",
+          },
+        ],
+        botId: "",
+      },
+    ];
+    manifest.icons = {
+      color: "resources/color.png",
+      outline: "resources/outline.png",
+    };
+
+    sinon.stub(manifestUtils, "getManifestV3").resolves(ok(manifest));
+    sinon.stub(fs, "pathExists").callsFake((filePath) => {
+      return true;
+    });
+    const result = (await teamsAppDriver.execute(args, mockedDriverContext)).result;
+    chai.assert(result.isErr());
+    if (result.isErr()) {
+      chai.assert.isTrue(result.error instanceof InvalidFileOutsideOfTheDirectotryError);
+    }
+  });
+
+  it("invalid response template file", async () => {
+    const args: CreateAppPackageArgs = {
+      manifestPath:
+        "./tests/plugins/resource/appstudio/resources-multi-env/templates/appPackage/v3.manifest.template.json",
+      outputZipPath:
+        "./tests/plugins/resource/appstudio/resources-multi-env/build/appPackage/appPackage.dev.zip",
+      outputJsonPath:
+        "./tests/plugins/resource/appstudio/resources-multi-env/build/appPackage/manifest.dev.json",
+    };
+
+    const manifest = new TeamsAppManifest();
+    manifest.composeExtensions = [
+      {
+        composeExtensionType: "apiBased",
+        apiSpecificationFile: "resources/openai.yml",
+        commands: [
+          {
+            id: "GET /repairs",
+            apiResponseRenderingTemplateFile: "../repairs.json",
+            title: "fake",
+          },
+        ],
+        botId: "",
+      },
+    ];
+    manifest.icons = {
+      color: "resources/color.png",
+      outline: "resources/outline.png",
+    };
+
+    sinon.stub(manifestUtils, "getManifestV3").resolves(ok(manifest));
+    sinon.stub(fs, "pathExists").callsFake((filePath) => {
+      return true;
+    });
+    const result = (await teamsAppDriver.execute(args, mockedDriverContext)).result;
+    chai.assert(result.isErr());
+    if (result.isErr()) {
+      chai.assert.isTrue(result.error instanceof InvalidFileOutsideOfTheDirectotryError);
+    }
+  });
 });


### PR DESCRIPTION
Bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/24879976

1) Files outside directory is not allowed:
![image](https://github.com/OfficeDev/TeamsFx/assets/71362691/496173b1-2cca-48d5-9377-3918f2020c5c)

2) Deal with "../", this cannot be the filename in zip directly
![image](https://github.com/OfficeDev/TeamsFx/assets/71362691/d513aed4-62fe-4863-81a4-847db0d303e8)