### PR TITLE
refactor: update migration for azure parameters file not existing

### DIFF
--- a/packages/fx-core/src/core/middleware/projectMigratorV3.ts
+++ b/packages/fx-core/src/core/middleware/projectMigratorV3.ts
@@ -503,10 +503,12 @@ export async function azureParameterMigration(context: MigrationContext): Promis
       continue;
     }
 
-    const content = await fs.readFile(
-      path.join(context.projectPath, configFolderPath, fileName),
-      "utf-8"
-    );
+    const parameterPath = path.join(context.projectPath, configFolderPath, fileName);
+    // double confirm for file existence as fsReadDirSync may return deleted file names
+    if (!fs.pathExistsSync(parameterPath)) {
+      continue;
+    }
+    const content = await fs.readFile(parameterPath, "utf-8");
 
     const newContent = replacePlaceholdersForV3(content, bicepContent);
     await context.fsWriteFile(path.join(azureFolderPath, fileName), newContent);

--- a/packages/fx-core/tests/core/middleware/migration/projectMigrationV3.test.ts
+++ b/packages/fx-core/tests/core/middleware/migration/projectMigrationV3.test.ts
@@ -764,6 +764,29 @@ describe("azureParameterMigration", () => {
       assert.equal(error.innerError.message, "templates/azure/provision.bicep does not exist");
     }
   });
+
+  it("azure.parameter.dev.json is not existing", async () => {
+    // Stub
+    sandbox.stub(fs, "pathExistsSync").returns(false);
+
+    const migrationContext = await mockMigrationContext(projectPath);
+
+    // Stub
+    await copyTestProject(Constants.manifestsMigrationHappyPath, projectPath);
+
+    // Action
+    await azureParameterMigration(migrationContext);
+
+    // Assert
+    const azureParameterDevFilePath = path.join(
+      projectPath,
+      "templates",
+      "azure",
+      "azure.parameters.dev.json"
+    );
+
+    assert.isFalse(await fs.pathExists(azureParameterDevFilePath));
+  });
 });
 
 describe("updateLaunchJson", () => {


### PR DESCRIPTION
[readdirSync returns deleted folder · Issue #4760 · nodejs/node (github.com)](https://github.com/nodejs/node/issues/4760)
Add double confirm for file existing