### PR TITLE
fix: replace build to appPackage folder

### DIFF
--- a/templates/csharp/ai-assistant-bot/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/ai-assistant-bot/{{ProjectName}}.csproj.tpl
@@ -10,9 +10,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="build/**/*" />
+    <None Remove="appPackage/**/*" />
     <None Remove="devTools/**" />
-    <Content Remove="build/**/*" />
+    <Content Remove="appPackage/**/*" />
     <Content Remove="devTools/**/*" />
     <None Include="env/**/*" />
   </ItemGroup>

--- a/templates/csharp/ai-bot/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/ai-bot/{{ProjectName}}.csproj.tpl
@@ -10,9 +10,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="build/**/*" />
+    <None Remove="appPackage/**/*" />
     <None Remove="devTools/**" />
-    <Content Remove="build/**/*" />
+    <Content Remove="appPackage/**/*" />
     <Content Remove="devTools/**/*" />
     <None Include="env/**/*" />
   </ItemGroup>

--- a/templates/csharp/command-and-response/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/command-and-response/{{ProjectName}}.csproj.tpl
@@ -10,9 +10,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="build/**/*" />
+    <None Remove="appPackage/**/*" />
     <None Remove="devTools/**" />
-    <Content Remove="build/**/*" />
+    <Content Remove="appPackage/**/*" />
     <Content Remove="devTools/**/*" />
   </ItemGroup>
 

--- a/templates/csharp/copilot-plugin-existing-api-api-key/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/copilot-plugin-existing-api-api-key/{{ProjectName}}.csproj.tpl
@@ -11,8 +11,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="build/**/*" />
-    <Content Remove="build/**/*" />
+    <None Remove="appPackage/**/*" />
+    <Content Remove="appPackage/**/*" />
   </ItemGroup>
 
 </Project>

--- a/templates/csharp/copilot-plugin-existing-api/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/copilot-plugin-existing-api/{{ProjectName}}.csproj.tpl
@@ -11,8 +11,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="build/**/*" />
-    <Content Remove="build/**/*" />
+    <None Remove="appPackage/**/*" />
+    <Content Remove="appPackage/**/*" />
   </ItemGroup>
 
 </Project>

--- a/templates/csharp/copilot-plugin-from-oai-plugin/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/copilot-plugin-from-oai-plugin/{{ProjectName}}.csproj.tpl
@@ -11,8 +11,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="build/**/*" />
-    <Content Remove="build/**/*" />
+    <None Remove="appPackage/**/*" />
+    <Content Remove="appPackage/**/*" />
   </ItemGroup>
 
 </Project>

--- a/templates/csharp/copilot-plugin-from-scratch/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/copilot-plugin-from-scratch/{{ProjectName}}.csproj.tpl
@@ -13,8 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="build/**/*" />
-    <Content Remove="build/**/*" />
+    <None Remove="appPackage/**/*" />
+    <Content Remove="appPackage/**/*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/templates/csharp/default-bot/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/default-bot/{{ProjectName}}.csproj.tpl
@@ -10,9 +10,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="build/**/*" />
+    <None Remove="appPackage/**/*" />
     <None Remove="devTools/**" />
-    <Content Remove="build/**/*" />
+    <Content Remove="appPackage/**/*" />
     <Content Remove="devTools/**/*" />
   </ItemGroup>
 

