### PR TITLE
ci: update tear down condition

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -265,8 +265,8 @@ jobs:
           npx ts-node src/scripts/testPlan.ts report ./testplan.json src/e2e/mochawesome-report/mochawesome.json
 
   tear-down:
-    if: ${{ always() }}
     needs: [execute-case, e2e-coverage]
+    if: (needs.execute-case.result != 'skipped' || needs.e2e-coverage.result != 'skipped')
     runs-on: ubuntu-latest
     env:
       AZURE_ACCOUNT_NAME: ${{ secrets.TEST_USER_NAME }}


### PR DESCRIPTION
https://github.com/OfficeDev/TeamsFx/pull/10620

if execute-cases or e2e-coverage skipped, the tear-down should always skipped