### PR TITLE
fix: bot app error handling in template and SDK

### DIFF
--- a/packages/sdk/src/conversationWithCloudAdapter/conversation.ts
+++ b/packages/sdk/src/conversationWithCloudAdapter/conversation.ts
@@ -158,17 +158,20 @@ export class ConversationBot {
       // This check writes out errors to console.
       console.error(`[onTurnError] unhandled error`, error);
 
-      // Send a trace activity, which will be displayed in Bot Framework Emulator
-      await context.sendTraceActivity(
-        "OnTurnError Trace",
-        error instanceof Error ? error.message : error,
-        "https://www.botframework.com/schemas/error",
-        "TurnError"
-      );
+      // Only send error message for user messages, not for other message types so the bot doesn't spam a channel or chat.
+      if (context.activity.type === "message") {
+        // Send a trace activity, which will be displayed in Bot Framework Emulator
+        await context.sendTraceActivity(
+          "OnTurnError Trace",
+          error instanceof Error ? error.message : error,
+          "https://www.botframework.com/schemas/error",
+          "TurnError"
+        );
 
-      // Send a message to the user
-      await context.sendActivity(`The bot encountered unhandled error: ${error.message}`);
-      await context.sendActivity("To continue to run this bot, please fix the bot source code.");
+        // Send a message to the user
+        await context.sendActivity(`The bot encountered unhandled error: ${error.message}`);
+        await context.sendActivity("To continue to run this bot, please fix the bot source code.");
+      }
     };
 
     return adapter;

--- a/packages/sdk/test/unit/node/conversationWithCloudAdapter/conversation.spec.ts
+++ b/packages/sdk/test/unit/node/conversationWithCloudAdapter/conversation.spec.ts
@@ -125,8 +125,9 @@ describe("ConversationBot Tests - Node", () => {
     assert.isTrue(called);
   });
 
-  it("onTurnError correctly handles error", async () => {
+  it("onTurnError correctly handles error when it's message activity", async () => {
     const context = sandbox.createStubInstance(TurnContext);
+    sandbox.stub(TurnContext.prototype, "activity").value({ type: "message" });
     const conversationBot = new ConversationBot({});
     const error = new Error("test error");
     await conversationBot.adapter.onTurnError(context, error);
@@ -139,5 +140,31 @@ describe("ConversationBot Tests - Node", () => {
         "To continue to run this bot, please fix the bot source code."
       )
     );
+  });
+
+  it("onTurnError correctly handles error with error string", async () => {
+    const context = sandbox.createStubInstance(TurnContext);
+    sandbox.stub(TurnContext.prototype, "activity").value({ type: "message" });
+    const conversationBot = new ConversationBot({});
+    const error = "test error";
+    await conversationBot.adapter.onTurnError(context, error as any);
+    assert.isTrue(context.sendActivity.calledTwice);
+    assert.isTrue(
+      context.sendActivity.calledWith(`The bot encountered unhandled error: undefined`)
+    );
+    assert.isTrue(
+      context.sendActivity.calledWith(
+        "To continue to run this bot, please fix the bot source code."
+      )
+    );
+  });
+
+  it("onTurnError skip to handle error when it's not message activity", async () => {
+    const context = sandbox.createStubInstance(TurnContext);
+    sandbox.stub(TurnContext.prototype, "activity").value({ type: "invoke" });
+    const conversationBot = new ConversationBot({});
+    const error = new Error("test error");
+    await conversationBot.adapter.onTurnError(context, error);
+    assert.isFalse(context.sendActivity.called);
   });
 });

--- a/templates/js/ai-assistant-bot/src/index.js
+++ b/templates/js/ai-assistant-bot/src/index.js
@@ -33,17 +33,20 @@ const onTurnErrorHandler = async (context, error) => {
   //       application insights.
   console.error(`\n [onTurnError] unhandled error: ${error}`);
 
-  // Send a trace activity, which will be displayed in Bot Framework Emulator
-  await context.sendTraceActivity(
-    "OnTurnError Trace",
-    `${error}`,
-    "https://www.botframework.com/schemas/error",
-    "TurnError"
-  );
+  // Only send error message for user messages, not for other message types so the bot doesn't spam a channel or chat.
+  if (context.activity.type === "message") {
+    // Send a trace activity, which will be displayed in Bot Framework Emulator
+    await context.sendTraceActivity(
+      "OnTurnError Trace",
+      `${error}`,
+      "https://www.botframework.com/schemas/error",
+      "TurnError"
+    );
 
-  // Send a message to the user
-  await context.sendActivity("The bot encountered an error or bug.");
-  await context.sendActivity("To continue to run this bot, please fix the bot source code.");
+    // Send a message to the user
+    await context.sendActivity("The bot encountered an error or bug.");
+    await context.sendActivity("To continue to run this bot, please fix the bot source code.");
+  }
 };
 
 // Set the onTurnError for the singleton CloudAdapter.

