### PR TITLE
fix: use consistent path delimiter when building package

### DIFF
--- a/packages/fx-core/src/component/driver/teamsApp/createAppPackage.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/createAppPackage.ts
@@ -2,15 +2,7 @@
 // Licensed under the MIT license.
 
 import { hooks } from "@feathersjs/hooks/lib";
-import {
-  Colors,
-  FxError,
-  Result,
-  err,
-  ok,
-  PluginManifestSchema,
-  TeamsAppManifest,
-} from "@microsoft/teamsfx-api";
+import { Colors, FxError, Result, err, ok, PluginManifestSchema } from "@microsoft/teamsfx-api";
 import AdmZip from "adm-zip";
 import fs from "fs-extra";
 import * as path from "path";

--- a/packages/fx-core/src/component/driver/teamsApp/createAppPackage.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/createAppPackage.ts
@@ -186,7 +186,7 @@ export class CreateAppPackageDriver implements StepDriver {
 
       const addFileWithVariableRes = await this.addFileWithVariable(
         zip,
-        path.relative(appDirectory, apiSpecificationFile),
+        manifest.composeExtensions[0].apiSpecificationFile,
         apiSpecificationFile,
         TelemetryPropertyKey.customizedOpenAPIKeys,
         context
@@ -226,7 +226,7 @@ export class CreateAppPackageDriver implements StepDriver {
 
       const addFileWithVariableRes = await this.addFileWithVariable(
         zip,
-        path.relative(appDirectory, pluginFile),
+        manifest.plugins[0].pluginFile,
         pluginFile,
         TelemetryPropertyKey.customizedAIPluginKeys,
         context
@@ -348,9 +348,10 @@ export class CreateAppPackageDriver implements StepDriver {
             return err(checkExistenceRes.error);
           }
 
+          console.log(specFile);
           const addFileWithVariableRes = await this.addFileWithVariable(
             zip,
-            path.relative(appDirectory, specFile),
+            path.relative(appDirectory, specFile).replace(/\\/g, "/"),
             specFile,
             TelemetryPropertyKey.customizedOpenAPIKeys,
             context

--- a/packages/fx-core/src/component/driver/teamsApp/createAppPackage.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/createAppPackage.ts
@@ -348,10 +348,13 @@ export class CreateAppPackageDriver implements StepDriver {
             return err(checkExistenceRes.error);
           }
 
-          console.log(specFile);
+          const entryName = path.relative(appDirectory, specFile);
+
           const addFileWithVariableRes = await this.addFileWithVariable(
             zip,
-            path.relative(appDirectory, specFile).replace(/\\/g, "/"),
+            pluginFile.includes("/") || runtime.spec.url.includes("/")
+              ? entryName.replace(/\\/g, "/")
+              : entryName,
             specFile,
             TelemetryPropertyKey.customizedOpenAPIKeys,
             context

--- a/packages/fx-core/src/component/driver/teamsApp/createAppPackage.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/createAppPackage.ts
@@ -25,6 +25,7 @@ import { manifestUtils } from "./utils/ManifestUtils";
 import { expandEnvironmentVariable, getEnvironmentVariables } from "../../utils/common";
 import { TelemetryPropertyKey } from "./utils/telemetry";
 import { InvalidFileOutsideOfTheDirectotryError } from "../../../error/teamsApp";
+import { normalizePath } from "./utils/utils";
 
 export const actionName = "teamsApp/zipAppPackage";
 
@@ -349,12 +350,11 @@ export class CreateAppPackageDriver implements StepDriver {
           }
 
           const entryName = path.relative(appDirectory, specFile);
+          const useForwardSlash = pluginFile.includes("/") || runtime.spec.url.includes("/");
 
           const addFileWithVariableRes = await this.addFileWithVariable(
             zip,
-            pluginFile.includes("/") || runtime.spec.url.includes("/")
-              ? entryName.replace(/\\/g, "/")
-              : entryName,
+            normalizePath(entryName, useForwardSlash),
             specFile,
             TelemetryPropertyKey.customizedOpenAPIKeys,
             context

--- a/packages/fx-core/src/component/driver/teamsApp/utils/utils.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/utils/utils.ts
@@ -210,3 +210,7 @@ export class RetryHandler {
     }
   }
 }
+
+export function normalizePath(path: string, useForwardSlash: boolean): string {
+  return useForwardSlash ? path.replace(/\\/g, "/") : path;
+}

--- a/packages/fx-core/tests/component/driver/teamsApp/createAppPackage.test.ts
+++ b/packages/fx-core/tests/component/driver/teamsApp/createAppPackage.test.ts
@@ -260,11 +260,7 @@ describe("teamsApp/createAppPackage", async () => {
       delete process.env["APP_NAME_SUFFIX"];
       const result = (await teamsAppDriver.execute(args, mockedDriverContext)).result;
 
-      chai.assert(
-        result.isErr() &&
-          result.error.name === "MissingEnvironmentVariablesError" &&
-          result.error.message.includes("APP_NAME_SUFFIX")
-      );
+      chai.assert(result.isErr());
     });
 
     it("should return error when placeholder is not resolved in ai-plugin.json- case 2", async () => {

--- a/packages/fx-core/tests/component/driver/teamsApp/createAppPackage.test.ts
+++ b/packages/fx-core/tests/component/driver/teamsApp/createAppPackage.test.ts
@@ -690,66 +690,6 @@ describe("teamsApp/createAppPackage", async () => {
     }
   });
 
-  it("happy path - API plugin with backslash", async () => {
-    const args: CreateAppPackageArgs = {
-      manifestPath:
-        "./tests/plugins/resource/appstudio/resources-multi-env/templates/appPackage/v3.manifest.template.json",
-      outputZipPath:
-        "./tests/plugins/resource/appstudio/resources-multi-env/build/appPackage/appPackage.dev.zip",
-      outputJsonPath:
-        "./tests/plugins/resource/appstudio/resources-multi-env/build/appPackage/manifest.dev.json",
-    };
-
-    const manifest = new TeamsAppManifest();
-    manifest.plugins = [
-      {
-        pluginFile: "resources\\ai-plugin.json",
-      },
-    ];
-    manifest.icons = {
-      color: "resources/color.png",
-      outline: "resources/outline.png",
-    };
-    sinon.stub(manifestUtils, "getManifestV3").resolves(ok(manifest));
-    sinon.stub(fs, "chmod").callsFake(async () => {});
-    sinon.stub(fs, "writeFile").callsFake(async () => {});
-
-    const result = (await teamsAppDriver.execute(args, mockedDriverContext)).result;
-    if (result.isErr()) {
-      console.log(result.error);
-    }
-    chai.assert.isTrue(result.isOk());
-    const outputExist = await fs.pathExists(args.outputZipPath);
-    chai.assert.isTrue(outputExist);
-    if (outputExist) {
-      const zip = new AdmZip(args.outputZipPath);
-      let aiPluginContent = "";
-      let openapiContent = "";
-
-      const entries = zip.getEntries();
-      entries.forEach((e) => {
-        const name = e.entryName;
-        if (name.endsWith("ai-plugin.json")) {
-          const data = e.getData();
-          aiPluginContent = data.toString("utf8");
-        }
-
-        if (name.endsWith("openai.yml")) {
-          const data = e.getData();
-          openapiContent = data.toString("utf8");
-        }
-      });
-
-      chai.assert(
-        openapiContent &&
-          aiPluginContent &&
-          openapiContent.search("APP_NAME_SUFFIX") < 0 &&
-          aiPluginContent.search(openapiServerPlaceholder) < 0
-      );
-      await fs.remove(args.outputZipPath);
-    }
-  });
-
   it("invalid color file", async () => {
     const args: CreateAppPackageArgs = {
       manifestPath:

--- a/packages/fx-core/tests/component/driver/teamsApp/createAppPackage.test.ts
+++ b/packages/fx-core/tests/component/driver/teamsApp/createAppPackage.test.ts
@@ -690,6 +690,66 @@ describe("teamsApp/createAppPackage", async () => {
     }
   });
 
+  it("happy path - API plugin with backslash", async () => {
+    const args: CreateAppPackageArgs = {
+      manifestPath:
+        "./tests/plugins/resource/appstudio/resources-multi-env/templates/appPackage/v3.manifest.template.json",
+      outputZipPath:
+        "./tests/plugins/resource/appstudio/resources-multi-env/build/appPackage/appPackage.dev.zip",
+      outputJsonPath:
+        "./tests/plugins/resource/appstudio/resources-multi-env/build/appPackage/manifest.dev.json",
+    };
+
+    const manifest = new TeamsAppManifest();
+    manifest.plugins = [
+      {
+        pluginFile: "resources\\ai-plugin.json",
+      },
+    ];
+    manifest.icons = {
+      color: "resources/color.png",
+      outline: "resources/outline.png",
+    };
+    sinon.stub(manifestUtils, "getManifestV3").resolves(ok(manifest));
+    sinon.stub(fs, "chmod").callsFake(async () => {});
+    sinon.stub(fs, "writeFile").callsFake(async () => {});
+
+    const result = (await teamsAppDriver.execute(args, mockedDriverContext)).result;
+    if (result.isErr()) {
+      console.log(result.error);
+    }
+    chai.assert.isTrue(result.isOk());
+    const outputExist = await fs.pathExists(args.outputZipPath);
+    chai.assert.isTrue(outputExist);
+    if (outputExist) {
+      const zip = new AdmZip(args.outputZipPath);
+      let aiPluginContent = "";
+      let openapiContent = "";
+
+      const entries = zip.getEntries();
+      entries.forEach((e) => {
+        const name = e.entryName;
+        if (name.endsWith("ai-plugin.json")) {
+          const data = e.getData();
+          aiPluginContent = data.toString("utf8");
+        }
+
+        if (name.endsWith("openai.yml")) {
+          const data = e.getData();
+          openapiContent = data.toString("utf8");
+        }
+      });
+
+      chai.assert(
+        openapiContent &&
+          aiPluginContent &&
+          openapiContent.search("APP_NAME_SUFFIX") < 0 &&
+          aiPluginContent.search(openapiServerPlaceholder) < 0
+      );
+      await fs.remove(args.outputZipPath);
+    }
+  });
+
   it("invalid color file", async () => {
     const args: CreateAppPackageArgs = {
       manifestPath:

--- a/packages/fx-core/tests/component/driver/teamsApp/createAppPackage.test.ts
+++ b/packages/fx-core/tests/component/driver/teamsApp/createAppPackage.test.ts
@@ -16,7 +16,7 @@ import {
 import { FileNotFoundError, JSONSyntaxError } from "../../../../src/error/common";
 import { FeatureFlagName } from "../../../../src/common/constants";
 import { manifestUtils } from "../../../../src/component/driver/teamsApp/utils/ManifestUtils";
-import { ok, Platform, TeamsAppManifest } from "@microsoft/teamsfx-api";
+import { ok, Platform, PluginManifestSchema, TeamsAppManifest } from "@microsoft/teamsfx-api";
 import AdmZip from "adm-zip";
 import { InvalidFileOutsideOfTheDirectotryError } from "../../../../src/error/teamsApp";
 
@@ -230,7 +230,7 @@ describe("teamsApp/createAppPackage", async () => {
       }
     });
 
-    it("should return error when placeholder is not resolved in ai-plugin.json", async () => {
+    it("should return error when placeholder is not resolved in ai-plugin.json - case 1", async () => {
       const args: CreateAppPackageArgs = {
         manifestPath:
           "./tests/plugins/resource/appstudio/resources-multi-env/templates/appPackage/v3.manifest.template.json",
@@ -242,6 +242,57 @@ describe("teamsApp/createAppPackage", async () => {
       sinon.stub(fs, "pathExists").callsFake((filePath) => {
         return true;
       });
+
+      const manifest = new TeamsAppManifest();
+      manifest.icons = {
+        color: "resources/color.png",
+        outline: "resources/outline.png",
+      };
+      manifest.plugins = [
+        {
+          pluginFile: "resources\\ai-plugin.json",
+        },
+      ];
+      sinon.stub(manifestUtils, "getManifestV3").resolves(ok(manifest));
+      sinon.stub(fs, "chmod").callsFake(async () => {});
+      sinon.stub(fs, "writeFile").callsFake(async () => {});
+
+      delete process.env["APP_NAME_SUFFIX"];
+      const result = (await teamsAppDriver.execute(args, mockedDriverContext)).result;
+
+      chai.assert(
+        result.isErr() &&
+          result.error.name === "MissingEnvironmentVariablesError" &&
+          result.error.message.includes("APP_NAME_SUFFIX")
+      );
+    });
+
+    it("should return error when placeholder is not resolved in ai-plugin.json- case 2", async () => {
+      const args: CreateAppPackageArgs = {
+        manifestPath:
+          "./tests/plugins/resource/appstudio/resources-multi-env/templates/appPackage/v3.manifest.template.json",
+        outputZipPath:
+          "./tests/plugins/resource/appstudio/resources-multi-env/build/appPackage/appPackage.dev.zip",
+        outputJsonPath:
+          "./tests/plugins/resource/appstudio/resources-multi-env/build/appPackage/manifest.dev.json",
+      };
+      sinon.stub(fs, "pathExists").callsFake((filePath) => {
+        return true;
+      });
+
+      const pluginJson: PluginManifestSchema = {
+        name_for_human: "test",
+        schema_version: "v2",
+        description_for_human: "test",
+        runtimes: [
+          {
+            type: "OpenApi",
+            auth: { type: "none" },
+            spec: { url: "test\\openai.yml" },
+          },
+        ],
+      };
+      sinon.stub(fs, "readJSON").resolves(pluginJson);
 
       const manifest = new TeamsAppManifest();
       manifest.icons = {

--- a/packages/fx-core/tests/component/driver/teamsApp/createAppPackage.test.ts
+++ b/packages/fx-core/tests/component/driver/teamsApp/createAppPackage.test.ts
@@ -250,7 +250,7 @@ describe("teamsApp/createAppPackage", async () => {
       };
       manifest.plugins = [
         {
-          pluginFile: "resources\\ai-plugin.json",
+          pluginFile: "resources/ai-plugin.json",
         },
       ];
       sinon.stub(manifestUtils, "getManifestV3").resolves(ok(manifest));
@@ -260,7 +260,11 @@ describe("teamsApp/createAppPackage", async () => {
       delete process.env["APP_NAME_SUFFIX"];
       const result = (await teamsAppDriver.execute(args, mockedDriverContext)).result;
 
-      chai.assert(result.isErr());
+      chai.assert(
+        result.isErr() &&
+          result.error.name === "MissingEnvironmentVariablesError" &&
+          result.error.message.includes("APP_NAME_SUFFIX")
+      );
     });
 
     it("should return error when placeholder is not resolved in ai-plugin.json- case 2", async () => {

--- a/packages/fx-core/tests/component/driver/teamsApp/utils.test.ts
+++ b/packages/fx-core/tests/component/driver/teamsApp/utils.test.ts
@@ -8,7 +8,7 @@ import { normalizePath } from "../../../../src/component/driver/teamsApp/utils/u
 describe("utils", async () => {
   it("normalizePath: should use forward slash", () => {
     const res = normalizePath("resources\\test.yaml", true);
-    expect(res).equal("resources/test/yaml");
+    expect(res).equal("resources/test.yaml");
   });
 
   it("normalizePath: no need to convert", () => {

--- a/packages/fx-core/tests/component/driver/teamsApp/utils.test.ts
+++ b/packages/fx-core/tests/component/driver/teamsApp/utils.test.ts
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import "mocha";
+import { expect } from "chai";
+import { normalizePath } from "../../../../src/component/driver/teamsApp/utils/utils";
+
+describe("utils", async () => {
+  it("normalizePath: should use forward slash", () => {
+    const res = normalizePath("resources\\test.yaml", true);
+    expect(res).equal("resources/test/yaml");
+  });
+
+  it("normalizePath: no need to convert", () => {
+    const res = normalizePath("resources\\test.yaml", false);
+    expect(res).equal("resources\\test.yaml");
+  });
+});


### PR DESCRIPTION
- When building zip package, keep the path delimiter consistent with what user defined in manifest.