### PR TITLE
feat: provide multi tenant SSO help link when related error happens

### DIFF
--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -439,6 +439,7 @@
   "error.aad.manifest.OptionalClaimsMissingIdtypClaim": "optionalClaims access token doesn't contain idtyp claim\n",
   "error.aad.manifest.AADManifestIssues": "Microsoft Entra manifest has following issues that may potentially break the Teams App:\n",
   "error.aad.manifest.DeleteOrUpdatePermissionFailed": "Unable to update or delete an existing permission when it's enabled. One possible reason is that the ACCESS_AS_USER_PERMISSION_ID environment variable is changed for selected environment. Ensure your permission id(s) are identical with the actual Microsoft Entra application and try again.\n",
+  "error.aad.manifest.HostNameNotOnVerifiedDomain": "Unable to set identifierUri because the value is not on verified domain: %s",
   "error.aad.manifest.UnknownResourceAppId": "Unknown resourceAppId %s",
   "error.aad.manifest.UnknownResourceAccessType": "Unknown resourceAccess: %s",
   "error.aad.manifest.UnknownResourceAccessId": "Unknown resourceAccess id: %s, if you're using permission as resourceAccess id, please try to use permission id instead.",

--- a/packages/fx-core/src/component/driver/aad/error/aadManifestError.ts
+++ b/packages/fx-core/src/component/driver/aad/error/aadManifestError.ts
@@ -80,3 +80,18 @@ export class DeleteOrUpdatePermissionFailedError extends UserError {
     });
   }
 }
+
+export class HostNameNotOnVerifiedDomainError extends UserError {
+  constructor(actionName: string, errorMessage: string) {
+    super({
+      source: actionName,
+      name: "HostNameNotOnVerifiedDomain",
+      message: getDefaultString("error.aad.manifest.HostNameNotOnVerifiedDomain", errorMessage),
+      displayMessage: getLocalizedString(
+        "error.aad.manifest.HostNameNotOnVerifiedDomain",
+        errorMessage
+      ),
+      helpLink: "https://aka.ms/teamsfx-aad-manifest",
+    });
+  }
+}

--- a/packages/fx-core/src/component/driver/aad/error/aadManifestError.ts
+++ b/packages/fx-core/src/component/driver/aad/error/aadManifestError.ts
@@ -91,7 +91,7 @@ export class HostNameNotOnVerifiedDomainError extends UserError {
         "error.aad.manifest.HostNameNotOnVerifiedDomain",
         errorMessage
       ),
-      helpLink: "https://aka.ms/teamsfx-aad-manifest",
+      helpLink: "https://aka.ms/teamsfx-multi-tenant",
     });
   }
 }

--- a/packages/fx-core/src/component/driver/aad/utility/aadAppClient.ts
+++ b/packages/fx-core/src/component/driver/aad/utility/aadAppClient.ts
@@ -135,7 +135,7 @@ export class AadAppClient {
         if (err.response.data.error?.code === aadErrorCode.hostNameNotOnVerifiedDomain) {
           throw new HostNameNotOnVerifiedDomainError(
             AadAppClient.name,
-            err.response.data.error?.message ?? ""
+            err.response.data.error.message
           );
         }
       }

--- a/packages/fx-core/src/component/driver/aad/utility/constants.ts
+++ b/packages/fx-core/src/component/driver/aad/utility/constants.ts
@@ -29,6 +29,7 @@ export const permissionsKeys = {
 
 export const aadErrorCode = {
   permissionErrorCode: "CannotDeleteOrUpdateEnabledEntitlement",
+  hostNameNotOnVerifiedDomain: "HostNameNotOnVerifiedDomain", // Using unverified domain in multi tenant scenario
 };
 
 export const constants = {

--- a/packages/fx-core/tests/component/driver/aad/aadAppClient.test.ts
+++ b/packages/fx-core/tests/component/driver/aad/aadAppClient.test.ts
@@ -351,6 +351,7 @@ describe("AadAppClient", async () => {
           expect(err.message).equals(
             "Unable to set identifierUri because the value is not on verified domain: Mocked error message"
           );
+          expect(err.helpLink).equals("https://aka.ms/teamsfx-multi-tenant");
         }
       );
     });