--- a/templates/js/ai-bot/src/index.js
+++ b/templates/js/ai-bot/src/index.js
@@ -33,17 +33,20 @@ const onTurnErrorHandler = async (context, error) => {
   //       application insights.
   console.error(`\n [onTurnError] unhandled error: ${error}`);
 
-  // Send a trace activity, which will be displayed in Bot Framework Emulator
-  await context.sendTraceActivity(
-    "OnTurnError Trace",
-    `${error}`,
-    "https://www.botframework.com/schemas/error",
-    "TurnError"
-  );
+  // Only send error message for user messages, not for other message types so the bot doesn't spam a channel or chat.
+  if (context.activity.type === "message") {
+    // Send a trace activity, which will be displayed in Bot Framework Emulator
+    await context.sendTraceActivity(
+      "OnTurnError Trace",
+      `${error}`,
+      "https://www.botframework.com/schemas/error",
+      "TurnError"
+    );
 
-  // Send a message to the user
-  await context.sendActivity("The bot encountered an error or bug.");
-  await context.sendActivity("To continue to run this bot, please fix the bot source code.");
+    // Send a message to the user
+    await context.sendActivity("The bot encountered an error or bug.");
+    await context.sendActivity("To continue to run this bot, please fix the bot source code.");
+  }
 };
 
 // Set the onTurnError for the singleton CloudAdapter.

--- a/templates/js/command-and-response/package.json.tpl
+++ b/templates/js/command-and-response/package.json.tpl
@@ -23,7 +23,7 @@
     },
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
-        "@microsoft/teamsfx": "^2.2.0",
+        "@microsoft/teamsfx": "^2.3.0-rc",
         "botbuilder": "^4.20.0",
         "restify": "^10.0.0"
     },

--- a/templates/js/default-bot/index.js
+++ b/templates/js/default-bot/index.js
@@ -35,9 +35,12 @@ adapter.onTurnError = async (context, error) => {
   //       configuration instructions.
   console.error(`\n [onTurnError] unhandled error: ${error}`);
 
-  // Send a message to the user
-  await context.sendActivity(`The bot encountered an unhandled error:\n ${error.message}`);
-  await context.sendActivity("To continue to run this bot, please fix the bot source code.");
+  // Only send error message for user messages, not for other message types so the bot doesn't spam a channel or chat.
+  if (context.activity.type === "message") {
+    // Send a message to the user
+    await context.sendActivity(`The bot encountered an unhandled error:\n ${error.message}`);
+    await context.sendActivity("To continue to run this bot, please fix the bot source code.");
+  }
 };
 
 // Create the bot that will handle incoming messages.

--- a/templates/js/non-sso-tab-default-bot/bot/index.js
+++ b/templates/js/non-sso-tab-default-bot/bot/index.js
@@ -35,9 +35,12 @@ adapter.onTurnError = async (context, error) => {
   //       configuration instructions.
   console.error(`\n [onTurnError] unhandled error: ${error}`);
 
-  // Send a message to the user
-  await context.sendActivity(`The bot encountered an unhandled error:\n ${error.message}`);
-  await context.sendActivity("To continue to run this bot, please fix the bot source code.");
+  // Only send error message for user messages, not for other message types so the bot doesn't spam a channel or chat.
+  if (context.activity.type === "message") {
+    // Send a message to the user
+    await context.sendActivity(`The bot encountered an unhandled error:\n ${error.message}`);
+    await context.sendActivity("To continue to run this bot, please fix the bot source code.");
+  }
 };
 
 // Create the bot that will handle incoming messages.

--- a/templates/js/notification-http-timer-trigger/package.json.tpl
+++ b/templates/js/notification-http-timer-trigger/package.json.tpl
@@ -22,7 +22,7 @@
     },
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
-        "@microsoft/teamsfx": "^2.3.0",
+        "@microsoft/teamsfx": "^2.3.0-rc",
         "botbuilder": "^4.20.0"
     },
     "devDependencies": {

--- a/templates/js/notification-http-trigger/package.json.tpl
+++ b/templates/js/notification-http-trigger/package.json.tpl
@@ -22,7 +22,7 @@
     },
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
-        "@microsoft/teamsfx": "^2.3.0",
+        "@microsoft/teamsfx": "^2.3.0-rc",
         "botbuilder": "^4.20.0"
     },
     "devDependencies": {

--- a/templates/js/notification-restify/package.json.tpl
+++ b/templates/js/notification-restify/package.json.tpl
@@ -23,7 +23,7 @@
     },
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
-        "@microsoft/teamsfx": "^2.3.0",
+        "@microsoft/teamsfx": "^2.3.0-rc",
         "botbuilder": "^4.20.0",
         "restify": "^10.0.0"
     },

