### PR TITLE
fix: change notification templates to use new SDK

### DIFF
--- a/templates/js/notification-http-timer-trigger/package.json.tpl
+++ b/templates/js/notification-http-timer-trigger/package.json.tpl
@@ -22,7 +22,7 @@
     },
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
-        "@microsoft/teamsfx": "^2.3.0-rc-hotfix.0",
+        "@microsoft/teamsfx": "^2.3.1-beta",
         "botbuilder": "^4.20.0"
     },
     "devDependencies": {

--- a/templates/js/notification-http-trigger/package.json.tpl
+++ b/templates/js/notification-http-trigger/package.json.tpl
@@ -22,7 +22,7 @@
     },
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
-        "@microsoft/teamsfx": "^2.3.0-rc-hotfix.0",
+        "@microsoft/teamsfx": "^2.3.1-beta",
         "botbuilder": "^4.20.0"
     },
     "devDependencies": {

--- a/templates/js/notification-restify/package.json.tpl
+++ b/templates/js/notification-restify/package.json.tpl
@@ -23,7 +23,7 @@
     },
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
-        "@microsoft/teamsfx": "^2.3.0-rc-hotfix.0",
+        "@microsoft/teamsfx": "^2.3.1-beta",
         "botbuilder": "^4.20.0",
         "restify": "^10.0.0"
     },

--- a/templates/js/notification-timer-trigger/package.json.tpl
+++ b/templates/js/notification-timer-trigger/package.json.tpl
@@ -22,7 +22,7 @@
     },
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
-        "@microsoft/teamsfx": "^2.3.0-rc-hotfix.0",
+        "@microsoft/teamsfx": "^2.3.1-beta",
         "botbuilder": "^4.20.0"
     },
     "devDependencies": {

--- a/templates/ts/notification-http-timer-trigger/package.json.tpl
+++ b/templates/ts/notification-http-timer-trigger/package.json.tpl
@@ -26,7 +26,7 @@
     },
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
-        "@microsoft/teamsfx": "^2.3.0-rc-hotfix.0",
+        "@microsoft/teamsfx": "^2.3.1-beta.0",
         "botbuilder": "^4.20.0"
     },
     "devDependencies": {

--- a/templates/ts/notification-http-trigger/package.json.tpl
+++ b/templates/ts/notification-http-trigger/package.json.tpl
@@ -26,7 +26,7 @@
     },
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
-        "@microsoft/teamsfx": "^2.3.0-rc-hotfix.0",
+        "@microsoft/teamsfx": "^2.3.1-beta",
         "botbuilder": "^4.20.0"
     },
     "devDependencies": {

--- a/templates/ts/notification-restify/package.json.tpl
+++ b/templates/ts/notification-restify/package.json.tpl
@@ -24,7 +24,7 @@
     },
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
-        "@microsoft/teamsfx": "^2.3.0-rc-hotfix.0",
+        "@microsoft/teamsfx": "^2.3.1-beta",
         "botbuilder": "^4.20.0",
         "restify": "^10.0.0"
     },

--- a/templates/ts/notification-timer-trigger/package.json.tpl
+++ b/templates/ts/notification-timer-trigger/package.json.tpl
@@ -26,7 +26,7 @@
     },
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
-        "@microsoft/teamsfx": "^2.3.0-rc-hotfix.0",
+        "@microsoft/teamsfx": "^2.3.1-beta",
         "botbuilder": "^4.20.0"
     },
     "devDependencies": {


### PR DESCRIPTION
Manually update notification tempaltes to beta version so that CD pipeline will update these templates to the latest beta version

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/25757321/