### PR TITLE
refactor: rename filter options

### DIFF
--- a/packages/cli/tests/unit/utils.tests.ts
+++ b/packages/cli/tests/unit/utils.tests.ts
@@ -137,7 +137,6 @@ projectId: 00000000-0000-0000-0000-000000000000`;
 
     this.afterEach(() => {
       sandbox.restore();
-      core.sampleProvider["sampleCollection"] = undefined;
     });
 
     it("filters samples have maximum cli verion", async () => {

--- a/packages/cli/tests/unit/utils.tests.ts
+++ b/packages/cli/tests/unit/utils.tests.ts
@@ -144,9 +144,9 @@ projectId: 00000000-0000-0000-0000-000000000000`;
       sandbox.stub(core.sampleProvider, "fetchSampleConfig").callsFake(async () => {
         core.sampleProvider["samplesConfig"] = {
           filterOptions: {
-            types: ["Tab"],
+            capabilities: ["Tab"],
             languages: ["TS"],
-            techniques: ["Azure"],
+            technologies: ["Azure"],
           },
           samples: [
             {
@@ -187,9 +187,9 @@ projectId: 00000000-0000-0000-0000-000000000000`;
       sandbox.stub(core.sampleProvider, "fetchSampleConfig").callsFake(async () => {
         core.sampleProvider["samplesConfig"] = {
           filterOptions: {
-            types: ["Tab"],
+            capabilities: ["Tab"],
             languages: ["TS"],
-            techniques: ["Azure"],
+            technologies: ["Azure"],
           },
           samples: [
             {

--- a/packages/fx-core/src/common/samples.ts
+++ b/packages/fx-core/src/common/samples.ts
@@ -58,7 +58,6 @@ type SampleConfigType = {
 };
 
 class SampleProvider {
-  private sampleCollection: SampleCollection | undefined;
   private samplesConfig: SampleConfigType | undefined;
   private branchOrTag = SampleConfigTag;
 
@@ -92,58 +91,54 @@ class SampleProvider {
   }
 
   public get SampleCollection(): SampleCollection {
-    if (!this.sampleCollection) {
-      const samples =
-        this.samplesConfig?.samples.map((sample) => {
-          const isExternal = sample["downloadUrlInfo"] ? true : false;
-          let gifUrl =
+    const samples =
+      this.samplesConfig?.samples.map((sample) => {
+        const isExternal = sample["downloadUrlInfo"] ? true : false;
+        let gifUrl =
+          sample["gifPath"] !== undefined
+            ? `https://raw.githubusercontent.com/${SampleConfigOwner}/${SampleConfigRepo}/${
+                this.branchOrTag
+              }/${sample["id"] as string}/${sample["gifPath"] as string}`
+            : undefined;
+        let thumbnailUrl = `https://raw.githubusercontent.com/${SampleConfigOwner}/${SampleConfigRepo}/${
+          this.branchOrTag
+        }/${sample["id"] as string}/${sample["thumbnailPath"] as string}`;
+        if (isExternal) {
+          const info = sample["downloadUrlInfo"] as SampleUrlInfo;
+          gifUrl =
             sample["gifPath"] !== undefined
-              ? `https://raw.githubusercontent.com/${SampleConfigOwner}/${SampleConfigRepo}/${
-                  this.branchOrTag
-                }/${sample["id"] as string}/${sample["gifPath"] as string}`
+              ? `https://raw.githubusercontent.com/${info.owner}/${info.repository}/${info.ref}/${
+                  info.dir
+                }/${sample["gifPath"] as string}`
               : undefined;
-          let thumbnailUrl = `https://raw.githubusercontent.com/${SampleConfigOwner}/${SampleConfigRepo}/${
-            this.branchOrTag
-          }/${sample["id"] as string}/${sample["thumbnailPath"] as string}`;
-          if (isExternal) {
-            const info = sample["downloadUrlInfo"] as SampleUrlInfo;
-            gifUrl =
-              sample["gifPath"] !== undefined
-                ? `https://raw.githubusercontent.com/${info.owner}/${info.repository}/${info.ref}/${
-                    info.dir
-                  }/${sample["gifPath"] as string}`
-                : undefined;
-            thumbnailUrl = `https://raw.githubusercontent.com/${info.owner}/${info.repository}/${
-              info.ref
-            }/${info.dir}/${sample["thumbnailPath"] as string}`;
-          }
-          return {
-            ...sample,
-            onboardDate: new Date(sample["onboardDate"] as string),
-            downloadUrlInfo: isExternal
-              ? sample["downloadUrlInfo"]
-              : {
-                  owner: SampleConfigOwner,
-                  repository: SampleConfigRepo,
-                  ref: this.branchOrTag,
-                  dir: sample["id"] as string,
-                },
-            gifUrl: gifUrl,
-            thumbnailUrl: thumbnailUrl,
-          } as SampleConfig;
-        }) || [];
+          thumbnailUrl = `https://raw.githubusercontent.com/${info.owner}/${info.repository}/${
+            info.ref
+          }/${info.dir}/${sample["thumbnailPath"] as string}`;
+        }
+        return {
+          ...sample,
+          onboardDate: new Date(sample["onboardDate"] as string),
+          downloadUrlInfo: isExternal
+            ? sample["downloadUrlInfo"]
+            : {
+                owner: SampleConfigOwner,
+                repository: SampleConfigRepo,
+                ref: this.branchOrTag,
+                dir: sample["id"] as string,
+              },
+          gifUrl: gifUrl,
+          thumbnailUrl: thumbnailUrl,
+        } as SampleConfig;
+      }) || [];
 
-      this.sampleCollection = {
-        samples,
-        filterOptions: {
-          capabilities: this.samplesConfig?.filterOptions["capabilities"] || [],
-          languages: this.samplesConfig?.filterOptions["languages"] || [],
-          technologies: this.samplesConfig?.filterOptions["technologies"] || [],
-        },
-      };
-    }
-
-    return this.sampleCollection;
+    return {
+      samples,
+      filterOptions: {
+        capabilities: this.samplesConfig?.filterOptions["capabilities"] || [],
+        languages: this.samplesConfig?.filterOptions["languages"] || [],
+        technologies: this.samplesConfig?.filterOptions["technologies"] || [],
+      },
+    };
   }
 
   private async fetchRawFileContent(branchOrTag: string): Promise<unknown> {

--- a/packages/fx-core/src/common/samples.ts
+++ b/packages/fx-core/src/common/samples.ts
@@ -9,7 +9,6 @@ import { SampleUrlInfo, sendRequestWithTimeout } from "../component/generator/ut
 import { ErrorContextMW } from "../core/globalVars";
 import { AccessGithubError } from "../error/common";
 import { FeatureFlagName } from "./constants";
-import { isVideoFilterEnabled } from "./featureFlags";
 
 const packageJson = require("../../package.json");
 
@@ -47,9 +46,9 @@ export interface SampleConfig {
 interface SampleCollection {
   samples: SampleConfig[];
   filterOptions: {
-    types: string[];
+    capabilities: string[];
     languages: string[];
-    techniques: string[];
+    technologies: string[];
   };
 }
 
@@ -137,9 +136,9 @@ class SampleProvider {
       this.sampleCollection = {
         samples,
         filterOptions: {
-          types: this.samplesConfig?.filterOptions["types"] || [],
+          capabilities: this.samplesConfig?.filterOptions["capabilities"] || [],
           languages: this.samplesConfig?.filterOptions["languages"] || [],
-          techniques: this.samplesConfig?.filterOptions["techniques"] || [],
+          technologies: this.samplesConfig?.filterOptions["technologies"] || [],
         },
       };
     }

--- a/packages/fx-core/tests/common/samples-config-v3.json
+++ b/packages/fx-core/tests/common/samples-config-v3.json
@@ -1,15 +1,16 @@
 {
     "filterOptions": {
-        "types": [
+        "capabilities": [
             "Tab",
             "Bot",
-            "Message extension"
+            "Message Extension",
+            "Meeting"
         ],
         "languages": [
-            "JS",
-            "TS"
+            "JavaScript",
+            "TypeScript"
         ],
-        "techniques": [
+        "technologies": [
             "Azure",
             "Adaptive Cards",
             "SSO",

--- a/packages/fx-core/tests/common/samples.test.ts
+++ b/packages/fx-core/tests/common/samples.test.ts
@@ -51,7 +51,6 @@ describe("Samples", () => {
       sandbox.restore();
       sampleProvider["samplesConfig"] = undefined;
       process.env["TEAMSFX_SAMPLE_CONFIG_BRANCH"] = undefined;
-      (sampleProvider as any).sampleCollection = undefined;
     });
 
     it("download sample config on 'dev' branch in alpha version", async () => {
@@ -235,7 +234,6 @@ describe("Samples", () => {
       chai.expect(sampleConfigV3.samples.find((sampleInConfig) => sampleInConfig.id === sample.id))
         .exist;
     }
-    (sampleProvider as any).sampleCollection = undefined;
   });
 
   it("External sample url can be retrieved correctly in v3", () => {
@@ -264,7 +262,6 @@ describe("Samples", () => {
     chai.expect(faked?.downloadUrlInfo).equals(fakedExternalSample.downloadUrlInfo);
     chai.expect(faked?.gifUrl).equals(undefined);
 
-    (sampleProvider as any).sampleCollection = undefined;
     sampleConfigV3.samples.splice(sampleConfigV3.samples.length - 1, 1);
   });
 
@@ -311,7 +308,6 @@ describe("Samples", () => {
   });
 
   it("returns empty sample collection when sample config is undefined", () => {
-    (sampleProvider as any).sampleCollection = undefined;
     const sampleCollection = sampleProvider.SampleCollection;
 
     chai.expect(sampleCollection.filterOptions.capabilities).to.deep.equal([]);

--- a/packages/fx-core/tests/common/samples.test.ts
+++ b/packages/fx-core/tests/common/samples.test.ts
@@ -19,9 +19,9 @@ describe("Samples", () => {
   const sandbox = sinon.createSandbox();
   const fakedSampleConfig = {
     filterOptions: {
-      types: ["Tab"],
+      capabilities: ["Tab"],
       languages: ["TS"],
-      techniques: ["Azure"],
+      technologies: ["Azure"],
     },
     samples: [
       {
@@ -78,7 +78,7 @@ describe("Samples", () => {
       });
       chai.expect(samples[0].gifUrl).equal(undefined);
       const filterOptions = sampleProvider.SampleCollection.filterOptions;
-      chai.expect(filterOptions.types).to.deep.equal(["Tab"]);
+      chai.expect(filterOptions.capabilities).to.deep.equal(["Tab"]);
     });
 
     it("download sample config of prerelease branch in prerelease(beta) version", async () => {
@@ -314,7 +314,7 @@ describe("Samples", () => {
     (sampleProvider as any).sampleCollection = undefined;
     const sampleCollection = sampleProvider.SampleCollection;
 
-    chai.expect(sampleCollection.filterOptions.types).to.deep.equal([]);
+    chai.expect(sampleCollection.filterOptions.capabilities).to.deep.equal([]);
     chai.expect(sampleCollection.samples).to.deep.equal([]);
   });
 });

--- a/packages/vscode-extension/src/controls/sampleGallery/ISamples.ts
+++ b/packages/vscode-extension/src/controls/sampleGallery/ISamples.ts
@@ -12,7 +12,7 @@ export type SampleGalleryState = {
   // keep filtering state here to recover after navigating back from detail page
   layout: "grid" | "list";
   query: string;
-  filterTags: Record<string, string[]>;
+  filterTags: SampleFilterOptionType;
 };
 
 export interface SampleInfo {
@@ -47,9 +47,9 @@ export type SampleProps = {
 };
 
 export type SampleFilterOptionType = {
-  types: string[];
+  capabilities: string[];
   languages: string[];
-  techniques: string[];
+  technologies: string[];
 };
 
 export type SampleFilterProps = {
@@ -57,8 +57,8 @@ export type SampleFilterProps = {
   filterOptions: SampleFilterOptionType;
   layout: "grid" | "list";
   query: string;
-  filterTags: Record<string, string[]>;
+  filterTags: SampleFilterOptionType;
 
   onLayoutChanged: (layout: "grid" | "list") => void;
-  onFilterConditionChanged: (query: string, filterTags: Record<string, string[]>) => void;
+  onFilterConditionChanged: (query: string, filterTags: SampleFilterOptionType) => void;
 };

--- a/packages/vscode-extension/src/controls/sampleGallery/SampleGallery.tsx
+++ b/packages/vscode-extension/src/controls/sampleGallery/SampleGallery.tsx
@@ -25,9 +25,9 @@ import SampleListItem from "./sampleListItem";
 export default class SampleGallery extends React.Component<unknown, SampleGalleryState> {
   private samples: SampleInfo[] = [];
   private filterOptions: SampleFilterOptionType = {
-    types: [],
+    capabilities: [],
     languages: [],
-    techniques: [],
+    technologies: [],
   };
 
   constructor(props: unknown) {
@@ -36,7 +36,7 @@ export default class SampleGallery extends React.Component<unknown, SampleGaller
       loading: true,
       layout: "grid",
       query: "",
-      filterTags: { types: [], languages: [], techniques: [] },
+      filterTags: { capabilities: [], languages: [], technologies: [] },
     };
   }
 
@@ -203,9 +203,9 @@ export default class SampleGallery extends React.Component<unknown, SampleGaller
           [TelemetryProperty.TriggerFrom]: triggerFrom,
           [TelemetryProperty.SampleAppName]: id,
           [TelemetryProperty.SearchText]: this.state.query,
-          [TelemetryProperty.SampleFilters]: this.state.filterTags.types
+          [TelemetryProperty.SampleFilters]: this.state.filterTags.capabilities
             .concat(this.state.filterTags.languages)
-            .concat(this.state.filterTags.techniques)
+            .concat(this.state.filterTags.technologies)
             .join(","),
           [TelemetryProperty.Layout]: this.state.layout,
         },
@@ -228,9 +228,9 @@ export default class SampleGallery extends React.Component<unknown, SampleGaller
           [TelemetryProperty.TriggerFrom]: TelemetryTriggerFrom.SampleGallery,
           [TelemetryProperty.Layout]: newLayout,
           [TelemetryProperty.SearchText]: this.state.query,
-          [TelemetryProperty.SampleFilters]: this.state.filterTags.types
+          [TelemetryProperty.SampleFilters]: this.state.filterTags.capabilities
             .concat(this.state.filterTags.languages)
-            .concat(this.state.filterTags.techniques)
+            .concat(this.state.filterTags.technologies)
             .join(","),
         },
       },
@@ -245,24 +245,24 @@ export default class SampleGallery extends React.Component<unknown, SampleGaller
     this.setState({ layout: newLayout });
   };
 
-  private onFilterConditionChanged = (query: string, filterTags: Record<string, string[]>) => {
-    let filteredSamples = this.samples.filter((sample: SampleInfo) => {
-      for (const key in filterTags) {
-        if (filterTags[key].length === 0) {
-          continue;
-        }
-        let isMatch = false;
-        for (const tag of filterTags[key]) {
-          if (sample.tags.findIndex((value) => value.includes(tag)) >= 0) {
-            isMatch = true;
-            break;
-          }
-        }
-        if (!isMatch) {
-          return false;
+  private onFilterConditionChanged = (query: string, filterTags: SampleFilterOptionType) => {
+    const containsTag = (targets: string[], tags: string[]) => {
+      if (targets.length === 0) {
+        return true;
+      }
+      for (const target of targets) {
+        if (tags.findIndex((value) => value.toLowerCase().includes(target.toLowerCase())) >= 0) {
+          return true;
         }
       }
-      return true;
+      return false;
+    };
+    let filteredSamples = this.samples.filter((sample: SampleInfo) => {
+      return (
+        containsTag(filterTags.capabilities, sample.tags) &&
+        containsTag(filterTags.languages, sample.tags) &&
+        containsTag(filterTags.technologies, sample.tags)
+      );
     });
     if (query !== "") {
       const fuse = new Fuse(filteredSamples, {
@@ -282,9 +282,9 @@ export default class SampleGallery extends React.Component<unknown, SampleGaller
           [TelemetryProperty.TriggerFrom]: triggerFrom,
           [TelemetryProperty.SampleAppName]: sample.id,
           [TelemetryProperty.SearchText]: this.state.query,
-          [TelemetryProperty.SampleFilters]: this.state.filterTags.types
+          [TelemetryProperty.SampleFilters]: this.state.filterTags.capabilities
             .concat(this.state.filterTags.languages)
-            .concat(this.state.filterTags.techniques)
+            .concat(this.state.filterTags.technologies)
             .join(","),
           [TelemetryProperty.Layout]: this.state.layout,
         },
@@ -308,9 +308,9 @@ export default class SampleGallery extends React.Component<unknown, SampleGaller
           [TelemetryProperty.TriggerFrom]: triggerFrom,
           [TelemetryProperty.SampleAppName]: sample.id,
           [TelemetryProperty.SearchText]: this.state.query,
-          [TelemetryProperty.SampleFilters]: this.state.filterTags.types
+          [TelemetryProperty.SampleFilters]: this.state.filterTags.capabilities
             .concat(this.state.filterTags.languages)
-            .concat(this.state.filterTags.techniques)
+            .concat(this.state.filterTags.technologies)
             .join(","),
           [TelemetryProperty.Layout]: this.state.layout,
         },

--- a/packages/vscode-extension/src/controls/sampleGallery/sampleListItem.scss
+++ b/packages/vscode-extension/src/controls/sampleGallery/sampleListItem.scss
@@ -56,6 +56,8 @@
       flex-grow: 1;
       flex-shrink: 2;
       min-width: 4.5px;
+      height: 20px;
+      cursor:pointer;
     }
 
     .tagSection {

--- a/packages/vscode-extension/src/controls/sampleGallery/sampleListItem.tsx
+++ b/packages/vscode-extension/src/controls/sampleGallery/sampleListItem.tsx
@@ -60,7 +60,7 @@ export default class SampleListItem extends React.Component<SampleProps, unknown
               })}
           </div>
         </div>
-        <div className="padding" />
+        <div className="padding" onClick={this.onSampleTitleClicked} />
         {sample.versionComparisonResult != 0 && (
           <div className="info">
             <span className="codicon codicon-info"></span>


### PR DESCRIPTION
Effect:
![image](https://github.com/OfficeDev/TeamsFx/assets/886116/89684b45-e79f-41eb-9cda-28d0ccbb74a7)

Related PR:
https://github.com/OfficeDev/TeamsFx-Samples/pull/1073

Also fix: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/25663359