### PR TITLE
fix: should not zip manifest / validation app /etc. for test tool

### DIFF
--- a/packages/fx-core/src/question/other.ts
+++ b/packages/fx-core/src/question/other.ts
@@ -508,7 +508,8 @@ export function selectTargetEnvQuestion(
         if (throwErrorIfNoEnv) throw res.error;
         return [defaultValueIfNoEnv];
       }
-      return res.value;
+      // "testtool" env is a pure local env and doesn't have manifest
+      return res.value.filter((env) => env !== environmentNameManager.getTestToolEnvName());
     },
     skipSingleOption: true,
     forgetLastValue: true,

--- a/packages/fx-core/tests/question/other.test.ts
+++ b/packages/fx-core/tests/question/other.test.ts
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+import { Inputs, Platform } from "@microsoft/teamsfx-api";
+import { assert } from "chai";
+import "mocha";
+import { QuestionNames } from "../../src/question/questionNames";
+import { selectTargetEnvQuestion } from "../../src/question/other";
+import { environmentNameManager } from "../../src/core/environmentName";
+
+describe("env question", () => {
+  it("should not show testtool env", async () => {
+    const dynamicOptions = selectTargetEnvQuestion(
+      QuestionNames.TargetEnvName,
+      false
+    ).dynamicOptions;
+    const inputs: Inputs = {
+      platform: Platform.VSCode,
+    };
+    if (dynamicOptions) {
+      const envs = (await dynamicOptions(inputs)) as string[];
+      assert.notInclude(envs, environmentNameManager.getTestToolEnvName());
+    }
+  });
+
+  it("should not show testtool env for non-remote", async () => {
+    const dynamicOptions = selectTargetEnvQuestion(
+      QuestionNames.TargetEnvName,
+      true
+    ).dynamicOptions;
+    const inputs: Inputs = {
+      platform: Platform.VSCode,
+    };
+    if (dynamicOptions) {
+      const envs = (await dynamicOptions(inputs)) as string[];
+      assert.notInclude(envs, environmentNameManager.getTestToolEnvName());
+    }
+  });
+});


### PR DESCRIPTION
Test tool is pure local and doesn't support manifest so it is meaningless to zip manifest / validate application / etc. It will always fail. Hide testtool env in env selection UI because only entrypoint for deploy in testtool env is tasks.json.

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/25758411