### PR TITLE
feat(core): bump sample tag version

### DIFF
--- a/packages/fx-core/src/common/samples.ts
+++ b/packages/fx-core/src/common/samples.ts
@@ -15,9 +15,8 @@ const packageJson = require("../../package.json");
 const SampleConfigOwner = "OfficeDev";
 const SampleConfigRepo = "TeamsFx-Samples";
 const SampleConfigFile = ".config/samples-config-v3.json";
-export const SampleConfigTag = "v2.3.0";
-// rc and prerelease tag is only different with stable tag when there will a breaking change.
-export const SampleConfigTagForRc = "v2.3.0";
+export const SampleConfigTag = "v2.4.0";
+// prerelease tag is always using a branch.
 export const SampleConfigBranchForPrerelease = "v3";
 
 export interface SampleConfig {
@@ -71,8 +70,8 @@ class SampleProvider {
       // prerelease build version always use branch head for prerelease.
       this.branchOrTag = SampleConfigBranchForPrerelease;
     } else if (version.includes("rc")) {
-      // rc version(before next stable TTK) always use prerelease tag
-      this.branchOrTag = SampleConfigTagForRc;
+      // if there is a breaking change, the tag is not used by any stable version.
+      this.branchOrTag = SampleConfigTag;
     } else {
       // stable version uses the head of branch defined by feature flag when available
       this.branchOrTag = SampleConfigTag;

--- a/packages/fx-core/tests/common/samples.test.ts
+++ b/packages/fx-core/tests/common/samples.test.ts
@@ -7,7 +7,6 @@ import { err } from "@microsoft/teamsfx-api";
 import {
   SampleConfigBranchForPrerelease,
   SampleConfigTag,
-  SampleConfigTagForRc,
   sampleProvider,
 } from "../../src/common/samples";
 import sampleConfigV3 from "./samples-config-v3.json";
@@ -110,7 +109,7 @@ describe("Samples", () => {
       sandbox.stub(axios, "get").callsFake(async (url: string, config) => {
         if (
           url ===
-          `https://raw.githubusercontent.com/OfficeDev/TeamsFx-Samples/${SampleConfigTagForRc}/.config/samples-config-v3.json`
+          `https://raw.githubusercontent.com/OfficeDev/TeamsFx-Samples/${SampleConfigTag}/.config/samples-config-v3.json`
         ) {
           return { data: fakedSampleConfig, status: 200 };
         } else {
@@ -124,7 +123,7 @@ describe("Samples", () => {
       chai.expect(samples[0].downloadUrlInfo).deep.equal({
         owner: "OfficeDev",
         repository: "TeamsFx-Samples",
-        ref: SampleConfigTagForRc,
+        ref: SampleConfigTag,
         dir: "hello-world-tab-with-backend",
       });
       chai.expect(samples[0].gifUrl).equal(undefined);

--- a/packages/fx-core/tests/component/generator/generator.test.ts
+++ b/packages/fx-core/tests/component/generator/generator.test.ts
@@ -421,6 +421,9 @@ describe("Generator error", async () => {
   it("sample not found error", async () => {
     sandbox.stub(generatorUtils, "getSampleInfoFromName").returns(mockedSampleInfo);
     sandbox.stub(generatorUtils, "downloadDirectory").resolves([] as string[]);
+    sandbox
+      .stub(generatorUtils, "sendRequestWithTimeout")
+      .resolves({ data: sampleConfigV3 } as AxiosResponse);
 
     const result = await Generator.generateSample(ctx, tmpDir, "test");
     if (result.isErr()) {


### PR DESCRIPTION
Related task: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/25518911

Sample config has breaking change.
'v2.4.0' tag will be published before next RC & stable TTK release.