### PR TITLE
fix: update privacy link

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ provided by the bot. You will only need to do this once across all repos using o
 
 ## Telemetry
 
-Teams Toolkit collects usage data and sends it to Microsoft to help improve our products and services. Read our [Privacy Statement](https://privacy.microsoft.com/privacystatement) and [Data Collection Notice](https://docs.opensource.microsoft.com/content/releasing/telemetry.html) to learn more. Learn more in our [FAQ](https://code.visualstudio.com/docs/supporting/faq#_how-to-disable-telemetry-reporting).
+Teams Toolkit collects usage data and sends it to Microsoft to help improve our products and services. Read our [Privacy Statement](https://go.microsoft.com/fwlink/?LinkId=521839) and [Data Collection Notice](https://docs.opensource.microsoft.com/content/releasing/telemetry.html) to learn more. Learn more in our [FAQ](https://code.visualstudio.com/docs/supporting/faq#_how-to-disable-telemetry-reporting).
 
 ## Trademarks
 


### PR DESCRIPTION
update privacy link in Readme according Privacy Review feedback.

<img width="880" alt="image" src="https://github.com/OfficeDev/TeamsFx/assets/26411726/839e8c45-21eb-46a3-b685-281cd4ac2cc1">


https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/27503595