### PR TITLE
fix: github lfs file download in samples

### DIFF
--- a/packages/fx-core/tests/component/generator/generator.test.ts
+++ b/packages/fx-core/tests/component/generator/generator.test.ts
@@ -359,6 +359,31 @@ describe("Generator utils", () => {
     assert.equal(data, mockFileData);
   });
 
+  it("download directory with LFS files", async () => {
+    const axiosStub = sandbox.stub(axios, "get");
+    const sampleName = "test";
+    const mockFileName = "test.txt";
+    const mockFileData = "test data";
+    const lfsData =
+      "version https://git-lfs.github.com/spec/v1\noid sha256:548c1fe07b6b278da680ccd84483be06262521f2e3\nsize 100";
+    const fileInfo = [{ type: "file", path: `${sampleName}/${mockFileName}` }];
+    axiosStub.onFirstCall().resolves({ status: 200, data: { tree: fileInfo } });
+    axiosStub.onSecondCall().resolves({ status: 200, data: lfsData });
+    axiosStub.onThirdCall().resolves({ status: 200, data: mockFileData });
+    await fs.ensureDir(tmpDir);
+    await downloadDirectory(
+      {
+        owner: "OfficeDev",
+        repository: "TeamsFx-Samples",
+        ref: "dev",
+        dir: "test",
+      },
+      tmpDir
+    );
+    const data = await fs.readFile(path.join(tmpDir, mockFileName), "utf8");
+    assert.equal(data, mockFileData);
+  });
+
   it("limit concurrency", async () => {
     const data = [1, 10, 2, 3];
     let res: number[] = [];

--- a/packages/vscode-extension/src/controls/sampleGallery/sampleCard.tsx
+++ b/packages/vscode-extension/src/controls/sampleGallery/sampleCard.tsx
@@ -28,7 +28,6 @@ export default class SampleCard extends React.Component<SampleProps, { imageUrl:
         className="thumbnail"
         src={this.state.imageUrl}
         onError={() => {
-          console.log(`!!!error ${this.state.imageUrl}`);
           const downloadUrlInfo = sample.downloadUrlInfo;
           this.setState({
             imageUrl: `https://media.githubusercontent.com/media/${downloadUrlInfo.owner}/${downloadUrlInfo.repository}/${downloadUrlInfo.ref}/${downloadUrlInfo.dir}/${sample.thumbnailPath}`,


### PR DESCRIPTION
Related bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/27041735