### PR TITLE
perf(spec-parser): update add new api logic to use list function

### DIFF
--- a/packages/fx-core/src/common/spec-parser/interfaces.ts
+++ b/packages/fx-core/src/common/spec-parser/interfaces.ts
@@ -85,7 +85,6 @@ export enum ErrorType {
   MultipleAPIKeyNotSupported = "multiple-api-key-not-supported",
 
   ListFailed = "list-failed",
-  ListOperationMapFailed = "list-operation-map-failed",
   listSupportedAPIInfoFailed = "list-supported-api-info-failed",
   FilterSpecFailed = "filter-spec-failed",
   UpdateManifestFailed = "update-manifest-failed",
@@ -192,5 +191,6 @@ export interface APIInfo {
 export interface ListAPIResult {
   api: string;
   server: string;
+  operationId: string;
   auth?: OpenAPIV3.ApiKeySecurityScheme;
 }

--- a/packages/fx-core/src/common/spec-parser/specParser.browser.ts
+++ b/packages/fx-core/src/common/spec-parser/specParser.browser.ts
@@ -141,15 +141,6 @@ export class SpecParser {
   }
 
   /**
-   * List all the OpenAPI operations in the specification file and return a map of operationId and operation path.
-   * @returns A map of operationId and operation path, such as [{'getPetById': 'GET /pets/{petId}'}, {'getUser': 'GET /user/{userId}'}]
-   */
-  // eslint-disable-next-line @typescript-eslint/require-await
-  async listOperationMap(): Promise<Map<string, string>> {
-    throw new Error("Method not implemented.");
-  }
-
-  /**
    * Generates and update artifacts from the OpenAPI specification file. Generate Adaptive Cards, update Teams app manifest, and generate a new OpenAPI specification file.
    * @param manifestPath A file path of the Teams app manifest file to update.
    * @param filter An array of strings that represent the filters to apply when generating the artifacts. If filter is empty, it would process nothing.

--- a/packages/fx-core/src/component/generator/copilotPlugin/helper.ts
+++ b/packages/fx-core/src/component/generator/copilotPlugin/helper.ts
@@ -181,8 +181,11 @@ export async function listOperations(
       const manifest = await manifestUtils._readAppManifest(teamsManifestPath);
       if (manifest.isOk()) {
         const existingOperationIds = manifestUtils.getOperationIds(manifest.value);
-        const operationMaps = await specParser.listOperationMap();
-        const existingOperations = existingOperationIds.map((key) => operationMaps.get(key));
+
+        const existingOperations = existingOperationIds.map(
+          (key) => operations.find((item) => item.operationId === key)?.api
+        );
+
         operations = operations.filter(
           (operation: ListAPIResult) => !existingOperations.includes(operation.api)
         );

--- a/packages/fx-core/src/core/FxCore.ts
+++ b/packages/fx-core/src/core/FxCore.ts
@@ -1150,7 +1150,9 @@ export class FxCore {
     ConcurrentLockerMW,
   ])
   async copilotPluginAddAPI(inputs: Inputs): Promise<Result<undefined, FxError>> {
-    const newOperations = inputs[QuestionNames.ApiOperation] as string[];
+    const newOperations = (inputs[QuestionNames.ApiOperation] as ApiOperation[])?.map(
+      (item) => item.id
+    );
     const url = inputs[QuestionNames.ApiSpecLocation] ?? inputs.openAIPluginManifest?.api.url;
     const manifestPath = inputs[QuestionNames.ManifestPath];
 
@@ -1162,15 +1164,16 @@ export class FxCore {
     const apiSpecificationFile = manifestRes.value.composeExtensions![0].apiSpecificationFile;
     const outputAPISpecPath = path.join(path.dirname(manifestPath), apiSpecificationFile!);
 
-    // Merge exisiting operations in manifest.json
+    // Merge existing operations in manifest.json
     const specParser = new SpecParser(url, { allowAPIKeyAuth: isApiKeyEnabled() });
     const existingOperationIds = manifestUtils.getOperationIds(manifestRes.value);
-    const operationMaps = await specParser.listOperationMap();
+    const apiResultList = await specParser.list();
 
     const existingOperations: string[] = [];
     for (const id of existingOperationIds) {
-      if (operationMaps.get(id)) {
-        existingOperations.push(operationMaps.get(id)!);
+      const operation = apiResultList.find((item) => item.operationId === id);
+      if (operation) {
+        existingOperations.push(operation.api);
       }
     }
 

--- a/packages/fx-core/src/question/create.ts
+++ b/packages/fx-core/src/question/create.ts
@@ -1578,8 +1578,8 @@ export function apiOperationQuestion(includeExistingAPIs = true): MultiSelectQue
           if (operation) {
             if (operation.data.authName) {
               authNames.add(operation.data.authName);
+              serverUrls.add(operation.data.serverUrl);
             }
-            serverUrls.add(operation.data.serverUrl);
           }
         }
 

--- a/packages/fx-core/tests/common/spec-parser/specParser.browser.test.ts
+++ b/packages/fx-core/tests/common/spec-parser/specParser.browser.test.ts
@@ -777,19 +777,6 @@ describe("SpecParser in Browser", () => {
     });
   });
 
-  describe("listOperationMap", async () => {
-    it("should throw an error if loading the spec fails", async () => {
-      try {
-        const specPath = "valid-spec.yaml";
-        const specParser = new SpecParser(specPath);
-        await specParser.listOperationMap();
-        expect.fail("Should throw not implemented error");
-      } catch (error) {
-        expect(error.message).to.equal("Method not implemented.");
-      }
-    });
-  });
-
   describe("list", () => {
     it("should throw an error when the SwaggerParser library throws an error", async () => {
       try {

--- a/packages/fx-core/tests/common/spec-parser/specParser.test.ts
+++ b/packages/fx-core/tests/common/spec-parser/specParser.test.ts
@@ -1059,145 +1059,6 @@ describe("SpecParser", () => {
     });
   });
 
-  describe("listOperationMap", () => {
-    it("should return a map of operation IDs to paths", async () => {
-      const specPath = "valid-spec.yaml";
-      const specParser = new SpecParser(specPath);
-      const spec = {
-        paths: {
-          "/pets": {
-            get: {
-              operationId: "getPetById",
-              security: [{ api_key: [] }],
-            },
-            post: {
-              operationId: "createPet",
-              requestBody: {
-                content: {
-                  "application/json": {
-                    schema: {
-                      type: "object",
-                      required: ["name"],
-                      properties: {
-                        name: {
-                          type: "string",
-                        },
-                      },
-                    },
-                  },
-                },
-              },
-              responses: {
-                200: {
-                  content: {
-                    "application/json": {
-                      schema: {
-                        type: "object",
-                        properties: {
-                          name: {
-                            type: "string",
-                          },
-                        },
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-          "/user/{userId}": {
-            get: {
-              operationId: "getUserById",
-              parameters: [
-                {
-                  name: "userId",
-                  in: "path",
-                  schema: {
-                    type: "string",
-                  },
-                },
-              ],
-              responses: {
-                200: {
-                  content: {
-                    "application/json": {
-                      schema: {
-                        type: "object",
-                        properties: {
-                          name: {
-                            type: "string",
-                          },
-                        },
-                      },
-                    },
-                  },
-                },
-              },
-            },
-            post: {
-              operationId: "createUser",
-              security: [{ api_key: [] }],
-            },
-          },
-          "/store/order": {
-            get: {
-              parameters: [
-                {
-                  name: "orderId",
-                  in: "query",
-                  schema: {
-                    type: "string",
-                  },
-                },
-              ],
-              responses: {
-                201: {
-                  content: {
-                    "application/json": {
-                      schema: {},
-                    },
-                  },
-                },
-              },
-            },
-            post: {
-              operationId: "placeOrder",
-            },
-          },
-        },
-      };
-
-      const parseStub = sinon.stub(specParser.parser, "parse").resolves(spec as any);
-      const dereferenceStub = sinon.stub(specParser.parser, "dereference").resolves(spec as any);
-
-      const expected = new Map<string, string>([
-        ["createPet", "POST /pets"],
-        ["getUserById", "GET /user/{userId}"],
-        ["getStoreOrder", "GET /store/order"],
-      ]);
-      const result = await specParser.listOperationMap();
-      expect(result).to.deep.equal(expected);
-    });
-
-    it("should throw an error if loading the spec fails", async () => {
-      const specPath = "valid-spec.yaml";
-      const specParser = new SpecParser(specPath);
-      const expectedError = new SpecParserError(
-        "Failed to load spec",
-        ErrorType.ListOperationMapFailed
-      );
-
-      sinon.stub(specParser as any, "loadSpec").rejects(expectedError);
-      try {
-        await specParser.listOperationMap();
-        expect.fail("Expected an error to be thrown");
-      } catch (err) {
-        expect((err as SpecParserError).message).contain("Failed to load spec");
-        expect((err as SpecParserError).errorType).to.equal(ErrorType.ListOperationMapFailed);
-      }
-    });
-  });
-
   describe("list", () => {
     it("should return a list of HTTP methods and paths for all GET with 1 parameter and without security", async () => {
       const specPath = "valid-spec.yaml";
@@ -1266,6 +1127,7 @@ describe("SpecParser", () => {
         {
           api: "GET /user/{userId}",
           server: "https://server1",
+          operationId: "getUserById",
         },
       ]);
     });
@@ -1341,6 +1203,7 @@ describe("SpecParser", () => {
         {
           api: "GET /user/{userId}",
           server: "https://server5",
+          operationId: "getUserById",
         },
       ]);
     });
@@ -1408,6 +1271,7 @@ describe("SpecParser", () => {
           api: "GET /user/{userId}",
           server: "https://server1",
           auth: { type: "apiKey", name: "api_key", in: "header" },
+          operationId: "getUserById",
         },
       ]);
     });
@@ -1531,11 +1395,13 @@ describe("SpecParser", () => {
           api: "GET /user/{userId}",
           server: "https://server1",
           auth: { type: "apiKey", name: "api_key1", in: "header" },
+          operationId: "getUserById",
         },
         {
           api: "POST /user/{userId}",
           server: "https://server1",
           auth: { type: "apiKey", name: "api_key1", in: "header" },
+          operationId: "postUserById",
         },
       ]);
     });

--- a/packages/fx-core/tests/common/spec-parser/specParser.test.ts
+++ b/packages/fx-core/tests/common/spec-parser/specParser.test.ts
@@ -1132,6 +1132,71 @@ describe("SpecParser", () => {
       ]);
     });
 
+    it("should generate an operationId if not exist", async () => {
+      const specPath = "valid-spec.yaml";
+      const specParser = new SpecParser(specPath);
+      const spec = {
+        servers: [
+          {
+            url: "https://server1",
+          },
+        ],
+        paths: {
+          "/user/{userId}": {
+            get: {
+              parameters: [
+                {
+                  name: "userId",
+                  in: "path",
+                  schema: {
+                    type: "string",
+                  },
+                },
+              ],
+              responses: {
+                200: {
+                  content: {
+                    "application/json": {
+                      schema: {
+                        type: "object",
+                        properties: {
+                          name: {
+                            type: "string",
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            post: {
+              operationId: "createUser",
+              security: [{ api_key: [] }],
+            },
+          },
+          "/store/order": {
+            post: {
+              operationId: "placeOrder",
+            },
+          },
+        },
+      };
+
+      const parseStub = sinon.stub(specParser.parser, "parse").resolves(spec as any);
+      const dereferenceStub = sinon.stub(specParser.parser, "dereference").resolves(spec as any);
+
+      const result = await specParser.list();
+
+      expect(result).to.deep.equal([
+        {
+          api: "GET /user/{userId}",
+          server: "https://server1",
+          operationId: "getUserUserId",
+        },
+      ]);
+    });
+
     it("should return correct server information", async () => {
       const specPath = "valid-spec.yaml";
       const specParser = new SpecParser(specPath, { allowAPIKeyAuth: true });

--- a/packages/fx-core/tests/core/FxCore.test.ts
+++ b/packages/fx-core/tests/core/FxCore.test.ts
@@ -1507,16 +1507,16 @@ describe("copilotPlugin", async () => {
         commands: [],
       },
     ];
-    const operationMap = new Map<string, string>([
-      ["getUserById", "GET /user/{userId}"],
-      ["getStoreOrder", "GET /store/order"],
-    ]);
+    const listResult = [
+      { operationId: "getUserById", server: "https://server", api: "GET /user/{userId}" },
+      { operationId: "getStoreOrder", server: "https://server", api: "GET /store/order" },
+    ];
     const core = new FxCore(tools);
     sinon.stub(SpecParser.prototype, "generate").resolves({
       warnings: [],
       allSuccess: true,
     });
-    sinon.stub(SpecParser.prototype, "listOperationMap").resolves(operationMap);
+    sinon.stub(SpecParser.prototype, "list").resolves(listResult);
     sinon.stub(manifestUtils, "_readAppManifest").resolves(ok(manifest));
     sinon.stub(validationUtils, "validateInputs").resolves(undefined);
     const result = await core.copilotPluginAddAPI(inputs);
@@ -1560,16 +1560,18 @@ describe("copilotPlugin", async () => {
         ],
       },
     ];
-    const operationMap = new Map<string, string>([
-      ["getUserById", "GET /user/{userId}"],
-      ["getStoreOrder", "GET /store/order"],
-    ]);
+
+    const listResult = [
+      { operationId: "getUserById", server: "https://server", api: "GET /user/{userId}" },
+      { operationId: "getStoreOrder", server: "https://server", api: "GET /store/order" },
+    ];
+
     const core = new FxCore(tools);
     sinon.stub(SpecParser.prototype, "generate").resolves({
       warnings: [{ type: WarningType.OperationOnlyContainsOptionalParam, content: "fakeMessage" }],
       allSuccess: false,
     });
-    sinon.stub(SpecParser.prototype, "listOperationMap").resolves(operationMap);
+    sinon.stub(SpecParser.prototype, "list").resolves(listResult);
     sinon.stub(manifestUtils, "_readAppManifest").resolves(ok(manifest));
     sinon.stub(validationUtils, "validateInputs").resolves(undefined);
     const result = await core.copilotPluginAddAPI(inputs);

--- a/packages/fx-core/tests/question/create.test.ts
+++ b/packages/fx-core/tests/question/create.test.ts
@@ -1147,6 +1147,38 @@ describe("scaffold question", () => {
           );
         });
 
+        it(" validate operations should success when selected APIs with multiple server url but only one contains auth", async () => {
+          const question = apiOperationQuestion();
+          const inputs: Inputs = {
+            platform: Platform.VSCode,
+            [QuestionNames.ApiSpecLocation]: "apispec",
+            supportedApisFromApiSpec: [
+              {
+                id: "operation1",
+                label: "operation1",
+                groupName: "1",
+                data: {
+                  authName: "auth1",
+                  serverUrl: "https://server1",
+                },
+              },
+              {
+                id: "operation2",
+                label: "operation2",
+                groupName: "2",
+                data: {
+                  serverUrl: "https://server2",
+                },
+              },
+            ],
+          };
+
+          const validationSchema = question.validation as FuncValidation<string[]>;
+          const res = await validationSchema.validFunc!(["operation1", "operation2"], inputs);
+
+          assert.isUndefined(res);
+        });
+
         it(" validate operations should return error message when select APIs with multiple auth", async () => {
           const question = apiOperationQuestion();
           const inputs: Inputs = {
@@ -1247,8 +1279,9 @@ describe("scaffold question", () => {
                 in: "header",
                 type: "apiKey",
               },
+              operationId: "getOperation1",
             },
-            { api: "get operation2", server: "https://server2" },
+            { api: "get operation2", server: "https://server2", operationId: "getOperation2" },
           ]);
           sandbox.stub(fs, "pathExists").resolves(true);
 
@@ -1294,9 +1327,10 @@ describe("scaffold question", () => {
                 in: "header",
                 type: "apiKey",
               },
+              operationId: "getOperation1",
             },
 
-            { api: "get operation2", server: "https://server2" },
+            { api: "get operation2", server: "https://server2", operationId: "getOperation2" },
           ]);
 
           const validationSchema = question.validation as FuncValidation<string>;
@@ -1338,8 +1372,9 @@ describe("scaffold question", () => {
                 in: "header",
                 type: "apiKey",
               },
+              operationId: "getOperation1",
             },
-            { api: "get operation2", server: "https://server2" },
+            { api: "get operation2", server: "https://server2", operationId: "getOperation2" },
           ]);
 
           let err: Error | undefined = undefined;
@@ -1448,10 +1483,6 @@ describe("scaffold question", () => {
             platform: Platform.VSCode,
             "manifest-path": "fakePath",
           };
-          const operationMap = new Map<string, string>([
-            ["getUserById", "GET /user/{userId}"],
-            ["getStoreOrder", "GET /store/order"],
-          ]);
 
           sandbox
             .stub(SpecParser.prototype, "validate")
@@ -1465,10 +1496,10 @@ describe("scaffold question", () => {
                 in: "header",
                 type: "apiKey",
               },
+              operationId: "getUserById",
             },
-            { api: "GET /store/order", server: "https://server2" },
+            { api: "GET /store/order", server: "https://server2", operationId: "getStoreOrder" },
           ]);
-          sandbox.stub(SpecParser.prototype, "listOperationMap").resolves(operationMap);
           sandbox.stub(manifestUtils, "_readAppManifest").resolves(ok({} as any));
           sandbox.stub(manifestUtils, "getOperationIds").returns(["getUserById"]);
           sandbox.stub(fs, "pathExists").resolves(true);
@@ -1494,10 +1525,6 @@ describe("scaffold question", () => {
             platform: Platform.VSCode,
             "manifest-path": "fakePath",
           };
-          const operationMap = new Map<string, string>([
-            ["getUserById", "GET /user/{userId}"],
-            ["getStoreOrder", "GET /store/order"],
-          ]);
 
           sandbox
             .stub(SpecParser.prototype, "validate")
@@ -1511,10 +1538,10 @@ describe("scaffold question", () => {
                 in: "header",
                 type: "apiKey",
               },
+              operationId: "getUserById",
             },
-            { api: "GET /store/order", server: "https://server2" },
+            { api: "GET /store/order", server: "https://server2", operationId: "getStoreOrder" },
           ]);
-          sandbox.stub(SpecParser.prototype, "listOperationMap").resolves(operationMap);
           sandbox.stub(manifestUtils, "_readAppManifest").resolves(ok({} as any));
           sandbox.stub(manifestUtils, "getOperationIds").returns(["getUserById", "getStoreOrder"]);
           sandbox.stub(fs, "pathExists").resolves(true);
@@ -1552,8 +1579,9 @@ describe("scaffold question", () => {
                 in: "header",
                 type: "apiKey",
               },
+              operationId: "getUserById",
             },
-            { api: "GET /store/order", server: "https://server2" },
+            { api: "GET /store/order", server: "https://server2", operationId: "getStoreOrder" },
           ]);
 
           const validationRes = await (question.validation as any).validFunc!("test.com", inputs);
@@ -1592,8 +1620,9 @@ describe("scaffold question", () => {
                 in: "header",
                 type: "apiKey",
               },
+              operationId: "getUserById",
             },
-            { api: "GET /store/order", server: "https://server2" },
+            { api: "GET /store/order", server: "https://server2", operationId: "getStoreOrder" },
           ]);
 
           const validationRes = await (question.validation as any).validFunc!("test.com", inputs);
@@ -1632,8 +1661,9 @@ describe("scaffold question", () => {
                 in: "header",
                 type: "apiKey",
               },
+              operationId: "getUserById",
             },
-            { api: "GET /store/order", server: "https://server2" },
+            { api: "GET /store/order", server: "https://server2", operationId: "getStoreOrder" },
           ]);
 
           const res = await (question.additionalValidationOnAccept as any).validFunc(


### PR DESCRIPTION
- Update list function to have operationId property
- Use list function instead of listOperationMap when add new api, remove listOperationMap api
- Fix update teams manifest doesn't contain auth property
- Fix domain check