### PR TITLE
refactor: tools may not be initialized for some CLI commands

### DIFF
--- a/packages/fx-core/src/common/wrappedAxiosClient.ts
+++ b/packages/fx-core/src/common/wrappedAxiosClient.ts
@@ -55,7 +55,7 @@ export class WrappedAxiosClient {
       eventName = TelemetryEvent.DependencyApi;
     }
 
-    TOOLS.telemetryReporter?.sendTelemetryEvent(`${eventName}-start`, properties);
+    TOOLS?.telemetryReporter?.sendTelemetryEvent(`${eventName}-start`, properties);
     return request;
   }
 
@@ -86,7 +86,7 @@ export class WrappedAxiosClient {
     } else {
       eventName = TelemetryEvent.DependencyApi;
     }
-    TOOLS.telemetryReporter?.sendTelemetryEvent(eventName, properties);
+    TOOLS?.telemetryReporter?.sendTelemetryEvent(eventName, properties);
     return response;
   }
 
@@ -136,7 +136,7 @@ export class WrappedAxiosClient {
       eventName = TelemetryEvent.DependencyApi;
     }
 
-    TOOLS.telemetryReporter?.sendTelemetryErrorEvent(eventName, properties);
+    TOOLS?.telemetryReporter?.sendTelemetryErrorEvent(eventName, properties);
     return Promise.reject(error);
   }
 

--- a/packages/fx-core/tests/common/wrappedAxiosClient.test.ts
+++ b/packages/fx-core/tests/common/wrappedAxiosClient.test.ts
@@ -69,6 +69,52 @@ describe("Wrapped Axios Client Test", () => {
     WrappedAxiosClient.onRejected(mockedError);
   });
 
+  it("TOOLS not initialized", async () => {
+    setTools(undefined as any);
+
+    const mockedRequest = {
+      method: "POST",
+      baseURL: getAppStudioEndpoint(),
+      url: "/amer/api/appdefinitions/v2/import",
+      params: {
+        overwriteIfAppAlreadyExists: true,
+      },
+      status: 200,
+      data: {},
+    } as any;
+    WrappedAxiosClient.onRequest(mockedRequest);
+
+    const mockedResponse = {
+      request: {
+        method: "GET",
+        host: getAppStudioEndpoint(),
+        path: "/api/appdefinitions/manifest",
+      },
+      config: {
+        params: {},
+      },
+      status: 200,
+      data: {},
+    } as any;
+    WrappedAxiosClient.onResponse(mockedResponse);
+
+    const mockedError = {
+      request: {
+        method: "GET",
+        host: getAppStudioEndpoint(),
+        path: "/api/appdefinitions/fakeId",
+      },
+      config: {},
+      response: {
+        status: 404,
+        headers: {
+          "x-ms-correlation-id": uuid(),
+        },
+      },
+    } as any;
+    WrappedAxiosClient.onRejected(mockedError);
+  });
+
   it("TDP API start telemetry", async () => {
     const mockedRequest = {
       method: "POST",


### PR DESCRIPTION
For some CLI commands, TOOLS may be undefined without initialization, cause following error:

```
(×) Error: m365.UnhandledError: An unexpected error has occurred while performing the m365 task. {"stack":"TypeError: Cannot read properties of undefined (reading 'method')\n    at
onRejected (C:\\DevDiv\\Microsoft.Teams.Extensibility\\TeamsFx\\packages\\fx-core\\build\\common\\wrappedAxiosClient.js:73:38)\
n   
```