### PR TITLE
feat: expose test tool checker for VS

### DIFF
--- a/packages/fx-core/src/common/deps-checker/coreDepsLoggerAdapter.ts
+++ b/packages/fx-core/src/common/deps-checker/coreDepsLoggerAdapter.ts
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { LogLevel, LogProvider } from "@microsoft/teamsfx-api";
+import os from "os";
+import { DepsLogger } from "./depsLogger";
+
+export class CoreDepsLoggerAdapter implements DepsLogger {
+  private detailLogLines: string[] = [];
+  private logProvider: LogProvider;
+
+  public constructor(logProvider: LogProvider) {
+    this.logProvider = logProvider;
+  }
+
+  public debug(message: string): void {
+    this.addToDetailCache(LogLevel.Debug, message);
+  }
+
+  public info(message: string): void {
+    this.addToDetailCache(LogLevel.Info, message);
+    this.logProvider.info(message);
+  }
+
+  public warning(message: string): void {
+    this.addToDetailCache(LogLevel.Warning, message);
+    this.logProvider.warning(message);
+  }
+
+  public error(message: string): void {
+    this.addToDetailCache(LogLevel.Error, message);
+    this.logProvider.error(message);
+  }
+
+  public appendLine(message: string): void {
+    this.logProvider.log(LogLevel.Info, message);
+  }
+
+  public append(message: string): void {
+    this.logProvider.log(LogLevel.Info, message);
+  }
+
+  public cleanup(): void {
+    this.detailLogLines = [];
+  }
+
+  public printDetailLog(): void {
+    this.logProvider.error(this.detailLogLines.join(os.EOL));
+  }
+
+  private addToDetailCache(level: LogLevel, message: string): void {
+    const line = `${String(LogLevel[level])} ${new Date().toISOString()}: ${message}`;
+    this.detailLogLines.push(line);
+  }
+}

--- a/packages/fx-core/src/common/deps-checker/coreDepsTelemetryAdapter.ts
+++ b/packages/fx-core/src/common/deps-checker/coreDepsTelemetryAdapter.ts
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { DepsTelemetry } from "./depsTelemetry";
+import { SystemError, TelemetryReporter, UserError } from "@microsoft/teamsfx-api";
+import os from "os";
+import { DepsCheckerEvent, TelemetryMessurement } from "./constant";
+import { TelemetryProperty, fillInTelemetryPropsForFxError } from "../telemetry";
+import { TelemetryMeasurement } from "../../component/utils/depsChecker/common";
+
+export class CoreDepsTelemetryAdapter implements DepsTelemetry {
+  private readonly _telemetryComponentType = "core:debug:envchecker";
+  private readonly _telemetryReporter: TelemetryReporter;
+
+  constructor(telemetryReporter: TelemetryReporter) {
+    this._telemetryReporter = telemetryReporter;
+  }
+
+  public sendEvent(
+    eventName: DepsCheckerEvent,
+    properties: { [key: string]: string } = {},
+    timecost?: number
+  ): void {
+    this.addCommonProps(properties);
+    const measurements: { [p: string]: number } = {};
+
+    if (timecost) {
+      measurements[TelemetryMessurement.completionTime] = timecost;
+    }
+
+    this._telemetryReporter.sendTelemetryEvent(eventName, properties, measurements);
+  }
+
+  public async sendEventWithDuration(
+    eventName: DepsCheckerEvent,
+    action: () => Promise<void>
+  ): Promise<void> {
+    const start = performance.now();
+    await action();
+    // use seconds instead of milliseconds
+    const timecost = Number(((performance.now() - start) / 1000).toFixed(2));
+    this.sendEvent(eventName, {}, timecost);
+  }
+
+  public sendUserErrorEvent(eventName: DepsCheckerEvent, errorMessage: string): void {
+    const properties: { [key: string]: string } = {};
+    const error = new UserError(this._telemetryComponentType, eventName, errorMessage);
+    fillInTelemetryPropsForFxError(properties, error);
+    this._telemetryReporter.sendTelemetryErrorEvent(eventName, {
+      ...this.addCommonProps(),
+      ...properties,
+    });
+  }
+
+  public sendSystemErrorEvent(
+    eventName: DepsCheckerEvent,
+    errorMessage: string,
+    errorStack: string
+  ): void {
+    const properties: { [key: string]: string } = {};
+    const error = new SystemError(
+      this._telemetryComponentType,
+      eventName,
+      `errorMsg=${errorMessage},errorStack=${errorStack}`
+    );
+    error.stack = errorStack;
+    fillInTelemetryPropsForFxError(properties, error);
+    this._telemetryReporter.sendTelemetryErrorEvent(eventName, {
+      ...this.addCommonProps(),
+      ...properties,
+    });
+  }
+
+  private addCommonProps(properties: { [key: string]: string } = {}): { [key: string]: string } {
+    properties[TelemetryMeasurement.OSArch] = os.arch();
+    properties[TelemetryMeasurement.OSRelease] = os.release();
+    properties[TelemetryProperty.Component] = this._telemetryComponentType;
+    return properties;
+  }
+}

