### PR TITLE
feat(chat): split match requests under 3K token limitation

### DIFF
--- a/packages/vscode-extension/src/chat/commands/create/helper.ts
+++ b/packages/vscode-extension/src/chat/commands/create/helper.ts
@@ -124,7 +124,7 @@ async function matchSamples(
       projectMetadata = [...sampleExampleMetadata];
     }
   }
-  if (projectMetadata.length > 2) {
+  if (projectMetadata.length > sampleExampleMetadata.length) {
     matchedSamples.push(
       ...(await sendCopilotMatchRequest(
         getProjectMatchSystemPrompt(projectMetadata, sampleExamples),

--- a/packages/vscode-extension/src/chat/commands/create/helper.ts
+++ b/packages/vscode-extension/src/chat/commands/create/helper.ts
@@ -3,6 +3,7 @@
 
 import axios from "axios";
 import * as fs from "fs-extra";
+import { includes } from "lodash";
 import * as path from "path";
 import * as tmp from "tmp";
 
@@ -17,14 +18,22 @@ import {
   ChatRequest,
   ChatResponseFileTree,
   ChatResponseStream,
+  LanguageModelChatSystemMessage,
   LanguageModelChatUserMessage,
   Uri,
 } from "vscode";
 import { getProjectMatchSystemPrompt } from "../../prompts";
 import { IChatTelemetryData } from "../../types";
-import { getCopilotResponseAsString, getSampleDownloadUrlInfo } from "../../utils";
+import {
+  countMessageTokens,
+  getCopilotResponseAsString,
+  getSampleDownloadUrlInfo,
+} from "../../utils";
 import * as teamsTemplateMetadata from "./templateMetadata.json";
 import { ProjectMetadata } from "./types";
+
+const TOKEN_LIMITS = 2700;
+const SCORE_LIMIT = 0.7;
 
 export async function matchProject(
   request: ChatRequest,
@@ -32,31 +41,122 @@ export async function matchProject(
   telemetryMetadata: IChatTelemetryData
 ): Promise<ProjectMetadata[]> {
   const allProjectMetadata = [...getTeamsTemplateMetadata(), ...(await getTeamsSampleMetadata())];
-  const messages = [
-    getProjectMatchSystemPrompt(allProjectMetadata),
-    new LanguageModelChatUserMessage(request.prompt),
+  const matchedProjects = [
+    ...(await matchSamples(request, token, telemetryMetadata)),
+    ...(await matchTemplates(request, token, telemetryMetadata)),
   ];
-
-  telemetryMetadata.chatMessages.push(...messages);
-
-  const response = await getCopilotResponseAsString("copilot-gpt-3.5-turbo", messages, token);
-  const matchedProjectId: string[] = [];
-  if (response) {
-    try {
-      const responseJson = JSON.parse(response);
-      if (responseJson && responseJson.app) {
-        matchedProjectId.push(...(responseJson.app as string[]));
-      }
-    } catch (e) {}
-  }
+  matchedProjects.sort((a, b) => b.score - a.score);
   const result: ProjectMetadata[] = [];
-  for (const id of matchedProjectId) {
+  for (const { id, score } of matchedProjects) {
+    if (score < SCORE_LIMIT) {
+      break;
+    }
     const matchedProject = allProjectMetadata.find((config) => config.id === id);
     if (matchedProject) {
       result.push(matchedProject);
     }
   }
   return result;
+}
+
+async function matchTemplates(
+  request: ChatRequest,
+  token: CancellationToken,
+  telemetryMetadata: IChatTelemetryData
+): Promise<Array<{ id: string; score: number }>> {
+  const templateExamples = [
+    {
+      user: "an app shown in sharepoint",
+      app: "tab-spfx",
+    },
+    {
+      user: "a tab app",
+      app: "tab-non-sso",
+    },
+    {
+      user: "a bot that accepts commands",
+      app: "command-bot",
+    },
+  ];
+  const templateMetadata = getTeamsTemplateMetadata();
+  const matchedTemplates = await sendCopilotMatchRequest(
+    getProjectMatchSystemPrompt(templateMetadata, templateExamples),
+    request,
+    token,
+    telemetryMetadata
+  );
+  return matchedTemplates;
+}
+
+async function matchSamples(
+  request: ChatRequest,
+  token: CancellationToken,
+  telemetryMetadata: IChatTelemetryData
+): Promise<Array<{ id: string; score: number }>> {
+  const sampleMetadata = await getTeamsSampleMetadata();
+  const sampleExamples = [
+    {
+      user: "an app that manages to-do list and works in Outlook",
+      app: "todo-list-with-Azure-backend-M365",
+    },
+    {
+      user: "an app to send notification to a lot of users",
+      app: "large-scale-notification",
+    },
+  ];
+  const exampleIds = sampleExamples.map((example) => example.app);
+  const sampleExampleMetadata = sampleMetadata.filter((config) => includes(exampleIds, config.id));
+  const remainingSampleMetadata = sampleMetadata.filter(
+    (config) => !includes(exampleIds, config.id)
+  );
+  let index = 0;
+  let projectMetadata: ProjectMetadata[] = [...sampleExampleMetadata];
+  const matchedSamples: Array<{ id: string; score: number }> = [];
+  while (index < remainingSampleMetadata.length) {
+    projectMetadata.push(remainingSampleMetadata[index]);
+    index += 1;
+    const systemPrompt = getProjectMatchSystemPrompt(projectMetadata, sampleExamples);
+    const tokenNumber = countMessageTokens(systemPrompt);
+    if (tokenNumber > TOKEN_LIMITS) {
+      matchedSamples.push(
+        ...(await sendCopilotMatchRequest(systemPrompt, request, token, telemetryMetadata))
+      );
+      projectMetadata = [...sampleExampleMetadata];
+    }
+  }
+  if (projectMetadata.length > 2) {
+    matchedSamples.push(
+      ...(await sendCopilotMatchRequest(
+        getProjectMatchSystemPrompt(projectMetadata, sampleExamples),
+        request,
+        token,
+        telemetryMetadata
+      ))
+    );
+  }
+  return matchedSamples;
+}
+
+async function sendCopilotMatchRequest(
+  systemPrompt: LanguageModelChatSystemMessage,
+  request: ChatRequest,
+  token: CancellationToken,
+  telemetryMetadata: IChatTelemetryData
+) {
+  const messages = [systemPrompt, new LanguageModelChatUserMessage(request.prompt)];
+  telemetryMetadata.chatMessages.push(...messages);
+
+  const response = await getCopilotResponseAsString("copilot-gpt-3.5-turbo", messages, token);
+
+  if (response) {
+    try {
+      const responseJson = JSON.parse(response);
+      if (responseJson && responseJson.app) {
+        return responseJson.app as Array<{ id: string; score: number }>;
+      }
+    } catch (e) {}
+  }
+  return [];
 }
 
 export function getTeamsTemplateMetadata(): ProjectMetadata[] {

--- a/packages/vscode-extension/src/chat/prompts.ts
+++ b/packages/vscode-extension/src/chat/prompts.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { ProjectMetadata } from "./commands/create/types";
 import * as vscode from "vscode";
 import { localize } from "../utils/localizeUtils";
+import { ProjectMetadata } from "./commands/create/types";
 
 export const defaultSystemPrompt = () => {
   const defaultNoConcuptualAnswer = localize(
@@ -47,38 +47,21 @@ export const describeScenarioSystemPrompt = new vscode.LanguageModelChatSystemMe
   `You are an advisor for Teams App developers. You need to describe the project based on the name and description field of user's JSON content. You should control the output between 50 and 80 words.`
 );
 
-export function getProjectMatchSystemPrompt(projectMetadata: ProjectMetadata[]) {
+export function getProjectMatchSystemPrompt(
+  projectMetadata: ProjectMetadata[],
+  examples: Array<{ user: string; app: string }>
+) {
   const appsDescription = projectMetadata
     .map((config) => `'${config.id}' (${config.description})`)
     .join(", ");
-  const examples = [
-    {
-      user: "an app that manages to-do list and works in Outlook",
-      app: "todo-list-with-Azure-backend-M365",
-    },
-    {
-      user: "an app to send notification to a lot of users",
-      app: "large-scale-notification",
-    },
-    {
-      user: "an app shown in sharepoint",
-      app: "tab-spfx",
-    },
-    {
-      user: "a tab app",
-      app: "tab-non-sso",
-    },
-    {
-      user: "a bot that accepts commands",
-      app: "command-bot",
-    },
-  ];
   const exampleDescription = examples
     .map(
       (example, index) =>
-        `${index + 1}. User asks: ${example.user}, return { "app": [${example.app}]}.`
+        `${index + 1}. User asks: ${example.user}, return { "app": [ { "id": ${
+          example.app
+        }, "score": 1.0 }]}.`
     )
     .join(" ");
-  return new vscode.LanguageModelChatSystemMessage(`You are an expert in determining which of the following apps the user is interested in. The apps are: ${appsDescription}. Your job is to determine which app would most help the user based on their query. Choose at most three of the available apps as the best matched app. Only respond with a JSON object containing the app you choose. Do not respond in a conversational tone, only JSON. For example: ${exampleDescription}
+  return new vscode.LanguageModelChatSystemMessage(`You are an expert in determining which of the following apps the user is interested in. The apps are: ${appsDescription}. Your job is to determine which app would most help the user based on their query. Choose the best matched apps. Only respond with a JSON object containing the apps you choose with a float number between 0-1.0 representing confidence. Do not respond in a conversational tone, only JSON. For example: ${exampleDescription}
   `);
 }

--- a/packages/vscode-extension/test/chat/commands/create/helper.test.ts
+++ b/packages/vscode-extension/test/chat/commands/create/helper.test.ts
@@ -49,7 +49,12 @@ describe("chat create helper", () => {
         .stub(telemetry.ChatTelemetryData, "createByParticipant")
         .returns(chatTelemetryDataMock);
       const sendTelemetryEventStub = sandbox.stub(ExtTelemetry, "sendTelemetryEvent");
-      sandbox.stub(util, "getCopilotResponseAsString").resolves('{"app":["test1"]}');
+      sandbox
+        .stub(util, "getCopilotResponseAsString")
+        .onFirstCall()
+        .resolves('{"app":[{"id": "test1", "score": 1.0}]}')
+        .onSecondCall()
+        .resolves('{"app":[{"id": "test2", "score": 0.5}]}');
 
       const token = new CancellationToken();
       const result = await helper.matchProject(


### PR DESCRIPTION
1. Prevent token exceeds limitation (3K) when we have more and more samples.
2. Improve system prompt to include a score in response, it helps to sort matched ones and find most related templates/samples.