### PR TITLE
fix(vsc): color of search box and sample card shadow

### DIFF
--- a/packages/vscode-extension/src/controls/sampleGallery/sampleCard.scss
+++ b/packages/vscode-extension/src/controls/sampleGallery/sampleCard.scss
@@ -168,7 +168,7 @@
 body.vscode-light {
   .sample-card {
     background-color: #FFF;
-    box-shadow: 0px 2px 16px rgb(0 0 0 / 16%);
+    box-shadow: 0px 2px 4px rgb(0 0 0 / 16%);
   }
 
   .sample-card:not(.unavailable):hover {

--- a/packages/vscode-extension/src/controls/sampleGallery/sampleCard.tsx
+++ b/packages/vscode-extension/src/controls/sampleGallery/sampleCard.tsx
@@ -6,7 +6,6 @@ import "./sampleCard.scss";
 import * as React from "react";
 
 import { FontIcon, Image } from "@fluentui/react";
-import { VSCodeTag } from "@vscode/webview-ui-toolkit/react";
 
 import Turtle from "../../../img/webview/sample/turtle.svg";
 import { TelemetryTriggerFrom } from "../../telemetry/extTelemetryEvents";

--- a/packages/vscode-extension/src/controls/sampleGallery/sampleFilter.scss
+++ b/packages/vscode-extension/src/controls/sampleGallery/sampleFilter.scss
@@ -28,7 +28,7 @@
     border: 1px solid var(--vscode-menu-separatorBackground, #3C3C3C);
     height: 24px;
     color: var(--vscode-peekViewTitleDescription-foreground, #CCCCCC);
-    background: var(--vscode-diffEditor-unchangedRegionBackground);
+    background: rgba(255, 255, 255, 0.1);
 
     input::placeholder {
       color: "#A0A0A0";

--- a/packages/vscode-extension/src/controls/sampleGallery/sampleFilter.tsx
+++ b/packages/vscode-extension/src/controls/sampleGallery/sampleFilter.tsx
@@ -205,7 +205,7 @@ export default class SampleFilter extends React.Component<SampleFilterProps, unk
       "span:first-child": {
         height: 24,
         lineHeight: 21,
-        backgroundColor: "var(--vscode-diffEditor-unchangedRegionBackground)",
+        backgroundColor: "rgba(255, 255, 255, 0.1)",
         color: "var(--vscode-peekViewTitleDescription-foreground, #CCCCCC)",
         fontSize: 13,
         border: "1px solid var(--vscode-menu-separatorBackground, #3C3C3C)",
@@ -214,7 +214,6 @@ export default class SampleFilter extends React.Component<SampleFilterProps, unk
       },
     };
     const caretStyle: IStyle = {
-      backgroundColor: "var(--vscode-diffEditor-unchangedRegionBackground)",
       color: "var(--vscode-dropdown-foreground, #CCCCCC)",
       fontSize: 11,
       lineHeight: 16,


### PR DESCRIPTION
Related bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/25858387

Effect:
![image](https://github.com/OfficeDev/TeamsFx/assets/886116/c56568ce-f78b-43f6-a720-2bef9562360c)
