### PR TITLE
feat: add feature flag for ME test tool

### DIFF
--- a/packages/fx-core/src/common/constants.ts
+++ b/packages/fx-core/src/common/constants.ts
@@ -60,6 +60,7 @@ export class FeatureFlagName {
   static readonly ApiCopilotPlugin = "API_COPILOT_PLUGIN";
   static readonly SampleConfigBranch = "TEAMSFX_SAMPLE_CONFIG_BRANCH";
   static readonly TestTool = "TEAMSFX_TEST_TOOL";
+  static readonly METestTool = "TEAMSFX_ME_TEST_TOOL";
   static readonly ApiKey = "API_COPILOT_API_KEY";
   static readonly MultipleParameters = "API_COPILOT_MULTIPLE_PARAMETERS";
   static readonly TeamsFxRebranding = "TEAMSFX_REBRANDING";

--- a/packages/fx-core/src/common/featureFlags.ts
+++ b/packages/fx-core/src/common/featureFlags.ts
@@ -50,6 +50,10 @@ export function enableTestToolByDefault(): boolean {
   return isFeatureFlagEnabled(FeatureFlagName.TestTool, true);
 }
 
+export function enableMETestToolByDefault(): boolean {
+  return isFeatureFlagEnabled(FeatureFlagName.METestTool, true);
+}
+
 export function isApiKeyEnabled(): boolean {
   return isFeatureFlagEnabled(FeatureFlagName.ApiKey, false);
 }

--- a/packages/fx-core/src/component/generator/generator.ts
+++ b/packages/fx-core/src/component/generator/generator.ts
@@ -35,7 +35,11 @@ import {
   renderTemplateFileData,
   renderTemplateFileName,
 } from "./utils";
-import { enableTestToolByDefault, isNewProjectTypeEnabled } from "../../common/featureFlags";
+import {
+  enableMETestToolByDefault,
+  enableTestToolByDefault,
+  isNewProjectTypeEnabled,
+} from "../../common/featureFlags";
 import { Utils } from "@microsoft/m365-spec-parser";
 
 export class Generator {
@@ -69,6 +73,7 @@ export class Generator {
       ApiSpecAuthRegistrationIdEnvName: safeRegistrationIdEnvName,
       ApiSpecPath: apiKeyAuthData?.openapiSpecPath ?? "",
       enableTestToolByDefault: enableTestToolByDefault() ? "true" : "",
+      enableMETestToolByDefault: enableMETestToolByDefault() ? "true" : "",
       useOpenAI: llmServiceData?.llmService === "llm-service-openai" ? "true" : "",
       useAzureOpenAI: llmServiceData?.llmService === "llm-service-azure-openai" ? "true" : "",
       openAIKey: llmServiceData?.openAIKey ?? "",

--- a/packages/fx-core/tests/component/generator/generator.test.ts
+++ b/packages/fx-core/tests/component/generator/generator.test.ts
@@ -799,6 +799,18 @@ describe("Generator happy path", async () => {
     assert.equal(vars.enableTestToolByDefault, "");
   });
 
+  it("template variables when ME test tool enabled", async () => {
+    sandbox.stub(process, "env").value({ TEAMSFX_ME_TEST_TOOL: "true" });
+    const vars = Generator.getDefaultVariables("test");
+    assert.equal(vars.enableMETestToolByDefault, "true");
+  });
+
+  it("template variables when ME test tool disabled", async () => {
+    sandbox.stub(process, "env").value({ TEAMSFX_ME_TEST_TOOL: "false" });
+    const vars = Generator.getDefaultVariables("test");
+    assert.equal(vars.enableMETestToolByDefault, "");
+  });
+
   it("template variables when new project enabled", async () => {
     sandbox.stub(process, "env").value({
       TEAMSFX_NEW_PROJECT_TYPE: "true",

--- a/templates/js/m365-message-extension/.vscode/launch.json.tpl
+++ b/templates/js/m365-message-extension/.vscode/launch.json.tpl
@@ -122,7 +122,12 @@
             ],
             "preLaunchTask": "Start Teams App (Test Tool)",
             "presentation": {
+{{#enableMETestToolByDefault}}
                 "group": "group 0: Teams App Test Tool",
+{{/enableMETestToolByDefault}}
+{{^enableMETestToolByDefault}}
+                "group": "group 3: Teams App Test Tool",
+{{/enableMETestToolByDefault}}
                 "order": 1
             },
             "stopAll": true


### PR DESCRIPTION
Add feature flag to control whether test tool is the default launch profile in ME templates. In preview version enable it by default.

AZDO feature: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/25153944/