### PR TITLE
fix: add instructions to debug in Test Tool in GettingStarted.md

### DIFF
--- a/templates/csharp/ai-assistant-bot/GettingStarted.md
+++ b/templates/csharp/ai-assistant-bot/GettingStarted.md
@@ -29,48 +29,14 @@ Before running or debugging your bot, please follow these steps to setup your ow
    > . ./Create-Assistant.ps1 -OPENAI_API_KEY xxxxxx
    ```
 1. The above command will output the properties of the new created assistant, including the ID like "id: asst_xxx..."
-{{#enableTestToolByDefault}}
-1. Fill in both OpenAI API Key and the created Assistant ID into `appsettings.TestTool.json`
-   ```
-   "OpenAI": {
-      "ApiKey": "<your-openai-api-key>",
-      "AssistantId": "<your-openai-assistant-id>"
-   }
-   ```
 
-**If you already have an Assistant created**
-
-1. Fill in both OpenAI API Key and the created Assistant ID into `appsettings.TestTool.json`
-   ```
-   "OpenAI": {
-      "ApiKey": "<your-openai-api-key>",
-      "AssistantId": "<your-openai-assistant-id>"
-   }
-   ```
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-1. Fill in both OpenAI API Key and the created Assistant ID into `env/.env.local.user`
-   ```
-   SECRET_OPENAI_API_KEY=<your-openai-api-key>
-   SECRET_OPENAI_ASSISTANT_ID=<your-openai-assistant-id>
-   ```
-
-**If you already have an Assistant created**
+### Debug bot app in Teams Web Client
 
 1. Fill in both OpenAI API Key and the created Assistant ID into `env/.env.local.user`
    ```
    SECRET_OPENAI_API_KEY=<your-openai-api-key>
    SECRET_OPENAI_ASSISTANT_ID=<your-openai-assistant-id>
    ```
-{{/enableTestToolByDefault}}
-
-### Run Teams Bot locally
-
-{{#enableTestToolByDefault}}
-1. Press F5, or select the Debug > Start Debugging menu in Visual Studio
-1. In Teams App Test Tool from the launched browser, type and send anything to your bot to trigger a response
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
 1. In the debug dropdown menu, select Dev Tunnels > Create A Tunnel (set authentication type to Public) or select an existing public dev tunnel
 1. Right-click your project and select Teams Toolkit > Prepare Teams App Dependencies
 1. If prompted, sign in with a Microsoft 365 account for the Teams organization you want 
@@ -78,7 +44,18 @@ to install the app to
 1. Press F5, or select the Debug > Start Debugging menu in Visual Studio
 1. In the launched browser, select the Add button to load the app in Teams
 1. In the chat bar, type and send anything to your bot to trigger a response
-{{/enableTestToolByDefault}}
+
+### Debug bot app in Teams App Test Tool
+1. Fill in both OpenAI API Key and the created Assistant ID into `appsettings.TestTool.json`
+   ```
+   "OpenAI": {
+      "ApiKey": "<your-openai-api-key>",
+      "AssistantId": "<your-openai-assistant-id>"
+   }
+   ```
+1. Select `Teams App Test Tool (browser)` in debug dropdown menu
+1. Press F5, or select the Debug > Start Debugging menu in Visual Studio
+1. In Teams App Test Tool from the launched browser, type and send anything to your bot to trigger a response 
 
 ## Extend the AI Assistant Bot template with more AI capabilities
 

--- a/templates/csharp/ai-bot/GettingStarted.md
+++ b/templates/csharp/ai-bot/GettingStarted.md
@@ -11,26 +11,8 @@ The app template is built using the Teams AI library, which provides the capabil
 >
 > - [Azure OpenAI](https://aka.ms/oai/access) resource or an account with [OpenAI](https://platform.openai.com).
 
-{{#enableTestToolByDefault}}
-1. Fill in your OpenAI API Key or Azure OpenAI settings in `appsettings.TestTool.json`
-    ```
-    # If using OpenAI
-    "OpenAI": {
-      "ApiKey": "<your-openai-api-key>"
-    },
+### Debug bot app in Teams Web Client
 
-    # If using Azure OpenAI
-    "Azure": {
-      "OpenAIApiKey": "<your-azure-openai-api-key>",
-      "OpenAIEndpoint": "<your-azure-openai-endpoint>"
-    }
-    ```
-
-2. If using Azure OpenAI, update "gpt-35-turbo" in `Program.cs` to your own model deployment name
-3. Press F5, or select the Debug > Start Debugging menu in Visual Studio
-4. In Teams App Test Tool from the launched browser, type and send anything to your bot to trigger a response
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
 1. Fill in your OpenAI API Key or Azure OpenAI settings in `env/.env.local.user`
     ```
     # If using OpenAI
@@ -49,7 +31,27 @@ to install the app to
 6. Press F5, or select the Debug > Start Debugging menu in Visual Studio
 7. In the launched browser, select the Add button to load the app in Teams
 8. In the chat bar, type and send anything to your bot to trigger a response
-{{/enableTestToolByDefault}}
+
+### Debug bot app in Teams App Test Tool
+
+1. Fill in your OpenAI API Key or Azure OpenAI settings in `appsettings.TestTool.json`
+    ```
+    # If using OpenAI
+    "OpenAI": {
+      "ApiKey": "<your-openai-api-key>"
+    },
+
+    # If using Azure OpenAI
+    "Azure": {
+      "OpenAIApiKey": "<your-azure-openai-api-key>",
+      "OpenAIEndpoint": "<your-azure-openai-endpoint>"
+    }
+    ```
+
+2. If using Azure OpenAI, update "gpt-35-turbo" in `Program.cs` to your own model deployment name
+3. Select `Teams App Test Tool (browser)` in debug dropdown menu
+4. Press F5, or select the Debug > Start Debugging menu in Visual Studio
+5. In Teams App Test Tool from the launched browser, type and send anything to your bot to trigger a response
 
 ## Extend the AI Chat Bot template with more AI capabilities
 


### PR DESCRIPTION
Add instructions to debug in Test Tool in GettingStarted.md for AI chat bot and Assistant bot template.

Preview:
1. AI chat bot‘s GettingStarted.md: https://github.com/OfficeDev/TeamsFx/blob/qinezh/doc/templates/csharp/ai-bot/GettingStarted.md
2.Assistant bot's GettingStarted.md: https://github.com/OfficeDev/TeamsFx/blob/qinezh/doc/templates/csharp/ai-assistant-bot/GettingStarted.md