--- a/packages/fx-core/tests/component/driver/aad/aadAppClient.test.ts
+++ b/packages/fx-core/tests/component/driver/aad/aadAppClient.test.ts
@@ -12,9 +12,11 @@ import axiosRetry from "axios-retry";
 import MockAdapter from "axios-mock-adapter";
 import { SystemError, err } from "@microsoft/teamsfx-api";
 import { AADManifest } from "../../../../src/component/driver/aad/interface/AADManifest";
-import { IAADDefinition } from "../../../../src/component/driver/aad/interface/IAADDefinition";
 import { SignInAudience } from "../../../../src/component/driver/aad/interface/signInAudience";
-import { DeleteOrUpdatePermissionFailedError } from "../../../../src/component/driver/aad/error/aadManifestError";
+import {
+  DeleteOrUpdatePermissionFailedError,
+  HostNameNotOnVerifiedDomainError,
+} from "../../../../src/component/driver/aad/error/aadManifestError";
 chai.use(chaiAsPromised);
 const expect = chai.expect;
 
@@ -321,6 +323,33 @@ describe("AadAppClient", async () => {
           expect(err.name).equals("DeleteOrUpdatePermissionFailed");
           expect(err.message).equals(
             "Unable to update or delete an existing permission when it's enabled. One possible reason is that the ACCESS_AS_USER_PERMISSION_ID environment variable is changed for selected environment. Ensure your permission id(s) are identical with the actual Microsoft Entra application and try again.\n"
+          );
+        }
+      );
+    });
+
+    it("should throw error when request failed with HostNameNotOnVerifiedDomain", async () => {
+      const expectedError = {
+        error: {
+          code: "HostNameNotOnVerifiedDomain",
+          message: "Mocked error message",
+        },
+      };
+
+      sinon.stub(axiosInstance, "patch").rejects({
+        isAxiosError: true,
+        response: {
+          status: 400,
+          data: expectedError,
+        },
+      });
+      await expect(aadAppClient.updateAadApp(mockedManifest)).to.eventually.be.rejected.then(
+        (err) => {
+          expect(err instanceof HostNameNotOnVerifiedDomainError).to.be.true;
+          expect(err.source).equals("AadAppClient");
+          expect(err.name).equals("HostNameNotOnVerifiedDomain");
+          expect(err.message).equals(
+            "Unable to set identifierUri because the value is not on verified domain: Mocked error message"
           );
         }
       );

--- a/packages/fx-core/tests/component/driver/aad/aadAppClient.test.ts
+++ b/packages/fx-core/tests/component/driver/aad/aadAppClient.test.ts
@@ -6,7 +6,7 @@ import * as sinon from "sinon";
 import { AadAppClient } from "../../../../src/component/driver/aad/utility/aadAppClient";
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
-import axios, { AxiosInstance } from "axios";
+import axios, { AxiosInstance, isAxiosError } from "axios";
 import { MockedLogProvider, MockedM365Provider } from "../../../plugins/solution/util";
 import axiosRetry from "axios-retry";
 import MockAdapter from "axios-mock-adapter";
@@ -352,6 +352,23 @@ describe("AadAppClient", async () => {
             "Unable to set identifierUri because the value is not on verified domain: Mocked error message"
           );
           expect(err.helpLink).equals("https://aka.ms/teamsfx-multi-tenant");
+        }
+      );
+    });
+
+    it("should throw error when request failed with no error property", async () => {
+      const expectedError = {};
+
+      sinon.stub(axiosInstance, "patch").rejects({
+        isAxiosError: true,
+        response: {
+          status: 400,
+          data: expectedError,
+        },
+      });
+      await expect(aadAppClient.updateAadApp(mockedManifest)).to.eventually.be.rejected.then(
+        (err) => {
+          expect(isAxiosError(err)).to.be.true;
         }
       );
     });


### PR DESCRIPTION
If `aadApp/update` action failed with HostNameNotOnVerifiedDomain error, it means user is trying to update a multi tenant AAD app but not using a verified domain in application id uri. Throw a specific error with multi tenant SSO help link to guide users how to enable SSO for a multi tenant AAD app.


https://dev.azure.com/msazure/Microsoft%20Teams%20Extensibility/_workitems/edit/25053148