### PR TITLE
perf(spec-parser): update to support type b ai-plugin

### DIFF
--- a/packages/spec-parser/package.json
+++ b/packages/spec-parser/package.json
@@ -9,7 +9,7 @@
   "types": "dist/src/index.d.ts",
   "scripts": {
     "build": "rollup -c",
-    "test:unit:node": "nyc --no-clean -- mocha \"test/*.test.ts\" -r config/mocha.env.ts --config config/.mocharc.json",
+    "test:unit:node": "nyc --no-clean -- mocha -r config/mocha.env.ts --config config/.mocharc.json",
     "test:unit:browser": "karma start karma.conf.cjs --single-run --unit",
     "test:unit": "npm run test:unit:node && npm run test:unit:browser ",
     "lint:staged": "lint-staged",

--- a/packages/spec-parser/src/constants.ts
+++ b/packages/spec-parser/src/constants.ts
@@ -35,13 +35,6 @@ export class ConstantString {
 
   static readonly UnsupportedSchema = "Unsupported schema in %s %s: %s";
 
-  // TODO: better reasoning/responding description/instruction
-  static readonly ReasoningDescription = "Call API using parameters";
-  static readonly ReasoningInstruction = "Extract parameters from user message to call API";
-  static readonly RespondingDescription = "Returns result in JSON format";
-  static readonly RespondingInstruction =
-    "Extract and include as much relevant information as possible from the JSON result to meet the user's needs.";
-
   static readonly WrappedCardVersion = "devPreview";
   static readonly WrappedCardSchema =
     "https://developer.microsoft.com/json-schemas/teams/vDevPreview/MicrosoftTeams.ResponseRenderingTemplate.schema.json";
@@ -55,7 +48,6 @@ export class ConstantString {
   static readonly TextBlockType = "TextBlock";
   static readonly ContainerType = "Container";
   static readonly RegistrationIdPostfix = "REGISTRATION_ID";
-  static readonly ApiPluginDefaultName = "ai-plugin.json";
   static readonly ResponseCodeFor20X = [
     "200",
     "201",

--- a/packages/spec-parser/src/constants.ts
+++ b/packages/spec-parser/src/constants.ts
@@ -33,6 +33,8 @@ export class ConstantString {
   static readonly MultipleAPIKeyNotSupported =
     "Multiple API keys are not supported. Please make sure that all selected APIs use the same API key.";
 
+  static readonly UnsupportedSchema = "Unsupported schema in %s %s: %s";
+
   static readonly WrappedCardVersion = "devPreview";
   static readonly WrappedCardSchema =
     "https://developer.microsoft.com/json-schemas/teams/vDevPreview/MicrosoftTeams.ResponseRenderingTemplate.schema.json";

--- a/packages/spec-parser/src/constants.ts
+++ b/packages/spec-parser/src/constants.ts
@@ -35,6 +35,13 @@ export class ConstantString {
 
   static readonly UnsupportedSchema = "Unsupported schema in %s %s: %s";
 
+  // TODO: better reasoning/responding description/instruction
+  static readonly ReasoningDescription = "Call API using parameters";
+  static readonly ReasoningInstruction = "Extract parameters from user message to call API";
+  static readonly RespondingDescription = "Returns result in JSON format";
+  static readonly RespondingInstruction =
+    "Extract and include as much relevant information as possible from the JSON result to meet the user's needs.";
+
   static readonly WrappedCardVersion = "devPreview";
   static readonly WrappedCardSchema =
     "https://developer.microsoft.com/json-schemas/teams/vDevPreview/MicrosoftTeams.ResponseRenderingTemplate.schema.json";

--- a/packages/spec-parser/src/constants.ts
+++ b/packages/spec-parser/src/constants.ts
@@ -46,6 +46,7 @@ export class ConstantString {
   static readonly TextBlockType = "TextBlock";
   static readonly ContainerType = "Container";
   static readonly RegistrationIdPostfix = "REGISTRATION_ID";
+  static readonly ApiPluginDefaultName = "ai-plugin.json";
   static readonly ResponseCodeFor20X = [
     "200",
     "201",

--- a/packages/spec-parser/src/interfaces.ts
+++ b/packages/spec-parser/src/interfaces.ts
@@ -187,6 +187,7 @@ export interface ParseOptions {
   allowAPIKeyAuth?: boolean;
   allowMultipleParameters?: boolean;
   allowOauth2?: boolean;
+  isCopilot?: boolean;
 }
 
 export interface APIInfo {

--- a/packages/spec-parser/src/manifestUpdater.ts
+++ b/packages/spec-parser/src/manifestUpdater.ts
@@ -32,6 +32,15 @@ export class ManifestUpdater {
       },
     ];
 
+    ManifestUpdater.updateManifestDescription(manifest, spec);
+
+    const specRelativePath = ManifestUpdater.getRelativePath(manifestPath, outputSpecPath);
+    const apiPlugin = ManifestUpdater.generatePluginManifestSchema(spec, specRelativePath);
+
+    return [manifest, apiPlugin];
+  }
+
+  static updateManifestDescription(manifest: TeamsAppManifest, spec: OpenAPIV3.Document): void {
     manifest.description = {
       short: spec.info.title.slice(0, ConstantString.ShortDescriptionMaxLens),
       full: (spec.info.description ?? manifest.description.full)?.slice(
@@ -39,12 +48,6 @@ export class ManifestUpdater {
         ConstantString.FullDescriptionMaxLens
       ),
     };
-
-    const specRelativePath = ManifestUpdater.getRelativePath(manifestPath, outputSpecPath);
-
-    const apiPlugin = ManifestUpdater.generatePluginManifestSchema(spec, specRelativePath);
-
-    return [manifest, apiPlugin];
   }
 
   static mapOpenAPISchemaToFuncParam(
@@ -157,13 +160,12 @@ export class ManifestUpdater {
                 parameters: parameters,
                 states: {
                   reasoning: {
-                    description: "Use the parameters to call API",
-                    instructions: [],
+                    description: ConstantString.ReasoningDescription,
+                    instructions: [ConstantString.ReasoningInstruction],
                   },
                   responding: {
-                    description: "Returns result in JSON format.",
-                    instructions:
-                      "Extract and include as much relevant information as possible from the JSON result to meet the user's needs.",
+                    description: ConstantString.RespondingDescription,
+                    instructions: [ConstantString.RespondingInstruction],
                   },
                 },
               };
@@ -249,14 +251,8 @@ export class ManifestUpdater {
         }
       }
 
-      updatedPart.description = {
-        short: spec.info.title.slice(0, ConstantString.ShortDescriptionMaxLens),
-        full: (spec.info.description ?? originalManifest.description.full)?.slice(
-          0,
-          ConstantString.FullDescriptionMaxLens
-        ),
-      };
-
+      updatedPart.description = originalManifest.description;
+      ManifestUpdater.updateManifestDescription(updatedPart, spec);
       updatedPart.composeExtensions = isMe === undefined || isMe === true ? [composeExtension] : [];
 
       const updatedManifest = { ...originalManifest, ...updatedPart };

--- a/packages/spec-parser/src/manifestUpdater.ts
+++ b/packages/spec-parser/src/manifestUpdater.ts
@@ -23,12 +23,13 @@ export class ManifestUpdater {
   static async updateManifestWithAiPlugin(
     manifestPath: string,
     outputSpecPath: string,
+    apiPluginFileName: string,
     spec: OpenAPIV3.Document
   ): Promise<[TeamsAppManifest, PluginManifestSchema]> {
     const manifest: TeamsAppManifest = await fs.readJSON(manifestPath);
     manifest.apiPlugins = [
       {
-        pluginFile: ConstantString.ApiPluginDefaultName,
+        pluginFile: apiPluginFileName,
       },
     ];
 
@@ -160,12 +161,12 @@ export class ManifestUpdater {
                 parameters: parameters,
                 states: {
                   reasoning: {
-                    description: ConstantString.ReasoningDescription,
-                    instructions: [ConstantString.ReasoningInstruction],
+                    description: "",
+                    instructions: [],
                   },
                   responding: {
-                    description: ConstantString.RespondingDescription,
-                    instructions: [ConstantString.RespondingInstruction],
+                    description: "",
+                    instructions: [],
                   },
                 },
               };

--- a/packages/spec-parser/src/manifestUpdater.ts
+++ b/packages/spec-parser/src/manifestUpdater.ts
@@ -23,13 +23,14 @@ export class ManifestUpdater {
   static async updateManifestWithAiPlugin(
     manifestPath: string,
     outputSpecPath: string,
-    apiPluginFileName: string,
+    apiPluginFilePath: string,
     spec: OpenAPIV3.Document
   ): Promise<[TeamsAppManifest, PluginManifestSchema]> {
     const manifest: TeamsAppManifest = await fs.readJSON(manifestPath);
+    const apiPluginRelativePath = ManifestUpdater.getRelativePath(manifestPath, apiPluginFilePath);
     manifest.apiPlugins = [
       {
-        pluginFile: apiPluginFileName,
+        pluginFile: apiPluginRelativePath,
       },
     ];
 
@@ -159,16 +160,6 @@ export class ManifestUpdater {
                 name: operationId,
                 description: description,
                 parameters: parameters,
-                states: {
-                  reasoning: {
-                    description: "",
-                    instructions: [],
-                  },
-                  responding: {
-                    description: "",
-                    instructions: [],
-                  },
-                },
               };
 
               functions.push(funcObj);

--- a/packages/spec-parser/src/manifestUpdater.ts
+++ b/packages/spec-parser/src/manifestUpdater.ts
@@ -13,9 +13,176 @@ import {
   IComposeExtension,
   IMessagingExtensionCommand,
   TeamsAppManifest,
+  PluginManifestSchema,
+  FunctionObject,
+  FunctionParameters,
+  FunctionParameter,
 } from "@microsoft/teams-manifest";
 
 export class ManifestUpdater {
+  static async updateManifestWithAiPlugin(
+    manifestPath: string,
+    outputSpecPath: string,
+    spec: OpenAPIV3.Document
+  ): Promise<[TeamsAppManifest, PluginManifestSchema]> {
+    const manifest: TeamsAppManifest = await fs.readJSON(manifestPath);
+    manifest.apiPlugins = [
+      {
+        pluginFile: ConstantString.ApiPluginDefaultName,
+      },
+    ];
+
+    manifest.description = {
+      short: spec.info.title.slice(0, ConstantString.ShortDescriptionMaxLens),
+      full: (spec.info.description ?? manifest.description.full)?.slice(
+        0,
+        ConstantString.FullDescriptionMaxLens
+      ),
+    };
+
+    const specRelativePath = ManifestUpdater.getRelativePath(manifestPath, outputSpecPath);
+
+    const apiPlugin = ManifestUpdater.generatePluginManifestSchema(spec, specRelativePath);
+
+    return [manifest, apiPlugin];
+  }
+
+  static mapOpenAPISchemaToFuncParam(schema: OpenAPIV3.SchemaObject): FunctionParameter {
+    let parameter: FunctionParameter;
+    if (
+      schema.type === "string" ||
+      schema.type === "boolean" ||
+      schema.type === "integer" ||
+      schema.type === "number" ||
+      schema.type === "array"
+    ) {
+      parameter = schema as any;
+    } else {
+      throw new SpecParserError(
+        "Unsupported schema for pluginFile: " + JSON.stringify(schema),
+        ErrorType.UpdateManifestFailed
+      );
+    }
+
+    return parameter;
+  }
+
+  static generatePluginManifestSchema(
+    spec: OpenAPIV3.Document,
+    specRelativePath: string
+  ): PluginManifestSchema {
+    const functions: FunctionObject[] = [];
+    const functionNames: string[] = [];
+
+    const paths = spec.paths;
+
+    if (paths) {
+      for (const pathUrl in paths) {
+        const pathItem = paths[pathUrl];
+        if (pathItem) {
+          const operations = pathItem;
+          for (const method in operations) {
+            if (ConstantString.AllOperationMethods.includes(method)) {
+              const operationItem = (operations as any)[method] as OpenAPIV3.OperationObject;
+              if (operationItem) {
+                const operationId = operationItem.operationId!;
+                const description = operationItem.description ?? "";
+                const paramObject = operationItem.parameters as OpenAPIV3.ParameterObject[];
+                const requestBody = operationItem.requestBody as OpenAPIV3.ParameterObject;
+
+                const parameters: FunctionParameters = {
+                  type: "object",
+                  properties: {},
+                  required: [],
+                };
+
+                if (paramObject) {
+                  for (let i = 0; i < paramObject.length; i++) {
+                    const param = paramObject[i];
+
+                    const schema = param.schema as OpenAPIV3.SchemaObject;
+
+                    parameters.properties![param.name] =
+                      ManifestUpdater.mapOpenAPISchemaToFuncParam(schema);
+
+                    if (param.required) {
+                      parameters.required!.push(param.name);
+                    }
+
+                    if (!parameters.properties![param.name].description) {
+                      parameters.properties![param.name].description = param.description;
+                    }
+                  }
+                }
+
+                if (requestBody) {
+                  const requestJsonBody = requestBody.content!["application/json"];
+                  const requestBodySchema = requestJsonBody.schema as OpenAPIV3.SchemaObject;
+
+                  // requestBodySchema can only be object, because we only support application/json
+                  if (requestBodySchema.type === "object") {
+                    if (requestBodySchema.required) {
+                      parameters.required!.push(...requestBodySchema.required);
+                    }
+
+                    for (const property in requestBodySchema.properties) {
+                      const schema = requestBodySchema.properties[
+                        property
+                      ] as OpenAPIV3.SchemaObject;
+                      parameters.properties![property] =
+                        ManifestUpdater.mapOpenAPISchemaToFuncParam(schema);
+                    }
+                  }
+                }
+
+                const funcObj: FunctionObject = {
+                  name: operationId,
+                  description: description,
+                  parameters: parameters,
+                  states: {
+                    reasoning: {
+                      description: "Use the parameters to call API",
+                      instructions: [],
+                    },
+                    responding: {
+                      description: "Returns result in JSON format.",
+                      instructions:
+                        "Extract and include as much relevant information as possible from the JSON result to meet the user's needs.",
+                    },
+                  },
+                };
+
+                functions.push(funcObj);
+                functionNames.push(operationId);
+              }
+            }
+          }
+        }
+      }
+    }
+
+    const apiPlugin: PluginManifestSchema = {
+      schema_version: "v2",
+      name_for_human: spec.info.title ?? "<Please add title of the plugin>",
+      description_for_human: spec.info.description ?? "<Please add description of the plugin>",
+      functions: functions,
+      runtimes: [
+        {
+          type: "OpenApi",
+          auth: {
+            type: "none", // TODO, support auth in the future
+          },
+          spec: {
+            url: specRelativePath,
+          },
+          run_for_functions: functionNames,
+        },
+      ],
+    };
+
+    return apiPlugin;
+  }
+
   static async updateManifest(
     manifestPath: string,
     outputSpecPath: string,

--- a/packages/spec-parser/src/specFilter.ts
+++ b/packages/spec-parser/src/specFilter.ts
@@ -16,7 +16,8 @@ export class SpecFilter {
     allowMissingId: boolean,
     allowAPIKeyAuth: boolean,
     allowMultipleParameters: boolean,
-    allowOauth2: boolean
+    allowOauth2: boolean,
+    isCopilot: boolean
   ): OpenAPIV3.Document {
     try {
       const newSpec = { ...unResolveSpec };
@@ -33,7 +34,8 @@ export class SpecFilter {
             allowMissingId,
             allowAPIKeyAuth,
             allowMultipleParameters,
-            allowOauth2
+            allowOauth2,
+            isCopilot
           )
         ) {
           continue;

--- a/packages/spec-parser/src/specParser.browser.ts
+++ b/packages/spec-parser/src/specParser.browser.ts
@@ -170,13 +170,14 @@ export class SpecParser {
    * @param manifestPath A file path of the Teams app manifest file to update.
    * @param filter An array of strings that represent the filters to apply when generating the artifacts. If filter is empty, it would process nothing.
    * @param outputSpecPath File path of the new OpenAPI specification file to generate. If not specified or empty, no spec file will be generated.
+   * @param pluginFilePath File path of the api plugin file to generate.
    */
   // eslint-disable-next-line @typescript-eslint/require-await
   async generateForCopilot(
     manifestPath: string,
     filter: string[],
     outputSpecPath: string,
-    apiPluginFileName: string,
+    pluginFilePath: string,
     signal?: AbortSignal
   ): Promise<GenerateResult> {
     throw new Error("Method not implemented.");

--- a/packages/spec-parser/src/specParser.browser.ts
+++ b/packages/spec-parser/src/specParser.browser.ts
@@ -37,6 +37,7 @@ export class SpecParser {
     allowAPIKeyAuth: false,
     allowMultipleParameters: false,
     allowOauth2: false,
+    isCopilot: false,
   };
 
   /**
@@ -92,7 +93,8 @@ export class SpecParser {
         this.options.allowMissingId,
         this.options.allowAPIKeyAuth,
         this.options.allowMultipleParameters,
-        this.options.allowOauth2
+        this.options.allowOauth2,
+        this.options.isCopilot
       );
     } catch (err) {
       throw new SpecParserError((err as Error).toString(), ErrorType.ValidateFailed);
@@ -168,6 +170,21 @@ export class SpecParser {
    * @param manifestPath A file path of the Teams app manifest file to update.
    * @param filter An array of strings that represent the filters to apply when generating the artifacts. If filter is empty, it would process nothing.
    * @param outputSpecPath File path of the new OpenAPI specification file to generate. If not specified or empty, no spec file will be generated.
+   */
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async generateForCopilot(
+    manifestPath: string,
+    filter: string[],
+    outputSpecPath: string,
+    signal?: AbortSignal
+  ): Promise<GenerateResult> {
+    throw new Error("Method not implemented.");
+  }
+  /**
+   * Generates and update artifacts from the OpenAPI specification file. Generate Adaptive Cards, update Teams app manifest, and generate a new OpenAPI specification file.
+   * @param manifestPath A file path of the Teams app manifest file to update.
+   * @param filter An array of strings that represent the filters to apply when generating the artifacts. If filter is empty, it would process nothing.
+   * @param outputSpecPath File path of the new OpenAPI specification file to generate. If not specified or empty, no spec file will be generated.
    * @param adaptiveCardFolder Folder path where the Adaptive Card files will be generated. If not specified or empty, Adaptive Card files will not be generated.
    * @param isMe Boolean that indicates whether the project is an Messaging Extension. For Messaging Extension, composeExtensions will be added in Teams app manifest.
    */
@@ -206,7 +223,8 @@ export class SpecParser {
       this.options.allowMissingId,
       this.options.allowAPIKeyAuth,
       this.options.allowMultipleParameters,
-      this.options.allowOauth2
+      this.options.allowOauth2,
+      this.options.isCopilot
     );
     this.apiMap = result;
     return result;

--- a/packages/spec-parser/src/specParser.browser.ts
+++ b/packages/spec-parser/src/specParser.browser.ts
@@ -176,6 +176,7 @@ export class SpecParser {
     manifestPath: string,
     filter: string[],
     outputSpecPath: string,
+    apiPluginFileName: string,
     signal?: AbortSignal
   ): Promise<GenerateResult> {
     throw new Error("Method not implemented.");

--- a/packages/spec-parser/src/specParser.ts
+++ b/packages/spec-parser/src/specParser.ts
@@ -417,27 +417,3 @@ export class SpecParser {
     return result;
   }
 }
-
-async function test() {
-  const testFolder = path.resolve("../", path.dirname(__dirname), "test-material");
-  const manifest = testFolder + "/manifest.json";
-  const spec = testFolder + "/petstore.yaml";
-  const parser = new SpecParser(spec, {
-    allowMultipleParameters: true,
-    allowMissingId: true,
-    allowOauth2: false,
-    allowAPIKeyAuth: false,
-    isCopilot: true,
-  });
-
-  const list = await parser.list();
-  console.log(list);
-  const validate = await parser.validate();
-  console.log(validate);
-
-  const apis = list.map((item) => item.api);
-  const result = await parser.generateForCopilot(manifest, apis, testFolder + "/" + "result.yaml");
-
-  console.log(await parser.list());
-}
-void test();

--- a/packages/spec-parser/src/specParser.ts
+++ b/packages/spec-parser/src/specParser.ts
@@ -224,6 +224,7 @@ export class SpecParser {
     manifestPath: string,
     filter: string[],
     outputSpecPath: string,
+    apiPluginFileName: string,
     signal?: AbortSignal
   ): Promise<GenerateResult> {
     const result: GenerateResult = {
@@ -251,13 +252,11 @@ export class SpecParser {
       const [updatedManifest, apiPlugin] = await ManifestUpdater.updateManifestWithAiPlugin(
         manifestPath,
         outputSpecPath,
+        apiPluginFileName,
         newSpec
       );
 
-      const apiPluginFilePath = path.join(
-        path.dirname(manifestPath),
-        ConstantString.ApiPluginDefaultName
-      );
+      const apiPluginFilePath = path.join(path.dirname(manifestPath), apiPluginFileName);
       await fs.outputJSON(manifestPath, updatedManifest, { spaces: 2 });
       await fs.outputJSON(apiPluginFilePath, apiPlugin, { spaces: 2 });
     } catch (err) {

--- a/packages/spec-parser/src/specParser.ts
+++ b/packages/spec-parser/src/specParser.ts
@@ -219,12 +219,13 @@ export class SpecParser {
    * @param manifestPath A file path of the Teams app manifest file to update.
    * @param filter An array of strings that represent the filters to apply when generating the artifacts. If filter is empty, it would process nothing.
    * @param outputSpecPath File path of the new OpenAPI specification file to generate. If not specified or empty, no spec file will be generated.
+   * @param pluginFilePath File path of the api plugin file to generate.
    */
   async generateForCopilot(
     manifestPath: string,
     filter: string[],
     outputSpecPath: string,
-    apiPluginFileName: string,
+    pluginFilePath: string,
     signal?: AbortSignal
   ): Promise<GenerateResult> {
     const result: GenerateResult = {
@@ -252,13 +253,12 @@ export class SpecParser {
       const [updatedManifest, apiPlugin] = await ManifestUpdater.updateManifestWithAiPlugin(
         manifestPath,
         outputSpecPath,
-        apiPluginFileName,
+        pluginFilePath,
         newSpec
       );
 
-      const apiPluginFilePath = path.join(path.dirname(manifestPath), apiPluginFileName);
       await fs.outputJSON(manifestPath, updatedManifest, { spaces: 2 });
-      await fs.outputJSON(apiPluginFilePath, apiPlugin, { spaces: 2 });
+      await fs.outputJSON(pluginFilePath, apiPlugin, { spaces: 2 });
     } catch (err) {
       if (err instanceof SpecParserError) {
         throw err;

--- a/packages/spec-parser/src/specParser.ts
+++ b/packages/spec-parser/src/specParser.ts
@@ -45,6 +45,7 @@ export class SpecParser {
     allowAPIKeyAuth: false,
     allowMultipleParameters: false,
     allowOauth2: false,
+    isCopilot: false,
   };
 
   /**
@@ -96,7 +97,8 @@ export class SpecParser {
         this.options.allowMissingId,
         this.options.allowAPIKeyAuth,
         this.options.allowMultipleParameters,
-        this.options.allowOauth2
+        this.options.allowOauth2,
+        this.options.isCopilot
       );
     } catch (err) {
       throw new SpecParserError((err as Error).toString(), ErrorType.ValidateFailed);
@@ -194,7 +196,8 @@ export class SpecParser {
         this.options.allowMissingId,
         this.options.allowAPIKeyAuth,
         this.options.allowMultipleParameters,
-        this.options.allowOauth2
+        this.options.allowOauth2,
+        this.options.isCopilot
       );
 
       if (signal?.aborted) {
@@ -209,6 +212,62 @@ export class SpecParser {
       }
       throw new SpecParserError((err as Error).toString(), ErrorType.GetSpecFailed);
     }
+  }
+
+  /**
+   * Generates and update artifacts from the OpenAPI specification file. Generate Adaptive Cards, update Teams app manifest, and generate a new OpenAPI specification file.
+   * @param manifestPath A file path of the Teams app manifest file to update.
+   * @param filter An array of strings that represent the filters to apply when generating the artifacts. If filter is empty, it would process nothing.
+   * @param outputSpecPath File path of the new OpenAPI specification file to generate. If not specified or empty, no spec file will be generated.
+   */
+  async generateForCopilot(
+    manifestPath: string,
+    filter: string[],
+    outputSpecPath: string,
+    signal?: AbortSignal
+  ): Promise<GenerateResult> {
+    const result: GenerateResult = {
+      allSuccess: true,
+      warnings: [],
+    };
+
+    try {
+      const newSpecs = await this.getFilteredSpecs(filter, signal);
+      const newUnResolvedSpec = newSpecs[0];
+      const newSpec = newSpecs[1];
+
+      let resultStr;
+      if (outputSpecPath.endsWith(".yaml") || outputSpecPath.endsWith(".yml")) {
+        resultStr = jsyaml.dump(newUnResolvedSpec);
+      } else {
+        resultStr = JSON.stringify(newUnResolvedSpec, null, 2);
+      }
+      await fs.outputFile(outputSpecPath, resultStr);
+
+      if (signal?.aborted) {
+        throw new SpecParserError(ConstantString.CancelledMessage, ErrorType.Cancelled);
+      }
+
+      const [updatedManifest, apiPlugin] = await ManifestUpdater.updateManifestWithAiPlugin(
+        manifestPath,
+        outputSpecPath,
+        newSpec
+      );
+
+      const apiPluginFilePath = path.join(
+        path.dirname(manifestPath),
+        ConstantString.ApiPluginDefaultName
+      );
+      await fs.outputJSON(manifestPath, updatedManifest, { spaces: 2 });
+      await fs.outputJSON(apiPluginFilePath, apiPlugin, { spaces: 2 });
+    } catch (err) {
+      if (err instanceof SpecParserError) {
+        throw err;
+      }
+      throw new SpecParserError((err as Error).toString(), ErrorType.GenerateFailed);
+    }
+
+    return result;
   }
 
   /**
@@ -351,9 +410,34 @@ export class SpecParser {
       this.options.allowMissingId,
       this.options.allowAPIKeyAuth,
       this.options.allowMultipleParameters,
-      this.options.allowOauth2
+      this.options.allowOauth2,
+      this.options.isCopilot
     );
     this.apiMap = result;
     return result;
   }
 }
+
+async function test() {
+  const testFolder = path.resolve("../", path.dirname(__dirname), "test-material");
+  const manifest = testFolder + "/manifest.json";
+  const spec = testFolder + "/petstore.yaml";
+  const parser = new SpecParser(spec, {
+    allowMultipleParameters: true,
+    allowMissingId: true,
+    allowOauth2: false,
+    allowAPIKeyAuth: false,
+    isCopilot: true,
+  });
+
+  const list = await parser.list();
+  console.log(list);
+  const validate = await parser.validate();
+  console.log(validate);
+
+  const apis = list.map((item) => item.api);
+  const result = await parser.generateForCopilot(manifest, apis, testFolder + "/" + "result.yaml");
+
+  console.log(await parser.list());
+}
+void test();

--- a/packages/spec-parser/src/utils.ts
+++ b/packages/spec-parser/src/utils.ts
@@ -217,6 +217,11 @@ export class Utils {
 
         if (requestJsonBody) {
           const requestBodySchema = requestJsonBody.schema as OpenAPIV3.SchemaObject;
+
+          if (isCopilot && requestBodySchema.type !== "object") {
+            return false;
+          }
+
           requestBodyParamResult = Utils.checkPostBody(
             requestBodySchema,
             requestBody.required,

--- a/packages/spec-parser/src/utils.ts
+++ b/packages/spec-parser/src/utils.ts
@@ -19,7 +19,22 @@ import {
 import { IMessagingExtensionCommand } from "@microsoft/teams-manifest";
 
 export class Utils {
-  static checkParameters(paramObject: OpenAPIV3.ParameterObject[]): CheckParamResult {
+  static hasNestedObjectInSchema(schema: OpenAPIV3.SchemaObject): boolean {
+    if (schema.type === "object") {
+      for (const property in schema.properties) {
+        const nestedSchema = schema.properties[property] as OpenAPIV3.SchemaObject;
+        if (nestedSchema.type === "object") {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  static checkParameters(
+    paramObject: OpenAPIV3.ParameterObject[],
+    isCopilot: boolean
+  ): CheckParamResult {
     const paramResult = {
       requiredNum: 0,
       optionalNum: 0,
@@ -33,7 +48,22 @@ export class Utils {
     for (let i = 0; i < paramObject.length; i++) {
       const param = paramObject[i];
       const schema = param.schema as OpenAPIV3.SchemaObject;
+
+      if (isCopilot && this.hasNestedObjectInSchema(schema)) {
+        paramResult.isValid = false;
+        continue;
+      }
+
       const isRequiredWithoutDefault = param.required && schema.default === undefined;
+
+      if (isCopilot) {
+        if (isRequiredWithoutDefault) {
+          paramResult.requiredNum = paramResult.requiredNum + 1;
+        } else {
+          paramResult.optionalNum = paramResult.optionalNum + 1;
+        }
+        continue;
+      }
 
       if (param.in === "header" || param.in === "cookie") {
         if (isRequiredWithoutDefault) {
@@ -66,7 +96,11 @@ export class Utils {
     return paramResult;
   }
 
-  static checkPostBody(schema: OpenAPIV3.SchemaObject, isRequired = false): CheckParamResult {
+  static checkPostBody(
+    schema: OpenAPIV3.SchemaObject,
+    isRequired = false,
+    isCopilot = false
+  ): CheckParamResult {
     const paramResult = {
       requiredNum: 0,
       optionalNum: 0,
@@ -78,6 +112,11 @@ export class Utils {
     }
 
     const isRequiredWithoutDefault = isRequired && schema.default === undefined;
+
+    if (isCopilot && this.hasNestedObjectInSchema(schema)) {
+      paramResult.isValid = false;
+      return paramResult;
+    }
 
     if (
       schema.type === "string" ||
@@ -99,14 +138,15 @@ export class Utils {
         }
         const result = Utils.checkPostBody(
           properties[property] as OpenAPIV3.SchemaObject,
-          isRequired
+          isRequired,
+          isCopilot
         );
         paramResult.requiredNum += result.requiredNum;
         paramResult.optionalNum += result.optionalNum;
         paramResult.isValid = paramResult.isValid && result.isValid;
       }
     } else {
-      if (isRequiredWithoutDefault) {
+      if (isRequiredWithoutDefault && !isCopilot) {
         paramResult.isValid = false;
       }
     }
@@ -134,7 +174,8 @@ export class Utils {
     allowMissingId: boolean,
     allowAPIKeyAuth: boolean,
     allowMultipleParameters: boolean,
-    allowOauth2: boolean
+    allowOauth2: boolean,
+    isCopilot: boolean
   ): boolean {
     const pathObj = spec.paths[path];
     method = method.toLocaleLowerCase();
@@ -176,17 +217,26 @@ export class Utils {
 
         if (requestJsonBody) {
           const requestBodySchema = requestJsonBody.schema as OpenAPIV3.SchemaObject;
-          requestBodyParamResult = Utils.checkPostBody(requestBodySchema, requestBody.required);
+          requestBodyParamResult = Utils.checkPostBody(
+            requestBodySchema,
+            requestBody.required,
+            isCopilot
+          );
         }
 
         if (!requestBodyParamResult.isValid) {
           return false;
         }
 
-        const paramResult = Utils.checkParameters(paramObject);
+        const paramResult = Utils.checkParameters(paramObject, isCopilot);
 
         if (!paramResult.isValid) {
           return false;
+        }
+
+        // Copilot support arbitrary parameters
+        if (isCopilot) {
+          return true;
         }
 
         if (requestBodyParamResult.requiredNum + paramResult.requiredNum > 1) {
@@ -399,7 +449,8 @@ export class Utils {
     allowMissingId: boolean,
     allowAPIKeyAuth: boolean,
     allowMultipleParameters: boolean,
-    allowOauth2: boolean
+    allowOauth2: boolean,
+    isCopilot: boolean
   ): ErrorResult[] {
     const errors: ErrorResult[] = [];
 
@@ -435,7 +486,8 @@ export class Utils {
             allowMissingId,
             allowAPIKeyAuth,
             allowMultipleParameters,
-            allowOauth2
+            allowOauth2,
+            isCopilot
           )
         ) {
           if (operationObject?.servers && operationObject.servers.length >= 1) {
@@ -631,7 +683,8 @@ export class Utils {
     allowMissingId: boolean,
     allowAPIKeyAuth: boolean,
     allowMultipleParameters: boolean,
-    allowOauth2: boolean
+    allowOauth2: boolean,
+    isCopilot: boolean
   ): {
     [key: string]: OpenAPIV3.OperationObject;
   } {
@@ -649,7 +702,8 @@ export class Utils {
             allowMissingId,
             allowAPIKeyAuth,
             allowMultipleParameters,
-            allowOauth2
+            allowOauth2,
+            isCopilot
           )
         ) {
           const operationObject = (methods as any)[method] as OpenAPIV3.OperationObject;
@@ -667,7 +721,8 @@ export class Utils {
     allowMissingId: boolean,
     allowAPIKeyAuth: boolean,
     allowMultipleParameters: boolean,
-    allowOauth2: boolean
+    allowOauth2: boolean,
+    isCopilot: boolean
   ): ValidateResult {
     const errors: ErrorResult[] = [];
     const warnings: WarningResult[] = [];
@@ -685,7 +740,8 @@ export class Utils {
       allowMissingId,
       allowAPIKeyAuth,
       allowMultipleParameters,
-      allowOauth2
+      allowOauth2,
+      isCopilot
     );
     errors.push(...serverErrors);
 
@@ -707,7 +763,8 @@ export class Utils {
       allowMissingId,
       allowAPIKeyAuth,
       allowMultipleParameters,
-      allowOauth2
+      allowOauth2,
+      isCopilot
     );
     if (Object.keys(apiMap).length === 0) {
       errors.push({

--- a/packages/spec-parser/test/browser/specParser.browser.test.ts
+++ b/packages/spec-parser/test/browser/specParser.browser.test.ts
@@ -771,6 +771,25 @@ describe("SpecParser in Browser", () => {
     });
   });
 
+  describe("generateForCopilot", () => {
+    it("should throw not implemented error", async () => {
+      try {
+        const specParser = new SpecParser("path/to/spec.yaml");
+        const filter = ["get /hello"];
+        const outputSpecPath = "path/to/output.yaml";
+        const result = await specParser.generateForCopilot(
+          "path/to/manifest.json",
+          filter,
+          outputSpecPath,
+          "ai-plugin"
+        );
+        expect.fail("Should throw not implemented error");
+      } catch (error: any) {
+        expect(error.message).to.equal("Method not implemented.");
+      }
+    });
+  });
+
   describe("list", () => {
     it("should throw an error when the SwaggerParser library throws an error", async () => {
       try {

--- a/packages/spec-parser/test/manifestUpdater.test.ts
+++ b/packages/spec-parser/test/manifestUpdater.test.ts
@@ -73,7 +73,7 @@ describe("updateManifestWithAiPlugin", () => {
     };
     const manifestPath = "/path/to/your/manifest.json";
     const outputSpecPath = "/path/to/your/spec/outputSpec.yaml";
-    const pluginFileName = "ai-plugin.json";
+    const pluginFilePath = "/path/to/your/ai-plugin.json";
 
     sinon.stub(fs, "pathExists").resolves(true);
     const originalManifest = {
@@ -85,7 +85,7 @@ describe("updateManifestWithAiPlugin", () => {
       description: { short: "My API", full: "My API description" },
       apiPlugins: [
         {
-          pluginFile: pluginFileName,
+          pluginFile: "ai-plugin.json",
         },
       ],
     };
@@ -108,16 +108,6 @@ describe("updateManifestWithAiPlugin", () => {
             },
             required: ["limit"],
           },
-          states: {
-            reasoning: {
-              description: "",
-              instructions: [],
-            },
-            responding: {
-              description: "",
-              instructions: [],
-            },
-          },
         },
         {
           name: "createPet",
@@ -130,16 +120,6 @@ describe("updateManifestWithAiPlugin", () => {
                 type: "string",
                 description: "Name of the pet",
               },
-            },
-          },
-          states: {
-            reasoning: {
-              description: "",
-              instructions: [],
-            },
-            responding: {
-              description: "",
-              instructions: [],
             },
           },
         },
@@ -162,7 +142,7 @@ describe("updateManifestWithAiPlugin", () => {
     const [manifest, apiPlugin] = await ManifestUpdater.updateManifestWithAiPlugin(
       manifestPath,
       outputSpecPath,
-      pluginFileName,
+      pluginFilePath,
       spec
     );
 
@@ -231,7 +211,7 @@ describe("updateManifestWithAiPlugin", () => {
     };
     const manifestPath = "/path/to/your/manifest.json";
     const outputSpecPath = "/path/to/your/spec/outputSpec.yaml";
-    const pluginFileName = "ai-plugin.json";
+    const pluginFilePath = "/path/to/your/ai-plugin.json";
 
     sinon.stub(fs, "pathExists").resolves(true);
     const originalManifest = {
@@ -243,7 +223,7 @@ describe("updateManifestWithAiPlugin", () => {
       description: { short: "My API", full: "My API description" },
       apiPlugins: [
         {
-          pluginFile: pluginFileName,
+          pluginFile: "ai-plugin.json",
         },
       ],
     };
@@ -270,16 +250,6 @@ describe("updateManifestWithAiPlugin", () => {
             },
             required: ["limit"],
           },
-          states: {
-            reasoning: {
-              description: "",
-              instructions: [],
-            },
-            responding: {
-              description: "",
-              instructions: [],
-            },
-          },
         },
         {
           name: "createPet",
@@ -292,16 +262,6 @@ describe("updateManifestWithAiPlugin", () => {
                 type: "string",
                 description: "Name of the pet",
               },
-            },
-          },
-          states: {
-            reasoning: {
-              description: "",
-              instructions: [],
-            },
-            responding: {
-              description: "",
-              instructions: [],
             },
           },
         },
@@ -324,7 +284,7 @@ describe("updateManifestWithAiPlugin", () => {
     const [manifest, apiPlugin] = await ManifestUpdater.updateManifestWithAiPlugin(
       manifestPath,
       outputSpecPath,
-      pluginFileName,
+      pluginFilePath,
       spec
     );
 
@@ -348,7 +308,7 @@ describe("updateManifestWithAiPlugin", () => {
     };
     const manifestPath = "/path/to/your/manifest.json";
     const outputSpecPath = "/path/to/your/spec/outputSpec.yaml";
-    const pluginFileName = "ai-plugin.json";
+    const pluginFilePath = "/path/to/your/ai-plugin.json";
 
     sinon.stub(fs, "pathExists").resolves(true);
     const originalManifest = {
@@ -360,7 +320,7 @@ describe("updateManifestWithAiPlugin", () => {
       description: { short: "My API", full: "My API description" },
       apiPlugins: [
         {
-          pluginFile: pluginFileName,
+          pluginFile: "ai-plugin.json",
         },
       ],
     };
@@ -388,7 +348,7 @@ describe("updateManifestWithAiPlugin", () => {
     const [manifest, apiPlugin] = await ManifestUpdater.updateManifestWithAiPlugin(
       manifestPath,
       outputSpecPath,
-      pluginFileName,
+      pluginFilePath,
       spec
     );
 
@@ -452,7 +412,7 @@ describe("updateManifestWithAiPlugin", () => {
     };
     const manifestPath = "/path/to/your/manifest.json";
     const outputSpecPath = "/path/to/your/spec/outputSpec.yaml";
-    const pluginFileName = "ai-plugin.json";
+    const pluginFilePath = "/path/to/your/ai-plugin.json";
 
     sinon.stub(fs, "pathExists").resolves(true);
     const originalManifest = {
@@ -467,7 +427,7 @@ describe("updateManifestWithAiPlugin", () => {
       },
       apiPlugins: [
         {
-          pluginFile: pluginFileName,
+          pluginFile: "ai-plugin.json",
         },
       ],
     };
@@ -491,16 +451,6 @@ describe("updateManifestWithAiPlugin", () => {
             },
             required: ["limit"],
           },
-          states: {
-            reasoning: {
-              description: "",
-              instructions: [],
-            },
-            responding: {
-              description: "",
-              instructions: [],
-            },
-          },
         },
         {
           name: "createPet",
@@ -513,16 +463,6 @@ describe("updateManifestWithAiPlugin", () => {
                 type: "string",
                 description: "Name of the pet",
               },
-            },
-          },
-          states: {
-            reasoning: {
-              description: "",
-              instructions: [],
-            },
-            responding: {
-              description: "",
-              instructions: [],
             },
           },
         },
@@ -545,7 +485,7 @@ describe("updateManifestWithAiPlugin", () => {
     const [manifest, apiPlugin] = await ManifestUpdater.updateManifestWithAiPlugin(
       manifestPath,
       outputSpecPath,
-      pluginFileName,
+      pluginFilePath,
       spec
     );
 
@@ -603,13 +543,13 @@ describe("updateManifestWithAiPlugin", () => {
 
     sinon.stub(fs, "readJSON").resolves(originalManifest);
 
-    const pluginFileName = "ai-plugin.json";
+    const pluginFilePath = "/path/to/your/ai-plugin.json";
 
     try {
       await ManifestUpdater.updateManifestWithAiPlugin(
         manifestPath,
         outputSpecPath,
-        pluginFileName,
+        pluginFilePath,
         spec
       );
       expect.fail("Expected updateManifest to throw a SpecParserError");
@@ -673,13 +613,13 @@ describe("updateManifestWithAiPlugin", () => {
     };
 
     sinon.stub(fs, "readJSON").resolves(originalManifest);
-    const pluginFileName = "ai-plugin.json";
+    const pluginFilePath = "/path/to/your/ai-plugin.json";
 
     try {
       await ManifestUpdater.updateManifestWithAiPlugin(
         manifestPath,
         outputSpecPath,
-        pluginFileName,
+        pluginFilePath,
         spec
       );
       expect.fail("Expected updateManifest to throw a SpecParserError");

--- a/packages/spec-parser/test/manifestUpdater.test.ts
+++ b/packages/spec-parser/test/manifestUpdater.test.ts
@@ -108,13 +108,12 @@ describe("updateManifestWithAiPlugin", () => {
           },
           states: {
             reasoning: {
-              description: "Use the parameters to call API",
-              instructions: [],
+              description: ConstantString.ReasoningDescription,
+              instructions: [ConstantString.ReasoningInstruction],
             },
             responding: {
-              description: "Returns result in JSON format.",
-              instructions:
-                "Extract and include as much relevant information as possible from the JSON result to meet the user's needs.",
+              description: ConstantString.RespondingDescription,
+              instructions: [ConstantString.RespondingInstruction],
             },
           },
         },
@@ -133,13 +132,12 @@ describe("updateManifestWithAiPlugin", () => {
           },
           states: {
             reasoning: {
-              description: "Use the parameters to call API",
-              instructions: [],
+              description: ConstantString.ReasoningDescription,
+              instructions: [ConstantString.ReasoningInstruction],
             },
             responding: {
-              description: "Returns result in JSON format.",
-              instructions:
-                "Extract and include as much relevant information as possible from the JSON result to meet the user's needs.",
+              description: ConstantString.RespondingDescription,
+              instructions: [ConstantString.RespondingInstruction],
             },
           },
         },
@@ -169,7 +167,7 @@ describe("updateManifestWithAiPlugin", () => {
     expect(apiPlugin).to.deep.equal(expectedApiPlugins);
   });
 
-  it("should update the manifest with the correct manifest and apiPlugin files", async () => {
+  it("should update the manifest with the correct manifest and apiPlugin files with optional parameters", async () => {
     const spec: any = {
       openapi: "3.0.2",
       info: {
@@ -269,13 +267,12 @@ describe("updateManifestWithAiPlugin", () => {
           },
           states: {
             reasoning: {
-              description: "Use the parameters to call API",
-              instructions: [],
+              description: ConstantString.ReasoningDescription,
+              instructions: [ConstantString.ReasoningInstruction],
             },
             responding: {
-              description: "Returns result in JSON format.",
-              instructions:
-                "Extract and include as much relevant information as possible from the JSON result to meet the user's needs.",
+              description: ConstantString.RespondingDescription,
+              instructions: [ConstantString.RespondingInstruction],
             },
           },
         },
@@ -294,13 +291,12 @@ describe("updateManifestWithAiPlugin", () => {
           },
           states: {
             reasoning: {
-              description: "Use the parameters to call API",
-              instructions: [],
+              description: ConstantString.ReasoningDescription,
+              instructions: [ConstantString.ReasoningInstruction],
             },
             responding: {
-              description: "Returns result in JSON format.",
-              instructions:
-                "Extract and include as much relevant information as possible from the JSON result to meet the user's needs.",
+              description: ConstantString.RespondingDescription,
+              instructions: [ConstantString.RespondingInstruction],
             },
           },
         },
@@ -486,13 +482,12 @@ describe("updateManifestWithAiPlugin", () => {
           },
           states: {
             reasoning: {
-              description: "Use the parameters to call API",
-              instructions: [],
+              description: ConstantString.ReasoningDescription,
+              instructions: [ConstantString.ReasoningInstruction],
             },
             responding: {
-              description: "Returns result in JSON format.",
-              instructions:
-                "Extract and include as much relevant information as possible from the JSON result to meet the user's needs.",
+              description: ConstantString.RespondingDescription,
+              instructions: [ConstantString.RespondingInstruction],
             },
           },
         },
@@ -511,13 +506,12 @@ describe("updateManifestWithAiPlugin", () => {
           },
           states: {
             reasoning: {
-              description: "Use the parameters to call API",
-              instructions: [],
+              description: ConstantString.ReasoningDescription,
+              instructions: [ConstantString.ReasoningInstruction],
             },
             responding: {
-              description: "Returns result in JSON format.",
-              instructions:
-                "Extract and include as much relevant information as possible from the JSON result to meet the user's needs.",
+              description: ConstantString.RespondingDescription,
+              instructions: [ConstantString.RespondingInstruction],
             },
           },
         },

--- a/packages/spec-parser/test/manifestUpdater.test.ts
+++ b/packages/spec-parser/test/manifestUpdater.test.ts
@@ -73,6 +73,8 @@ describe("updateManifestWithAiPlugin", () => {
     };
     const manifestPath = "/path/to/your/manifest.json";
     const outputSpecPath = "/path/to/your/spec/outputSpec.yaml";
+    const pluginFileName = "ai-plugin.json";
+
     sinon.stub(fs, "pathExists").resolves(true);
     const originalManifest = {
       name: { short: "Original Name", full: "Original Full Name" },
@@ -83,7 +85,7 @@ describe("updateManifestWithAiPlugin", () => {
       description: { short: "My API", full: "My API description" },
       apiPlugins: [
         {
-          pluginFile: "ai-plugin.json",
+          pluginFile: pluginFileName,
         },
       ],
     };
@@ -108,12 +110,12 @@ describe("updateManifestWithAiPlugin", () => {
           },
           states: {
             reasoning: {
-              description: ConstantString.ReasoningDescription,
-              instructions: [ConstantString.ReasoningInstruction],
+              description: "",
+              instructions: [],
             },
             responding: {
-              description: ConstantString.RespondingDescription,
-              instructions: [ConstantString.RespondingInstruction],
+              description: "",
+              instructions: [],
             },
           },
         },
@@ -132,12 +134,12 @@ describe("updateManifestWithAiPlugin", () => {
           },
           states: {
             reasoning: {
-              description: ConstantString.ReasoningDescription,
-              instructions: [ConstantString.ReasoningInstruction],
+              description: "",
+              instructions: [],
             },
             responding: {
-              description: ConstantString.RespondingDescription,
-              instructions: [ConstantString.RespondingInstruction],
+              description: "",
+              instructions: [],
             },
           },
         },
@@ -160,6 +162,7 @@ describe("updateManifestWithAiPlugin", () => {
     const [manifest, apiPlugin] = await ManifestUpdater.updateManifestWithAiPlugin(
       manifestPath,
       outputSpecPath,
+      pluginFileName,
       spec
     );
 
@@ -228,6 +231,8 @@ describe("updateManifestWithAiPlugin", () => {
     };
     const manifestPath = "/path/to/your/manifest.json";
     const outputSpecPath = "/path/to/your/spec/outputSpec.yaml";
+    const pluginFileName = "ai-plugin.json";
+
     sinon.stub(fs, "pathExists").resolves(true);
     const originalManifest = {
       name: { short: "Original Name", full: "Original Full Name" },
@@ -238,7 +243,7 @@ describe("updateManifestWithAiPlugin", () => {
       description: { short: "My API", full: "My API description" },
       apiPlugins: [
         {
-          pluginFile: "ai-plugin.json",
+          pluginFile: pluginFileName,
         },
       ],
     };
@@ -267,12 +272,12 @@ describe("updateManifestWithAiPlugin", () => {
           },
           states: {
             reasoning: {
-              description: ConstantString.ReasoningDescription,
-              instructions: [ConstantString.ReasoningInstruction],
+              description: "",
+              instructions: [],
             },
             responding: {
-              description: ConstantString.RespondingDescription,
-              instructions: [ConstantString.RespondingInstruction],
+              description: "",
+              instructions: [],
             },
           },
         },
@@ -291,12 +296,12 @@ describe("updateManifestWithAiPlugin", () => {
           },
           states: {
             reasoning: {
-              description: ConstantString.ReasoningDescription,
-              instructions: [ConstantString.ReasoningInstruction],
+              description: "",
+              instructions: [],
             },
             responding: {
-              description: ConstantString.RespondingDescription,
-              instructions: [ConstantString.RespondingInstruction],
+              description: "",
+              instructions: [],
             },
           },
         },
@@ -319,6 +324,7 @@ describe("updateManifestWithAiPlugin", () => {
     const [manifest, apiPlugin] = await ManifestUpdater.updateManifestWithAiPlugin(
       manifestPath,
       outputSpecPath,
+      pluginFileName,
       spec
     );
 
@@ -342,6 +348,8 @@ describe("updateManifestWithAiPlugin", () => {
     };
     const manifestPath = "/path/to/your/manifest.json";
     const outputSpecPath = "/path/to/your/spec/outputSpec.yaml";
+    const pluginFileName = "ai-plugin.json";
+
     sinon.stub(fs, "pathExists").resolves(true);
     const originalManifest = {
       name: { short: "Original Name", full: "Original Full Name" },
@@ -352,7 +360,7 @@ describe("updateManifestWithAiPlugin", () => {
       description: { short: "My API", full: "My API description" },
       apiPlugins: [
         {
-          pluginFile: "ai-plugin.json",
+          pluginFile: pluginFileName,
         },
       ],
     };
@@ -380,6 +388,7 @@ describe("updateManifestWithAiPlugin", () => {
     const [manifest, apiPlugin] = await ManifestUpdater.updateManifestWithAiPlugin(
       manifestPath,
       outputSpecPath,
+      pluginFileName,
       spec
     );
 
@@ -443,6 +452,8 @@ describe("updateManifestWithAiPlugin", () => {
     };
     const manifestPath = "/path/to/your/manifest.json";
     const outputSpecPath = "/path/to/your/spec/outputSpec.yaml";
+    const pluginFileName = "ai-plugin.json";
+
     sinon.stub(fs, "pathExists").resolves(true);
     const originalManifest = {
       name: { short: "Original Name", full: "Original Full Name" },
@@ -456,7 +467,7 @@ describe("updateManifestWithAiPlugin", () => {
       },
       apiPlugins: [
         {
-          pluginFile: "ai-plugin.json",
+          pluginFile: pluginFileName,
         },
       ],
     };
@@ -482,12 +493,12 @@ describe("updateManifestWithAiPlugin", () => {
           },
           states: {
             reasoning: {
-              description: ConstantString.ReasoningDescription,
-              instructions: [ConstantString.ReasoningInstruction],
+              description: "",
+              instructions: [],
             },
             responding: {
-              description: ConstantString.RespondingDescription,
-              instructions: [ConstantString.RespondingInstruction],
+              description: "",
+              instructions: [],
             },
           },
         },
@@ -506,12 +517,12 @@ describe("updateManifestWithAiPlugin", () => {
           },
           states: {
             reasoning: {
-              description: ConstantString.ReasoningDescription,
-              instructions: [ConstantString.ReasoningInstruction],
+              description: "",
+              instructions: [],
             },
             responding: {
-              description: ConstantString.RespondingDescription,
-              instructions: [ConstantString.RespondingInstruction],
+              description: "",
+              instructions: [],
             },
           },
         },
@@ -534,6 +545,7 @@ describe("updateManifestWithAiPlugin", () => {
     const [manifest, apiPlugin] = await ManifestUpdater.updateManifestWithAiPlugin(
       manifestPath,
       outputSpecPath,
+      pluginFileName,
       spec
     );
 
@@ -591,8 +603,15 @@ describe("updateManifestWithAiPlugin", () => {
 
     sinon.stub(fs, "readJSON").resolves(originalManifest);
 
+    const pluginFileName = "ai-plugin.json";
+
     try {
-      await ManifestUpdater.updateManifestWithAiPlugin(manifestPath, outputSpecPath, spec);
+      await ManifestUpdater.updateManifestWithAiPlugin(
+        manifestPath,
+        outputSpecPath,
+        pluginFileName,
+        spec
+      );
       expect.fail("Expected updateManifest to throw a SpecParserError");
     } catch (err: any) {
       expect(err).to.be.instanceOf(SpecParserError);
@@ -654,9 +673,15 @@ describe("updateManifestWithAiPlugin", () => {
     };
 
     sinon.stub(fs, "readJSON").resolves(originalManifest);
+    const pluginFileName = "ai-plugin.json";
 
     try {
-      await ManifestUpdater.updateManifestWithAiPlugin(manifestPath, outputSpecPath, spec);
+      await ManifestUpdater.updateManifestWithAiPlugin(
+        manifestPath,
+        outputSpecPath,
+        pluginFileName,
+        spec
+      );
       expect.fail("Expected updateManifest to throw a SpecParserError");
     } catch (err: any) {
       expect(err).to.be.instanceOf(SpecParserError);

--- a/packages/spec-parser/test/specFilter.test.ts
+++ b/packages/spec-parser/test/specFilter.test.ts
@@ -155,6 +155,7 @@ describe("specFilter", () => {
       true,
       false,
       false,
+      false,
       false
     );
     expect(actualSpec).to.deep.equal(expectedSpec);
@@ -202,6 +203,7 @@ describe("specFilter", () => {
       unResolveSpec,
       unResolveSpec,
       true,
+      false,
       false,
       false,
       false
@@ -253,6 +255,7 @@ describe("specFilter", () => {
       filter,
       unResolvedSpec as any,
       unResolvedSpec as any,
+      false,
       false,
       false,
       false,
@@ -339,6 +342,7 @@ describe("specFilter", () => {
       true,
       false,
       false,
+      false,
       false
     );
 
@@ -348,7 +352,7 @@ describe("specFilter", () => {
   it("should not filter anything if filter item not exist", () => {
     const filter = ["get /hello"];
     const clonedSpec = { ...unResolveSpec };
-    SpecFilter.specFilter(filter, unResolveSpec, unResolveSpec, true, false, false, false);
+    SpecFilter.specFilter(filter, unResolveSpec, unResolveSpec, true, false, false, false, false);
     expect(clonedSpec).to.deep.equal(unResolveSpec);
   });
 
@@ -381,6 +385,7 @@ describe("specFilter", () => {
       true,
       false,
       false,
+      false,
       false
     );
 
@@ -390,7 +395,7 @@ describe("specFilter", () => {
   it("should not modify the original OpenAPI spec", () => {
     const filter = ["get /hello"];
     const clonedSpec = { ...unResolveSpec };
-    SpecFilter.specFilter(filter, unResolveSpec, unResolveSpec, true, false, false, false);
+    SpecFilter.specFilter(filter, unResolveSpec, unResolveSpec, true, false, false, false, false);
     expect(clonedSpec).to.deep.equal(unResolveSpec);
   });
 
@@ -402,7 +407,7 @@ describe("specFilter", () => {
       .throws(new Error("isSupportedApi error"));
 
     try {
-      SpecFilter.specFilter(filter, unResolveSpec, unResolveSpec, true, false, false, false);
+      SpecFilter.specFilter(filter, unResolveSpec, unResolveSpec, true, false, false, false, false);
       expect.fail("Expected specFilter to throw a SpecParserError");
     } catch (err: any) {
       expect(err).to.be.instanceOf(SpecParserError);

--- a/packages/spec-parser/test/specParser.test.ts
+++ b/packages/spec-parser/test/specParser.test.ts
@@ -549,6 +549,166 @@ describe("SpecParser", () => {
     });
   });
 
+  describe("generateForCopilot", () => {
+    it("should throw an error if the signal is aborted", async () => {
+      const manifestPath = "path/to/manifest";
+      const filter = ["GET /pet/{petId}"];
+      const specPath = "path/to/spec";
+      const signal = { aborted: true } as AbortSignal;
+      const parser = new SpecParser("/path/to/spec.yaml");
+
+      try {
+        await parser.generateForCopilot(manifestPath, filter, specPath, signal);
+        expect.fail("Expected an error to be thrown");
+      } catch (err) {
+        expect((err as SpecParserError).message).contain(ConstantString.CancelledMessage);
+        expect((err as SpecParserError).errorType).to.equal(ErrorType.Cancelled);
+      }
+    });
+
+    it("should throw an error if the signal is aborted after loadSpec", async () => {
+      const manifestPath = "path/to/manifest";
+      const filter = ["GET /pet/{petId}"];
+      const specPath = "path/to/spec";
+      const adaptiveCardFolder = "path/to/adaptiveCardFolder";
+      try {
+        const signal = { aborted: false } as any;
+
+        const specParser = new SpecParser("path/to/spec.yaml");
+        const spec = { openapi: "3.0.0", paths: {} };
+
+        const parseStub = sinon.stub(specParser as any, "loadSpec").callsFake(async () => {
+          signal.aborted = true;
+          return Promise.resolve();
+        });
+        const dereferenceStub = sinon.stub(specParser.parser, "dereference").resolves(spec as any);
+        await specParser.generateForCopilot(manifestPath, filter, specPath, signal);
+        expect.fail("Expected an error to be thrown");
+      } catch (err) {
+        expect((err as SpecParserError).message).contain(ConstantString.CancelledMessage);
+        expect((err as SpecParserError).errorType).to.equal(ErrorType.Cancelled);
+      }
+    });
+
+    it("should throw an error if the signal is aborted after specFilter", async () => {
+      try {
+        const signal = { aborted: false } as any;
+
+        const specParser = new SpecParser("path/to/spec.yaml");
+        const spec = { openapi: "3.0.0", paths: {} };
+        const parseStub = sinon.stub(specParser.parser, "parse").resolves(spec as any);
+        const dereferenceStub = sinon.stub(specParser.parser, "dereference").resolves(spec as any);
+        const specFilterStub = sinon
+          .stub(SpecFilter, "specFilter")
+          .callsFake((filter: string[], unResolveSpec: any) => {
+            signal.aborted = true;
+            return {} as any;
+          });
+        const outputFileStub = sinon.stub(fs, "outputFile").resolves();
+        const outputJSONStub = sinon.stub(fs, "outputJSON").resolves();
+        const JsyamlSpy = sinon.spy(jsyaml, "dump");
+
+        const filter = ["get /hello"];
+
+        const outputSpecPath = "path/to/output.yaml";
+
+        await specParser.generateForCopilot(
+          "path/to/manifest.json",
+          filter,
+          outputSpecPath,
+          signal
+        );
+
+        expect.fail("Expected an error to be thrown");
+      } catch (err) {
+        expect((err as SpecParserError).message).contain(ConstantString.CancelledMessage);
+        expect((err as SpecParserError).errorType).to.equal(ErrorType.Cancelled);
+      }
+    });
+
+    it("should generate a new spec and write it to a yaml file if spec contains api", async () => {
+      const specParser = new SpecParser("path/to/spec.yaml");
+      const spec = {
+        openapi: "3.0.0",
+        paths: {
+          "/hello": {
+            get: {
+              responses: {
+                200: {
+                  content: {
+                    "application/json": {
+                      schema: {
+                        type: "object",
+                        properties: {
+                          name: {
+                            type: "string",
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      const parseStub = sinon.stub(specParser.parser, "parse").resolves(spec as any);
+      const dereferenceStub = sinon.stub(specParser.parser, "dereference").resolves(spec as any);
+      const specFilterStub = sinon.stub(SpecFilter, "specFilter").returns({} as any);
+      const outputFileStub = sinon.stub(fs, "outputFile").resolves();
+      const outputJSONStub = sinon.stub(fs, "outputJSON").resolves();
+      const JsyamlSpy = sinon.spy(jsyaml, "dump");
+
+      const updateManifestWithAiPluginStub = sinon
+        .stub(ManifestUpdater, "updateManifestWithAiPlugin")
+        .resolves([{}, {}] as any);
+
+      const filter = ["get /hello"];
+
+      const outputSpecPath = "path/to/output.yaml";
+      const result = await specParser.generateForCopilot(
+        "path/to/manifest.json",
+        filter,
+        outputSpecPath
+      );
+
+      expect(result.allSuccess).to.be.true;
+      expect(JsyamlSpy.calledOnce).to.be.true;
+      expect(specFilterStub.calledOnce).to.be.true;
+      expect(outputFileStub.calledOnce).to.be.true;
+      expect(updateManifestWithAiPluginStub.calledOnce).to.be.true;
+      expect(outputFileStub.firstCall.args[0]).to.equal(outputSpecPath);
+      expect(outputJSONStub.calledTwice).to.be.true;
+    });
+
+    it("should throw a SpecParserError if outputFile throws an error", async () => {
+      const specParser = new SpecParser("path/to/spec.yaml");
+      const spec = { openapi: "3.0.0", paths: {} };
+      const parseStub = sinon.stub(specParser.parser, "parse").resolves(spec as any);
+      const dereferenceStub = sinon.stub(specParser.parser, "dereference").resolves(spec as any);
+      const specFilterStub = sinon.stub(SpecFilter, "specFilter").resolves();
+      const outputFileStub = sinon.stub(fs, "outputFile").throws(new Error("outputFile error"));
+      const outputJSONStub = sinon.stub(fs, "outputJSON").resolves();
+      const JSONStringifySpy = sinon.spy(JSON, "stringify");
+      const JsyamlSpy = sinon.spy(jsyaml, "dump");
+      const manifestUpdaterStub = sinon.stub(ManifestUpdater, "updateManifest").resolves([] as any);
+
+      const filter = ["get /hello"];
+
+      const outputSpecPath = "path/to/output.json";
+
+      try {
+        await specParser.generateForCopilot("path/to/manifest.json", filter, outputSpecPath);
+        expect.fail("Expected generate to throw a SpecParserError");
+      } catch (err: any) {
+        expect(err).to.be.instanceOf(SpecParserError);
+        expect(err.errorType).to.equal(ErrorType.GenerateFailed);
+        expect(err.message).to.equal("Error: outputFile error");
+      }
+    });
+  });
+
   describe("generate", () => {
     it("should throw an error if the signal is aborted", async () => {
       const manifestPath = "path/to/manifest";

--- a/packages/spec-parser/test/specParser.test.ts
+++ b/packages/spec-parser/test/specParser.test.ts
@@ -556,10 +556,10 @@ describe("SpecParser", () => {
       const specPath = "path/to/spec";
       const signal = { aborted: true } as AbortSignal;
       const specParser = new SpecParser("/path/to/spec.yaml");
-      const pluginFileName = "ai-plugin.json";
+      const pluginFilePath = "ai-plugin.json";
 
       try {
-        await specParser.generateForCopilot(manifestPath, filter, specPath, pluginFileName, signal);
+        await specParser.generateForCopilot(manifestPath, filter, specPath, pluginFilePath, signal);
         expect.fail("Expected an error to be thrown");
       } catch (err) {
         expect((err as SpecParserError).message).contain(ConstantString.CancelledMessage);
@@ -572,7 +572,7 @@ describe("SpecParser", () => {
       const filter = ["GET /pet/{petId}"];
       const specPath = "path/to/spec";
       const adaptiveCardFolder = "path/to/adaptiveCardFolder";
-      const pluginFileName = "ai-plugin.json";
+      const pluginFilePath = "ai-plugin.json";
 
       try {
         const signal = { aborted: false } as any;
@@ -585,7 +585,7 @@ describe("SpecParser", () => {
           return Promise.resolve();
         });
         const dereferenceStub = sinon.stub(specParser.parser, "dereference").resolves(spec as any);
-        await specParser.generateForCopilot(manifestPath, filter, specPath, pluginFileName, signal);
+        await specParser.generateForCopilot(manifestPath, filter, specPath, pluginFilePath, signal);
         expect.fail("Expected an error to be thrown");
       } catch (err) {
         expect((err as SpecParserError).message).contain(ConstantString.CancelledMessage);
@@ -610,7 +610,7 @@ describe("SpecParser", () => {
         const outputFileStub = sinon.stub(fs, "outputFile").resolves();
         const outputJSONStub = sinon.stub(fs, "outputJSON").resolves();
         const JsyamlSpy = sinon.spy(jsyaml, "dump");
-        const pluginFileName = "ai-plugin.json";
+        const pluginFilePath = "ai-plugin.json";
 
         const filter = ["get /hello"];
 
@@ -620,7 +620,7 @@ describe("SpecParser", () => {
           "path/to/manifest.json",
           filter,
           outputSpecPath,
-          pluginFileName,
+          pluginFilePath,
           signal
         );
 
@@ -651,13 +651,13 @@ describe("SpecParser", () => {
         const filter = ["get /hello"];
 
         const outputSpecPath = "path/to/output.yaml";
-        const pluginFileName = "ai-plugin.json";
+        const pluginFilePath = "ai-plugin.json";
 
         await specParser.generateForCopilot(
           "path/to/manifest.json",
           filter,
           outputSpecPath,
-          pluginFileName,
+          pluginFilePath,
           signal
         );
 
@@ -709,12 +709,12 @@ describe("SpecParser", () => {
       const filter = ["get /hello"];
 
       const outputSpecPath = "path/to/output.yaml";
-      const pluginFileName = "ai-plugin.json";
+      const pluginFilePath = "ai-plugin.json";
       const result = await specParser.generateForCopilot(
         "path/to/manifest.json",
         filter,
         outputSpecPath,
-        pluginFileName
+        pluginFilePath
       );
 
       expect(result.allSuccess).to.be.true;
@@ -741,14 +741,14 @@ describe("SpecParser", () => {
       const filter = ["get /hello"];
 
       const outputSpecPath = "path/to/output.json";
-      const pluginFileName = "ai-plugin.json";
+      const pluginFilePath = "ai-plugin.json";
 
       try {
         await specParser.generateForCopilot(
           "path/to/manifest.json",
           filter,
           outputSpecPath,
-          pluginFileName
+          pluginFilePath
         );
         expect.fail("Expected generate to throw a SpecParserError");
       } catch (err: any) {

--- a/packages/spec-parser/test/specParser.test.ts
+++ b/packages/spec-parser/test/specParser.test.ts
@@ -555,10 +555,11 @@ describe("SpecParser", () => {
       const filter = ["GET /pet/{petId}"];
       const specPath = "path/to/spec";
       const signal = { aborted: true } as AbortSignal;
-      const parser = new SpecParser("/path/to/spec.yaml");
+      const specParser = new SpecParser("/path/to/spec.yaml");
+      const pluginFileName = "ai-plugin.json";
 
       try {
-        await parser.generateForCopilot(manifestPath, filter, specPath, signal);
+        await specParser.generateForCopilot(manifestPath, filter, specPath, pluginFileName, signal);
         expect.fail("Expected an error to be thrown");
       } catch (err) {
         expect((err as SpecParserError).message).contain(ConstantString.CancelledMessage);
@@ -571,6 +572,8 @@ describe("SpecParser", () => {
       const filter = ["GET /pet/{petId}"];
       const specPath = "path/to/spec";
       const adaptiveCardFolder = "path/to/adaptiveCardFolder";
+      const pluginFileName = "ai-plugin.json";
+
       try {
         const signal = { aborted: false } as any;
 
@@ -582,7 +585,7 @@ describe("SpecParser", () => {
           return Promise.resolve();
         });
         const dereferenceStub = sinon.stub(specParser.parser, "dereference").resolves(spec as any);
-        await specParser.generateForCopilot(manifestPath, filter, specPath, signal);
+        await specParser.generateForCopilot(manifestPath, filter, specPath, pluginFileName, signal);
         expect.fail("Expected an error to be thrown");
       } catch (err) {
         expect((err as SpecParserError).message).contain(ConstantString.CancelledMessage);
@@ -607,6 +610,7 @@ describe("SpecParser", () => {
         const outputFileStub = sinon.stub(fs, "outputFile").resolves();
         const outputJSONStub = sinon.stub(fs, "outputJSON").resolves();
         const JsyamlSpy = sinon.spy(jsyaml, "dump");
+        const pluginFileName = "ai-plugin.json";
 
         const filter = ["get /hello"];
 
@@ -616,6 +620,7 @@ describe("SpecParser", () => {
           "path/to/manifest.json",
           filter,
           outputSpecPath,
+          pluginFileName,
           signal
         );
 
@@ -646,11 +651,13 @@ describe("SpecParser", () => {
         const filter = ["get /hello"];
 
         const outputSpecPath = "path/to/output.yaml";
+        const pluginFileName = "ai-plugin.json";
 
         await specParser.generateForCopilot(
           "path/to/manifest.json",
           filter,
           outputSpecPath,
+          pluginFileName,
           signal
         );
 
@@ -702,10 +709,12 @@ describe("SpecParser", () => {
       const filter = ["get /hello"];
 
       const outputSpecPath = "path/to/output.yaml";
+      const pluginFileName = "ai-plugin.json";
       const result = await specParser.generateForCopilot(
         "path/to/manifest.json",
         filter,
-        outputSpecPath
+        outputSpecPath,
+        pluginFileName
       );
 
       expect(result.allSuccess).to.be.true;
@@ -732,9 +741,15 @@ describe("SpecParser", () => {
       const filter = ["get /hello"];
 
       const outputSpecPath = "path/to/output.json";
+      const pluginFileName = "ai-plugin.json";
 
       try {
-        await specParser.generateForCopilot("path/to/manifest.json", filter, outputSpecPath);
+        await specParser.generateForCopilot(
+          "path/to/manifest.json",
+          filter,
+          outputSpecPath,
+          pluginFileName
+        );
         expect.fail("Expected generate to throw a SpecParserError");
       } catch (err: any) {
         expect(err).to.be.instanceOf(SpecParserError);

--- a/packages/spec-parser/test/utils.test.ts
+++ b/packages/spec-parser/test/utils.test.ts
@@ -1243,6 +1243,75 @@ describe("utils", () => {
       assert.strictEqual(result, true);
     });
 
+    it("should return false if method is POST, but parameters contain nested object", () => {
+      const method = "POST";
+      const path = "/users";
+      const spec = {
+        paths: {
+          "/users": {
+            post: {
+              parameters: [
+                {
+                  in: "query",
+                  required: true,
+                  schema: {
+                    type: "object",
+                    required: ["name"],
+                    properties: {
+                      name: {
+                        type: "object",
+                        properties: {
+                          id: {
+                            type: "string",
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              ],
+              requestBody: {
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "string",
+                    },
+                  },
+                },
+              },
+              responses: {
+                200: {
+                  content: {
+                    "application/json": {
+                      schema: {
+                        type: "object",
+                        properties: {
+                          name: {
+                            type: "string",
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      const result = Utils.isSupportedApi(
+        method,
+        path,
+        spec as any,
+        true,
+        false,
+        false,
+        false,
+        true
+      );
+      assert.strictEqual(result, false);
+    });
+
     it("should return false if method is POST, but requestBody contain nested object", () => {
       const method = "POST";
       const path = "/users";
@@ -1650,6 +1719,10 @@ describe("utils", () => {
                   required: true,
                   schema: { type: "string" },
                 },
+                {
+                  in: "query",
+                  schema: { type: "string" },
+                },
               ],
               responses: {
                 200: {
@@ -1901,6 +1974,55 @@ describe("utils", () => {
         false,
         false,
         false
+      );
+      assert.strictEqual(result, false);
+    });
+
+    it("should return false if method is POST, and request body schema is not object", () => {
+      const method = "POST";
+      const path = "/users";
+      const spec = {
+        paths: {
+          "/users": {
+            post: {
+              requestBody: {
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "string",
+                    },
+                  },
+                },
+              },
+              responses: {
+                200: {
+                  content: {
+                    "application/json": {
+                      schema: {
+                        type: "object",
+                        properties: {
+                          name: {
+                            type: "string",
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      const result = Utils.isSupportedApi(
+        method,
+        path,
+        spec as any,
+        true,
+        false,
+        false,
+        false,
+        true
       );
       assert.strictEqual(result, false);
     });

--- a/packages/spec-parser/test/utils.test.ts
+++ b/packages/spec-parser/test/utils.test.ts
@@ -100,7 +100,16 @@ describe("utils", () => {
           },
         },
       };
-      const result = Utils.isSupportedApi(method, path, spec as any, true, false, false, false);
+      const result = Utils.isSupportedApi(
+        method,
+        path,
+        spec as any,
+        true,
+        false,
+        false,
+        false,
+        false
+      );
       assert.strictEqual(result, true);
     });
 
@@ -138,7 +147,16 @@ describe("utils", () => {
           },
         },
       };
-      const result = Utils.isSupportedApi(method, path, spec as any, false, false, false, false);
+      const result = Utils.isSupportedApi(
+        method,
+        path,
+        spec as any,
+        false,
+        false,
+        false,
+        false,
+        false
+      );
       assert.strictEqual(result, false);
     });
 
@@ -190,7 +208,16 @@ describe("utils", () => {
           },
         },
       };
-      const result = Utils.isSupportedApi(method, path, spec as any, true, false, false, false);
+      const result = Utils.isSupportedApi(
+        method,
+        path,
+        spec as any,
+        true,
+        false,
+        false,
+        false,
+        false
+      );
       assert.strictEqual(result, true);
     });
 
@@ -262,7 +289,16 @@ describe("utils", () => {
           },
         },
       };
-      const result = Utils.isSupportedApi(method, path, spec as any, true, false, false, false);
+      const result = Utils.isSupportedApi(
+        method,
+        path,
+        spec as any,
+        true,
+        false,
+        false,
+        false,
+        false
+      );
       assert.strictEqual(result, false);
     });
 
@@ -334,7 +370,16 @@ describe("utils", () => {
           },
         },
       };
-      const result = Utils.isSupportedApi(method, path, spec as any, true, true, false, false);
+      const result = Utils.isSupportedApi(
+        method,
+        path,
+        spec as any,
+        true,
+        true,
+        false,
+        false,
+        false
+      );
       assert.strictEqual(result, true);
     });
 
@@ -407,7 +452,16 @@ describe("utils", () => {
           },
         },
       };
-      const result = Utils.isSupportedApi(method, path, spec as any, true, true, false, false);
+      const result = Utils.isSupportedApi(
+        method,
+        path,
+        spec as any,
+        true,
+        true,
+        false,
+        false,
+        false
+      );
       assert.strictEqual(result, false);
     });
 
@@ -481,7 +535,16 @@ describe("utils", () => {
           },
         },
       };
-      const result = Utils.isSupportedApi(method, path, spec as any, true, false, false, true);
+      const result = Utils.isSupportedApi(
+        method,
+        path,
+        spec as any,
+        true,
+        false,
+        false,
+        true,
+        false
+      );
       assert.strictEqual(result, true);
     });
 
@@ -560,7 +623,16 @@ describe("utils", () => {
           },
         },
       };
-      const result = Utils.isSupportedApi(method, path, spec as any, true, true, false, false);
+      const result = Utils.isSupportedApi(
+        method,
+        path,
+        spec as any,
+        true,
+        true,
+        false,
+        false,
+        false
+      );
       assert.strictEqual(result, false);
     });
 
@@ -639,7 +711,16 @@ describe("utils", () => {
           },
         },
       };
-      const result = Utils.isSupportedApi(method, path, spec as any, true, true, false, true);
+      const result = Utils.isSupportedApi(
+        method,
+        path,
+        spec as any,
+        true,
+        true,
+        false,
+        true,
+        false
+      );
       assert.strictEqual(result, true);
     });
 
@@ -692,7 +773,16 @@ describe("utils", () => {
           },
         },
       };
-      const result = Utils.isSupportedApi(method, path, spec as any, true, false, false, false);
+      const result = Utils.isSupportedApi(
+        method,
+        path,
+        spec as any,
+        true,
+        false,
+        false,
+        false,
+        false
+      );
       assert.strictEqual(result, true);
     });
 
@@ -745,8 +835,79 @@ describe("utils", () => {
           },
         },
       };
-      const result = Utils.isSupportedApi(method, path, spec as any, true, false, false, false);
+      const result = Utils.isSupportedApi(
+        method,
+        path,
+        spec as any,
+        true,
+        false,
+        false,
+        false,
+        false
+      );
       assert.strictEqual(result, false);
+    });
+
+    it("should return true if method is POST, path is valid, parameter is supported and both postBody and parameters contains multiple required param for copilot", () => {
+      const method = "POST";
+      const path = "/users";
+      const spec = {
+        paths: {
+          "/users": {
+            post: {
+              parameters: [
+                {
+                  in: "query",
+                  required: true,
+                  schema: { type: "string" },
+                },
+              ],
+              requestBody: {
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "object",
+                      required: ["name"],
+                      properties: {
+                        name: {
+                          type: "string",
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+              responses: {
+                200: {
+                  content: {
+                    "application/json": {
+                      schema: {
+                        type: "object",
+                        properties: {
+                          name: {
+                            type: "string",
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      const result = Utils.isSupportedApi(
+        method,
+        path,
+        spec as any,
+        true,
+        false,
+        true,
+        false,
+        true
+      );
+      assert.strictEqual(result, true);
     });
 
     it("should support multiple required parameters", () => {
@@ -798,7 +959,16 @@ describe("utils", () => {
           },
         },
       };
-      const result = Utils.isSupportedApi(method, path, spec as any, true, false, true, false);
+      const result = Utils.isSupportedApi(
+        method,
+        path,
+        spec as any,
+        true,
+        false,
+        true,
+        false,
+        false
+      );
       assert.strictEqual(result, true);
     });
 
@@ -859,8 +1029,87 @@ describe("utils", () => {
           },
         },
       };
-      const result = Utils.isSupportedApi(method, path, spec as any, true, false, true, false);
+      const result = Utils.isSupportedApi(
+        method,
+        path,
+        spec as any,
+        true,
+        false,
+        true,
+        false,
+        false
+      );
       assert.strictEqual(result, false);
+    });
+
+    it("should not support multiple required parameters count larger than 5 for copilot", () => {
+      const method = "POST";
+      const path = "/users";
+      const spec = {
+        paths: {
+          "/users": {
+            post: {
+              requestBody: {
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "object",
+                      required: ["id1", "id2", "id3", "id4", "id5", "id6"],
+                      properties: {
+                        id1: {
+                          type: "string",
+                        },
+                        id2: {
+                          type: "string",
+                        },
+                        id3: {
+                          type: "string",
+                        },
+                        id4: {
+                          type: "string",
+                        },
+                        id5: {
+                          type: "string",
+                        },
+                        id6: {
+                          type: "string",
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+              responses: {
+                200: {
+                  content: {
+                    "application/json": {
+                      schema: {
+                        type: "object",
+                        properties: {
+                          name: {
+                            type: "string",
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      const result = Utils.isSupportedApi(
+        method,
+        path,
+        spec as any,
+        true,
+        false,
+        true,
+        false,
+        true
+      );
+      assert.strictEqual(result, true);
     });
 
     it("should return false if method is POST, but requestBody contains unsupported parameter and required", () => {
@@ -915,7 +1164,16 @@ describe("utils", () => {
           },
         },
       };
-      const result = Utils.isSupportedApi(method, path, spec as any, true, false, false, false);
+      const result = Utils.isSupportedApi(
+        method,
+        path,
+        spec as any,
+        true,
+        false,
+        false,
+        false,
+        false
+      );
       assert.strictEqual(result, false);
     });
 
@@ -972,8 +1230,84 @@ describe("utils", () => {
           },
         },
       };
-      const result = Utils.isSupportedApi(method, path, spec as any, true, false, false, false);
+      const result = Utils.isSupportedApi(
+        method,
+        path,
+        spec as any,
+        true,
+        false,
+        false,
+        false,
+        false
+      );
       assert.strictEqual(result, true);
+    });
+
+    it("should return false if method is POST, but requestBody contain nested object", () => {
+      const method = "POST";
+      const path = "/users";
+      const spec = {
+        paths: {
+          "/users": {
+            post: {
+              parameters: [
+                {
+                  in: "query",
+                  required: true,
+                  schema: { type: "string" },
+                },
+              ],
+              requestBody: {
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "object",
+                      required: ["name"],
+                      properties: {
+                        name: {
+                          type: "object",
+                          properties: {
+                            id: {
+                              type: "string",
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+              responses: {
+                200: {
+                  content: {
+                    "application/json": {
+                      schema: {
+                        type: "object",
+                        properties: {
+                          name: {
+                            type: "string",
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      const result = Utils.isSupportedApi(
+        method,
+        path,
+        spec as any,
+        true,
+        false,
+        false,
+        false,
+        true
+      );
+      assert.strictEqual(result, false);
     });
 
     it("should return true if method is POST, path is valid, parameter is supported and only one required param in postBody", () => {
@@ -1010,7 +1344,16 @@ describe("utils", () => {
           },
         },
       };
-      const result = Utils.isSupportedApi(method, path, spec as any, true, false, false, false);
+      const result = Utils.isSupportedApi(
+        method,
+        path,
+        spec as any,
+        true,
+        false,
+        false,
+        false,
+        false
+      );
       assert.strictEqual(result, true);
     });
 
@@ -1048,7 +1391,16 @@ describe("utils", () => {
           },
         },
       };
-      const result = Utils.isSupportedApi(method, path, spec as any, true, false, false, false);
+      const result = Utils.isSupportedApi(
+        method,
+        path,
+        spec as any,
+        true,
+        false,
+        false,
+        false,
+        false
+      );
       assert.strictEqual(result, false);
     });
 
@@ -1085,7 +1437,16 @@ describe("utils", () => {
           },
         },
       };
-      const result = Utils.isSupportedApi(method, path, spec as any, true, false, false, false);
+      const result = Utils.isSupportedApi(
+        method,
+        path,
+        spec as any,
+        true,
+        false,
+        false,
+        false,
+        false
+      );
       assert.strictEqual(result, false);
     });
 
@@ -1122,7 +1483,16 @@ describe("utils", () => {
           },
         },
       };
-      const result = Utils.isSupportedApi(method, path, spec as any, true, false, false, false);
+      const result = Utils.isSupportedApi(
+        method,
+        path,
+        spec as any,
+        true,
+        false,
+        false,
+        false,
+        false
+      );
       assert.strictEqual(result, false);
     });
 
@@ -1160,7 +1530,16 @@ describe("utils", () => {
           },
         },
       };
-      const result = Utils.isSupportedApi(method, path, spec as any, true, false, false, false);
+      const result = Utils.isSupportedApi(
+        method,
+        path,
+        spec as any,
+        true,
+        false,
+        false,
+        false,
+        false
+      );
       assert.strictEqual(result, false);
     });
 
@@ -1198,11 +1577,20 @@ describe("utils", () => {
           },
         },
       };
-      const result = Utils.isSupportedApi(method, path, spec as any, true, false, false, false);
+      const result = Utils.isSupportedApi(
+        method,
+        path,
+        spec as any,
+        true,
+        false,
+        false,
+        false,
+        false
+      );
       assert.strictEqual(result, false);
     });
 
-    it("should return false if parameter is in header and required supported", () => {
+    it("should return false if parameter is in header and required", () => {
       const method = "GET";
       const path = "/users";
       const spec = {
@@ -1236,8 +1624,64 @@ describe("utils", () => {
           },
         },
       };
-      const result = Utils.isSupportedApi(method, path, spec as any, true, false, false, false);
+      const result = Utils.isSupportedApi(
+        method,
+        path,
+        spec as any,
+        true,
+        false,
+        false,
+        false,
+        false
+      );
       assert.strictEqual(result, false);
+    });
+
+    it("should return true if parameter is in header and required for copilot", () => {
+      const method = "GET";
+      const path = "/users";
+      const spec = {
+        paths: {
+          "/users": {
+            get: {
+              parameters: [
+                {
+                  in: "header",
+                  required: true,
+                  schema: { type: "string" },
+                },
+              ],
+              responses: {
+                200: {
+                  content: {
+                    "application/json": {
+                      schema: {
+                        type: "object",
+                        properties: {
+                          name: {
+                            type: "string",
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      const result = Utils.isSupportedApi(
+        method,
+        path,
+        spec as any,
+        true,
+        false,
+        false,
+        false,
+        true
+      );
+      assert.strictEqual(result, true);
     });
 
     it("should return false if there is no parameters", () => {
@@ -1263,8 +1707,53 @@ describe("utils", () => {
           },
         },
       };
-      const result = Utils.isSupportedApi(method, path, spec as any, true, false, false, false);
+      const result = Utils.isSupportedApi(
+        method,
+        path,
+        spec as any,
+        true,
+        false,
+        false,
+        false,
+        false
+      );
       assert.strictEqual(result, false);
+    });
+
+    it("should return true if there is no parameters for copilot", () => {
+      const method = "GET";
+      const path = "/users";
+      const spec = {
+        paths: {
+          "/users": {
+            get: {
+              parameters: [],
+              responses: {
+                200: {
+                  content: {
+                    "application/json": {
+                      schema: {
+                        type: "string",
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      const result = Utils.isSupportedApi(
+        method,
+        path,
+        spec as any,
+        true,
+        false,
+        false,
+        false,
+        true
+      );
+      assert.strictEqual(result, true);
     });
 
     it("should return false if parameters is null", () => {
@@ -1289,7 +1778,16 @@ describe("utils", () => {
           },
         },
       };
-      const result = Utils.isSupportedApi(method, path, spec as any, true, false, false, false);
+      const result = Utils.isSupportedApi(
+        method,
+        path,
+        spec as any,
+        true,
+        false,
+        false,
+        false,
+        false
+      );
       assert.strictEqual(result, false);
     });
 
@@ -1321,7 +1819,16 @@ describe("utils", () => {
           },
         },
       };
-      const result = Utils.isSupportedApi(method, path, spec as any, true, false, false, false);
+      const result = Utils.isSupportedApi(
+        method,
+        path,
+        spec as any,
+        true,
+        false,
+        false,
+        false,
+        false
+      );
       assert.strictEqual(result, false);
     });
 
@@ -1385,7 +1892,16 @@ describe("utils", () => {
           },
         },
       };
-      const result = Utils.isSupportedApi(method, path, spec as any, true, false, false, false);
+      const result = Utils.isSupportedApi(
+        method,
+        path,
+        spec as any,
+        true,
+        false,
+        false,
+        false,
+        false
+      );
       assert.strictEqual(result, false);
     });
 
@@ -1433,7 +1949,16 @@ describe("utils", () => {
           },
         },
       };
-      const result = Utils.isSupportedApi(method, path, spec as any, true, false, false, false);
+      const result = Utils.isSupportedApi(
+        method,
+        path,
+        spec as any,
+        true,
+        false,
+        false,
+        false,
+        false
+      );
       assert.strictEqual(result, false);
     });
   });
@@ -1470,7 +1995,7 @@ describe("utils", () => {
         { in: "query", required: true, schema: { type: "string" } },
         { in: "path", required: false, schema: { type: "string" } },
       ];
-      const result = Utils.checkParameters(paramObject as OpenAPIV3.ParameterObject[]);
+      const result = Utils.checkParameters(paramObject as OpenAPIV3.ParameterObject[], false);
       assert.strictEqual(result.isValid, true);
     });
 
@@ -1479,7 +2004,7 @@ describe("utils", () => {
         { in: "query", required: true, schema: { type: "string" } },
         { in: "path", required: true, schema: { type: "string" } },
       ];
-      const result = Utils.checkParameters(paramObject as OpenAPIV3.ParameterObject[]);
+      const result = Utils.checkParameters(paramObject as OpenAPIV3.ParameterObject[], false);
       assert.strictEqual(result.isValid, true);
       assert.strictEqual(result.requiredNum, 2);
       assert.strictEqual(result.optionalNum, 0);
@@ -1491,7 +2016,7 @@ describe("utils", () => {
         { in: "path", required: false, schema: { type: "string" } },
         { in: "header", required: true, schema: { type: "string" } },
       ];
-      const result = Utils.checkParameters(paramObject as OpenAPIV3.ParameterObject[]);
+      const result = Utils.checkParameters(paramObject as OpenAPIV3.ParameterObject[], false);
       assert.strictEqual(result.isValid, false);
     });
 
@@ -1501,7 +2026,7 @@ describe("utils", () => {
         { in: "path", required: false, schema: { type: "string" } },
         { in: "header", required: true, schema: { type: "string", default: "value" } },
       ];
-      const result = Utils.checkParameters(paramObject as OpenAPIV3.ParameterObject[]);
+      const result = Utils.checkParameters(paramObject as OpenAPIV3.ParameterObject[], false);
       assert.strictEqual(result.isValid, true);
       // header param is ignored
       assert.strictEqual(result.requiredNum, 1);
@@ -1514,7 +2039,7 @@ describe("utils", () => {
         { in: "path", required: false, schema: { type: "string" } },
         { in: "query", required: true, schema: { type: "string" } },
       ];
-      const result = Utils.checkParameters(paramObject as OpenAPIV3.ParameterObject[]);
+      const result = Utils.checkParameters(paramObject as OpenAPIV3.ParameterObject[], false);
       assert.strictEqual(result.isValid, true);
       assert.strictEqual(result.requiredNum, 1);
       assert.strictEqual(result.optionalNum, 2);
@@ -1526,7 +2051,7 @@ describe("utils", () => {
         { in: "path", required: false, schema: { type: "string" } },
         { in: "query", required: true, schema: { type: "array", default: ["item"] } },
       ];
-      const result = Utils.checkParameters(paramObject as OpenAPIV3.ParameterObject[]);
+      const result = Utils.checkParameters(paramObject as OpenAPIV3.ParameterObject[], false);
       assert.strictEqual(result.isValid, true);
       assert.strictEqual(result.requiredNum, 1);
       assert.strictEqual(result.optionalNum, 1);
@@ -1538,7 +2063,7 @@ describe("utils", () => {
         { in: "path", required: false, schema: { type: "string" } },
         { in: "header", required: false, schema: { type: "string" } },
       ];
-      const result = Utils.checkParameters(paramObject as OpenAPIV3.ParameterObject[]);
+      const result = Utils.checkParameters(paramObject as OpenAPIV3.ParameterObject[], false);
       assert.strictEqual(result.isValid, true);
       assert.strictEqual(result.requiredNum, 1);
       assert.strictEqual(result.optionalNum, 1);
@@ -1549,7 +2074,7 @@ describe("utils", () => {
         { in: "query", required: true, schema: { type: "string" } },
         { in: "path", required: true, schema: { type: "array" } },
       ];
-      const result = Utils.checkParameters(paramObject as OpenAPIV3.ParameterObject[]);
+      const result = Utils.checkParameters(paramObject as OpenAPIV3.ParameterObject[], false);
       assert.strictEqual(result.isValid, false);
     });
 
@@ -1558,7 +2083,7 @@ describe("utils", () => {
         { in: "query", required: false, schema: { type: "string" } },
         { in: "path", required: true, schema: { type: "object" } },
       ];
-      const result = Utils.checkParameters(paramObject as OpenAPIV3.ParameterObject[]);
+      const result = Utils.checkParameters(paramObject as OpenAPIV3.ParameterObject[], false);
       assert.strictEqual(result.isValid, false);
     });
 
@@ -1567,7 +2092,7 @@ describe("utils", () => {
         { in: "query", required: false, schema: { type: "string" } },
         { in: "path", required: false, schema: { type: "object" } },
       ];
-      const result = Utils.checkParameters(paramObject as OpenAPIV3.ParameterObject[]);
+      const result = Utils.checkParameters(paramObject as OpenAPIV3.ParameterObject[], false);
       assert.strictEqual(result.isValid, true);
       assert.strictEqual(result.requiredNum, 0);
       assert.strictEqual(result.optionalNum, 1);
@@ -1731,7 +2256,14 @@ describe("utils", () => {
   describe("validateServer", () => {
     it("should return an error if there is no server information", () => {
       const spec = { paths: {} };
-      const errors = Utils.validateServer(spec as OpenAPIV3.Document, true, false, false, false);
+      const errors = Utils.validateServer(
+        spec as OpenAPIV3.Document,
+        true,
+        false,
+        false,
+        false,
+        false
+      );
       assert.deepStrictEqual(errors, [
         {
           type: ErrorType.NoServerInformation,
@@ -1750,7 +2282,7 @@ describe("utils", () => {
           },
         },
       };
-      const errors = Utils.validateServer(spec as any, true, false, false, false);
+      const errors = Utils.validateServer(spec as any, true, false, false, false, false);
       assert.deepStrictEqual(errors, [
         {
           type: ErrorType.NoServerInformation,
@@ -1764,7 +2296,14 @@ describe("utils", () => {
         servers: [{ url: "https://example.com" }],
         paths: {},
       };
-      const errors = Utils.validateServer(spec as OpenAPIV3.Document, true, false, false, false);
+      const errors = Utils.validateServer(
+        spec as OpenAPIV3.Document,
+        true,
+        false,
+        false,
+        false,
+        false
+      );
       assert.deepStrictEqual(errors, []);
     });
 
@@ -1776,7 +2315,7 @@ describe("utils", () => {
           },
         },
       };
-      const errors = Utils.validateServer(spec as any, true, false, false, false);
+      const errors = Utils.validateServer(spec as any, true, false, false, false, false);
       assert.deepStrictEqual(errors, []);
     });
 
@@ -1808,7 +2347,7 @@ describe("utils", () => {
           },
         },
       };
-      const errors = Utils.validateServer(spec as any, true, false, false, false);
+      const errors = Utils.validateServer(spec as any, true, false, false, false, false);
       assert.deepStrictEqual(errors, []);
     });
 
@@ -1842,7 +2381,7 @@ describe("utils", () => {
           },
         },
       };
-      const errors = Utils.validateServer(spec as any, true, false, false, false);
+      const errors = Utils.validateServer(spec as any, true, false, false, false, false);
       assert.deepStrictEqual(errors, []);
     });
 
@@ -1876,7 +2415,7 @@ describe("utils", () => {
           },
         },
       };
-      const errors = Utils.validateServer(spec as any, true, false, false, false);
+      const errors = Utils.validateServer(spec as any, true, false, false, false, false);
       assert.deepStrictEqual(errors, [
         {
           type: ErrorType.RelativeServerUrlNotSupported,
@@ -1894,6 +2433,35 @@ describe("utils", () => {
           data: "ftp",
         },
       ]);
+    });
+  });
+
+  describe("hasNestedObjectInSchema", () => {
+    it("should return false if schema type is not object", () => {
+      const schema: OpenAPIV3.SchemaObject = {
+        type: "string",
+      };
+      expect(Utils.hasNestedObjectInSchema(schema)).to.be.false;
+    });
+
+    it("should return false if schema type is object but no nested object property", () => {
+      const schema: OpenAPIV3.SchemaObject = {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+        },
+      };
+      expect(Utils.hasNestedObjectInSchema(schema)).to.be.false;
+    });
+
+    it("should return true if schema type is object and has nested object property", () => {
+      const schema: OpenAPIV3.SchemaObject = {
+        type: "object",
+        properties: {
+          nestedObject: { type: "object" },
+        },
+      };
+      expect(Utils.hasNestedObjectInSchema(schema)).to.be.true;
     });
   });
 


### PR DESCRIPTION
Example:

Code sample:
```ts
  const testFolder = path.resolve("../", path.dirname(__dirname), "test-material");
  const manifest = testFolder + "/manifest.json";
  const spec = testFolder + "/petstore.yaml";
  const parser = new SpecParser(spec, {
    allowMultipleParameters: true,
    isCopilot: true,
  });
  const list = await parser.list();
  const validate = await parser.validate();
  const apis = list.map((item) => item.api);
  const result = await parser.generateForCopilot(manifest, apis, testFolder + "/" + "result.yaml", "ai-plugin.json");
```

OpenAPI spec file:
```yaml
openapi: 3.0.0
info:
  title: Phone Service
  description: >-
    http service to operate phone via http request, such as send message, get
    contacts, etc
  version: 1.0.2
servers:
  - url: https://dcg.microsoft.com
paths:
  /DeviceDataConnector/devices/default/contacts:
    get:
      operationId: getContactList
      summary: Get contact list from device.
      description: Get contact list from device.
      parameters:
        - name: top
          in: query
          description: The top number of contacts to return, default is 100
          required: false
          schema:
            type: string
        - name: filter
          in: query
          description: >-
            The filter used to filter the contacts, currently support filter by
            name, company and location, such as `filter=name has $contactName`,
            also it supports `and` and `or` operator, such as `filter=name has
            $contactName or company has $company`
          required: false
          schema:
            type: string
        - name: name
          in: query
          description: The parameter to filter the contacts by name, such as `name=Tom`
          required: false
          schema:
            type: string
        - name: company
          in: query
          description: >-
            The parameter to filter the contacts by company, such as
            `company=Microsoft`
          required: false
          schema:
            type: string
      responses:
        '200':
         ...
```

Generated manifest file:
```json
{
  "$schema": "https://raw.githubusercontent.com/OfficeDev/microsoft-teams-app-schema/preview/DevPreview/MicrosoftTeams.schema.json",
  "manifestVersion": "devPreview",
  "version": "1.0.0",
  "id": "${{TEAMS_APP_ID}}",
  "packageName": "com.microsoft.teams.extension",
  "developer": {
    "name": "Teams App, Inc.",
    "websiteUrl": "https://www.example.com",
    "privacyUrl": "https://www.example.com/termofuse",
    "termsOfUseUrl": "https://www.example.com/privacy"
  },
  "icons": {
    "color": "color.png",
    "outline": "outline.png"
  },
  "name": {
    "short": "Phone Service",
    "full": "Phone Service"
  },
  "description": {
    "short": "Phone Service",
    "full": "http service to operate phone via http request, such as send message, get contacts, etc"
  },
  "accentColor": "#FFFFFF",
  "composeExtensions": [],
  "permissions": [
    "identity",
    "messageTeamMembers"
  ],
  "validDomains": [],
  "apiPlugins": [
    {
      "pluginFile": "ai-plugin.json"
    }
  ]
}

```

Generated ai-plugin file:
```json
{
  "schema_version": "v2",
  "name_for_human": "Phone Service",
  "description_for_human": "http service to operate phone via http request, such as send message, get contacts, etc",
  "functions": [
    {
      "name": "getContactList",
      "description": "Get contact list from device.",
      "parameters": {
        "type": "object",
        "properties": {
          "top": {
            "type": "string",
            "description": "The top number of contacts to return, default is 100"
          },
          "filter": {
            "type": "string",
            "description": "The filter used to filter the contacts, currently support filter by name, company and location, such as `filter=name has $contactName`, also it supports `and` and `or` operator, such as `filter=name has $contactName or company has $company`"
          },
          "name": {
            "type": "string",
            "description": "The parameter to filter the contacts by name, such as `name=Tom`"
          },
          "company": {
            "type": "string",
            "description": "The parameter to filter the contacts by company, such as `company=Microsoft`"
          }
        },
        "required": []
      },
      "states": {
        "reasoning": {
          "description": "",
          "instructions": []
        },
        "responding": {
          "description": "",
          "instructions": []
        }
      }
    }
  ],
  "runtimes": [
    {
      "type": "OpenApi",
      "auth": {
        "type": "none"
      },
      "spec": {
        "url": "result.yaml"
      },
      "run_for_functions": [
        "getContactList"
      ]
    }
  ]
}
```