### PR TITLE
fix: launch group name for action ME template

### DIFF
--- a/templates/js/message-extension-action/.vscode/launch.json.tpl
+++ b/templates/js/message-extension-action/.vscode/launch.json.tpl
@@ -76,7 +76,7 @@
                 "group": "group 0: Teams App Test Tool",
 {{/enableMETestToolByDefault}}
 {{^enableMETestToolByDefault}}
-                "group": "group 3: Teams App Test Tool",
+                "group": "group 2: Teams App Test Tool",
 {{/enableMETestToolByDefault}}
                 "order": 1
             },
@@ -90,7 +90,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-                "group": "all",
+                "group": "group 1: Teams",
                 "order": 1
             },
             "stopAll": true
@@ -103,7 +103,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-                "group": "all",
+                "group": "group 1: Teams",
                 "order": 2
             },
             "stopAll": true

--- a/templates/ts/message-extension-action/.vscode/launch.json.tpl
+++ b/templates/ts/message-extension-action/.vscode/launch.json.tpl
@@ -76,7 +76,7 @@
                 "group": "group 0: Teams App Test Tool",
 {{/enableMETestToolByDefault}}
 {{^enableMETestToolByDefault}}
-                "group": "group 3: Teams App Test Tool",
+                "group": "group 2: Teams App Test Tool",
 {{/enableMETestToolByDefault}}
                 "order": 1
             },
@@ -90,7 +90,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-                "group": "all",
+                "group": "group 1: Teams",
                 "order": 1
             },
             "stopAll": true
@@ -103,7 +103,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-                "group": "all",
+                "group": "group 1: Teams",
                 "order": 2
             },
             "stopAll": true


### PR DESCRIPTION
Currently, even if TEAMSFX_ME_TEST_TOOL is enabled, this template won't use test tool as default launch profile.

Fix action ME group name. Other ME templates doesn't have this issue because they are already in this format.

AZDO feature: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/25153944/