### PR TITLE
fix: (.NET) bot app error handling in template

### DIFF
--- a/templates/csharp/ai-assistant-bot/AdapterWithErrorHandler.cs.tpl
+++ b/templates/csharp/ai-assistant-bot/AdapterWithErrorHandler.cs.tpl
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.TraceExtensions;
 using Microsoft.Bot.Connector.Authentication;
+using Microsoft.Bot.Schema;
 
 namespace {{SafeProjectName}}
 {
@@ -17,12 +18,16 @@ namespace {{SafeProjectName}}
                 // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
-                // Send a message to the user
-                await turnContext.SendActivityAsync($"The bot encountered an unhandled error: {exception.Message}");
-                await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
+                // Only send error message for user messages, not for other message types so the bot doesn't spam a channel or chat.
+                if (turnContext.Activity.Type == ActivityTypes.Message)
+                {
+                    // Send a message to the user
+                    await turnContext.SendActivityAsync($"The bot encountered an unhandled error: {exception.Message}");
+                    await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
 
-                // Send a trace activity
-                await turnContext.TraceActivityAsync("OnTurnError Trace", exception.Message, "https://www.botframework.com/schemas/error", "TurnError");
+                    // Send a trace activity
+                    await turnContext.TraceActivityAsync("OnTurnError Trace", exception.Message, "https://www.botframework.com/schemas/error", "TurnError");
+                }
             };
         }
     }

--- a/templates/csharp/ai-bot/AdapterWithErrorHandler.cs.tpl
+++ b/templates/csharp/ai-bot/AdapterWithErrorHandler.cs.tpl
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.TraceExtensions;
 using Microsoft.Bot.Connector.Authentication;
+using Microsoft.Bot.Schema;
 
 namespace {{SafeProjectName}}
 {
@@ -17,12 +18,16 @@ namespace {{SafeProjectName}}
                 // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
-                // Send a message to the user
-                await turnContext.SendActivityAsync($"The bot encountered an unhandled error: {exception.Message}");
-                await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
+                // Only send error message for user messages, not for other message types so the bot doesn't spam a channel or chat.
+                if (turnContext.Activity.Type == ActivityTypes.Message)
+                {
+                    // Send a message to the user
+                    await turnContext.SendActivityAsync($"The bot encountered an unhandled error: {exception.Message}");
+                    await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
 
-                // Send a trace activity
-                await turnContext.TraceActivityAsync("OnTurnError Trace", exception.Message, "https://www.botframework.com/schemas/error", "TurnError");
+                    // Send a trace activity
+                    await turnContext.TraceActivityAsync("OnTurnError Trace", exception.Message, "https://www.botframework.com/schemas/error", "TurnError");
+                }
             };
         }
     }

--- a/templates/csharp/command-and-response/AdapterWithErrorHandler.cs.tpl
+++ b/templates/csharp/command-and-response/AdapterWithErrorHandler.cs.tpl
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.TraceExtensions;
 using Microsoft.Bot.Connector.Authentication;
+using Microsoft.Bot.Schema;
 
 namespace {{SafeProjectName}}
 {
@@ -17,12 +18,16 @@ namespace {{SafeProjectName}}
                 // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
-                // Send a message to the user
-                await turnContext.SendActivityAsync($"The bot encountered an unhandled error: {exception.Message}");
-                await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
+                // Only send error message for user messages, not for other message types so the bot doesn't spam a channel or chat.
+                if (turnContext.Activity.Type == ActivityTypes.Message)
+                {
+                    // Send a message to the user
+                    await turnContext.SendActivityAsync($"The bot encountered an unhandled error: {exception.Message}");
+                    await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
 
-                // Send a trace activity
-                await turnContext.TraceActivityAsync("OnTurnError Trace", exception.Message, "https://www.botframework.com/schemas/error", "TurnError");
+                    // Send a trace activity
+                    await turnContext.TraceActivityAsync("OnTurnError Trace", exception.Message, "https://www.botframework.com/schemas/error", "TurnError");
+                }
             };
         }
     }

--- a/templates/csharp/default-bot/AdapterWithErrorHandler.cs.tpl
+++ b/templates/csharp/default-bot/AdapterWithErrorHandler.cs.tpl
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.TraceExtensions;
 using Microsoft.Bot.Connector.Authentication;
