### PR TITLE
fix(vsc): sample gallery support LFS image in GitHub rep

### DIFF
--- a/packages/fx-core/src/common/samples.ts
+++ b/packages/fx-core/src/common/samples.ts
@@ -15,7 +15,7 @@ const packageJson = require("../../package.json");
 const SampleConfigOwner = "OfficeDev";
 const SampleConfigRepo = "TeamsFx-Samples";
 const SampleConfigFile = ".config/samples-config-v3.json";
-export const SampleConfigTag = "v2.4.0";
+export const SampleConfigTag = "v2.5.0";
 // prerelease tag is always using a branch.
 export const SampleConfigBranchForPrerelease = "main";
 

--- a/packages/fx-core/src/common/samples.ts
+++ b/packages/fx-core/src/common/samples.ts
@@ -31,7 +31,7 @@ export interface SampleConfig {
   time: string;
   configuration: string;
   suggested: boolean;
-  thumbnailUrl: string;
+  thumbnailPath: string;
   gifUrl?: string;
   // maximum TTK & CLI version to run sample
   maximumToolkitVersion?: string;
@@ -120,9 +120,6 @@ class SampleProvider {
                 sample["id"] as string
               }/${sample["gifPath"] as string}`
             : undefined;
-        let thumbnailUrl = `https://raw.githubusercontent.com/${SampleConfigOwner}/${SampleConfigRepo}/${ref}/${
-          sample["id"] as string
-        }/${sample["thumbnailPath"] as string}`;
         if (isExternal) {
           const info = sample["downloadUrlInfo"] as SampleUrlInfo;
           gifUrl =
@@ -131,9 +128,6 @@ class SampleProvider {
                   info.dir
                 }/${sample["gifPath"] as string}`
               : undefined;
-          thumbnailUrl = `https://raw.githubusercontent.com/${info.owner}/${info.repository}/${
-            info.ref
-          }/${info.dir}/${sample["thumbnailPath"] as string}`;
         }
         return {
           ...sample,
@@ -147,7 +141,6 @@ class SampleProvider {
                 dir: sample["id"] as string,
               },
           gifUrl: gifUrl,
-          thumbnailUrl: thumbnailUrl,
         } as SampleConfig;
       }) || [];
 

