### PR TITLE
refactor: use arrow function

### DIFF
--- a/packages/fx-core/src/common/wrappedAxiosClient.ts
+++ b/packages/fx-core/src/common/wrappedAxiosClient.ts
@@ -8,14 +8,13 @@ import axios, {
   InternalAxiosRequestConfig,
 } from "axios";
 import { TOOLS } from "../core/globalVars";
-import { APP_STUDIO_API_NAMES } from "../component/driver/teamsApp/constants";
+import { APP_STUDIO_API_NAMES, Constants } from "../component/driver/teamsApp/constants";
 import {
   TelemetryPropertyKey,
   TelemetryPropertyValue,
 } from "../component/driver/teamsApp/utils/telemetry";
 import { TelemetryEvent, TelemetryProperty } from "./telemetry";
 import { DeveloperPortalAPIFailedError } from "../error/teamsApp";
-import { Constants } from "../component/driver/teamsApp/constants";
 import { HttpMethod } from "../component/constant/commonConstant";
 
 /**
@@ -27,10 +26,8 @@ export class WrappedAxiosClient {
 
     instance.interceptors.request.use((request) => this.onRequest(request));
 
-    instance.interceptors.response.use(
-      (response) => this.onResponse(response),
-      (error) => this.onRejected(error)
-    );
+    // eslint-disable-next-line prettier/prettier
+    instance.interceptors.response.use((response) => this.onResponse(response), (error) => this.onRejected(error));
 
     return instance;
   }

--- a/packages/fx-core/src/common/wrappedAxiosClient.ts
+++ b/packages/fx-core/src/common/wrappedAxiosClient.ts
@@ -25,9 +25,12 @@ export class WrappedAxiosClient {
   public static create(config?: CreateAxiosDefaults): AxiosInstance {
     const instance = axios.create(config);
 
-    instance.interceptors.request.use(this.onRequest);
+    instance.interceptors.request.use((request) => this.onRequest(request));
 
-    instance.interceptors.response.use(this.onResponse, this.onRejected);
+    instance.interceptors.response.use(
+      (response) => this.onResponse(response),
+      (error) => this.onRejected(error)
+    );
 
     return instance;
   }
@@ -39,17 +42,17 @@ export class WrappedAxiosClient {
   public static onRequest(request: InternalAxiosRequestConfig) {
     const method = request.method!;
     const fullPath = `${request.baseURL ?? ""}${request.url ?? ""}`;
-    const apiName = WrappedAxiosClient.convertUrlToApiName(fullPath, method);
+    const apiName = this.convertUrlToApiName(fullPath, method);
 
     const properties: { [key: string]: string } = {
       url: `<${apiName}-url>`,
       method: method,
-      params: WrappedAxiosClient.generateParameters(request.params),
-      ...WrappedAxiosClient.generateExtraProperties(fullPath, request.data),
+      params: this.generateParameters(request.params),
+      ...this.generateExtraProperties(fullPath, request.data),
     };
 
     let eventName: string;
-    if (WrappedAxiosClient.isTDPApi(fullPath)) {
+    if (this.isTDPApi(fullPath)) {
       eventName = TelemetryEvent.AppStudioApi;
     } else {
       eventName = TelemetryEvent.DependencyApi;
@@ -69,19 +72,19 @@ export class WrappedAxiosClient {
     const fullPath = `${(response.request.host as string) ?? ""}${
       (response.request.path as string) ?? ""
     }`;
-    const apiName = WrappedAxiosClient.convertUrlToApiName(fullPath, method);
+    const apiName = this.convertUrlToApiName(fullPath, method);
 
     const properties: { [key: string]: string } = {
       url: `<${apiName}-url>`,
       method: method,
-      params: WrappedAxiosClient.generateParameters(response.config.params),
+      params: this.generateParameters(response.config.params),
       [TelemetryPropertyKey.success]: TelemetryPropertyValue.success,
       "status-code": response.status.toString(),
-      ...WrappedAxiosClient.generateExtraProperties(fullPath, response.data),
+      ...this.generateExtraProperties(fullPath, response.data),
     };
 
     let eventName: string;
-    if (WrappedAxiosClient.isTDPApi(fullPath)) {
+    if (this.isTDPApi(fullPath)) {
       eventName = TelemetryEvent.AppStudioApi;
     } else {
       eventName = TelemetryEvent.DependencyApi;
@@ -100,24 +103,28 @@ export class WrappedAxiosClient {
     const fullPath = `${(error.request.host as string) ?? ""}${
       (error.request.path as string) ?? ""
     }`;
-    const apiName = WrappedAxiosClient.convertUrlToApiName(fullPath, method);
+    const apiName = this.convertUrlToApiName(fullPath, method);
 
     let requestData: any;
-    if (error.config?.data) {
-      requestData = JSON.parse(error.config.data);
+    if (error.config?.data && typeof error.config.data === "string") {
+      try {
+        requestData = JSON.parse(error.config.data);
+      } catch (error) {
+        requestData = undefined;
+      }
     }
     const properties: { [key: string]: string } = {
       url: `<${apiName}-url>`,
       method: method,
-      params: WrappedAxiosClient.generateParameters(error.config!.params),
+      params: this.generateParameters(error.config!.params),
       [TelemetryPropertyKey.success]: TelemetryPropertyValue.failure,
       [TelemetryPropertyKey.errorMessage]: JSON.stringify(error.response!.data),
       "status-code": error.response!.status.toString() ?? "undefined",
-      ...WrappedAxiosClient.generateExtraProperties(fullPath, requestData),
+      ...this.generateExtraProperties(fullPath, requestData),
     };
 
     let eventName: string;
-    if (WrappedAxiosClient.isTDPApi(fullPath)) {
+    if (this.isTDPApi(fullPath)) {
       const correlationId = error.response!.headers[Constants.CORRELATION_ID];
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       const extraData = error.response?.data ? `data: ${JSON.stringify(error.response.data)}` : "";

--- a/packages/fx-core/src/common/wrappedAxiosClient.ts
+++ b/packages/fx-core/src/common/wrappedAxiosClient.ts
@@ -55,7 +55,7 @@ export class WrappedAxiosClient {
       eventName = TelemetryEvent.DependencyApi;
     }
 
-    TOOLS.telemetryReporter?.sendTelemetryEvent(`${eventName}-start`, properties);
+    TOOLS?.telemetryReporter?.sendTelemetryEvent(`${eventName}-start`, properties);
     return request;
   }
 
@@ -86,7 +86,7 @@ export class WrappedAxiosClient {
     } else {
       eventName = TelemetryEvent.DependencyApi;
     }
-    TOOLS.telemetryReporter?.sendTelemetryEvent(eventName, properties);
+    TOOLS?.telemetryReporter?.sendTelemetryEvent(eventName, properties);
     return response;
   }
 
@@ -136,7 +136,7 @@ export class WrappedAxiosClient {
       eventName = TelemetryEvent.DependencyApi;
     }
 
-    TOOLS.telemetryReporter?.sendTelemetryErrorEvent(eventName, properties);
+    TOOLS?.telemetryReporter?.sendTelemetryErrorEvent(eventName, properties);
     return Promise.reject(error);
   }
 

--- a/packages/fx-core/tests/common/wrappedAxiosClient.test.ts
+++ b/packages/fx-core/tests/common/wrappedAxiosClient.test.ts
@@ -69,6 +69,52 @@ describe("Wrapped Axios Client Test", () => {
     WrappedAxiosClient.onRejected(mockedError);
   });
 
+  it("TOOLS not initialized", async () => {
+    setTools(undefined as any);
+
+    const mockedRequest = {
+      method: "POST",
+      baseURL: getAppStudioEndpoint(),
+      url: "/amer/api/appdefinitions/v2/import",
+      params: {
+        overwriteIfAppAlreadyExists: true,
+      },
+      status: 200,
+      data: {},
+    } as any;
+    WrappedAxiosClient.onRequest(mockedRequest);
+
+    const mockedResponse = {
+      request: {
+        method: "GET",
+        host: getAppStudioEndpoint(),
+        path: "/api/appdefinitions/manifest",
+      },
+      config: {
+        params: {},
+      },
+      status: 200,
+      data: {},
+    } as any;
+    WrappedAxiosClient.onResponse(mockedResponse);
+
+    const mockedError = {
+      request: {
+        method: "GET",
+        host: getAppStudioEndpoint(),
+        path: "/api/appdefinitions/fakeId",
+      },
+      config: {},
+      response: {
+        status: 404,
+        headers: {
+          "x-ms-correlation-id": uuid(),
+        },
+      },
+    } as any;
+    WrappedAxiosClient.onRejected(mockedError);
+  });
+
   it("TDP API start telemetry", async () => {
     const mockedRequest = {
       method: "POST",

--- a/packages/fx-core/tests/common/wrappedAxiosClient.test.ts
+++ b/packages/fx-core/tests/common/wrappedAxiosClient.test.ts
@@ -5,6 +5,7 @@ import "mocha";
 import * as chai from "chai";
 import * as sinon from "sinon";
 import { v4 as uuid } from "uuid";
+import axios, { AxiosInstance } from "axios";
 import { WrappedAxiosClient } from "../../src/common/wrappedAxiosClient";
 import {
   APP_STUDIO_API_NAMES,
@@ -21,6 +22,21 @@ describe("Wrapped Axios Client Test", () => {
 
   afterEach(() => {
     sinon.restore();
+  });
+
+  it("create", async () => {
+    const testAxiosInstance = {
+      interceptors: {
+        request: {
+          use: sinon.stub(),
+        },
+        response: {
+          use: sinon.stub(),
+        },
+      },
+    } as any as AxiosInstance;
+    sinon.stub(axios, "create").returns(testAxiosInstance);
+    WrappedAxiosClient.create();
   });
 
   it("No telemetry reporter", async () => {
@@ -58,7 +74,9 @@ describe("Wrapped Axios Client Test", () => {
         host: getAppStudioEndpoint(),
         path: "/api/appdefinitions/fakeId",
       },
-      config: {},
+      config: {
+        data: "Invalid JSON",
+      },
       response: {
         status: 404,
         headers: {


### PR DESCRIPTION
1) Use arrow function to solve `this context` in callback.
https://stackoverflow.com/questions/20279484/how-to-access-the-correct-this-inside-a-callback/20279485#20279485

2) Request body may have buffer file, cannot be parsed as JSON object.