### PR TITLE
feat: open sample from url support

### DIFF
--- a/packages/vscode-extension/.vscode/settings.json
+++ b/packages/vscode-extension/.vscode/settings.json
@@ -11,5 +11,8 @@
     ".nyc_output": true,
   },
   // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-  "typescript.tsc.autoDetect": "off"
+  "typescript.tsc.autoDetect": "off",
+  "terminal.integrated.env.osx": {
+    "PATH": "usr/local/opt/node@18/bin:/Users/hermanwen/.nvm/versions/node/v18.19.0/bin:/usr/local/opt/node@16/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/usr/local/share/dotnet:~/.dotnet/tools:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/hermanwen/.orbstack/bin:/Volumes/Office/NugetCache/.tools/azureauth/0.4.0:/Users/hermanwen/.azureauth/latest",
+  }
 }

--- a/packages/vscode-extension/.vscode/settings.json
+++ b/packages/vscode-extension/.vscode/settings.json
@@ -11,8 +11,5 @@
     ".nyc_output": true,
   },
   // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-  "typescript.tsc.autoDetect": "off",
-  "terminal.integrated.env.osx": {
-    "PATH": "usr/local/opt/node@18/bin:/Users/hermanwen/.nvm/versions/node/v18.19.0/bin:/usr/local/opt/node@16/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/usr/local/share/dotnet:~/.dotnet/tools:/Library/Frameworks/Mono.framework/Versions/Current/Commands:/Users/hermanwen/.orbstack/bin:/Volumes/Office/NugetCache/.tools/azureauth/0.4.0:/Users/hermanwen/.azureauth/latest",
-  }
+  "typescript.tsc.autoDetect": "off"
 }

--- a/packages/vscode-extension/src/controls/Commands.ts
+++ b/packages/vscode-extension/src/controls/Commands.ts
@@ -14,4 +14,5 @@ export enum Commands {
   UpgradeToolkit = "upgrade-toolkit",
   StoreData = "store-data",
   GetData = "get-data",
+  OpenDesignatedSample = "open-designated-sample",
 }

--- a/packages/vscode-extension/src/controls/sampleGallery/SampleGallery.tsx
+++ b/packages/vscode-extension/src/controls/sampleGallery/SampleGallery.tsx
@@ -70,13 +70,10 @@ export default class SampleGallery extends React.Component<unknown, SampleGaller
     );
     if (this.state.loading) {
       return <div className="sample-gallery">{titleSection}</div>;
-    } else if (this.state.selectedSampleId) {
-      const selectedSample = this.samples.filter(
-        (sample: SampleInfo) => sample.id == this.state.selectedSampleId
-      )[0];
+    } else if (this.selectedSample) {
       return (
         <SampleDetailPage
-          sample={selectedSample}
+          sample={this.selectedSample}
           selectSample={this.onSampleSelected}
           createSample={this.onCreateSample}
           viewGitHub={this.onViewGithub}
@@ -173,6 +170,16 @@ export default class SampleGallery extends React.Component<unknown, SampleGaller
     }
   }
 
+  private get selectedSample(): SampleInfo | null {
+    if (!this.state.selectedSampleId) {
+      return null;
+    }
+    const selectedSamples = this.samples.filter(
+      (sample: SampleInfo) => sample.id == this.state.selectedSampleId
+    );
+    return selectedSamples.length > 0 ? selectedSamples[0] : null;
+  }
+
   private messageHandler = (event: any) => {
     const message = event.data.message;
     switch (message) {
@@ -193,6 +200,9 @@ export default class SampleGallery extends React.Component<unknown, SampleGaller
             layout: value || "grid",
           });
         }
+        break;
+      case Commands.OpenDesignatedSample:
+        this.onSampleSelected(event.data.sampleId, TelemetryTriggerFrom.ExternalUrl);
         break;
       default:
         break;

--- a/packages/vscode-extension/src/controls/sampleGallery/sampleDetailPage.tsx
+++ b/packages/vscode-extension/src/controls/sampleGallery/sampleDetailPage.tsx
@@ -30,6 +30,20 @@ export default class SampleDetailPage extends React.Component<SampleProps, Sampl
     });
   }
 