+using Microsoft.Bot.Schema;
 
 namespace {{SafeProjectName}};
 
@@ -17,12 +18,16 @@ public class AdapterWithErrorHandler : CloudAdapter
             // to add telemetry capture to your bot.
             logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
-            // Send a message to the user
-            await turnContext.SendActivityAsync("The bot encountered an error or bug.");
-            await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
+            // Only send error message for user messages, not for other message types so the bot doesn't spam a channel or chat.
+            if (turnContext.Activity.Type == ActivityTypes.Message)
+            {
+                // Send a message to the user
+                await turnContext.SendActivityAsync("The bot encountered an error or bug.");
+                await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
 
-            // Send a trace activity, which will be displayed in the Bot Framework Emulator
-            await turnContext.TraceActivityAsync("OnTurnError Trace", exception.Message, "https://www.botframework.com/schemas/error", "TurnError");
+                // Send a trace activity, which will be displayed in the Bot Framework Emulator
+                await turnContext.TraceActivityAsync("OnTurnError Trace", exception.Message, "https://www.botframework.com/schemas/error", "TurnError");
+            }
         };
     }
 }

--- a/templates/csharp/notification-http-timer-trigger-isolated/AdapterWithErrorHandler.cs.tpl
+++ b/templates/csharp/notification-http-timer-trigger-isolated/AdapterWithErrorHandler.cs.tpl
@@ -2,6 +2,7 @@ using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.TraceExtensions;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Logging;
+using Microsoft.Bot.Schema;
 
 namespace {{SafeProjectName}}
 {
@@ -17,11 +18,16 @@ namespace {{SafeProjectName}}
                 // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
                 // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
-                // Send a message to the user
-                await turnContext.SendActivityAsync($"The bot encountered an unhandled error: {exception.Message}");
-                await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
-                // Send a trace activity
-                await turnContext.TraceActivityAsync("OnTurnError Trace", exception.Message, "https://www.botframework.com/schemas/error", "TurnError");
+                // Only send error message for user messages, not for other message types so the bot doesn't spam a channel or chat.
+                if (turnContext.Activity.Type == ActivityTypes.Message)
+                {
+                    // Send a message to the user
+                    await turnContext.SendActivityAsync($"The bot encountered an unhandled error: {exception.Message}");
+                    await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
+
+                    // Send a trace activity
+                    await turnContext.TraceActivityAsync("OnTurnError Trace", exception.Message, "https://www.botframework.com/schemas/error", "TurnError");
+                }
             };
         }
     }

--- a/templates/csharp/notification-http-timer-trigger/AdapterWithErrorHandler.cs.tpl
+++ b/templates/csharp/notification-http-timer-trigger/AdapterWithErrorHandler.cs.tpl
@@ -2,6 +2,7 @@ using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.TraceExtensions;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Logging;
+using Microsoft.Bot.Schema;
 
 namespace {{SafeProjectName}}
 {
@@ -17,11 +18,16 @@ namespace {{SafeProjectName}}
                 // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
                 // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
-                // Send a message to the user
-                await turnContext.SendActivityAsync($"The bot encountered an unhandled error: {exception.Message}");
-                await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
-                // Send a trace activity
-                await turnContext.TraceActivityAsync("OnTurnError Trace", exception.Message, "https://www.botframework.com/schemas/error", "TurnError");
+                // Only send error message for user messages, not for other message types so the bot doesn't spam a channel or chat.
+                if (turnContext.Activity.Type == ActivityTypes.Message)
+                {
+                    // Send a message to the user
+                    await turnContext.SendActivityAsync($"The bot encountered an unhandled error: {exception.Message}");
+                    await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
+
+                    // Send a trace activity
+                    await turnContext.TraceActivityAsync("OnTurnError Trace", exception.Message, "https://www.botframework.com/schemas/error", "TurnError");
+                }
             };
         }
     }

