### PR TITLE
fix: metaos addin should be recognized as teamsapp project

### DIFF
--- a/packages/fx-core/tests/common/officeAddInProjectSetting.test.ts
+++ b/packages/fx-core/tests/common/officeAddInProjectSetting.test.ts
@@ -3,6 +3,7 @@ import * as fs from "fs-extra";
 import mockFs from "mock-fs";
 import * as sinon from "sinon";
 import * as projectSettingsHelper from "../../src/common/projectSettingsHelper";
+import { OfficeManifestType } from "../../src/common/projectSettingsHelper";
 
 describe("validateIsOfficeAddInProject", () => {
   const sandbox = sinon.createSandbox();
@@ -19,7 +20,13 @@ describe("validateIsOfficeAddInProject", () => {
   });
 
   it("should return true if manifest list is not empty", () => {
-    fetchManifestListStub.returns(["manifest.xml"]);
+    fetchManifestListStub.callsFake((workspace: string, type: OfficeManifestType) => {
+      if (type == OfficeManifestType.XmlAddIn) {
+        return ["manifest.xml"];
+      } else {
+        return [];
+      }
+    });
     mockFs({
       "/test/manifest.xml": "",
     });
@@ -38,32 +45,111 @@ describe("validateIsOfficeAddInProject", () => {
     fetchManifestListStub.throws(new Error("Error fetching manifest list"));
     chai.expect(projectSettingsHelper.isValidOfficeAddInProject("")).to.be.false;
   });
+
+  it("should return false if both manifest.xml and manifest.json exist", () => {
+    fetchManifestListStub.callsFake((workspace: string, type: OfficeManifestType) => {
+      if (type == OfficeManifestType.XmlAddIn) {
+        return ["manifest.xml"];
+      } else if (type == OfficeManifestType.MetaOsAddIn) {
+        return ["manifest.json"];
+      } else {
+        return [];
+      }
+    });
+    mockFs({
+      "/test/manifest.xml": "",
+      "/test/manifest.json": "",
+    });
+    chai.expect(projectSettingsHelper.isValidOfficeAddInProject("/test")).to.be.false;
+  });
 });
 
 describe("fetchManifestList", () => {
-  let readdirSyncStub: any, isOfficeAddInManifestStub: any;
+  let readdirSyncStub: any, isOfficeXmlAddInManifestStub: any, isOfficeMetaOsAddInManifestStub: any;
 
   beforeEach(() => {
     readdirSyncStub = sinon.stub(fs, "readdirSync");
-    isOfficeAddInManifestStub = sinon.stub(projectSettingsHelper, "isOfficeAddInManifest");
+    isOfficeXmlAddInManifestStub = sinon.stub(projectSettingsHelper, "isOfficeXmlAddInManifest");
+    isOfficeMetaOsAddInManifestStub = sinon.stub(
+      projectSettingsHelper,
+      "isOfficeMetaOsAddInManifest"
+    );
   });
 
   afterEach(() => {
     readdirSyncStub.restore();
-    isOfficeAddInManifestStub.restore();
+    isOfficeXmlAddInManifestStub.restore();
+    isOfficeMetaOsAddInManifestStub.restore();
+    mockFs.restore();
   });
 
   it("should return undefined if workspacePath is not provided", () => {
     chai.expect(projectSettingsHelper.fetchManifestList()).to.be.undefined;
   });
 
-  it("should return manifest list if workspacePath is provided", () => {
+  it("should return manifest.xml if type is OfficeManifestType.XmlAddIn", () => {
     mockFs({
       "/test/manifest.xml": "",
     });
     readdirSyncStub.returns(["manifest.xml"]);
-    isOfficeAddInManifestStub.callsFake((fileName: string) => fileName === "manifest.xml");
-    chai.expect(projectSettingsHelper.fetchManifestList("/test")).to.deep.equal(["manifest.xml"]);
-    mockFs.restore();
+    isOfficeXmlAddInManifestStub.callsFake((fileName: string) => fileName === "manifest.xml");
+    chai
+      .expect(
+        projectSettingsHelper.fetchManifestList(
+          "/test",
+          projectSettingsHelper.OfficeManifestType.XmlAddIn
+        )
+      )
+      .to.deep.equal(["manifest.xml"]);
+  });
+
+  it("should return manifest.json if type is OfficeManifestType.MetaOsAddIn", () => {
+    mockFs({
+      "/test/manifest.json": "",
+    });
+    readdirSyncStub.returns(["manifest.json"]);
+    isOfficeMetaOsAddInManifestStub.callsFake((fileName: string) => fileName === "manifest.json");
+    chai
+      .expect(
+        projectSettingsHelper.fetchManifestList(
+          "/test",
+          projectSettingsHelper.OfficeManifestType.MetaOsAddIn
+        )
+      )
+      .to.deep.equal(["manifest.json"]);
+  });
+
+  it("should return false if both manifest.xml and manifest.json exist but type is OfficeManifestType.XmlAddIn", () => {
+    mockFs({
+      "/test/manifest.xml": "",
+      "/test/manifest.json": "",
+    });
+    readdirSyncStub.returns(["manifest.xml", "manifest.json"]);
+    isOfficeXmlAddInManifestStub.callsFake((fileName: string) => fileName === "manifest.xml");
+    chai
+      .expect(
+        projectSettingsHelper.fetchManifestList(
+          "/test",
+          projectSettingsHelper.OfficeManifestType.XmlAddIn
+        )
+      )
+      .to.deep.equal(["manifest.xml"]);
+  });
+
+  it("should return true if manifest.json exist and type is OfficeManifestType.MetaOsAddIn", () => {
+    mockFs({
+      "/test/manifest.xml": "",
+      "/test/manifest.json": "",
+    });
+    readdirSyncStub.returns(["manifest.xml", "manifest.json"]);
+    isOfficeMetaOsAddInManifestStub.callsFake((fileName: string) => fileName === "manifest.json");
+    chai
+      .expect(
+        projectSettingsHelper.fetchManifestList(
+          "/test",
+          projectSettingsHelper.OfficeManifestType.MetaOsAddIn
+        )
+      )
+      .to.deep.equal(["manifest.json"]);
   });
 });

--- a/packages/fx-core/tests/core/other.test.ts
+++ b/packages/fx-core/tests/core/other.test.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { ResourceManagementClient } from "@azure/arm-resources";
 import { TokenCredential } from "@azure/identity";
 import { AzureAccountProvider, Settings, SubscriptionInfo } from "@microsoft/teamsfx-api";
 import { assert } from "chai";
@@ -14,8 +13,11 @@ import sinon from "sinon";
 import { isFeatureFlagEnabled } from "../../src/common/featureFlags";
 import { execPowerShell, execShell } from "../../src/common/local/process";
 import { TaskDefinition } from "../../src/common/local/taskDefinition";
-import { isValidProject } from "../../src/common/projectSettingsHelper";
-import { resourceGroupHelper } from "../../src/component/utils/ResourceGroupHelper";
+import {
+  isValidOfficeAddInProject,
+  isValidProject,
+  isValidProjectV3,
+} from "../../src/common/projectSettingsHelper";
 import { cpUtils } from "../../src/component/utils/depsChecker/cpUtils";
 import { MyTokenCredential } from "../plugins/solution/util";
 import { randomAppName } from "./utils";
@@ -229,6 +231,7 @@ describe("Other test case", () => {
     };
     sandbox.stub(fs, "readJsonSync").returns(projectSettings);
     sandbox.stub(fs, "existsSync").returns(true);
+    sandbox.stub(fs, "readdirSync").returns([]);
     const isValid = isValidProject("aaa");
     assert.isTrue(isValid);
   });
@@ -243,6 +246,7 @@ describe("Other test case", () => {
       };
       sandbox.stub(fs, "readJsonSync").returns(settings);
       sandbox.stub(fs, "existsSync").returns(true);
+      sandbox.stub(fs, "readdirSync").returns([]);
       const isValid = isValidProject("aaa");
       assert.isTrue(isValid);
     } finally {
@@ -278,5 +282,13 @@ describe("Other test case", () => {
     } finally {
       mockedEnvRestore();
     }
+  });
+  it("projectSettingsHelper - isValidProjectV3 - office add-in", () => {
+    sandbox.stub(fs, "readdirSync").returns(["manifest.xml"] as any);
+    assert.equal(isValidProjectV3("test"), false);
+  });
+  it("projectSettingsHelper - isValidOfficeAddInProject - metaos add-in", () => {
+    sandbox.stub(fs, "readdirSync").returns(["manifest.json", "manifest.xml"] as any);
+    assert.equal(isValidOfficeAddInProject("test"), false);
   });
 });


### PR DESCRIPTION
For office metaos add in project, all of the manifest.xml, mainfest.json and teamsapp.yml exist. It should be recognized as TeamsApp project and the TTK treeview should show. 

Bug link: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/27180052%22%20created