--- a/templates/js/notification-timer-trigger/package.json.tpl
+++ b/templates/js/notification-timer-trigger/package.json.tpl
@@ -22,7 +22,7 @@
     },
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
-        "@microsoft/teamsfx": "^2.3.0",
+        "@microsoft/teamsfx": "^2.3.0-rc",
         "botbuilder": "^4.20.0"
     },
     "devDependencies": {

--- a/templates/js/workflow/package.json.tpl
+++ b/templates/js/workflow/package.json.tpl
@@ -23,7 +23,7 @@
     },
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
-        "@microsoft/teamsfx": "^2.2.0",
+        "@microsoft/teamsfx": "^2.3.0-rc",
         "botbuilder": "^4.20.0",
         "restify": "^10.0.0"
     },

--- a/templates/ts/ai-assistant-bot/src/index.ts
+++ b/templates/ts/ai-assistant-bot/src/index.ts
@@ -33,17 +33,20 @@ const onTurnErrorHandler = async (context, error) => {
   //       application insights.
   console.error(`\n [onTurnError] unhandled error: ${error}`);
 
-  // Send a trace activity, which will be displayed in Bot Framework Emulator
-  await context.sendTraceActivity(
-    "OnTurnError Trace",
-    `${error}`,
-    "https://www.botframework.com/schemas/error",
-    "TurnError"
-  );
+  // Only send error message for user messages, not for other message types so the bot doesn't spam a channel or chat.
+  if (context.activity.type === "message") {
+    // Send a trace activity, which will be displayed in Bot Framework Emulator
+    await context.sendTraceActivity(
+      "OnTurnError Trace",
+      `${error}`,
+      "https://www.botframework.com/schemas/error",
+      "TurnError"
+    );
 
-  // Send a message to the user
-  await context.sendActivity("The bot encountered an error or bug.");
-  await context.sendActivity("To continue to run this bot, please fix the bot source code.");
+    // Send a message to the user
+    await context.sendActivity("The bot encountered an error or bug.");
+    await context.sendActivity("To continue to run this bot, please fix the bot source code.");
+  }
 };
 
 // Set the onTurnError for the singleton CloudAdapter.

--- a/templates/ts/ai-bot/src/index.ts
+++ b/templates/ts/ai-bot/src/index.ts
@@ -33,17 +33,20 @@ const onTurnErrorHandler = async (context, error) => {
   //       application insights.
   console.error(`\n [onTurnError] unhandled error: ${error}`);
 
-  // Send a trace activity, which will be displayed in Bot Framework Emulator
-  await context.sendTraceActivity(
-    "OnTurnError Trace",
-    `${error}`,
-    "https://www.botframework.com/schemas/error",
-    "TurnError"
-  );
+  // Only send error message for user messages, not for other message types so the bot doesn't spam a channel or chat.
+  if (context.activity.type === "message") {
+    // Send a trace activity, which will be displayed in Bot Framework Emulator
+    await context.sendTraceActivity(
+      "OnTurnError Trace",
+      `${error}`,
+      "https://www.botframework.com/schemas/error",
+      "TurnError"
+    );
 
-  // Send a message to the user
-  await context.sendActivity("The bot encountered an error or bug.");
-  await context.sendActivity("To continue to run this bot, please fix the bot source code.");
+    // Send a message to the user
+    await context.sendActivity("The bot encountered an error or bug.");
+    await context.sendActivity("To continue to run this bot, please fix the bot source code.");
+  }
 };
 
 // Set the onTurnError for the singleton CloudAdapter.

--- a/templates/ts/command-and-response/package.json.tpl
+++ b/templates/ts/command-and-response/package.json.tpl
@@ -23,7 +23,7 @@
         "url": "https://github.com"
     },
     "dependencies": {
-        "@microsoft/teamsfx": "^2.2.0",
+        "@microsoft/teamsfx": "^2.3.0-rc",
         "botbuilder": "^4.20.0",
         "restify": "^10.0.0"
     },

--- a/templates/ts/default-bot/index.ts
+++ b/templates/ts/default-bot/index.ts
@@ -36,17 +36,20 @@ const onTurnErrorHandler = async (context: TurnContext, error: Error) => {
   //       application insights.
   console.error(`\n [onTurnError] unhandled error: ${error}`);
 
-  // Send a trace activity, which will be displayed in Bot Framework Emulator
-  await context.sendTraceActivity(
-    "OnTurnError Trace",
-    `${error}`,
-    "https://www.botframework.com/schemas/error",
-    "TurnError"
-  );
+  // Only send error message for user messages, not for other message types so the bot doesn't spam a channel or chat.
+  if (context.activity.type === "message") {
+    // Send a trace activity, which will be displayed in Bot Framework Emulator
+    await context.sendTraceActivity(
+      "OnTurnError Trace",
+      `${error}`,
+      "https://www.botframework.com/schemas/error",
+      "TurnError"
+    );
 
-  // Send a message to the user
-  await context.sendActivity(`The bot encountered unhandled error:\n ${error.message}`);
-  await context.sendActivity("To continue to run this bot, please fix the bot source code.");
+    // Send a message to the user
+    await context.sendActivity(`The bot encountered unhandled error:\n ${error.message}`);
+    await context.sendActivity("To continue to run this bot, please fix the bot source code.");
+  }
 };
 
 // Set the onTurnError for the singleton CloudAdapter.

