### PR TITLE
feat: add placePTInSln and new project type feature flag

### DIFF
--- a/packages/fx-core/src/common/constants.ts
+++ b/packages/fx-core/src/common/constants.ts
@@ -65,4 +65,5 @@ export class FeatureFlagName {
   static readonly MultipleParameters = "API_COPILOT_MULTIPLE_PARAMETERS";
   static readonly TeamsFxRebranding = "TEAMSFX_REBRANDING";
   static readonly TdpTemplateCliTest = "TEAMSFX_TDP_TEMPLATE_CLI_TEST";
+  static readonly NewProjectType = "TEAMSFX_NEW_PROJECT_TYPE";
 }

--- a/packages/fx-core/src/common/featureFlags.ts
+++ b/packages/fx-core/src/common/featureFlags.ts
@@ -68,3 +68,7 @@ export function isTeamsFxRebrandingEnabled(): boolean {
 export function isTdpTemplateCliTestEnabled(): boolean {
   return isFeatureFlagEnabled(FeatureFlagName.TdpTemplateCliTest, false);
 }
+
+export function isNewProjectTypeEnabled(): boolean {
+  return isFeatureFlagEnabled(FeatureFlagName.NewProjectType, true);
+}

--- a/packages/fx-core/src/component/coordinator/index.ts
+++ b/packages/fx-core/src/component/coordinator/index.ts
@@ -401,6 +401,7 @@ class Coordinator {
             appName,
             safeProjectNameFromVS,
             inputs.targetFramework,
+            inputs.placeProjectFileInSolutionDir === "true",
             undefined,
             {
               llmService,

--- a/packages/fx-core/src/component/generator/copilotPlugin/generator.ts
+++ b/packages/fx-core/src/component/generator/copilotPlugin/generator.ts
@@ -223,6 +223,7 @@ export class CopilotPluginGenerator {
           appName,
           safeProjectNameFromVS,
           inputs.targetFramework,
+          inputs.placeProjectFileInSolutionDir === "true",
           {
             authName: apiKeyAuthData.authName,
             openapiSpecPath: normalizePath(
@@ -235,7 +236,8 @@ export class CopilotPluginGenerator {
         context.templateVariables = Generator.getDefaultVariables(
           appName,
           safeProjectNameFromVS,
-          inputs.targetFramework
+          inputs.targetFramework,
+          inputs.placeProjectFileInSolutionDir === "true"
         );
       }
       const filters = inputs[QuestionNames.ApiOperation] as string[];

--- a/packages/fx-core/src/component/generator/generator.ts
+++ b/packages/fx-core/src/component/generator/generator.ts
@@ -35,7 +35,7 @@ import {
   renderTemplateFileData,
   renderTemplateFileName,
 } from "./utils";
-import { enableTestToolByDefault } from "../../common/featureFlags";
+import { enableTestToolByDefault, isNewProjectTypeEnabled } from "../../common/featureFlags";
 import { Utils } from "@microsoft/m365-spec-parser";
 
 export class Generator {
@@ -43,6 +43,7 @@ export class Generator {
     appName: string,
     safeProjectNameFromVS?: string,
     targetFramework?: string,
+    placeProjectFileInSolutionDir?: boolean,
     apiKeyAuthData?: { authName: string; openapiSpecPath: string; registrationIdEnvName: string },
     llmServiceData?: {
       llmService?: string;
@@ -61,6 +62,7 @@ export class Generator {
       appName: appName,
       ProjectName: appName,
       TargetFramework: targetFramework ?? "net8.0",
+      PlaceProjectFileInSolutionDir: placeProjectFileInSolutionDir ? "true" : "",
       SafeProjectName: safeProjectName,
       SafeProjectNameLowerCase: safeProjectName.toLocaleLowerCase(),
       ApiSpecAuthName: apiKeyAuthData?.authName ?? "",
@@ -72,6 +74,7 @@ export class Generator {
       openAIKey: llmServiceData?.openAIKey ?? "",
       azureOpenAIKey: llmServiceData?.azureOpenAIKey ?? "",
       azureOpenAIEndpoint: llmServiceData?.azureOpenAIEndpoint ?? "",
+      isNewProjectTypeEnabled: isNewProjectTypeEnabled() ? "true" : "",
     };
   }
   @hooks([

--- a/packages/fx-core/tests/component/generator/generator.test.ts
+++ b/packages/fx-core/tests/component/generator/generator.test.ts
@@ -817,7 +817,7 @@ describe("Generator happy path", async () => {
   });
 
   it("template variables with custom copilot - OpenAI", async () => {
-    const vars = Generator.getDefaultVariables("test", "test", undefined, undefined, {
+    const vars = Generator.getDefaultVariables("test", "test", undefined, false, undefined, {
       llmService: "llm-service-openAI",
       openAIKey: "test-key",
     });
@@ -829,7 +829,7 @@ describe("Generator happy path", async () => {
   });
 
   it("template variables with custom copilot - Azure OpenAI", async () => {
-    const vars = Generator.getDefaultVariables("test", "test", undefined, undefined, {
+    const vars = Generator.getDefaultVariables("test", "test", undefined, false, undefined, {
       llmService: "llm-service-azureOpenAI",
       azureOpenAIKey: "test-key",
       azureOpenAIEndpoint: "test-endpoint",
@@ -843,7 +843,7 @@ describe("Generator happy path", async () => {
 
   it("template variables when contains auth", async () => {
     sandbox.stub(process, "env").value({ TEAMSFX_TEST_TOOL: "false" });
-    const vars = Generator.getDefaultVariables("Test", "Test", "net6", {
+    const vars = Generator.getDefaultVariables("Test", "Test", "net6", false, {
       authName: "authName",
       openapiSpecPath: "path/to/spec.yaml",
       registrationIdEnvName: "AUTHNAME_REGISTRATION_ID",
@@ -859,7 +859,7 @@ describe("Generator happy path", async () => {
 
   it("template variables when contains auth with special characters", async () => {
     sandbox.stub(process, "env").value({ TEAMSFX_TEST_TOOL: "false" });
-    const vars = Generator.getDefaultVariables("Test", "Test", "net6", {
+    const vars = Generator.getDefaultVariables("Test", "Test", "net6", false, {
       authName: "authName",
       openapiSpecPath: "path/to/spec.yaml",
       registrationIdEnvName: "AUTH-NAME_REGISTRATION*ID",
@@ -875,7 +875,7 @@ describe("Generator happy path", async () => {
 
   it("template variables when contains auth with name not start with [A-Z]", async () => {
     sandbox.stub(process, "env").value({ TEAMSFX_TEST_TOOL: "false" });
-    const vars = Generator.getDefaultVariables("Test", "Test", undefined, {
+    const vars = Generator.getDefaultVariables("Test", "Test", undefined, false, {
       authName: "authName",
       openapiSpecPath: "path/to/spec.yaml",
       registrationIdEnvName: "*AUTH-NAME_REGISTRATION*ID",

--- a/packages/fx-core/tests/component/generator/generator.test.ts
+++ b/packages/fx-core/tests/component/generator/generator.test.ts
@@ -799,6 +799,23 @@ describe("Generator happy path", async () => {
     assert.equal(vars.enableTestToolByDefault, "");
   });
 
+  it("template variables when new project enabled", async () => {
+    sandbox.stub(process, "env").value({ TEAMSFX_NEW_PROJECT_TYPE: "true" });
+    const vars = Generator.getDefaultVariables("test");
+    assert.equal(vars.isNewProjectTypeEnabled, "true");
+  });
+
+  it("template variables when test tool disabled", async () => {
+    sandbox.stub(process, "env").value({ TEAMSFX_NEW_PROJECT_TYPE: "false" });
+    const vars = Generator.getDefaultVariables("test");
+    assert.equal(vars.isNewProjectTypeEnabled, "");
+  });
+
+  it("template variables when set placeProjectFileInSolutionDir to true", async () => {
+    const vars = Generator.getDefaultVariables("test", undefined, undefined, true);
+    assert.equal(vars.PlaceProjectFileInSolutionDir, "true");
+  });
+
   it("template variables with custom copilot - OpenAI", async () => {
     const vars = Generator.getDefaultVariables("test", "test", undefined, undefined, {
       llmService: "llm-service-openAI",


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/26963508
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/27130362

Use `placeProjectFileInSolutionDir` to adjust whether users want to scaffold project in the solution root folder. It means the `.csproj` is placed with `.sln` in the same directory.

Use `TEAMSFX_NEW_PROJECT_TYPE` for easy callback. If we want to hide this feature, we can turn it off.