### PR TITLE
feat: [minor]import existing Office Addin[MetaOS]

### DIFF
--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -235,6 +235,7 @@
   "core.generator.officeAddin.importProject.copyFiles": "Copying files...",
   "core.generator.officeAddin.importProject.convertProject": "Converting project...",
   "core.generator.officeAddin.importProject.updateManifest": "Modifying manifest...",
+  "core.generator.officeAddin.importOfficeProject.title": "Importing Existing Office Add-in Project",
   "core.TabOption.description": "UI-based app",
   "core.TabOption.detail": "Teams-aware webpages embedded in Microsoft Teams",
   "core.DashboardOption.label": "Dashboard",

--- a/packages/fx-core/src/common/featureFlags.ts
+++ b/packages/fx-core/src/common/featureFlags.ts
@@ -21,6 +21,8 @@ export function initializePreviewFeatureFlags(): void {
   process.env[FeatureFlagName.AadManifest] = "true";
   process.env[FeatureFlagName.ApiConnect] = "true";
   process.env[FeatureFlagName.DeployManifest] = "true";
+  // Force the feature to close until it needs to be released.
+  process.env[FeatureFlagName.OfficeAddin] = "false";
 }
 
 export function isCLIDotNetEnabled(): boolean {

--- a/packages/fx-core/src/component/generator/officeAddin/generator.ts
+++ b/packages/fx-core/src/component/generator/officeAddin/generator.ts
@@ -109,10 +109,11 @@ export class OfficeAddinGenerator {
         ? "wxpo" // wxpo - support word, excel, powerpoint, outlook
         : inputs[QuestionNames.OfficeAddinHost];
     const workingDir = process.cwd();
-    const importProgress = context.userInteraction.createProgressBar(
-      getLocalizedString("core.generator.officeAddin.importProject.title"),
-      3
-    );
+    const importProgressStr =
+      projectType === ProjectTypeOptions.officeAddin().id
+        ? getLocalizedString("core.generator.officeAddin.importOfficeProject.title")
+        : getLocalizedString("core.generator.officeAddin.importProject.title");
+    const importProgress = context.userInteraction.createProgressBar(importProgressStr, 3);
 
     process.chdir(addinRoot);
     try {
@@ -180,7 +181,7 @@ export class OfficeAddinGenerator {
 
 // TODO: update to handle different hosts when support for them is implemented
 // TODO: handle multiple scopes
-type OfficeHost = "Outlook"; // | "Word" | "OneNote" | "PowerPoint" | "Project" | "Excel"
+type OfficeHost = "Outlook" | "Word" | "Excel" | "PowerPoint"; // | "OneNote" | "Project"
 async function getHost(addinManifestPath: string): Promise<OfficeHost> {
   // Read add-in manifest file
   const addinManifest: devPreview.DevPreviewSchema = await ManifestUtil.loadFromPath(
@@ -188,18 +189,25 @@ async function getHost(addinManifestPath: string): Promise<OfficeHost> {
   );
   let host: OfficeHost = "Outlook";
   switch (addinManifest.extensions?.[0].requirements?.scopes?.[0]) {
-    // case "document":
-    //   host = "Word";
+    case "document":
+      host = "Word";
+      break;
     case "mail":
       host = "Outlook";
+      break;
     // case "notebook":
     //   host = "OneNote";
-    // case "presentation":
-    //   host = "PowerPoint";
+    case "presentation":
+      host = "PowerPoint";
+      break;
     // case "project":
     //   host = "Project";
-    // case "workbook":
-    //   host = "Excel";
+    case "workbook":
+      host = "Excel";
+      break;
+    default:
+      host = "Outlook";
+      break;
   }
   return host;
 }

--- a/packages/fx-core/src/component/generator/officeAddin/generator.ts
+++ b/packages/fx-core/src/component/generator/officeAddin/generator.ts
@@ -182,7 +182,7 @@ export class OfficeAddinGenerator {
 // TODO: update to handle different hosts when support for them is implemented
 // TODO: handle multiple scopes
 type OfficeHost = "Outlook" | "Word" | "Excel" | "PowerPoint"; // | "OneNote" | "Project"
-async function getHost(addinManifestPath: string): Promise<OfficeHost> {
+export async function getHost(addinManifestPath: string): Promise<OfficeHost> {
   // Read add-in manifest file
   const addinManifest: devPreview.DevPreviewSchema = await ManifestUtil.loadFromPath(
     addinManifestPath
@@ -204,9 +204,6 @@ async function getHost(addinManifestPath: string): Promise<OfficeHost> {
     //   host = "Project";
     case "workbook":
       host = "Excel";
-      break;
-    default:
-      host = "Outlook";
       break;
   }
   return host;

--- a/packages/fx-core/src/question/create.ts
+++ b/packages/fx-core/src/question/create.ts
@@ -183,8 +183,9 @@ function projectTypeQuestion(): SingleSelectQuestion {
     ProjectTypeOptions.me(Platform.CLI),
     isOfficeXMLAddinEnabled()
       ? ProjectTypeOptions.officeXMLAddin(Platform.CLI)
+      : isOfficeJSONAddinEnabled()
+      ? ProjectTypeOptions.officeAddin(Platform.CLI)
       : ProjectTypeOptions.outlookAddin(Platform.CLI),
-    ProjectTypeOptions.officeAddin(Platform.CLI),
   ];
   return {
     name: QuestionNames.ProjectType,

--- a/packages/fx-core/src/question/create.ts
+++ b/packages/fx-core/src/question/create.ts
@@ -181,11 +181,9 @@ function projectTypeQuestion(): SingleSelectQuestion {
     ProjectTypeOptions.bot(Platform.CLI),
     ProjectTypeOptions.tab(Platform.CLI),
     ProjectTypeOptions.me(Platform.CLI),
-    isOfficeXMLAddinEnabled()
-      ? ProjectTypeOptions.officeXMLAddin(Platform.CLI)
-      : isOfficeJSONAddinEnabled()
-      ? ProjectTypeOptions.officeAddin(Platform.CLI)
-      : ProjectTypeOptions.outlookAddin(Platform.CLI),
+    ProjectTypeOptions.officeXMLAddin(Platform.CLI),
+    ProjectTypeOptions.officeAddin(Platform.CLI),
+    ProjectTypeOptions.outlookAddin(Platform.CLI),
   ];
   return {
     name: QuestionNames.ProjectType,

--- a/packages/fx-core/src/question/inputs/CreateProjectInputs.ts
+++ b/packages/fx-core/src/question/inputs/CreateProjectInputs.ts
@@ -14,7 +14,13 @@ export interface CreateProjectInputs extends Inputs {
   /** @description Teams Toolkit: select runtime for your app */
   runtime?: "node" | "dotnet";
   /** @description New Project */
-  "project-type"?: "bot-type" | "tab-type" | "me-type" | "outlook-addin-type" | "office-addin-type";
+  "project-type"?:
+    | "bot-type"
+    | "tab-type"
+    | "me-type"
+    | "office-xml-addin-type"
+    | "office-addin-type"
+    | "outlook-addin-type";
   /** @description Select to create an Outlook, Word, Excel, or PowerPoint Add-in */
   "addin-host"?: "outlook" | "word" | "excel" | "powerpoint";
   /** @description Capabilities */

--- a/packages/fx-core/tests/component/generator/officeAddinGenerator.test.ts
+++ b/packages/fx-core/tests/component/generator/officeAddinGenerator.test.ts
@@ -1,4 +1,3 @@
-import { ProjectType } from "./../../../../spec-parser/src/interfaces";
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 

--- a/packages/fx-core/tests/component/generator/officeAddinGenerator.test.ts
+++ b/packages/fx-core/tests/component/generator/officeAddinGenerator.test.ts
@@ -1,3 +1,4 @@
+import { ProjectType } from "./../../../../spec-parser/src/interfaces";
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
@@ -87,6 +88,7 @@ describe("OfficeAddinGenerator for Outlook Addin", function () {
     const inputs: Inputs = {
       platform: Platform.CLI,
       projectPath: testFolder,
+      ProjectType: ProjectTypeOptions.outlookAddin().id,
       "app-name": "outlook-addin-test",
     };
     const doScaffoldStub = sinon
@@ -105,6 +107,7 @@ describe("OfficeAddinGenerator for Outlook Addin", function () {
     const inputs: Inputs = {
       platform: Platform.CLI,
       projectPath: testFolder,
+      ProjectType: ProjectTypeOptions.outlookAddin().id,
       "app-name": "outlook-addin-test",
     };
     sinon.stub(OfficeAddinGenerator, "doScaffolding").resolves(err(mockedError));
@@ -119,6 +122,7 @@ describe("OfficeAddinGenerator for Outlook Addin", function () {
     const inputs: Inputs = {
       platform: Platform.CLI,
       projectPath: testFolder,
+      ProjectType: ProjectTypeOptions.outlookAddin().id,
       "app-name": "outlook-addin-test",
     };
     sinon.stub(OfficeAddinGenerator, "doScaffolding").resolves(ok(undefined));
@@ -133,8 +137,10 @@ describe("OfficeAddinGenerator for Outlook Addin", function () {
     const inputs: Inputs = {
       platform: Platform.CLI,
       projectPath: testFolder,
+      ProjectType: ProjectTypeOptions.outlookAddin().id,
       "app-name": "outlook-addin-test",
     };
+    inputs[QuestionNames.ProjectType] = ProjectTypeOptions.outlookAddin().id;
     inputs[QuestionNames.Capabilities] = "json-taskpane";
     inputs[QuestionNames.OfficeAddinFolder] = undefined;
     inputs[QuestionNames.ProgrammingLanguage] = "typescript";
@@ -153,6 +159,7 @@ describe("OfficeAddinGenerator for Outlook Addin", function () {
       projectPath: testFolder,
       "app-name": "outlook-addin-test",
     };
+    inputs[QuestionNames.ProjectType] = ProjectTypeOptions.outlookAddin().id;
     inputs[QuestionNames.Capabilities] = "json-taskpane";
     inputs[QuestionNames.OfficeAddinFolder] = undefined;
     inputs[QuestionNames.ProgrammingLanguage] = "typescript";
@@ -171,6 +178,7 @@ describe("OfficeAddinGenerator for Outlook Addin", function () {
       projectPath: testFolder,
       "app-name": "outlook-addin-test",
     };
+    inputs[QuestionNames.ProjectType] = ProjectTypeOptions.outlookAddin().id;
     inputs[QuestionNames.Capabilities] = "json-taskpane";
     inputs[QuestionNames.OfficeAddinFolder] = "somepath";
     inputs[QuestionNames.ProgrammingLanguage] = "typescript";
@@ -211,6 +219,7 @@ describe("OfficeAddinGenerator for Outlook Addin", function () {
       projectPath: testFolder,
       "app-name": "outlook-addin-test",
     };
+    inputs[QuestionNames.ProjectType] = ProjectTypeOptions.outlookAddin().id;
     inputs[QuestionNames.Capabilities] = "json-taskpane";
     inputs[QuestionNames.OfficeAddinFolder] = "somepath";
     inputs[QuestionNames.ProgrammingLanguage] = "typescript";
@@ -287,6 +296,7 @@ describe("OfficeAddinGenerator for Outlook Addin", function () {
     const inputs: Inputs = {
       platform: Platform.CLI,
       projectPath: testFolder,
+      ProjectType: ProjectTypeOptions.outlookAddin().id,
       "app-name": "outlook-addin-test",
       "programming-language": undefined,
     };
@@ -302,6 +312,7 @@ describe("OfficeAddinGenerator for Outlook Addin", function () {
     const inputs: Inputs = {
       platform: Platform.CLI,
       projectPath: testFolder,
+      ProjectType: ProjectTypeOptions.outlookAddin().id,
       "app-name": "outlook-addin-test",
       "programming-language": "typescript",
     };
@@ -317,6 +328,7 @@ describe("OfficeAddinGenerator for Outlook Addin", function () {
     const inputs: Inputs = {
       platform: Platform.CLI,
       projectPath: testFolder,
+      ProjectType: ProjectTypeOptions.outlookAddin().id,
       "app-name": "outlook-addin-test",
       "programming-language": "javascript",
     };
@@ -779,13 +791,13 @@ describe("OfficeAddinGenerator for Office Addin", function () {
     const inputs: Inputs = {
       platform: Platform.CLI,
       projectPath: testFolder,
-      [QuestionNames.ProjectType]: ProjectTypeOptions.officeAddin().id,
-      [QuestionNames.AppName]: "office-addin-test",
-      [QuestionNames.OfficeAddinFramework]: "default",
+      "app-name": "office-addin-test",
     };
+    inputs[QuestionNames.ProjectType] = ProjectTypeOptions.officeAddin().id;
     inputs[QuestionNames.Capabilities] = "json-taskpane";
     inputs[QuestionNames.OfficeAddinFolder] = undefined;
     inputs[QuestionNames.ProgrammingLanguage] = "typescript";
+    inputs[QuestionNames.OfficeAddinFramework] = "default";
 
     sinon.stub(OfficeAddinGenerator, "childProcessExec").resolves();
     sinon.stub(HelperMethods, "downloadProjectTemplateZipFile").rejects(new UserCancelError());
@@ -799,13 +811,13 @@ describe("OfficeAddinGenerator for Office Addin", function () {
     const inputs: Inputs = {
       platform: Platform.CLI,
       projectPath: testFolder,
-      "project-type": ProjectTypeOptions.officeAddin().id,
       "app-name": "office-addin-test",
-      "office-addin-framework-type": "default",
     };
+    inputs[QuestionNames.ProjectType] = ProjectTypeOptions.officeAddin().id;
     inputs[QuestionNames.Capabilities] = "json-taskpane";
     inputs[QuestionNames.OfficeAddinFolder] = "somepath";
     inputs[QuestionNames.ProgrammingLanguage] = "typescript";
+    inputs[QuestionNames.OfficeAddinFramework] = "default";
     inputs[QuestionNames.OfficeAddinManifest] = "manifest.json";
 
     const copyAddinFilesStub = sinon
@@ -834,20 +846,22 @@ describe("OfficeAddinGenerator for Office Addin", function () {
     chai.expect(result.isOk()).to.eq(true);
     chai.expect(copyAddinFilesStub.calledOnce).to.be.true;
     chai.expect(updateManifestStub.calledOnce).to.be.true;
-    chai.expect(inputs[QuestionNames.OfficeAddinHost]).to.eq("Outlook");
+    chai
+      .expect(inputs[QuestionNames.OfficeAddinHost])
+      .to.be.oneOf(["Outlook", "Excel", "Word", "PowerPoint"]);
   });
 
   it("should copy addin files and convert manifest if addin folder is specified with xml manifest", async () => {
     const inputs: Inputs = {
       platform: Platform.CLI,
       projectPath: testFolder,
-      "project-type": ProjectTypeOptions.officeAddin().id,
       "app-name": "office-addin-test",
-      "office-addin-framework-type": "default",
     };
+    inputs[QuestionNames.ProjectType] = ProjectTypeOptions.officeAddin().id;
     inputs[QuestionNames.Capabilities] = "json-taskpane";
     inputs[QuestionNames.OfficeAddinFolder] = "somepath";
     inputs[QuestionNames.ProgrammingLanguage] = "typescript";
+    inputs[QuestionNames.OfficeAddinFramework] = "default";
     inputs[QuestionNames.OfficeAddinManifest] = "manifest.xml";
 
     let progressBarStartCalled = 0;
@@ -903,7 +917,9 @@ describe("OfficeAddinGenerator for Office Addin", function () {
     chai.expect(copyAddinFilesStub.calledOnce).to.be.true;
     chai.expect(updateManifestStub.calledOnce).to.be.true;
     chai.expect(convertProjectStub.calledOnce).to.be.true;
-    chai.expect(inputs[QuestionNames.OfficeAddinHost]).to.eq("Outlook");
+    chai
+      .expect(inputs[QuestionNames.OfficeAddinHost])
+      .to.be.oneOf(["Outlook", "Excel", "Word", "PowerPoint"]);
     chai.expect(progressBarStartCalled).to.eq(1);
     chai.expect(progressBarNextCalled).to.eq(3);
     chai.expect(progessBarEndCalled).to.eq(1);
@@ -921,11 +937,13 @@ describe("OfficeAddinGenerator for Office Addin", function () {
     const inputs: Inputs = {
       platform: Platform.CLI,
       projectPath: testFolder,
-      "project-type": ProjectTypeOptions.officeAddin().id,
       "app-name": "office-addin-test",
-      "programming-language": undefined,
-      "office-addin-framework-type": "default",
     };
+    inputs[QuestionNames.ProjectType] = ProjectTypeOptions.officeAddin().id;
+    inputs[QuestionNames.Capabilities] = "json-taskpane";
+    inputs[QuestionNames.ProgrammingLanguage] = undefined;
+    inputs[QuestionNames.OfficeAddinFramework] = "default";
+
     sinon.stub(OfficeAddinGenerator, "doScaffolding").resolves(ok(undefined));
     const stub = sinon.stub(Generator, "generateTemplate").resolves(ok(undefined));
 
@@ -938,11 +956,13 @@ describe("OfficeAddinGenerator for Office Addin", function () {
     const inputs: Inputs = {
       platform: Platform.CLI,
       projectPath: testFolder,
-      "project-type": ProjectTypeOptions.officeAddin().id,
       "app-name": "office-addin-test",
-      "programming-language": "typescript",
-      "office-addin-framework-type": "default",
     };
+    inputs[QuestionNames.ProjectType] = ProjectTypeOptions.officeAddin().id;
+    inputs[QuestionNames.Capabilities] = "json-taskpane";
+    inputs[QuestionNames.ProgrammingLanguage] = "typescript";
+    inputs[QuestionNames.OfficeAddinFramework] = "default";
+
     sinon.stub(OfficeAddinGenerator, "doScaffolding").resolves(ok(undefined));
     const stub = sinon.stub(Generator, "generateTemplate").resolves(ok(undefined));
 
@@ -956,11 +976,13 @@ describe("OfficeAddinGenerator for Office Addin", function () {
     const inputs: Inputs = {
       platform: Platform.CLI,
       projectPath: testFolder,
-      "project-type": ProjectTypeOptions.officeAddin().id,
       "app-name": "office-addin-test",
-      "programming-language": "JavaScript",
-      "office-addin-framework-type": "default",
     };
+    inputs[QuestionNames.ProjectType] = ProjectTypeOptions.officeAddin().id;
+    inputs[QuestionNames.Capabilities] = "json-taskpane";
+    inputs[QuestionNames.ProgrammingLanguage] = "JavaScript";
+    inputs[QuestionNames.OfficeAddinFramework] = "default";
+
     sinon.stub(OfficeAddinGenerator, "doScaffolding").resolves(ok(undefined));
     const stub = sinon.stub(Generator, "generateTemplate").resolves(ok(undefined));
 

--- a/packages/manifest/devPreviewSchema.json
+++ b/packages/manifest/devPreviewSchema.json
@@ -1297,7 +1297,7 @@
           "items": {
             "type": "string",
             "enum": [
-              "mail"
+              "mail", "document", "workbook", "presentation"
             ]
           }
         },


### PR DESCRIPTION
### Background:

- [PM Spec](https://microsoft.sharepoint.com/:w:/t/OfficePlatform/EQTzlom9CSFGgAOIro3-sDsBTsmVkXxz6IWCUoJVLp6L9w?e=vW0Dla)

- [ADO Link](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/27130363)
-
When isOfficeJSONAddinEnabled(default false) is true: 
![image](https://github.com/OfficeDev/TeamsFx/assets/95617492/7c8af551-649d-4908-8431-12aa204c90db)

### Description
This change is to import existing add-in for Office add-in(json).