### PR TITLE
fix: update error message when symlink exist

### DIFF
--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -571,7 +571,7 @@
   "depChecker.learnMoreButtonText": "Learn more",
   "depChecker.needInstallNpm": "You must have NPM installed to debug your local functions.",
   "depChecker.failToValidateFuncCoreTool": "Unable to validate Azure Functions Core Tools after installation.",
-  "depChecker.symlinkDirAlreadyExist": "The destination of the symlink already exists",
+  "depChecker.symlinkDirAlreadyExist": "The destination of the symlink (%s) already exists, please remove it and try again.",
   "depChecker.portableFuncNodeNotMatched": "Your Node.js (@NodeVersion) is incompatible with Teams Toolkit Azure Functions Core Tools (@FuncVersion).",
   "depChecker.invalidFuncVersion": "The format of version %s is invalid.",
   "depChecker.noSentinelFile": "Azure Functions Core Tools installation is incomplete.",

--- a/packages/fx-core/src/common/deps-checker/constant/message.ts
+++ b/packages/fx-core/src/common/deps-checker/constant/message.ts
@@ -16,7 +16,8 @@ export const Messages = {
     getLocalizedString("depChecker.portableFuncNodeNotMatched")
       .replace("@NodeVersion", nodeVersion)
       .replace("@FuncVersion", funcVersion),
-  symlinkDirAlreadyExist: () => getLocalizedString("depChecker.symlinkDirAlreadyExist"),
+  symlinkDirAlreadyExist: (linkFilePath: string) =>
+    getLocalizedString("depChecker.symlinkDirAlreadyExist", linkFilePath),
   invalidFuncVersion: (version: string) =>
     getLocalizedString("depChecker.invalidFuncVersion", version),
   noSentinelFile: () => getLocalizedString("depChecker.noSentinelFile"),

--- a/packages/fx-core/src/common/deps-checker/util/fileHelper.ts
+++ b/packages/fx-core/src/common/deps-checker/util/fileHelper.ts
@@ -27,7 +27,7 @@ export async function createSymlink(target: string, linkFilePath: string): Promi
   await unlinkSymlink(linkFilePath);
   // check if destination already exists
   if (await fs.pathExists(linkFilePath)) {
-    throw new DepsCheckerError(Messages.symlinkDirAlreadyExist(), v3DefaultHelpLink);
+    throw new DepsCheckerError(Messages.symlinkDirAlreadyExist(linkFilePath), v3DefaultHelpLink);
   }
 
   return await fs.ensureSymlink(


### PR DESCRIPTION
work item: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/27470834/

Added the symlink path and instructions when the error occurs.
![image](https://github.com/OfficeDev/TeamsFx/assets/15644078/ef4ae819-700e-4fb5-87f2-2c60cffc182a)