--- a/templates/csharp/notification-http-trigger-isolated/AdapterWithErrorHandler.cs.tpl
+++ b/templates/csharp/notification-http-trigger-isolated/AdapterWithErrorHandler.cs.tpl
@@ -2,6 +2,7 @@ using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.TraceExtensions;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Logging;
+using Microsoft.Bot.Schema;
 
 namespace {{SafeProjectName}}
 {
@@ -17,11 +18,17 @@ namespace {{SafeProjectName}}
                 // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
                 // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
-                // Send a message to the user
-                await turnContext.SendActivityAsync($"The bot encountered an unhandled error: {exception.Message}");
-                await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
-                // Send a trace activity
-                await turnContext.TraceActivityAsync("OnTurnError Trace", exception.Message, "https://www.botframework.com/schemas/error", "TurnError");
+
+                // Only send error message for user messages, not for other message types so the bot doesn't spam a channel or chat.
+                if (turnContext.Activity.Type == ActivityTypes.Message)
+                {
+                    // Send a message to the user
+                    await turnContext.SendActivityAsync($"The bot encountered an unhandled error: {exception.Message}");
+                    await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
+
+                    // Send a trace activity
+                    await turnContext.TraceActivityAsync("OnTurnError Trace", exception.Message, "https://www.botframework.com/schemas/error", "TurnError");
+                }
             };
         }
     }

--- a/templates/csharp/notification-http-trigger/AdapterWithErrorHandler.cs.tpl
+++ b/templates/csharp/notification-http-trigger/AdapterWithErrorHandler.cs.tpl
@@ -2,6 +2,7 @@ using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.TraceExtensions;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Logging;
+using Microsoft.Bot.Schema;
 
 namespace {{SafeProjectName}}
 {
@@ -17,11 +18,17 @@ namespace {{SafeProjectName}}
                 // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
                 // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
-                // Send a message to the user
-                await turnContext.SendActivityAsync($"The bot encountered an unhandled error: {exception.Message}");
-                await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
-                // Send a trace activity
-                await turnContext.TraceActivityAsync("OnTurnError Trace", exception.Message, "https://www.botframework.com/schemas/error", "TurnError");
+
+                // Only send error message for user messages, not for other message types so the bot doesn't spam a channel or chat.
+                if (turnContext.Activity.Type == ActivityTypes.Message)
+                {
+                    // Send a message to the user
+                    await turnContext.SendActivityAsync($"The bot encountered an unhandled error: {exception.Message}");
+                    await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
+
+                    // Send a trace activity
+                    await turnContext.TraceActivityAsync("OnTurnError Trace", exception.Message, "https://www.botframework.com/schemas/error", "TurnError");
+                }
             };
         }
     }

--- a/templates/csharp/notification-timer-trigger-isolated/AdapterWithErrorHandler.cs.tpl
+++ b/templates/csharp/notification-timer-trigger-isolated/AdapterWithErrorHandler.cs.tpl
@@ -2,6 +2,7 @@ using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.TraceExtensions;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Logging;
+using Microsoft.Bot.Schema;
 
 namespace {{SafeProjectName}}
 {
@@ -17,11 +18,17 @@ namespace {{SafeProjectName}}
                 // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
                 // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
-                // Send a message to the user
-                await turnContext.SendActivityAsync($"The bot encountered an unhandled error: {exception.Message}");
-                await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
-                // Send a trace activity
-                await turnContext.TraceActivityAsync("OnTurnError Trace", exception.Message, "https://www.botframework.com/schemas/error", "TurnError");
+
+                // Only send error message for user messages, not for other message types so the bot doesn't spam a channel or chat.
+                if (turnContext.Activity.Type == ActivityTypes.Message)
+                {
+                    // Send a message to the user
+                    await turnContext.SendActivityAsync($"The bot encountered an unhandled error: {exception.Message}");
+                    await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
+
+                    // Send a trace activity
+                    await turnContext.TraceActivityAsync("OnTurnError Trace", exception.Message, "https://www.botframework.com/schemas/error", "TurnError");
+                }
             };
         }
     }

--- a/templates/csharp/notification-timer-trigger/AdapterWithErrorHandler.cs.tpl
+++ b/templates/csharp/notification-timer-trigger/AdapterWithErrorHandler.cs.tpl
@@ -2,6 +2,7 @@ using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.TraceExtensions;
 using Microsoft.Bot.Connector.Authentication;
 using Microsoft.Extensions.Logging;
