### PR TITLE
fix: update replaced image path

### DIFF
--- a/packages/vscode-extension/src/controls/webviewPanel.ts
+++ b/packages/vscode-extension/src/controls/webviewPanel.ts
@@ -293,9 +293,9 @@ export class WebviewPanel {
 
   private replaceRelativeImagePaths(htmlContent: string, sample: SampleConfig) {
     const urlInfo = sample.downloadUrlInfo;
-    const imageUrlBase = `https://raw.githubusercontent.com/${urlInfo.owner}/${urlInfo.repository}/${urlInfo.ref}/${urlInfo.dir}`;
+    const imageUrl = `https://github.com/${urlInfo.owner}/${urlInfo.repository}/blob/${urlInfo.ref}/${urlInfo.dir}/${sample.thumbnailPath}?raw=1`;
     const imageRegex = /img\s+src="([^"]+)"/gm;
-    return htmlContent.replace(imageRegex, `img src="${imageUrlBase}/$1"`);
+    return htmlContent.replace(imageRegex, `img src="${imageUrl}"`);
   }
 
   private getWebpageTitle(panelType: PanelType): string {


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/27194270
![image](https://github.com/OfficeDev/TeamsFx/assets/45935381/1c4f8df2-1769-431f-81f3-beba1741a477)
