### PR TITLE
fix: .net function-based notification package downgrade

### DIFF
--- a/templates/csharp/notification-http-timer-trigger/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/notification-http-timer-trigger/{{ProjectName}}.csproj.tpl
@@ -30,6 +30,8 @@
       <!-- Exclude TeamsFx wwwroot static files which are for frontend only. -->
       <ExcludeAssets>contentFiles</ExcludeAssets>
     </PackageReference>
+    <!-- Fix system package downgrade -->
+    <PackageReference Include="Microsoft.NETCore.Targets" Version="3.1.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/templates/csharp/notification-http-trigger/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/notification-http-trigger/{{ProjectName}}.csproj.tpl
@@ -30,6 +30,8 @@
       <!-- Exclude TeamsFx wwwroot static files which are for frontend only. -->
       <ExcludeAssets>contentFiles</ExcludeAssets>
     </PackageReference>
+    <!-- Fix system package downgrade -->
+    <PackageReference Include="Microsoft.NETCore.Targets" Version="3.1.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/templates/csharp/notification-timer-trigger/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/notification-timer-trigger/{{ProjectName}}.csproj.tpl
@@ -30,6 +30,8 @@
       <!-- Exclude TeamsFx wwwroot static files which are for frontend only. -->
       <ExcludeAssets>contentFiles</ExcludeAssets>
     </PackageReference>
+    <!-- Fix system package downgrade -->
+    <PackageReference Include="Microsoft.NETCore.Targets" Version="3.1.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fix: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/25944655/
E2E Test: N/A

Fix the package downgrade issue by adding the empty `Microsoft.NETCore.Targets` package to remove the legacy `runtime.json` file. More details can be found from https://stackoverflow.com/questions/74453395/serilog-net-7-error-nu1605-detected-package-downgrade-and-microsoft-netco