### PR TITLE
feat: add flag for controlling chat participant and disable it when release rc/beta

### DIFF
--- a/.github/scripts/chat-participant-disabled.sh
+++ b/.github/scripts/chat-participant-disabled.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+filePath=packages/vscode-extension/src/chat/consts.ts
+echo "Replace placeholders in $filePath"
+sed -i -e "s@const IsChatParticipantEnabled = true@const IsChatParticipantEnabled = false@g" $filePath
+echo "Replace Done."

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -188,6 +188,23 @@ jobs:
           git add packages/fx-core/src/common/m365/serviceConstant.ts
           git commit -m "build: replace sideloading placeholders"
 
+      - name: disable chat participant in package.json
+        if: ${{ github.event_name == 'workflow_dispatch' && contains(fromJson('[\"rc\", \"stable\"]'), github.event.inputs.preid) }}
+        uses: jossef/action-set-json-field@v1
+        with:
+          file: ./packages/vscode-extension/package.json
+          field: contributes.chatParticipants
+          value: '[]'
+
+      - name: disable chat participant environment variable
+        if: ${{ github.event_name == 'workflow_dispatch' && contains(fromJson('[\"rc\", \"stable\"]'), github.event.inputs.preid) }}
+        run: bash .github/scripts/chat-participant-disabled.sh
+
+      - name: commit change on local
+        run: |
+          git add ./packages/vscode-extension/package.json ./packages/vscode-extension/src/chat/consts.ts
+          git commit -m "build: disable chat participant"
+
       - name: update cli ai key
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.preid != 'alpha' }}
         uses: jossef/action-set-json-field@v1

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -188,19 +188,21 @@ jobs:
           git add packages/fx-core/src/common/m365/serviceConstant.ts
           git commit -m "build: replace sideloading placeholders"
 
-      - name: disable chat participant in package.json
-        if: ${{ github.event_name == 'workflow_dispatch' && contains(fromJson('[\"rc\", \"stable\"]'), github.event.inputs.preid) }}
-        uses: jossef/action-set-json-field@v1
-        with:
-          file: ./packages/vscode-extension/package.json
-          field: contributes.chatParticipants
-          value: '[]'
-
       - name: disable chat participant environment variable
-        if: ${{ github.event_name == 'workflow_dispatch' && contains(fromJson('[\"rc\", \"stable\"]'), github.event.inputs.preid) }}
+        if: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.preid == 'stable' || github.event.inputs.preid == 'rc') }}
         run: bash .github/scripts/chat-participant-disabled.sh
 
+      - name: disable chat participant in package.json
+        if: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.preid == 'stable' || github.event.inputs.preid == 'rc') }}
+        uses: jossef/action-set-json-field@v2.1
+        with:
+          file: packages/vscode-extension/package.json
+          field: contributes.chatParticipants
+          value: '[]'
+          parse_json: true
+
       - name: commit change on local
+        if: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.preid == 'stable' || github.event.inputs.preid == 'rc') }}
         run: |
           git add ./packages/vscode-extension/package.json ./packages/vscode-extension/src/chat/consts.ts
           git commit -m "build: disable chat participant"

--- a/packages/fx-core/src/common/constants.ts
+++ b/packages/fx-core/src/common/constants.ts
@@ -67,4 +67,5 @@ export class FeatureFlagName {
   static readonly AsyncAppValidation = "TEAMSFX_ASYNC_APP_VALIDATION";
   static readonly NewProjectType = "TEAMSFX_NEW_PROJECT_TYPE";
   static readonly ApiMeSSO = "API_ME_SSO";
+  static readonly ChatParticipant = "TEAMSFX_CHAT_PARTICIPANT";
 }

--- a/packages/fx-core/src/common/featureFlags.ts
+++ b/packages/fx-core/src/common/featureFlags.ts
@@ -84,6 +84,10 @@ export function isApiMeSSOEnabled(): boolean {
   return isFeatureFlagEnabled(FeatureFlagName.ApiMeSSO, false);
 }
 
+export function isChatParticipantEnabled(): boolean {
+  return isFeatureFlagEnabled(FeatureFlagName.ChatParticipant, false);
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // Notes for Office Addin Feature flags:
 // Case 1: TEAMSFX_OFFICE_ADDIN = false, TEAMSFX_OFFICE_XML_ADDIN = false

--- a/packages/vscode-extension/src/chat/consts.ts
+++ b/packages/vscode-extension/src/chat/consts.ts
@@ -37,3 +37,5 @@ export const BaseTokensPerMessage = 3;
  * Since gpt-3.5-turbo-0613 each name costs 1 token
  */
 export const BaseTokensPerName = 1;
+
+export const IsChatParticipantEnabled = true;

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -63,7 +63,12 @@ import { TelemetryEvent, TelemetryTriggerFrom } from "./telemetry/extTelemetryEv
 import accountTreeViewProviderInstance from "./treeview/account/accountTreeViewProvider";
 import TreeViewManagerInstance from "./treeview/treeViewManager";
 import { UriHandler } from "./uriHandler";
-import { delay, hasAdaptiveCardInWorkspace, isM365Project } from "./utils/commonUtils";
+import {
+  FeatureFlags,
+  delay,
+  hasAdaptiveCardInWorkspace,
+  isM365Project,
+} from "./utils/commonUtils";
 import { loadLocalizedStrings } from "./utils/localizeUtils";
 import { checkProjectTypeAndSendTelemetry } from "./utils/projectChecker";
 import { ReleaseNote } from "./utils/releaseNote";
@@ -74,6 +79,7 @@ import {
   CHAT_CREATE_SAMPLE_COMMAND_ID,
   CHAT_EXECUTE_COMMAND_ID,
   CHAT_OPENURL_COMMAND_ID,
+  IsChatParticipantEnabled,
   chatParticipantName,
 } from "./chat/consts";
 import followupProvider from "./chat/followupProvider";
@@ -125,6 +131,15 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // UI is ready to show & interact
   await vscode.commands.executeCommand("setContext", "fx-extension.isTeamsFx", isTeamsFxProject);
+
+  // control whether to show chat participant entries
+  await vscode.commands.executeCommand(
+    "setContext",
+    "fx-extension.isChatParticipantEnabled",
+    IsChatParticipantEnabled
+  );
+
+  process.env[FeatureFlags.ChatParticipant] = IsChatParticipantEnabled.toString();
 
   await vscode.commands.executeCommand(
     "setContext",

--- a/packages/vscode-extension/src/utils/commonUtils.ts
+++ b/packages/vscode-extension/src/utils/commonUtils.ts
@@ -144,6 +144,7 @@ export class FeatureFlags {
   static readonly DevTunnelTest = "TEAMSFX_DEV_TUNNEL_TEST";
   static readonly Preview = "TEAMSFX_PREVIEW";
   static readonly DevelopCopilotPlugin = "DEVELOP_COPILOT_PLUGIN";
+  static readonly ChatParticipant = "TEAMSFX_CHAT_PARTICIPANT";
 }
 
 // Determine whether feature flag is enabled based on environment variable setting


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/26624499

Add `TEAMSFX_CHAT_PARTICIPANT` flag and set it to `true` in the code. When releasing `rc/stable`, change it to false for hiding other entries of chat participant.

Set `contributes.chatParticipants` to `[]` to hide chat participant when releasing `rc/stable`.

Use `fx-extension.isChatParticipantEnabled` in `package.json` to control the welcome page content and webview content.

Test in https://github.com/OfficeDev/TeamsFx/actions/runs/8462480742.