### PR TITLE
fix: validation error when AAD manifest does not contain accessToken property

### DIFF
--- a/packages/fx-core/src/component/driver/aad/utility/aadManifestHelper.ts
+++ b/packages/fx-core/src/component/driver/aad/utility/aadManifestHelper.ts
@@ -204,7 +204,7 @@ export class AadManifestHelper {
     // if manifest doesn't contain optionalClaims or access token doesn't contain idtyp clams
     if (!manifest.optionalClaims) {
       warningMsg += AadManifestErrorMessage.OptionalClaimsIsMissing;
-    } else if (!manifest.optionalClaims.accessToken.find((item) => item.name === "idtyp")) {
+    } else if (!manifest.optionalClaims.accessToken?.find((item) => item.name === "idtyp")) {
       warningMsg += AadManifestErrorMessage.OptionalClaimsMissingIdtypClaim;
     }
 

--- a/packages/fx-core/tests/component/driver/aad/aadManifestHelper.test.ts
+++ b/packages/fx-core/tests/component/driver/aad/aadManifestHelper.test.ts
@@ -48,6 +48,13 @@ describe("Microsoft Entra manifest helper Test", () => {
     chai.expect(warning).contain(AadManifestErrorMessage.OptionalClaimsMissingIdtypClaim.trimEnd());
   });
 
+  it("validateManifest with no accessToken property", async () => {
+    const invalidAadManifest = JSON.parse(JSON.stringify(fakeAadManifest));
+    delete invalidAadManifest.optionalClaims.accessToken;
+    const warning = AadManifestHelper.validateManifest(invalidAadManifest);
+    chai.expect(warning).contain(AadManifestErrorMessage.OptionalClaimsMissingIdtypClaim.trimEnd());
+  });
+
   it("processRequiredResourceAccessInManifest with id", async () => {
     const manifestWithId: any = {
       requiredResourceAccess: [


### PR DESCRIPTION
fix validation error when AAD manifest does not contain accessToken property in optionalClaims

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/27212864