### PR TITLE
fix: set api name as categories for TDP error

### DIFF
--- a/packages/fx-core/src/error/teamsApp.ts
+++ b/packages/fx-core/src/error/teamsApp.ts
@@ -25,7 +25,7 @@ export class DeveloperPortalAPIFailedError extends SystemError {
         extraData
       ),
       displayMessage: getLocalizedString("error.appstudio.apiFailed"),
-      categories: [ErrorCategory.Unhandled],
+      categories: [ErrorCategory.Unhandled, apiName],
     };
     super(errorOptions);
   }


### PR DESCRIPTION
fix: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/26254996