### PR TITLE
fix: use default yaml file when env is not provided

### DIFF
--- a/packages/fx-core/src/component/utils/pathUtils.ts
+++ b/packages/fx-core/src/component/utils/pathUtils.ts
@@ -11,7 +11,7 @@ import { environmentNameManager } from "../../core/environmentName";
 
 class PathUtils {
   getYmlFilePath(projectPath: string, env?: string): string {
-    const envName = env || process.env.TEAMSFX_ENV;
+    const envName = env || process.env.TEAMSFX_ENV || "dev";
     if (!envName) throw new MissingRequiredInputError("env", "PathUtils");
     const ymlPath = path.join(
       projectPath,


### PR DESCRIPTION
fix: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/26461634