### PR TITLE
feat: update templates to support test tool

### DIFF
--- a/packages/fx-core/src/common/deps-checker/internal/testToolChecker.ts
+++ b/packages/fx-core/src/common/deps-checker/internal/testToolChecker.ts
@@ -33,7 +33,7 @@ interface InstallationInfoFile {
 export class TestToolChecker implements DepsChecker {
   private telemetryProperties: { [key: string]: string };
   private readonly name = "Teams App Test Tool";
-  private readonly npmPackageName = "@microsoft/teams-app-test-tool-cli";
+  private readonly npmPackageName = "@microsoft/teams-app-test-tool";
   private readonly timeout = 5 * 60 * 1000;
   private readonly checkUpdateTimeout = 10 * 1000;
   private readonly commandName = isWindows() ? "teamsapptester.cmd" : "teamsapptester";
@@ -401,7 +401,7 @@ export class TestToolChecker implements DepsChecker {
       const files = await fs.readdir(dir);
       for (const fileName of files) {
         const fullPath = path.join(dir, fileName);
-        if (fileName.match(/microsoft-teams-app-test-tool-cli.*\.tgz/i)) {
+        if (fileName.match(/microsoft-teams-app-test-tool.*\.tgz/i)) {
           try {
             const st = await fs.stat(fullPath);
             if (st.isFile()) {

--- a/packages/fx-core/src/common/featureFlags.ts
+++ b/packages/fx-core/src/common/featureFlags.ts
@@ -52,8 +52,8 @@ export function isCliV3Enabled(): boolean {
   return isFeatureFlagEnabled("TEAMSFX_CLI_V3", false);
 }
 
-export function isTestToolEnabled(): boolean {
-  return isFeatureFlagEnabled(FeatureFlagName.TestTool, false);
+export function enableTestToolByDefault(): boolean {
+  return isFeatureFlagEnabled(FeatureFlagName.TestTool, true);
 }
 
 export function isApiKeyEnabled(): boolean {

--- a/packages/fx-core/src/component/driver/devTool/installDriver.ts
+++ b/packages/fx-core/src/component/driver/devTool/installDriver.ts
@@ -128,8 +128,7 @@ export class ToolsInstallDriverImpl {
     }
 
     if (args.testTool) {
-      // Disable test tool until test tool npm package is published to prevent blocking users who accidentally add this action by intellisense.
-      // await this.resolveTestTool(`${args.testTool.version}`, args.testTool.symlinkDir);
+      await this.resolveTestTool(`${args.testTool.version}`, args.testTool.symlinkDir);
     }
 
     return res;

--- a/packages/fx-core/src/component/driver/devTool/interfaces/InstallToolArgs.ts
+++ b/packages/fx-core/src/component/driver/devTool/interfaces/InstallToolArgs.ts
@@ -34,5 +34,5 @@ interface FuncArgs {
 
 interface TestToolArgs {
   version: string | number;
-  symlinkDir?: string;
+  symlinkDir: string;
 }

--- a/packages/fx-core/src/component/generator/generator.ts
+++ b/packages/fx-core/src/component/generator/generator.ts
@@ -35,6 +35,7 @@ import {
 } from "./generatorAction";
 import { getSampleInfoFromName, renderTemplateFileData, renderTemplateFileName } from "./utils";
 import { sampleProvider } from "../../common/samples";
+import { enableTestToolByDefault } from "../../common/featureFlags";
 
 export class Generator {
   public static getDefaultVariables(
@@ -52,6 +53,7 @@ export class Generator {
       ApiSpecAuthName: apiKeyAuthData?.authName ?? "",
       ApiSpecAuthRegistrationIdEnvName: apiKeyAuthData?.registrationIdEnvName ?? "",
       ApiSpecPath: apiKeyAuthData?.openapiSpecPath ?? "",
+      enableTestToolByDefault: enableTestToolByDefault() ? "true" : "",
     };
   }
   @hooks([

--- a/packages/fx-core/tests/common/deps-checker/testToolChecker.test.ts
+++ b/packages/fx-core/tests/common/deps-checker/testToolChecker.test.ts
@@ -428,7 +428,7 @@ describe("Test Tool Checker Test", () => {
       const versionRange = "~1.2.3";
       const mockProjectPath = "./projectPath";
       mockfs({
-        [path.join(mockProjectPath, "microsoft-teams-app-test-tool-cli-1.2.3.tgz")]: "",
+        [path.join(mockProjectPath, "microsoft-teams-app-test-tool-1.2.3.tgz")]: "",
       });
       const envStatus = mockEnvironment(sandbox, {
         nodeVersion: "v18.16.1",
@@ -444,7 +444,7 @@ describe("Test Tool Checker Test", () => {
       // Assert
       expect(envStatus.npmInstallArgs).not.undefined;
       const fileArg = envStatus.npmInstallArgs?.filter((arg) =>
-        arg.includes("microsoft-teams-app-test-tool-cli")
+        arg.includes("microsoft-teams-app-test-tool")
       )?.[0];
       expect(fileArg).not.empty;
       let parsed: url.URL | undefined;

--- a/packages/fx-core/tests/component/generator/generator.test.ts
+++ b/packages/fx-core/tests/component/generator/generator.test.ts
@@ -558,6 +558,18 @@ describe("Generator happy path", async () => {
     assert.isTrue(result.isOk());
   });
 
+  it("template variables when test tool enabled", async () => {
+    sandbox.stub(process, "env").value({ TEAMSFX_TEST_TOOL: "true" });
+    const vars = Generator.getDefaultVariables("test");
+    assert.equal(vars.enableTestToolByDefault, "true");
+  });
+
+  it("template variables when test tool disabled", async () => {
+    sandbox.stub(process, "env").value({ TEAMSFX_TEST_TOOL: "false" });
+    const vars = Generator.getDefaultVariables("test");
+    assert.equal(vars.enableTestToolByDefault, "");
+  });
+
   it("template from source code", async () => {
     const templateName = "test";
     const language = "ts";

--- a/templates/ts/notification-restify/.gitignore
+++ b/templates/ts/notification-restify/.gitignore
@@ -17,5 +17,7 @@ node_modules/
 lib/
 
 # Local data
+.localConfigs.testTool
 .localConfigs
 .notification.localstore.json
+.notification.testtoolstore.json

--- a/templates/ts/notification-restify/.localConfigs.testTool
+++ b/templates/ts/notification-restify/.localConfigs.testTool
@@ -1,0 +1,4 @@
+# A gitignored place holder file for local runtime configurations when debug in test tool
+BOT_ID=
+BOT_PASSWORD=
+TEAMSFX_NOTIFICATION_STORE_FILENAME=.notification.testtoolstore.json

--- a/templates/ts/notification-restify/.vscode/launch.json.tpl
+++ b/templates/ts/notification-restify/.vscode/launch.json.tpl
@@ -7,7 +7,7 @@
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
-                "group": "remote",
+                "group": "3-remote",
                 "order": 1
             },
             "internalConsoleOptions": "neverOpen"
@@ -18,7 +18,7 @@
             "request": "launch",
             "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
             "presentation": {
-                "group": "remote",
+                "group": "3-remote",
                 "order": 2
             },
             "internalConsoleOptions": "neverOpen"
@@ -73,7 +73,12 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-                "group": "all",
+{{#enableTestToolByDefault}}
+                "group": "2-local",
+{{/enableTestToolByDefault}}
+{{^enableTestToolByDefault}}
+                "group": "1-local",
+{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true
@@ -86,10 +91,32 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-                "group": "all",
+{{#enableTestToolByDefault}}
+                "group": "2-local",
+{{/enableTestToolByDefault}}
+{{^enableTestToolByDefault}}
+                "group": "1-local",
+{{/enableTestToolByDefault}}
                 "order": 2
             },
             "stopAll": true
-        }
+        },
+        {
+            "name": "Debug in Test Tool",
+            "configurations": [
+                "Attach to Local Service"
+            ],
+            "preLaunchTask": "Start Teams App (Test Tool)",
+            "presentation": {
+{{#enableTestToolByDefault}}
+                "group": "1-local",
+{{/enableTestToolByDefault}}
+{{^enableTestToolByDefault}}
+                "group": "2-local",
+{{/enableTestToolByDefault}}
+                "order": 1
+            },
+            "stopAll": true
+        },
     ]
 }

--- a/templates/ts/notification-restify/.vscode/tasks.json
+++ b/templates/ts/notification-restify/.vscode/tasks.json
@@ -5,6 +5,105 @@
     "version": "2.0.0",
     "tasks": [
         {
+            "label": "Start Teams App (Test Tool)",
+            "dependsOn": [
+                "Validate prerequisites (Test Tool)",
+                "Deploy (Test Tool)",
+                "Start application (Test Tool)",
+                "Start Test Tool",
+            ],
+            "dependsOrder": "sequence"
+        },
+        {
+            // Check all required prerequisites.
+            // See https://aka.ms/teamsfx-tasks/check-prerequisites to know the details and how to customize the args.
+            "label": "Validate prerequisites (Test Tool)",
+            "type": "teamsfx",
+            "command": "debug-check-prerequisites",
+            "args": {
+                "prerequisites": [
+                    "nodejs", // Validate if Node.js is installed.
+                    "portOccupancy" // Validate available ports to ensure those debug ones are not occupied.
+                ],
+                "portOccupancy": [
+                    3978, // app service port
+                    9239, // app inspector port for Node.js debugger
+                    56150, // test tool port
+                ]
+            }
+        },
+        {
+            // Build project.
+            // See https://aka.ms/teamsfx-tasks/deploy to know the details and how to customize the args.
+            "label": "Deploy (Test Tool)",
+            "type": "teamsfx",
+            "command": "deploy",
+            "args": {
+                "env": "testtool",
+            }
+        },
+        {
+            "label": "Start application (Test Tool)",
+            "type": "shell",
+            "command": "npm run dev:teamsfx:testtool",
+            "isBackground": true,
+            "options": {
+                "cwd": "${workspaceFolder}",
+            },
+            "problemMatcher": {
+                "pattern": [
+                    {
+                        "regexp": "^.*$",
+                        "file": 0,
+                        "location": 1,
+                        "message": 2
+                    }
+                ],
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": "[nodemon] starting",
+                    "endsPattern": "restify listening to|Bot/ME service listening at|[nodemon] app crashed"
+                }
+            }
+        },
+        {
+            "label": "Start Test Tool",
+            "type": "shell",
+            "command": "npm run dev:teamsfx:launch-testtool",
+            "isBackground": true,
+            "options": {
+                "env": {
+                  "PATH": "${workspaceFolder}/devTools/teamsapptester/node_modules/.bin:${env:PATH}"
+                }
+            },
+            "windows": {
+                "options": {
+                    "env": {
+                        "PATH": "${workspaceFolder}/devTools/teamsapptester/node_modules/.bin;${env:PATH}"
+                    }
+                }
+            },
+            "problemMatcher": {
+                "pattern": [
+                    {
+                        "regexp": "^.*$",
+                        "file": 0,
+                        "location": 1,
+                        "message": 2
+                    }
+                ],
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": ".*",
+                    "endsPattern": "Listening on"
+                }
+            },
+            "presentation": {
+                "panel": "dedicated",
+                "reveal": "silent"
+            }
+        },
+        {
             "label": "Start Teams App Locally",
             "dependsOn": [
                 "Validate prerequisites",

--- a/templates/ts/notification-restify/env/.env.testtool
+++ b/templates/ts/notification-restify/env/.env.testtool
@@ -1,0 +1,7 @@
+# This file includes environment variables that can be committed to git. It's gitignored by default because it represents your local development environment.
+
+# Built-in environment variables
+TEAMSFX_ENV=testtool
+
+# Environment variables used by test tool
+TEAMSAPPTESTER_PORT=56150

--- a/templates/ts/notification-restify/package.json.tpl
+++ b/templates/ts/notification-restify/package.json.tpl
@@ -10,6 +10,8 @@
     "main": "./lib/index.js",
     "scripts": {
         "dev:teamsfx": "env-cmd --silent -f .localConfigs npm run dev",
+        "dev:teamsfx:testtool": "env-cmd --silent -f .localConfigs.testTool npm run dev",
+        "dev:teamsfx:launch-testtool": "env-cmd --silent -f env/.env.testtool teamsapptester start",
         "dev": "nodemon --watch ./src --exec node --inspect=9239 --signal SIGINT -r ts-node/register ./src/index.ts",
         "build": "tsc --build && shx cp -r ./src/adaptiveCards ./lib/src",
         "start": "node ./lib/src/index.js",

--- a/templates/ts/notification-restify/teamsapp.testtool.yml
+++ b/templates/ts/notification-restify/teamsapp.testtool.yml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/teams-toolkit/v1.3/yaml.schema.json
+# Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
+# Visit https://aka.ms/teamsfx-actions for details on actions
+version: v1.3
+
+deploy:
+  # Install development tool(s)
+  - uses: devTool/install
+    with:
+      testTool:
+        version: ~0.1.0
+        symlinkDir: ./devTools/teamsapptester
+
+  # Run npm command
+  - uses: cli/runNpmCommand
+    with:
+      args: install --no-audit

--- a/templates/ts/notification-restify/teamsapp.testtool.yml
+++ b/templates/ts/notification-restify/teamsapp.testtool.yml
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.1.0
+        version: ~0.1.0-beta
         symlinkDir: ./devTools/teamsapptester
 
   # Run npm command


### PR DESCRIPTION
- if `enableTestToolByDefault` set to true, F5 will launch debug in test tool by default, otherwise, debug in test tool launch profile will still be scaffolded but not the default launch profile.
- `enableTestToolByDefault` is enabled by default
- update test tool driver to match new package name

TODO: README and other bot templates

<img width="334" alt="image" src="https://github.com/OfficeDev/TeamsFx/assets/9698542/8a3557a5-5584-4e33-b3aa-3c60562fb104">

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/16357625/