### PR TITLE
fix: remove outdated docs from template README

### DIFF
--- a/templates/js/sso-tab-with-obo-flow/api/README.md
+++ b/templates/js/sso-tab-with-obo-flow/api/README.md
@@ -40,7 +40,6 @@ const response = await axios.default.get(endpoint + "/api/" + functionName, {
 ### Add More Functions
 
 - From Visual Studio Code, open the command palette, select `Teams: Add Resources` and select `Azure Function App`.
-- From TeamsFx CLI: run command `teamsapp resource add azure-function --function-name <your-function-name>` in your project directory.
 
 ## Change Node.js runtime version
 

--- a/templates/ts/sso-tab-with-obo-flow/api/README.md
+++ b/templates/ts/sso-tab-with-obo-flow/api/README.md
@@ -40,7 +40,6 @@ const response = await axios.default.get(endpoint + "/api/" + functionName, {
 ### Add More Functions
 
 - From Visual Studio Code, open the command palette, select `Teams: Add Resources` and select `Azure Function App`.
-- From TeamsFx CLI: run command `teamsapp resource add azure-function --function-name <your-function-name>` in your project directory.
 
 ## Change Node.js runtime version
 


### PR DESCRIPTION
- AzFunc project README references old & no-longer available TeamsFx CLI command ... this removes it
- see #10795 for discussion & confirmation

- fixes #10795