### PR TITLE
refactor: improve error handling for generator

### DIFF
--- a/packages/fx-core/src/component/generator/generator.ts
+++ b/packages/fx-core/src/component/generator/generator.ts
@@ -31,7 +31,7 @@ import {
   GeneratorContext,
   TemplateActionSeq,
 } from "./generatorAction";
-import { cleanupFolder, renderTemplateFileData, renderTemplateFileName } from "./utils";
+import { renderTemplateFileData, renderTemplateFileName } from "./utils";
 import { enableTestToolByDefault } from "../../common/featureFlags";
 import { getSafeRegistrationIdEnvName } from "../../common/spec-parser/utils";
 

--- a/packages/fx-core/src/component/generator/generatorAction.ts
+++ b/packages/fx-core/src/component/generator/generatorAction.ts
@@ -41,7 +41,11 @@ export interface GeneratorContext {
 
   onActionStart?: (action: GeneratorAction, context: GeneratorContext) => Promise<void>;
   onActionEnd?: (action: GeneratorAction, context: GeneratorContext) => Promise<void>;
-  onActionError: (action: GeneratorAction, context: GeneratorContext, error: Error) => void;
+  onActionError: (
+    action: GeneratorAction,
+    context: GeneratorContext,
+    error: Error
+  ) => Promise<void>;
 }
 
 export interface GeneratorAction {

--- a/packages/fx-core/src/component/generator/generatorAction.ts
+++ b/packages/fx-core/src/component/generator/generatorAction.ts
@@ -19,7 +19,6 @@ import {
   unzip,
   zipFolder,
 } from "./utils";
-import { sampleProvider } from "../../common/samples";
 
 export interface GeneratorContext {
   name: string;

--- a/packages/fx-core/src/component/generator/generatorAction.ts
+++ b/packages/fx-core/src/component/generator/generatorAction.ts
@@ -9,18 +9,21 @@ import { LogProvider } from "@microsoft/teamsfx-api";
 
 import { FeatureFlagName } from "../../common/constants";
 import { getTemplatesFolder } from "../../folder";
-import { MissKeyError } from "./error";
+import { MissKeyError, SampleNotFoundError, TemplateNotFoundError } from "./error";
 import {
   downloadDirectory,
   fetchTemplateZipUrl,
   fetchZipFromUrl,
+  getSampleInfoFromName,
   SampleUrlInfo,
   unzip,
   zipFolder,
 } from "./utils";
+import { sampleProvider } from "../../common/samples";
 
 export interface GeneratorContext {
   name: string;
+  language?: string;
   destination: string;
   logProvider: LogProvider;
   tryLimits?: number;
@@ -38,11 +41,7 @@ export interface GeneratorContext {
 
   onActionStart?: (action: GeneratorAction, context: GeneratorContext) => Promise<void>;
   onActionEnd?: (action: GeneratorAction, context: GeneratorContext) => Promise<void>;
-  onActionError?: (
-    action: GeneratorAction,
-    context: GeneratorContext,
-    error: Error
-  ) => Promise<void>;
+  onActionError: (action: GeneratorAction, context: GeneratorContext, error: Error) => void;
 }
 
 export interface GeneratorAction {
@@ -55,6 +54,7 @@ export enum GeneratorActionName {
   FetchTemplateUrlWithTag = "FetchTemplatesUrlWithTag",
   FetchZipFromUrl = "FetchZipFromUrl",
   FetchTemplateZipFromLocal = "FetchTemplateZipFromLocal",
+  FetchSampleInfo = "FetchSampleInfo",
   DownloadDirectory = "DownloadDirectory",
   Unzip = "Unzip",
 }
@@ -82,11 +82,19 @@ export const fetchTemplateZipFromSourceCodeAction: GeneratorAction = {
       __dirname,
       "../../../../../",
       "templates",
-      context.name
+      context.language!
     );
 
     context.zip = zipFolder(templateSourceCodePath);
     return Promise.resolve();
+  },
+};
+
+export const fetchSampleInfoAction: GeneratorAction = {
+  name: GeneratorActionName.FetchSampleInfo,
+  run: async (context: GeneratorContext) => {
+    const sample = await getSampleInfoFromName(context.name);
+    context.sampleInfo = sample.downloadUrlInfo;
   },
 };
 
@@ -99,6 +107,9 @@ export const downloadDirectoryAction: GeneratorAction = {
     }
 
     context.outputs = await downloadDirectory(context.sampleInfo, context.destination);
+    if (!context.outputs?.length) {
+      throw new SampleNotFoundError(context.name);
+    }
   },
 };
 
@@ -110,7 +121,11 @@ export const fetchTemplateUrlWithTagAction: GeneratorAction = {
     }
 
     context.logProvider.debug(`Fetching template url with tag: ${JSON.stringify(context)}`);
-    context.url = await fetchTemplateZipUrl(context.name, context.tryLimits, context.timeoutInMs);
+    context.url = await fetchTemplateZipUrl(
+      context.language!,
+      context.tryLimits,
+      context.timeoutInMs
+    );
   },
 };
 