--- a/templates/csharp/link-unfurling/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/link-unfurling/{{ProjectName}}.csproj.tpl
@@ -10,8 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="build/**/*" />
-    <Content Remove="build/**/*" />
+    <None Remove="appPackage/**/*" />
+    <Content Remove="appPackage/**/*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/templates/csharp/message-extension-action/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/message-extension-action/{{ProjectName}}.csproj.tpl
@@ -10,8 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="build/**/*" />
-    <Content Remove="build/**/*" />
+    <None Remove="appPackage/**/*" />
+    <Content Remove="appPackage/**/*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/templates/csharp/message-extension-copilot/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/message-extension-copilot/{{ProjectName}}.csproj.tpl
@@ -10,8 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="build/**/*" />
-    <Content Remove="build/**/*" />
+    <None Remove="appPackage/**/*" />
+    <Content Remove="appPackage/**/*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/templates/csharp/message-extension-search/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/message-extension-search/{{ProjectName}}.csproj.tpl
@@ -10,8 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="build/**/*" />
-    <Content Remove="build/**/*" />
+    <None Remove="appPackage/**/*" />
+    <Content Remove="appPackage/**/*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/templates/csharp/message-extension/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/message-extension/{{ProjectName}}.csproj.tpl
@@ -10,8 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="build/**/*" />
-    <Content Remove="build/**/*" />
+    <None Remove="appPackage/**/*" />
+    <Content Remove="appPackage/**/*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/templates/csharp/non-sso-tab-ssr/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/non-sso-tab-ssr/{{ProjectName}}.csproj.tpl
@@ -10,8 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="build/**/*" />
-    <Content Remove="build/**/*" />
+    <None Remove="appPackage/**/*" />
+    <Content Remove="appPackage/**/*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/templates/csharp/non-sso-tab/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/non-sso-tab/{{ProjectName}}.csproj.tpl
@@ -10,8 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="build/**/*" />
-    <Content Remove="build/**/*" />
+    <None Remove="appPackage/**/*" />
+    <Content Remove="appPackage/**/*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/templates/csharp/notification-http-timer-trigger/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/notification-http-timer-trigger/{{ProjectName}}.csproj.tpl
@@ -12,9 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="build/**/*" />
+    <None Remove="appPackage/**/*" />
     <None Remove="devTools/**" />
-    <Content Remove="build/**/*" />
+    <Content Remove="appPackage/**/*" />
     <Content Remove="devTools/**/*" />
   </ItemGroup>
 

--- a/templates/csharp/notification-http-trigger/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/notification-http-trigger/{{ProjectName}}.csproj.tpl
@@ -12,9 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="build/**/*" />
+    <None Remove="appPackage/**/*" />
     <None Remove="devTools/**" />
-    <Content Remove="build/**/*" />
+    <Content Remove="appPackage/**/*" />
     <Content Remove="devTools/**/*" />
   </ItemGroup>
 

--- a/templates/csharp/notification-timer-trigger/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/notification-timer-trigger/{{ProjectName}}.csproj.tpl
@@ -12,9 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="build/**/*" />
+    <None Remove="appPackage/**/*" />
     <None Remove="devTools/**" />
-    <Content Remove="build/**/*" />
+    <Content Remove="appPackage/**/*" />
     <Content Remove="devTools/**/*" />
   </ItemGroup>
 

--- a/templates/csharp/notification-webapi/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/notification-webapi/{{ProjectName}}.csproj.tpl
@@ -10,9 +10,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="build/**/*" />
+    <None Remove="appPackage/**/*" />
     <None Remove="devTools/**" />
-    <Content Remove="build/**/*" />
+    <Content Remove="appPackage/**/*" />
     <Content Remove="devTools/**/*" />
   </ItemGroup>
 

--- a/templates/csharp/sso-tab-ssr/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/sso-tab-ssr/{{ProjectName}}.csproj.tpl
@@ -10,8 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="build/**/*" />
-    <Content Remove="build/**/*" />
+    <None Remove="appPackage/**/*" />
+    <Content Remove="appPackage/**/*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/templates/csharp/sso-tab/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/sso-tab/{{ProjectName}}.csproj.tpl
@@ -10,8 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="build/**/*" />
-    <Content Remove="build/**/*" />
+    <None Remove="appPackage/**/*" />
+    <Content Remove="appPackage/**/*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/templates/csharp/workflow/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/workflow/{{ProjectName}}.csproj.tpl
@@ -10,9 +10,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="build/**/*" />
+    <None Remove="appPackage/**/*" />
     <None Remove="devTools/**" />
-    <Content Remove="build/**/*" />
+    <Content Remove="appPackage/**/*" />
     <Content Remove="devTools/**/*" />
   </ItemGroup>
 


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/26259922

`build` folder has no files and it has been placed under `appPackage` by `fx-core`. It will make the json as content files and copy them to output folder automatically.

`dotnet8` seems to lock the `manifest.dev.json` file. It will try to copy this file when building the project, so the lock will return the error. After setting it as non-content file, the issue will be worked around.