+  public componentDidUpdate(
+    prevProps: Readonly<SampleProps>,
+    _prevState: Readonly<SampleDetailState>,
+    _snapshot?: any
+  ): void {
+    // Reload the sample readme when sampleId is changed
+    if (this.props.sample.id !== prevProps.sample.id) {
+      vscode.postMessage({
+        command: Commands.LoadSampleReadme,
+        data: this.props.sample,
+      });
+    }
+  }
+
   public render() {
     const sample = this.props.sample;
     const header = (

--- a/packages/vscode-extension/src/controls/webviewPanel.ts
+++ b/packages/vscode-extension/src/controls/webviewPanel.ts
@@ -53,19 +53,20 @@ export class WebviewPanel {
             new WebviewPanel(panelType, column || vscode.ViewColumn.One)
           );
     }
-
-    if (!args || (args && args.length === 0)) {
+    // if args empty or undefined, return
+    if (!args?.length) {
       return;
     }
     if (panelType == PanelType.SampleGallery && args.length > 1) {
       try {
         const sampleId = args[1] as string;
-        void WebviewPanel.currentPanels
-          .find((panel) => panel.panelType === panelType)!
-          .panel.webview.postMessage({
+        const panel = WebviewPanel.currentPanels.find((panel) => panel.panelType === panelType);
+        if (panel) {
+          void panel.panel.webview.postMessage({
             message: Commands.OpenDesignatedSample,
             sampleId: sampleId,
           });
+        }
       } catch (e) {}
     }
   }

--- a/packages/vscode-extension/src/controls/webviewPanel.ts
+++ b/packages/vscode-extension/src/controls/webviewPanel.ts
@@ -33,7 +33,7 @@ export class WebviewPanel {
   private panelType: PanelType = PanelType.SampleGallery;
   private disposables: vscode.Disposable[] = [];
 
-  public static createOrShow(panelType: PanelType, isToSide?: boolean) {
+  public static createOrShow(panelType: PanelType, isToSide?: boolean, args?: any[]) {
     const column = vscode.window.activeTextEditor
       ? vscode.window.activeTextEditor.viewColumn
       : undefined;
@@ -52,6 +52,21 @@ export class WebviewPanel {
         : WebviewPanel.currentPanels.push(
             new WebviewPanel(panelType, column || vscode.ViewColumn.One)
           );
+    }
+
+    if (!args || (args && args.length === 0)) {
+      return;
+    }
+    if (panelType == PanelType.SampleGallery && args.length > 1) {
+      try {
+        const sampleId = args[1] as string;
+        void WebviewPanel.currentPanels
+          .find((panel) => panel.panelType === panelType)!
+          .panel.webview.postMessage({
+            message: Commands.OpenDesignatedSample,
+            sampleId: sampleId,
+          });
+      } catch (e) {}
     }
   }
 

--- a/packages/vscode-extension/src/controls/webviewPanel.ts
+++ b/packages/vscode-extension/src/controls/webviewPanel.ts
@@ -24,6 +24,7 @@ import { localize } from "../utils/localizeUtils";
 import { compare } from "../utils/versionUtil";
 import { Commands } from "./Commands";
 import { PanelType } from "./PanelType";
+import { isTriggerFromWalkThrough } from "../utils/commonUtils";
 
 export class WebviewPanel {
   private static readonly viewType = "react";
@@ -33,7 +34,7 @@ export class WebviewPanel {
   private panelType: PanelType = PanelType.SampleGallery;
   private disposables: vscode.Disposable[] = [];
 
-  public static createOrShow(panelType: PanelType, isToSide?: boolean, args?: any[]) {
+  public static createOrShow(panelType: PanelType, args?: any[]) {
     const column = vscode.window.activeTextEditor
       ? vscode.window.activeTextEditor.viewColumn
       : undefined;
@@ -45,6 +46,7 @@ export class WebviewPanel {
         .find((panel) => panel.panelType === panelType)!
         .panel.reveal(column);
     } else {
+      const isToSide = isTriggerFromWalkThrough(args);
       isToSide
         ? WebviewPanel.currentPanels.push(
             new WebviewPanel(panelType, column || vscode.ViewColumn.Two)

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -1452,7 +1452,7 @@ async function ShowScaffoldingWarningSummary(
 
 export async function openSamplesHandler(args?: any[]): Promise<Result<null, FxError>> {
   ExtTelemetry.sendTelemetryEvent(TelemetryEvent.Samples, getTriggerFromProperty(args));
-  WebviewPanel.createOrShow(PanelType.SampleGallery, isTriggerFromWalkThrough(args));
+  WebviewPanel.createOrShow(PanelType.SampleGallery, isTriggerFromWalkThrough(args), args);
   return Promise.resolve(ok(null));
 }
 

--- a/packages/vscode-extension/src/handlers.ts
+++ b/packages/vscode-extension/src/handlers.ts
@@ -1452,7 +1452,7 @@ async function ShowScaffoldingWarningSummary(
 
 export async function openSamplesHandler(args?: any[]): Promise<Result<null, FxError>> {
   ExtTelemetry.sendTelemetryEvent(TelemetryEvent.Samples, getTriggerFromProperty(args));
-  WebviewPanel.createOrShow(PanelType.SampleGallery, isTriggerFromWalkThrough(args), args);
+  WebviewPanel.createOrShow(PanelType.SampleGallery, args);
   return Promise.resolve(ok(null));
 }
 

--- a/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
@@ -370,6 +370,7 @@ export enum TelemetrySuccess {
 
 export enum TelemetryTriggerFrom {
   CommandPalette = "CommandPalette",
+  ExternalUrl = "ExternalUrl",
   TreeView = "TreeView",
   ViewTitleNavigation = "ViewTitleNavigation",
   Webview = "Webview",

--- a/packages/vscode-extension/src/uriHandler.ts
+++ b/packages/vscode-extension/src/uriHandler.ts
@@ -9,11 +9,13 @@ import { localize } from "./utils/localizeUtils";
 
 enum Referrer {
   DeveloperPortal = "developerportal",
+  OfficeDoc = "officedoc",
 }
 interface QueryParams {
   appId?: string;
   referrer?: string;
   login_hint?: string;
+  sampleId?: string;
 }
 
 let isRunning = false;
@@ -63,6 +65,22 @@ export class UriHandler extends vscode.EventEmitter<vscode.Uri> implements vscod
             isRunning = false;
           }
         );
+    } else if (queryParamas.referrer === Referrer.OfficeDoc) {
+      if (!queryParamas.sampleId) {
+        void vscode.window.showErrorMessage(
+          localize("teamstoolkit.devPortalIntegration.invalidLink")
+        );
+        return;
+      }
+      isRunning = true;
+      vscode.commands.executeCommand("fx-extension.openSamples", false, queryParamas.sampleId).then(
+        () => {
+          isRunning = false;
+        },
+        () => {
+          isRunning = false;
+        }
+      );
     }
   }
 }

--- a/packages/vscode-extension/src/uriHandler.ts
+++ b/packages/vscode-extension/src/uriHandler.ts
@@ -25,12 +25,6 @@ export class UriHandler extends vscode.EventEmitter<vscode.Uri> implements vscod
       this.fire(uri);
       return;
     }
-    if (isRunning) {
-      void vscode.window.showWarningMessage(
-        localize("teamstoolkit.devPortalIntegration.blockingMessage")
-      );
-      return;
-    }
 
     if (!uri.query) {
       void vscode.window.showErrorMessage(
@@ -47,6 +41,12 @@ export class UriHandler extends vscode.EventEmitter<vscode.Uri> implements vscod
     }
 
     if (queryParamas.referrer === Referrer.DeveloperPortal) {
+      if (isRunning) {
+        void vscode.window.showWarningMessage(
+          localize("teamstoolkit.devPortalIntegration.blockingMessage")
+        );
+        return;
+      }
       if (!queryParamas.appId) {
         void vscode.window.showErrorMessage(
           localize("teamstoolkit.devPortalIntegration.invalidLink")
@@ -72,15 +72,7 @@ export class UriHandler extends vscode.EventEmitter<vscode.Uri> implements vscod
         );
         return;
       }
-      isRunning = true;
-      vscode.commands.executeCommand("fx-extension.openSamples", false, queryParamas.sampleId).then(
-        () => {
-          isRunning = false;
-        },
-        () => {
-          isRunning = false;
-        }
-      );
+      void vscode.commands.executeCommand("fx-extension.openSamples", false, queryParamas.sampleId);
     }
   }
 }

--- a/packages/vscode-extension/src/uriHandler.ts
+++ b/packages/vscode-extension/src/uriHandler.ts
@@ -6,6 +6,7 @@ import * as vscode from "vscode";
 
 import { codeSpacesAuthComplete } from "./commonlib/common/constant";
 import { localize } from "./utils/localizeUtils";
+import { TelemetryTriggerFrom } from "./telemetry/extTelemetryEvents";
 
 enum Referrer {
   DeveloperPortal = "developerportal",
@@ -72,7 +73,11 @@ export class UriHandler extends vscode.EventEmitter<vscode.Uri> implements vscod
         );
         return;
       }
-      void vscode.commands.executeCommand("fx-extension.openSamples", false, queryParamas.sampleId);
+      void vscode.commands.executeCommand(
+        "fx-extension.openSamples",
+        TelemetryTriggerFrom.ExternalUrl,
+        queryParamas.sampleId
+      );
     }
   }
 }

--- a/packages/vscode-extension/src/utils/commonUtils.ts
+++ b/packages/vscode-extension/src/utils/commonUtils.ts
@@ -371,6 +371,8 @@ export function getTriggerFromProperty(args?: any[]) {
       return { [TelemetryProperty.TriggerFrom]: TelemetryTriggerFrom.WalkThrough };
     case TelemetryTriggerFrom.Auto:
       return { [TelemetryProperty.TriggerFrom]: TelemetryTriggerFrom.Auto };
+    case TelemetryTriggerFrom.ExternalUrl:
+      return { [TelemetryProperty.TriggerFrom]: TelemetryTriggerFrom.ExternalUrl };
     case TelemetryTriggerFrom.Other:
       return { [TelemetryProperty.TriggerFrom]: TelemetryTriggerFrom.Other };
     default:

--- a/packages/vscode-extension/test/extension/handlers.test.ts
+++ b/packages/vscode-extension/test/extension/handlers.test.ts
@@ -933,7 +933,7 @@ describe("handlers", () => {
 
     await handlers.openSamplesHandler();
 
-    sandbox.assert.calledOnceWithExactly(createOrShow, PanelType.SampleGallery, false);
+    sandbox.assert.calledOnceWithExactly(createOrShow, PanelType.SampleGallery, false, undefined);
   });
 
   it("openReadMeHandler", async () => {

--- a/packages/vscode-extension/test/extension/handlers.test.ts
+++ b/packages/vscode-extension/test/extension/handlers.test.ts
@@ -933,7 +933,7 @@ describe("handlers", () => {
 
     await handlers.openSamplesHandler();
 
-    sandbox.assert.calledOnceWithExactly(createOrShow, PanelType.SampleGallery, false, undefined);
+    sandbox.assert.calledOnceWithExactly(createOrShow, PanelType.SampleGallery, undefined);
   });
 
   it("openReadMeHandler", async () => {

--- a/packages/vscode-extension/test/extension/uriHandler.test.ts
+++ b/packages/vscode-extension/test/extension/uriHandler.test.ts
@@ -81,4 +81,35 @@ describe("uri handler", () => {
       chai.assert.isTrue(false);
     }
   });
+
+  it("invalid uri missing sampleId", async () => {
+    const handler = new UriHandler();
+    const uri = vscode.Uri.parse(
+      "vscode://TeamsDevApp.ms-teams-vscode-extension?referrer=officedoc"
+    );
+    const showMessage = sandbox.stub(vscode.window, "showErrorMessage");
+    await handler.handleUri(uri);
+
+    sandbox.assert.calledOnce(showMessage);
+  });
+
+  it("valid designated sample callback uri", async () => {
+    const handler = new UriHandler();
+    const uri = vscode.Uri.parse(
+      "vscode://TeamsDevApp.ms-teams-vscode-extension?referrer=officedoc&sampleId=hello-world-teams-tab-and-outlook-add-in"
+    );
+
+    const executeCommand = sandbox
+      .stub(vscode.commands, "executeCommand")
+      .returns(Promise.reject(""));
+    await handler.handleUri(uri);
+
+    chai.assert.isTrue(executeCommand.calledOnce);
+    sandbox.assert.calledOnceWithExactly(
+      executeCommand,
+      "fx-extension.openSamples",
+      false,
+      "hello-world-teams-tab-and-outlook-add-in"
+    );
+  });
 });

--- a/packages/vscode-extension/test/extension/uriHandler.test.ts
+++ b/packages/vscode-extension/test/extension/uriHandler.test.ts
@@ -70,6 +70,20 @@ describe("uri handler", () => {
     sandbox.assert.calledOnceWithExactly(executeCommand, "fx-extension.openFromTdp", "1", "test");
   });
 
+  it("dev portal running", async () => {
+    const handler = new UriHandler();
+    const uri = vscode.Uri.parse(
+      "vscode://test.test?appId=1&referrer=developerportal&login_hint=test"
+    );
+
+    const showMessage = sandbox.stub(vscode.window, "showWarningMessage");
+    handler.handleUri(uri);
+    // call twice to trigger isRunning logic
+    await handler.handleUri(uri);
+
+    chai.assert.isTrue(showMessage.calledOnce);
+  });
+
   it("valid code spaces callback uri", async () => {
     try {
       const handler = new UriHandler();

--- a/packages/vscode-extension/test/extension/uriHandler.test.ts
+++ b/packages/vscode-extension/test/extension/uriHandler.test.ts
@@ -3,6 +3,7 @@ import * as sinon from "sinon";
 import * as vscode from "vscode";
 
 import { UriHandler } from "../../src/uriHandler";
+import { TelemetryTriggerFrom } from "../../src/telemetry/extTelemetryEvents";
 
 describe("uri handler", () => {
   const sandbox = sinon.createSandbox();
@@ -122,7 +123,7 @@ describe("uri handler", () => {
     sandbox.assert.calledOnceWithExactly(
       executeCommand,
       "fx-extension.openSamples",
-      false,
+      TelemetryTriggerFrom.ExternalUrl,
       "hello-world-teams-tab-and-outlook-add-in"
     );
   });


### PR DESCRIPTION
Support using Uri to launch TTK and open designated sample detail page in sample gallery.

feature link: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/26879784

example link: [vscode://TeamsDevApp.ms-teams-vscode-extension?referrer=officedoc&sampleId=hello-world-teams-tab-and-outlook-add-in](url)