### PR TITLE
fix: function project name

### DIFF
--- a/templates/csharp/notification-http-timer-trigger-isolated/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/notification-http-timer-trigger-isolated/{{ProjectName}}.csproj.tpl
@@ -6,6 +6,7 @@
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
     <OutputType>Exe</OutputType>
+    <RootNamespace>{{SafeProjectName}}</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/templates/csharp/notification-http-trigger-isolated/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/notification-http-trigger-isolated/{{ProjectName}}.csproj.tpl
@@ -6,6 +6,7 @@
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
     <OutputType>Exe</OutputType>
+    <RootNamespace>{{SafeProjectName}}</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/templates/csharp/notification-timer-trigger-isolated/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/notification-timer-trigger-isolated/{{ProjectName}}.csproj.tpl
@@ -6,6 +6,7 @@
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
     <OutputType>Exe</OutputType>
+    <RootNamespace>{{SafeProjectName}}</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fix the function notification name with '.'. If you do not add '<RootNamespace>{{SafeProjectName}}</RootNamespace>', the azure-functions-dotnet-worker will use the unsafe project name as the namespace.

Fix: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/26897390/