### PR TITLE
perf: use summary for action description if it not exist

### DIFF
--- a/packages/fx-core/src/component/generator/copilotPlugin/helper.ts
+++ b/packages/fx-core/src/component/generator/copilotPlugin/helper.ts
@@ -898,7 +898,7 @@ async function updateActionForCustomApi(
 
       actions.push({
         name: item.item.operationId,
-        description: item.item.description,
+        description: item.item.description ?? item.item.summary,
         parameters: parameters,
       });
     }


### PR DESCRIPTION
[Bug 27622836](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/27622836): action.json should contain information of summary