### PR TITLE
perf(spec-parser): add teams ai app support

### DIFF
--- a/packages/fx-core/src/common/spec-parser/constants.ts
+++ b/packages/fx-core/src/common/spec-parser/constants.ts
@@ -40,6 +40,7 @@ export class ConstantString {
 
   static readonly GetMethod = "get";
   static readonly PostMethod = "post";
+  static readonly SupportedMethods = ["get"]; // For Teams AI project, we only support GET method
   static readonly AdaptiveCardVersion = "1.5";
   static readonly AdaptiveCardSchema = "http://adaptivecards.io/schemas/adaptive-card.json";
   static readonly AdaptiveCardType = "AdaptiveCard";

--- a/packages/fx-core/src/common/spec-parser/generateTeamsAiMaterial.ts
+++ b/packages/fx-core/src/common/spec-parser/generateTeamsAiMaterial.ts
@@ -1,0 +1,148 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+"use strict";
+
+import { OpenAPIV3 } from "openapi-types";
+import { ErrorType } from "./interfaces";
+import { SpecParserError } from "./specParserError";
+import { ConstantString } from "./constants";
+
+export interface Action {
+  name: string;
+  description: string;
+  parameters: OpenAPIV3.NonArraySchemaObject;
+}
+
+export interface ActionCode {
+  name: string;
+  pathUrl: string;
+  code: string;
+}
+
+export interface Config {
+  schema: number;
+  description: string;
+  type: string;
+  completion: Completion;
+  augmentation: Augmentation;
+}
+
+export interface Completion {
+  model: string;
+  completion_type: string;
+  include_history: boolean;
+  include_input: boolean;
+  max_input_tokens: number;
+  max_tokens: number;
+  temperature: number;
+  top_p: number;
+  presence_penalty: number;
+  frequency_penalty: number;
+  stop_sequences: any[];
+}
+
+export interface Augmentation {
+  augmentation_type: string;
+}
+
+const codeTemplate = `
+app.ai.action("{{operationId}}", async (context: TurnContext, state: ApplicationTurnState, parameter: any) => {
+  const client = await api.getClient();
+  const path = await client.paths["{{pathUrl}}"];
+  if (path && path.get) {
+      const result = await path.get(parameter);
+      await context.sendActivity(JSON.stringify(result.data));
+  } else {
+      await context.sendActivity("no result");
+  }
+  return "result";
+});`;
+
+export function generateTeamsAiMaterial(
+  spec: OpenAPIV3.Document
+): [Action[], Config, string, ActionCode[]] {
+  try {
+    const paths = spec.paths;
+    const actions: Action[] = [];
+    const actionCodes: ActionCode[] = [];
+    if (paths) {
+      for (const pathUrl in paths) {
+        const pathItem = paths[pathUrl];
+        if (pathItem) {
+          const operations = pathItem;
+          for (const method in operations) {
+            if (ConstantString.SupportedMethods.includes(method)) {
+              const operationItem = (operations as any)[method] as OpenAPIV3.OperationObject;
+              if (operationItem) {
+                const operationId = operationItem.operationId!;
+                const description = operationItem.description ?? "";
+                const paramObject = operationItem.parameters as OpenAPIV3.ParameterObject[];
+                const parameters: any = {
+                  type: "object",
+                  properties: {} as OpenAPIV3.SchemaObject,
+                  required: [],
+                };
+                if (paramObject) {
+                  for (let i = 0; i < paramObject.length; i++) {
+                    const param = paramObject[i];
+                    const schema = param.schema as OpenAPIV3.SchemaObject;
+                    parameters.properties[param.name] = schema;
+                    console.log(param.name);
+                    parameters.properties[param.name].description = param.description ?? "";
+                    if (param.required) {
+                      parameters.required?.push(param.name);
+                    }
+                  }
+                }
+
+                actions.push({
+                  name: operationId,
+                  description: description,
+                  parameters: parameters,
+                });
+
+                actionCodes.push({
+                  name: operationId,
+                  pathUrl: pathUrl,
+                  code: codeTemplate
+                    .replace("{{operationId}}", operationId)
+                    .replace("{{pathUrl}}", pathUrl),
+                });
+              }
+            }
+          }
+        }
+      }
+    }
+
+    const configObject: Config = {
+      schema: 1.1,
+      description: spec.info.description ?? "",
+      type: "completion",
+      completion: {
+        model: "gpt-35-turbo",
+        completion_type: "chat",
+        include_history: true,
+        include_input: true,
+        max_input_tokens: 2800,
+        max_tokens: 1000,
+        temperature: 0.2,
+        top_p: 0.0,
+        presence_penalty: 0.6,
+        frequency_penalty: 0.0,
+        stop_sequences: [],
+      },
+      augmentation: {
+        augmentation_type: "sequence",
+      },
+    };
+
+    const prompt = `The following is a conversation with an AI assistant.\nThe assistant can help to call APIs for the open api spec file${
+      spec.info.description ? ". " + spec.info.description : "."
+    }\n\ncontext:\nAvailable actions: {{getAction}}.`;
+
+    return [actions, configObject, prompt, actionCodes];
+  } catch (err) {
+    throw new SpecParserError((err as Error).toString(), ErrorType.UpdateTeamsAiAppFailed);
+  }
+}

--- a/packages/fx-core/src/common/spec-parser/interfaces.ts
+++ b/packages/fx-core/src/common/spec-parser/interfaces.ts
@@ -90,6 +90,7 @@ export enum ErrorType {
   UpdateManifestFailed = "update-manifest-failed",
   GenerateAdaptiveCardFailed = "generate-adaptive-card-failed",
   GenerateFailed = "generate-failed",
+  UpdateTeamsAiAppFailed = "update-teams-ai-app-failed",
   ValidateFailed = "validate-failed",
 
   Cancelled = "cancelled",

--- a/packages/fx-core/src/common/spec-parser/manifestUpdater.ts
+++ b/packages/fx-core/src/common/spec-parser/manifestUpdater.ts
@@ -105,8 +105,8 @@ export async function generateCommands(
 
         // Currently only support GET and POST method
         for (const method in operations) {
-          if (method === ConstantString.PostMethod || method === ConstantString.GetMethod) {
-            const operationItem = operations[method];
+          if (ConstantString.SupportedMethods.includes(method)) {
+            const operationItem = (operations as any)[method] as OpenAPIV3.OperationObject;
             if (operationItem) {
               const [command, warning] = parseApiInfo(operationItem, allowMultipleParameters);
 

--- a/packages/fx-core/src/common/spec-parser/utils.ts
+++ b/packages/fx-core/src/common/spec-parser/utils.ts
@@ -138,17 +138,14 @@ export function isSupportedApi(
   const pathObj = spec.paths[path];
   method = method.toLocaleLowerCase();
   if (pathObj) {
-    if (
-      (method === ConstantString.PostMethod || method === ConstantString.GetMethod) &&
-      pathObj[method]
-    ) {
-      const securities = pathObj[method]!.security;
+    if (ConstantString.SupportedMethods.includes(method) && (pathObj as any)[method]) {
+      const securities = ((pathObj as any)[method] as OpenAPIV3.OperationObject).security;
       const authArray = getAuthArray(securities, spec);
       if (!isSupportedAuth(authArray, allowAPIKeyAuth, allowOauth2)) {
         return false;
       }
 
-      const operationObject = pathObj[method] as OpenAPIV3.OperationObject;
+      const operationObject = (pathObj as any)[method] as OpenAPIV3.OperationObject;
       if (!allowMissingId && !operationObject.operationId) {
         return false;
       }


### PR DESCRIPTION
```ts
async function test() {
  const specParser = new SpecParser(__dirname + "/teamsai.yaml", { allowMultipleParameters: true });
  const validationRes = await specParser.validate();
  const apiResultList = await specParser.list();
  const [actionJson, configJson, prompt, actionCode] = await specParser.updateTeamsAiApp(
    [
      "GET /pet/{petId}",
      "GET /pet/findByTags",
      "GET /store/order/{orderId}",
      "GET /user/login",
      "GET /user/{username}",
    ],
    __dirname + "/teamsai.spec.yaml"
  );
  console.log(JSON.stringify(actionJson, null, 2));
  console.log(JSON.stringify(configJson, null, 2));
  console.log(JSON.stringify(prompt, null, 2));
  console.log(JSON.stringify(actionCode, null, 2));
}
```

result:

actionJson
```json

  {
    "name": "getPetById",
    "description": "Returns a single pet",
    "parameters": {
      "type": "object",
      "properties": {
        "petId": {
          "type": "integer",
          "format": "int64",
          "description": "ID of pet to return"
        },
        "petName": {
          "type": "string",
          "description": "Name of the pet to return"
        }
      },
      "required": [
        "petId",
        "petName"
      ]
    }
  },
  {
    "name": "findPetsByTags",
    "description": "Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
    "parameters": {
      "type": "object",
      "properties": {
        "tags": {
          "type": "string",
          "description": "Tags to filter by"
        }
      },
      "required": []
    }
  }...
]
```

config.json
```json
{
  "schema": 1.1,
  "description": "This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about\nSwagger at [http://swagger.io](http://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!\nYou can now help us improve the API whether it's by making changes to the definition itself or to the code.\nThat way, with time, we can improve the API in general, and expose some of the new features in OAS3.\n\nSome useful links:\n- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)\n- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)",
  "type": "completion",
  "completion": {
    "model": "gpt-35-turbo",
    "completion_type": "chat",
    "include_history": true,
    "include_input": true,
    "max_input_tokens": 2800,
    "max_tokens": 1000,
    "temperature": 0.2,
    "top_p": 0,
    "presence_penalty": 0.6,
    "frequency_penalty": 0,
    "stop_sequences": []
  },
  "augmentation": {
    "augmentation_type": "sequence"
  }
}
```

prompt
```
The following is a conversation with an AI assistant.
The assistant can help to call APIs for the open api spec file. This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
Swagger at [http://swagger.io](http://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
You can now help us improve the API whether it's by making changes to the definition itself or to the code.
That way, with time, we can improve the API in general, and expose some of the new features in OAS3

Some useful links:
[The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
[The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)

context:
Available actions: {{getAction}}.
```

actionCode:
```json
[
  {
    "name": "getPetById",
    "pathUrl": "/pet/{petId}",
    "code": "\napp.ai.action(\"getPetById\", async (context: TurnContext, state: ApplicationTurnState, parameter: any) => {\n  const client = await api.getClient();\n  const path = await client.paths[\"/pet/{petId}\"];\n  if (path && path.get) {\n      const result = await path.get(parameter);\n      await context.sendActivity(JSON.stringify(result.data));\n  } else {\n      await context.sendActivity(\"no result\");\n  }\n  return \"result\";\n});"
  },
  {
    "name": "findPetsByTags",
    "pathUrl": "/pet/findByTags",
    "code": "\napp.ai.action(\"findPetsByTags\", async (context: TurnContext, state: ApplicationTurnState, parameter: any) => {\n  const client = await api.getClient();\n  const path = await client.paths[\"/pet/findByTags\"];\n  if (path && path.get) {\n      const result = await path.get(parameter);\n      await context.sendActivity(JSON.stringify(result.data));\n  } else {\n      await context.sendActivity(\"no result\");\n  }\n  return \"result\";\n});"
  }
```