### PR TITLE
fix(core): show warning when app name length is 24

### DIFF
--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -210,7 +210,7 @@
   "core.QuestionAppName.validation.pattern": "Application name must start with letters and contain at least two letters or digits. It can not contain some special characters.",
   "core.QuestionAppName.validation.maxlength": "Application name is longer than the maximum length of 30.",
   "core.QuestionAppName.validation.pathExist": "Path exists: %s. Select a different application name.",
-  "core.QuestionAppName.validation.lengthWarning": "Application name may exceed the length limitation in local debug. You could change it in manifest file.",
+  "core.QuestionAppName.validation.lengthWarning": "Your application name may exceed the maximum length of 30 characters because Teams Toolkit will automatically append a \"-local\" suffix for the Teams application registered for local debugging purposes. You may continue, but make sure to update your application name in the \"manifest.json\" file.",
   "core.ProgrammingLanguageQuestion.placeholder": "Select a programming language.",
   "core.ProgrammingLanguageQuestion.placeholder.spfx": "SPFx is currently supporting TypeScript only.",
   "core.option.tutorial": "Open tutorial",

--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -210,6 +210,7 @@
   "core.QuestionAppName.validation.pattern": "Application name must start with letters and contain at least two letters or digits. It can not contain some special characters.",
   "core.QuestionAppName.validation.maxlength": "Application name is longer than the maximum length of 30.",
   "core.QuestionAppName.validation.pathExist": "Path exists: %s. Select a different application name.",
+  "core.QuestionAppName.validation.lengthWarning": "Application name may exceed the length limitation in local debug. You could change it in manifest file.",
   "core.ProgrammingLanguageQuestion.placeholder": "Select a programming language.",
   "core.ProgrammingLanguageQuestion.placeholder.spfx": "SPFx is currently supporting TypeScript only.",
   "core.option.tutorial": "Open tutorial",

--- a/packages/fx-core/src/question/create.ts
+++ b/packages/fx-core/src/question/create.ts
@@ -1166,6 +1166,15 @@ export function appNameQuestion(): TextInputQuestion {
           pattern: AppNamePattern,
           maxLength: 30,
         };
+        if (input.length === 24) {
+          // show warning notification because it may exceed the Teams app name max length after appending suffix
+          const context = createContextV3();
+          void context.userInteraction.showMessage(
+            "warn",
+            getLocalizedString("core.QuestionAppName.validation.lengthWarning"),
+            false
+          );
+        }
         const appName = input;
         const validateResult = jsonschema.validate(appName, schema);
         if (validateResult.errors && validateResult.errors.length > 0) {

--- a/packages/fx-core/tests/question/create.test.ts
+++ b/packages/fx-core/tests/question/create.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 import {
+  Context,
   FuncValidation,
   FxError,
   Inputs,
@@ -50,6 +51,8 @@ import { QuestionNames } from "../../src/question/questionNames";
 import { QuestionTreeVisitor, traverse } from "../../src/ui/visitor";
 import { MockTools, MockUserInteraction, randomAppName } from "../core/utils";
 import { isApiCopilotPluginEnabled } from "../../src/common/featureFlags";
+import { MockedUserInteraction } from "../plugins/solution/util";
+import * as utils from "../../src/component/utils";
 
 export async function callFuncs(question: Question, inputs: Inputs, answer?: string) {
   if (question.default && typeof question.default !== "string") {
@@ -1971,6 +1974,19 @@ describe("scaffold question", () => {
       sandbox.stub<any, any>(fs, "pathExists").resolves(false);
       validRes = await validFunc(inputs.appName, inputs);
       assert.isTrue(validRes === undefined);
+    });
+
+    it("app name has 24 length", async () => {
+      const mockedUI = new MockedUserInteraction();
+      sandbox.stub(utils, "createContextV3").returns({
+        userInteraction: mockedUI,
+      } as Context);
+      const showMessageStub = sandbox.stub(mockedUI, "showMessage");
+
+      const input = "abcdefghijklmnopqrstuvwx";
+      await validFunc(input);
+
+      assert.isTrue(showMessageStub.calledOnce);
     });
 
     it("app name exceed maxlength of 30", async () => {


### PR DESCRIPTION
Related bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/24965003