### PR TITLE
feat: update search message extension template for test tool

### DIFF
--- a/templates/js/m365-message-extension/.gitignore
+++ b/templates/js/m365-message-extension/.gitignore
@@ -2,6 +2,9 @@
 env/.env.*.user
 env/.env.local
 .localConfigs
+.localConfigs.testTool
+.notification.localstore.json
+.notification.testtoolstore.json
 appPackage/build
 
 # dependencies

--- a/templates/js/m365-message-extension/.vscode/launch.json
+++ b/templates/js/m365-message-extension/.vscode/launch.json
@@ -116,6 +116,18 @@
     ],
     "compounds": [
         {
+            "name": "Debug in Test Tool (Preview)",
+            "configurations": [
+                "Attach to Local Service"
+            ],
+            "preLaunchTask": "Start Teams App (Test Tool)",
+            "presentation": {
+                "group": "group 0: Teams App Test Tool",
+                "order": 1
+            },
+            "stopAll": true
+        },
+        {
             "name": "Debug in Teams (Edge)",
             "configurations": [
                 "Launch App in Teams (Edge)",

--- a/templates/js/m365-message-extension/.vscode/tasks.json
+++ b/templates/js/m365-message-extension/.vscode/tasks.json
@@ -5,6 +5,105 @@
     "version": "2.0.0",
     "tasks": [
         {
+            "label": "Start Teams App (Test Tool)",
+            "dependsOn": [
+                "Validate prerequisites (Test Tool)",
+                "Deploy (Test Tool)",
+                "Start application (Test Tool)",
+                "Start Test Tool"
+            ],
+            "dependsOrder": "sequence"
+        },
+        {
+            // Check all required prerequisites.
+            // See https://aka.ms/teamsfx-tasks/check-prerequisites to know the details and how to customize the args.
+            "label": "Validate prerequisites (Test Tool)",
+            "type": "teamsfx",
+            "command": "debug-check-prerequisites",
+            "args": {
+                "prerequisites": [
+                    "nodejs", // Validate if Node.js is installed.
+                    "portOccupancy" // Validate available ports to ensure those debug ones are not occupied.
+                ],
+                "portOccupancy": [
+                    3978, // app service port
+                    9239, // app inspector port for Node.js debugger
+                    56150 // test tool port
+                ]
+            }
+        },
+        {
+            // Build project.
+            // See https://aka.ms/teamsfx-tasks/deploy to know the details and how to customize the args.
+            "label": "Deploy (Test Tool)",
+            "type": "teamsfx",
+            "command": "deploy",
+            "args": {
+                "env": "testtool"
+            }
+        },
+        {
+            "label": "Start application (Test Tool)",
+            "type": "shell",
+            "command": "npm run dev:teamsfx:testtool",
+            "isBackground": true,
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "problemMatcher": {
+                "pattern": [
+                    {
+                        "regexp": "^.*$",
+                        "file": 0,
+                        "location": 1,
+                        "message": 2
+                    }
+                ],
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": "[nodemon] starting",
+                    "endsPattern": "restify listening to|Bot/ME service listening at|[nodemon] app crashed"
+                }
+            }
+        },
+        {
+            "label": "Start Test Tool",
+            "type": "shell",
+            "command": "npm run dev:teamsfx:launch-testtool",
+            "isBackground": true,
+            "options": {
+                "env": {
+                    "PATH": "${workspaceFolder}/devTools/teamsapptester/node_modules/.bin:${env:PATH}"
+                }
+            },
+            "windows": {
+                "options": {
+                    "env": {
+                        "PATH": "${workspaceFolder}/devTools/teamsapptester/node_modules/.bin;${env:PATH}"
+                    }
+                }
+            },
+            "problemMatcher": {
+                "pattern": [
+                    {
+                        "regexp": "^.*$",
+                        "file": 0,
+                        "location": 1,
+                        "message": 2
+                    }
+                ],
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": ".*",
+                    "endsPattern": "Listening on"
+                }
+            },
+            "presentation": {
+                "panel": "dedicated",
+                "reveal": "silent"
+            }
+        },
+        {
             "label": "Start Teams App Locally",
             "dependsOn": [
                 "Validate prerequisites",

--- a/templates/js/m365-message-extension/.webappignore
+++ b/templates/js/m365-message-extension/.webappignore
@@ -2,6 +2,9 @@
 .fx
 .deployment
 .localConfigs
+.localConfigs.testTool
+.notification.localstore.json
+.notification.testtoolstore.json
 .vscode
 *.js.map
 *.ts.map

--- a/templates/js/m365-message-extension/env/.env.testtool
+++ b/templates/js/m365-message-extension/env/.env.testtool
@@ -1,0 +1,8 @@
+# This file includes environment variables that can be committed to git. It's gitignored by default because it represents your local development environment.
+
+# Built-in environment variables
+TEAMSFX_ENV=testtool
+
+# Environment variables used by test tool
+TEAMSAPPTESTER_PORT=56150
+TEAMSFX_NOTIFICATION_STORE_FILENAME=.notification.testtoolstore.json

--- a/templates/js/m365-message-extension/package.json.tpl
+++ b/templates/js/m365-message-extension/package.json.tpl
@@ -13,6 +13,8 @@
   "main": "./src/index.js",
   "scripts": {
     "dev:teamsfx": "env-cmd --silent -f .localConfigs npm run dev",
+    "dev:teamsfx:testtool": "env-cmd --silent -f .localConfigs.testTool npm run dev",
+    "dev:teamsfx:launch-testtool": "env-cmd --silent -f env/.env.testtool teamsapptester start",
     "dev": "nodemon --inspect=9239 --signal SIGINT ./src/index.js",
     "start": "node ./src/index.js",
     "watch": "nodemon ./src/index.js"

--- a/templates/js/m365-message-extension/teamsapp.testtool.yml
+++ b/templates/js/m365-message-extension/teamsapp.testtool.yml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/teams-toolkit/v1.3/yaml.schema.json
+# Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
+# Visit https://aka.ms/teamsfx-actions for details on actions
+version: v1.3
+
+deploy:
+  # Install development tool(s)
+  - uses: devTool/install
+    with:
+      testTool:
+        version: ~0.2.0-alpha
+        symlinkDir: ./devTools/teamsapptester
+
+  # Run npm command
+  - uses: cli/runNpmCommand
+    with:
+      args: install --no-audit
+
+  # Generate runtime environment variables
+  - uses: file/createOrUpdateEnvironmentFile
+    with:
+      target: ./.localConfigs.testTool
+      envs:
+        TEAMSFX_NOTIFICATION_STORE_FILENAME: ${{TEAMSFX_NOTIFICATION_STORE_FILENAME}}


### PR DESCRIPTION
Update search message extension js template to add default test tool launch profile.

For now, the test tool version is alpha version. This allows for testing before test tool beta is released. Before TTK RC release, I will change to beta version.

TODO: other bot based message extension templates, README

Test:

https://github.com/OfficeDev/TeamsFx/assets/9698542/9eab1820-67f8-49a9-a2ed-413bd42cf3d6


Similar changes for bot templates: #10270 

AZDO feature: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/25153944/