### PR TITLE
refactor: remove unused error message

### DIFF
--- a/packages/vscode-extension/src/commonlib/codeFlowLogin.ts
+++ b/packages/vscode-extension/src/commonlib/codeFlowLogin.ts
@@ -332,14 +332,6 @@ export class CodeFlowLogin {
             }
           })
           .catch(async (error) => {
-            VsCodeLogInstance.error(
-              "[Login] " +
-                stringUtil.format(
-                  localize("teamstoolkit.codeFlowLogin.silentAcquireToken"),
-                  path.join(os.homedir(), ".fx", "account"),
-                  error.message
-                )
-            );
             if (!(await checkIsOnline())) {
               return undefined;
             }
@@ -385,14 +377,6 @@ export class CodeFlowLogin {
           return err(LoginCodeFlowError(new Error("No token response.")));
         }
       } catch (error) {
-        VsCodeLogInstance.error(
-          "[Login] " +
-            stringUtil.format(
-              localize("teamstoolkit.codeFlowLogin.silentAcquireToken"),
-              path.join(os.homedir(), ".fx", "account"),
-              error.message
-            )
-        );
         if (!(await checkIsOnline())) {
           return error(CheckOnlineError());
         }


### PR DESCRIPTION
Remove 'silentAcquireToken' error, as the Teams toolkit automatically clears the cache when unable to obtain the token.