### PR TITLE
fix: expected a string but received a undefined error when AAD manifest misses required id

### DIFF
--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -434,6 +434,8 @@
   "error.aad.manifest.RequiredResourceAccessIsMissing": "requiredResourceAccess is missing\n",
   "error.aad.manifest.Oauth2PermissionsIsMissing": "oauth2Permissions is missing\n",
   "error.aad.manifest.PreAuthorizedApplicationsIsMissing": "preAuthorizedApplications is missing\n",
+  "error.aad.manifest.ResourceAppIdIsMissing": "Some item(s) in requiredResourceAccess misses resourceAppId property.",
+  "error.aad.manifest.ResourceAccessIdIsMissing": "Some item(s) in resourceAccess misses id property.",
   "error.aad.manifest.AccessTokenAcceptedVersionIs1": "accessTokenAcceptedVersion is 1\n",
   "error.aad.manifest.OptionalClaimsIsMissing": "optionalClaims is missing\n",
   "error.aad.manifest.OptionalClaimsMissingIdtypClaim": "optionalClaims access token doesn't contain idtyp claim\n",

--- a/packages/fx-core/src/component/driver/aad/error/aadManifestError.ts
+++ b/packages/fx-core/src/component/driver/aad/error/aadManifestError.ts
@@ -42,6 +42,30 @@ export class UnknownResourceAppIdUserError extends UserError {
   }
 }
 
+export class MissingResourceAppIdUserError extends UserError {
+  constructor(actionName: string) {
+    super({
+      source: actionName,
+      name: "MissingResourceAppId",
+      message: getDefaultString("error.aad.manifest.ResourceAppIdIsMissing"),
+      displayMessage: getLocalizedString("error.aad.manifest.ResourceAppIdIsMissing"),
+      helpLink: "https://aka.ms/teamsfx-aad-manifest",
+    });
+  }
+}
+
+export class MissingResourceAccessIdUserError extends UserError {
+  constructor(actionName: string) {
+    super({
+      source: actionName,
+      name: "MissingResourceAccessId",
+      message: getDefaultString("error.aad.manifest.ResourceAccessIdIsMissing"),
+      displayMessage: getLocalizedString("error.aad.manifest.ResourceAccessIdIsMissing"),
+      helpLink: "https://aka.ms/teamsfx-aad-manifest",
+    });
+  }
+}
+
 export class UnknownResourceAccessIdUserError extends UserError {
   constructor(actionName: string, unknownId: string) {
     super({

--- a/packages/fx-core/src/component/driver/aad/utility/aadManifestHelper.ts
+++ b/packages/fx-core/src/component/driver/aad/utility/aadManifestHelper.ts
@@ -7,6 +7,8 @@ import isUUID from "validator/lib/isUUID";
 import { getPermissionMap } from "../permissions";
 import {
   AadManifestErrorMessage,
+  MissingResourceAccessIdUserError,
+  MissingResourceAppIdUserError,
   UnknownResourceAccessIdUserError,
   UnknownResourceAccessTypeUserError,
   UnknownResourceAppIdUserError,
@@ -217,6 +219,9 @@ export class AadManifestHelper {
     manifest.requiredResourceAccess?.forEach((requiredResourceAccessItem) => {
       const resourceIdOrName = requiredResourceAccessItem.resourceAppId;
       let resourceId = resourceIdOrName;
+      if (!resourceIdOrName) {
+        throw new MissingResourceAppIdUserError(componentName);
+      }
       if (!isUUID(resourceIdOrName)) {
         resourceId = map[resourceIdOrName]?.id;
         if (!resourceId) {
@@ -227,6 +232,9 @@ export class AadManifestHelper {
 
       requiredResourceAccessItem.resourceAccess?.forEach((resourceAccessItem) => {
         const resourceAccessIdOrName = resourceAccessItem.id;
+        if (!resourceAccessIdOrName) {
+          throw new MissingResourceAccessIdUserError(componentName);
+        }
         if (!isUUID(resourceAccessIdOrName)) {
           let resourceAccessId;
           if (resourceAccessItem.type === "Scope") {

--- a/packages/fx-core/tests/component/driver/aad/aadManifestHelper.test.ts
+++ b/packages/fx-core/tests/component/driver/aad/aadManifestHelper.test.ts
@@ -147,6 +147,48 @@ describe("Microsoft Entra manifest helper Test", () => {
       .to.throw("Unknown resourceAppId Invalid Id");
   });
 
+  it("processRequiredResourceAccessInManifest with no resourceAppId", async () => {
+    const manifestWithInvalidSting: any = {
+      requiredResourceAccess: [
+        {
+          resourceAccess: [
+            {
+              id: "User.Read",
+              type: "Scope",
+            },
+          ],
+        },
+      ],
+    };
+
+    chai
+      .expect(() => {
+        AadManifestHelper.processRequiredResourceAccessInManifest(manifestWithInvalidSting);
+      })
+      .to.throw("Some item(s) in requiredResourceAccess misses resourceAppId property.");
+  });
+
+  it("processRequiredResourceAccessInManifest with no resourceAccess id", async () => {
+    const manifestWithInvalidSting: any = {
+      requiredResourceAccess: [
+        {
+          resourceAppId: "Microsoft Graph",
+          resourceAccess: [
+            {
+              type: "Scope",
+            },
+          ],
+        },
+      ],
+    };
+
+    chai
+      .expect(() => {
+        AadManifestHelper.processRequiredResourceAccessInManifest(manifestWithInvalidSting);
+      })
+      .to.throw("Some item(s) in resourceAccess misses id property.");
+  });
+
   it("processRequiredResourceAccessInManifest with no requiredResourceAccess", async () => {
     const manifest: any = {};
 


### PR DESCRIPTION
https://dev.azure.com/msazure/Microsoft%20Teams%20Extensibility/_workitems/edit/25519522

The expected AAD manifest snippet should look like this:
``` js
requiredResourceAccess: [
        {
          resourceAppId: "Microsoft Graph",
          resourceAccess: [
            {
              id: "User.Read",
              type: "Scope",
            },
          ],
        },
      ],
```

If the AAD manifest misses `resourceAppId` property, the error would be: Some item(s) in requiredResourceAccess misses resourceAppId property.

If the AAD manifest misses `id` proerty, the error would be: Some item(s) in resourceAccess misses id property.