### PR TITLE
perf(spec-parser): allow list oauth2 api

### DIFF
--- a/packages/fx-core/src/common/spec-parser/interfaces.ts
+++ b/packages/fx-core/src/common/spec-parser/interfaces.ts
@@ -185,6 +185,7 @@ export interface ParseOptions {
   allowSwagger?: boolean;
   allowAPIKeyAuth?: boolean;
   allowMultipleParameters?: boolean;
+  allowOauth2?: boolean;
 }
 
 export interface APIInfo {
@@ -201,5 +202,10 @@ export interface ListAPIResult {
   api: string;
   server: string;
   operationId: string;
-  auth?: OpenAPIV3.ApiKeySecurityScheme;
+  auth?: OpenAPIV3.SecuritySchemeObject;
+}
+
+export interface AuthSchema {
+  authSchema: OpenAPIV3.SecuritySchemeObject;
+  name: string;
 }

--- a/packages/fx-core/src/common/spec-parser/specFilter.ts
+++ b/packages/fx-core/src/common/spec-parser/specFilter.ts
@@ -14,7 +14,8 @@ export function specFilter(
   resolvedSpec: OpenAPIV3.Document,
   allowMissingId: boolean,
   allowAPIKeyAuth: boolean,
-  allowMultipleParameters: boolean
+  allowMultipleParameters: boolean,
+  allowOauth2: boolean
 ): OpenAPIV3.Document {
   try {
     const newSpec = { ...unResolveSpec };
@@ -30,7 +31,8 @@ export function specFilter(
           resolvedSpec,
           allowMissingId,
           allowAPIKeyAuth,
-          allowMultipleParameters
+          allowMultipleParameters,
+          allowOauth2
         )
       ) {
         continue;

--- a/packages/fx-core/src/common/spec-parser/specParser.browser.ts
+++ b/packages/fx-core/src/common/spec-parser/specParser.browser.ts
@@ -36,6 +36,7 @@ export class SpecParser {
     allowSwagger: false,
     allowAPIKeyAuth: false,
     allowMultipleParameters: false,
+    allowOauth2: false,
   };
 
   /**
@@ -86,7 +87,8 @@ export class SpecParser {
         !!this.isSwaggerFile,
         this.options.allowMissingId,
         this.options.allowAPIKeyAuth,
-        this.options.allowMultipleParameters
+        this.options.allowMultipleParameters,
+        this.options.allowOauth2
       );
     } catch (err) {
       throw new SpecParserError((err as Error).toString(), ErrorType.ValidateFailed);
@@ -185,7 +187,8 @@ export class SpecParser {
       spec,
       this.options.allowMissingId,
       this.options.allowAPIKeyAuth,
-      this.options.allowMultipleParameters
+      this.options.allowMultipleParameters,
+      this.options.allowAPIKeyAuth
     );
     this.apiMap = result;
     return result;

--- a/packages/fx-core/src/common/spec-parser/utils.ts
+++ b/packages/fx-core/src/common/spec-parser/utils.ts
@@ -225,7 +225,7 @@ export function isSupportedAuth(
 
     for (const auths of authSchemaArray) {
       if (auths.length === 1) {
-        if (allowAPIKeyAuth && !allowOauth2 && isAPIKeyAuth(auths[0].authSchema)) {
+        if (!allowOauth2 && allowAPIKeyAuth && isAPIKeyAuth(auths[0].authSchema)) {
           return true;
         } else if (!allowAPIKeyAuth && allowOauth2 && isBearerTokenAuth(auths[0].authSchema)) {
           return true;

--- a/packages/fx-core/src/common/spec-parser/utils.ts
+++ b/packages/fx-core/src/common/spec-parser/utils.ts
@@ -6,6 +6,7 @@ import { OpenAPIV3 } from "openapi-types";
 import SwaggerParser from "@apidevtools/swagger-parser";
 import { ConstantString } from "./constants";
 import {
+  AuthSchema,
   CheckParamResult,
   ErrorResult,
   ErrorType,
@@ -131,7 +132,8 @@ export function isSupportedApi(
   spec: OpenAPIV3.Document,
   allowMissingId: boolean,
   allowAPIKeyAuth: boolean,
-  allowMultipleParameters: boolean
+  allowMultipleParameters: boolean,
+  allowOauth2: boolean
 ): boolean {
   const pathObj = spec.paths[path];
   method = method.toLocaleLowerCase();
@@ -141,18 +143,8 @@ export function isSupportedApi(
       pathObj[method]
     ) {
       const securities = pathObj[method]!.security;
-      const apiKeyAuthArr = getAPIKeyAuthArray(securities, spec);
-
-      if (!allowAPIKeyAuth && securities) {
-        return false;
-      }
-
-      if (allowAPIKeyAuth && securities && apiKeyAuthArr.length === 0) {
-        return false;
-      }
-
-      // Currently we don't support multiple apiKey auth
-      if (apiKeyAuthArr.length > 0 && apiKeyAuthArr.every((auths) => auths.length > 1)) {
+      const authArray = getAuthArray(securities, spec);
+      if (!isSupportedAuth(authArray, allowAPIKeyAuth, allowOauth2)) {
         return false;
       }
 
@@ -216,29 +208,74 @@ export function isSupportedApi(
   return false;
 }
 
-export function getAPIKeyAuthArray(
+export function isSupportedAuth(
+  authSchemaArray: AuthSchema[][],
+  allowAPIKeyAuth: boolean,
+  allowOauth2: boolean
+): boolean {
+  if (authSchemaArray.length === 0) {
+    return true;
+  }
+
+  if (allowAPIKeyAuth || allowOauth2) {
+    // Currently we don't support multiple auth in one operation
+    if (authSchemaArray.length > 0 && authSchemaArray.every((auths) => auths.length > 1)) {
+      return false;
+    }
+
+    for (const auths of authSchemaArray) {
+      if (auths.length === 1) {
+        if (allowAPIKeyAuth && !allowOauth2 && isAPIKeyAuth(auths[0].authSchema)) {
+          return true;
+        } else if (!allowAPIKeyAuth && allowOauth2 && isBearerTokenAuth(auths[0].authSchema)) {
+          return true;
+        } else if (
+          allowAPIKeyAuth &&
+          allowOauth2 &&
+          (isAPIKeyAuth(auths[0].authSchema) || isBearerTokenAuth(auths[0].authSchema))
+        ) {
+          return true;
+        }
+      }
+    }
+  }
+
+  return false;
+}
+
+export function isAPIKeyAuth(authSchema: OpenAPIV3.SecuritySchemeObject): boolean {
+  return authSchema.type === "apiKey";
+}
+
+export function isBearerTokenAuth(authSchema: OpenAPIV3.SecuritySchemeObject): boolean {
+  return (
+    authSchema.type === "oauth2" ||
+    authSchema.type === "openIdConnect" ||
+    (authSchema.type === "http" && authSchema.scheme === "bearer")
+  );
+}
+
+export function getAuthArray(
   securities: OpenAPIV3.SecurityRequirementObject[] | undefined,
   spec: OpenAPIV3.Document
-): OpenAPIV3.ApiKeySecurityScheme[][] {
-  const result: OpenAPIV3.ApiKeySecurityScheme[][] = [];
+): AuthSchema[][] {
+  const result: AuthSchema[][] = [];
   const securitySchemas = spec.components?.securitySchemes;
   if (securities && securitySchemas) {
     for (let i = 0; i < securities.length; i++) {
       const security = securities[i];
 
-      let apiKeyAuthArray: OpenAPIV3.ApiKeySecurityScheme[] = [];
+      const authArray: AuthSchema[] = [];
       for (const name in security) {
         const auth = securitySchemas[name] as OpenAPIV3.SecuritySchemeObject;
-        if (auth.type === "apiKey") {
-          apiKeyAuthArray.push(auth);
-        } else {
-          apiKeyAuthArray = [];
-          break;
-        }
+        authArray.push({
+          authSchema: auth,
+          name: name,
+        });
       }
 
-      if (apiKeyAuthArray.length > 0) {
-        result.push(apiKeyAuthArray);
+      if (authArray.length > 0) {
+        result.push(authArray);
       }
     }
   }
@@ -344,7 +381,8 @@ export function validateServer(
   spec: OpenAPIV3.Document,
   allowMissingId: boolean,
   allowAPIKeyAuth: boolean,
-  allowMultipleParameters: boolean
+  allowMultipleParameters: boolean,
+  allowOauth2: boolean
 ): ErrorResult[] {
   const errors: ErrorResult[] = [];
 
@@ -373,7 +411,15 @@ export function validateServer(
     for (const method in methods) {
       const operationObject = (methods as any)[method] as OpenAPIV3.OperationObject;
       if (
-        isSupportedApi(method, path, spec, allowMissingId, allowAPIKeyAuth, allowMultipleParameters)
+        isSupportedApi(
+          method,
+          path,
+          spec,
+          allowMissingId,
+          allowAPIKeyAuth,
+          allowMultipleParameters,
+          allowOauth2
+        )
       ) {
         if (operationObject?.servers && operationObject.servers.length >= 1) {
           hasOperationLevelServers = true;
@@ -564,7 +610,8 @@ export function listSupportedAPIs(
   spec: OpenAPIV3.Document,
   allowMissingId: boolean,
   allowAPIKeyAuth: boolean,
-  allowMultipleParameters: boolean
+  allowMultipleParameters: boolean,
+  allowOauth2: boolean
 ): {
   [key: string]: OpenAPIV3.OperationObject;
 } {
@@ -575,7 +622,15 @@ export function listSupportedAPIs(
     for (const method in methods) {
       // For developer preview, only support GET operation with only 1 parameter without auth
       if (
-        isSupportedApi(method, path, spec, allowMissingId, allowAPIKeyAuth, allowMultipleParameters)
+        isSupportedApi(
+          method,
+          path,
+          spec,
+          allowMissingId,
+          allowAPIKeyAuth,
+          allowMultipleParameters,
+          allowOauth2
+        )
       ) {
         const operationObject = (methods as any)[method] as OpenAPIV3.OperationObject;
         result[`${method.toUpperCase()} ${path}`] = operationObject;
@@ -591,7 +646,8 @@ export function validateSpec(
   isSwaggerFile: boolean,
   allowMissingId: boolean,
   allowAPIKeyAuth: boolean,
-  allowMultipleParameters: boolean
+  allowMultipleParameters: boolean,
+  allowOauth2: boolean
 ): ValidateResult {
   const errors: ErrorResult[] = [];
   const warnings: WarningResult[] = [];
@@ -608,7 +664,8 @@ export function validateSpec(
     spec,
     allowMissingId,
     allowAPIKeyAuth,
-    allowMultipleParameters
+    allowMultipleParameters,
+    allowOauth2
   );
   errors.push(...serverErrors);
 
@@ -625,7 +682,13 @@ export function validateSpec(
   }
 
   // No supported API
-  const apiMap = listSupportedAPIs(spec, allowMissingId, allowAPIKeyAuth, allowMultipleParameters);
+  const apiMap = listSupportedAPIs(
+    spec,
+    allowMissingId,
+    allowAPIKeyAuth,
+    allowMultipleParameters,
+    allowOauth2
+  );
   if (Object.keys(apiMap).length === 0) {
     errors.push({
       type: ErrorType.NoSupportedApi,

--- a/packages/fx-core/src/component/driver/apiKey/create.ts
+++ b/packages/fx-core/src/component/driver/apiKey/create.ts
@@ -193,7 +193,7 @@ export class CreateApiKeyDriver implements StepDriver {
     const operations = await parser.list();
     const domains = operations
       .filter((value) => {
-        return value.auth?.name === args.name;
+        return value.auth?.type === "apiKey" && value.auth?.name === args.name;
       })
       .map((value) => {
         return value.server;

--- a/packages/fx-core/src/component/generator/copilotPlugin/helper.ts
+++ b/packages/fx-core/src/component/generator/copilotPlugin/helper.ts
@@ -233,7 +233,7 @@ function sortOperations(operations: ListAPIResult[]): ApiOperation[] {
       },
     };
 
-    if (operation.auth) {
+    if (operation.auth && operation.auth.type === "apiKey") {
       result.data.authName = operation.auth.name;
     }
     operationsWithSeparator.push(result);

--- a/packages/fx-core/src/core/FxCore.ts
+++ b/packages/fx-core/src/core/FxCore.ts
@@ -1261,7 +1261,7 @@ export class FxCore {
         for (const api of operations) {
           const operation = apiResultList.find((op) => op.api === api);
           if (operation) {
-            if (operation.auth) {
+            if (operation.auth && operation.auth.type === "apiKey") {
               authNames.add(operation.auth.name);
               serverUrls.add(operation.server);
             }

--- a/packages/fx-core/tests/common/spec-parser/specFilter.test.ts
+++ b/packages/fx-core/tests/common/spec-parser/specFilter.test.ts
@@ -148,7 +148,7 @@ describe("specFilter", () => {
       },
     };
 
-    const actualSpec = specFilter(filter, unResolveSpec, unResolveSpec, true, false, false);
+    const actualSpec = specFilter(filter, unResolveSpec, unResolveSpec, true, false, false, false);
     expect(actualSpec).to.deep.equal(expectedSpec);
   });
 
@@ -189,7 +189,7 @@ describe("specFilter", () => {
       },
     };
 
-    const actualSpec = specFilter(filter, unResolveSpec, unResolveSpec, true, false, false);
+    const actualSpec = specFilter(filter, unResolveSpec, unResolveSpec, true, false, false, false);
     expect(actualSpec).to.deep.equal(expectedSpec);
   });
 
@@ -237,6 +237,7 @@ describe("specFilter", () => {
       filter,
       unResolvedSpec as any,
       unResolvedSpec as any,
+      false,
       false,
       false,
       false
@@ -321,6 +322,7 @@ describe("specFilter", () => {
       unResolvedSpec as any,
       true,
       false,
+      false,
       false
     );
 
@@ -330,7 +332,7 @@ describe("specFilter", () => {
   it("should not filter anything if filter item not exist", () => {
     const filter = ["get /hello"];
     const clonedSpec = { ...unResolveSpec };
-    specFilter(filter, unResolveSpec, unResolveSpec, true, false, false);
+    specFilter(filter, unResolveSpec, unResolveSpec, true, false, false, false);
     expect(clonedSpec).to.deep.equal(unResolveSpec);
   });
 
@@ -362,6 +364,7 @@ describe("specFilter", () => {
       unResolvedSpec as any,
       true,
       false,
+      false,
       false
     );
 
@@ -371,7 +374,7 @@ describe("specFilter", () => {
   it("should not modify the original OpenAPI spec", () => {
     const filter = ["get /hello"];
     const clonedSpec = { ...unResolveSpec };
-    specFilter(filter, unResolveSpec, unResolveSpec, true, false, false);
+    specFilter(filter, unResolveSpec, unResolveSpec, true, false, false, false);
     expect(clonedSpec).to.deep.equal(unResolveSpec);
   });
 
@@ -383,7 +386,7 @@ describe("specFilter", () => {
       .throws(new Error("isSupportedApi error"));
 
     try {
-      specFilter(filter, unResolveSpec, unResolveSpec, true, false, false);
+      specFilter(filter, unResolveSpec, unResolveSpec, true, false, false, false);
       expect.fail("Expected specFilter to throw a SpecParserError");
     } catch (err) {
       expect(err).to.be.instanceOf(SpecParserError);

--- a/packages/fx-core/tests/common/spec-parser/utils.test.ts
+++ b/packages/fx-core/tests/common/spec-parser/utils.test.ts
@@ -114,7 +114,7 @@ describe("utils", () => {
           },
         },
       };
-      const result = isSupportedApi(method, path, spec as any, true, false, false);
+      const result = isSupportedApi(method, path, spec as any, true, false, false, false);
       assert.strictEqual(result, true);
     });
 
@@ -152,7 +152,7 @@ describe("utils", () => {
           },
         },
       };
-      const result = isSupportedApi(method, path, spec as any, false, false, false);
+      const result = isSupportedApi(method, path, spec as any, false, false, false, false);
       assert.strictEqual(result, false);
     });
 
@@ -204,7 +204,7 @@ describe("utils", () => {
           },
         },
       };
-      const result = isSupportedApi(method, path, spec as any, true, false, false);
+      const result = isSupportedApi(method, path, spec as any, true, false, false, false);
       assert.strictEqual(result, true);
     });
 
@@ -276,7 +276,7 @@ describe("utils", () => {
           },
         },
       };
-      const result = isSupportedApi(method, path, spec as any, true, false, false);
+      const result = isSupportedApi(method, path, spec as any, true, false, false, false);
       assert.strictEqual(result, false);
     });
 
@@ -348,7 +348,7 @@ describe("utils", () => {
           },
         },
       };
-      const result = isSupportedApi(method, path, spec as any, true, true, false);
+      const result = isSupportedApi(method, path, spec as any, true, true, false, false);
       assert.strictEqual(result, true);
     });
 
@@ -427,7 +427,7 @@ describe("utils", () => {
           },
         },
       };
-      const result = isSupportedApi(method, path, spec as any, true, true, false);
+      const result = isSupportedApi(method, path, spec as any, true, true, false, false);
       assert.strictEqual(result, false);
     });
 
@@ -480,7 +480,7 @@ describe("utils", () => {
           },
         },
       };
-      const result = isSupportedApi(method, path, spec as any, true, false, false);
+      const result = isSupportedApi(method, path, spec as any, true, false, false, false);
       assert.strictEqual(result, true);
     });
 
@@ -533,7 +533,7 @@ describe("utils", () => {
           },
         },
       };
-      const result = isSupportedApi(method, path, spec as any, true, false, false);
+      const result = isSupportedApi(method, path, spec as any, true, false, false, false);
       assert.strictEqual(result, false);
     });
 
@@ -586,7 +586,7 @@ describe("utils", () => {
           },
         },
       };
-      const result = isSupportedApi(method, path, spec as any, true, false, true);
+      const result = isSupportedApi(method, path, spec as any, true, false, true, false);
       assert.strictEqual(result, true);
     });
 
@@ -647,7 +647,7 @@ describe("utils", () => {
           },
         },
       };
-      const result = isSupportedApi(method, path, spec as any, true, false, true);
+      const result = isSupportedApi(method, path, spec as any, true, false, true, false);
       assert.strictEqual(result, false);
     });
 
@@ -703,7 +703,7 @@ describe("utils", () => {
           },
         },
       };
-      const result = isSupportedApi(method, path, spec as any, true, false, false);
+      const result = isSupportedApi(method, path, spec as any, true, false, false, false);
       assert.strictEqual(result, false);
     });
 
@@ -760,7 +760,7 @@ describe("utils", () => {
           },
         },
       };
-      const result = isSupportedApi(method, path, spec as any, true, false, false);
+      const result = isSupportedApi(method, path, spec as any, true, false, false, false);
       assert.strictEqual(result, true);
     });
 
@@ -798,7 +798,7 @@ describe("utils", () => {
           },
         },
       };
-      const result = isSupportedApi(method, path, spec as any, true, false, false);
+      const result = isSupportedApi(method, path, spec as any, true, false, false, false);
       assert.strictEqual(result, true);
     });
 
@@ -836,7 +836,7 @@ describe("utils", () => {
           },
         },
       };
-      const result = isSupportedApi(method, path, spec as any, true, false, false);
+      const result = isSupportedApi(method, path, spec as any, true, false, false, false);
       assert.strictEqual(result, false);
     });
 
@@ -873,7 +873,7 @@ describe("utils", () => {
           },
         },
       };
-      const result = isSupportedApi(method, path, spec as any, true, false, false);
+      const result = isSupportedApi(method, path, spec as any, true, false, false, false);
       assert.strictEqual(result, false);
     });
 
@@ -910,7 +910,7 @@ describe("utils", () => {
           },
         },
       };
-      const result = isSupportedApi(method, path, spec as any, true, false, false);
+      const result = isSupportedApi(method, path, spec as any, true, false, false, false);
       assert.strictEqual(result, false);
     });
 
@@ -948,7 +948,7 @@ describe("utils", () => {
           },
         },
       };
-      const result = isSupportedApi(method, path, spec as any, true, false, false);
+      const result = isSupportedApi(method, path, spec as any, true, false, false, false);
       assert.strictEqual(result, false);
     });
 
@@ -986,7 +986,7 @@ describe("utils", () => {
           },
         },
       };
-      const result = isSupportedApi(method, path, spec as any, true, false, false);
+      const result = isSupportedApi(method, path, spec as any, true, false, false, false);
       assert.strictEqual(result, false);
     });
 
@@ -1024,7 +1024,7 @@ describe("utils", () => {
           },
         },
       };
-      const result = isSupportedApi(method, path, spec as any, true, false, false);
+      const result = isSupportedApi(method, path, spec as any, true, false, false, false);
       assert.strictEqual(result, false);
     });
 
@@ -1051,7 +1051,7 @@ describe("utils", () => {
           },
         },
       };
-      const result = isSupportedApi(method, path, spec as any, true, false, false);
+      const result = isSupportedApi(method, path, spec as any, true, false, false, false);
       assert.strictEqual(result, false);
     });
 
@@ -1077,7 +1077,7 @@ describe("utils", () => {
           },
         },
       };
-      const result = isSupportedApi(method, path, spec as any, true, false, false);
+      const result = isSupportedApi(method, path, spec as any, true, false, false, false);
       assert.strictEqual(result, false);
     });
 
@@ -1109,7 +1109,7 @@ describe("utils", () => {
           },
         },
       };
-      const result = isSupportedApi(method, path, spec as any, true, false, false);
+      const result = isSupportedApi(method, path, spec as any, true, false, false, false);
       assert.strictEqual(result, false);
     });
   });
@@ -1407,7 +1407,7 @@ describe("utils", () => {
   describe("validateServer", () => {
     it("should return an error if there is no server information", () => {
       const spec = { paths: {} };
-      const errors = validateServer(spec as OpenAPIV3.Document, true, false, false);
+      const errors = validateServer(spec as OpenAPIV3.Document, true, false, false, false);
       assert.deepStrictEqual(errors, [
         {
           type: ErrorType.NoServerInformation,
@@ -1426,7 +1426,7 @@ describe("utils", () => {
           },
         },
       };
-      const errors = validateServer(spec as any, true, false, false);
+      const errors = validateServer(spec as any, true, false, false, false);
       assert.deepStrictEqual(errors, [
         {
           type: ErrorType.NoServerInformation,
@@ -1440,7 +1440,7 @@ describe("utils", () => {
         servers: [{ url: "https://example.com" }],
         paths: {},
       };
-      const errors = validateServer(spec as OpenAPIV3.Document, true, false, false);
+      const errors = validateServer(spec as OpenAPIV3.Document, true, false, false, false);
       assert.deepStrictEqual(errors, []);
     });
 
@@ -1452,7 +1452,7 @@ describe("utils", () => {
           },
         },
       };
-      const errors = validateServer(spec as any, true, false, false);
+      const errors = validateServer(spec as any, true, false, false, false);
       assert.deepStrictEqual(errors, []);
     });
 
@@ -1484,7 +1484,7 @@ describe("utils", () => {
           },
         },
       };
-      const errors = validateServer(spec as any, true, false, false);
+      const errors = validateServer(spec as any, true, false, false, false);
       assert.deepStrictEqual(errors, []);
     });
 
@@ -1518,7 +1518,7 @@ describe("utils", () => {
           },
         },
       };
-      const errors = validateServer(spec as any, true, false, false);
+      const errors = validateServer(spec as any, true, false, false, false);
       assert.deepStrictEqual(errors, []);
     });
 
@@ -1552,7 +1552,7 @@ describe("utils", () => {
           },
         },
       };
-      const errors = validateServer(spec as any, true, false, false);
+      const errors = validateServer(spec as any, true, false, false, false);
       assert.deepStrictEqual(errors, [
         {
           type: ErrorType.RelativeServerUrlNotSupported,

--- a/packages/fx-core/tests/common/spec-parser/utils.test.ts
+++ b/packages/fx-core/tests/common/spec-parser/utils.test.ts
@@ -352,7 +352,154 @@ describe("utils", () => {
       assert.strictEqual(result, true);
     });
 
-    it("should return false if allowAPIKeyAuth is true but contains aad auth", () => {
+    it("should return false if allowAPIKeyAuth is true but contains multiple apiKey auth", () => {
+      const method = "POST";
+      const path = "/users";
+      const spec = {
+        components: {
+          securitySchemes: {
+            api_key: {
+              type: "apiKey",
+              name: "api_key",
+              in: "header",
+            },
+            api_key2: {
+              type: "apiKey",
+              name: "api_key2",
+              in: "header",
+            },
+          },
+        },
+        paths: {
+          "/users": {
+            post: {
+              security: [
+                {
+                  api_key2: [],
+                  api_key: [],
+                },
+              ],
+              parameters: [
+                {
+                  in: "query",
+                  required: false,
+                  schema: { type: "string" },
+                },
+              ],
+              requestBody: {
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "object",
+                      required: ["name"],
+                      properties: {
+                        name: {
+                          type: "string",
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+              responses: {
+                200: {
+                  content: {
+                    "application/json": {
+                      schema: {
+                        type: "object",
+                        properties: {
+                          name: {
+                            type: "string",
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      const result = isSupportedApi(method, path, spec as any, true, true, false, false);
+      assert.strictEqual(result, false);
+    });
+
+    it("should return true if allowOauth2 is true and contains aad auth", () => {
+      const method = "POST";
+      const path = "/users";
+      const spec = {
+        components: {
+          securitySchemes: {
+            oauth: {
+              type: "oauth2",
+              flows: {
+                implicit: {
+                  authorizationUrl: "https://example.com/api/oauth/dialog",
+                  scopes: {
+                    "write:pets": "modify pets in your account",
+                    "read:pets": "read your pets",
+                  },
+                },
+              },
+            },
+          },
+        },
+        paths: {
+          "/users": {
+            post: {
+              security: [
+                {
+                  oauth: ["read:pets"],
+                },
+              ],
+              parameters: [
+                {
+                  in: "query",
+                  required: false,
+                  schema: { type: "string" },
+                },
+              ],
+              requestBody: {
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "object",
+                      required: ["name"],
+                      properties: {
+                        name: {
+                          type: "string",
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+              responses: {
+                200: {
+                  content: {
+                    "application/json": {
+                      schema: {
+                        type: "object",
+                        properties: {
+                          name: {
+                            type: "string",
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      const result = isSupportedApi(method, path, spec as any, true, false, false, true);
+      assert.strictEqual(result, true);
+    });
+
+    it("should return false if allowAPIKeyAuth is true, allowOauth2 is false, but contains aad auth", () => {
       const method = "POST";
       const path = "/users";
       const spec = {
@@ -429,6 +576,85 @@ describe("utils", () => {
       };
       const result = isSupportedApi(method, path, spec as any, true, true, false, false);
       assert.strictEqual(result, false);
+    });
+
+    it("should return false if allowAPIKeyAuth is true, allowOauth2 is false, and contains aad auth", () => {
+      const method = "POST";
+      const path = "/users";
+      const spec = {
+        components: {
+          securitySchemes: {
+            api_key: {
+              type: "apiKey",
+              name: "api_key",
+              in: "header",
+            },
+            oauth: {
+              type: "oauth2",
+              flows: {
+                implicit: {
+                  authorizationUrl: "https://example.com/api/oauth/dialog",
+                  scopes: {
+                    "write:pets": "modify pets in your account",
+                    "read:pets": "read your pets",
+                  },
+                },
+              },
+            },
+          },
+        },
+        paths: {
+          "/users": {
+            post: {
+              security: [
+                {
+                  oauth: ["read:pets"],
+                },
+              ],
+              parameters: [
+                {
+                  in: "query",
+                  required: false,
+                  schema: { type: "string" },
+                },
+              ],
+              requestBody: {
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "object",
+                      required: ["name"],
+                      properties: {
+                        name: {
+                          type: "string",
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+              responses: {
+                200: {
+                  content: {
+                    "application/json": {
+                      schema: {
+                        type: "object",
+                        properties: {
+                          name: {
+                            type: "string",
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      const result = isSupportedApi(method, path, spec as any, true, true, false, true);
+      assert.strictEqual(result, true);
     });
 
     it("should return true if method is POST, path is valid, parameter is supported and only one required param in parameters", () => {


### PR DESCRIPTION
Add support to list APIs with below auth type:

```
authSchema.type === "oauth2" ||
authSchema.type === "openIdConnect" ||
(authSchema.type === "http" && authSchema.scheme === "bearer")
```
