### PR TITLE
fix: clean staggged app

### DIFF
--- a/packages/tests/src/commonlib/appStudioValidator.ts
+++ b/packages/tests/src/commonlib/appStudioValidator.ts
@@ -85,6 +85,7 @@ export class AppStudioValidator {
     teamsAppId?: string
   ): Promise<void> {
     if (!teamsAppId) {
+      console.warn("teamsAppId is undefined, no need to cancel staged app.");
       return;
     }
     const appStudioTokenRes = await this.provider.getAccessToken({

--- a/packages/tests/src/e2e/bot/CommandBotHappyPathCommon.ts
+++ b/packages/tests/src/e2e/bot/CommandBotHappyPathCommon.ts
@@ -124,7 +124,15 @@ export function happyPathTest(runtime: Runtime): void {
 
     this.afterEach(async () => {
       console.log(`[Successfully] start to clean up for ${projectPath}`);
-      await cleanUp(appName, projectPath, false, true, false, teamsAppId);
+      await cleanUp(
+        appName,
+        projectPath,
+        false,
+        true,
+        false,
+        envName,
+        teamsAppId
+      );
     });
   });
 }


### PR DESCRIPTION
There are 4 test cases with publish command, only one doesn't clean up the stagged app due to undefined app id:
![image](https://github.com/OfficeDev/TeamsFx/assets/71362691/3c8c626c-486a-44dd-ba74-8d7d7136b62a)

After fix, it will be cleaned:
![image](https://github.com/OfficeDev/TeamsFx/assets/71362691/478e2965-01c7-4f64-8e0e-a4abafec36ef)

https://github.com/OfficeDev/TeamsFx/actions/runs/8136634546/job/22233947472

Related bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/27001733

