### PR TITLE
refactor: error if listOpenAPISpecOperationsRequest

### DIFF
--- a/packages/fx-core/src/component/generator/copilotPlugin/helper.ts
+++ b/packages/fx-core/src/component/generator/copilotPlugin/helper.ts
@@ -341,24 +341,8 @@ export async function listPluginExistingOperations(
   }
 
   const specParser = new SpecParser(apiSpecFilePath, copilotPluginParserOptions);
-  const validationRes = await specParser.validate();
-  validationRes.errors = formatValidationErrors(validationRes.errors);
-
-  if (validationRes.status === ValidationStatus.Error) {
-    const errorMessage = getLocalizedString(
-      "core.createProjectQuestion.apiSpec.multipleValidationErrors.message"
-    );
-    throw new UserError(
-      "listPluginExistingOperations",
-      invalidApiSpecErrorName,
-      errorMessage,
-      errorMessage
-    );
-  }
-
   const listResult = await specParser.list();
-  const operations = listResult.APIs.filter((value) => value.isValid);
-  return operations.map((o) => o.api);
+  return listResult.APIs.map((o) => o.api);
 }
 
 export function logValidationResults(

--- a/packages/fx-core/tests/component/generator/copilotPluginGenerator.test.ts
+++ b/packages/fx-core/tests/component/generator/copilotPluginGenerator.test.ts
@@ -1089,34 +1089,6 @@ describe("listPluginExistingOperations", () => {
     }
     expect(hasException).to.be.true;
   });
-
-  it("invalid openapi spec", async () => {
-    sandbox
-      .stub(PluginManifestUtils.prototype, "getApiSpecFilePathFromTeamsManifest")
-      .resolves(ok(["openapi.yaml"]));
-
-    sandbox.stub(SpecParser.prototype, "validate").resolves({
-      status: ValidationStatus.Error,
-      warnings: [],
-      errors: [
-        {
-          type: ErrorType.NoServerInformation,
-          content: "content",
-        },
-      ],
-    });
-
-    let hasException = false;
-
-    try {
-      await listPluginExistingOperations(teamsManifestWithPlugin, "manifestPath", "openapi.yaml");
-    } catch (e) {
-      hasException = true;
-      expect(e.source).equal("listPluginExistingOperations");
-      expect(e.name).equal("invalid-api-spec");
-    }
-    expect(hasException).to.be.true;
-  });
 });
 
 describe("updateForCustomApi", async () => {

--- a/packages/server/src/serverConnection.ts
+++ b/packages/server/src/serverConnection.ts
@@ -479,13 +479,8 @@ export default class ServerConnection implements IServerConnection {
       (inputs) => this.core.copilotPluginListOperations(inputs),
       inputs
     );
-    if (res.isErr()) {
-      const msg = res.error.map((e) => e.content).join("\n");
-      return standardizeResult(
-        err(new UserError("Fx-VS", "ListOpenAPISpecOperationsError", msg, msg))
-      );
-    }
-    return standardizeResult(ok(res.value));
+
+    return standardizeResult(res);
   }
 
   public async checkAndInstallTestTool(

--- a/packages/server/tests/serverConnection.test.ts
+++ b/packages/server/tests/serverConnection.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { err, Inputs, ok, Platform, Stage, Void } from "@microsoft/teamsfx-api";
+import { err, Inputs, ok, Platform, Stage, UserError, Void } from "@microsoft/teamsfx-api";
 import * as tools from "@microsoft/teamsfx-core/build/common/tools";
 import { assert } from "chai";
 import "mocha";
@@ -452,7 +452,7 @@ describe("serverConnections", () => {
 
   it("copilotPluginListOperations fail", async () => {
     const connection = new ServerConnection(msgConn);
-    const fake = sandbox.fake.resolves(err([{ content: "error1" }, { content: "error2" }]));
+    const fake = sandbox.fake.resolves(err(new UserError("source", "name", "", "")));
     sandbox.replace(connection["core"], "copilotPluginListOperations", fake);
     const res = await connection.listOpenAPISpecOperationsRequest(
       {} as Inputs,
@@ -460,7 +460,7 @@ describe("serverConnections", () => {
     );
     assert.isTrue(res.isErr());
     if (res.isErr()) {
-      assert.equal(res.error.message, "error1\nerror2");
+      assert.equal(res.error.source, "source");
     }
   });
 


### PR DESCRIPTION
Format validation error in fx-core rather than server so that server will get a consistent error format.