--- a/templates/ts/non-sso-tab-default-bot/bot/index.ts
+++ b/templates/ts/non-sso-tab-default-bot/bot/index.ts
@@ -36,17 +36,20 @@ const onTurnErrorHandler = async (context: TurnContext, error: Error) => {
   //       application insights.
   console.error(`\n [onTurnError] unhandled error: ${error}`);
 
-  // Send a trace activity, which will be displayed in Bot Framework Emulator
-  await context.sendTraceActivity(
-    "OnTurnError Trace",
-    `${error}`,
-    "https://www.botframework.com/schemas/error",
-    "TurnError"
-  );
+  // Only send error message for user messages, not for other message types so the bot doesn't spam a channel or chat.
+  if (context.activity.type === "message") {
+    // Send a trace activity, which will be displayed in Bot Framework Emulator
+    await context.sendTraceActivity(
+      "OnTurnError Trace",
+      `${error}`,
+      "https://www.botframework.com/schemas/error",
+      "TurnError"
+    );
 
-  // Send a message to the user
-  await context.sendActivity(`The bot encountered unhandled error:\n ${error.message}`);
-  await context.sendActivity("To continue to run this bot, please fix the bot source code.");
+    // Send a message to the user
+    await context.sendActivity(`The bot encountered unhandled error:\n ${error.message}`);
+    await context.sendActivity("To continue to run this bot, please fix the bot source code.");
+  }
 };
 
 // Set the onTurnError for the singleton CloudAdapter.

--- a/templates/ts/notification-http-timer-trigger/package.json.tpl
+++ b/templates/ts/notification-http-timer-trigger/package.json.tpl
@@ -26,7 +26,7 @@
     },
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
-        "@microsoft/teamsfx": "^2.3.0",
+        "@microsoft/teamsfx": "^2.3.0-rc",
         "botbuilder": "^4.20.0"
     },
     "devDependencies": {

--- a/templates/ts/notification-http-trigger/package.json.tpl
+++ b/templates/ts/notification-http-trigger/package.json.tpl
@@ -26,7 +26,7 @@
     },
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
-        "@microsoft/teamsfx": "^2.3.0",
+        "@microsoft/teamsfx": "^2.3.0-rc",
         "botbuilder": "^4.20.0"
     },
     "devDependencies": {

--- a/templates/ts/notification-restify/package.json.tpl
+++ b/templates/ts/notification-restify/package.json.tpl
@@ -24,7 +24,7 @@
     },
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
-        "@microsoft/teamsfx": "^2.3.0",
+        "@microsoft/teamsfx": "^2.3.0-rc",
         "botbuilder": "^4.20.0",
         "restify": "^10.0.0"
     },

--- a/templates/ts/notification-timer-trigger/package.json.tpl
+++ b/templates/ts/notification-timer-trigger/package.json.tpl
@@ -26,7 +26,7 @@
     },
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
-        "@microsoft/teamsfx": "^2.3.0",
+        "@microsoft/teamsfx": "^2.3.0-rc",
         "botbuilder": "^4.20.0"
     },
     "devDependencies": {

--- a/templates/ts/workflow/package.json.tpl
+++ b/templates/ts/workflow/package.json.tpl
@@ -24,7 +24,7 @@
     },
     "dependencies": {
         "@microsoft/adaptivecards-tools": "^1.0.0",
-        "@microsoft/teamsfx": "^2.2.0",
+        "@microsoft/teamsfx": "^2.3.0-rc",
         "botbuilder": "^4.20.0",
         "restify": "^10.0.0"
     },


### PR DESCRIPTION
Update bot templates and SDK to send a message on error only when the activity is a message directed to it.

This PR covers:
* Update the error handling part in ConversationBot of TeamsFx SDK
* Update the error handling part in Bot app JS/TS template if TeamsFx SDK is not used.
* Update the SDK version in Bot app JS/TS template if Teams SDK is used.

The updates to .NET version of TeamsFx SDK and bot template will be covered in another separated PR, as it's not related to the 5.6.0 release.

work item: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/27024570/
related issue: https://github.com/OfficeDev/TeamsFx/issues/10865