### PR TITLE
feat(sdk): support to set notification localstore file name with env variable

### DIFF
--- a/packages/dotnet-sdk/src/TeamsFx.Test/Conversation/LocalFileStorageTest.cs
+++ b/packages/dotnet-sdk/src/TeamsFx.Test/Conversation/LocalFileStorageTest.cs
@@ -69,5 +69,19 @@ namespace Microsoft.TeamsFx.Test.Conversation
             Assert.AreEqual(1, list.Length);
             Assert.AreEqual("activity-2", list[0].ActivityId);
         }
+
+        [TestMethod]
+        public async Task Set_FileNameWithEnvironmentVariable()
+        {
+            var previous = Environment.GetEnvironmentVariable("TEAMSFX_NOTIFICATION_STORE_FILENAME");
+            Environment.SetEnvironmentVariable("TEAMSFX_NOTIFICATION_STORE_FILENAME", ".notification.testtool.json");
+            var storage = new LocalFileStorage(testDir);
+            await storage.Write("key-1", new ConversationReference { ActivityId = "activity-1" });
+            Environment.SetEnvironmentVariable("TEAMSFX_NOTIFICATION_STORE_FILENAME", previous);
+
+            var storeFile = Path.Combine(testDir, ".notification.testtool.json");
+            Assert.IsTrue(File.Exists(storeFile));
+
+        }
     }
 }

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/LocalFileStorage.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/LocalFileStorage.cs
@@ -10,12 +10,12 @@ namespace Microsoft.TeamsFx.Conversation
     [Obsolete]
     internal sealed class LocalFileStorage : INotificationTargetStorage
     {
-        private const string LocalFileName = ".notification.localstore.json";
         private readonly string _filePath;
 
         public LocalFileStorage(string dirName)
         {
-            _filePath = Path.Combine(dirName, LocalFileName);
+            var localFileName = Environment.GetEnvironmentVariable("TEAMSFX_NOTIFICATION_STORE_FILENAME") ?? ".notification.localstore.json";
+            _filePath = Path.Combine(dirName, localFileName);
         }
 
         public async Task<ConversationReference> Read(string key, CancellationToken cancellationToken = default)


### PR DESCRIPTION
(For .NET SDK) Support to set notification local store via environment variable, so Test Tool can save conversation reference in a separated file.


Related PR (for Node.js): https://github.com/OfficeDev/TeamsFx/pull/10253
Work item: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/23787334