### PR TITLE
fix: disable strictTypes for dev preview schema

### DIFF
--- a/packages/manifest/src/index.ts
+++ b/packages/manifest/src/index.ts
@@ -56,7 +56,7 @@ export class ManifestUtil {
     manifest: T,
     schema: JSONSchemaType<T>
   ): Promise<string[]> {
-    const ajv = new Ajv({ formats: { uri: true }, allErrors: true });
+    const ajv = new Ajv({ formats: { uri: true }, allErrors: true, strictTypes: false });
     const validate = ajv.compile(schema);
     const valid = validate(manifest);
     if (!valid && validate.errors) {


### PR DESCRIPTION
For bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/26399801

Opened an issue to improve dev preview schema: 
https://github.com/microsoft/json-schemas/issues/173