### PR TITLE
fix: api me from scratch cannot debug after upgrading to .net 8

### DIFF
--- a/templates/csharp/copilot-plugin-from-scratch/Models/RepairModel.cs.tpl
+++ b/templates/csharp/copilot-plugin-from-scratch/Models/RepairModel.cs.tpl
@@ -2,7 +2,7 @@ namespace {{SafeProjectName}}.Models
 {
     public class RepairModel
     {
-        public int Id { get; set; }
+        public string Id { get; set; }
 
         public string Title { get; set; }
 

--- a/templates/csharp/copilot-plugin-from-scratch/Program.cs
+++ b/templates/csharp/copilot-plugin-from-scratch/Program.cs
@@ -1,0 +1,14 @@
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+var host = new HostBuilder()
+    .ConfigureFunctionsWorkerDefaults()
+    .ConfigureServices(services =>
+    {
+        services.AddApplicationInsightsTelemetryWorkerService();
+        services.ConfigureFunctionsApplicationInsights();
+    })
+    .Build();
+
+host.Run();

--- a/templates/csharp/copilot-plugin-from-scratch/Program.cs
+++ b/templates/csharp/copilot-plugin-from-scratch/Program.cs
@@ -1,14 +1,7 @@
-using Microsoft.Azure.Functions.Worker;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 var host = new HostBuilder()
     .ConfigureFunctionsWorkerDefaults()
-    .ConfigureServices(services =>
-    {
-        services.AddApplicationInsightsTelemetryWorkerService();
-        services.ConfigureFunctionsApplicationInsights();
-    })
     .Build();
 
 host.Run();

--- a/templates/csharp/copilot-plugin-from-scratch/Repair.cs.tpl
+++ b/templates/csharp/copilot-plugin-from-scratch/Repair.cs.tpl
@@ -1,5 +1,3 @@
-using {{SafeProjectName}}.Models;
-using System.Net;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;

--- a/templates/csharp/copilot-plugin-from-scratch/RepairData.cs.tpl
+++ b/templates/csharp/copilot-plugin-from-scratch/RepairData.cs.tpl
@@ -9,7 +9,7 @@ namespace {{SafeProjectName}}
             return new List<RepairModel>
             {
                 new() {
-                    Id = 1,
+                    Id = "1",
                     Title = "Oil change",
                     Description = "Need to drain the old engine oil and replace it with fresh oil to keep the engine lubricated and running smoothly.",
                     AssignedTo = "Karin Blair",
@@ -17,7 +17,7 @@ namespace {{SafeProjectName}}
                     Image = "https://www.howmuchisit.org/wp-content/uploads/2011/01/oil-change.jpg"
                 },
                 new() {
-                    Id = 2,
+                    Id = "2",
                     Title = "Brake repairs",
                     Description = "Conduct brake repairs, including replacing worn brake pads, resurfacing or replacing brake rotors, and repairing or replacing other components of the brake system.",
                     AssignedTo = "Issac Fielder",
@@ -25,7 +25,7 @@ namespace {{SafeProjectName}}
                     Image = "https://upload.wikimedia.org/wikipedia/commons/7/71/Disk_brake_dsc03680.jpg"
                 },
                 new() {
-                    Id = 3,
+                    Id = "3",
                     Title = "Tire service",
                     Description = "Rotate and replace tires, moving them from one position to another on the vehicle to ensure even wear and removing worn tires and installing new ones.",
                     AssignedTo = "Karin Blair",
@@ -33,7 +33,7 @@ namespace {{SafeProjectName}}
                     Image = "https://th.bing.com/th/id/OIP.N64J4jmqmnbQc5dHvTm-QAHaE8?pid=ImgDet&rs=1"
                 },
                 new() {
-                    Id = 4,
+                    Id = "4",
                     Title = "Battery replacement",
                     Description = "Remove the old battery and install a new one to ensure that the vehicle start reliably and the electrical systems function properly.",
                     AssignedTo = "Ashley McCarthy",
@@ -41,7 +41,7 @@ namespace {{SafeProjectName}}
                     Image = "https://i.stack.imgur.com/4ftuj.jpg"
                 },
                 new() {
-                    Id = 5,
+                    Id = "5",
                     Title = "Engine tune-up",
                     Description = "This can include a variety of services such as replacing spark plugs, air filters, and fuel filters to keep the engine running smoothly and efficiently.",
                     AssignedTo = "Karin Blair",
@@ -49,7 +49,7 @@ namespace {{SafeProjectName}}
                     Image = "https://th.bing.com/th/id/R.e4c01dd9f232947e6a92beb0a36294a5?rik=P076LRx7J6Xnrg&riu=http%3a%2f%2fupload.wikimedia.org%2fwikipedia%2fcommons%2ff%2ff3%2f1990_300zx_engine.jpg&ehk=f8KyT78eO3b%2fBiXzh6BZr7ze7f56TWgPST%2bY%2f%2bHqhXQ%3d&risl=&pid=ImgRaw&r=0"
                 },
                 new() {
-                    Id = 6,
+                    Id = "6",
                     Title = "Suspension and steering repairs",
                     Description = "This can include repairing or replacing components of the suspension and steering systems to ensure that the vehicle handles and rides smoothly.",
                     AssignedTo = "Daisy Phillips",

--- a/templates/csharp/copilot-plugin-from-scratch/host.json
+++ b/templates/csharp/copilot-plugin-from-scratch/host.json
@@ -1,11 +1,8 @@
 {
   "version": "2.0",
   "logging": {
-    "applicationInsights": {
-      "samplingSettings": {
-        "isEnabled": true,
-        "excludedTypes": "Request"
-      }
+    "logLevel": {
+      "Function": "Information"
     }
   }
 }

--- a/templates/csharp/copilot-plugin-from-scratch/infra/azure.bicep
+++ b/templates/csharp/copilot-plugin-from-scratch/infra/azure.bicep
@@ -53,7 +53,7 @@ resource functionApp 'Microsoft.Web/sites@2021-02-01' = {
         }
         {
           name: 'FUNCTIONS_WORKER_RUNTIME'
-          value: 'dotnet' // Set runtime to .NET
+          value: 'dotnet-isolated' // Use .NET isolated process
         }
         {
           name: 'WEBSITE_CONTENTAZUREFILECONNECTIONSTRING'

--- a/templates/csharp/copilot-plugin-from-scratch/local.settings.json
+++ b/templates/csharp/copilot-plugin-from-scratch/local.settings.json
@@ -2,6 +2,6 @@
   "IsEncrypted": false,
   "Values": {
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
-    "FUNCTIONS_WORKER_RUNTIME": "dotnet"
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated"
   }
 }

--- a/templates/csharp/copilot-plugin-from-scratch/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/copilot-plugin-from-scratch/{{ProjectName}}.csproj.tpl
@@ -21,8 +21,6 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.20.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.16.2" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.21.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/templates/csharp/copilot-plugin-from-scratch/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/copilot-plugin-from-scratch/{{ProjectName}}.csproj.tpl
@@ -4,6 +4,7 @@
     <TargetFramework>{{TargetFramework}}</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,7 +18,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.1" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.20.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.16.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.21.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -28,6 +33,10 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="System.Threading.ExecutionContext" Alias="ExecutionContext"/>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/25770678

- Migrating .NET apps from the in-process model to the [isolated worker model](https://learn.microsoft.com/en-us/azure/azure-functions/migrate-dotnet-to-isolated-model?tabs=net8). Currently, our Azure Function runtime uses the in-process model, but .NET 8 is not yet supported on the in-process model.
- Change the data type of the "Id" field in the repair data model to `string` for consistency with VSC.