@@ -138,7 +153,7 @@ export const fetchTemplateFromLocalAction: GeneratorAction = {
     context.logProvider.debug(`Fetching zip from local: ${JSON.stringify(context)}`);
     context.fallback = true;
     const fallbackPath = path.join(getTemplatesFolder(), "fallback");
-    const fileName = `${context.name}.zip`;
+    const fileName = `${context.language!}.zip`;
     const zipPath: string = path.join(fallbackPath, fileName);
 
     const data: Buffer = await fs.readFile(zipPath);
@@ -150,6 +165,9 @@ export const fetchTemplateFromLocalAction: GeneratorAction = {
       context.fileDataReplaceFn,
       context.filterFn
     );
+    if (!context.outputs?.length) {
+      throw new TemplateNotFoundError(context.name);
+    }
   },
 };
 
@@ -179,4 +197,7 @@ export const TemplateActionSeq: GeneratorAction[] = [
 ];
 
 export const SampleActionSeq: GeneratorAction[] = [fetchZipFromUrlAction, unzipAction];
-export const DownloadDirectoryActionSeq: GeneratorAction[] = [downloadDirectoryAction];
+export const DownloadDirectoryActionSeq: GeneratorAction[] = [
+  fetchSampleInfoAction,
+  downloadDirectoryAction,
+];

--- a/packages/fx-core/src/component/generator/utils.ts
+++ b/packages/fx-core/src/component/generator/utils.ts
@@ -233,6 +233,12 @@ export function zipFolder(folderPath: string): AdmZip {
   return zip;
 }
 
+export async function cleanupFolder(folder: string): Promise<void> {
+  if (await fs.pathExists(folder)) {
+    await fs.rm(folder, { recursive: true });
+  }
+}
+
 export async function downloadDirectory(
   sampleInfo: SampleUrlInfo,
   dstPath: string,

--- a/packages/fx-core/src/component/generator/utils.ts
+++ b/packages/fx-core/src/component/generator/utils.ts
@@ -233,12 +233,6 @@ export function zipFolder(folderPath: string): AdmZip {
   return zip;
 }
 
-export async function cleanupFolder(folder: string): Promise<void> {
-  if (await fs.pathExists(folder)) {
-    await fs.rm(folder, { recursive: true });
-  }
-}
-
 export async function downloadDirectory(
   sampleInfo: SampleUrlInfo,
   dstPath: string,

--- a/packages/fx-core/tests/component/generator/generator.test.ts
+++ b/packages/fx-core/tests/component/generator/generator.test.ts
@@ -29,6 +29,7 @@ import {
   fetchTemplateFromLocalAction,
   fetchZipFromUrlAction,
   unzipAction,
+  fetchSampleInfoAction,
 } from "../../../src/component/generator/generatorAction";
 import * as generatorUtils from "../../../src/component/generator/utils";
 import mockedEnv from "mocked-env";
@@ -415,6 +416,14 @@ describe("Generator error", async () => {
     const result = await Generator.generateTemplate(ctx, tmpDir, "bot", "ts");
     if (result.isErr()) {
       assert.equal(result.error.innerError.name, "UnzipError");
+    }
+  });
+
+  it("fetch sample info fail", async () => {
+    sandbox.stub(fetchSampleInfoAction, "run").throws(new Error("test"));
+    const result = await Generator.generateSample(ctx, tmpDir, "test");
+    if (result.isErr()) {
+      assert.equal(result.error.innerError.name, "DownloadSampleNetworkError");
     }
   });
 

--- a/packages/fx-core/tests/component/generator/generator.test.ts
+++ b/packages/fx-core/tests/component/generator/generator.test.ts
@@ -405,6 +405,8 @@ describe("Generator error", async () => {
     const result = await Generator.generateTemplate(ctx, tmpDir, "bot", "ts");
     if (result.isErr()) {
       assert.equal(result.error.innerError.name, "TemplateZipFallbackError");
+    } else {
+      assert.fail("template fallback error should be thrown.");
     }
   });
 
@@ -416,6 +418,8 @@ describe("Generator error", async () => {
     const result = await Generator.generateTemplate(ctx, tmpDir, "bot", "ts");
     if (result.isErr()) {
       assert.equal(result.error.innerError.name, "UnzipError");
+    } else {
+      assert.fail("upzip error should be thrown.");
     }
   });
 
@@ -424,6 +428,8 @@ describe("Generator error", async () => {
     const result = await Generator.generateSample(ctx, tmpDir, "test");
     if (result.isErr()) {
       assert.equal(result.error.innerError.name, "DownloadSampleNetworkError");
+    } else {
+      assert.fail("fetch sample info error should be thrown.");
     }
   });
 

--- a/packages/fx-core/tests/component/generator/generatorAction.test.ts
+++ b/packages/fx-core/tests/component/generator/generatorAction.test.ts
@@ -11,6 +11,7 @@ import {
   GeneratorContext,
 } from "../../../src/component/generator/generatorAction";
 import { MockTools } from "../../core/utils";
+import { sampleDefaultOnActionError } from "../../../src/component/generator/generator";
 
 describe("Generator Actions", async () => {
   const tools = new MockTools();
@@ -20,6 +21,7 @@ describe("Generator Actions", async () => {
       name: "test",
       destination: "test",
       logProvider: tools.logProvider,
+      onActionError: sampleDefaultOnActionError,
     };
     try {
       downloadDirectoryAction.run(generatorContext);


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/25860181/

1.	Generate template and generate sample should only do below:
-	Construct generator context
-	Loop over generate actions
-	Merge telemetry
2.	Errors should only be thrown in action and utils
3.	If catched error is already BaseComponentError, throw the error;
If not, classify error according to action name 