+using Microsoft.Bot.Schema;
 
 namespace {{SafeProjectName}}
 {
@@ -17,11 +18,17 @@ namespace {{SafeProjectName}}
                 // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
                 // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
-                // Send a message to the user
-                await turnContext.SendActivityAsync($"The bot encountered an unhandled error: {exception.Message}");
-                await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
-                // Send a trace activity
-                await turnContext.TraceActivityAsync("OnTurnError Trace", exception.Message, "https://www.botframework.com/schemas/error", "TurnError");
+
+                // Only send error message for user messages, not for other message types so the bot doesn't spam a channel or chat.
+                if (turnContext.Activity.Type == ActivityTypes.Message)
+                {
+                    // Send a message to the user
+                    await turnContext.SendActivityAsync($"The bot encountered an unhandled error: {exception.Message}");
+                    await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
+
+                    // Send a trace activity
+                    await turnContext.TraceActivityAsync("OnTurnError Trace", exception.Message, "https://www.botframework.com/schemas/error", "TurnError");
+                }
             };
         }
     }

--- a/templates/csharp/notification-webapi/AdapterWithErrorHandler.cs.tpl
+++ b/templates/csharp/notification-webapi/AdapterWithErrorHandler.cs.tpl
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.TraceExtensions;
 using Microsoft.Bot.Connector.Authentication;
+using Microsoft.Bot.Schema;
 
 namespace {{SafeProjectName}}
 {
@@ -16,11 +17,17 @@ namespace {{SafeProjectName}}
                 // Azure Application Insights. Visit https://aka.ms/bottelemetry to see how
                 // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
-                // Send a message to the user
-                await turnContext.SendActivityAsync($"The bot encountered an unhandled error: {exception.Message}");
-                await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
-                // Send a trace activity
-                await turnContext.TraceActivityAsync("OnTurnError Trace", exception.Message, "https://www.botframework.com/schemas/error", "TurnError");
+
+                // Only send error message for user messages, not for other message types so the bot doesn't spam a channel or chat.
+                if (turnContext.Activity.Type == ActivityTypes.Message)
+                {
+                    // Send a message to the user
+                    await turnContext.SendActivityAsync($"The bot encountered an unhandled error: {exception.Message}");
+                    await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
+
+                    // Send a trace activity
+                    await turnContext.TraceActivityAsync("OnTurnError Trace", exception.Message, "https://www.botframework.com/schemas/error", "TurnError");
+                }
             };
         }
     }

--- a/templates/csharp/workflow/AdapterWithErrorHandler.cs.tpl
+++ b/templates/csharp/workflow/AdapterWithErrorHandler.cs.tpl
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.TraceExtensions;
 using Microsoft.Bot.Connector.Authentication;
+using Microsoft.Bot.Schema;
 
 namespace {{SafeProjectName}}
 {
@@ -17,12 +18,16 @@ namespace {{SafeProjectName}}
                 // to add telemetry capture to your bot.
                 logger.LogError(exception, $"[OnTurnError] unhandled error : {exception.Message}");
 
-                // Send a message to the user
-                await turnContext.SendActivityAsync($"The bot encountered an unhandled error: {exception.Message}");
-                await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
+                // Only send error message for user messages, not for other message types so the bot doesn't spam a channel or chat.
+                if (turnContext.Activity.Type == ActivityTypes.Message)
+                {
+                    // Send a message to the user
+                    await turnContext.SendActivityAsync($"The bot encountered an unhandled error: {exception.Message}");
+                    await turnContext.SendActivityAsync("To continue to run this bot, please fix the bot source code.");
 
-                // Send a trace activity
-                await turnContext.TraceActivityAsync("OnTurnError Trace", exception.Message, "https://www.botframework.com/schemas/error", "TurnError");
+                    // Send a trace activity
+                    await turnContext.TraceActivityAsync("OnTurnError Trace", exception.Message, "https://www.botframework.com/schemas/error", "TurnError");
+                }
             };
         }
     }


### PR DESCRIPTION
Update .NET bot templates to send a message on error only when the activity is a message directed to it.

related PR: https://github.com/OfficeDev/TeamsFx/pull/10979
related issue: https://github.com/OfficeDev/TeamsFx/issues/10865
work item: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/27024570/