### PR TITLE
fix: remove commands from link unfurling manifest

### DIFF
--- a/templates/csharp/link-unfurling/appPackage/manifest.json.tpl
+++ b/templates/csharp/link-unfurling/appPackage/manifest.json.tpl
@@ -28,24 +28,6 @@
         {
             "botId": "${{BOT_ID}}",
             "commands": [
-                {
-                    "id": "searchQuery",
-                    "context": [
-                        "compose",
-                        "commandBox"
-                    ],
-                    "description": "Test command to run query",
-                    "title": "Search",
-                    "type": "query",
-                    "parameters": [
-                        {
-                            "name": "searchQuery",
-                            "title": "Search Query",
-                            "description": "Your search query",
-                            "inputType": "text"
-                        }
-                    ]
-                }
             ],
             "messageHandlers": [
                 {

--- a/templates/js/link-unfurling/appPackage/manifest.json.tpl
+++ b/templates/js/link-unfurling/appPackage/manifest.json.tpl
@@ -28,24 +28,6 @@
         {
             "botId": "${{BOT_ID}}",
             "commands": [
-                {
-                    "id": "searchQuery",
-                    "context": [
-                        "compose",
-                        "commandBox"
-                    ],
-                    "description": "Test command to run query",
-                    "title": "Search",
-                    "type": "query",
-                    "parameters": [
-                        {
-                            "name": "searchQuery",
-                            "title": "Search Query",
-                            "description": "Your search query",
-                            "inputType": "text"
-                        }
-                    ]
-                }
             ],
             "messageHandlers": [
                 {

--- a/templates/ts/link-unfurling/appPackage/manifest.json.tpl
+++ b/templates/ts/link-unfurling/appPackage/manifest.json.tpl
@@ -28,24 +28,6 @@
         {
             "botId": "${{BOT_ID}}",
             "commands": [
-                {
-                    "id": "searchQuery",
-                    "context": [
-                        "compose",
-                        "commandBox"
-                    ],
-                    "description": "Test command to run query",
-                    "title": "Search",
-                    "type": "query",
-                    "parameters": [
-                        {
-                            "name": "searchQuery",
-                            "title": "Search Query",
-                            "description": "Your search query",
-                            "inputType": "text"
-                        }
-                    ]
-                }
             ],
             "messageHandlers": [
                 {


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/26265585