--- a/packages/fx-core/src/common/deps-checker/index.ts
+++ b/packages/fx-core/src/common/deps-checker/index.ts
@@ -10,3 +10,5 @@ export * from "./depsManager";
 export * from "./depsTelemetry";
 export * from "./constant";
 export * from "./util";
+export * from "./coreDepsLoggerAdapter";
+export * from "./coreDepsTelemetryAdapter";

--- a/packages/fx-core/tests/common/deps-checker/coreDepsLoggerAdapter.test.ts
+++ b/packages/fx-core/tests/common/deps-checker/coreDepsLoggerAdapter.test.ts
@@ -11,7 +11,7 @@ import * as sinon from "sinon";
 import { LogProvider } from "@microsoft/teamsfx-api";
 import { CoreDepsLoggerAdapter } from "../../../src/common/deps-checker/coreDepsLoggerAdapter";
 
-describe("Func Tools Checker Test", () => {
+describe("CoreDepsLoggerAdapter", () => {
   const sandbox = sinon.createSandbox();
 
   afterEach(() => {

--- a/packages/fx-core/tests/common/deps-checker/coreDepsLoggerAdapter.test.ts
+++ b/packages/fx-core/tests/common/deps-checker/coreDepsLoggerAdapter.test.ts
@@ -1,0 +1,105 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * @author Aocheng Wang <aochengwang@microsoft.com>
+ */
+import "mocha";
+
+import chai from "chai";
+import * as sinon from "sinon";
+import { LogProvider } from "@microsoft/teamsfx-api";
+import { CoreDepsLoggerAdapter } from "../../../src/common/deps-checker/coreDepsLoggerAdapter";
+
+describe("Func Tools Checker Test", () => {
+  const sandbox = sinon.createSandbox();
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("append", () => {
+    // Arrange
+    let text = "";
+    const stub = sandbox.stub().callsFake((_level, _text: string) => (text = _text));
+    const logProvider = { log: stub } as any as LogProvider;
+
+    // Act
+    const adapter = new CoreDepsLoggerAdapter(logProvider);
+    adapter.append("test");
+
+    // Assert
+    chai.assert.match(text, /test/);
+  });
+
+  it("appendLine", () => {
+    // Arrange
+    let text = "";
+    const stub = sandbox.stub().callsFake((_level, _text: string) => (text = _text));
+    const logProvider = { log: stub } as any as LogProvider;
+
+    // Act
+    const adapter = new CoreDepsLoggerAdapter(logProvider);
+    adapter.appendLine("test");
+
+    // Assert
+    chai.assert.match(text, /test/);
+  });
+
+  it("error", () => {
+    // Arrange
+    let text = "";
+    const stub = sandbox.stub().callsFake((_text: string) => (text = _text));
+    const logProvider = { error: stub } as any as LogProvider;
+
+    // Act
+    const adapter = new CoreDepsLoggerAdapter(logProvider);
+    adapter.error("test");
+
+    // Assert
+    chai.assert.match(text, /test/);
+  });
+
+  it("info", () => {
+    // Arrange
+    let text = "";
+    const stub = sandbox.stub().callsFake((_text: string) => (text = _text));
+    const logProvider = { info: stub } as any as LogProvider;
+
+    // Act
+    const adapter = new CoreDepsLoggerAdapter(logProvider);
+    adapter.info("test");
+
+    // Assert
+    chai.assert.match(text, /test/);
+  });
+
+  it("warning", () => {
+    // Arrange
+    let text = "";
+    const stub = sandbox.stub().callsFake((_text: string) => (text = _text));
+    const logProvider = { warning: stub } as any as LogProvider;
+
+    // Act
+    const adapter = new CoreDepsLoggerAdapter(logProvider);
+    adapter.warning("test");
+
+    // Assert
+    chai.assert.match(text, /test/);
+  });
+
+  it("debug", () => {
+    // Arrange
+    let text = "";
+    const stub = sandbox.stub().callsFake((_text: string) => (text = _text));
+    const logProvider = { error: stub } as any as LogProvider;
+
+    // Act
+    const adapter = new CoreDepsLoggerAdapter(logProvider);
+    adapter.debug("error");
+    adapter.printDetailLog();
+
+    // Assert
+    chai.assert.match(text, /error/);
+  });
+});

--- a/packages/fx-core/tests/common/deps-checker/coreDepsTelemetryAdapter.test.ts
+++ b/packages/fx-core/tests/common/deps-checker/coreDepsTelemetryAdapter.test.ts
@@ -13,7 +13,7 @@ import { TelemetryReporter } from "@microsoft/teamsfx-api";
 import { CoreDepsTelemetryAdapter } from "../../../src/common/deps-checker/coreDepsTelemetryAdapter";
 import { DepsCheckerEvent } from "../../../src/common/deps-checker/constant";
 
-describe("Func Tools Checker Test", () => {
+describe("CoreDepsTelemetryAdapter", () => {
   const sandbox = sinon.createSandbox();
 
   beforeEach(() => {

--- a/packages/fx-core/tests/common/deps-checker/coreDepsTelemetryAdapter.test.ts
+++ b/packages/fx-core/tests/common/deps-checker/coreDepsTelemetryAdapter.test.ts
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * @author Aocheng Wang <aochengwang@microsoft.com>
+ */
+import "mocha";
+
+import chai from "chai";
+import os from "os";
+import * as sinon from "sinon";
+import { TelemetryReporter } from "@microsoft/teamsfx-api";
+import { CoreDepsTelemetryAdapter } from "../../../src/common/deps-checker/coreDepsTelemetryAdapter";
+import { DepsCheckerEvent } from "../../../src/common/deps-checker/constant";
+
+describe("Func Tools Checker Test", () => {
+  const sandbox = sinon.createSandbox();
+
+  beforeEach(() => {
+    sandbox.stub(os, "arch").returns("mock");
+    sandbox.stub(os, "release").returns("mock");
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("sendEvent", () => {
+    // Arrange
+    const stub = sandbox.stub();
+    const reporter = { sendTelemetryEvent: stub } as any as TelemetryReporter;
+
+    // Act
+    const adapter = new CoreDepsTelemetryAdapter(reporter);
+    adapter.sendEvent(DepsCheckerEvent.dotnetAlreadyInstalled, { property1: "value1" }, 42);
+
+    // Assert
+    sinon.assert.calledWith(
+      stub,
+      DepsCheckerEvent.dotnetAlreadyInstalled,
+      {
+        component: "core:debug:envchecker",
+        ["os-arch"]: "mock",
+        ["os-release"]: "mock",
+        property1: "value1",
+      },
+      { ["completion-time"]: 42 }
+    );
+  });
+  it("sendUserErrorEvent", () => {
+    // Arrange
+    let eventName = "";
+    const telemetryReporter = {
+      sendTelemetryErrorEvent(_eventName: string) {
+        eventName = _eventName;
+      },
+    } as any as TelemetryReporter;
+
+    // Act
+    const adapter = new CoreDepsTelemetryAdapter(telemetryReporter);
+    adapter.sendUserErrorEvent(DepsCheckerEvent.dotnetAlreadyInstalled, "error");
+
+    // Assert
+    chai.assert.equal(eventName, DepsCheckerEvent.dotnetAlreadyInstalled);
+  });
+  it("sendSystemErrorEvent", () => {
+    // Arrange
+    let eventName = "";
+    const telemetryReporter = {
+      sendTelemetryErrorEvent(_eventName: string) {
+        eventName = _eventName;
+      },
+    } as any as TelemetryReporter;
+
+    // Act
+    const adapter = new CoreDepsTelemetryAdapter(telemetryReporter);
+    adapter.sendUserErrorEvent(DepsCheckerEvent.dotnetAlreadyInstalled, "error");
+
+    // Assert
+    chai.assert.equal(eventName, DepsCheckerEvent.dotnetAlreadyInstalled);
+  });
+});

--- a/packages/server/src/apis.ts
+++ b/packages/server/src/apis.ts
@@ -29,7 +29,7 @@ import {
   TokenRequest,
   Void,
 } from "@microsoft/teamsfx-api";
-import { VersionCheckRes } from "@microsoft/teamsfx-core";
+import { DependencyStatus, TestToolInstallOptions, VersionCheckRes } from "@microsoft/teamsfx-core";
 import {
   CancellationToken,
   NotificationType2,
@@ -179,6 +179,11 @@ export interface IServerConnection {
     inputs: Inputs,
     token: CancellationToken
   ) => Promise<Result<ApiOperation[], FxError>>;
+  checkAndInstallTestTool: (
+    inputs: Inputs,
+    options: TestToolInstallOptions,
+    token: CancellationToken
+  ) => Promise<Result<DependencyStatus, FxError>>;
 }
 
 /**

--- a/packages/server/src/apis.ts
+++ b/packages/server/src/apis.ts
@@ -180,8 +180,7 @@ export interface IServerConnection {
     token: CancellationToken
   ) => Promise<Result<ApiOperation[], FxError>>;
   checkAndInstallTestTool: (
-    inputs: Inputs,
-    options: TestToolInstallOptions,
+    options: TestToolInstallOptions & { correlationId: string },
     token: CancellationToken
   ) => Promise<Result<DependencyStatus, FxError>>;
 }

--- a/packages/server/src/serverConnection.ts
+++ b/packages/server/src/serverConnection.ts
@@ -463,11 +463,10 @@ export default class ServerConnection implements IServerConnection {
   }
 
   public async checkAndInstallTestTool(
-    inputs: Inputs,
-    options: TestToolInstallOptions,
+    options: TestToolInstallOptions & { correlationId: string },
     token: CancellationToken
   ): Promise<Result<DependencyStatus, FxError>> {
-    const corrId = inputs.correlationId || "";
+    const corrId = options.correlationId || "";
 
     const depsManager = new DepsManager(
       new CoreDepsLoggerAdapter(this.tools.logProvider),

--- a/packages/server/tests/serverConnection.test.ts
+++ b/packages/server/tests/serverConnection.test.ts
@@ -464,4 +464,14 @@ describe("serverConnections", () => {
     );
     assert.isTrue(res.isOk());
   });
+  it("checkAndInstallTestTool error", async () => {
+    const connection = new ServerConnection(msgConn);
+    sandbox.stub(DepsManager.prototype, "ensureDependency").rejects("MockError");
+    const res = await connection.checkAndInstallTestTool(
+      {} as TestToolInstallOptions & { correlationId: string },
+      {} as CancellationToken
+    );
+    assert.isFalse(res.isOk());
+    assert.match(res._unsafeUnwrapErr().message, /MockError/);
+  });
 });

--- a/packages/server/tests/serverConnection.test.ts
+++ b/packages/server/tests/serverConnection.test.ts
@@ -10,6 +10,7 @@ import { Duplex } from "stream";
 import { CancellationToken, createMessageConnection } from "vscode-jsonrpc";
 import { setFunc } from "../src/customizedFuncAdapter";
 import ServerConnection from "../src/serverConnection";
+import { DependencyStatus, DepsManager, TestToolInstallOptions } from "@microsoft/teamsfx-core";
 
 class TestStream extends Duplex {
   _write(chunk: string, _encoding: string, done: () => void) {
@@ -451,6 +452,16 @@ describe("serverConnections", () => {
     const fake = sandbox.fake.resolves(ok(undefined));
     sandbox.replace(connection["core"], "copilotPluginAddAPI", fake);
     const res = await connection.copilotPluginAddAPIRequest({} as Inputs, {} as CancellationToken);
+    assert.isTrue(res.isOk());
+  });
+
+  it("checkAndInstallTestTool", async () => {
+    const connection = new ServerConnection(msgConn);
+    sandbox.stub(DepsManager.prototype, "ensureDependency").resolves({} as DependencyStatus);
+    const res = await connection.checkAndInstallTestTool(
+      {} as TestToolInstallOptions & { correlationId: string },
+      {} as CancellationToken
+    );
     assert.isTrue(res.isOk());
   });
 });


### PR DESCRIPTION
In server, expose testToolChecker logic from core, for VS test tool automatic installation feature.


https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/23787334