--- a/packages/fx-core/src/component/generator/utils.ts
+++ b/packages/fx-core/src/component/generator/utils.ts
@@ -242,6 +242,7 @@ export async function downloadDirectory(
 ): Promise<string[]> {
   const { samplePaths, fileUrlPrefix } = await getSampleFileInfo(sampleInfo, retryLimits);
   await downloadSampleFiles(
+    sampleInfo,
     fileUrlPrefix,
     samplePaths,
     dstPath,
@@ -283,6 +284,7 @@ async function getSampleFileInfo(urlInfo: SampleUrlInfo, retryLimits: number): P
 }
 
 async function downloadSampleFiles(
+  sampleInfo: SampleUrlInfo,
   fileUrlPrefix: string,
   samplePaths: string[],
   dstPath: string,
@@ -291,8 +293,19 @@ async function downloadSampleFiles(
   concurrencyLimits: number
 ): Promise<void> {
   const downloadCallback = async (samplePath: string) => {
+    const lfsRegex = /^.*oid sha256:[0-9a-f]+\nsize \d+/gm;
     const file = (await sendRequestWithRetry(async () => {
-      return await axios.get(fileUrlPrefix + samplePath, { responseType: "arraybuffer" });
+      const content = await axios.get(fileUrlPrefix + samplePath, { responseType: "arraybuffer" });
+      if (lfsRegex.test(content.data.toString())) {
+        return await axios.get(
+          `https://media.githubusercontent.com/media/${sampleInfo.owner}/${sampleInfo.repository}/${sampleInfo.ref}/${samplePath}`,
+          {
+            responseType: "arraybuffer",
+          }
+        );
+      } else {
+        return content;
+      }
     }, retryLimits)) as unknown as any;
     const filePath = path.join(dstPath, path.relative(`${relativePath}/`, samplePath));
     await fs.ensureFile(filePath);

--- a/packages/fx-core/tests/common/samples.test.ts
+++ b/packages/fx-core/tests/common/samples.test.ts
@@ -33,7 +33,7 @@ describe("Samples", () => {
         tags: ["Tab", "TS", "Azure function"],
         time: "5min to run",
         configuration: "Ready for debug",
-        thumbnailUrl: "",
+        thumbnailPath: "",
         suggested: true,
       },
     ],
@@ -234,7 +234,7 @@ describe("Samples", () => {
         tags: ["External"],
         time: "5min to run",
         configuration: "Ready for debug",
-        thumbnailUrl: "",
+        thumbnailPath: "",
         onboardDate: new Date(),
         suggested: false,
         downloadUrlInfo: {
@@ -269,7 +269,7 @@ describe("Samples", () => {
         tags: ["External"],
         time: "5min to run",
         configuration: "Ready for debug",
-        thumbnailUrl: "",
+        thumbnailPath: "",
         onboardDate: new Date(),
         suggested: false,
         downloadUrlInfo: {
@@ -302,7 +302,7 @@ describe("Samples", () => {
         tags: ["External"],
         time: "5min to run",
         configuration: "Ready for debug",
-        thumbnailUrl: "",
+        thumbnailPath: "",
         onboardDate: new Date(),
         suggested: false,
         downloadUrlInfo: {

--- a/packages/fx-core/tests/component/generator/generator.test.ts
+++ b/packages/fx-core/tests/component/generator/generator.test.ts
@@ -358,6 +358,31 @@ describe("Generator utils", () => {
     assert.equal(data, mockFileData);
   });
 
+  it("download directory with LFS files", async () => {
+    const axiosStub = sandbox.stub(axios, "get");
+    const sampleName = "test";
+    const mockFileName = "test.txt";
+    const mockFileData = "test data";
+    const lfsData =
+      "version https://git-lfs.github.com/spec/v1\noid sha256:548c1fe07b6b278da680ccd84483be06262521f2e3\nsize 100";
+    const fileInfo = [{ type: "file", path: `${sampleName}/${mockFileName}` }];
+    axiosStub.onFirstCall().resolves({ status: 200, data: { tree: fileInfo } });
+    axiosStub.onSecondCall().resolves({ status: 200, data: lfsData });
+    axiosStub.onThirdCall().resolves({ status: 200, data: mockFileData });
+    await fs.ensureDir(tmpDir);
+    await downloadDirectory(
+      {
+        owner: "OfficeDev",
+        repository: "TeamsFx-Samples",
+        ref: "dev",
+        dir: "test",
+      },
+      tmpDir
+    );
+    const data = await fs.readFile(path.join(tmpDir, mockFileName), "utf8");
+    assert.equal(data, mockFileData);
+  });
+
   it("limit concurrency", async () => {
     const data = [1, 10, 2, 3];
     let res: number[] = [];

--- a/packages/fx-core/tests/component/generator/generator.test.ts
+++ b/packages/fx-core/tests/component/generator/generator.test.ts
@@ -59,7 +59,7 @@ const mockedSampleInfo: SampleConfig = {
   time: "",
   configuration: "test-configuration",
   suggested: false,
-  thumbnailUrl: "",
+  thumbnailPath: "",
   gifUrl: "",
   downloadUrlInfo: {
     owner: "OfficeDev",

--- a/packages/vscode-extension/src/controls/sampleGallery/ISamples.ts
+++ b/packages/vscode-extension/src/controls/sampleGallery/ISamples.ts
@@ -37,7 +37,7 @@ export interface SampleInfo {
     ref: string;
     dir: string;
   };
-  thumbnailUrl: string;
+  thumbnailPath: string;
   gifUrl?: string;
   // -1 means TTK is lower than required.
   versionComparisonResult: -1 | 0 | 1;

--- a/packages/vscode-extension/src/controls/sampleGallery/sampleCard.tsx
+++ b/packages/vscode-extension/src/controls/sampleGallery/sampleCard.tsx
@@ -11,15 +11,31 @@ import Turtle from "../../../img/webview/sample/turtle.svg";
 import { TelemetryTriggerFrom } from "../../telemetry/extTelemetryEvents";
 import { SampleProps } from "./ISamples";
 
-export default class SampleCard extends React.Component<SampleProps, unknown> {
+export default class SampleCard extends React.Component<SampleProps, { imageUrl: string }> {
   constructor(props: SampleProps) {
     super(props);
+    const downloadUrlInfo = props.sample.downloadUrlInfo;
+    this.state = {
+      imageUrl: `https://raw.githubusercontent.com/${downloadUrlInfo.owner}/${downloadUrlInfo.repository}/${downloadUrlInfo.ref}/${downloadUrlInfo.dir}/${props.sample.thumbnailPath}`,
+    };
   }
 
   render() {
     const sample = this.props.sample;
     const unavailable = sample.versionComparisonResult != 0;
-    const previewImage = <Image className="thumbnail" src={sample.thumbnailUrl} />;
+    const previewImage = (
+      <Image
+        className="thumbnail"
+        src={this.state.imageUrl}
+        onError={() => {
+          console.log(`!!!error ${this.state.imageUrl}`);
+          const downloadUrlInfo = sample.downloadUrlInfo;
+          this.setState({
+            imageUrl: `https://media.githubusercontent.com/media/${downloadUrlInfo.owner}/${downloadUrlInfo.repository}/${downloadUrlInfo.ref}/${downloadUrlInfo.dir}/${sample.thumbnailPath}`,
+          });
+        }}
+      />
+    );
     const legacySampleImage = (
       <div className="unavailableSampleImage">
         <Turtle className="turtle" />

--- a/packages/vscode-extension/src/controls/sampleGallery/sampleCard.tsx
+++ b/packages/vscode-extension/src/controls/sampleGallery/sampleCard.tsx
@@ -28,7 +28,6 @@ export default class SampleCard extends React.Component<SampleProps, { imageUrl:
         className="thumbnail"
         src={this.state.imageUrl}
         onError={() => {
-          console.log(`!!!error ${this.state.imageUrl}`);
           const downloadUrlInfo = sample.downloadUrlInfo;
           this.setState({
             imageUrl: `https://media.githubusercontent.com/media/${downloadUrlInfo.owner}/${downloadUrlInfo.repository}/${downloadUrlInfo.ref}/${downloadUrlInfo.dir}/${sample.thumbnailPath}`,


### PR DESCRIPTION
Cherry picked following PRs:
* https://github.com/OfficeDev/TeamsFx/pull/10908
* https://github.com/OfficeDev/TeamsFx/pull/10973

Bump sample tag to v2.5.0 to prevent showing blank thumbnail of teams-chef-bot.