### PR TITLE
fix: add preview tag to custom-copilot-basic template

### DIFF
--- a/packages/fx-core/src/question/create.ts
+++ b/packages/fx-core/src/question/create.ts
@@ -704,6 +704,7 @@ export class CapabilityOptions {
       detail: getLocalizedString(
         "core.createProjectQuestion.capability.customCopilotBasicOption.detail"
       ),
+      description: getLocalizedString("core.createProjectQuestion.option.description.preview"),
     };
   }
 


### PR DESCRIPTION
workitem: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/27178154
E2E TEST: N/A

add preview tag for template:
![image](https://github.com/OfficeDev/TeamsFx/assets/109947924/0e883582-03cf-40d6-92de-87be1fd900f6)
