### PR TITLE
fix: symlinkDir for testTool doesn't need to be optional

### DIFF
--- a/packages/fx-core/resource/yaml-schema/v1.3/yaml.schema.json
+++ b/packages/fx-core/resource/yaml-schema/v1.3/yaml.schema.json
@@ -1222,7 +1222,7 @@
               "type": "object",
               "description": "Install Teams App Test Tool. This will output environment variables specified by `testToolPath` to current environment's .env file.",
               "additionalProperties": false,
-              "required": ["version"],
+              "required": ["version", "symlinkDir"],
               "properties": {
                 "version": {
                   "oneOf": [


### PR DESCRIPTION
Because 

1. VS may well not use yaml to install test tool so no need to consider schema for VS
2. func install has optional symlinkDir because of historic version so no need to keep consistent with it
3. If use manually delete symlinkDir property, start test tool will fail.

As a result, change symlinkDir to required.

