### PR TITLE
fix: restore value split rule

### DIFF
--- a/packages/cli/src/commands/engine.ts
+++ b/packages/cli/src/commands/engine.ts
@@ -370,7 +370,7 @@ class CLIEngine {
                 if (option.value === undefined) {
                   option.value = [];
                 }
-                const values = nextToken.split(/[,\s]+/);
+                const values = nextToken.split(",");
                 for (const v of values) {
                   option.value.push(v);
                 }


### PR DESCRIPTION
fix: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/26509430