### PR TITLE
fix: fix office xml addin related static templates bug

### DIFF
--- a/templates/js/office-xml-addin-excel-cf/README.md
+++ b/templates/js/office-xml-addin-excel-cf/README.md
@@ -50,7 +50,7 @@ You can check whether your manifest file is valid by either of the following way
 
 - [Custom functions overview](https://learn.microsoft.com/office/dev/add-ins/excel/custom-functions-overview)
 - [Custom functions runtime](https://learn.microsoft.com/office/dev/add-ins/excel/custom-functions-runtime)
-- [Custom functions Troubleshoot](https://learn.microsoft.com/en-us/office/dev/add-ins/excel/custom-functions-troubleshooting)
+- [Custom functions troubleshoot](https://learn.microsoft.com/en-us/office/dev/add-ins/excel/custom-functions-troubleshooting)
 - [Office Add-ins documentation](https://learn.microsoft.com/office/dev/add-ins/overview/office-add-ins)
 - More Office Add-ins samples at [OfficeDev on Github](https://github.com/officedev)
 

--- a/templates/js/office-xml-addin-excel-cf/README.md
+++ b/templates/js/office-xml-addin-excel-cf/README.md
@@ -49,8 +49,8 @@ You can check whether your manifest file is valid by either of the following way
 ## Additional resources
 
 - [Custom functions overview](https://learn.microsoft.com/office/dev/add-ins/excel/custom-functions-overview)
-- [Custom functions best practices](https://learn.microsoft.com/office/dev/add-ins/excel/custom-functions-best-practices)
 - [Custom functions runtime](https://learn.microsoft.com/office/dev/add-ins/excel/custom-functions-runtime)
+- [Custom functions Troubleshoot](https://learn.microsoft.com/en-us/office/dev/add-ins/excel/custom-functions-troubleshooting)
 - [Office Add-ins documentation](https://learn.microsoft.com/office/dev/add-ins/overview/office-add-ins)
 - More Office Add-ins samples at [OfficeDev on Github](https://github.com/officedev)
 

--- a/templates/js/office-xml-addin-excel-manifest-only/manifest.xml
+++ b/templates/js/office-xml-addin-excel-manifest-only/manifest.xml
@@ -24,7 +24,7 @@
   <HighResolutionIconUrl DefaultValue="https://localhost:3000/assets/icon-80.png"/>
 
   <!--If you plan to submit this add-in to the Office Store, uncomment the SupportUrl element below-->
-  <!--<SupportUrl DefaultValue="[Insert the URL of a page that provides support information for the app]" />-->
+  <SupportUrl DefaultValue="https://localhost:3000" />
 
   <!-- Domains that will be allowed when navigating. For example, if you use ShowTaskpane and then have an href link, navigation will only be allowed if the domain is on this list. -->
   <AppDomains>

--- a/templates/js/office-xml-addin-powerpoint-manifest-only/manifest.xml
+++ b/templates/js/office-xml-addin-powerpoint-manifest-only/manifest.xml
@@ -24,7 +24,7 @@
   <HighResolutionIconUrl DefaultValue="https://localhost:3000/assets/icon-80.png.png"/>
 
   <!--If you plan to submit this add-in to the Office Store, uncomment the SupportUrl element below-->
-  <!--<SupportUrl DefaultValue="[Insert the URL of a page that provides support information for the app]" />-->
+  <SupportUrl DefaultValue="https://localhost:3000" />
 
   <!-- Domains that will be allowed when navigating. For example, if you use ShowTaskpane and then have an href link, navigation will only be allowed if the domain is on this list. -->
   <AppDomains>

--- a/templates/js/office-xml-addin-word-manifest-only/manifest.xml
+++ b/templates/js/office-xml-addin-word-manifest-only/manifest.xml
@@ -24,7 +24,7 @@
   <HighResolutionIconUrl DefaultValue="https://localhost:3000/assets/icon-80.png"/>
 
   <!--If you plan to submit this add-in to the Office Store, uncomment the SupportUrl element below-->
-  <!--<SupportUrl DefaultValue="[Insert the URL of a page that provides support information for the app]" />-->
+  <SupportUrl DefaultValue="https://localhost:3000" />
 
   <!-- Domains that will be allowed when navigating. For example, if you use ShowTaskpane and then have an href link, navigation will only be allowed if the domain is on this list. -->
   <AppDomains>

--- a/templates/ts/office-xml-addin-excel-cf/README.md
+++ b/templates/ts/office-xml-addin-excel-cf/README.md
@@ -50,7 +50,7 @@ You can check whether your manifest file is valid by either of the following way
 
 - [Custom functions overview](https://learn.microsoft.com/office/dev/add-ins/excel/custom-functions-overview)
 - [Custom functions runtime](https://learn.microsoft.com/office/dev/add-ins/excel/custom-functions-runtime)
-- [Custom functions Troubleshoot](https://learn.microsoft.com/en-us/office/dev/add-ins/excel/custom-functions-troubleshooting)
+- [Custom functions troubleshoot](https://learn.microsoft.com/en-us/office/dev/add-ins/excel/custom-functions-troubleshooting)
 - [Office Add-ins documentation](https://learn.microsoft.com/office/dev/add-ins/overview/office-add-ins)
 - More Office Add-ins samples at [OfficeDev on Github](https://github.com/officedev)
 

--- a/templates/ts/office-xml-addin-excel-cf/README.md
+++ b/templates/ts/office-xml-addin-excel-cf/README.md
@@ -49,8 +49,8 @@ You can check whether your manifest file is valid by either of the following way
 ## Additional resources
 
 - [Custom functions overview](https://learn.microsoft.com/office/dev/add-ins/excel/custom-functions-overview)
-- [Custom functions best practices](https://learn.microsoft.com/office/dev/add-ins/excel/custom-functions-best-practices)
 - [Custom functions runtime](https://learn.microsoft.com/office/dev/add-ins/excel/custom-functions-runtime)
+- [Custom functions Troubleshoot](https://learn.microsoft.com/en-us/office/dev/add-ins/excel/custom-functions-troubleshooting)
 - [Office Add-ins documentation](https://learn.microsoft.com/office/dev/add-ins/overview/office-add-ins)
 - More Office Add-ins samples at [OfficeDev on Github](https://github.com/officedev)
 


### PR DESCRIPTION
This PR fix the following BUGS:
* [27333350](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/27333350): The validate manifest should works now.
* [27333404](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/27333404): Replace the 404 link with another link in README.