### PR TITLE
fix(vsc): description of sample gallery offline page

### DIFF
--- a/packages/vscode-extension/src/controls/sampleGallery/offlinePage.scss
+++ b/packages/vscode-extension/src/controls/sampleGallery/offlinePage.scss
@@ -18,10 +18,17 @@
   }
 
   .offlineMessage {
-    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
     font-size: 14px;
     font-style: normal;
     font-weight: 400;
     line-height: 20px;
+
+    ul {
+      margin-top: 0;
+      padding-inline-start: 20px;
+    }
   }
 }

--- a/packages/vscode-extension/src/controls/sampleGallery/offlinePage.tsx
+++ b/packages/vscode-extension/src/controls/sampleGallery/offlinePage.tsx
@@ -18,9 +18,15 @@ export default class OfflinePage extends React.Component<unknown, unknown> {
         <div className="offlineImage">
           <OfflineImage height="118px" width="118px" />
         </div>
-        <div className="offlineTitle">You're offline.</div>
+        <div className="offlineTitle">The sample gallery can't be reached.</div>
         <div className="offlineMessage">
-          Connect to the internet to browse Teams Toolkit samples.
+          Github.com takes too long to respond.
+          <br />
+          Try:
+          <ul>
+            <li>Checking the connection.</li>
+            <li>Checking the proxy and the firewall.</li>
+          </ul>
         </div>
       </div>
     );


### PR DESCRIPTION
Related bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/26207252
Effect:
![offline-page](https://github.com/OfficeDev/TeamsFx/assets/886116/90d629a8-ad8b-4ee9-9ee0-4ed3f4ec20f7)
