### PR TITLE
fix(vsc): sample gallery support LFS image in GitHub repo

### DIFF
--- a/packages/fx-core/src/common/samples.ts
+++ b/packages/fx-core/src/common/samples.ts
@@ -31,7 +31,7 @@ export interface SampleConfig {
   time: string;
   configuration: string;
   suggested: boolean;
-  thumbnailUrl: string;
+  thumbnailPath: string;
   gifUrl?: string;
   // maximum TTK & CLI version to run sample
   maximumToolkitVersion?: string;
@@ -120,9 +120,6 @@ class SampleProvider {
                 sample["id"] as string
               }/${sample["gifPath"] as string}`
             : undefined;
-        let thumbnailUrl = `https://raw.githubusercontent.com/${SampleConfigOwner}/${SampleConfigRepo}/${ref}/${
-          sample["id"] as string
-        }/${sample["thumbnailPath"] as string}`;
         if (isExternal) {
           const info = sample["downloadUrlInfo"] as SampleUrlInfo;
           gifUrl =
@@ -131,9 +128,6 @@ class SampleProvider {
                   info.dir
                 }/${sample["gifPath"] as string}`
               : undefined;
-          thumbnailUrl = `https://raw.githubusercontent.com/${info.owner}/${info.repository}/${
-            info.ref
-          }/${info.dir}/${sample["thumbnailPath"] as string}`;
         }
         return {
           ...sample,
@@ -147,7 +141,6 @@ class SampleProvider {
                 dir: sample["id"] as string,
               },
           gifUrl: gifUrl,
-          thumbnailUrl: thumbnailUrl,
         } as SampleConfig;
       }) || [];
 

--- a/packages/fx-core/tests/common/samples.test.ts
+++ b/packages/fx-core/tests/common/samples.test.ts
@@ -33,7 +33,7 @@ describe("Samples", () => {
         tags: ["Tab", "TS", "Azure function"],
         time: "5min to run",
         configuration: "Ready for debug",
-        thumbnailUrl: "",
+        thumbnailPath: "",
         suggested: true,
       },
     ],
@@ -234,7 +234,7 @@ describe("Samples", () => {
         tags: ["External"],
         time: "5min to run",
         configuration: "Ready for debug",
-        thumbnailUrl: "",
+        thumbnailPath: "",
         onboardDate: new Date(),
         suggested: false,
         downloadUrlInfo: {
@@ -269,7 +269,7 @@ describe("Samples", () => {
         tags: ["External"],
         time: "5min to run",
         configuration: "Ready for debug",
-        thumbnailUrl: "",
+        thumbnailPath: "",
         onboardDate: new Date(),
         suggested: false,
         downloadUrlInfo: {
@@ -302,7 +302,7 @@ describe("Samples", () => {
         tags: ["External"],
         time: "5min to run",
         configuration: "Ready for debug",
-        thumbnailUrl: "",
+        thumbnailPath: "",
         onboardDate: new Date(),
         suggested: false,
         downloadUrlInfo: {

--- a/packages/fx-core/tests/component/generator/generator.test.ts
+++ b/packages/fx-core/tests/component/generator/generator.test.ts
@@ -64,7 +64,7 @@ const mockedSampleInfo: SampleConfig = {
   time: "",
   configuration: "test-configuration",
   suggested: false,
-  thumbnailUrl: "",
+  thumbnailPath: "",
   gifUrl: "",
   downloadUrlInfo: {
     owner: "OfficeDev",

--- a/packages/vscode-extension/src/controls/sampleGallery/ISamples.ts
+++ b/packages/vscode-extension/src/controls/sampleGallery/ISamples.ts
@@ -37,7 +37,7 @@ export interface SampleInfo {
     ref: string;
     dir: string;
   };
-  thumbnailUrl: string;
+  thumbnailPath: string;
   gifUrl?: string;
   // -1 means TTK is lower than required.
   versionComparisonResult: -1 | 0 | 1;

--- a/packages/vscode-extension/src/controls/sampleGallery/sampleCard.tsx
+++ b/packages/vscode-extension/src/controls/sampleGallery/sampleCard.tsx
@@ -11,15 +11,31 @@ import Turtle from "../../../img/webview/sample/turtle.svg";
 import { TelemetryTriggerFrom } from "../../telemetry/extTelemetryEvents";
 import { SampleProps } from "./ISamples";
 
-export default class SampleCard extends React.Component<SampleProps, unknown> {
+export default class SampleCard extends React.Component<SampleProps, { imageUrl: string }> {
   constructor(props: SampleProps) {
     super(props);
+    const downloadUrlInfo = props.sample.downloadUrlInfo;
+    this.state = {
+      imageUrl: `https://raw.githubusercontent.com/${downloadUrlInfo.owner}/${downloadUrlInfo.repository}/${downloadUrlInfo.ref}/${downloadUrlInfo.dir}/${props.sample.thumbnailPath}`,
+    };
   }
 
   render() {
     const sample = this.props.sample;
     const unavailable = sample.versionComparisonResult != 0;
-    const previewImage = <Image className="thumbnail" src={sample.thumbnailUrl} />;
+    const previewImage = (
+      <Image
+        className="thumbnail"
+        src={this.state.imageUrl}
+        onError={() => {
+          console.log(`!!!error ${this.state.imageUrl}`);
+          const downloadUrlInfo = sample.downloadUrlInfo;
+          this.setState({
+            imageUrl: `https://media.githubusercontent.com/media/${downloadUrlInfo.owner}/${downloadUrlInfo.repository}/${downloadUrlInfo.ref}/${downloadUrlInfo.dir}/${sample.thumbnailPath}`,
+          });
+        }}
+      />
+    );
     const legacySampleImage = (
       <div className="unavailableSampleImage">
         <Turtle className="turtle" />


### PR DESCRIPTION
Related bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/26625207

LFS image has a different URL with raw content.