### PR TITLE
perf: not allow res/req body has type other than json

### DIFF
--- a/packages/spec-parser/package.json
+++ b/packages/spec-parser/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "@microsoft/spec-parser",
+  "name": "@microsoft/m365-spec-parser",
   "version": "0.0.1",
   "type": "module",
-  "description": "Parser for OpenAPI specification files",
+  "description": "OpenAPI specification files Parser for M365 Apps",
   "main": "dist/index.node.cjs.js",
   "browser": "dist/index.esm2017.js",
   "module": "dist/index.esm2017.mjs",

--- a/packages/spec-parser/src/utils.ts
+++ b/packages/spec-parser/src/utils.ts
@@ -157,7 +157,12 @@ export class Utils {
   
         const requestBody = operationObject.requestBody as OpenAPIV3.RequestBodyObject;
         const requestJsonBody = requestBody?.content["application/json"];
-  
+
+        const mediaTypesCount = Object.keys(requestBody?.content || {}).length;
+        if (mediaTypesCount > 1) {
+          return false;
+        }
+
         const responseJson = Utils.getResponseJson(operationObject);
         if (Object.keys(responseJson).length === 0) {
           return false;
@@ -289,7 +294,7 @@ export class Utils {
   static updateFirstLetter(str: string): string {
     return str.charAt(0).toUpperCase() + str.slice(1);
   }
-  
+
   static getResponseJson(
     operationObject: OpenAPIV3.OperationObject | undefined
   ): OpenAPIV3.MediaTypeObject {
@@ -297,6 +302,12 @@ export class Utils {
   
     for (const code of ConstantString.ResponseCodeFor20X) {
       const responseObject = operationObject?.responses?.[code] as OpenAPIV3.ResponseObject;
+
+      const mediaTypesCount = Object.keys(responseObject?.content || {}).length;
+      if (mediaTypesCount > 1) {
+        return {};
+      }
+
       if (responseObject?.content?.["application/json"]) {
         json = responseObject.content["application/json"];
         break;

--- a/packages/spec-parser/test/utils.test.ts
+++ b/packages/spec-parser/test/utils.test.ts
@@ -1324,6 +1324,118 @@ describe("utils", () => {
       const result = Utils.isSupportedApi(method, path, spec as any, true, false, false, false);
       assert.strictEqual(result, false);
     });
+
+    it("should return false if method is POST, but request body contains media type other than application/json", () => {
+      const method = "POST";
+      const path = "/users";
+      const spec = {
+        paths: {
+          "/users": {
+            post: {
+              parameters: [
+                {
+                  in: "query",
+                  required: true,
+                  schema: { type: "string" },
+                },
+              ],
+              requestBody: {
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "object",
+                      required: ["name"],
+                      properties: {
+                        name: {
+                          type: "string",
+                        },
+                      },
+                    },
+                  },
+                  "application/xml": {
+                    schema: {
+                      type: "object",
+                      required: ["name"],
+                      properties: {
+                        name: {
+                          type: "string",
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+              responses: {
+                200: {
+                  content: {
+                    "application/json": {
+                      schema: {
+                        type: "object",
+                        properties: {
+                          name: {
+                            type: "string",
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      const result = Utils.isSupportedApi(method, path, spec as any, true, false, false, false);
+      assert.strictEqual(result, false);
+    });
+
+    it("should return false if method is GET, but response body contains media type other than application/json", () => {
+      const method = "GET";
+      const path = "/users";
+      const spec = {
+        paths: {
+          "/users": {
+            get: {
+              parameters: [
+                {
+                  in: "query",
+                  required: true,
+                  schema: { type: "string" },
+                },
+              ],
+              responses: {
+                200: {
+                  content: {
+                    "application/json": {
+                      schema: {
+                        type: "object",
+                        properties: {
+                          name: {
+                            type: "string",
+                          },
+                        },
+                      },
+                    },
+                    "application/xml": {
+                      schema: {
+                        type: "object",
+                        properties: {
+                          name: {
+                            type: "string",
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      const result = Utils.isSupportedApi(method, path, spec as any, true, false, false, false);
+      assert.strictEqual(result, false);
+    });
   });
 
   describe("getUrlProtocol", () => {


### PR DESCRIPTION
[Bug 25973952](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/25973952): Should not allow API if response body and request body has type other than "application/json"