### PR TITLE
fix: generator telemetry sends wrong templateName

### DIFF
--- a/packages/fx-core/src/component/generator/generator.ts
+++ b/packages/fx-core/src/component/generator/generator.ts
@@ -85,9 +85,10 @@ export class Generator {
     actionContext?: ActionContext
   ): Promise<Result<undefined, FxError>> {
     const replaceMap = ctx.templateVariables ?? {};
+    const lang = language ?? commonTemplateName;
     const generatorContext: GeneratorContext = {
       name: scenario,
-      language: language ?? commonTemplateName,
+      language: lang,
       destination: destinationPath,
       logProvider: ctx.logProvider,
       fileNameReplaceFn: (fileName, fileData) =>
@@ -99,9 +100,7 @@ export class Generator {
       filterFn: (fileName) => fileName.replace(/\\/g, "/").startsWith(`${scenario}/`),
       onActionError: templateDefaultOnActionError,
     };
-    const templateName = generatorContext.language
-      ? `${scenario}-${generatorContext.language}`
-      : scenario;
+    const templateName = `${scenario}-${lang}`;
     merge(actionContext?.telemetryProps, {
       [TelemetryProperty.TemplateName]: templateName,
     });

--- a/packages/fx-core/src/component/generator/generator.ts
+++ b/packages/fx-core/src/component/generator/generator.ts
@@ -99,7 +99,9 @@ export class Generator {
       filterFn: (fileName) => fileName.replace(/\\/g, "/").startsWith(`${scenario}/`),
       onActionError: templateDefaultOnActionError,
     };
-    const templateName = `${scenario}-${generatorContext.name}`;
+    const templateName = generatorContext.language
+      ? `${scenario}-${generatorContext.language}`
+      : scenario;
     merge(actionContext?.telemetryProps, {
       [TelemetryProperty.TemplateName]: templateName,
     });

--- a/packages/fx-core/tests/component/generator/generator.test.ts
+++ b/packages/fx-core/tests/component/generator/generator.test.ts
@@ -32,6 +32,7 @@ import {
   fetchZipFromUrlAction,
   unzipAction,
   fetchSampleInfoAction,
+  TemplateActionSeq,
 } from "../../../src/component/generator/generatorAction";
 import * as generatorUtils from "../../../src/component/generator/utils";
 import mockedEnv from "mocked-env";
@@ -957,6 +958,25 @@ describe("Generator happy path", async () => {
       assert.fail("local template creation failure");
     }
     assert.isTrue(result.isOk());
+  });
+
+  it("telemetry contains correct template name", async () => {
+    const templateName = "test";
+    const language = "ts";
+    const actionContext: ActionContext = {
+      telemetryProps: {},
+    };
+
+    sandbox.replace(TemplateActionSeq, "values", () => [] as any);
+    const result = await Generator.generateTemplate(
+      context,
+      tmpDir,
+      templateName,
+      language,
+      actionContext
+    );
+
+    assert.equal(actionContext.telemetryProps?.["template-name"], `${templateName}-${language}`);
   });
 
   it("template from downloading when local version is not higher than online version", async () => {

--- a/packages/fx-core/tests/component/generator/generator.test.ts
+++ b/packages/fx-core/tests/component/generator/generator.test.ts
@@ -39,7 +39,10 @@ import mockedEnv from "mocked-env";
 import { FeatureFlagName } from "../../../src/common/constants";
 import { sampleProvider, SampleConfig } from "../../../src/common/samples";
 import templateConfig from "../../../src/common/templates-config.json";
-import { placeholderDelimiters } from "../../../src/component/generator/constant";
+import {
+  commonTemplateName,
+  placeholderDelimiters,
+} from "../../../src/component/generator/constant";
 import sampleConfigV3 from "../../common/samples-config-v3.json";
 import Mustache from "mustache";
 import * as folderUtils from "../../../../fx-core/src/folder";
@@ -977,6 +980,27 @@ describe("Generator happy path", async () => {
     );
 
     assert.equal(actionContext.telemetryProps?.["template-name"], `${templateName}-${language}`);
+  });
+
+  it("telemetry contains correct template name when language undefined", async () => {
+    const templateName = "test";
+    const actionContext: ActionContext = {
+      telemetryProps: {},
+    };
+
+    sandbox.replace(TemplateActionSeq, "values", () => [] as any);
+    const result = await Generator.generateTemplate(
+      context,
+      tmpDir,
+      templateName,
+      undefined,
+      actionContext
+    );
+
+    assert.equal(
+      actionContext.telemetryProps?.["template-name"],
+      `${templateName}-${commonTemplateName}`
+    );
   });
 
   it("template from downloading when local version is not higher than online version", async () => {


### PR DESCRIPTION
templateName should be 'scenario-language', for example 'non-sso-tab-js'