### PR TITLE
fix: missing property value when `create env`

### DIFF
--- a/packages/fx-core/src/core/FxCore.ts
+++ b/packages/fx-core/src/core/FxCore.ts
@@ -983,6 +983,8 @@ export class FxCore {
         if (match) {
           if (match[1].startsWith("TEAMSFX_ENV=")) {
             writeStream.write(`TEAMSFX_ENV=${targetEnvName}${os.EOL}`);
+          } else if (match[1].startsWith("APP_NAME_SUFFIX=")) {
+            writeStream.write(`APP_NAME_SUFFIX=${targetEnvName}${os.EOL}`);
           } else {
             writeStream.write(`${match[1]}${os.EOL}`);
           }

--- a/packages/fx-core/tests/core/FxCore.test.ts
+++ b/packages/fx-core/tests/core/FxCore.test.ts
@@ -898,6 +898,7 @@ describe("createEnvCopyV3", async () => {
   const sourceEnvContent = [
     "# this is a comment",
     "TEAMSFX_ENV=dev",
+    "APP_NAME_SUFFIX=dev",
     "",
     "_KEY1=value1",
     "KEY2=value2",
@@ -939,6 +940,10 @@ describe("createEnvCopyV3", async () => {
     assert(
       writeStreamContent[1] === `TEAMSFX_ENV=newEnv${os.EOL}`,
       "TEAMSFX_ENV's value should be new env name"
+    );
+    assert(
+      writeStreamContent[1] === `APP_NAME_SUFFIX=newEnv${os.EOL}`,
+      "APP_NAME_SUFFIX's value should be new env name"
     );
     assert(writeStreamContent[2] === `${os.EOL}`, "empty line should be coped");
     assert(

--- a/packages/fx-core/tests/core/FxCore.test.ts
+++ b/packages/fx-core/tests/core/FxCore.test.ts
@@ -942,20 +942,20 @@ describe("createEnvCopyV3", async () => {
       "TEAMSFX_ENV's value should be new env name"
     );
     assert(
-      writeStreamContent[1] === `APP_NAME_SUFFIX=newEnv${os.EOL}`,
+      writeStreamContent[2] === `APP_NAME_SUFFIX=newEnv${os.EOL}`,
       "APP_NAME_SUFFIX's value should be new env name"
     );
-    assert(writeStreamContent[2] === `${os.EOL}`, "empty line should be coped");
+    assert(writeStreamContent[3] === `${os.EOL}`, "empty line should be coped");
     assert(
-      writeStreamContent[3] === `_KEY1=${os.EOL}`,
+      writeStreamContent[4] === `_KEY1=${os.EOL}`,
       "key starts with _ should be copied with empty value"
     );
     assert(
-      writeStreamContent[4] === `KEY2=${os.EOL}`,
+      writeStreamContent[5] === `KEY2=${os.EOL}`,
       "key not starts with _ should be copied with empty value"
     );
     assert(
-      writeStreamContent[5] === `SECRET_KEY3=${os.EOL}`,
+      writeStreamContent[6] === `SECRET_KEY3=${os.EOL}`,
       "key not starts with SECRET_ should be copied with empty value"
     );
   });


### PR DESCRIPTION
fix: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/27192083