### PR TITLE
refactor: cleanup test tool flag

### DIFF
--- a/templates/csharp/ai-assistant-bot/.{{NewProjectTypeName}}/launchSettings.json.tpl
+++ b/templates/csharp/ai-assistant-bot/.{{NewProjectTypeName}}/launchSettings.json.tpl
@@ -1,25 +1,15 @@
 {
   "profiles": {
-{{#enableTestToolByDefault}}
     // Launch project within Teams App Test Tool
     "Teams App Test Tool (browser)": {
       "commandName": "Project",
       "launchTestTool": true,
       "launchUrl": "http://localhost:56150",
     },
-{{/enableTestToolByDefault}}
     // Launch project within Teams
     "Microsoft Teams (browser)": {
       "commandName": "Project",
       "launchUrl": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&appTenantId=${{TEAMS_APP_TENANT_ID}}&login_hint=${{TEAMSFX_M365_USER_NAME}}",
     },
-{{^enableTestToolByDefault}}
-    // Launch project within Teams App Test Tool
-    "Teams App Test Tool (browser)": {
-      "commandName": "Project",
-      "launchTestTool": true,
-      "launchUrl": "http://localhost:56150",
-    },
-{{/enableTestToolByDefault}}
   }
 }

--- a/templates/csharp/ai-assistant-bot/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
+++ b/templates/csharp/ai-assistant-bot/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
@@ -4,11 +4,6 @@
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup>
-{{#enableTestToolByDefault}}
     <ActiveDebugProfile>Teams App Test Tool (browser)</ActiveDebugProfile>
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-    <ActiveDebugProfile>Microsoft Teams (browser)</ActiveDebugProfile>
-{{/enableTestToolByDefault}}
   </PropertyGroup>
 </Project>

--- a/templates/csharp/ai-assistant-bot/.{{NewProjectTypeName}}/{{ProjectName}}.slnLaunch.user.tpl
+++ b/templates/csharp/ai-assistant-bot/.{{NewProjectTypeName}}/{{ProjectName}}.slnLaunch.user.tpl
@@ -1,5 +1,4 @@
 [
-{{#enableTestToolByDefault}}
   {
     "Name": "Teams App Test Tool (browser)",
     "Projects": [
@@ -20,7 +19,6 @@
       }
     ]
   },
-{{/enableTestToolByDefault}}
   {
     "Name": "Microsoft Teams (browser)",
     "Projects": [
@@ -40,30 +38,5 @@
         "DebugTarget": "Start Project"
       }
     ]
-{{#enableTestToolByDefault}}
   }
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-  },
-  {
-    "Name": "Teams App Test Tool (browser)",
-    "Projects": [
-      {
-        "Name": "{{NewProjectTypeName}}\\{{NewProjectTypeName}}.{{NewProjectTypeExt}}",
-        "Action": "StartWithoutDebugging",
-        "DebugTarget": "Teams App Test Tool (browser)"
-      },
-      {
-{{#PlaceProjectFileInSolutionDir}}
-        "Name": "{{ProjectName}}.csproj",
-{{/PlaceProjectFileInSolutionDir}}
-{{^PlaceProjectFileInSolutionDir}}
-        "Name": "{{ProjectName}}\\{{ProjectName}}.csproj",
-{{/PlaceProjectFileInSolutionDir}}
-        "Action": "Start",
-        "DebugTarget": "Teams App Test Tool"
-      }
-    ]
-  }
-{{/enableTestToolByDefault}}
 ]

--- a/templates/csharp/ai-assistant-bot/Properties/launchSettings.json.tpl
+++ b/templates/csharp/ai-assistant-bot/Properties/launchSettings.json.tpl
@@ -1,7 +1,6 @@
 {
   "profiles": {
 {{^isNewProjectTypeEnabled}}
-{{#enableTestToolByDefault}}
     // Debug project within Teams App Test Tool
     "Teams App Test Tool (browser)": {
       "commandName": "Project",
@@ -16,7 +15,6 @@
       },
       "hotReloadProfile": "aspnetcore"
     },
-{{/enableTestToolByDefault}}
     // Debug project within Teams
     "Microsoft Teams (browser)": {
       "commandName": "Project",
@@ -29,22 +27,6 @@
       },
       "hotReloadProfile": "aspnetcore"
     },
-{{^enableTestToolByDefault}}
-    // Debug project within Teams App Test Tool
-    "Teams App Test Tool (browser)": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "launchTestTool": true,
-      "launchUrl": "http://localhost:56150",
-      "applicationUrl": "http://localhost:5130",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
-        "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.testtoolstore.json"
-      },
-      "hotReloadProfile": "aspnetcore"
-    },
-{{/enableTestToolByDefault}}
     //// Uncomment following profile to debug project only (without launching Teams)
     //,
     //"Start Project (not in Teams)": {
@@ -58,7 +40,6 @@
     //}
 {{/isNewProjectTypeEnabled}}
 {{#isNewProjectTypeEnabled}}
-{{#enableTestToolByDefault}}
     "Teams App Test Tool": {
       "commandName": "Project",
       "dotnetRunMessages": true,
@@ -69,7 +50,6 @@
       },
       "hotReloadProfile": "aspnetcore"
     },
-{{/enableTestToolByDefault}}
     "Start Project": {
       "commandName": "Project",
       "dotnetRunMessages": true,
@@ -79,18 +59,6 @@
       },
       "hotReloadProfile": "aspnetcore"
     },
-{{^enableTestToolByDefault}}
-    "Teams App Test Tool": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "applicationUrl": "http://localhost:5130",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
-        "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.testtoolstore.json"
-      },
-      "hotReloadProfile": "aspnetcore"
-    },
-{{/enableTestToolByDefault}}
 {{/isNewProjectTypeEnabled}}
   }
 }

--- a/templates/csharp/ai-bot/.{{NewProjectTypeName}}/launchSettings.json.tpl
+++ b/templates/csharp/ai-bot/.{{NewProjectTypeName}}/launchSettings.json.tpl
@@ -1,25 +1,15 @@
 {
   "profiles": {
-{{#enableTestToolByDefault}}
     // Launch project within Teams App Test Tool
     "Teams App Test Tool (browser)": {
       "commandName": "Project",
       "launchTestTool": true,
       "launchUrl": "http://localhost:56150",
     },
-{{/enableTestToolByDefault}}
     // Launch project within Teams
     "Microsoft Teams (browser)": {
       "commandName": "Project",
       "launchUrl": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&appTenantId=${{TEAMS_APP_TENANT_ID}}&login_hint=${{TEAMSFX_M365_USER_NAME}}",
-    },
-{{^enableTestToolByDefault}}
-    // Launch project within Teams App Test Tool
-    "Teams App Test Tool (browser)": {
-      "commandName": "Project",
-      "launchTestTool": true,
-      "launchUrl": "http://localhost:56150",
-    },
-{{/enableTestToolByDefault}}
+    }
   }
 }

--- a/templates/csharp/ai-bot/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
+++ b/templates/csharp/ai-bot/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
@@ -4,11 +4,6 @@
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup>
-{{#enableTestToolByDefault}}
     <ActiveDebugProfile>Teams App Test Tool (browser)</ActiveDebugProfile>
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-    <ActiveDebugProfile>Microsoft Teams (browser)</ActiveDebugProfile>
-{{/enableTestToolByDefault}}
   </PropertyGroup>
 </Project>

--- a/templates/csharp/ai-bot/.{{NewProjectTypeName}}/{{ProjectName}}.slnLaunch.user.tpl
+++ b/templates/csharp/ai-bot/.{{NewProjectTypeName}}/{{ProjectName}}.slnLaunch.user.tpl
@@ -1,5 +1,4 @@
 [
-{{#enableTestToolByDefault}}
   {
     "Name": "Teams App Test Tool (browser)",
     "Projects": [
@@ -20,7 +19,6 @@
       }
     ]
   },
-{{/enableTestToolByDefault}}
   {
     "Name": "Microsoft Teams (browser)",
     "Projects": [
@@ -40,30 +38,5 @@
         "DebugTarget": "Start Project"
       }
     ]
-{{#enableTestToolByDefault}}
   }
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-  },
-  {
-    "Name": "Teams App Test Tool (browser)",
-    "Projects": [
-      {
-        "Name": "{{NewProjectTypeName}}\\{{NewProjectTypeName}}.{{NewProjectTypeExt}}",
-        "Action": "StartWithoutDebugging",
-        "DebugTarget": "Teams App Test Tool (browser)"
-      },
-      {
-{{#PlaceProjectFileInSolutionDir}}
-        "Name": "{{ProjectName}}.csproj",
-{{/PlaceProjectFileInSolutionDir}}
-{{^PlaceProjectFileInSolutionDir}}
-        "Name": "{{ProjectName}}\\{{ProjectName}}.csproj",
-{{/PlaceProjectFileInSolutionDir}}
-        "Action": "Start",
-        "DebugTarget": "Teams App Test Tool"
-      }
-    ]
-  }
-{{/enableTestToolByDefault}}
 ]

--- a/templates/csharp/ai-bot/Properties/launchSettings.json.tpl
+++ b/templates/csharp/ai-bot/Properties/launchSettings.json.tpl
@@ -1,7 +1,6 @@
 {
   "profiles": {
 {{^isNewProjectTypeEnabled}}
-{{#enableTestToolByDefault}}
     // Debug project within Teams App Test Tool
     "Teams App Test Tool (browser)": {
       "commandName": "Project",
@@ -16,7 +15,6 @@
       },
       "hotReloadProfile": "aspnetcore"
     },
-{{/enableTestToolByDefault}}
     // Debug project within Teams
     "Microsoft Teams (browser)": {
       "commandName": "Project",
@@ -29,22 +27,6 @@
       },
       "hotReloadProfile": "aspnetcore"
     },
-{{^enableTestToolByDefault}}
-    // Debug project within Teams App Test Tool
-    "Teams App Test Tool (browser)": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "launchTestTool": true,
-      "launchUrl": "http://localhost:56150",
-      "applicationUrl": "http://localhost:5130",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
-        "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.testtoolstore.json"
-      },
-      "hotReloadProfile": "aspnetcore"
-    },
-{{/enableTestToolByDefault}}
     //// Uncomment following profile to debug project only (without launching Teams)
     //,
     //"Start Project (not in Teams)": {
@@ -58,7 +40,6 @@
     //}
 {{/isNewProjectTypeEnabled}}
 {{#isNewProjectTypeEnabled}}
-{{#enableTestToolByDefault}}
     "Teams App Test Tool": {
       "commandName": "Project",
       "dotnetRunMessages": true,
@@ -69,7 +50,6 @@
       },
       "hotReloadProfile": "aspnetcore"
     },
-{{/enableTestToolByDefault}}
     "Start Project": {
       "commandName": "Project",
       "dotnetRunMessages": true,
@@ -79,18 +59,6 @@
       },
       "hotReloadProfile": "aspnetcore"
     },
-{{^enableTestToolByDefault}}
-    "Teams App Test Tool": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "applicationUrl": "http://localhost:5130",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
-        "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.testtoolstore.json"
-      },
-      "hotReloadProfile": "aspnetcore"
-    },
-{{/enableTestToolByDefault}}
 {{/isNewProjectTypeEnabled}}
   }
 }

--- a/templates/csharp/command-and-response/.{{NewProjectTypeName}}/GettingStarted.md.tpl
+++ b/templates/csharp/command-and-response/.{{NewProjectTypeName}}/GettingStarted.md.tpl
@@ -2,22 +2,9 @@
 
 ## Quick Start
 
-{{#enableTestToolByDefault}}
 1. Press F5, or select the Debug > Start Debugging menu in Visual Studio
 </br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/debug-button.png)
 2. In Teams App Test Tool from the launched browser, type and send "helloWorld" to your app to trigger a response
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-1. In the debug dropdown menu, select Dev Tunnels > Create A Tunnel (set authentication type to Public) or select an existing public dev tunnel
-</br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/create-devtunnel-button.png)
-2. Right-click your `{{NewProjectTypeName}}` project and select Teams Toolkit > Prepare Teams App Dependencies
-3. If prompted, sign in with a Microsoft 365 account for the Teams organization you want 
-to install the app to
-4. Press F5, or select the Debug > Start Debugging menu in Visual Studio
-</br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/debug-button.png)
-5. In the launched browser, select the Add button to load the app in Teams
-6. In the chat bar, type and send "helloWorld" to your app to trigger a response
-{{/enableTestToolByDefault}}
 
 ## Start multiple profiles
 Instead of launching the app in Teams client with default profile, you can also run your app with other profile like App Test Tool, office.com and outlook or even Copilot. You can select profile to start.
@@ -25,20 +12,11 @@ Instead of launching the app in Teams client with default profile, you can also 
 2. Check "Enable Multi-Project Launch Profiles"
 </br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/enable-multiple-profiles-feature.png)
 
-{{^enableTestToolByDefault}}
-### Start the app in Teams App Test Tool
-1. Select `Teams App Test Tool (browser)` in debug dropdown menu
-</br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/switch-to-test-tool.png)
-2. Press F5, or select the Debug > Start Debugging menu in Visual Studio
-</br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/debug-button.png)
-{{/enableTestToolByDefault}}
-{{#enableTestToolByDefault}}
 ### Start the app in Microsoft Teams
 1. In the debug dropdown menu, select `Microsoft Teams (browser)`.
 </br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/switch-to-teams.png)
 2. Press F5, or select the Debug > Start Debugging menu in Visual Studio
 </br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/debug-button.png)
-{{/enableTestToolByDefault}}
 
 ## Learn more
 

--- a/templates/csharp/command-and-response/.{{NewProjectTypeName}}/launchSettings.json.tpl
+++ b/templates/csharp/command-and-response/.{{NewProjectTypeName}}/launchSettings.json.tpl
@@ -1,25 +1,15 @@
 {
   "profiles": {
-{{#enableTestToolByDefault}}
     // Launch project within Teams App Test Tool
     "Teams App Test Tool (browser)": {
       "commandName": "Project",
       "launchTestTool": true,
       "launchUrl": "http://localhost:56150",
     },
-{{/enableTestToolByDefault}}
     // Launch project within Teams
     "Microsoft Teams (browser)": {
       "commandName": "Project",
       "launchUrl": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&appTenantId=${{TEAMS_APP_TENANT_ID}}&login_hint=${{TEAMSFX_M365_USER_NAME}}",
-    },
-{{^enableTestToolByDefault}}
-    // Launch project within Teams App Test Tool
-    "Teams App Test Tool (browser)": {
-      "commandName": "Project",
-      "launchTestTool": true,
-      "launchUrl": "http://localhost:56150",
-    },
-{{/enableTestToolByDefault}}
+    }
   }
 }

--- a/templates/csharp/command-and-response/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
+++ b/templates/csharp/command-and-response/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
@@ -4,11 +4,6 @@
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup>
-{{#enableTestToolByDefault}}
     <ActiveDebugProfile>Teams App Test Tool (browser)</ActiveDebugProfile>
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-    <ActiveDebugProfile>Microsoft Teams (browser)</ActiveDebugProfile>
-{{/enableTestToolByDefault}}
   </PropertyGroup>
 </Project>

--- a/templates/csharp/command-and-response/.{{NewProjectTypeName}}/{{ProjectName}}.slnLaunch.user.tpl
+++ b/templates/csharp/command-and-response/.{{NewProjectTypeName}}/{{ProjectName}}.slnLaunch.user.tpl
@@ -1,5 +1,4 @@
 [
-{{#enableTestToolByDefault}}
   {
     "Name": "Teams App Test Tool (browser)",
     "Projects": [
@@ -20,7 +19,6 @@
       }
     ]
   },
-{{/enableTestToolByDefault}}
   {
     "Name": "Microsoft Teams (browser)",
     "Projects": [
@@ -40,30 +38,5 @@
         "DebugTarget": "Start Project"
       }
     ]
-{{#enableTestToolByDefault}}
   }
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-  },
-  {
-    "Name": "Teams App Test Tool (browser)",
-    "Projects": [
-      {
-        "Name": "{{NewProjectTypeName}}\\{{NewProjectTypeName}}.{{NewProjectTypeExt}}",
-        "Action": "StartWithoutDebugging",
-        "DebugTarget": "Teams App Test Tool (browser)"
-      },
-      {
-{{#PlaceProjectFileInSolutionDir}}
-        "Name": "{{ProjectName}}.csproj",
-{{/PlaceProjectFileInSolutionDir}}
-{{^PlaceProjectFileInSolutionDir}}
-        "Name": "{{ProjectName}}\\{{ProjectName}}.csproj",
-{{/PlaceProjectFileInSolutionDir}}
-        "Action": "Start",
-        "DebugTarget": "Teams App Test Tool"
-      }
-    ]
-  }
-{{/enableTestToolByDefault}}
 ]

--- a/templates/csharp/command-and-response/GettingStarted.md.tpl
+++ b/templates/csharp/command-and-response/GettingStarted.md.tpl
@@ -2,19 +2,8 @@
 
 ## Quick Start
 
-{{#enableTestToolByDefault}}
 1. Press F5, or select the Debug > Start Debugging menu in Visual Studio
 2. In Teams App Test Tool from the launched browser, type and send "helloWorld" to your app to trigger a response
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-1. In the debug dropdown menu, select Dev Tunnels > Create A Tunnel (set authentication type to Public) or select an existing public dev tunnel
-2. Right-click your project and select Teams Toolkit > Prepare Teams App Dependencies
-3. If prompted, sign in with a Microsoft 365 account for the Teams organization you want 
-to install the app to
-4. Press F5, or select the Debug > Start Debugging menu in Visual Studio
-5. In the launched browser, select the Add button to load the app in Teams
-6. In the chat bar, type and send "helloWorld" to your app to trigger a response
-{{/enableTestToolByDefault}}
 
 ## Learn more
 

--- a/templates/csharp/command-and-response/Properties/launchSettings.json.tpl
+++ b/templates/csharp/command-and-response/Properties/launchSettings.json.tpl
@@ -1,7 +1,6 @@
 ﻿{
   "profiles": {
 {{^isNewProjectTypeEnabled}}
-{{#enableTestToolByDefault}}
     // Debug project within Teams App Test Tool
     "Teams App Test Tool (browser)": {
       "commandName": "Project",
@@ -16,7 +15,6 @@
       },
       "hotReloadProfile": "aspnetcore"
     },
-{{/enableTestToolByDefault}}
     // Debug project within Teams
     "Microsoft Teams (browser)": {
       "commandName": "Project",
@@ -29,22 +27,6 @@
       },
       "hotReloadProfile": "aspnetcore"
     },
-{{^enableTestToolByDefault}}
-    // Debug project within Teams App Test Tool
-    "Teams App Test Tool (browser)": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "launchTestTool": true,
-      "launchUrl": "http://localhost:56150",
-      "applicationUrl": "http://localhost:5130",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
-        "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.testtoolstore.json"
-      },
-      "hotReloadProfile": "aspnetcore"
-    },
-{{/enableTestToolByDefault}}
     //// Uncomment following profile to debug project only (without launching Teams)
     //,
     //"Start Project (not in Teams)": {
@@ -58,7 +40,6 @@
     //}
 {{/isNewProjectTypeEnabled}}
 {{#isNewProjectTypeEnabled}}
-{{#enableTestToolByDefault}}
     // Debug project within Teams App Test Tool
     "Teams App Test Tool": {
       "commandName": "Project",
@@ -70,7 +51,6 @@
       },
       "hotReloadProfile": "aspnetcore"
     },
-{{/enableTestToolByDefault}}
     // Debug project within Teams
     "Start Project": {
       "commandName": "Project",
@@ -81,19 +61,6 @@
       },
       "hotReloadProfile": "aspnetcore"
     },
-{{^enableTestToolByDefault}}
-    // Debug project within Teams App Test Tool
-    "Teams App Test Tool": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "applicationUrl": "http://localhost:5130",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
-        "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.testtoolstore.json"
-      },
-      "hotReloadProfile": "aspnetcore"
-    },
-{{/enableTestToolByDefault}}
 {{/isNewProjectTypeEnabled}}
   }
 }

--- a/templates/csharp/default-bot/.{{NewProjectTypeName}}/GettingStarted.md.tpl
+++ b/templates/csharp/default-bot/.{{NewProjectTypeName}}/GettingStarted.md.tpl
@@ -1,22 +1,9 @@
 # Welcome to Teams Toolkit!
 
 ## Quick Start
-{{#enableTestToolByDefault}}
 1. Press F5, or select the Debug > Start Debugging menu in Visual Studio
 </br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/debug-button.png)
 2. In Teams App Test Tool from the launched browser, type and send anything to your bot to trigger a response
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-1. In the debug dropdown menu, select Dev Tunnels > Create A Tunnel (set authentication type to Public) or select an existing public dev tunnel
-</br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/create-devtunnel-button.png)
-2. Right-click your `{{NewProjectTypeName}}` project and select Teams Toolkit > Prepare Teams App Dependencies
-3. If prompted, sign in with a Microsoft 365 account for the Teams organization you want 
-to install the app to
-4. Press F5, or select the Debug > Start Debugging menu in Visual Studio
-</br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/debug-button.png)
-5. In the launched browser, select the Add button to load the app in Teams
-6. In the chat bar, type and send anything to your bot to trigger a response
-{{/enableTestToolByDefault}}
 
 ## Start multiple profiles
 Instead of launching the app in Teams client with default profile, you can also run your app with other profile like App Test Tool, office.com and outlook or even Copilot. You can select profile to start.
@@ -24,20 +11,11 @@ Instead of launching the app in Teams client with default profile, you can also 
 2. Check "Enable Multi-Project Launch Profiles"
 </br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/enable-multiple-profiles-feature.png)
 
-{{^enableTestToolByDefault}}
 ### Start the app in Teams App Test Tool
 1. Select `Teams App Test Tool (browser)` in debug dropdown menu
 </br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/switch-to-test-tool.png)
 2. Press F5, or select the Debug > Start Debugging menu in Visual Studio
 </br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/debug-button.png)
-{{/enableTestToolByDefault}}
-{{#enableTestToolByDefault}}
-### Start the app in Microsoft Teams
-1. In the debug dropdown menu, select `Microsoft Teams (browser)`.
-</br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/switch-to-teams.png)
-2. Press F5, or select the Debug > Start Debugging menu in Visual Studio
-</br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/debug-button.png)
-{{/enableTestToolByDefault}}
 
 ## Learn more
 

--- a/templates/csharp/default-bot/.{{NewProjectTypeName}}/launchSettings.json.tpl
+++ b/templates/csharp/default-bot/.{{NewProjectTypeName}}/launchSettings.json.tpl
@@ -1,25 +1,15 @@
 {
   "profiles": {
-{{#enableTestToolByDefault}}
     // Launch project within Teams App Test Tool
     "Teams App Test Tool (browser)": {
       "commandName": "Project",
       "launchTestTool": true,
       "launchUrl": "http://localhost:56150",
     },
-{{/enableTestToolByDefault}}
     // Launch project within Teams
     "Microsoft Teams (browser)": {
       "commandName": "Project",
       "launchUrl": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&appTenantId=${{TEAMS_APP_TENANT_ID}}&login_hint=${{TEAMSFX_M365_USER_NAME}}",
     },
-{{^enableTestToolByDefault}}
-    // Launch project within Teams App Test Tool
-    "Teams App Test Tool (browser)": {
-      "commandName": "Project",
-      "launchTestTool": true,
-      "launchUrl": "http://localhost:56150",
-    },
-{{/enableTestToolByDefault}}
   }
 }

--- a/templates/csharp/default-bot/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
+++ b/templates/csharp/default-bot/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
@@ -4,11 +4,6 @@
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup>
-{{#enableTestToolByDefault}}
     <ActiveDebugProfile>Teams App Test Tool (browser)</ActiveDebugProfile>
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-    <ActiveDebugProfile>Microsoft Teams (browser)</ActiveDebugProfile>
-{{/enableTestToolByDefault}}
   </PropertyGroup>
 </Project>

--- a/templates/csharp/default-bot/.{{NewProjectTypeName}}/{{ProjectName}}.slnLaunch.user.tpl
+++ b/templates/csharp/default-bot/.{{NewProjectTypeName}}/{{ProjectName}}.slnLaunch.user.tpl
@@ -1,5 +1,4 @@
 [
-{{#enableTestToolByDefault}}
   {
     "Name": "Teams App Test Tool (browser)",
     "Projects": [
@@ -20,7 +19,6 @@
       }
     ]
   },
-{{/enableTestToolByDefault}}
   {
     "Name": "Microsoft Teams (browser)",
     "Projects": [
@@ -40,30 +38,5 @@
         "DebugTarget": "Start Project"
       }
     ]
-{{#enableTestToolByDefault}}
   }
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-  },
-  {
-    "Name": "Teams App Test Tool (browser)",
-    "Projects": [
-      {
-        "Name": "{{NewProjectTypeName}}\\{{NewProjectTypeName}}.{{NewProjectTypeExt}}",
-        "Action": "StartWithoutDebugging",
-        "DebugTarget": "Teams App Test Tool (browser)"
-      },
-      {
-{{#PlaceProjectFileInSolutionDir}}
-        "Name": "{{ProjectName}}.csproj",
-{{/PlaceProjectFileInSolutionDir}}
-{{^PlaceProjectFileInSolutionDir}}
-        "Name": "{{ProjectName}}\\{{ProjectName}}.csproj",
-{{/PlaceProjectFileInSolutionDir}}
-        "Action": "Start",
-        "DebugTarget": "Teams App Test Tool"
-      }
-    ]
-  }
-{{/enableTestToolByDefault}}
 ]

--- a/templates/csharp/default-bot/GettingStarted.md.tpl
+++ b/templates/csharp/default-bot/GettingStarted.md.tpl
@@ -1,19 +1,8 @@
 # Welcome to Teams Toolkit!
 
 ## Quick Start
-{{#enableTestToolByDefault}}
 1. Press F5, or select the Debug > Start Debugging menu in Visual Studio
 2. In Teams App Test Tool from the launched browser, type and send anything to your bot to trigger a response
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-1. In the debug dropdown menu, select Dev Tunnels > Create A Tunnel (set authentication type to Public) or select an existing public dev tunnel
-2. Right-click your project and select Teams Toolkit > Prepare Teams App Dependencies
-3. If prompted, sign in with a Microsoft 365 account for the Teams organization you want 
-to install the app to
-4. Press F5, or select the Debug > Start Debugging menu in Visual Studio
-5. In the launched browser, select the Add button to load the app in Teams
-6. In the chat bar, type and send anything to your bot to trigger a response
-{{/enableTestToolByDefault}}
 
 ## Learn more
 

--- a/templates/csharp/default-bot/Properties/launchSettings.json.tpl
+++ b/templates/csharp/default-bot/Properties/launchSettings.json.tpl
@@ -1,7 +1,6 @@
 {
   "profiles": {
 {{^isNewProjectTypeEnabled}}
-{{#enableTestToolByDefault}}
     // Debug project within Teams App Test Tool
     "Teams App Test Tool (browser)": {
       "commandName": "Project",
@@ -16,7 +15,6 @@
       },
       "hotReloadProfile": "aspnetcore"
     },
-{{/enableTestToolByDefault}}
     // Debug project within Teams
     "Microsoft Teams (browser)": {
       "commandName": "Project",
@@ -29,22 +27,6 @@
       },
       "hotReloadProfile": "aspnetcore"
     },
-{{^enableTestToolByDefault}}
-    // Debug project within Teams App Test Tool
-    "Teams App Test Tool (browser)": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "launchTestTool": true,
-      "launchUrl": "http://localhost:56150",
-      "applicationUrl": "http://localhost:5130",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
-        "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.testtoolstore.json"
-      },
-      "hotReloadProfile": "aspnetcore"
-    },
-{{/enableTestToolByDefault}}
     //// Uncomment following profile to debug project only (without launching Teams)
     //,
     //"Start Project (not in Teams)": {
@@ -58,7 +40,6 @@
     //}
 {{/isNewProjectTypeEnabled}}
 {{#isNewProjectTypeEnabled}}
-{{#enableTestToolByDefault}}
     // Debug project within Teams App Test Tool
     "Teams App Test Tool": {
       "commandName": "Project",
@@ -70,7 +51,6 @@
       },
       "hotReloadProfile": "aspnetcore"
     },
-{{/enableTestToolByDefault}}
     // Debug project within Teams
     "Start Project": {
       "commandName": "Project",
@@ -81,19 +61,6 @@
       },
       "hotReloadProfile": "aspnetcore"
     },
-{{^enableTestToolByDefault}}
-    // Debug project within Teams App Test Tool
-    "Teams App Test Tool": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "applicationUrl": "http://localhost:5130",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
-        "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.testtoolstore.json"
-      },
-      "hotReloadProfile": "aspnetcore"
-    },
-{{/enableTestToolByDefault}}
 {{/isNewProjectTypeEnabled}}
   }
 }

--- a/templates/csharp/link-unfurling/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
+++ b/templates/csharp/link-unfurling/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
@@ -4,6 +4,6 @@
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup>
-    <ActiveDebugProfile>Teams App Test Tool (browser)</ActiveDebugProfile>
+    <ActiveDebugProfile>Microsoft Teams (browser)</ActiveDebugProfile>
   </PropertyGroup>
 </Project>

--- a/templates/csharp/link-unfurling/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
+++ b/templates/csharp/link-unfurling/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
@@ -4,11 +4,6 @@
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup>
-{{#enableTestToolByDefault}}
     <ActiveDebugProfile>Teams App Test Tool (browser)</ActiveDebugProfile>
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-    <ActiveDebugProfile>Microsoft Teams (browser)</ActiveDebugProfile>
-{{/enableTestToolByDefault}}
   </PropertyGroup>
 </Project>

--- a/templates/csharp/message-extension-action/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
+++ b/templates/csharp/message-extension-action/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
@@ -4,6 +4,6 @@
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup>
-    <ActiveDebugProfile>Teams App Test Tool (browser)</ActiveDebugProfile>
+    <ActiveDebugProfile>Microsoft Teams (browser)</ActiveDebugProfile>
   </PropertyGroup>
 </Project>

--- a/templates/csharp/message-extension-action/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
+++ b/templates/csharp/message-extension-action/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
@@ -4,11 +4,6 @@
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup>
-{{#enableTestToolByDefault}}
     <ActiveDebugProfile>Teams App Test Tool (browser)</ActiveDebugProfile>
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-    <ActiveDebugProfile>Microsoft Teams (browser)</ActiveDebugProfile>
-{{/enableTestToolByDefault}}
   </PropertyGroup>
 </Project>

--- a/templates/csharp/message-extension-copilot/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
+++ b/templates/csharp/message-extension-copilot/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
@@ -4,6 +4,6 @@
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup>
-    <ActiveDebugProfile>Teams App Test Tool (browser)</ActiveDebugProfile>
+    <ActiveDebugProfile>Microsoft Teams (browser)</ActiveDebugProfile>
   </PropertyGroup>
 </Project>

--- a/templates/csharp/message-extension-copilot/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
+++ b/templates/csharp/message-extension-copilot/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
@@ -4,11 +4,6 @@
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup>
-{{#enableTestToolByDefault}}
     <ActiveDebugProfile>Teams App Test Tool (browser)</ActiveDebugProfile>
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-    <ActiveDebugProfile>Microsoft Teams (browser)</ActiveDebugProfile>
-{{/enableTestToolByDefault}}
   </PropertyGroup>
 </Project>

--- a/templates/csharp/message-extension-search/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
+++ b/templates/csharp/message-extension-search/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
@@ -4,6 +4,6 @@
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup>
-    <ActiveDebugProfile>Teams App Test Tool (browser)</ActiveDebugProfile>
+    <ActiveDebugProfile>Microsoft Teams (browser)</ActiveDebugProfile>
   </PropertyGroup>
 </Project>

--- a/templates/csharp/message-extension-search/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
+++ b/templates/csharp/message-extension-search/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
@@ -4,11 +4,6 @@
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup>
-{{#enableTestToolByDefault}}
     <ActiveDebugProfile>Teams App Test Tool (browser)</ActiveDebugProfile>
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-    <ActiveDebugProfile>Microsoft Teams (browser)</ActiveDebugProfile>
-{{/enableTestToolByDefault}}
   </PropertyGroup>
 </Project>

--- a/templates/csharp/message-extension/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
+++ b/templates/csharp/message-extension/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
@@ -4,6 +4,6 @@
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup>
-    <ActiveDebugProfile>Teams App Test Tool (browser)</ActiveDebugProfile>
+    <ActiveDebugProfile>Microsoft Teams (browser)</ActiveDebugProfile>
   </PropertyGroup>
 </Project>

--- a/templates/csharp/message-extension/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
+++ b/templates/csharp/message-extension/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
@@ -4,11 +4,6 @@
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup>
-{{#enableTestToolByDefault}}
     <ActiveDebugProfile>Teams App Test Tool (browser)</ActiveDebugProfile>
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-    <ActiveDebugProfile>Microsoft Teams (browser)</ActiveDebugProfile>
-{{/enableTestToolByDefault}}
   </PropertyGroup>
 </Project>

--- a/templates/csharp/non-sso-tab-ssr/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
+++ b/templates/csharp/non-sso-tab-ssr/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
@@ -4,6 +4,6 @@
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup>
-    <ActiveDebugProfile>Teams App Test Tool (browser)</ActiveDebugProfile>
+    <ActiveDebugProfile>Microsoft Teams (browser)</ActiveDebugProfile>
   </PropertyGroup>
 </Project>

--- a/templates/csharp/non-sso-tab-ssr/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
+++ b/templates/csharp/non-sso-tab-ssr/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
@@ -4,11 +4,6 @@
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup>
-{{#enableTestToolByDefault}}
     <ActiveDebugProfile>Teams App Test Tool (browser)</ActiveDebugProfile>
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-    <ActiveDebugProfile>Microsoft Teams (browser)</ActiveDebugProfile>
-{{/enableTestToolByDefault}}
   </PropertyGroup>
 </Project>

--- a/templates/csharp/non-sso-tab/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
+++ b/templates/csharp/non-sso-tab/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
@@ -4,6 +4,6 @@
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup>
-    <ActiveDebugProfile>Teams App Test Tool (browser)</ActiveDebugProfile>
+    <ActiveDebugProfile>Microsoft Teams (browser)</ActiveDebugProfile>
   </PropertyGroup>
 </Project>

--- a/templates/csharp/non-sso-tab/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
+++ b/templates/csharp/non-sso-tab/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
@@ -4,11 +4,6 @@
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup>
-{{#enableTestToolByDefault}}
     <ActiveDebugProfile>Teams App Test Tool (browser)</ActiveDebugProfile>
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-    <ActiveDebugProfile>Microsoft Teams (browser)</ActiveDebugProfile>
-{{/enableTestToolByDefault}}
   </PropertyGroup>
 </Project>

--- a/templates/csharp/notification-http-timer-trigger-isolated/.{{NewProjectTypeName}}/GettingStarted.md.tpl
+++ b/templates/csharp/notification-http-timer-trigger-isolated/.{{NewProjectTypeName}}/GettingStarted.md.tpl
@@ -2,7 +2,6 @@
 
 ## Quick Start
 
-{{#enableTestToolByDefault}}
 1. Press F5, or select the Debug > Start Debugging menu in Visual Studio
 </br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/debug-button.png)
 2. Teams App Test Tool will be opened in the launched browser 
@@ -11,22 +10,6 @@ the notification(replace <endpoint> with real endpoint, for example localhost:51
 
    Invoke-WebRequest -Uri "http://<endpoint>/api/notification" -Method Post
    
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-1. In the debug dropdown menu, select Dev Tunnels > Create A Tunnel (set authentication type to Public) or select an existing public dev tunnel
-</br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/create-devtunnel-button.png)
-2. Right-click your `{{NewProjectTypeName}}` project and select Teams Toolkit > Prepare Teams App Dependencies
-3. If prompted, sign in with a Microsoft 365 account for the Teams organization you want 
-to install the app to
-4. Press F5, or select the Debug > Start Debugging menu in Visual Studio
-</br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/debug-button.png)
-5. In the launched browser, select the Add button to load the app in Teams
-6. [If you selected http trigger] Open Windows PowerShell and post a HTTP request to trigger 
-the notification(replace <endpoint> with real endpoint, for example localhost:5130):
-
-   Invoke-WebRequest -Uri "http://<endpoint>/api/notification" -Method Post
-   
-{{/enableTestToolByDefault}}
 
 ## Start multiple profiles
 Instead of launching the app in Teams client with default profile, you can also run your app with other profile like App Test Tool, office.com and outlook or even Copilot. You can select profile to start.
@@ -34,20 +17,11 @@ Instead of launching the app in Teams client with default profile, you can also 
 2. Check "Enable Multi-Project Launch Profiles"
 </br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/enable-multiple-profiles-feature.png)
 
-{{^enableTestToolByDefault}}
-### Start the app in Teams App Test Tool
-1. Select `Teams App Test Tool (browser)` in debug dropdown menu
-</br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/switch-to-test-tool.png)
-2. Press F5, or select the Debug > Start Debugging menu in Visual Studio
-</br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/debug-button.png)
-{{/enableTestToolByDefault}}
-{{#enableTestToolByDefault}}
 ### Start the app in Microsoft Teams
 1. In the debug dropdown menu, select `Microsoft Teams (browser)`.
 </br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/switch-to-teams.png)
 2. Press F5, or select the Debug > Start Debugging menu in Visual Studio
 </br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/debug-button.png)
-{{/enableTestToolByDefault}}
 
 ## Learn more
 

--- a/templates/csharp/notification-http-timer-trigger-isolated/.{{NewProjectTypeName}}/launchSettings.json.tpl
+++ b/templates/csharp/notification-http-timer-trigger-isolated/.{{NewProjectTypeName}}/launchSettings.json.tpl
@@ -1,25 +1,15 @@
 {
   "profiles": {
-{{#enableTestToolByDefault}}
     // Launch project within Teams App Test Tool
     "Teams App Test Tool (browser)": {
       "commandName": "Project",
       "launchTestTool": true,
       "launchUrl": "http://localhost:56150",
     },
-{{/enableTestToolByDefault}}
     // Launch project within Teams
     "Microsoft Teams (browser)": {
       "commandName": "Project",
       "launchUrl": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&appTenantId=${{TEAMS_APP_TENANT_ID}}&login_hint=${{TEAMSFX_M365_USER_NAME}}",
     },
-{{^enableTestToolByDefault}}
-    // Launch project within Teams App Test Tool
-    "Teams App Test Tool (browser)": {
-      "commandName": "Project",
-      "launchTestTool": true,
-      "launchUrl": "http://localhost:56150",
-    },
-{{/enableTestToolByDefault}}
   }
 }

--- a/templates/csharp/notification-http-timer-trigger-isolated/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
+++ b/templates/csharp/notification-http-timer-trigger-isolated/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
@@ -4,11 +4,6 @@
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup>
-{{#enableTestToolByDefault}}
     <ActiveDebugProfile>Teams App Test Tool (browser)</ActiveDebugProfile>
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-    <ActiveDebugProfile>Microsoft Teams (browser)</ActiveDebugProfile>
-{{/enableTestToolByDefault}}
   </PropertyGroup>
 </Project>

--- a/templates/csharp/notification-http-timer-trigger-isolated/.{{NewProjectTypeName}}/{{ProjectName}}.slnLaunch.user.tpl
+++ b/templates/csharp/notification-http-timer-trigger-isolated/.{{NewProjectTypeName}}/{{ProjectName}}.slnLaunch.user.tpl
@@ -1,5 +1,4 @@
 [
-{{#enableTestToolByDefault}}
   {
     "Name": "Teams App Test Tool (browser)",
     "Projects": [
@@ -20,7 +19,6 @@
       }
     ]
   },
-{{/enableTestToolByDefault}}
   {
     "Name": "Microsoft Teams (browser)",
     "Projects": [
@@ -40,30 +38,5 @@
         "DebugTarget": "Start Project"
       }
     ]
-{{#enableTestToolByDefault}}
   }
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-  },
-  {
-    "Name": "Teams App Test Tool (browser)",
-    "Projects": [
-      {
-        "Name": "{{NewProjectTypeName}}\\{{NewProjectTypeName}}.{{NewProjectTypeExt}}",
-        "Action": "StartWithoutDebugging",
-        "DebugTarget": "Teams App Test Tool (browser)"
-      },
-      {
-{{#PlaceProjectFileInSolutionDir}}
-        "Name": "{{ProjectName}}.csproj",
-{{/PlaceProjectFileInSolutionDir}}
-{{^PlaceProjectFileInSolutionDir}}
-        "Name": "{{ProjectName}}\\{{ProjectName}}.csproj",
-{{/PlaceProjectFileInSolutionDir}}
-        "Action": "Start",
-        "DebugTarget": "Teams App Test Tool"
-      }
-    ]
-  }
-{{/enableTestToolByDefault}}
 ]

--- a/templates/csharp/notification-http-timer-trigger-isolated/GettingStarted.md.tpl
+++ b/templates/csharp/notification-http-timer-trigger-isolated/GettingStarted.md.tpl
@@ -2,7 +2,6 @@
 
 ## Quick Start
 
-{{#enableTestToolByDefault}}
 1. Press F5, or select the Debug > Start Debugging menu in Visual Studio
 2. Teams App Test Tool will be opened in the launched browser 
 3. [If you selected http trigger] Open Windows PowerShell and post a HTTP request to trigger 
@@ -10,20 +9,6 @@ the notification(replace <endpoint> with real endpoint, for example localhost:51
 
    Invoke-WebRequest -Uri "http://<endpoint>/api/notification" -Method Post
    
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-1. In the debug dropdown menu, select Dev Tunnels > Create A Tunnel (set authentication type to Public) or select an existing public dev tunnel
-2. Right-click your project and select Teams Toolkit > Prepare Teams App Dependencies
-3. If prompted, sign in with a Microsoft 365 account for the Teams organization you want 
-to install the app to
-4. Press F5, or select the Debug > Start Debugging menu in Visual Studio
-5. In the launched browser, select the Add button to load the app in Teams
-6. [If you selected http trigger] Open Windows PowerShell and post a HTTP request to trigger 
-the notification(replace <endpoint> with real endpoint, for example localhost:5130):
-
-   Invoke-WebRequest -Uri "http://<endpoint>/api/notification" -Method Post
-   
-{{/enableTestToolByDefault}}
 ## Learn more
 
 New to Teams app development or Teams Toolkit? Learn more about 

--- a/templates/csharp/notification-http-timer-trigger-isolated/Properties/launchSettings.json.tpl
+++ b/templates/csharp/notification-http-timer-trigger-isolated/Properties/launchSettings.json.tpl
@@ -1,7 +1,6 @@
 {
   "profiles": {
 {{^isNewProjectTypeEnabled}}
-{{#enableTestToolByDefault}}
     // Debug project within Teams App Test Tool
     "Teams App Test Tool (browser)": {
       "commandName": "Project",
@@ -16,7 +15,6 @@
         "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "../../.." // Path to project folder $(MSBuildProjectDirectory)
       }
     },
-{{/enableTestToolByDefault}}
     // Debug project within Teams
     "Microsoft Teams (browser)": {
       "commandName": "Project",
@@ -29,22 +27,6 @@
         "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "../../.." // Path to project folder $(MSBuildProjectDirectory)
       }
     },
-{{^enableTestToolByDefault}}
-    // Debug project within Teams App Test Tool
-    "Teams App Test Tool (browser)": {
-      "commandName": "Project",
-      "commandLineArgs": "host start --port 5130 --pause-on-error",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "launchTestTool": true,
-      "launchUrl": "http://localhost:56150",
-      "environmentVariables": {
-        "AZURE_FUNCTIONS_ENVIRONMENT": "TestTool",
-        "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.testtoolstore.json",
-        "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "../../.." // Path to project folder $(MSBuildProjectDirectory)
-      }
-    },
-{{/enableTestToolByDefault}}
     //// Uncomment following profile to debug project only (without launching Teams)
     //,
     //"Start Project (not in Teams)": {
@@ -58,7 +40,6 @@
     //}
 {{/isNewProjectTypeEnabled}}
 {{#isNewProjectTypeEnabled}}
-{{#enableTestToolByDefault}}
     // Launch project with TestTool environment, will be used by Teams App Test Tool
     "Teams App Test Tool": {
       "commandName": "Project",
@@ -71,7 +52,6 @@
         "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "../../.."
       }
     },
-{{/enableTestToolByDefault}}
     // Launch project directly
     "Start Project": {
       "commandName": "Project",
@@ -83,20 +63,6 @@
         "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "../../.."
       }
     },
-{{^enableTestToolByDefault}}
-    // Launch project with TestTool environment, will be used by Teams App Test Tool
-    "Teams App Test Tool": {
-      "commandName": "Project",
-      "commandLineArgs": "host start --port 5130 --pause-on-error",
-      "dotnetRunMessages": true,
-      "environmentVariables": {
-        "AZURE_FUNCTIONS_ENVIRONMENT": "TestTool",
-        "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.testtoolstore.json",
-        // Path to project folder $(MSBuildProjectDirectory), used in Microsoft.TeamsFx package.
-        "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "../../.."
-      }
-    },
-{{/enableTestToolByDefault}}
 {{/isNewProjectTypeEnabled}}
   }
 }

--- a/templates/csharp/notification-http-timer-trigger/.{{NewProjectTypeName}}/GettingStarted.md.tpl
+++ b/templates/csharp/notification-http-timer-trigger/.{{NewProjectTypeName}}/GettingStarted.md.tpl
@@ -2,7 +2,6 @@
 
 ## Quick Start
 
-{{#enableTestToolByDefault}}
 1. Press F5, or select the Debug > Start Debugging menu in Visual Studio
 </br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/debug-button.png)
 2. Teams App Test Tool will be opened in the launched browser 
@@ -11,22 +10,6 @@ the notification(replace <endpoint> with real endpoint, for example localhost:51
 
    Invoke-WebRequest -Uri "http://<endpoint>/api/notification" -Method Post
    
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-1. In the debug dropdown menu, select Dev Tunnels > Create A Tunnel (set authentication type to Public) or select an existing public dev tunnel
-</br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/create-devtunnel-button.png)
-2. Right-click your `{{NewProjectTypeName}}` project and select Teams Toolkit > Prepare Teams App Dependencies
-3. If prompted, sign in with a Microsoft 365 account for the Teams organization you want 
-to install the app to
-4. Press F5, or select the Debug > Start Debugging menu in Visual Studio
-</br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/debug-button.png)
-5. In the launched browser, select the Add button to load the app in Teams
-6. [If you selected http trigger] Open Windows PowerShell and post a HTTP request to trigger 
-the notification(replace <endpoint> with real endpoint, for example localhost:5130):
-
-   Invoke-WebRequest -Uri "http://<endpoint>/api/notification" -Method Post
-   
-{{/enableTestToolByDefault}}
 
 ## Start multiple profiles
 Instead of launching the app in Teams client with default profile, you can also run your app with other profile like App Test Tool, office.com and outlook or even Copilot. You can select profile to start.
@@ -34,20 +17,11 @@ Instead of launching the app in Teams client with default profile, you can also 
 2. Check "Enable Multi-Project Launch Profiles"
 </br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/enable-multiple-profiles-feature.png)
 
-{{^enableTestToolByDefault}}
-### Start the app in Teams App Test Tool
-1. Select `Teams App Test Tool (browser)` in debug dropdown menu
-</br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/switch-to-test-tool.png)
-2. Press F5, or select the Debug > Start Debugging menu in Visual Studio
-</br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/debug-button.png)
-{{/enableTestToolByDefault}}
-{{#enableTestToolByDefault}}
 ### Start the app in Microsoft Teams
 1. In the debug dropdown menu, select `Microsoft Teams (browser)`.
 </br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/switch-to-teams.png)
 2. Press F5, or select the Debug > Start Debugging menu in Visual Studio
 </br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/debug-button.png)
-{{/enableTestToolByDefault}}
 
 ## Learn more
 

--- a/templates/csharp/notification-http-timer-trigger/.{{NewProjectTypeName}}/launchSettings.json.tpl
+++ b/templates/csharp/notification-http-timer-trigger/.{{NewProjectTypeName}}/launchSettings.json.tpl
@@ -1,25 +1,15 @@
 {
   "profiles": {
-{{#enableTestToolByDefault}}
     // Launch project within Teams App Test Tool
     "Teams App Test Tool (browser)": {
       "commandName": "Project",
       "launchTestTool": true,
       "launchUrl": "http://localhost:56150",
     },
-{{/enableTestToolByDefault}}
     // Launch project within Teams
     "Microsoft Teams (browser)": {
       "commandName": "Project",
       "launchUrl": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&appTenantId=${{TEAMS_APP_TENANT_ID}}&login_hint=${{TEAMSFX_M365_USER_NAME}}",
     },
-{{^enableTestToolByDefault}}
-    // Launch project within Teams App Test Tool
-    "Teams App Test Tool (browser)": {
-      "commandName": "Project",
-      "launchTestTool": true,
-      "launchUrl": "http://localhost:56150",
-    },
-{{/enableTestToolByDefault}}
   }
 }

--- a/templates/csharp/notification-http-timer-trigger/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
+++ b/templates/csharp/notification-http-timer-trigger/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
@@ -4,11 +4,6 @@
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup>
-{{#enableTestToolByDefault}}
     <ActiveDebugProfile>Teams App Test Tool (browser)</ActiveDebugProfile>
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-    <ActiveDebugProfile>Microsoft Teams (browser)</ActiveDebugProfile>
-{{/enableTestToolByDefault}}
   </PropertyGroup>
 </Project>

--- a/templates/csharp/notification-http-timer-trigger/.{{NewProjectTypeName}}/{{ProjectName}}.slnLaunch.user.tpl
+++ b/templates/csharp/notification-http-timer-trigger/.{{NewProjectTypeName}}/{{ProjectName}}.slnLaunch.user.tpl
@@ -1,5 +1,4 @@
 [
-{{#enableTestToolByDefault}}
   {
     "Name": "Teams App Test Tool (browser)",
     "Projects": [
@@ -20,7 +19,6 @@
       }
     ]
   },
-{{/enableTestToolByDefault}}
   {
     "Name": "Microsoft Teams (browser)",
     "Projects": [
@@ -40,30 +38,5 @@
         "DebugTarget": "Start Project"
       }
     ]
-{{#enableTestToolByDefault}}
   }
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-  },
-  {
-    "Name": "Teams App Test Tool (browser)",
-    "Projects": [
-      {
-        "Name": "{{NewProjectTypeName}}\\{{NewProjectTypeName}}.{{NewProjectTypeExt}}",
-        "Action": "StartWithoutDebugging",
-        "DebugTarget": "Teams App Test Tool (browser)"
-      },
-      {
-{{#PlaceProjectFileInSolutionDir}}
-        "Name": "{{ProjectName}}.csproj",
-{{/PlaceProjectFileInSolutionDir}}
-{{^PlaceProjectFileInSolutionDir}}
-        "Name": "{{ProjectName}}\\{{ProjectName}}.csproj",
-{{/PlaceProjectFileInSolutionDir}}
-        "Action": "Start",
-        "DebugTarget": "Teams App Test Tool"
-      }
-    ]
-  }
-{{/enableTestToolByDefault}}
 ]

--- a/templates/csharp/notification-http-timer-trigger/GettingStarted.md.tpl
+++ b/templates/csharp/notification-http-timer-trigger/GettingStarted.md.tpl
@@ -2,7 +2,6 @@
 
 ## Quick Start
 
-{{#enableTestToolByDefault}}
 1. Press F5, or select the Debug > Start Debugging menu in Visual Studio
 2. Teams App Test Tool will be opened in the launched browser 
 3. [If you selected http trigger] Open Windows PowerShell and post a HTTP request to trigger 
@@ -10,20 +9,6 @@ the notification(replace <endpoint> with real endpoint, for example localhost:51
 
    Invoke-WebRequest -Uri "http://<endpoint>/api/notification" -Method Post
    
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-1. In the debug dropdown menu, select Dev Tunnels > Create A Tunnel (set authentication type to Public) or select an existing public dev tunnel
-2. Right-click your project and select Teams Toolkit > Prepare Teams App Dependencies
-3. If prompted, sign in with a Microsoft 365 account for the Teams organization you want 
-to install the app to
-4. Press F5, or select the Debug > Start Debugging menu in Visual Studio
-5. In the launched browser, select the Add button to load the app in Teams
-6. [If you selected http trigger] Open Windows PowerShell and post a HTTP request to trigger 
-the notification(replace <endpoint> with real endpoint, for example localhost:5130):
-
-   Invoke-WebRequest -Uri "http://<endpoint>/api/notification" -Method Post
-   
-{{/enableTestToolByDefault}}
 ## Learn more
 
 New to Teams app development or Teams Toolkit? Learn more about 

--- a/templates/csharp/notification-http-timer-trigger/Properties/launchSettings.json.tpl
+++ b/templates/csharp/notification-http-timer-trigger/Properties/launchSettings.json.tpl
@@ -1,7 +1,6 @@
 {
   "profiles": {
 {{^isNewProjectTypeEnabled}}
-{{#enableTestToolByDefault}}
     // Debug project within Teams App Test Tool
     "Teams App Test Tool (browser)": {
       "commandName": "Project",
@@ -16,7 +15,6 @@
         "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "../../.." // Path to project folder $(MSBuildProjectDirectory)
       }
     },
-{{/enableTestToolByDefault}}
     // Debug project within Teams
     "Microsoft Teams (browser)": {
       "commandName": "Project",
@@ -29,22 +27,6 @@
         "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "../../.." // Path to project folder $(MSBuildProjectDirectory)
       }
     },
-{{^enableTestToolByDefault}}
-    // Debug project within Teams App Test Tool
-    "Teams App Test Tool (browser)": {
-      "commandName": "Project",
-      "commandLineArgs": "host start --port 5130 --pause-on-error",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "launchTestTool": true,
-      "launchUrl": "http://localhost:56150",
-      "environmentVariables": {
-        "AZURE_FUNCTIONS_ENVIRONMENT": "TestTool",
-        "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.testtoolstore.json",
-        "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "../../.." // Path to project folder $(MSBuildProjectDirectory)
-      }
-    },
-{{/enableTestToolByDefault}}
     //// Uncomment following profile to debug project only (without launching Teams)
     //,
     //"Start Project (not in Teams)": {
@@ -58,7 +40,6 @@
     //}
 {{/isNewProjectTypeEnabled}}
 {{#isNewProjectTypeEnabled}}
-{{#enableTestToolByDefault}}
     // Launch project with TestTool environment, will be used by Teams App Test Tool
     "Teams App Test Tool": {
       "commandName": "Project",
@@ -71,7 +52,6 @@
         "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "../../.."
       }
     },
-{{/enableTestToolByDefault}}
     // Launch project directly
     "Start Project": {
       "commandName": "Project",
@@ -83,20 +63,6 @@
         "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "../../.."
       }
     },
-{{^enableTestToolByDefault}}
-    // Launch project with TestTool environment, will be used by Teams App Test Tool
-    "Teams App Test Tool": {
-      "commandName": "Project",
-      "commandLineArgs": "host start --port 5130 --pause-on-error",
-      "dotnetRunMessages": true,
-      "environmentVariables": {
-        "AZURE_FUNCTIONS_ENVIRONMENT": "TestTool",
-        "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.testtoolstore.json",
-        // Path to project folder $(MSBuildProjectDirectory), used in Microsoft.TeamsFx package.
-        "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "../../.."
-      }
-    },
-{{/enableTestToolByDefault}}
 {{/isNewProjectTypeEnabled}}
   }
 }

--- a/templates/csharp/notification-http-trigger-isolated/.{{NewProjectTypeName}}/GettingStarted.md.tpl
+++ b/templates/csharp/notification-http-trigger-isolated/.{{NewProjectTypeName}}/GettingStarted.md.tpl
@@ -2,7 +2,6 @@
 
 ## Quick Start
 
-{{#enableTestToolByDefault}}
 1. Press F5, or select the Debug > Start Debugging menu in Visual Studio
 </br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/debug-button.png)
 2. Teams App Test Tool will be opened in the launched browser 
@@ -11,22 +10,6 @@ the notification(replace <endpoint> with real endpoint, for example localhost:51
 
    Invoke-WebRequest -Uri "http://<endpoint>/api/notification" -Method Post
    
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-1. In the debug dropdown menu, select Dev Tunnels > Create A Tunnel (set authentication type to Public) or select an existing public dev tunnel
-</br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/create-devtunnel-button.png)
-2. Right-click your `{{NewProjectTypeName}}` project and select Teams Toolkit > Prepare Teams App Dependencies
-3. If prompted, sign in with a Microsoft 365 account for the Teams organization you want 
-to install the app to
-4. Press F5, or select the Debug > Start Debugging menu in Visual Studio
-</br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/debug-button.png)
-5. In the launched browser, select the Add button to load the app in Teams
-6. [If you selected http trigger] Open Windows PowerShell and post a HTTP request to trigger 
-the notification(replace <endpoint> with real endpoint, for example localhost:5130):
-
-   Invoke-WebRequest -Uri "http://<endpoint>/api/notification" -Method Post
-   
-{{/enableTestToolByDefault}}
 
 ## Start multiple profiles
 Instead of launching the app in Teams client with default profile, you can also run your app with other profile like App Test Tool, office.com and outlook or even Copilot. You can select profile to start.
@@ -34,20 +17,11 @@ Instead of launching the app in Teams client with default profile, you can also 
 2. Check "Enable Multi-Project Launch Profiles"
 </br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/enable-multiple-profiles-feature.png)
 
-{{^enableTestToolByDefault}}
-### Start the app in Teams App Test Tool
-1. Select `Teams App Test Tool (browser)` in debug dropdown menu
-</br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/switch-to-test-tool.png)
-2. Press F5, or select the Debug > Start Debugging menu in Visual Studio
-</br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/debug-button.png)
-{{/enableTestToolByDefault}}
-{{#enableTestToolByDefault}}
 ### Start the app in Microsoft Teams
 1. In the debug dropdown menu, select `Microsoft Teams (browser)`.
 </br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/switch-to-teams.png)
 2. Press F5, or select the Debug > Start Debugging menu in Visual Studio
 </br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/debug-button.png)
-{{/enableTestToolByDefault}}
 
 ## Learn more
 

--- a/templates/csharp/notification-http-trigger-isolated/.{{NewProjectTypeName}}/launchSettings.json.tpl
+++ b/templates/csharp/notification-http-trigger-isolated/.{{NewProjectTypeName}}/launchSettings.json.tpl
@@ -1,25 +1,15 @@
 {
   "profiles": {
-{{#enableTestToolByDefault}}
     // Launch project within Teams App Test Tool
     "Teams App Test Tool (browser)": {
       "commandName": "Project",
       "launchTestTool": true,
       "launchUrl": "http://localhost:56150",
     },
-{{/enableTestToolByDefault}}
     // Launch project within Teams
     "Microsoft Teams (browser)": {
       "commandName": "Project",
       "launchUrl": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&appTenantId=${{TEAMS_APP_TENANT_ID}}&login_hint=${{TEAMSFX_M365_USER_NAME}}",
     },
-{{^enableTestToolByDefault}}
-    // Launch project within Teams App Test Tool
-    "Teams App Test Tool (browser)": {
-      "commandName": "Project",
-      "launchTestTool": true,
-      "launchUrl": "http://localhost:56150",
-    },
-{{/enableTestToolByDefault}}
   }
 }

--- a/templates/csharp/notification-http-trigger-isolated/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
+++ b/templates/csharp/notification-http-trigger-isolated/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
@@ -4,11 +4,6 @@
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup>
-{{#enableTestToolByDefault}}
     <ActiveDebugProfile>Teams App Test Tool (browser)</ActiveDebugProfile>
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-    <ActiveDebugProfile>Microsoft Teams (browser)</ActiveDebugProfile>
-{{/enableTestToolByDefault}}
   </PropertyGroup>
 </Project>

--- a/templates/csharp/notification-http-trigger-isolated/.{{NewProjectTypeName}}/{{ProjectName}}.slnLaunch.user.tpl
+++ b/templates/csharp/notification-http-trigger-isolated/.{{NewProjectTypeName}}/{{ProjectName}}.slnLaunch.user.tpl
@@ -1,5 +1,4 @@
 [
-{{#enableTestToolByDefault}}
   {
     "Name": "Teams App Test Tool (browser)",
     "Projects": [
@@ -20,7 +19,6 @@
       }
     ]
   },
-{{/enableTestToolByDefault}}
   {
     "Name": "Microsoft Teams (browser)",
     "Projects": [
@@ -40,30 +38,5 @@
         "DebugTarget": "Start Project"
       }
     ]
-{{#enableTestToolByDefault}}
   }
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-  },
-  {
-    "Name": "Teams App Test Tool (browser)",
-    "Projects": [
-      {
-        "Name": "{{NewProjectTypeName}}\\{{NewProjectTypeName}}.{{NewProjectTypeExt}}",
-        "Action": "StartWithoutDebugging",
-        "DebugTarget": "Teams App Test Tool (browser)"
-      },
-      {
-{{#PlaceProjectFileInSolutionDir}}
-        "Name": "{{ProjectName}}.csproj",
-{{/PlaceProjectFileInSolutionDir}}
-{{^PlaceProjectFileInSolutionDir}}
-        "Name": "{{ProjectName}}\\{{ProjectName}}.csproj",
-{{/PlaceProjectFileInSolutionDir}}
-        "Action": "Start",
-        "DebugTarget": "Teams App Test Tool"
-      }
-    ]
-  }
-{{/enableTestToolByDefault}}
 ]

--- a/templates/csharp/notification-http-trigger-isolated/GettingStarted.md.tpl
+++ b/templates/csharp/notification-http-trigger-isolated/GettingStarted.md.tpl
@@ -2,7 +2,6 @@
 
 ## Quick Start
 
-{{#enableTestToolByDefault}}
 1. Press F5, or select the Debug > Start Debugging menu in Visual Studio
 2. Teams App Test Tool will be opened in the launched browser 
 3. [If you selected http trigger] Open Windows PowerShell and post a HTTP request to trigger 
@@ -10,20 +9,6 @@ the notification(replace <endpoint> with real endpoint, for example localhost:51
 
    Invoke-WebRequest -Uri "http://<endpoint>/api/notification" -Method Post
    
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-1. In the debug dropdown menu, select Dev Tunnels > Create A Tunnel (set authentication type to Public) or select an existing public dev tunnel
-2. Right-click your project and select Teams Toolkit > Prepare Teams App Dependencies
-3. If prompted, sign in with a Microsoft 365 account for the Teams organization you want 
-to install the app to
-4. Press F5, or select the Debug > Start Debugging menu in Visual Studio
-5. In the launched browser, select the Add button to load the app in Teams
-6. [If you selected http trigger] Open Windows PowerShell and post a HTTP request to trigger 
-the notification(replace <endpoint> with real endpoint, for example localhost:5130):
-
-   Invoke-WebRequest -Uri "http://<endpoint>/api/notification" -Method Post
-   
-{{/enableTestToolByDefault}}
 ## Learn more
 
 New to Teams app development or Teams Toolkit? Learn more about 

--- a/templates/csharp/notification-http-trigger-isolated/Properties/launchSettings.json.tpl
+++ b/templates/csharp/notification-http-trigger-isolated/Properties/launchSettings.json.tpl
@@ -1,7 +1,6 @@
 {
   "profiles": {
 {{^isNewProjectTypeEnabled}}
-{{#enableTestToolByDefault}}
     // Debug project within Teams App Test Tool
     "Teams App Test Tool (browser)": {
       "commandName": "Project",
@@ -16,7 +15,6 @@
         "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "../../.." // Path to project folder $(MSBuildProjectDirectory)
       }
     },
-{{/enableTestToolByDefault}}
     // Debug project within Teams
     "Microsoft Teams (browser)": {
       "commandName": "Project",
@@ -29,22 +27,6 @@
         "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "../../.." // Path to project folder $(MSBuildProjectDirectory)
       }
     },
-{{^enableTestToolByDefault}}
-    // Debug project within Teams App Test Tool
-    "Teams App Test Tool (browser)": {
-      "commandName": "Project",
-      "commandLineArgs": "host start --port 5130 --pause-on-error",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "launchTestTool": true,
-      "launchUrl": "http://localhost:56150",
-      "environmentVariables": {
-        "AZURE_FUNCTIONS_ENVIRONMENT": "TestTool",
-        "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.testtoolstore.json",
-        "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "../../.." // Path to project folder $(MSBuildProjectDirectory)
-      }
-    },
-{{/enableTestToolByDefault}}
     //// Uncomment following profile to debug project only (without launching Teams)
     //,
     //"Start Project (not in Teams)": {
@@ -58,7 +40,6 @@
     //}
 {{/isNewProjectTypeEnabled}}
 {{#isNewProjectTypeEnabled}}
-{{#enableTestToolByDefault}}
     // Launch project with TestTool environment, will be used by Teams App Test Tool
     "Teams App Test Tool": {
       "commandName": "Project",
@@ -71,7 +52,6 @@
         "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "../../.."
       }
     },
-{{/enableTestToolByDefault}}
     // Launch project directly
     "Start Project": {
       "commandName": "Project",
@@ -83,20 +63,6 @@
         "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "../../.."
       }
     },
-{{^enableTestToolByDefault}}
-    // Launch project with TestTool environment, will be used by Teams App Test Tool
-    "Teams App Test Tool": {
-      "commandName": "Project",
-      "commandLineArgs": "host start --port 5130 --pause-on-error",
-      "dotnetRunMessages": true,
-      "environmentVariables": {
-        "AZURE_FUNCTIONS_ENVIRONMENT": "TestTool",
-        "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.testtoolstore.json",
-        // Path to project folder $(MSBuildProjectDirectory), used in Microsoft.TeamsFx package.
-        "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "../../.."
-      }
-    },
-{{/enableTestToolByDefault}}
 {{/isNewProjectTypeEnabled}}
   }
 }

--- a/templates/csharp/notification-http-trigger/.{{NewProjectTypeName}}/GettingStarted.md.tpl
+++ b/templates/csharp/notification-http-trigger/.{{NewProjectTypeName}}/GettingStarted.md.tpl
@@ -2,7 +2,6 @@
 
 ## Quick Start
 
-{{#enableTestToolByDefault}}
 1. Press F5, or select the Debug > Start Debugging menu in Visual Studio
 </br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/debug-button.png)
 2. Teams App Test Tool will be opened in the launched browser 
@@ -11,22 +10,6 @@ the notification(replace <endpoint> with real endpoint, for example localhost:51
 
    Invoke-WebRequest -Uri "http://<endpoint>/api/notification" -Method Post
    
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-1. In the debug dropdown menu, select Dev Tunnels > Create A Tunnel (set authentication type to Public) or select an existing public dev tunnel
-</br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/create-devtunnel-button.png)
-2. Right-click your `{{NewProjectTypeName}}` project and select Teams Toolkit > Prepare Teams App Dependencies
-3. If prompted, sign in with a Microsoft 365 account for the Teams organization you want 
-to install the app to
-4. Press F5, or select the Debug > Start Debugging menu in Visual Studio
-</br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/debug-button.png)
-5. In the launched browser, select the Add button to load the app in Teams
-6. [If you selected http trigger] Open Windows PowerShell and post a HTTP request to trigger 
-the notification(replace <endpoint> with real endpoint, for example localhost:5130):
-
-   Invoke-WebRequest -Uri "http://<endpoint>/api/notification" -Method Post
-   
-{{/enableTestToolByDefault}}
 
 ## Start multiple profiles
 Instead of launching the app in Teams client with default profile, you can also run your app with other profile like App Test Tool, office.com and outlook or even Copilot. You can select profile to start.
@@ -34,20 +17,11 @@ Instead of launching the app in Teams client with default profile, you can also 
 2. Check "Enable Multi-Project Launch Profiles"
 </br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/enable-multiple-profiles-feature.png)
 
-{{^enableTestToolByDefault}}
-### Start the app in Teams App Test Tool
-1. Select `Teams App Test Tool (browser)` in debug dropdown menu
-</br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/switch-to-test-tool.png)
-2. Press F5, or select the Debug > Start Debugging menu in Visual Studio
-</br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/debug-button.png)
-{{/enableTestToolByDefault}}
-{{#enableTestToolByDefault}}
 ### Start the app in Microsoft Teams
 1. In the debug dropdown menu, select `Microsoft Teams (browser)`.
 </br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/switch-to-teams.png)
 2. Press F5, or select the Debug > Start Debugging menu in Visual Studio
 </br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/debug-button.png)
-{{/enableTestToolByDefault}}
 
 ## Learn more
 

--- a/templates/csharp/notification-http-trigger/.{{NewProjectTypeName}}/launchSettings.json.tpl
+++ b/templates/csharp/notification-http-trigger/.{{NewProjectTypeName}}/launchSettings.json.tpl
@@ -1,25 +1,15 @@
 {
   "profiles": {
-{{#enableTestToolByDefault}}
     // Launch project within Teams App Test Tool
     "Teams App Test Tool (browser)": {
       "commandName": "Project",
       "launchTestTool": true,
       "launchUrl": "http://localhost:56150",
     },
-{{/enableTestToolByDefault}}
     // Launch project within Teams
     "Microsoft Teams (browser)": {
       "commandName": "Project",
       "launchUrl": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&appTenantId=${{TEAMS_APP_TENANT_ID}}&login_hint=${{TEAMSFX_M365_USER_NAME}}",
     },
-{{^enableTestToolByDefault}}
-    // Launch project within Teams App Test Tool
-    "Teams App Test Tool (browser)": {
-      "commandName": "Project",
-      "launchTestTool": true,
-      "launchUrl": "http://localhost:56150",
-    },
-{{/enableTestToolByDefault}}
   }
 }

--- a/templates/csharp/notification-http-trigger/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
+++ b/templates/csharp/notification-http-trigger/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
@@ -4,11 +4,6 @@
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup>
-{{#enableTestToolByDefault}}
     <ActiveDebugProfile>Teams App Test Tool (browser)</ActiveDebugProfile>
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-    <ActiveDebugProfile>Microsoft Teams (browser)</ActiveDebugProfile>
-{{/enableTestToolByDefault}}
   </PropertyGroup>
 </Project>

--- a/templates/csharp/notification-http-trigger/.{{NewProjectTypeName}}/{{ProjectName}}.slnLaunch.user.tpl
+++ b/templates/csharp/notification-http-trigger/.{{NewProjectTypeName}}/{{ProjectName}}.slnLaunch.user.tpl
@@ -1,5 +1,4 @@
 [
-{{#enableTestToolByDefault}}
   {
     "Name": "Teams App Test Tool (browser)",
     "Projects": [
@@ -20,7 +19,6 @@
       }
     ]
   },
-{{/enableTestToolByDefault}}
   {
     "Name": "Microsoft Teams (browser)",
     "Projects": [
@@ -40,30 +38,5 @@
         "DebugTarget": "Start Project"
       }
     ]
-{{#enableTestToolByDefault}}
   }
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-  },
-  {
-    "Name": "Teams App Test Tool (browser)",
-    "Projects": [
-      {
-        "Name": "{{NewProjectTypeName}}\\{{NewProjectTypeName}}.{{NewProjectTypeExt}}",
-        "Action": "StartWithoutDebugging",
-        "DebugTarget": "Teams App Test Tool (browser)"
-      },
-      {
-{{#PlaceProjectFileInSolutionDir}}
-        "Name": "{{ProjectName}}.csproj",
-{{/PlaceProjectFileInSolutionDir}}
-{{^PlaceProjectFileInSolutionDir}}
-        "Name": "{{ProjectName}}\\{{ProjectName}}.csproj",
-{{/PlaceProjectFileInSolutionDir}}
-        "Action": "Start",
-        "DebugTarget": "Teams App Test Tool"
-      }
-    ]
-  }
-{{/enableTestToolByDefault}}
 ]

--- a/templates/csharp/notification-http-trigger/GettingStarted.md.tpl
+++ b/templates/csharp/notification-http-trigger/GettingStarted.md.tpl
@@ -2,7 +2,6 @@
 
 ## Quick Start
 
-{{#enableTestToolByDefault}}
 1. Press F5, or select the Debug > Start Debugging menu in Visual Studio
 2. Teams App Test Tool will be opened in the launched browser 
 3. [If you selected http trigger] Open Windows PowerShell and post a HTTP request to trigger 
@@ -10,20 +9,6 @@ the notification(replace <endpoint> with real endpoint, for example localhost:51
 
    Invoke-WebRequest -Uri "http://<endpoint>/api/notification" -Method Post
    
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-1. In the debug dropdown menu, select Dev Tunnels > Create A Tunnel (set authentication type to Public) or select an existing public dev tunnel
-2. Right-click your project and select Teams Toolkit > Prepare Teams App Dependencies
-3. If prompted, sign in with a Microsoft 365 account for the Teams organization you want 
-to install the app to
-4. Press F5, or select the Debug > Start Debugging menu in Visual Studio
-5. In the launched browser, select the Add button to load the app in Teams
-6. [If you selected http trigger] Open Windows PowerShell and post a HTTP request to trigger 
-the notification(replace <endpoint> with real endpoint, for example localhost:5130):
-
-   Invoke-WebRequest -Uri "http://<endpoint>/api/notification" -Method Post
-   
-{{/enableTestToolByDefault}}
 ## Learn more
 
 New to Teams app development or Teams Toolkit? Learn more about 

--- a/templates/csharp/notification-http-trigger/Properties/launchSettings.json.tpl
+++ b/templates/csharp/notification-http-trigger/Properties/launchSettings.json.tpl
@@ -1,7 +1,6 @@
 {
   "profiles": {
 {{^isNewProjectTypeEnabled}}
-{{#enableTestToolByDefault}}
     // Debug project within Teams App Test Tool
     "Teams App Test Tool (browser)": {
       "commandName": "Project",
@@ -16,7 +15,6 @@
         "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "../../.." // Path to project folder $(MSBuildProjectDirectory)
       }
     },
-{{/enableTestToolByDefault}}
     // Debug project within Teams
     "Microsoft Teams (browser)": {
       "commandName": "Project",
@@ -29,22 +27,6 @@
         "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "../../.." // Path to project folder $(MSBuildProjectDirectory)
       }
     },
-{{^enableTestToolByDefault}}
-    // Debug project within Teams App Test Tool
-    "Teams App Test Tool (browser)": {
-      "commandName": "Project",
-      "commandLineArgs": "host start --port 5130 --pause-on-error",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "launchTestTool": true,
-      "launchUrl": "http://localhost:56150",
-      "environmentVariables": {
-        "AZURE_FUNCTIONS_ENVIRONMENT": "TestTool",
-        "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.testtoolstore.json",
-        "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "../../.." // Path to project folder $(MSBuildProjectDirectory)
-      }
-    },
-{{/enableTestToolByDefault}}
     //// Uncomment following profile to debug project only (without launching Teams)
     //,
     //"Start Project (not in Teams)": {
@@ -58,7 +40,6 @@
     //}
 {{/isNewProjectTypeEnabled}}
 {{#isNewProjectTypeEnabled}}
-{{#enableTestToolByDefault}}
     // Launch project with TestTool environment, will be used by Teams App Test Tool
     "Teams App Test Tool": {
       "commandName": "Project",
@@ -71,7 +52,6 @@
         "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "../../.."
       }
     },
-{{/enableTestToolByDefault}}
     // Launch project directly
     "Start Project": {
       "commandName": "Project",
@@ -83,20 +63,6 @@
         "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "../../.."
       }
     },
-{{^enableTestToolByDefault}}
-    // Launch project with TestTool environment, will be used by Teams App Test Tool
-    "Teams App Test Tool": {
-      "commandName": "Project",
-      "commandLineArgs": "host start --port 5130 --pause-on-error",
-      "dotnetRunMessages": true,
-      "environmentVariables": {
-        "AZURE_FUNCTIONS_ENVIRONMENT": "TestTool",
-        "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.testtoolstore.json",
-        // Path to project folder $(MSBuildProjectDirectory), used in Microsoft.TeamsFx package.
-        "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "../../.."
-      }
-    },
-{{/enableTestToolByDefault}}
 {{/isNewProjectTypeEnabled}}
   }
 }

--- a/templates/csharp/notification-timer-trigger-isolated/.{{NewProjectTypeName}}/GettingStarted.md.tpl
+++ b/templates/csharp/notification-timer-trigger-isolated/.{{NewProjectTypeName}}/GettingStarted.md.tpl
@@ -2,7 +2,6 @@
 
 ## Quick Start
 
-{{#enableTestToolByDefault}}
 1. Press F5, or select the Debug > Start Debugging menu in Visual Studio
 </br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/debug-button.png)
 2. Teams App Test Tool will be opened in the launched browser 
@@ -11,22 +10,6 @@ the notification(replace <endpoint> with real endpoint, for example localhost:51
 
    Invoke-WebRequest -Uri "http://<endpoint>/api/notification" -Method Post
    
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-1. In the debug dropdown menu, select Dev Tunnels > Create A Tunnel (set authentication type to Public) or select an existing public dev tunnel
-</br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/create-devtunnel-button.png)
-2. Right-click your `{{NewProjectTypeName}}` project and select Teams Toolkit > Prepare Teams App Dependencies
-3. If prompted, sign in with a Microsoft 365 account for the Teams organization you want 
-to install the app to
-4. Press F5, or select the Debug > Start Debugging menu in Visual Studio
-</br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/debug-button.png)
-5. In the launched browser, select the Add button to load the app in Teams
-6. [If you selected http trigger] Open Windows PowerShell and post a HTTP request to trigger 
-the notification(replace <endpoint> with real endpoint, for example localhost:5130):
-
-   Invoke-WebRequest -Uri "http://<endpoint>/api/notification" -Method Post
-   
-{{/enableTestToolByDefault}}
 
 ## Start multiple profiles
 Instead of launching the app in Teams client with default profile, you can also run your app with other profile like App Test Tool, office.com and outlook or even Copilot. You can select profile to start.
@@ -34,20 +17,11 @@ Instead of launching the app in Teams client with default profile, you can also 
 2. Check "Enable Multi-Project Launch Profiles"
 </br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/enable-multiple-profiles-feature.png)
 
-{{^enableTestToolByDefault}}
-### Start the app in Teams App Test Tool
-1. Select `Teams App Test Tool (browser)` in debug dropdown menu
-</br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/switch-to-test-tool.png)
-2. Press F5, or select the Debug > Start Debugging menu in Visual Studio
-</br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/debug-button.png)
-{{/enableTestToolByDefault}}
-{{#enableTestToolByDefault}}
 ### Start the app in Microsoft Teams
 1. In the debug dropdown menu, select `Microsoft Teams (browser)`.
 </br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/switch-to-teams.png)
 2. Press F5, or select the Debug > Start Debugging menu in Visual Studio
 </br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/debug-button.png)
-{{/enableTestToolByDefault}}
 
 ## Learn more
 

--- a/templates/csharp/notification-timer-trigger-isolated/.{{NewProjectTypeName}}/launchSettings.json.tpl
+++ b/templates/csharp/notification-timer-trigger-isolated/.{{NewProjectTypeName}}/launchSettings.json.tpl
@@ -1,25 +1,15 @@
 {
   "profiles": {
-{{#enableTestToolByDefault}}
     // Launch project within Teams App Test Tool
     "Teams App Test Tool (browser)": {
       "commandName": "Project",
       "launchTestTool": true,
       "launchUrl": "http://localhost:56150",
     },
-{{/enableTestToolByDefault}}
     // Launch project within Teams
     "Microsoft Teams (browser)": {
       "commandName": "Project",
       "launchUrl": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&appTenantId=${{TEAMS_APP_TENANT_ID}}&login_hint=${{TEAMSFX_M365_USER_NAME}}",
     },
-{{^enableTestToolByDefault}}
-    // Launch project within Teams App Test Tool
-    "Teams App Test Tool (browser)": {
-      "commandName": "Project",
-      "launchTestTool": true,
-      "launchUrl": "http://localhost:56150",
-    },
-{{/enableTestToolByDefault}}
   }
 }

--- a/templates/csharp/notification-timer-trigger-isolated/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
+++ b/templates/csharp/notification-timer-trigger-isolated/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
@@ -4,11 +4,6 @@
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup>
-{{#enableTestToolByDefault}}
     <ActiveDebugProfile>Teams App Test Tool (browser)</ActiveDebugProfile>
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-    <ActiveDebugProfile>Microsoft Teams (browser)</ActiveDebugProfile>
-{{/enableTestToolByDefault}}
   </PropertyGroup>
 </Project>

--- a/templates/csharp/notification-timer-trigger-isolated/.{{NewProjectTypeName}}/{{ProjectName}}.slnLaunch.user.tpl
+++ b/templates/csharp/notification-timer-trigger-isolated/.{{NewProjectTypeName}}/{{ProjectName}}.slnLaunch.user.tpl
@@ -1,5 +1,4 @@
 [
-{{#enableTestToolByDefault}}
   {
     "Name": "Teams App Test Tool (browser)",
     "Projects": [
@@ -20,7 +19,6 @@
       }
     ]
   },
-{{/enableTestToolByDefault}}
   {
     "Name": "Microsoft Teams (browser)",
     "Projects": [
@@ -40,30 +38,5 @@
         "DebugTarget": "Start Project"
       }
     ]
-{{#enableTestToolByDefault}}
   }
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-  },
-  {
-    "Name": "Teams App Test Tool (browser)",
-    "Projects": [
-      {
-        "Name": "{{NewProjectTypeName}}\\{{NewProjectTypeName}}.{{NewProjectTypeExt}}",
-        "Action": "StartWithoutDebugging",
-        "DebugTarget": "Teams App Test Tool (browser)"
-      },
-      {
-{{#PlaceProjectFileInSolutionDir}}
-        "Name": "{{ProjectName}}.csproj",
-{{/PlaceProjectFileInSolutionDir}}
-{{^PlaceProjectFileInSolutionDir}}
-        "Name": "{{ProjectName}}\\{{ProjectName}}.csproj",
-{{/PlaceProjectFileInSolutionDir}}
-        "Action": "Start",
-        "DebugTarget": "Teams App Test Tool"
-      }
-    ]
-  }
-{{/enableTestToolByDefault}}
 ]

--- a/templates/csharp/notification-timer-trigger-isolated/GettingStarted.md.tpl
+++ b/templates/csharp/notification-timer-trigger-isolated/GettingStarted.md.tpl
@@ -2,7 +2,6 @@
 
 ## Quick Start
 
-{{#enableTestToolByDefault}}
 1. Press F5, or select the Debug > Start Debugging menu in Visual Studio
 2. Teams App Test Tool will be opened in the launched browser 
 3. [If you selected http trigger] Open Windows PowerShell and post a HTTP request to trigger 
@@ -10,20 +9,6 @@ the notification(replace <endpoint> with real endpoint, for example localhost:51
 
    Invoke-WebRequest -Uri "http://<endpoint>/api/notification" -Method Post
    
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-1. In the debug dropdown menu, select Dev Tunnels > Create A Tunnel (set authentication type to Public) or select an existing public dev tunnel
-2. Right-click your project and select Teams Toolkit > Prepare Teams App Dependencies
-3. If prompted, sign in with a Microsoft 365 account for the Teams organization you want 
-to install the app to
-4. Press F5, or select the Debug > Start Debugging menu in Visual Studio
-5. In the launched browser, select the Add button to load the app in Teams
-6. [If you selected http trigger] Open Windows PowerShell and post a HTTP request to trigger 
-the notification(replace <endpoint> with real endpoint, for example localhost:5130):
-
-   Invoke-WebRequest -Uri "http://<endpoint>/api/notification" -Method Post
-   
-{{/enableTestToolByDefault}}
 ## Learn more
 
 New to Teams app development or Teams Toolkit? Learn more about 

--- a/templates/csharp/notification-timer-trigger-isolated/Properties/launchSettings.json.tpl
+++ b/templates/csharp/notification-timer-trigger-isolated/Properties/launchSettings.json.tpl
@@ -1,7 +1,6 @@
 {
   "profiles": {
 {{^isNewProjectTypeEnabled}}
-{{#enableTestToolByDefault}}
     // Debug project within Teams App Test Tool
     "Teams App Test Tool (browser)": {
       "commandName": "Project",
@@ -16,7 +15,6 @@
         "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "../../.." // Path to project folder $(MSBuildProjectDirectory)
       }
     },
-{{/enableTestToolByDefault}}
     // Debug project within Teams
     "Microsoft Teams (browser)": {
       "commandName": "Project",
@@ -29,22 +27,6 @@
         "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "../../.." // Path to project folder $(MSBuildProjectDirectory)
       }
     },
-{{^enableTestToolByDefault}}
-    // Debug project within Teams App Test Tool
-    "Teams App Test Tool (browser)": {
-      "commandName": "Project",
-      "commandLineArgs": "host start --port 5130 --pause-on-error",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "launchTestTool": true,
-      "launchUrl": "http://localhost:56150",
-      "environmentVariables": {
-        "AZURE_FUNCTIONS_ENVIRONMENT": "TestTool",
-        "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.testtoolstore.json",
-        "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "../../.." // Path to project folder $(MSBuildProjectDirectory)
-      }
-    },
-{{/enableTestToolByDefault}}
     //// Uncomment following profile to debug project only (without launching Teams)
     //,
     //"Start Project (not in Teams)": {
@@ -58,7 +40,6 @@
     //}
 {{/isNewProjectTypeEnabled}}
 {{#isNewProjectTypeEnabled}}
-{{#enableTestToolByDefault}}
     // Launch project with TestTool environment, will be used by Teams App Test Tool
     "Teams App Test Tool": {
       "commandName": "Project",
@@ -71,7 +52,6 @@
         "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "../../.."
       }
     },
-{{/enableTestToolByDefault}}
     // Launch project directly
     "Start Project": {
       "commandName": "Project",
@@ -83,20 +63,6 @@
         "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "../../.."
       }
     },
-{{^enableTestToolByDefault}}
-    // Launch project with TestTool environment, will be used by Teams App Test Tool
-    "Teams App Test Tool": {
-      "commandName": "Project",
-      "commandLineArgs": "host start --port 5130 --pause-on-error",
-      "dotnetRunMessages": true,
-      "environmentVariables": {
-        "AZURE_FUNCTIONS_ENVIRONMENT": "TestTool",
-        "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.testtoolstore.json",
-        // Path to project folder $(MSBuildProjectDirectory), used in Microsoft.TeamsFx package.
-        "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "../../.."
-      }
-    },
-{{/enableTestToolByDefault}}
 {{/isNewProjectTypeEnabled}}
   }
 }

--- a/templates/csharp/notification-timer-trigger/.{{NewProjectTypeName}}/GettingStarted.md.tpl
+++ b/templates/csharp/notification-timer-trigger/.{{NewProjectTypeName}}/GettingStarted.md.tpl
@@ -2,7 +2,6 @@
 
 ## Quick Start
 
-{{#enableTestToolByDefault}}
 1. Press F5, or select the Debug > Start Debugging menu in Visual Studio
 </br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/debug-button.png)
 2. Teams App Test Tool will be opened in the launched browser 
@@ -11,22 +10,6 @@ the notification(replace <endpoint> with real endpoint, for example localhost:51
 
    Invoke-WebRequest -Uri "http://<endpoint>/api/notification" -Method Post
    
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-1. In the debug dropdown menu, select Dev Tunnels > Create A Tunnel (set authentication type to Public) or select an existing public dev tunnel
-</br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/create-devtunnel-button.png)
-2. Right-click your `{{NewProjectTypeName}}` project and select Teams Toolkit > Prepare Teams App Dependencies
-3. If prompted, sign in with a Microsoft 365 account for the Teams organization you want 
-to install the app to
-4. Press F5, or select the Debug > Start Debugging menu in Visual Studio
-</br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/debug-button.png)
-5. In the launched browser, select the Add button to load the app in Teams
-6. [If you selected http trigger] Open Windows PowerShell and post a HTTP request to trigger 
-the notification(replace <endpoint> with real endpoint, for example localhost:5130):
-
-   Invoke-WebRequest -Uri "http://<endpoint>/api/notification" -Method Post
-   
-{{/enableTestToolByDefault}}
 
 ## Start multiple profiles
 Instead of launching the app in Teams client with default profile, you can also run your app with other profile like App Test Tool, office.com and outlook or even Copilot. You can select profile to start.
@@ -34,20 +17,11 @@ Instead of launching the app in Teams client with default profile, you can also 
 2. Check "Enable Multi-Project Launch Profiles"
 </br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/enable-multiple-profiles-feature.png)
 
-{{^enableTestToolByDefault}}
-### Start the app in Teams App Test Tool
-1. Select `Teams App Test Tool (browser)` in debug dropdown menu
-</br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/switch-to-test-tool.png)
-2. Press F5, or select the Debug > Start Debugging menu in Visual Studio
-</br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/debug-button.png)
-{{/enableTestToolByDefault}}
-{{#enableTestToolByDefault}}
 ### Start the app in Microsoft Teams
 1. In the debug dropdown menu, select `Microsoft Teams (browser)`.
 </br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/switch-to-teams.png)
 2. Press F5, or select the Debug > Start Debugging menu in Visual Studio
 </br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/debug-button.png)
-{{/enableTestToolByDefault}}
 
 ## Learn more
 

--- a/templates/csharp/notification-timer-trigger/.{{NewProjectTypeName}}/launchSettings.json.tpl
+++ b/templates/csharp/notification-timer-trigger/.{{NewProjectTypeName}}/launchSettings.json.tpl
@@ -1,25 +1,15 @@
 {
   "profiles": {
-{{#enableTestToolByDefault}}
     // Launch project within Teams App Test Tool
     "Teams App Test Tool (browser)": {
       "commandName": "Project",
       "launchTestTool": true,
       "launchUrl": "http://localhost:56150",
     },
-{{/enableTestToolByDefault}}
     // Launch project within Teams
     "Microsoft Teams (browser)": {
       "commandName": "Project",
       "launchUrl": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&appTenantId=${{TEAMS_APP_TENANT_ID}}&login_hint=${{TEAMSFX_M365_USER_NAME}}",
     },
-{{^enableTestToolByDefault}}
-    // Launch project within Teams App Test Tool
-    "Teams App Test Tool (browser)": {
-      "commandName": "Project",
-      "launchTestTool": true,
-      "launchUrl": "http://localhost:56150",
-    },
-{{/enableTestToolByDefault}}
   }
 }

--- a/templates/csharp/notification-timer-trigger/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
+++ b/templates/csharp/notification-timer-trigger/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
@@ -4,11 +4,6 @@
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup>
-{{#enableTestToolByDefault}}
     <ActiveDebugProfile>Teams App Test Tool (browser)</ActiveDebugProfile>
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-    <ActiveDebugProfile>Microsoft Teams (browser)</ActiveDebugProfile>
-{{/enableTestToolByDefault}}
   </PropertyGroup>
 </Project>

--- a/templates/csharp/notification-timer-trigger/.{{NewProjectTypeName}}/{{ProjectName}}.slnLaunch.user.tpl
+++ b/templates/csharp/notification-timer-trigger/.{{NewProjectTypeName}}/{{ProjectName}}.slnLaunch.user.tpl
@@ -1,5 +1,4 @@
 [
-{{#enableTestToolByDefault}}
   {
     "Name": "Teams App Test Tool (browser)",
     "Projects": [
@@ -20,7 +19,6 @@
       }
     ]
   },
-{{/enableTestToolByDefault}}
   {
     "Name": "Microsoft Teams (browser)",
     "Projects": [
@@ -40,30 +38,5 @@
         "DebugTarget": "Start Project"
       }
     ]
-{{#enableTestToolByDefault}}
   }
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-  },
-  {
-    "Name": "Teams App Test Tool (browser)",
-    "Projects": [
-      {
-        "Name": "{{NewProjectTypeName}}\\{{NewProjectTypeName}}.{{NewProjectTypeExt}}",
-        "Action": "StartWithoutDebugging",
-        "DebugTarget": "Teams App Test Tool (browser)"
-      },
-      {
-{{#PlaceProjectFileInSolutionDir}}
-        "Name": "{{ProjectName}}.csproj",
-{{/PlaceProjectFileInSolutionDir}}
-{{^PlaceProjectFileInSolutionDir}}
-        "Name": "{{ProjectName}}\\{{ProjectName}}.csproj",
-{{/PlaceProjectFileInSolutionDir}}
-        "Action": "Start",
-        "DebugTarget": "Teams App Test Tool"
-      }
-    ]
-  }
-{{/enableTestToolByDefault}}
 ]

--- a/templates/csharp/notification-timer-trigger/GettingStarted.md.tpl
+++ b/templates/csharp/notification-timer-trigger/GettingStarted.md.tpl
@@ -2,7 +2,6 @@
 
 ## Quick Start
 
-{{#enableTestToolByDefault}}
 1. Press F5, or select the Debug > Start Debugging menu in Visual Studio
 2. Teams App Test Tool will be opened in the launched browser 
 3. [If you selected http trigger] Open Windows PowerShell and post a HTTP request to trigger 
@@ -10,20 +9,6 @@ the notification(replace <endpoint> with real endpoint, for example localhost:51
 
    Invoke-WebRequest -Uri "http://<endpoint>/api/notification" -Method Post
    
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-1. In the debug dropdown menu, select Dev Tunnels > Create A Tunnel (set authentication type to Public) or select an existing public dev tunnel
-2. Right-click your project and select Teams Toolkit > Prepare Teams App Dependencies
-3. If prompted, sign in with a Microsoft 365 account for the Teams organization you want 
-to install the app to
-4. Press F5, or select the Debug > Start Debugging menu in Visual Studio
-5. In the launched browser, select the Add button to load the app in Teams
-6. [If you selected http trigger] Open Windows PowerShell and post a HTTP request to trigger 
-the notification(replace <endpoint> with real endpoint, for example localhost:5130):
-
-   Invoke-WebRequest -Uri "http://<endpoint>/api/notification" -Method Post
-   
-{{/enableTestToolByDefault}}
 ## Learn more
 
 New to Teams app development or Teams Toolkit? Learn more about 

--- a/templates/csharp/notification-timer-trigger/Properties/launchSettings.json.tpl
+++ b/templates/csharp/notification-timer-trigger/Properties/launchSettings.json.tpl
@@ -1,7 +1,6 @@
 {
   "profiles": {
 {{^isNewProjectTypeEnabled}}
-{{#enableTestToolByDefault}}
     // Debug project within Teams App Test Tool
     "Teams App Test Tool (browser)": {
       "commandName": "Project",
@@ -16,7 +15,6 @@
         "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "../../.." // Path to project folder $(MSBuildProjectDirectory)
       }
     },
-{{/enableTestToolByDefault}}
     // Debug project within Teams
     "Microsoft Teams (browser)": {
       "commandName": "Project",
@@ -29,22 +27,6 @@
         "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "../../.." // Path to project folder $(MSBuildProjectDirectory)
       }
     },
-{{^enableTestToolByDefault}}
-    // Debug project within Teams App Test Tool
-    "Teams App Test Tool (browser)": {
-      "commandName": "Project",
-      "commandLineArgs": "host start --port 5130 --pause-on-error",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "launchTestTool": true,
-      "launchUrl": "http://localhost:56150",
-      "environmentVariables": {
-        "AZURE_FUNCTIONS_ENVIRONMENT": "TestTool",
-        "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.testtoolstore.json",
-        "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "../../.." // Path to project folder $(MSBuildProjectDirectory)
-      }
-    },
-{{/enableTestToolByDefault}}
     //// Uncomment following profile to debug project only (without launching Teams)
     //,
     //"Start Project (not in Teams)": {
@@ -58,7 +40,6 @@
     //}
 {{/isNewProjectTypeEnabled}}
 {{#isNewProjectTypeEnabled}}
-{{#enableTestToolByDefault}}
     // Launch project with TestTool environment, will be used by Teams App Test Tool
     "Teams App Test Tool": {
       "commandName": "Project",
@@ -71,7 +52,6 @@
         "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "../../.."
       }
     },
-{{/enableTestToolByDefault}}
     // Launch project directly
     "Start Project": {
       "commandName": "Project",
@@ -83,20 +63,6 @@
         "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "../../.."
       }
     },
-{{^enableTestToolByDefault}}
-    // Launch project with TestTool environment, will be used by Teams App Test Tool
-    "Teams App Test Tool": {
-      "commandName": "Project",
-      "commandLineArgs": "host start --port 5130 --pause-on-error",
-      "dotnetRunMessages": true,
-      "environmentVariables": {
-        "AZURE_FUNCTIONS_ENVIRONMENT": "TestTool",
-        "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.testtoolstore.json",
-        // Path to project folder $(MSBuildProjectDirectory), used in Microsoft.TeamsFx package.
-        "TEAMSFX_NOTIFICATION_LOCALSTORE_DIR": "../../.."
-      }
-    },
-{{/enableTestToolByDefault}}
 {{/isNewProjectTypeEnabled}}
   }
 }

--- a/templates/csharp/notification-webapi/.{{NewProjectTypeName}}/GettingStarted.md.tpl
+++ b/templates/csharp/notification-webapi/.{{NewProjectTypeName}}/GettingStarted.md.tpl
@@ -2,7 +2,6 @@
 
 ## Quick Start
 
-{{#enableTestToolByDefault}}
 1. Press F5, or select the Debug > Start Debugging menu in Visual Studio
 </br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/debug-button.png)
 2. Teams App Test Tool will be opened in the launched browser 
@@ -10,21 +9,6 @@
 
    Invoke-WebRequest -Uri "http://localhost:5130/api/notification" -Method Post
    
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-1. In the debug dropdown menu, select Dev Tunnels > Create A Tunnel (set authentication type to Public) or select an existing public dev tunnel
-</br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/create-devtunnel-button.png)
-2. Right-click your `{{NewProjectTypeName}}` project and select Teams Toolkit > Prepare Teams App Dependencies
-3. If prompted, sign in with a Microsoft 365 account for the Teams organization you want 
-to install the app to
-4. Press F5, or select the Debug > Start Debugging menu in Visual Studio
-</br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/debug-button.png)
-5. In the launched browser, select the Add button to load the app in Teams
-6. Open Windows PowerShell and post a HTTP request to trigger the notification:
-
-   Invoke-WebRequest -Uri "http://localhost:5130/api/notification" -Method Post
-
-{{/enableTestToolByDefault}}
 
 ## Start multiple profiles
 Instead of launching the app in Teams client with default profile, you can also run your app with other profile like App Test Tool, office.com and outlook or even Copilot. You can select profile to start.
@@ -32,20 +16,11 @@ Instead of launching the app in Teams client with default profile, you can also 
 2. Check "Enable Multi-Project Launch Profiles"
 </br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/enable-multiple-profiles-feature.png)
 
-{{^enableTestToolByDefault}}
-### Start the app in Teams App Test Tool
-1. Select `Teams App Test Tool (browser)` in debug dropdown menu
-</br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/switch-to-test-tool.png)
-2. Press F5, or select the Debug > Start Debugging menu in Visual Studio
-</br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/debug-button.png)
-{{/enableTestToolByDefault}}
-{{#enableTestToolByDefault}}
 ### Start the app in Microsoft Teams
 1. In the debug dropdown menu, select `Microsoft Teams (browser)`.
 </br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/switch-to-teams.png)
 2. Press F5, or select the Debug > Start Debugging menu in Visual Studio
 </br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/debug-button.png)
-{{/enableTestToolByDefault}}
 
 ## Learn more
 

--- a/templates/csharp/notification-webapi/.{{NewProjectTypeName}}/launchSettings.json.tpl
+++ b/templates/csharp/notification-webapi/.{{NewProjectTypeName}}/launchSettings.json.tpl
@@ -1,25 +1,15 @@
 {
   "profiles": {
-{{#enableTestToolByDefault}}
     // Launch project within Teams App Test Tool
     "Teams App Test Tool (browser)": {
       "commandName": "Project",
       "launchTestTool": true,
       "launchUrl": "http://localhost:56150",
     },
-{{/enableTestToolByDefault}}
     // Launch project within Teams
     "Microsoft Teams (browser)": {
       "commandName": "Project",
       "launchUrl": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&appTenantId=${{TEAMS_APP_TENANT_ID}}&login_hint=${{TEAMSFX_M365_USER_NAME}}",
     },
-{{^enableTestToolByDefault}}
-    // Launch project within Teams App Test Tool
-    "Teams App Test Tool (browser)": {
-      "commandName": "Project",
-      "launchTestTool": true,
-      "launchUrl": "http://localhost:56150",
-    },
-{{/enableTestToolByDefault}}
   }
 }

--- a/templates/csharp/notification-webapi/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
+++ b/templates/csharp/notification-webapi/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
@@ -4,11 +4,6 @@
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup>
-{{#enableTestToolByDefault}}
     <ActiveDebugProfile>Teams App Test Tool (browser)</ActiveDebugProfile>
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-    <ActiveDebugProfile>Microsoft Teams (browser)</ActiveDebugProfile>
-{{/enableTestToolByDefault}}
   </PropertyGroup>
 </Project>

--- a/templates/csharp/notification-webapi/.{{NewProjectTypeName}}/{{ProjectName}}.slnLaunch.user.tpl
+++ b/templates/csharp/notification-webapi/.{{NewProjectTypeName}}/{{ProjectName}}.slnLaunch.user.tpl
@@ -1,5 +1,4 @@
 [
-{{#enableTestToolByDefault}}
   {
     "Name": "Teams App Test Tool (browser)",
     "Projects": [
@@ -20,7 +19,6 @@
       }
     ]
   },
-{{/enableTestToolByDefault}}
   {
     "Name": "Microsoft Teams (browser)",
     "Projects": [
@@ -40,30 +38,5 @@
         "DebugTarget": "Start Project"
       }
     ]
-{{#enableTestToolByDefault}}
   }
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-  },
-  {
-    "Name": "Teams App Test Tool (browser)",
-    "Projects": [
-      {
-        "Name": "{{NewProjectTypeName}}\\{{NewProjectTypeName}}.{{NewProjectTypeExt}}",
-        "Action": "StartWithoutDebugging",
-        "DebugTarget": "Teams App Test Tool (browser)"
-      },
-      {
-{{#PlaceProjectFileInSolutionDir}}
-        "Name": "{{ProjectName}}.csproj",
-{{/PlaceProjectFileInSolutionDir}}
-{{^PlaceProjectFileInSolutionDir}}
-        "Name": "{{ProjectName}}\\{{ProjectName}}.csproj",
-{{/PlaceProjectFileInSolutionDir}}
-        "Action": "Start",
-        "DebugTarget": "Teams App Test Tool"
-      }
-    ]
-  }
-{{/enableTestToolByDefault}}
 ]

--- a/templates/csharp/notification-webapi/GettingStarted.md.tpl
+++ b/templates/csharp/notification-webapi/GettingStarted.md.tpl
@@ -2,26 +2,12 @@
 
 ## Quick Start
 
-{{#enableTestToolByDefault}}
 1. Press F5, or select the Debug > Start Debugging menu in Visual Studio
 2. Teams App Test Tool will be opened in the launched browser 
 3. Open Windows PowerShell and post a HTTP request to trigger the notification:
 
    Invoke-WebRequest -Uri "http://localhost:5130/api/notification" -Method Post
    
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-1. In the debug dropdown menu, select Dev Tunnels > Create A Tunnel (set authentication type to Public) or select an existing public dev tunnel
-2. Right-click your project and select Teams Toolkit > Prepare Teams App Dependencies
-3. If prompted, sign in with a Microsoft 365 account for the Teams organization you want 
-to install the app to
-4. Press F5, or select the Debug > Start Debugging menu in Visual Studio
-5. In the launched browser, select the Add button to load the app in Teams
-6. Open Windows PowerShell and post a HTTP request to trigger the notification:
-
-   Invoke-WebRequest -Uri "http://localhost:5130/api/notification" -Method Post
-
-{{/enableTestToolByDefault}}
 ## Learn more
 
 New to Teams app development or Teams Toolkit? Learn more about 

--- a/templates/csharp/notification-webapi/Properties/launchSettings.json.tpl
+++ b/templates/csharp/notification-webapi/Properties/launchSettings.json.tpl
@@ -1,7 +1,6 @@
 {
   "profiles": {
 {{^isNewProjectTypeEnabled}}
-{{#enableTestToolByDefault}}
     // Debug project within Teams App Test Tool
     "Teams App Test Tool (browser)": {
       "commandName": "Project",
@@ -16,7 +15,6 @@
       },
       "hotReloadProfile": "aspnetcore"
     },
-{{/enableTestToolByDefault}}
     // Debug project within Teams
     "Microsoft Teams (browser)": {
       "commandName": "Project",
@@ -29,22 +27,6 @@
       },
       "hotReloadProfile": "aspnetcore"
     },
-{{^enableTestToolByDefault}}
-    // Debug project within Teams App Test Tool
-    "Teams App Test Tool (browser)": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "launchTestTool": true,
-      "launchUrl": "http://localhost:56150",
-      "applicationUrl": "http://localhost:5130",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
-        "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.testtoolstore.json"
-      },
-      "hotReloadProfile": "aspnetcore"
-    },
-{{/enableTestToolByDefault}}
     //// Uncomment following profile to debug project only (without launching Teams)
     //,
     //"Start Project (not in Teams)": {
@@ -58,7 +40,6 @@
     //}
 {{/isNewProjectTypeEnabled}}
 {{#isNewProjectTypeEnabled}}
-{{#enableTestToolByDefault}}
     // Debug project within Teams App Test Tool
     "Teams App Test Tool": {
       "commandName": "Project",
@@ -70,7 +51,6 @@
       },
       "hotReloadProfile": "aspnetcore"
     },
-{{/enableTestToolByDefault}}
     // Debug project within Teams
     "Start Project": {
       "commandName": "Project",
@@ -81,19 +61,6 @@
       },
       "hotReloadProfile": "aspnetcore"
     },
-{{^enableTestToolByDefault}}
-    // Debug project within Teams App Test Tool
-    "Teams App Test Tool": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "applicationUrl": "http://localhost:5130",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
-        "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.testtoolstore.json"
-      },
-      "hotReloadProfile": "aspnetcore"
-    },
-{{/enableTestToolByDefault}}
 {{/isNewProjectTypeEnabled}}
   }
 }

--- a/templates/csharp/workflow/.{{NewProjectTypeName}}/GettingStarted.md.tpl
+++ b/templates/csharp/workflow/.{{NewProjectTypeName}}/GettingStarted.md.tpl
@@ -2,22 +2,9 @@
 
 ## Quick Start
 
-{{#enableTestToolByDefault}}
 1. Press F5, or select the Debug > Start Debugging menu in Visual Studio
 </br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/debug-button.png)
 2. In Teams App Test Tool from the launched browser, type and send "helloWorld" to your app to trigger a response
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-1. In the debug dropdown menu, select Dev Tunnels > Create A Tunnel (set authentication type to Public) or select an existing public dev tunnel
-</br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/create-devtunnel-button.png)
-2. Right-click your `{{NewProjectTypeName}}` project and select Teams Toolkit > Prepare Teams app dependencies
-3. If prompted, sign in with an M365 account for the Teams organization you want 
-to install the app to
-4. Press F5, or select the Debug > Start Debugging menu in Visual Studio
-</br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/debug-button.png)
-5. In the launched browser, select the Add button to load the app in Teams
-6. In the chat bar, type and send "helloWorld" to your app to trigger a response
-{{/enableTestToolByDefault}}
 
 ## Start multiple profiles
 Instead of launching the app in Teams client with default profile, you can also run your app with other profile like App Test Tool, office.com and outlook or even Copilot. You can select profile to start.
@@ -25,20 +12,11 @@ Instead of launching the app in Teams client with default profile, you can also 
 2. Check "Enable Multi-Project Launch Profiles"
 </br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/enable-multiple-profiles-feature.png)
 
-{{^enableTestToolByDefault}}
-### Start the app in Teams App Test Tool
-1. Select `Teams App Test Tool (browser)` in debug dropdown menu
-</br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/switch-to-test-tool.png)
-2. Press F5, or select the Debug > Start Debugging menu in Visual Studio
-</br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/debug-button.png)
-{{/enableTestToolByDefault}}
-{{#enableTestToolByDefault}}
 ### Start the app in Microsoft Teams
 1. In the debug dropdown menu, select `Microsoft Teams (browser)`.
 </br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/switch-to-teams.png)
 2. Press F5, or select the Debug > Start Debugging menu in Visual Studio
 </br>![image](https://raw.githubusercontent.com/OfficeDev/TeamsFx/dev/docs/images/visualstudio/debug/debug-button.png)
-{{/enableTestToolByDefault}}
 
 
 ## Learn more

--- a/templates/csharp/workflow/.{{NewProjectTypeName}}/launchSettings.json.tpl
+++ b/templates/csharp/workflow/.{{NewProjectTypeName}}/launchSettings.json.tpl
@@ -1,25 +1,15 @@
 {
   "profiles": {
-{{#enableTestToolByDefault}}
     // Launch project within Teams App Test Tool
     "Teams App Test Tool (browser)": {
       "commandName": "Project",
       "launchTestTool": true,
       "launchUrl": "http://localhost:56150",
     },
-{{/enableTestToolByDefault}}
     // Launch project within Teams
     "Microsoft Teams (browser)": {
       "commandName": "Project",
       "launchUrl": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&appTenantId=${{TEAMS_APP_TENANT_ID}}&login_hint=${{TEAMSFX_M365_USER_NAME}}",
     },
-{{^enableTestToolByDefault}}
-    // Launch project within Teams App Test Tool
-    "Teams App Test Tool (browser)": {
-      "commandName": "Project",
-      "launchTestTool": true,
-      "launchUrl": "http://localhost:56150",
-    },
-{{/enableTestToolByDefault}}
   }
 }

--- a/templates/csharp/workflow/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
+++ b/templates/csharp/workflow/.{{NewProjectTypeName}}/{{NewProjectTypeName}}.{{NewProjectTypeExt}}.user.tpl
@@ -4,11 +4,6 @@
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup>
-{{#enableTestToolByDefault}}
     <ActiveDebugProfile>Teams App Test Tool (browser)</ActiveDebugProfile>
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-    <ActiveDebugProfile>Microsoft Teams (browser)</ActiveDebugProfile>
-{{/enableTestToolByDefault}}
   </PropertyGroup>
 </Project>

--- a/templates/csharp/workflow/.{{NewProjectTypeName}}/{{ProjectName}}.slnLaunch.user.tpl
+++ b/templates/csharp/workflow/.{{NewProjectTypeName}}/{{ProjectName}}.slnLaunch.user.tpl
@@ -1,5 +1,4 @@
 [
-{{#enableTestToolByDefault}}
   {
     "Name": "Teams App Test Tool (browser)",
     "Projects": [
@@ -20,7 +19,6 @@
       }
     ]
   },
-{{/enableTestToolByDefault}}
   {
     "Name": "Microsoft Teams (browser)",
     "Projects": [
@@ -40,30 +38,5 @@
         "DebugTarget": "Start Project"
       }
     ]
-{{#enableTestToolByDefault}}
   }
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-  },
-  {
-    "Name": "Teams App Test Tool (browser)",
-    "Projects": [
-      {
-        "Name": "{{NewProjectTypeName}}\\{{NewProjectTypeName}}.{{NewProjectTypeExt}}",
-        "Action": "StartWithoutDebugging",
-        "DebugTarget": "Teams App Test Tool (browser)"
-      },
-      {
-{{#PlaceProjectFileInSolutionDir}}
-        "Name": "{{ProjectName}}.csproj",
-{{/PlaceProjectFileInSolutionDir}}
-{{^PlaceProjectFileInSolutionDir}}
-        "Name": "{{ProjectName}}\\{{ProjectName}}.csproj",
-{{/PlaceProjectFileInSolutionDir}}
-        "Action": "Start",
-        "DebugTarget": "Teams App Test Tool"
-      }
-    ]
-  }
-{{/enableTestToolByDefault}}
 ]

--- a/templates/csharp/workflow/GettingStarted.md.tpl
+++ b/templates/csharp/workflow/GettingStarted.md.tpl
@@ -2,19 +2,8 @@
 
 ## Quick Start
 
-{{#enableTestToolByDefault}}
 1. Press F5, or select the Debug > Start Debugging menu in Visual Studio
 2. In Teams App Test Tool from the launched browser, type and send "helloWorld" to your app to trigger a response
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-1. In the debug dropdown menu, select Dev Tunnels > Create A Tunnel (set authentication type to Public) or select an existing public dev tunnel
-2. Right-click your project and select Teams Toolkit > Prepare Teams app dependencies
-3. If prompted, sign in with an M365 account for the Teams organization you want 
-to install the app to
-4. Press F5, or select the Debug > Start Debugging menu in Visual Studio
-5. In the launched browser, select the Add button to load the app in Teams
-6. In the chat bar, type and send "helloWorld" to your app to trigger a response
-{{/enableTestToolByDefault}}
 
 ## Learn more
 

--- a/templates/csharp/workflow/Properties/launchSettings.json.tpl
+++ b/templates/csharp/workflow/Properties/launchSettings.json.tpl
@@ -1,7 +1,6 @@
 ﻿{
   "profiles": {
 {{^isNewProjectTypeEnabled}}
-{{#enableTestToolByDefault}}
     // Debug project within Teams App Test Tool
     "Teams App Test Tool (browser)": {
       "commandName": "Project",
@@ -16,7 +15,6 @@
       },
       "hotReloadProfile": "aspnetcore"
     },
-{{/enableTestToolByDefault}}
     // Debug project within Teams
     "Microsoft Teams (browser)": {
       "commandName": "Project",
@@ -29,22 +27,6 @@
       },
       "hotReloadProfile": "aspnetcore"
     },
-{{^enableTestToolByDefault}}
-    // Debug project within Teams App Test Tool
-    "Teams App Test Tool (browser)": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "launchTestTool": true,
-      "launchUrl": "http://localhost:56150",
-      "applicationUrl": "http://localhost:5130",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
-        "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.testtoolstore.json"
-      },
-      "hotReloadProfile": "aspnetcore"
-    },
-{{/enableTestToolByDefault}}
     //// Uncomment following profile to debug project only (without launching Teams)
     //,
     //"Start Project (not in Teams)": {
@@ -58,7 +40,6 @@
     //}
 {{/isNewProjectTypeEnabled}}
 {{#isNewProjectTypeEnabled}}
-{{#enableTestToolByDefault}}
     // Debug project within Teams App Test Tool
     "Teams App Test Tool": {
       "commandName": "Project",
@@ -70,7 +51,6 @@
       },
       "hotReloadProfile": "aspnetcore"
     },
-{{/enableTestToolByDefault}}
     // Debug project within Teams
     "Start Project": {
       "commandName": "Project",
@@ -81,19 +61,6 @@
       },
       "hotReloadProfile": "aspnetcore"
     },
-{{^enableTestToolByDefault}}
-    // Debug project within Teams App Test Tool
-    "Teams App Test Tool": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "applicationUrl": "http://localhost:5130",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
-        "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.testtoolstore.json"
-      },
-      "hotReloadProfile": "aspnetcore"
-    },
-{{/enableTestToolByDefault}}
 {{/isNewProjectTypeEnabled}}
   }
 }

--- a/templates/js/ai-assistant-bot/.vscode/launch.json.tpl
+++ b/templates/js/ai-assistant-bot/.vscode/launch.json.tpl
@@ -73,12 +73,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true
@@ -91,12 +86,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 2
             },
             "stopAll": true
@@ -108,12 +98,7 @@
             ],
             "preLaunchTask": "Start Teams App (Test Tool)",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "1-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "2-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true

--- a/templates/js/ai-assistant-bot/README.md.tpl
+++ b/templates/js/ai-assistant-bot/README.md.tpl
@@ -16,9 +16,6 @@ It showcases how to build an intelligent chat bot in Teams capable of helping us
 > To run the AI Assistant Bot template in your local dev machine, you will need:
 >
 > - [Node.js](https://nodejs.org/), supported versions: 16, 18
-{{^enableTestToolByDefault}}
-> - A [Microsoft 365 account for development](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts)
-{{/enableTestToolByDefault}}
 > - [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [Teams Toolkit CLI](https://aka.ms/teamsfx-toolkit-cli)
 > - An account with [OpenAI](https://platform.openai.com/).
 >
@@ -62,24 +59,12 @@ Before running or debugging your bot, please follow these steps to setup your ow
 ### Run Teams Bot locally
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
-{{#enableTestToolByDefault}}
 1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
 1. You will receive a welcome message from the bot, or send any message to get a response.
 
 **Congratulations**! You are running an application that can now interact with users in Teams App Test Tool:
 
 ![ai assistant bot in Teams App Test Tool](https://github.com/OfficeDev/TeamsFx/assets/15644078/90868166-115b-4394-a0d2-272bd985d0aa)
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-1. In the Account section, sign in with your [Microsoft 365 account](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts) if you haven't already.
-1. Press F5 to start debugging which launches your app in Teams using a web browser. Select `Debug in Teams (Edge)` or `Debug in Teams (Chrome)`.
-1. When Teams launches in the browser, select the Add button in the dialog to install your app to Teams.
-1. You will receive a welcome message from the bot, or send any message to get a response.
-
-**Congratulations**! You are running an application that can now interact with users in Teams:
-
-![ai assistant bot in Teams](https://github.com/OfficeDev/TeamsFx/assets/7642967/21480d90-307d-4074-84e0-c68a20e38134)
-{{/enableTestToolByDefault}}
 
 ## What's included in the template
 

--- a/templates/js/ai-bot/.vscode/launch.json.tpl
+++ b/templates/js/ai-bot/.vscode/launch.json.tpl
@@ -73,12 +73,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true
@@ -91,12 +86,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 2
             },
             "stopAll": true
@@ -108,12 +98,7 @@
             ],
             "preLaunchTask": "Start Teams App (Test Tool)",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "1-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "2-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true

--- a/templates/js/ai-bot/README.md.tpl
+++ b/templates/js/ai-bot/README.md.tpl
@@ -18,14 +18,10 @@ The app template is built using the Teams AI library, which provides the capabil
 > To run the AI Chat Bot template in your local dev machine, you will need:
 >
 > - [Node.js](https://nodejs.org/), supported versions: 16, 18
-{{^enableTestToolByDefault}}
-> - A [Microsoft 365 account for development](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts)
-{{/enableTestToolByDefault}}
 > - [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [Teams Toolkit CLI](https://aka.ms/teamsfx-toolkit-cli)
 > - An account with [OpenAI](https://platform.openai.com/).
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
-{{#enableTestToolByDefault}}
 1. In file *env/.env.testtool.user*, fill in your OpenAI key `SECRET_OPENAI_API_KEY=<your-key>`.
 1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
 1. You will receive a welcome message from the bot, or send any message to get a response.
@@ -33,18 +29,6 @@ The app template is built using the Teams AI library, which provides the capabil
 **Congratulations**! You are running an application that can now interact with users in Teams App Test Tool:
 
 ![ai chat bot](https://github.com/OfficeDev/TeamsFx/assets/9698542/9bd22201-8fda-4252-a0b3-79531c963e5e)
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-1. In the Account section, sign in with your [Microsoft 365 account](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts) if you haven't already.
-1. In file *env/.env.local.user*, fill in your OpenAI key `SECRET_OPENAI_API_KEY=<your-key>`.
-1. Press F5 to start debugging which launches your app in Teams using a web browser. Select `Debug in Teams (Edge)` or `Debug in Teams (Chrome)`.
-1. When Teams launches in the browser, select the Add button in the dialog to install your app to Teams.
-1. You will receive a welcome message from the bot, or send any message to get a response.
-
-**Congratulations**! You are running an application that can now interact with users in Teams:
-
-![ai chat bot](https://user-images.githubusercontent.com/7642967/258726187-8306610b-579e-4301-872b-1b5e85141eff.png)
-{{/enableTestToolByDefault}}
 
 ### Use Azure OpenAI
 
@@ -54,12 +38,7 @@ Above steps use OpenAI as AI service, optionally, you can also use Azure OpenAI 
 >
 > - Prepare your own [Azure OpenAI](https://aka.ms/oai/access) resource.
 
-{{#enableTestToolByDefault}}
 1. In file *env/.env.testtool.user*, fill in your Azure OpenAI key `SECRET_AZURE_OPENAI_API_KEY=<your-key>` and endpoint `SECRET_AZURE_OPENAI_ENDPOINT=<your-endpoint>`.
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-1. In file *env/.env.local.user*, fill in your Azure OpenAI key `SECRET_AZURE_OPENAI_API_KEY=<your-key>` and endpoint `SECRET_AZURE_OPENAI_ENDPOINT=<your-endpoint>`.
-{{/enableTestToolByDefault}}
 1. In `src/app.js`, comment out *"Use OpenAI"* part and uncomment *"use Azure OpenAI"* part, e.g.
     ```javascript
     const model = new OpenAIModel({

--- a/templates/js/command-and-response/.vscode/launch.json.tpl
+++ b/templates/js/command-and-response/.vscode/launch.json.tpl
@@ -73,12 +73,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true
@@ -91,12 +86,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 2
             },
             "stopAll": true
@@ -108,12 +98,7 @@
             ],
             "preLaunchTask": "Start Teams App (Test Tool)",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "1-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "2-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true

--- a/templates/js/command-and-response/README.md.tpl
+++ b/templates/js/command-and-response/README.md.tpl
@@ -11,9 +11,6 @@ The app template is built using the TeamsFx SDK, which provides a simple set of 
 > To run the command bot template in your local dev machine, you will need:
 >
 > - [Node.js](https://nodejs.org/), supported versions: 16, 18
-{{^enableTestToolByDefault}}
-> - An [Microsoft 365 account for development](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts)
-{{/enableTestToolByDefault}}
 > - [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [TeamsFx CLI](https://aka.ms/teamsfx-toolkit-cli)
 >
 > **Note**
@@ -21,26 +18,13 @@ The app template is built using the TeamsFx SDK, which provides a simple set of 
 > Your app can be installed into a team, or a group chat, or as personal app. See [Installation and Uninstallation](https://aka.ms/teamsfx-command-new#customize-installation).
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
-{{#enableTestToolByDefault}}
 2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
 3. The browser will pop up to open Teams App Test Tool.
 4. Type or select `helloWorld` in the chat to send it to your bot - this is the default command provided by the template.
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-2. In the Account section, sign in with your [Microsoft 365 account](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts) if you haven't already.
-3. Press F5 to start debugging which launches your app in Teams using a web browser. Select `Debug in Teams (Edge)` or `Debug in Teams (Chrome)`.
-4. When Teams launches in the browser, select the Add button in the dialog to install your app to Teams.
-5. Type or select `helloWorld` in the chat to send it to your bot - this is the default command provided by the template.
-{{/enableTestToolByDefault}}
 
 The bot will respond to the `helloWorld` command with an Adaptive Card:
 
-{{#enableTestToolByDefault}}
 ![Command and Response in Test Tool](https://github.com/OfficeDev/TeamsFx/assets/9698542/2636fd91-ec7f-4740-a5ea-b272575b0b7c)
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-![Command and Response in Teams](https://user-images.githubusercontent.com/11220663/165891754-16916b68-c1b5-499d-b6a8-bdfb195f1fd0.png)
-{{/enableTestToolByDefault}}
 
 ## What's included in the template
 

--- a/templates/js/custom-copilot-assistant-assistants-api/.vscode/launch.json.tpl
+++ b/templates/js/custom-copilot-assistant-assistants-api/.vscode/launch.json.tpl
@@ -73,12 +73,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true
@@ -91,12 +86,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 2
             },
             "stopAll": true
@@ -108,12 +98,7 @@
             ],
             "preLaunchTask": "Start Teams App (Test Tool)",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "1-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "2-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true

--- a/templates/js/custom-copilot-assistant-assistants-api/README.md.tpl
+++ b/templates/js/custom-copilot-assistant-assistants-api/README.md.tpl
@@ -16,9 +16,6 @@ It showcases how to build an AI agent in Teams capable of helping users accompli
 > To run the AI Agent template in your local dev machine, you will need:
 >
 > - [Node.js](https://nodejs.org/), supported versions: 16, 18
-{{^enableTestToolByDefault}}
-> - A [Microsoft 365 account for development](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts)
-{{/enableTestToolByDefault}}
 > - [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [Teams Toolkit CLI](https://aka.ms/teamsfx-toolkit-cli)
 > - An account with [OpenAI](https://platform.openai.com/).
 >
@@ -62,24 +59,12 @@ Before running or debugging your bot, please follow these steps to setup your ow
 ### Run Teams Bot locally
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
-{{#enableTestToolByDefault}}
 1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
 1. You can send any message to get a response from the bot.
 
 **Congratulations**! You are running an application that can now interact with users in Teams App Test Tool:
 
 ![AI Agent in Teams App Test Tool](https://github.com/OfficeDev/TeamsFx/assets/37978464/e3b458f3-5e74-460d-9df2-bf77ed8d9c54)
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-1. In the Account section, sign in with your [Microsoft 365 account](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts) if you haven't yet.
-1. Press F5 to start debugging which launches your app in Teams using a web browser. Select `Debug in Teams (Edge)` or `Debug in Teams (Chrome)`.
-1. When Teams launches in the browser, select the Add button in the dialog to install your app to Teams.
-1. You can send any message to get a response from the bot.
-
-**Congratulations**! You are running an application that can now interact with users in Teams:
-
-![AI Agent in Teams](https://github.com/OfficeDev/TeamsFx/assets/37978464/fd1cf673-e7d8-4826-9cac-e9481a74ee1e)
-{{/enableTestToolByDefault}}
 
 ## What's included in the template
 

--- a/templates/js/custom-copilot-assistant-new/.vscode/launch.json.tpl
+++ b/templates/js/custom-copilot-assistant-new/.vscode/launch.json.tpl
@@ -73,12 +73,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true
@@ -91,12 +86,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 2
             },
             "stopAll": true
@@ -108,12 +98,7 @@
             ],
             "preLaunchTask": "Start Teams App (Test Tool)",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "1-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "2-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true

--- a/templates/js/custom-copilot-assistant-new/README.md.tpl
+++ b/templates/js/custom-copilot-assistant-new/README.md.tpl
@@ -16,9 +16,6 @@ It showcases how to build an AI agent in Teams capable of chatting with users an
 > To run the AI Agent template in your local dev machine, you will need:
 >
 > - [Node.js](https://nodejs.org/), supported versions: 16, 18
-{{^enableTestToolByDefault}}
-> - A [Microsoft 365 account for development](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts)
-{{/enableTestToolByDefault}}
 > - [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [Teams Toolkit CLI](https://aka.ms/teamsfx-toolkit-cli)
 {{#useOpenAI}}
 > - An account with [OpenAI](https://platform.openai.com/)
@@ -28,7 +25,6 @@ It showcases how to build an AI agent in Teams capable of chatting with users an
 {{/useAzureOpenAI}}
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
-{{#enableTestToolByDefault}}
 {{#useOpenAI}}
 1. In file *env/.env.testtool.user*, fill in your OpenAI key `SECRET_OPENAI_API_KEY=<your-key>`.
 {{/useOpenAI}}
@@ -41,23 +37,6 @@ It showcases how to build an AI agent in Teams capable of chatting with users an
 **Congratulations**! You are running an application that can now interact with users in Teams App Test Tool:
 
 ![AI Agent](https://github.com/OfficeDev/TeamsFx/assets/37978464/053218b7-cb17-4db4-9b8a-50ca04c1cb55)
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-1. In the Account section, sign in with your [Microsoft 365 account](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts) if you haven't yet.
-{{#useOpenAI}}
-1. In file *env/.env.local.user*, fill in your OpenAI key `SECRET_OPENAI_API_KEY=<your-key>`.
-{{/useOpenAI}}
-{{#useAzureOpenAI}}
-1. In file *env/.env.local.user*, fill in your Azure OpenAI key `SECRET_AZURE_OPENAI_API_KEY=<your-key>`, endpoint `AZURE_OPENAI_ENDPOINT=<your-endpoint>`, and deployment name `AZURE_OPENAI_DEPLOYMENT_NAME=<your-deployment>`.
-{{/useAzureOpenAI}}
-1. Press F5 to start debugging which launches your app in Teams using a web browser. Select `Debug in Teams (Edge)` or `Debug in Teams (Chrome)`.
-1. When Teams launches in the browser, select the Add button in the dialog to install your app to Teams.
-1. You can send any message to get a response from the bot.
-
-**Congratulations**! You are running an application that can now interact with users in Teams:
-
-![AI Agent](https://github.com/OfficeDev/TeamsFx/assets/37978464/4e64c733-ee01-4938-8be1-9de0195b7244)
-{{/enableTestToolByDefault}}
 
 ## What's included in the template
 

--- a/templates/js/custom-copilot-basic/.vscode/launch.json.tpl
+++ b/templates/js/custom-copilot-basic/.vscode/launch.json.tpl
@@ -73,12 +73,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true
@@ -91,12 +86,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 2
             },
             "stopAll": true
@@ -108,12 +98,7 @@
             ],
             "preLaunchTask": "Start Teams App (Test Tool)",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "1-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "2-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true

--- a/templates/js/custom-copilot-basic/README.md.tpl
+++ b/templates/js/custom-copilot-basic/README.md.tpl
@@ -17,9 +17,6 @@ The app template is built using the Teams AI library, which provides the capabil
 > To run the Basic AI Chatbot template in your local dev machine, you will need:
 >
 > - [Node.js](https://nodejs.org/), supported versions: 16, 18.
-{{^enableTestToolByDefault}}
-> - A [Microsoft 365 account for development](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts).
-{{/enableTestToolByDefault}}
 > - [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) latest version or [Teams Toolkit CLI](https://aka.ms/teamsfx-toolkit-cli).
 {{#useOpenAI}}
 > - An account with [OpenAI](https://platform.openai.com/).
@@ -29,7 +26,6 @@ The app template is built using the Teams AI library, which provides the capabil
 {{/useAzureOpenAI}}
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
-{{#enableTestToolByDefault}}
 {{#useOpenAI}}
 1. In file *env/.env.testtool.user*, fill in your OpenAI key `SECRET_OPENAI_API_KEY=<your-key>`.
 {{/useOpenAI}}
@@ -42,23 +38,6 @@ The app template is built using the Teams AI library, which provides the capabil
 **Congratulations**! You are running an application that can now interact with users in Teams App Test Tool:
 
 ![ai chat bot](https://github.com/OfficeDev/TeamsFx/assets/9698542/9bd22201-8fda-4252-a0b3-79531c963e5e)
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-1. In the Account section, sign in with your [Microsoft 365 account](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts) if you haven't yet.
-{{#useOpenAI}}
-1. In file *env/.env.local.user*, fill in your OpenAI key `SECRET_OPENAI_API_KEY=<your-key>`.
-{{/useOpenAI}}
-{{#useAzureOpenAI}}
-1. In file *env/.env.local.user*, fill in your Azure OpenAI key `SECRET_AZURE_OPENAI_API_KEY=<your-key>`, endpoint `AZURE_OPENAI_ENDPOINT=<your-endpoint>`, and deployment name `AZURE_OPENAI_DEPLOYMENT_NAME=<your-deployment>`.
-{{/useAzureOpenAI}}
-1. Press F5 to start debugging which launches your app in Teams using a web browser. Select `Debug in Teams (Edge)` or `Debug in Teams (Chrome)`.
-1. When Teams launches in the browser, select the Add button in the dialog to install your app to Teams.
-1. You can send any message to get a response from the bot.
-
-**Congratulations**! You are running an application that can now interact with users in Teams:
-
-![ai chat bot](https://user-images.githubusercontent.com/7642967/258726187-8306610b-579e-4301-872b-1b5e85141eff.png)
-{{/enableTestToolByDefault}}
 
 ## What's included in the template
 

--- a/templates/js/custom-copilot-rag-custom-api/.vscode/launch.json.tpl
+++ b/templates/js/custom-copilot-rag-custom-api/.vscode/launch.json.tpl
@@ -73,12 +73,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true
@@ -91,12 +86,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 2
             },
             "stopAll": true
@@ -108,12 +98,7 @@
             ],
             "preLaunchTask": "Start Teams App (Test Tool)",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "1-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "2-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true

--- a/templates/js/custom-copilot-rag-custom-api/README.md.tpl
+++ b/templates/js/custom-copilot-rag-custom-api/README.md.tpl
@@ -17,9 +17,6 @@ The app template is built using the Teams AI library, which provides the capabil
 > To run the Custom Copilot from Custom API template in your local dev machine, you will need:
 >
 > - [Node.js](https://nodejs.org/), supported versions: 16, 18
-{{^enableTestToolByDefault}}
-> - A [Microsoft 365 account for development](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts)
-{{/enableTestToolByDefault}}
 > - [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [Teams Toolkit CLI](https://aka.ms/teamsfx-toolkit-cli)
 {{#useOpenAI}}
 > - An account with [OpenAI](https://platform.openai.com/)
@@ -29,7 +26,6 @@ The app template is built using the Teams AI library, which provides the capabil
 {{/useAzureOpenAI}}
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
-{{#enableTestToolByDefault}}
 {{#useOpenAI}}
 1. In file *env/.env.testtool.user*, fill in your OpenAI key `SECRET_OPENAI_API_KEY=<your-key>`.
 {{/useOpenAI}}
@@ -42,23 +38,6 @@ The app template is built using the Teams AI library, which provides the capabil
 **Congratulations**! You are running an application that can now interact with users in Teams App Test Tool:
 
 ![custom api template](https://github.com/OfficeDev/TeamsFx/assets/63089166/81f985a1-b81d-4c27-a82a-73a9b65ece1f)
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-1. In the Account section, sign in with your [Microsoft 365 account](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts) if you haven't yet.
-{{#useOpenAI}}
-1. In file *env/.env.local.user*, fill in your OpenAI key `SECRET_OPENAI_API_KEY=<your-key>`.
-{{/useOpenAI}}
-{{#useAzureOpenAI}}
-1. In file *env/.env.local.user*, fill in your Azure OpenAI key `SECRET_AZURE_OPENAI_ENDPOINT=<your-key>`, endpoint `SECRET_AZURE_OPENAI_ENDPOINT=<your-endpoint> and deployment name `AZURE_OPENAI_DEPLOYMENT=<your-deployment-name>`.
-{{/useAzureOpenAI}}
-1. Press F5 to start debugging which launches your app in Teams using a web browser. Select `Debug in Teams (Edge)` or `Debug in Teams (Chrome)`.
-1. When Teams launches in the browser, select the Add button in the dialog to install your app to Teams.
-1. You can send any message to get a response from the bot.
-
-**Congratulations**! You are running an application that can now interact with users in Teams:
-
-![custom api template](https://github.com/OfficeDev/TeamsFx/assets/63089166/19f4c825-c296-4d29-a957-bedb88b6aa5b)
-{{/enableTestToolByDefault}}
 
 ## What's included in the template
 

--- a/templates/js/default-bot/.vscode/launch.json.tpl
+++ b/templates/js/default-bot/.vscode/launch.json.tpl
@@ -73,12 +73,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true
@@ -91,12 +86,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 2
             },
             "stopAll": true
@@ -108,12 +98,7 @@
             ],
             "preLaunchTask": "Start Teams App (Test Tool)",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "1-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "2-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true

--- a/templates/js/default-bot/README.md.tpl
+++ b/templates/js/default-bot/README.md.tpl
@@ -15,13 +15,9 @@ A bot interaction can be a quick question and answer, or it can be a complex con
 > To run the Basic Bot template in your local dev machine, you will need:
 >
 > - [Node.js](https://nodejs.org/), supported versions: 16, 18
-{{^enableTestToolByDefault}}
-> - A [Microsoft 365 account for development](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts)
-{{/enableTestToolByDefault}}
 > - [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [Teams Toolkit CLI](https://aka.ms/teamsfx-toolkit-cli)
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
-{{#enableTestToolByDefault}}
 2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
 3. The browser will pop up to open Teams App Test Tool.
 4. You will receive a welcome message from the bot, and you can send anything to the bot to get an echoed response.
@@ -29,17 +25,6 @@ A bot interaction can be a quick question and answer, or it can be a complex con
 **Congratulations**! You are running an application that can now interact with users in Teams App Test Tool:
 
 ![basic bot](https://github.com/OfficeDev/TeamsFx/assets/9698542/bdf87809-7dd7-4926-bff0-4546ada25e4b)
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-2. In the Account section, sign in with your [Microsoft 365 account](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts) if you haven't already.
-3. Press F5 to start debugging which launches your app in Teams using a web browser. Select `Debug in Teams (Edge)` or `Debug in Teams (Chrome)`.
-4. When Teams launches in the browser, select the Add button in the dialog to install your app to Teams.
-5. You will receive a welcome message from the bot, and you can send anything to the bot to get an echoed response.
-
-**Congratulations**! You are running an application that can now interact with users in Teams:
-
-![basic bot](https://github.com/OfficeDev/TeamsFx/assets/25220706/170096d2-b353-4d4e-b55a-2c8ae4d97514)
-{{/enableTestToolByDefault}}
 
 ## What's included in the template
 

--- a/templates/js/notification-http-timer-trigger/.vscode/launch.json.tpl
+++ b/templates/js/notification-http-timer-trigger/.vscode/launch.json.tpl
@@ -73,12 +73,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true
@@ -91,12 +86,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 2
             },
             "stopAll": true
@@ -108,12 +98,7 @@
             ],
             "preLaunchTask": "Start Teams App (Test Tool)",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "1-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "2-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true

--- a/templates/js/notification-http-timer-trigger/README.md.tpl
+++ b/templates/js/notification-http-timer-trigger/README.md.tpl
@@ -12,9 +12,6 @@ The app template is built using the TeamsFx SDK, which provides a simple set of 
 > To run the notification bot template in your local dev machine, you will need:
 >
 > - [Node.js](https://nodejs.org/), supported versions: 16, 18
-{{^enableTestToolByDefault}}
-> - An [Microsoft 365 account for development](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts)
-{{/enableTestToolByDefault}}
 > - [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [TeamsFx CLI](https://aka.ms/teamsfx-toolkit-cli)
 >
 > **Note**
@@ -22,31 +19,16 @@ The app template is built using the TeamsFx SDK, which provides a simple set of 
 > Your app can be installed into a team, or a group chat, or as personal app. See [Installation and Uninstallation](https://aka.ms/teamsfx-notification-new#customize-installation).
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
-{{#enableTestToolByDefault}}
 2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
 3. The browser will pop up to open Teams App Test Tool.
 4. If you select `Timer Trigger`, wait for 30 seconds. If you select `HTTP Trigger`, send a POST request to `http://<endpoint>/api/notification` with your favorite tool (like `Postman`)
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-2. In the Account section, sign in with your [Microsoft 365 account](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts) if you haven't already.
-3. Press F5 to start debugging which launches your app in Teams using a web browser. Select `Debug in Teams (Edge)` or `Debug in Teams (Chrome)`.
-4. When Teams launches in the browser, select the Add button in the dialog to install your app to Teams.
-5. If you select `Timer Trigger`, wait for 30 seconds. If you select `HTTP Trigger`, send a POST request to `http://<endpoint>/api/notification` with your favorite tool (like `Postman`)
-{{/enableTestToolByDefault}}
 
    - When your project is running locally, replace `<endpoint>` with `localhost:3978`
    - When your project is deployed to Azure App Service, replace `<endpoint>` with the url from Azure App Service
 
-{{#enableTestToolByDefault}}
 The bot will send an Adaptive Card to Teams App Test Tool:
 
 ![Notification Message in Test Tool](https://github.com/OfficeDev/TeamsFx/assets/9698542/43ee64f4-5554-4e0b-854f-f7e20672cb25)
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-The bot will send an Adaptive Card to Teams:
-
-![Notification Message in Teams](https://user-images.githubusercontent.com/7642967/223006044-5003574e-2aee-4a41-9b71-c103d0439012.png)
-{{/enableTestToolByDefault}}
 
 ## What's included in the template
 

--- a/templates/js/notification-http-trigger/.vscode/launch.json.tpl
+++ b/templates/js/notification-http-trigger/.vscode/launch.json.tpl
@@ -73,12 +73,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true
@@ -91,12 +86,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 2
             },
             "stopAll": true
@@ -108,12 +98,7 @@
             ],
             "preLaunchTask": "Start Teams App (Test Tool)",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "1-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "2-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true

--- a/templates/js/notification-http-trigger/README.md.tpl
+++ b/templates/js/notification-http-trigger/README.md.tpl
@@ -12,9 +12,6 @@ The app template is built using the TeamsFx SDK, which provides a simple set of 
 > To run the notification bot template in your local dev machine, you will need:
 >
 > - [Node.js](https://nodejs.org/), supported versions: 16, 18
-{{^enableTestToolByDefault}}
-> - An [Microsoft 365 account for development](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts)
-{{/enableTestToolByDefault}}
 > - [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [TeamsFx CLI](https://aka.ms/teamsfx-toolkit-cli)
 >
 > **Note**
@@ -22,31 +19,16 @@ The app template is built using the TeamsFx SDK, which provides a simple set of 
 > Your app can be installed into a team, or a group chat, or as personal app. See [Installation and Uninstallation](https://aka.ms/teamsfx-notification-new#customize-installation).
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
-{{#enableTestToolByDefault}}
 2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
 3. The browser will pop up to open Teams App Test Tool.
 4. If you select `Timer Trigger`, wait for 30 seconds. If you select `HTTP Trigger`, send a POST request to `http://<endpoint>/api/notification` with your favorite tool (like `Postman`)
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-2. In the Account section, sign in with your [Microsoft 365 account](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts) if you haven't already.
-3. Press F5 to start debugging which launches your app in Teams using a web browser. Select `Debug in Teams (Edge)` or `Debug in Teams (Chrome)`.
-4. When Teams launches in the browser, select the Add button in the dialog to install your app to Teams.
-5. If you select `Timer Trigger`, wait for 30 seconds. If you select `HTTP Trigger`, send a POST request to `http://<endpoint>/api/notification` with your favorite tool (like `Postman`)
-{{/enableTestToolByDefault}}
 
    - When your project is running locally, replace `<endpoint>` with `localhost:3978`
    - When your project is deployed to Azure App Service, replace `<endpoint>` with the url from Azure App Service
 
-{{#enableTestToolByDefault}}
 The bot will send an Adaptive Card to Teams App Test Tool:
 
 ![Notification Message in Test Tool](https://github.com/OfficeDev/TeamsFx/assets/9698542/43ee64f4-5554-4e0b-854f-f7e20672cb25)
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-The bot will send an Adaptive Card to Teams:
-
-![Notification Message in Teams](https://user-images.githubusercontent.com/7642967/223006044-5003574e-2aee-4a41-9b71-c103d0439012.png)
-{{/enableTestToolByDefault}}
 
 ## What's included in the template
 

--- a/templates/js/notification-restify/.vscode/launch.json.tpl
+++ b/templates/js/notification-restify/.vscode/launch.json.tpl
@@ -73,12 +73,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true
@@ -91,12 +86,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 2
             },
             "stopAll": true
@@ -108,12 +98,7 @@
             ],
             "preLaunchTask": "Start Teams App (Test Tool)",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "1-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "2-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true

--- a/templates/js/notification-restify/README.md.tpl
+++ b/templates/js/notification-restify/README.md.tpl
@@ -12,9 +12,6 @@ The app template is built using the TeamsFx SDK, which provides a simple set of 
 > To run the notification bot template in your local dev machine, you will need:
 >
 > - [Node.js](https://nodejs.org/), supported versions: 16, 18
-{{^enableTestToolByDefault}}
-> - An [Microsoft 365 account for development](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts)
-{{/enableTestToolByDefault}}
 > - [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [TeamsFx CLI](https://aka.ms/teamsfx-toolkit-cli)
 >
 > **Note**
@@ -22,31 +19,16 @@ The app template is built using the TeamsFx SDK, which provides a simple set of 
 > Your app can be installed into a team, or a group chat, or as personal app. See [Installation and Uninstallation](https://aka.ms/teamsfx-notification-new#customize-installation).
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
-{{#enableTestToolByDefault}}
 2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
 3. The browser will pop up to open Teams App Test Tool.
 4. Send a POST request to `http://<endpoint>/api/notification` with your favorite tool (like `Postman`)
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-2. In the Account section, sign in with your [Microsoft 365 account](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts) if you haven't already.
-3. Press F5 to start debugging which launches your app in Teams using a web browser. Select `Debug in Teams (Edge)` or `Debug in Teams (Chrome)`.
-4. When Teams launches in the browser, select the Add button in the dialog to install your app to Teams.
-5. Send a POST request to `http://<endpoint>/api/notification` with your favorite tool (like `Postman`)
-{{/enableTestToolByDefault}}
 
    - When your project is running locally, replace `<endpoint>` with `localhost:3978`
    - When your project is deployed to Azure App Service, replace `<endpoint>` with the url from Azure App Service
 
-{{#enableTestToolByDefault}}
 The bot will send an Adaptive Card to Teams App Test Tool:
 
 ![Notification Message in Test Tool](https://github.com/OfficeDev/TeamsFx/assets/9698542/43ee64f4-5554-4e0b-854f-f7e20672cb25)
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-The bot will send an Adaptive Card to Teams:
-
-![Notification Message in Teams](https://user-images.githubusercontent.com/7642967/223006044-5003574e-2aee-4a41-9b71-c103d0439012.png)
-{{/enableTestToolByDefault}}
 
 ## What's included in the template
 

--- a/templates/js/notification-timer-trigger/.vscode/launch.json.tpl
+++ b/templates/js/notification-timer-trigger/.vscode/launch.json.tpl
@@ -73,12 +73,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true
@@ -91,12 +86,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 2
             },
             "stopAll": true
@@ -108,12 +98,7 @@
             ],
             "preLaunchTask": "Start Teams App (Test Tool)",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "1-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "2-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true

--- a/templates/js/notification-timer-trigger/README.md.tpl
+++ b/templates/js/notification-timer-trigger/README.md.tpl
@@ -13,9 +13,6 @@ The app template is built using the TeamsFx SDK, which provides a simple set of 
 > To run the notification bot template in your local dev machine, you will need:
 >
 > - [Node.js](https://nodejs.org/), supported versions: 16, 18
-{{^enableTestToolByDefault}}
-> - An [Microsoft 365 account for development](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts)
-{{/enableTestToolByDefault}}
 > - [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [TeamsFx CLI](https://aka.ms/teamsfx-toolkit-cli)
 >
 > **Note**
@@ -23,31 +20,16 @@ The app template is built using the TeamsFx SDK, which provides a simple set of 
 > Your app can be installed into a team, or a group chat, or as personal app. See [Installation and Uninstallation](https://aka.ms/teamsfx-notification-new#customize-installation).
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
-{{#enableTestToolByDefault}}
 2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
 3. The browser will pop up to open Teams App Test Tool.
 4. If you select `Timer Trigger`, wait for 30 seconds. If you select `HTTP Trigger`, send a POST request to `http://<endpoint>/api/notification` with your favorite tool (like `Postman`)
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-2. In the Account section, sign in with your [Microsoft 365 account](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts) if you haven't already.
-3. Press F5 to start debugging which launches your app in Teams using a web browser. Select `Debug in Teams (Edge)` or `Debug in Teams (Chrome)`.
-4. When Teams launches in the browser, select the Add button in the dialog to install your app to Teams.
-5. If you select `Timer Trigger`, wait for 30 seconds. If you select `HTTP Trigger`, send a POST request to `http://<endpoint>/api/notification` with your favorite tool (like `Postman`)
-{{/enableTestToolByDefault}}
 
    - When your project is running locally, replace `<endpoint>` with `localhost:3978`
    - When your project is deployed to Azure App Service, replace `<endpoint>` with the url from Azure App Service
 
-{{#enableTestToolByDefault}}
 The bot will send an Adaptive Card to Teams App Test Tool:
 
 ![Notification Message in Test Tool](https://github.com/OfficeDev/TeamsFx/assets/9698542/43ee64f4-5554-4e0b-854f-f7e20672cb25)
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-The bot will send an Adaptive Card to Teams:
-
-![Notification Message in Teams](https://user-images.githubusercontent.com/7642967/223006044-5003574e-2aee-4a41-9b71-c103d0439012.png)
-{{/enableTestToolByDefault}}
 
 ## What's included in the template
 

--- a/templates/js/workflow/.vscode/launch.json.tpl
+++ b/templates/js/workflow/.vscode/launch.json.tpl
@@ -73,12 +73,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true
@@ -91,12 +86,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 2
             },
             "stopAll": true
@@ -108,12 +98,7 @@
             ],
             "preLaunchTask": "Start Teams App (Test Tool)",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "1-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "2-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true

--- a/templates/js/workflow/README.md.tpl
+++ b/templates/js/workflow/README.md.tpl
@@ -11,9 +11,6 @@ The app template is built using the TeamsFx SDK, which provides a simple set of 
 > To run the workflow bot template in your local dev machine, you will need:
 >
 > - [Node.js](https://nodejs.org/), supported versions: 16, 18
-{{^enableTestToolByDefault}}
-> - An [Microsoft 365 account for development](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts)
-{{/enableTestToolByDefault}}
 > - [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [TeamsFx CLI](https://aka.ms/teamsfx-toolkit-cli)
 >
 > **Note**
@@ -21,38 +18,20 @@ The app template is built using the TeamsFx SDK, which provides a simple set of 
 > Your app can be installed into a team, or a group chat, or as personal app. See [Installation and Uninstallation](https://aka.ms/teamsfx-command-response#customize-installation).
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
-{{#enableTestToolByDefault}}
 2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
 3. The browser will pop up to open Teams App Test Tool.
 4. Type or select `helloWorld` in the chat to send it to your bot - this is the default command provided by the template.
 5. In the response from the bot, select the **DoStuff** button.
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-2. In the Account section, sign in with your [Microsoft 365 account](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts) if you haven't already.
-3. Press F5 to start debugging which launches your app in Teams using a web browser. Select `Debug in Teams (Edge)` or `Debug in Teams (Chrome)`.
-4. When Teams launches in the browser, select the Add button in the dialog to install your app to Teams.
-5. Type or select `helloWorld` in the chat to send it to your bot - this is the default command provided by the template.
-6. In the response from the bot, select the **DoStuff** button.
-{{/enableTestToolByDefault}}
 
 The bot will respond by updating the existing Adaptive Card to show the workflow is now complete! Continue reading to learn more about what's included in the template and how to customize it.
 
 Here is a screen shot of the application running:
 
-{{#enableTestToolByDefault}}
 ![Responds to command](https://github.com/OfficeDev/TeamsFx/assets/9698542/94173beb-2fff-44fa-87dc-f686677da631)
 
 When you click the `DoStuff` button, the above adaptive card will be updated to a new card as shown below:
 
 ![Responds to card action](https://github.com/OfficeDev/TeamsFx/assets/9698542/521ff12d-726c-4087-825a-112547cad836)
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-![Responds to command](https://user-images.githubusercontent.com/10163840/192477792-dc447b3a-e304-4cd8-b4df-b1eb9d226292.png)
-
-When you click the `DoStuff` button, the above adaptive card will be updated to a new card as shown below:
-
-![Responds to card action](https://user-images.githubusercontent.com/10163840/192477148-29d9edfc-085b-4d02-b3de-b47b9a456108.png)
-{{/enableTestToolByDefault}}
 
 ## What's included in the template
 

--- a/templates/python/custom-copilot-basic/.vscode/launch.json.tpl
+++ b/templates/python/custom-copilot-basic/.vscode/launch.json.tpl
@@ -78,12 +78,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true
@@ -99,12 +94,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 2
             },
             "stopAll": true
@@ -120,12 +110,7 @@
             ],
             "preLaunchTask": "Deploy (Test Tool)",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "1-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "2-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true

--- a/templates/python/custom-copilot-basic/README.md.tpl
+++ b/templates/python/custom-copilot-basic/README.md.tpl
@@ -25,16 +25,10 @@ The app template is built using the Teams AI library, which provides the capabil
 {{#useOpenAI}}
 > - An account with [OpenAI](https://platform.openai.com/).
 {{/useOpenAI}}
-{{^enableTestToolByDefault}}
-> - A [Microsoft 365 account for development](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts).
-{{/enableTestToolByDefault}}
-{{#enableTestToolByDefault}}
 > - [Node.js](https://nodejs.org/) (supported versions: 16, 18) for local debug in Test Tool.
-{{/enableTestToolByDefault}}
 
 1. First, Open the command box and enter `Python: Create Environment` to create and activate your desired virtual environment. Remember to select `src/requirements.txt` as dependencies to install when creating the virtual environment.
 1. select the Teams Toolkit icon on the left in the VS Code toolbar.
-{{#enableTestToolByDefault}}
 {{#useAzureOpenAI}}
 1. In file *env/.env.testtool.user*, fill in your Azure OpenAI key `SECRET_AZURE_OPENAI_API_KEY`, deployment name `AZURE_OPENAI_MODEL_DEPLOYMENT_NAME` and endpoint `AZURE_OPENAI_ENDPOINT`.
 {{/useAzureOpenAI}}
@@ -48,24 +42,6 @@ The app template is built using the Teams AI library, which provides the capabil
 **Congratulations**! You are running an application that can now interact with users in Teams App Test Tool:
 
 ![ai chat bot](https://github.com/OfficeDev/TeamsFx/assets/9698542/9bd22201-8fda-4252-a0b3-79531c963e5e)
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-1. In the Account section, sign in with your [Microsoft 365 account](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts) if you haven't already.
-{{#useAzureOpenAI}}
-1. In file *env/.env.local.user*, fill in your Azure OpenAI key `SECRET_AZURE_OPENAI_API_KEY`, deployment name `AZURE_OPENAI_MODEL_DEPLOYMENT_NAME` and endpoint `AZURE_OPENAI_ENDPOINT`.
-{{/useAzureOpenAI}}
-{{#useOpenAI}}
-1. In file *env/.env.local.user*, fill in your OpenAI key `SECRET_OPENAI_API_KEY`. 
-1. In this template, default model name is `gpt-3.5-turbo`. If you want to use a different model from OpenAI, fill in your model name in [src/config.py](./src/config.py).
-{{/useOpenAI}}
-1. Press F5 to start debugging which launches your app in Teams using a web browser. Select `Debug in Teams (Edge)` or `Debug in Teams (Chrome)`.
-1. When Teams launches in the browser, select the Add button in the dialog to install your app to Teams.
-1. You will receive a welcome message from the bot, or send any message to get a response.
-
-**Congratulations**! You are running an application that can now interact with users in Teams:
-
-![ai chat bot](https://user-images.githubusercontent.com/7642967/258726187-8306610b-579e-4301-872b-1b5e85141eff.png)
-{{/enableTestToolByDefault}}
 
 ## What's included in the template
 

--- a/templates/python/custom-copilot-rag-azure-ai-search/.vscode/launch.json.tpl
+++ b/templates/python/custom-copilot-rag-azure-ai-search/.vscode/launch.json.tpl
@@ -78,12 +78,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true
@@ -99,12 +94,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 2
             },
             "stopAll": true
@@ -120,12 +110,7 @@
             ],
             "preLaunchTask": "Deploy (Test Tool)",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "1-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "2-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true

--- a/templates/python/custom-copilot-rag-azure-ai-search/README.md.tpl
+++ b/templates/python/custom-copilot-rag-azure-ai-search/README.md.tpl
@@ -26,16 +26,10 @@ The app template is built using the Teams AI library, which provides the capabil
 > - An account with [OpenAI](https://platform.openai.com/).
 {{/useOpenAI}}
 > - An [Azure Search service](https://learn.microsoft.com/en-us/azure/search/search-what-is-azure-search).
-{{^enableTestToolByDefault}}
-> - A [Microsoft 365 account for development](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts).
-{{/enableTestToolByDefault}}
-{{#enableTestToolByDefault}}
 > - [Node.js](https://nodejs.org/) (supported versions: 16, 18) for local debug in Test Tool.
-{{/enableTestToolByDefault}}
 
 ### Configurations
 1. Open the command box and enter `Python: Create Environment` to create and activate your desired virtual environment. Remember to select `src/requirements.txt` as dependencies to install when creating the virtual environment.
-{{#enableTestToolByDefault}}
 {{#useAzureOpenAI}}
 1. In file *env/.env.testtool.user*, fill in your Azure OpenAI key `SECRET_AZURE_OPENAI_API_KEY`, deployment name `AZURE_OPENAI_MODEL_DEPLOYMENT_NAME`, endpoint `AZURE_OPENAI_ENDPOINT` and embedding deployment name `AZURE_OPENAI_EMBEDDING_DEPLOYMENT`.
 {{/useAzureOpenAI}}
@@ -44,25 +38,9 @@ The app template is built using the Teams AI library, which provides the capabil
 1. In this template, default model name is `gpt-3.5-turbo` and default embedding model name is `text-embedding-ada-002`. If you want to use different models from OpenAI, fill in your model names in [src/config.py](./src/config.py).
 {{/useOpenAI}}
 1. In file *env/.env.local.user*, fill in your Azure Search key `SECRET_AZURE_SEARCH_KEY` and endpoint `AZURE_SEARCH_ENDPOINT`.
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-{{#useAzureOpenAI}}
-1. In file *env/.env.local.user*, fill in your Azure OpenAI key `SECRET_AZURE_OPENAI_API_KEY`, deployment name `AZURE_OPENAI_MODEL_DEPLOYMENT_NAME`, endpoint `AZURE_OPENAI_ENDPOINT` and embedding deployment name `AZURE_OPENAI_EMBEDDING_DEPLOYMENT`.
-{{/useAzureOpenAI}}
-{{#useOpenAI}}
-1. In file *env/.env.local.user*, fill in your OpenAI key `SECRET_OPENAI_API_KEY`. 
-1. In this template, default model name is `gpt-3.5-turbo` and default embedding model name is `text-embedding-ada-002`. If you want to use different models from OpenAI, fill in your model names in [src/config.py](./src/config.py).
-{{/useOpenAI}}
-1. In file *env/.env.local.user*, fill in your Azure Search key `SECRET_AZURE_SEARCH_KEY` and endpoint `AZURE_SEARCH_ENDPOINT`.
-{{/enableTestToolByDefault}}
 
 ### Setting up index and documents
-{{^enableTestToolByDefault}}
-1. Azure Search key `SECRET_AZURE_SEARCH_KEY` and endpoint `AZURE_SEARCH_ENDPOINT` are loaded from *env/.env.local.user*. Please make sure you have already configured them.
-{{/enableTestToolByDefault}}
-{{#enableTestToolByDefault}}
 1. Azure Search key `SECRET_AZURE_SEARCH_KEY` and endpoint `AZURE_SEARCH_ENDPOINT` are loaded from *env/.env.testtool.user*. Please make sure you have already configured them.
-{{/enableTestToolByDefault}}
 1. Use command `python src/indexers/setup.py` to create index and upload documents in `src/indexers/data`.
 1. You will see the following information indicated the success of setup:
     ```
@@ -74,24 +52,13 @@ The app template is built using the Teams AI library, which provides the capabil
 
 ### Conversation with bot
 1. Select the Teams Toolkit icon on the left in the VS Code toolbar.
-{{^enableTestToolByDefault}}
-1. In the Account section, sign in with your [Microsoft 365 account](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts) if you haven't already.
-1. Press F5 to start debugging which launches your app in Teams using a web browser. Select `Debug in Teams (Edge)` or `Debug in Teams (Chrome)`.
-{{/enableTestToolByDefault}}
-{{#enableTestToolByDefault}}
 1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
-{{/enableTestToolByDefault}}
 1. When Teams launches in the browser, select the Add button in the dialog to install your app to Teams.
 1. You will receive a welcome message from the bot, or send any message to get a response.
 
 **Congratulations**! You are running an application that can now interact with users in Teams:
 
-{{#enableTestToolByDefault}}
 ![alt text](https://github.com/OfficeDev/TeamsFx/assets/109947924/3e0de761-b4c8-4ae2-9ede-8e9922e54765)
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-![alt text](https://github.com/OfficeDev/TeamsFx/assets/109947924/2c17e3e8-09c1-42b6-b47a-ac4234343883)
-{{/enableTestToolByDefault}}
 
 ## What's included in the template
 

--- a/templates/python/custom-copilot-rag-azure-ai-search/src/indexers/delete.py.tpl
+++ b/templates/python/custom-copilot-rag-azure-ai-search/src/indexers/delete.py.tpl
@@ -4,12 +4,7 @@ from azure.search.documents.indexes import SearchIndexClient
 
 from dotenv import load_dotenv
 
-{{#enableTestToolByDefault}}
 load_dotenv(f'{os.getcwd()}/env/.env.testtool.user')
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-load_dotenv(f'{os.getcwd()}/env/.env.local.user')
-{{/enableTestToolByDefault}}
 
 def delete_index(client: SearchIndexClient, name: str):
     client.delete_index(name)

--- a/templates/python/custom-copilot-rag-azure-ai-search/src/indexers/setup.py.tpl
+++ b/templates/python/custom-copilot-rag-azure-ai-search/src/indexers/setup.py.tpl
@@ -29,12 +29,7 @@ from get_data import get_doc_data
 
 from dotenv import load_dotenv
 
-{{#enableTestToolByDefault}}
 load_dotenv(f'{os.getcwd()}/env/.env.testtool.user')
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-load_dotenv(f'{os.getcwd()}/env/.env.local.user')
-{{/enableTestToolByDefault}}
 
 @dataclass
 class Doc:

--- a/templates/ts/ai-assistant-bot/.vscode/launch.json.tpl
+++ b/templates/ts/ai-assistant-bot/.vscode/launch.json.tpl
@@ -73,12 +73,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true
@@ -91,12 +86,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 2
             },
             "stopAll": true
@@ -108,12 +98,7 @@
             ],
             "preLaunchTask": "Start Teams App (Test Tool)",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "1-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "2-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true

--- a/templates/ts/ai-assistant-bot/README.md.tpl
+++ b/templates/ts/ai-assistant-bot/README.md.tpl
@@ -16,9 +16,6 @@ It showcases how to build an intelligent chat bot in Teams capable of helping us
 > To run the AI Assistant Bot template in your local dev machine, you will need:
 >
 > - [Node.js](https://nodejs.org/), supported versions: 16, 18
-{{^enableTestToolByDefault}}
-> - A [Microsoft 365 account for development](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts)
-{{/enableTestToolByDefault}}
 > - [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [Teams Toolkit CLI](https://aka.ms/teamsfx-toolkit-cli)
 > - An account with [OpenAI](https://platform.openai.com/).
 >
@@ -63,24 +60,12 @@ Before running or debugging your bot, please follow these steps to setup your ow
 ### Run Teams Bot locally
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
-{{#enableTestToolByDefault}}
 1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
 1. You will receive a welcome message from the bot, or send any message to get a response.
 
 **Congratulations**! You are running an application that can now interact with users in Teams App Test Tool:
 
 ![ai assistant bot in Teams App Test Tool](https://github.com/OfficeDev/TeamsFx/assets/15644078/90868166-115b-4394-a0d2-272bd985d0aa)
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-1. In the Account section, sign in with your [Microsoft 365 account](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts) if you haven't already.
-1. Press F5 to start debugging which launches your app in Teams using a web browser. Select `Debug in Teams (Edge)` or `Debug in Teams (Chrome)`.
-1. When Teams launches in the browser, select the Add button in the dialog to install your app to Teams.
-1. You will receive a welcome message from the bot, or send any message to get a response.
-
-**Congratulations**! You are running an application that can now interact with users in Teams:
-
-![ai assistant bot in Teams](https://github.com/OfficeDev/TeamsFx/assets/7642967/21480d90-307d-4074-84e0-c68a20e38134)
-{{/enableTestToolByDefault}}
 
 ## What's included in the template
 

--- a/templates/ts/ai-bot/.vscode/launch.json.tpl
+++ b/templates/ts/ai-bot/.vscode/launch.json.tpl
@@ -73,12 +73,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true
@@ -91,12 +86,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 2
             },
             "stopAll": true
@@ -108,12 +98,7 @@
             ],
             "preLaunchTask": "Start Teams App (Test Tool)",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "1-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "2-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true

--- a/templates/ts/ai-bot/README.md.tpl
+++ b/templates/ts/ai-bot/README.md.tpl
@@ -18,14 +18,10 @@ The app template is built using the Teams AI library, which provides the capabil
 > To run the AI Chat Bot template in your local dev machine, you will need:
 >
 > - [Node.js](https://nodejs.org/), supported versions: 16, 18
-{{^enableTestToolByDefault}}
-> - A [Microsoft 365 account for development](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts)
-{{/enableTestToolByDefault}}
 > - [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [Teams Toolkit CLI](https://aka.ms/teamsfx-toolkit-cli)
 > - An account with [OpenAI](https://platform.openai.com/).
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
-{{#enableTestToolByDefault}}
 1. In file *env/.env.testtool.user*, fill in your OpenAI key `SECRET_OPENAI_API_KEY=<your-key>`.
 1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
 1. You will receive a welcome message from the bot, or send any message to get a response.
@@ -33,18 +29,6 @@ The app template is built using the Teams AI library, which provides the capabil
 **Congratulations**! You are running an application that can now interact with users in Teams App Test Tool:
 
 ![ai chat bot](https://github.com/OfficeDev/TeamsFx/assets/9698542/9bd22201-8fda-4252-a0b3-79531c963e5e)
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-1. In the Account section, sign in with your [Microsoft 365 account](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts) if you haven't already.
-1. In file *env/.env.local.user*, fill in your OpenAI key `SECRET_OPENAI_API_KEY=<your-key>`.
-1. Press F5 to start debugging which launches your app in Teams using a web browser. Select `Debug in Teams (Edge)` or `Debug in Teams (Chrome)`.
-1. When Teams launches in the browser, select the Add button in the dialog to install your app to Teams.
-1. You will receive a welcome message from the bot, or send any message to get a response.
-
-**Congratulations**! You are running an application that can now interact with users in Teams:
-
-![ai chat bot](https://user-images.githubusercontent.com/7642967/258726187-8306610b-579e-4301-872b-1b5e85141eff.png)
-{{/enableTestToolByDefault}}
 
 ### Use Azure OpenAI
 
@@ -54,12 +38,7 @@ Above steps use OpenAI as AI service, optionally, you can also use Azure OpenAI 
 >
 > - Prepare your own [Azure OpenAI](https://aka.ms/oai/access) resource.
 
-{{#enableTestToolByDefault}}
 1. In file *env/.env.testtool.user*, fill in your Azure OpenAI key `SECRET_AZURE_OPENAI_API_KEY=<your-key>` and endpoint `SECRET_AZURE_OPENAI_ENDPOINT=<your-endpoint>`.
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-1. In file *env/.env.local.user*, fill in your Azure OpenAI key `SECRET_AZURE_OPENAI_API_KEY=<your-key>` and endpoint `SECRET_AZURE_OPENAI_ENDPOINT=<your-endpoint>`.
-{{/enableTestToolByDefault}}
 1. In `src/app.ts`, comment out *"Use OpenAI"* part and uncomment *"use Azure OpenAI"* part, e.g.
     ```typescript
     const model = new OpenAIModel({

--- a/templates/ts/command-and-response/.vscode/launch.json.tpl
+++ b/templates/ts/command-and-response/.vscode/launch.json.tpl
@@ -73,12 +73,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true
@@ -91,12 +86,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 2
             },
             "stopAll": true
@@ -108,12 +98,7 @@
             ],
             "preLaunchTask": "Start Teams App (Test Tool)",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "1-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "2-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true

--- a/templates/ts/command-and-response/README.md.tpl
+++ b/templates/ts/command-and-response/README.md.tpl
@@ -11,9 +11,6 @@ The app template is built using the TeamsFx SDK, which provides a simple set of 
 > To run the command bot template in your local dev machine, you will need:
 >
 > - [Node.js](https://nodejs.org/), supported versions: 16, 18
-{{^enableTestToolByDefault}}
-> - An [Microsoft 365 account for development](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts)
-{{/enableTestToolByDefault}}
 > - [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [TeamsFx CLI](https://aka.ms/teamsfx-toolkit-cli)
 >
 > **Note**
@@ -21,26 +18,13 @@ The app template is built using the TeamsFx SDK, which provides a simple set of 
 > Your app can be installed into a team, or a group chat, or as personal app. See [Installation and Uninstallation](https://aka.ms/teamsfx-command-new#customize-installation).
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
-{{#enableTestToolByDefault}}
 2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
 3. The browser will pop up to open Teams App Test Tool.
 4. Type or select `helloWorld` in the chat to send it to your bot - this is the default command provided by the template.
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-2. In the Account section, sign in with your [Microsoft 365 account](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts) if you haven't already.
-3. Press F5 to start debugging which launches your app in Teams using a web browser. Select `Debug in Teams (Edge)` or `Debug in Teams (Chrome)`.
-4. When Teams launches in the browser, select the Add button in the dialog to install your app to Teams.
-5. Type or select `helloWorld` in the chat to send it to your bot - this is the default command provided by the template.
-{{/enableTestToolByDefault}}
 
 The bot will respond to the `helloWorld` command with an Adaptive Card:
 
-{{#enableTestToolByDefault}}
 ![Command and Response in Test Tool](https://github.com/OfficeDev/TeamsFx/assets/9698542/2636fd91-ec7f-4740-a5ea-b272575b0b7c)
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-![Command and Response in Teams](https://user-images.githubusercontent.com/11220663/165891754-16916b68-c1b5-499d-b6a8-bdfb195f1fd0.png)
-{{/enableTestToolByDefault}}
 
 ## What's included in the template
 

--- a/templates/ts/custom-copilot-assistant-assistants-api/.vscode/launch.json.tpl
+++ b/templates/ts/custom-copilot-assistant-assistants-api/.vscode/launch.json.tpl
@@ -73,12 +73,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true
@@ -91,12 +86,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 2
             },
             "stopAll": true
@@ -108,12 +98,7 @@
             ],
             "preLaunchTask": "Start Teams App (Test Tool)",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "1-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "2-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true

--- a/templates/ts/custom-copilot-assistant-assistants-api/README.md.tpl
+++ b/templates/ts/custom-copilot-assistant-assistants-api/README.md.tpl
@@ -16,9 +16,6 @@ It showcases how to build an AI agent in Teams capable of helping users accompli
 > To run the AI Agent template in your local dev machine, you will need:
 >
 > - [Node.js](https://nodejs.org/), supported versions: 16, 18
-{{^enableTestToolByDefault}}
-> - A [Microsoft 365 account for development](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts)
-{{/enableTestToolByDefault}}
 > - [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [Teams Toolkit CLI](https://aka.ms/teamsfx-toolkit-cli)
 > - An account with [OpenAI](https://platform.openai.com/).
 >
@@ -63,24 +60,12 @@ Before running or debugging your bot, please follow these steps to setup your ow
 ### Run Teams Bot locally
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
-{{#enableTestToolByDefault}}
 1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
 1. You can send any message to get a response from the bot.
 
 **Congratulations**! You are running an application that can now interact with users in Teams App Test Tool:
 
 ![AI Agent in Teams App Test Tool](https://github.com/OfficeDev/TeamsFx/assets/37978464/e3b458f3-5e74-460d-9df2-bf77ed8d9c54)
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-1. In the Account section, sign in with your [Microsoft 365 account](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts) if you haven't yet.
-1. Press F5 to start debugging which launches your app in Teams using a web browser. Select `Debug in Teams (Edge)` or `Debug in Teams (Chrome)`.
-1. When Teams launches in the browser, select the Add button in the dialog to install your app to Teams.
-1. You can send any message to get a response from the bot.
-
-**Congratulations**! You are running an application that can now interact with users in Teams:
-
-![AI Agent in Teams](https://github.com/OfficeDev/TeamsFx/assets/37978464/fd1cf673-e7d8-4826-9cac-e9481a74ee1e)
-{{/enableTestToolByDefault}}
 
 ## What's included in the template
 

--- a/templates/ts/custom-copilot-assistant-new/.vscode/launch.json.tpl
+++ b/templates/ts/custom-copilot-assistant-new/.vscode/launch.json.tpl
@@ -73,12 +73,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true
@@ -91,12 +86,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 2
             },
             "stopAll": true
@@ -108,12 +98,7 @@
             ],
             "preLaunchTask": "Start Teams App (Test Tool)",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "1-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "2-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true

--- a/templates/ts/custom-copilot-assistant-new/README.md.tpl
+++ b/templates/ts/custom-copilot-assistant-new/README.md.tpl
@@ -16,9 +16,6 @@ It showcases how to build an AI agent in Teams capable of chatting with users an
 > To run the AI Agent template in your local dev machine, you will need:
 >
 > - [Node.js](https://nodejs.org/), supported versions: 16, 18
-{{^enableTestToolByDefault}}
-> - A [Microsoft 365 account for development](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts)
-{{/enableTestToolByDefault}}
 > - [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [Teams Toolkit CLI](https://aka.ms/teamsfx-toolkit-cli)
 {{#useOpenAI}}
 > - An account with [OpenAI](https://platform.openai.com/)
@@ -28,7 +25,6 @@ It showcases how to build an AI agent in Teams capable of chatting with users an
 {{/useAzureOpenAI}}
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
-{{#enableTestToolByDefault}}
 {{#useOpenAI}}
 1. In file *env/.env.testtool.user*, fill in your OpenAI key `SECRET_OPENAI_API_KEY=<your-key>`.
 {{/useOpenAI}}
@@ -41,23 +37,6 @@ It showcases how to build an AI agent in Teams capable of chatting with users an
 **Congratulations**! You are running an application that can now interact with users in Teams App Test Tool:
 
 ![AI Agent](https://github.com/OfficeDev/TeamsFx/assets/37978464/053218b7-cb17-4db4-9b8a-50ca04c1cb55)
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-1. In the Account section, sign in with your [Microsoft 365 account](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts) if you haven't yet.
-{{#useOpenAI}}
-1. In file *env/.env.local.user*, fill in your OpenAI key `SECRET_OPENAI_API_KEY=<your-key>`.
-{{/useOpenAI}}
-{{#useAzureOpenAI}}
-1. In file *env/.env.local.user*, fill in your Azure OpenAI key `SECRET_AZURE_OPENAI_API_KEY=<your-key>`, endpoint `AZURE_OPENAI_ENDPOINT=<your-endpoint>`, and deployment name `AZURE_OPENAI_DEPLOYMENT_NAME=<your-deployment>`.
-{{/useAzureOpenAI}}
-1. Press F5 to start debugging which launches your app in Teams using a web browser. Select `Debug in Teams (Edge)` or `Debug in Teams (Chrome)`.
-1. When Teams launches in the browser, select the Add button in the dialog to install your app to Teams.
-1. You can send any message to get a response from the bot.
-
-**Congratulations**! You are running an application that can now interact with users in Teams:
-
-![AI Agent](https://github.com/OfficeDev/TeamsFx/assets/37978464/4e64c733-ee01-4938-8be1-9de0195b7244)
-{{/enableTestToolByDefault}}
 
 ## What's included in the template
 

--- a/templates/ts/custom-copilot-basic/.vscode/launch.json.tpl
+++ b/templates/ts/custom-copilot-basic/.vscode/launch.json.tpl
@@ -73,12 +73,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true
@@ -91,12 +86,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 2
             },
             "stopAll": true
@@ -108,12 +98,7 @@
             ],
             "preLaunchTask": "Start Teams App (Test Tool)",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "1-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "2-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true

--- a/templates/ts/custom-copilot-basic/README.md.tpl
+++ b/templates/ts/custom-copilot-basic/README.md.tpl
@@ -17,9 +17,6 @@ The app template is built using the Teams AI library, which provides the capabil
 > To run the Basic AI Chatbot template in your local dev machine, you will need:
 >
 > - [Node.js](https://nodejs.org/), supported versions: 16, 18.
-{{^enableTestToolByDefault}}
-> - A [Microsoft 365 account for development](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts).
-{{/enableTestToolByDefault}}
 > - [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) latest version or [Teams Toolkit CLI](https://aka.ms/teamsfx-toolkit-cli).
 {{#useOpenAI}}
 > - An account with [OpenAI](https://platform.openai.com/).
@@ -29,7 +26,6 @@ The app template is built using the Teams AI library, which provides the capabil
 {{/useAzureOpenAI}}
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
-{{#enableTestToolByDefault}}
 {{#useOpenAI}}
 1. In file *env/.env.testtool.user*, fill in your OpenAI key `SECRET_OPENAI_API_KEY=<your-key>`.
 {{/useOpenAI}}
@@ -42,23 +38,6 @@ The app template is built using the Teams AI library, which provides the capabil
 **Congratulations**! You are running an application that can now interact with users in Teams App Test Tool:
 
 ![Basic AI Chatbot](https://github.com/OfficeDev/TeamsFx/assets/9698542/9bd22201-8fda-4252-a0b3-79531c963e5e)
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-1. In the Account section, sign in with your [Microsoft 365 account](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts) if you haven't yet.
-{{#useOpenAI}}
-1. In file *env/.env.local.user*, fill in your OpenAI key `SECRET_OPENAI_API_KEY=<your-key>`.
-{{/useOpenAI}}
-{{#useAzureOpenAI}}
-1. In file *env/.env.local.user*, fill in your Azure OpenAI key `SECRET_AZURE_OPENAI_API_KEY=<your-key>`, endpoint `AZURE_OPENAI_ENDPOINT=<your-endpoint>`, and deployment name `AZURE_OPENAI_DEPLOYMENT_NAME=<your-deployment>`.
-{{/useAzureOpenAI}}
-1. Press F5 to start debugging which launches your app in Teams using a web browser. Select `Debug in Teams (Edge)` or `Debug in Teams (Chrome)`.
-1. When Teams launches in the browser, select the Add button in the dialog to install your app to Teams.
-1. You can send any message to get a response from the bot.
-
-**Congratulations**! You are running an application that can now interact with users in Teams:
-
-![Basic AI Chatbot](https://user-images.githubusercontent.com/7642967/258726187-8306610b-579e-4301-872b-1b5e85141eff.png)
-{{/enableTestToolByDefault}}
 
 ## What's included in the template
 

--- a/templates/ts/custom-copilot-rag-custom-api/.vscode/launch.json.tpl
+++ b/templates/ts/custom-copilot-rag-custom-api/.vscode/launch.json.tpl
@@ -73,12 +73,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true
@@ -91,12 +86,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 2
             },
             "stopAll": true
@@ -108,12 +98,7 @@
             ],
             "preLaunchTask": "Start Teams App (Test Tool)",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "1-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "2-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true

--- a/templates/ts/custom-copilot-rag-custom-api/README.md.tpl
+++ b/templates/ts/custom-copilot-rag-custom-api/README.md.tpl
@@ -17,9 +17,6 @@ The app template is built using the Teams AI library, which provides the capabil
 > To run the Custom Copilot from Custom API template in your local dev machine, you will need:
 >
 > - [Node.js](https://nodejs.org/), supported versions: 16, 18
-{{^enableTestToolByDefault}}
-> - A [Microsoft 365 account for development](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts)
-{{/enableTestToolByDefault}}
 > - [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [Teams Toolkit CLI](https://aka.ms/teamsfx-toolkit-cli)
 {{#useOpenAI}}
 > - An account with [OpenAI](https://platform.openai.com/)
@@ -29,7 +26,6 @@ The app template is built using the Teams AI library, which provides the capabil
 {{/useAzureOpenAI}}
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
-{{#enableTestToolByDefault}}
 {{#useOpenAI}}
 1. In file *env/.env.testtool.user*, fill in your OpenAI key `SECRET_OPENAI_API_KEY=<your-key>`.
 {{/useOpenAI}}
@@ -42,23 +38,6 @@ The app template is built using the Teams AI library, which provides the capabil
 **Congratulations**! You are running an application that can now interact with users in Teams App Test Tool:
 
 ![custom api template](https://github.com/OfficeDev/TeamsFx/assets/63089166/81f985a1-b81d-4c27-a82a-73a9b65ece1f)
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-1. In the Account section, sign in with your [Microsoft 365 account](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts) if you haven't yet.
-{{#useOpenAI}}
-1. In file *env/.env.local.user*, fill in your OpenAI key `SECRET_OPENAI_API_KEY=<your-key>`.
-{{/useOpenAI}}
-{{#useAzureOpenAI}}
-1. In file *env/.env.local.user*, fill in your Azure OpenAI key `SECRET_AZURE_OPENAI_ENDPOINT=<your-key>`, endpoint `SECRET_AZURE_OPENAI_ENDPOINT=<your-endpoint> and deployment name `AZURE_OPENAI_DEPLOYMENT=<your-deployment-name>`.
-{{/useAzureOpenAI}}
-1. Press F5 to start debugging which launches your app in Teams using a web browser. Select `Debug in Teams (Edge)` or `Debug in Teams (Chrome)`.
-1. When Teams launches in the browser, select the Add button in the dialog to install your app to Teams.
-1. You can send any message to get a response from the bot.
-
-**Congratulations**! You are running an application that can now interact with users in Teams:
-
-![custom api template](https://github.com/OfficeDev/TeamsFx/assets/63089166/19f4c825-c296-4d29-a957-bedb88b6aa5b)
-{{/enableTestToolByDefault}}
 
 ## What's included in the template
 

--- a/templates/ts/default-bot/.vscode/launch.json.tpl
+++ b/templates/ts/default-bot/.vscode/launch.json.tpl
@@ -73,12 +73,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true
@@ -91,12 +86,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 2
             },
             "stopAll": true
@@ -108,12 +98,7 @@
             ],
             "preLaunchTask": "Start Teams App (Test Tool)",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "1-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "2-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true

--- a/templates/ts/default-bot/README.md.tpl
+++ b/templates/ts/default-bot/README.md.tpl
@@ -15,13 +15,9 @@ A bot interaction can be a quick question and answer, or it can be a complex con
 > To run the Basic Bot template in your local dev machine, you will need:
 >
 > - [Node.js](https://nodejs.org/), supported versions: 16, 18
-{{^enableTestToolByDefault}}
-> - A [Microsoft 365 account for development](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts)
-{{/enableTestToolByDefault}}
 > - [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [Teams Toolkit CLI](https://aka.ms/teamsfx-toolkit-cli)
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
-{{#enableTestToolByDefault}}
 2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
 3. The browser will pop up to open Teams App Test Tool.
 4. You will receive a welcome message from the bot, and you can send anything to the bot to get an echoed response.
@@ -29,17 +25,6 @@ A bot interaction can be a quick question and answer, or it can be a complex con
 **Congratulations**! You are running an application that can now interact with users in Teams App Test Tool:
 
 ![basic bot](https://github.com/OfficeDev/TeamsFx/assets/9698542/bdf87809-7dd7-4926-bff0-4546ada25e4b)
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-2. In the Account section, sign in with your [Microsoft 365 account](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts) if you haven't already.
-3. Press F5 to start debugging which launches your app in Teams using a web browser. Select `Debug in Teams (Edge)` or `Debug in Teams (Chrome)`.
-4. When Teams launches in the browser, select the Add button in the dialog to install your app to Teams.
-5. You will receive a welcome message from the bot, and you can send anything to the bot to get an echoed response.
-
-**Congratulations**! You are running an application that can now interact with users in Teams:
-
-![basic bot](https://github.com/OfficeDev/TeamsFx/assets/25220706/170096d2-b353-4d4e-b55a-2c8ae4d97514)
-{{/enableTestToolByDefault}}
 
 ## What's included in the template
 

--- a/templates/ts/notification-http-timer-trigger/.vscode/launch.json.tpl
+++ b/templates/ts/notification-http-timer-trigger/.vscode/launch.json.tpl
@@ -73,12 +73,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true
@@ -91,12 +86,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 2
             },
             "stopAll": true
@@ -108,12 +98,7 @@
             ],
             "preLaunchTask": "Start Teams App (Test Tool)",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "1-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "2-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true

--- a/templates/ts/notification-http-timer-trigger/README.md.tpl
+++ b/templates/ts/notification-http-timer-trigger/README.md.tpl
@@ -12,9 +12,6 @@ The app template is built using the TeamsFx SDK, which provides a simple set of 
 > To run the notification bot template in your local dev machine, you will need:
 >
 > - [Node.js](https://nodejs.org/), supported versions: 16, 18
-{{^enableTestToolByDefault}}
-> - An [Microsoft 365 account for development](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts)
-{{/enableTestToolByDefault}}
 > - [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [TeamsFx CLI](https://aka.ms/teamsfx-toolkit-cli)
 >
 > **Note**
@@ -22,31 +19,16 @@ The app template is built using the TeamsFx SDK, which provides a simple set of 
 > Your app can be installed into a team, or a group chat, or as personal app. See [Installation and Uninstallation](https://aka.ms/teamsfx-notification-new#customize-installation).
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
-{{#enableTestToolByDefault}}
 2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
 3. The browser will pop up to open Teams App Test Tool.
 4. If you select `Timer Trigger`, wait for 30 seconds. If you select `HTTP Trigger`, send a POST request to `http://<endpoint>/api/notification` with your favorite tool (like `Postman`)
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-2. In the Account section, sign in with your [Microsoft 365 account](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts) if you haven't already.
-3. Press F5 to start debugging which launches your app in Teams using a web browser. Select `Debug in Teams (Edge)` or `Debug in Teams (Chrome)`.
-4. When Teams launches in the browser, select the Add button in the dialog to install your app to Teams.
-5. If you select `Timer Trigger`, wait for 30 seconds. If you select `HTTP Trigger`, send a POST request to `http://<endpoint>/api/notification` with your favorite tool (like `Postman`)
-{{/enableTestToolByDefault}}
 
    - When your project is running locally, replace `<endpoint>` with `localhost:3978`
    - When your project is deployed to Azure App Service, replace `<endpoint>` with the url from Azure App Service
 
-{{#enableTestToolByDefault}}
 The bot will send an Adaptive Card to Teams App Test Tool:
 
 ![Notification Message in Test Tool](https://github.com/OfficeDev/TeamsFx/assets/9698542/43ee64f4-5554-4e0b-854f-f7e20672cb25)
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-The bot will send an Adaptive Card to Teams:
-
-![Notification Message in Teams](https://user-images.githubusercontent.com/7642967/223006044-5003574e-2aee-4a41-9b71-c103d0439012.png)
-{{/enableTestToolByDefault}}
 
 ## What's included in the template
 

--- a/templates/ts/notification-http-trigger/.vscode/launch.json.tpl
+++ b/templates/ts/notification-http-trigger/.vscode/launch.json.tpl
@@ -73,12 +73,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true
@@ -91,12 +86,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 2
             },
             "stopAll": true
@@ -108,12 +98,7 @@
             ],
             "preLaunchTask": "Start Teams App (Test Tool)",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "1-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "2-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true

--- a/templates/ts/notification-http-trigger/README.md.tpl
+++ b/templates/ts/notification-http-trigger/README.md.tpl
@@ -12,9 +12,6 @@ The app template is built using the TeamsFx SDK, which provides a simple set of 
 > To run the notification bot template in your local dev machine, you will need:
 >
 > - [Node.js](https://nodejs.org/), supported versions: 16, 18
-{{^enableTestToolByDefault}}
-> - An [Microsoft 365 account for development](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts)
-{{/enableTestToolByDefault}}
 > - [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [TeamsFx CLI](https://aka.ms/teamsfx-toolkit-cli)
 >
 > **Note**
@@ -22,31 +19,16 @@ The app template is built using the TeamsFx SDK, which provides a simple set of 
 > Your app can be installed into a team, or a group chat, or as personal app. See [Installation and Uninstallation](https://aka.ms/teamsfx-notification-new#customize-installation).
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
-{{#enableTestToolByDefault}}
 2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
 3. The browser will pop up to open Teams App Test Tool.
 4. If you select `Timer Trigger`, wait for 30 seconds. If you select `HTTP Trigger`, send a POST request to `http://<endpoint>/api/notification` with your favorite tool (like `Postman`)
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-2. In the Account section, sign in with your [Microsoft 365 account](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts) if you haven't already.
-3. Press F5 to start debugging which launches your app in Teams using a web browser. Select `Debug in Teams (Edge)` or `Debug in Teams (Chrome)`.
-4. When Teams launches in the browser, select the Add button in the dialog to install your app to Teams.
-5. If you select `Timer Trigger`, wait for 30 seconds. If you select `HTTP Trigger`, send a POST request to `http://<endpoint>/api/notification` with your favorite tool (like `Postman`)
-{{/enableTestToolByDefault}}
 
    - When your project is running locally, replace `<endpoint>` with `localhost:3978`
    - When your project is deployed to Azure App Service, replace `<endpoint>` with the url from Azure App Service
 
-{{#enableTestToolByDefault}}
 The bot will send an Adaptive Card to Teams App Test Tool:
 
 ![Notification Message in Test Tool](https://github.com/OfficeDev/TeamsFx/assets/9698542/43ee64f4-5554-4e0b-854f-f7e20672cb25)
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-The bot will send an Adaptive Card to Teams:
-
-![Notification Message in Teams](https://user-images.githubusercontent.com/7642967/223006044-5003574e-2aee-4a41-9b71-c103d0439012.png)
-{{/enableTestToolByDefault}}
 
 ## What's included in the template
 

--- a/templates/ts/notification-restify/.vscode/launch.json.tpl
+++ b/templates/ts/notification-restify/.vscode/launch.json.tpl
@@ -73,12 +73,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true
@@ -91,12 +86,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 2
             },
             "stopAll": true
@@ -108,12 +98,7 @@
             ],
             "preLaunchTask": "Start Teams App (Test Tool)",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "1-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "2-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true

--- a/templates/ts/notification-restify/README.md.tpl
+++ b/templates/ts/notification-restify/README.md.tpl
@@ -12,9 +12,6 @@ The app template is built using the TeamsFx SDK, which provides a simple set of 
 > To run the notification bot template in your local dev machine, you will need:
 >
 > - [Node.js](https://nodejs.org/), supported versions: 16, 18
-{{^enableTestToolByDefault}}
-> - An [Microsoft 365 account for development](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts)
-{{/enableTestToolByDefault}}
 > - [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [TeamsFx CLI](https://aka.ms/teamsfx-toolkit-cli)
 >
 > **Note**
@@ -22,31 +19,16 @@ The app template is built using the TeamsFx SDK, which provides a simple set of 
 > Your app can be installed into a team, or a group chat, or as personal app. See [Installation and Uninstallation](https://aka.ms/teamsfx-notification-new#customize-installation).
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
-{{#enableTestToolByDefault}}
 2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
 3. The browser will pop up to open Teams App Test Tool.
 4. Send a POST request to `http://<endpoint>/api/notification` with your favorite tool (like `Postman`)
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-2. In the Account section, sign in with your [Microsoft 365 account](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts) if you haven't already.
-3. Press F5 to start debugging which launches your app in Teams using a web browser. Select `Debug in Teams (Edge)` or `Debug in Teams (Chrome)`.
-4. When Teams launches in the browser, select the Add button in the dialog to install your app to Teams.
-5. Send a POST request to `http://<endpoint>/api/notification` with your favorite tool (like `Postman`)
-{{/enableTestToolByDefault}}
 
    - When your project is running locally, replace `<endpoint>` with `localhost:3978`
    - When your project is deployed to Azure App Service, replace `<endpoint>` with the url from Azure App Service
 
-{{#enableTestToolByDefault}}
 The bot will send an Adaptive Card to Teams App Test Tool:
 
 ![Notification Message in Test Tool](https://github.com/OfficeDev/TeamsFx/assets/9698542/52aa4826-e8b3-4341-b9e1-bcba50470861)
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-The bot will send an Adaptive Card to Teams:
-
-![Notification Message in Teams](https://user-images.githubusercontent.com/7642967/223006044-5003574e-2aee-4a41-9b71-c103d0439012.png)
-{{/enableTestToolByDefault}}
 
 ## What's included in the template
 

--- a/templates/ts/notification-timer-trigger/.vscode/launch.json.tpl
+++ b/templates/ts/notification-timer-trigger/.vscode/launch.json.tpl
@@ -73,12 +73,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true
@@ -91,12 +86,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 2
             },
             "stopAll": true
@@ -108,12 +98,7 @@
             ],
             "preLaunchTask": "Start Teams App (Test Tool)",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "1-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "2-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true

--- a/templates/ts/notification-timer-trigger/README.md.tpl
+++ b/templates/ts/notification-timer-trigger/README.md.tpl
@@ -12,9 +12,6 @@ The app template is built using the TeamsFx SDK, which provides a simple set of 
 > To run the notification bot template in your local dev machine, you will need:
 >
 > - [Node.js](https://nodejs.org/), supported versions: 16, 18
-{{^enableTestToolByDefault}}
-> - An [Microsoft 365 account for development](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts)
-{{/enableTestToolByDefault}}
 > - [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [TeamsFx CLI](https://aka.ms/teamsfx-toolkit-cli)
 >
 > **Note**
@@ -22,31 +19,16 @@ The app template is built using the TeamsFx SDK, which provides a simple set of 
 > Your app can be installed into a team, or a group chat, or as personal app. See [Installation and Uninstallation](https://aka.ms/teamsfx-notification-new#customize-installation).
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
-{{#enableTestToolByDefault}}
 2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
 3. The browser will pop up to open Teams App Test Tool.
 4. If you select `Timer Trigger`, wait for 30 seconds. If you select `HTTP Trigger`, send a POST request to `http://<endpoint>/api/notification` with your favorite tool (like `Postman`)
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-2. In the Account section, sign in with your [Microsoft 365 account](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts) if you haven't already.
-3. Press F5 to start debugging which launches your app in Teams using a web browser. Select `Debug in Teams (Edge)` or `Debug in Teams (Chrome)`.
-4. When Teams launches in the browser, select the Add button in the dialog to install your app to Teams.
-5. If you select `Timer Trigger`, wait for 30 seconds. If you select `HTTP Trigger`, send a POST request to `http://<endpoint>/api/notification` with your favorite tool (like `Postman`)
-{{/enableTestToolByDefault}}
 
    - When your project is running locally, replace `<endpoint>` with `localhost:3978`
    - When your project is deployed to Azure App Service, replace `<endpoint>` with the url from Azure App Service
 
-{{#enableTestToolByDefault}}
 The bot will send an Adaptive Card to Teams App Test Tool:
 
 ![Notification Message in Test Tool](https://github.com/OfficeDev/TeamsFx/assets/9698542/43ee64f4-5554-4e0b-854f-f7e20672cb25)
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-The bot will send an Adaptive Card to Teams:
-
-![Notification Message in Teams](https://user-images.githubusercontent.com/7642967/223006044-5003574e-2aee-4a41-9b71-c103d0439012.png)
-{{/enableTestToolByDefault}}
 
 ## What's included in the template
 

--- a/templates/ts/workflow/.vscode/launch.json.tpl
+++ b/templates/ts/workflow/.vscode/launch.json.tpl
@@ -73,12 +73,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true
@@ -91,12 +86,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 2
             },
             "stopAll": true
@@ -108,12 +98,7 @@
             ],
             "preLaunchTask": "Start Teams App (Test Tool)",
             "presentation": {
-{{#enableTestToolByDefault}}
                 "group": "1-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-                "group": "2-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true

--- a/templates/ts/workflow/README.md.tpl
+++ b/templates/ts/workflow/README.md.tpl
@@ -11,9 +11,6 @@ The app template is built using the TeamsFx SDK, which provides a simple set of 
 > To run the workflow bot template in your local dev machine, you will need:
 >
 > - [Node.js](https://nodejs.org/), supported versions: 16, 18
-{{^enableTestToolByDefault}}
-> - An [Microsoft 365 account for development](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts)
-{{/enableTestToolByDefault}}
 > - [Teams Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [TeamsFx CLI](https://aka.ms/teamsfx-toolkit-cli)
 >
 > **Note**
@@ -21,38 +18,20 @@ The app template is built using the TeamsFx SDK, which provides a simple set of 
 > Your app can be installed into a team, or a group chat, or as personal app. See [Installation and Uninstallation](https://aka.ms/teamsfx-command-response#customize-installation).
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
-{{#enableTestToolByDefault}}
 2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
 3. The browser will pop up to open Teams App Test Tool.
 4. Type or select `helloWorld` in the chat to send it to your bot - this is the default command provided by the template.
 5. In the response from the bot, select the **DoStuff** button.
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-2. In the Account section, sign in with your [Microsoft 365 account](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts) if you haven't already.
-3. Press F5 to start debugging which launches your app in Teams using a web browser. Select `Debug in Teams (Edge)` or `Debug in Teams (Chrome)`.
-4. When Teams launches in the browser, select the Add button in the dialog to install your app to Teams.
-5. Type or select `helloWorld` in the chat to send it to your bot - this is the default command provided by the template.
-6. In the response from the bot, select the **DoStuff** button.
-{{/enableTestToolByDefault}}
 
 The bot will respond by updating the existing Adaptive Card to show the workflow is now complete! Continue reading to learn more about what's included in the template and how to customize it.
 
 Here is a screen shot of the application running:
 
-{{#enableTestToolByDefault}}
 ![Responds to command](https://github.com/OfficeDev/TeamsFx/assets/9698542/94173beb-2fff-44fa-87dc-f686677da631)
 
 When you click the `DoStuff` button, the above adaptive card will be updated to a new card as shown below:
 
 ![Responds to card action](https://github.com/OfficeDev/TeamsFx/assets/9698542/521ff12d-726c-4087-825a-112547cad836)
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
-![Responds to command](https://user-images.githubusercontent.com/10163840/192477792-dc447b3a-e304-4cd8-b4df-b1eb9d226292.png)
-
-When you click the `DoStuff` button, the above adaptive card will be updated to a new card as shown below:
-
-![Responds to card action](https://user-images.githubusercontent.com/10163840/192477148-29d9edfc-085b-4d02-b3de-b47b9a456108.png)
-{{/enableTestToolByDefault}}
 
 ## What's included in the template
 


### PR DESCRIPTION
Since feature flag is already open by default in stable release, it is not needed. Clean up the feature flag for future use by message extension templates

AZDO feature: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/25153944/