### PR TITLE
fix: check zip package format before sideloading

### DIFF
--- a/packages/fx-core/src/common/m365/packageService.ts
+++ b/packages/fx-core/src/common/m365/packageService.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import axios from "axios";
+import AdmZip from "adm-zip";
 import FormData from "form-data";
 import fs from "fs-extra";
 
@@ -143,6 +143,7 @@ export class PackageService {
   @hooks([ErrorContextMW({ source: M365ErrorSource, component: M365ErrorComponent })])
   public async sideLoading(token: string, manifestPath: string): Promise<[string, string]> {
     try {
+      this.checkZip(manifestPath);
       const data = await fs.readFile(manifestPath);
       const content = new FormData();
       content.append("package", data);
@@ -444,5 +445,15 @@ export class PackageService {
     }
 
     return error;
+  }
+
+  private checkZip(path: string) {
+    try {
+      const zip = new AdmZip(path, {});
+      zip.getEntries();
+    } catch (error: any) {
+      this.logger?.debug(`Invalid input zip ${path}. ${error.message as string}`);
+      this.logger?.warning(`Please make sure input path is a valid app package zip. ${path}`);
+    }
   }
 }


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/26568238/

Show warning log if the input package is not a zip, in case the service error is not clear.