### PR TITLE
fix: get node version from spfx solution

### DIFF
--- a/packages/fx-core/src/component/generator/spfx/error.ts
+++ b/packages/fx-core/src/component/generator/spfx/error.ts
@@ -161,3 +161,13 @@ export function SolutionVersionMissingError(path: string): UserError {
     displayMessage: getLocalizedString("plugins.spfx.addWebPart.cannotFindSolutionVersion", path),
   });
 }
+
+export function CannotFindPropertyfromJsonError(field: string): UserError {
+  const message = `Cannot find property "${field}" from json.`;
+  return new UserError({
+    source: Constants.PLUGIN_NAME,
+    name: "CannotFindPropertyfromJson",
+    message,
+    displayMessage: message, // This message won't be shown to users. No need to localize.
+  });
+}

--- a/packages/fx-core/src/component/generator/spfx/spfxGenerator.ts
+++ b/packages/fx-core/src/component/generator/spfx/spfxGenerator.ts
@@ -849,7 +849,7 @@ export class SPFxGenerator {
     }
   }
 
-  public static async getNodeVersion(solutionPath: string, context: Context): Promise<string> {
+  private static async getNodeVersion(solutionPath: string, context: Context): Promise<string> {
     const packageJsonPath = path.join(solutionPath, Constants.PACKAGE_JSON_FILE);
 
     if (await fs.pathExists(packageJsonPath)) {

--- a/packages/fx-core/src/component/generator/spfx/spfxGenerator.ts
+++ b/packages/fx-core/src/component/generator/spfx/spfxGenerator.ts
@@ -849,7 +849,7 @@ export class SPFxGenerator {
     }
   }
 
-  private static async getNodeVersion(solutionPath: string, context: Context): Promise<string> {
+  public static async getNodeVersion(solutionPath: string, context: Context): Promise<string> {
     const packageJsonPath = path.join(solutionPath, Constants.PACKAGE_JSON_FILE);
 
     if (await fs.pathExists(packageJsonPath)) {

--- a/packages/fx-core/src/component/generator/spfx/utils/constants.ts
+++ b/packages/fx-core/src/component/generator/spfx/utils/constants.ts
@@ -24,6 +24,8 @@ export class Constants {
   public static readonly TEAMS_APP_NAME_MAX_LENGTH = 30;
   public static readonly YO_RC_VERSION = "version";
   public static readonly YO_RC_FILE = ".yo-rc.json";
+  public static readonly DEFAULT_NODE_VERSION = "16 || 18";
+  public static readonly PACKAGE_JSON_FILE = "package.json";
 }
 
 export class TelemetryKey {
@@ -69,4 +71,11 @@ export class ManifestTemplate {
   static readonly WEBSITE_URL = "https://products.office.com/en-us/sharepoint/collaboration";
   static readonly WEB_APP_INFO_RESOURCE = "https://{teamSiteDomain}";
   static readonly WEB_APP_INFO_ID = "00000003-0000-0ff1-ce00-000000000000";
+}
+
+export class GetNodeVersionFailedReson {
+  static readonly CannotFindFile = "cannotFindFile";
+  static readonly CannotFindEngines = "cannotFindEngines";
+  static readonly CannotFindEnginesVersion = "cannotFindEnginesVersion";
+  static readonly ReadContentError = "readContentError";
 }

--- a/packages/fx-core/src/component/generator/spfx/utils/constants.ts
+++ b/packages/fx-core/src/component/generator/spfx/utils/constants.ts
@@ -72,10 +72,3 @@ export class ManifestTemplate {
   static readonly WEB_APP_INFO_RESOURCE = "https://{teamSiteDomain}";
   static readonly WEB_APP_INFO_ID = "00000003-0000-0ff1-ce00-000000000000";
 }
-
-export class GetNodeVersionFailedReson {
-  static readonly CannotFindFile = "cannotFindFile";
-  static readonly CannotFindEngines = "cannotFindEngines";
-  static readonly CannotFindEnginesVersion = "cannotFindEnginesVersion";
-  static readonly ReadContentError = "readContentError";
-}

--- a/packages/fx-core/src/component/generator/spfx/utils/telemetryEvents.ts
+++ b/packages/fx-core/src/component/generator/spfx/utils/telemetryEvents.ts
@@ -10,6 +10,7 @@ export enum TelemetryEvents {
   UseNotRecommendedVersion = "use-not-recommended-spfx-version",
   CheckAddWebPartPackage = "check-add-web-part-package",
   LearnMoreVersionMismatch = "learn-more-version-mismatch",
+  GetSpfxNodeVersionFailed = "get-spfx-node-version-failed",
 }
 
 export enum TelemetryProperty {

--- a/packages/fx-core/tests/component/generator/spfxGenerator.test.ts
+++ b/packages/fx-core/tests/component/generator/spfxGenerator.test.ts
@@ -568,6 +568,86 @@ describe("SPFxGenerator", function () {
     chai.expect(writeAppManifestStub.calledTwice).to.eq(true);
   });
 
+  describe("get node versions from SPFx package.json", async () => {
+    it("found node version", async () => {
+      sinon.stub(fs, "pathExists").resolves(true);
+      sinon.stub(fs, "readJSON").callsFake((directory: string) => {
+        if (directory.includes("package.json")) {
+          return { engines: { node: ">= 10.13.0 < 11.0.0" } };
+        } else {
+          return "";
+        }
+      });
+      sinon.stub(Generator, "generateTemplate" as any).resolves(ok(undefined));
+      sinon.stub(cpUtils, "executeCommand").resolves("succeed");
+      const inputs: Inputs = {
+        platform: Platform.CLI,
+        projectPath: testFolder,
+        [QuestionNames.SPFxFramework]: "none",
+        [QuestionNames.SPFxWebpartDesc]: "test",
+        [QuestionNames.SPFxWebpartName]: "hello",
+        "app-name": "spfxTestApp",
+        "spfx-solution": "new",
+      };
+      const result = await SPFxGenerator.generate(context, inputs, testFolder);
+
+      chai.expect(context.templateVariables!.SpfxNodeVersion).eq(">= 10.13.0 < 11.0.0");
+      chai.expect(result.isOk()).to.eq(true);
+    });
+
+    it("cannot found engine", async () => {
+      sinon.stub(fs, "pathExists").resolves(true);
+      sinon.stub(fs, "readJSON").callsFake((directory: string) => {
+        if (directory.includes("package.json")) {
+          return {};
+        } else {
+          return "";
+        }
+      });
+      sinon.stub(Generator, "generateTemplate" as any).resolves(ok(undefined));
+      sinon.stub(cpUtils, "executeCommand").resolves("succeed");
+      const inputs: Inputs = {
+        platform: Platform.CLI,
+        projectPath: testFolder,
+        [QuestionNames.SPFxFramework]: "none",
+        [QuestionNames.SPFxWebpartDesc]: "test",
+        [QuestionNames.SPFxWebpartName]: "hello",
+        "app-name": "spfxTestApp",
+        "spfx-solution": "new",
+      };
+      const result = await SPFxGenerator.generate(context, inputs, testFolder);
+
+      chai.expect(context.templateVariables!.SpfxNodeVersion).eq("16 || 18");
+      chai.expect(result.isOk()).to.eq(true);
+    });
+
+    it("cannot found engines.node", async () => {
+      sinon.stub(fs, "pathExists").resolves(true);
+      sinon.stub(fs, "readJSON").callsFake((directory: string) => {
+        if (directory.includes("package.json")) {
+          return { engines: {} };
+        } else {
+          return "";
+        }
+      });
+      sinon.stub(Generator, "generateTemplate" as any).resolves(ok(undefined));
+      sinon.stub(cpUtils, "executeCommand").resolves("succeed");
+      const inputs: Inputs = {
+        platform: Platform.CLI,
+        projectPath: testFolder,
+        [QuestionNames.SPFxFramework]: "none",
+        [QuestionNames.SPFxWebpartDesc]: "test",
+        [QuestionNames.SPFxWebpartName]: "hello",
+        "app-name": "spfxTestApp",
+        "spfx-solution": "new",
+      };
+      const result = await SPFxGenerator.generate(context, inputs, testFolder);
+
+      chai.expect(context.templateVariables!.SpfxNodeVersion).eq("16 || 18");
+      chai.expect(result.isOk()).to.eq(true);
+    });
+  });
+
   describe("doYeomanScaffold: add web part", async () => {
     it("add web part with global package", async () => {
       const inputs: Inputs = {

--- a/templates/ts/spfx-tab/package.json.tpl
+++ b/templates/ts/spfx-tab/package.json.tpl
@@ -3,7 +3,7 @@
     "version": "0.0.1",
     "description": "",
     "engines": {
-        "node": "16"
+        "node": "{{{SpfxNodeVersion}}}"
     },
     "author": "",
     "scripts": {


### PR DESCRIPTION
[Bug 26215868](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/26215868): Update node version in SPFx templates

Get node versions from SPFx project rather than hardcode the value in the template.