### PR TITLE
fix: import spfx truncate app name

### DIFF
--- a/packages/fx-core/src/component/generator/spfx/spfxGenerator.ts
+++ b/packages/fx-core/src/component/generator/spfx/spfxGenerator.ts
@@ -564,18 +564,8 @@ export class SPFxGenerator {
       }
 
       // Truncate manifest app name if exceed limitation
-      if (localManifest.name.short.length > Constants.TEAMS_APP_NAME_MAX_LENGTH) {
-        localManifest.name.short = localManifest.name.short.substring(
-          0,
-          Constants.TEAMS_APP_NAME_MAX_LENGTH
-        );
-      }
-      if (remoteManifest.name.short.length > Constants.TEAMS_APP_NAME_MAX_LENGTH) {
-        remoteManifest.name.short = remoteManifest.name.short.substring(
-          0,
-          Constants.TEAMS_APP_NAME_MAX_LENGTH
-        );
-      }
+      localManifest.name.short = Utils.truncateAppShortName(localManifest.name.short);
+      remoteManifest.name.short = Utils.truncateAppShortName(remoteManifest.name.short);
 
       importDetails.push(`(.) Processing: Writing to save changes to manifest.local.json...`);
       await manifestUtils._writeAppManifest(

--- a/packages/fx-core/src/component/generator/spfx/utils/utils.ts
+++ b/packages/fx-core/src/component/generator/spfx/utils/utils.ts
@@ -8,6 +8,7 @@ import { LogProvider } from "@microsoft/teamsfx-api";
 import axios, { AxiosInstance } from "axios";
 import { cpUtils, DebugLogger } from "../../../../common/deps-checker/util/cpUtils";
 import * as os from "os";
+import { Constants } from "./constants";
 
 export class Utils {
   static async configure(configurePath: string, map: Map<string, string>): Promise<void> {
@@ -203,6 +204,30 @@ export class Utils {
     } catch (error) {
       return undefined;
     }
+  }
+
+  static truncateAppShortName(appName: string): string {
+    const appNameSuffixPlaceholder = "${{APP_NAME_SUFFIX}}";
+    const localSuffix = "local";
+
+    if (appName.endsWith(appNameSuffixPlaceholder)) {
+      const appNameWithouSuffix = appName.substring(
+        0,
+        appName.length - appNameSuffixPlaceholder.length
+      );
+      if (appNameWithouSuffix.length + localSuffix.length > Constants.TEAMS_APP_NAME_MAX_LENGTH) {
+        return (
+          appNameWithouSuffix.substring(
+            0,
+            Constants.TEAMS_APP_NAME_MAX_LENGTH - localSuffix.length
+          ) + appNameSuffixPlaceholder
+        );
+      }
+    } else if (appName.length > Constants.TEAMS_APP_NAME_MAX_LENGTH) {
+      return appName.substring(0, Constants.TEAMS_APP_NAME_MAX_LENGTH);
+    }
+
+    return appName;
   }
 }
 

--- a/packages/fx-core/tests/component/generator/spfxGenerator.test.ts
+++ b/packages/fx-core/tests/component/generator/spfxGenerator.test.ts
@@ -556,3 +556,28 @@ describe("SPFxGenerator", function () {
     chai.expect(writeAppManifestStub.calledTwice).to.eq(true);
   });
 });
+
+describe("Utils", () => {
+  it("truncate name with app name suffix", () => {
+    const appName = "thisisasuperlongappNameWithSuffix${{APP_NAME_SUFFIX}}";
+    const res = Utils.truncateAppShortName(appName);
+    chai.expect(res).equals("thisisasuperlongappNameWi${{APP_NAME_SUFFIX}}");
+  });
+  it("no need to truncate name with app name with suffix", () => {
+    const appName = "appNameWithSuffix${{APP_NAME_SUFFIX}}";
+    const res = Utils.truncateAppShortName(appName);
+    chai.expect(res).equals("appNameWithSuffix${{APP_NAME_SUFFIX}}");
+  });
+
+  it("truncate name with app name without suffix", () => {
+    const appName = "thisisasuperlongappNameWithoutSuffix";
+    const res = Utils.truncateAppShortName(appName);
+    chai.expect(res).equals("thisisasuperlongappNameWithout");
+  });
+
+  it("no need to truncate name with app name without suffix", () => {
+    const appName = "appNameWithoutSuffix";
+    const res = Utils.truncateAppShortName(appName);
+    chai.expect(res).equals("appNameWithoutSuffix");
+  });
+});


### PR DESCRIPTION
[Bug 26162235](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/26162235): Variable {{APP_NAME_SUFFIX}} will cut to be a string for the app name (> 10 characters) when importing SPFx project