### PR TITLE
refactor: return result after submission, avoid blocking other lifecycles

### DIFF
--- a/packages/fx-core/src/component/driver/teamsApp/validateTestCases.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/validateTestCases.ts
@@ -158,9 +158,9 @@ export class ValidateWithTestCasesDriver implements StepDriver {
       }
 
       if (response.status === AsyncAppValidationStatus.Completed) {
-        if (args.showMessage) {
+        if (args.showMessage && context.ui) {
           void context.ui
-            ?.showMessage(
+            .showMessage(
               "info",
               getLocalizedString("driver.teamsApp.summary.validateWithTestCases", response.status),
               false,
@@ -184,9 +184,9 @@ export class ValidateWithTestCasesDriver implements StepDriver {
           )
         );
       } else {
-        if (args.showMessage) {
+        if (args.showMessage && context.ui) {
           void context.ui
-            ?.showMessage(
+            .showMessage(
               "error",
               getLocalizedString(
                 "driver.teamsApp.summary.validateWithTestCases.result",

--- a/packages/fx-core/src/component/driver/teamsApp/validateTestCases.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/validateTestCases.ts
@@ -128,16 +128,16 @@ export class ValidateWithTestCasesDriver implements StepDriver {
     const validationRequestListUrl = `${getAppStudioEndpoint()}/apps/${teamsAppId}/app-validation`;
 
     try {
-      if (args.showProgressBar) {
-        context.progressBar = context.ui?.createProgressBar(this.progressTitle, 1);
-        await context.progressBar?.start();
+      if (args.showProgressBar && context.ui) {
+        context.progressBar = context.ui.createProgressBar(this.progressTitle, 1);
+        await context.progressBar.start();
 
         const message = getLocalizedString(
           "driver.teamsApp.progressBar.validateWithTestCases.step",
           response.status,
           validationRequestListUrl
         );
-        await context.progressBar?.next(message);
+        await context.progressBar.next(message);
       }
 
       while (
@@ -214,8 +214,8 @@ export class ValidateWithTestCasesDriver implements StepDriver {
         );
       }
     } finally {
-      if (args.showProgressBar) {
-        await context.progressBar?.end(true);
+      if (args.showProgressBar && context.progressBar) {
+        await context.progressBar.end(true);
       }
     }
   }


### PR DESCRIPTION
As test cases may run several minutes, return the submission result immediately.

The test cases are running, and show progress/pop up for the final result.