### PR TITLE
fix: update nodejs installation link

### DIFF
--- a/docs/vscode-extension/envchecker-help.md
+++ b/docs/vscode-extension/envchecker-help.md
@@ -102,7 +102,7 @@ Go to [the official website](https://docs.microsoft.com/azure/azure-resource-man
 
 ### NodeNotFound
 
-> Cannot find Node.js. Go to https://nodejs.org/about/releases/ to install Node.js (v16 is recommended).
+> Cannot find Node.js. Go to https://nodejs.org to install Node.js (v16 is recommended).
 
 As the Teams Toolkit project is implemented by `Node.js`, it's required to install the npm pacakges and run the project in local.  
 

--- a/packages/cli/src/cmds/preview/constants.ts
+++ b/packages/cli/src/cmds/preview/constants.ts
@@ -98,9 +98,9 @@ export const doctorResult = {
   NodeNotFound: `Cannot find Node.js.`,
   NodeNotSupported: `Node.js (@CurrentVersion) is not the officially supported version (@SupportedVersions). Your project may continue to work but we recommend to install the supported version.`,
   NodeSuccess: `Node.js version (@Version) is installed`,
-  InstallNode: "Go to https://nodejs.org/about/releases/ to install LTS Node.js.",
+  InstallNode: "Go to https://nodejs.org to install LTS Node.js.",
   InstallNodeV3:
-    "The supported node versions are specified in the package.json. Go to https://nodejs.org/about/releases/ to install a supported Node.js.",
+    "The supported node versions are specified in the package.json. Go to https://nodejs.org to install a supported Node.js.",
   SideLoadingDisabled:
     "Your Microsoft 365 tenant admin hasn't enabled custom app upload permission for your account. You can't install your app to Teams!",
   NotSignIn: "No Microsoft 365 account login",

--- a/packages/cli/src/resource/strings.json
+++ b/packages/cli/src/resource/strings.json
@@ -36,7 +36,7 @@
         "SignInSuccess": "Microsoft 365 Account (%s) is logged in and custom app upload permission is enabled."
       },
       "node" : {
-        "NotFound": "Cannot find Node.js. Node.js used for developing Teams apps with JavaScript or TypeScript using Teams Toolkit for Visual Studio Code. Visit https://nodejs.org/about/releases/ to install the LTS version.",
+        "NotFound": "Cannot find Node.js. Node.js used for developing Teams apps with JavaScript or TypeScript using Teams Toolkit for Visual Studio Code. Visit https://nodejs.org to install the LTS version.",
         "NotSupported": "Node.js (%s) is not the officially supported version (%s). Your project may continue to work but we recommend to install the supported version.",
         "Success": "Node.js version (%s) is installed."
       },

--- a/packages/fx-core/src/common/deps-checker/constant/helpLink.ts
+++ b/packages/fx-core/src/common/deps-checker/constant/helpLink.ts
@@ -9,7 +9,7 @@ export const functionDepsVersionsLink = "https://aka.ms/functions-node-versions"
 
 // TODO: remove this link after clean the useless code.
 export const nodeNotFoundHelpLink = `https://aka.ms/teamsfx-node`;
-export const nodeInstallationLink = "https://nodejs.org/about/releases/";
+export const nodeInstallationLink = "https://nodejs.org";
 
 export const dotnetDefaultHelpLink = "https://aka.ms/teamsfx-actions/devtool-install";
 export const dotnetExplanationHelpLink = dotnetDefaultHelpLink;

--- a/packages/vscode-extension/src/debug/depsChecker/doctorConstant.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/doctorConstant.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-const InstallNode = "Go to https://nodejs.org/about/releases/ to install LTS Node.js.";
+const InstallNode = "Go to https://nodejs.org to install LTS Node.js.";
 const InstallNodeV3 =
-  "The supported node versions are specified in the package.json. Go to https://nodejs.org/about/releases/ to install a supported Node.js.";
+  "The supported node versions are specified in the package.json. Go to https://nodejs.org to install a supported Node.js.";
 
 export const doctorConstant = {
   Tick: "(√) Done:",


### PR DESCRIPTION
Update node.js installation link from `https://nodejs.org/about/releases/` to `https://nodejs.org`.

work item: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/26243007