### PR TITLE
feat: add error with help link for AAD client secret errors

### DIFF
--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -597,6 +597,8 @@
   "driver.aadApp.error.generateSecretFailed": "Cannot generate client secret.",
   "driver.aadApp.error.invalidFieldInManifest": "Field %s is missing or invalid in Microsoft Entra app manifest.",
   "driver.aadApp.error.appNameTooLong": "The name for this Microsoft Entra app is too long. The maximum length is 120.",
+  "driver.aadApp.error.credentialInvalidLifetimeAsPerAppPolicy": "The client secret lifetime exceeds the max value allowed in your tenant. Set a shorter lifetime using the clientSecretExpireDays parameter.",
+  "driver.aadApp.error.credentialTypeNotAllowedAsPerAppPolicy": "Your tenant does not allow creating client secret for Microsoft Entra app. Please create and configure the Microsoft Entra app manually.",
   "driver.aadApp.progressBar.createAadAppTitle": "Creating Microsoft Entra application...",
   "driver.aadApp.progressBar.updateAadAppTitle": "Updating Microsoft Entra application...",
   "driver.aadApp.log.startExecuteDriver": "Executing action %s",

--- a/packages/fx-core/src/component/driver/aad/error/clientSecretNotAllowedError.ts
+++ b/packages/fx-core/src/component/driver/aad/error/clientSecretNotAllowedError.ts
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { UserError } from "@microsoft/teamsfx-api";
+import { getDefaultString, getLocalizedString } from "../../../../common/localizeUtils";
+import { constants } from "../utility/constants";
+
+const errorCode = "ClientSecretNotAllowed";
+const messageKey = "driver.aadApp.error.credentialTypeNotAllowedAsPerAppPolicy";
+
+export class ClientSecretNotAllowedError extends UserError {
+  constructor(actionName: string) {
+    super({
+      source: actionName,
+      name: errorCode,
+      message: getDefaultString(messageKey),
+      displayMessage: getLocalizedString(messageKey),
+      helpLink: constants.defaultHelpLink,
+    });
+  }
+}

--- a/packages/fx-core/src/component/driver/aad/error/credentialInvalidLifetimeError.ts
+++ b/packages/fx-core/src/component/driver/aad/error/credentialInvalidLifetimeError.ts
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { UserError } from "@microsoft/teamsfx-api";
+import { getDefaultString, getLocalizedString } from "../../../../common/localizeUtils";
+import { constants } from "../utility/constants";
+
+const errorCode = "CredentialInvalidLifetime";
+const messageKey = "driver.aadApp.error.credentialInvalidLifetimeAsPerAppPolicy";
+
+export class CredentialInvalidLifetimeError extends UserError {
+  constructor(actionName: string) {
+    super({
+      source: actionName,
+      name: errorCode,
+      message: getDefaultString(messageKey),
+      displayMessage: getLocalizedString(messageKey),
+      helpLink: constants.defaultHelpLink,
+    });
+  }
+}

--- a/packages/fx-core/src/component/driver/aad/utility/constants.ts
+++ b/packages/fx-core/src/component/driver/aad/utility/constants.ts
@@ -30,11 +30,14 @@ export const permissionsKeys = {
 export const aadErrorCode = {
   permissionErrorCode: "CannotDeleteOrUpdateEnabledEntitlement",
   hostNameNotOnVerifiedDomain: "HostNameNotOnVerifiedDomain", // Using unverified domain in multi tenant scenario
+  credentialInvalidLifetimeAsPerAppPolicy: "CredentialInvalidLifetimeAsPerAppPolicy",
+  credentialTypeNotAllowedAsPerAppPolicy: "CredentialTypeNotAllowedAsPerAppPolicy",
 };
 
 export const constants = {
   aadAppPasswordDisplayName: "default",
   oauthAuthorityPrefix: "https://login.microsoftonline.com",
+  defaultHelpLink: "https://aka.ms/teamsfx-actions/aadapp-create",
 };
 
 export const telemetryKeys = {

--- a/packages/fx-core/src/component/driver/aad/utility/constants.ts
+++ b/packages/fx-core/src/component/driver/aad/utility/constants.ts
@@ -36,3 +36,7 @@ export const constants = {
   aadAppPasswordDisplayName: "default",
   oauthAuthorityPrefix: "https://login.microsoftonline.com",
 };
+
+export const telemetryKeys = {
+  newAadApp: "new-aad-app",
+};


### PR DESCRIPTION
1. add error with help link for AAD client secret errors
2. Add new-aad-app telemetry to better understand use existing scenario

https://dev.azure.com/msazure/Microsoft%20Teams%20Extensibility/_workitems/edit/27314538
https://dev.azure.com/msazure/Microsoft%20Teams%20Extensibility/_workitems/edit/27314539
https://dev.azure.com/msazure/Microsoft%20Teams%20Extensibility/_workitems/edit/27314624