### PR TITLE
fix: preview Copilot plugin in CLI

### DIFF
--- a/packages/fx-core/src/common/m365/launchHelper.ts
+++ b/packages/fx-core/src/common/m365/launchHelper.ts
@@ -37,10 +37,11 @@ export class LaunchHelper {
       case HubTypes.teams: {
         let installAppPackage = true;
         if (
-          isApiME &&
-          !capabilities.includes("staticTab") &&
-          !capabilities.includes("configurableTab") &&
-          !capabilities.includes("Bot")
+          (isApiME &&
+            !capabilities.includes("staticTab") &&
+            !capabilities.includes("configurableTab") &&
+            !capabilities.includes("Bot")) ||
+          (capabilities.length === 1 && capabilities.includes("plugin"))
         ) {
           installAppPackage = false;
         }

--- a/packages/fx-core/tests/common/m365/launchHelper.test.ts
+++ b/packages/fx-core/tests/common/m365/launchHelper.test.ts
@@ -41,7 +41,7 @@ describe("LaunchHelper", () => {
       );
     });
 
-    it("getLaunchUrl: Teams, signed in, copilot plugin", async () => {
+    it("getLaunchUrl: Teams, signed in, API ME", async () => {
       sinon.stub(m365TokenProvider, "getStatus").resolves(
         ok({
           status: "",
@@ -55,6 +55,30 @@ describe("LaunchHelper", () => {
         HubTypes.teams,
         "test-id",
         ["MessageExtension"],
+        true,
+        true
+      );
+      chai.assert(result.isOk());
+      chai.assert.equal(
+        (result as any).value,
+        "https://teams.microsoft.com/?appTenantId=test-tid&login_hint=test-upn"
+      );
+    });
+
+    it("getLaunchUrl: Teams, signed in, copilot plugin", async () => {
+      sinon.stub(m365TokenProvider, "getStatus").resolves(
+        ok({
+          status: "",
+          accountInfo: {
+            tid: "test-tid",
+            upn: "test-upn",
+          },
+        })
+      );
+      const result = await launchHelper.getLaunchUrl(
+        HubTypes.teams,
+        "test-id",
+        ["plugin"],
         true,
         true
       );

--- a/packages/manifest/src/ManifestCommonProperties.ts
+++ b/packages/manifest/src/ManifestCommonProperties.ts
@@ -26,8 +26,4 @@ export interface ManifestCommonProperties {
    * Whether it's SPFx Teams app
    */
   isSPFx: boolean;
-  /**
-   * Whether it's an API plugin
-   */
-  isPlugin: boolean;
 }

--- a/packages/manifest/src/index.ts
+++ b/packages/manifest/src/index.ts
@@ -124,6 +124,7 @@ export class ManifestUtil {
       capabilities.push("Bot");
     }
     if (manifest.composeExtensions) {
+      capabilities.push("MessageExtension");
     }
 
     const properties: ManifestCommonProperties = {

--- a/packages/manifest/src/index.ts
+++ b/packages/manifest/src/index.ts
@@ -124,7 +124,6 @@ export class ManifestUtil {
       capabilities.push("Bot");
     }
     if (manifest.composeExtensions) {
-      capabilities.push("MessageExtension");
     }
 
     const properties: ManifestCommonProperties = {
@@ -134,7 +133,6 @@ export class ManifestUtil {
       manifestVersion: manifest.manifestVersion,
       isApiME: false,
       isSPFx: false,
-      isPlugin: false,
     };
 
     // If it's copilot plugin app
@@ -157,7 +155,7 @@ export class ManifestUtil {
 
     if ((manifest as TeamsAppManifest).plugins) {
       const apiPlugins = (manifest as TeamsAppManifest).plugins;
-      if (apiPlugins && apiPlugins.length > 0 && apiPlugins[0].file) properties.isPlugin = true;
+      if (apiPlugins && apiPlugins.length > 0 && apiPlugins[0].file) capabilities.push("plugin");
     }
 
     return properties;

--- a/packages/vscode-extension/src/codeLensProvider.ts
+++ b/packages/vscode-extension/src/codeLensProvider.ts
@@ -568,7 +568,7 @@ export class ApiPluginCodeLensProvider implements vscode.CodeLensProvider {
       const manifestContent = fs.readFileSync(manifestFilePath, "utf-8");
       const manifest = JSON.parse(manifestContent);
       const manifestProperties = ManifestUtil.parseCommonProperties(manifest);
-      if (!manifestProperties.isPlugin) {
+      if (!manifestProperties.capabilities.includes("plugin")) {
         return [];
       }
 

--- a/packages/vscode-extension/test/extension/handlers.test.ts
+++ b/packages/vscode-extension/test/extension/handlers.test.ts
@@ -2531,7 +2531,6 @@ describe("autoOpenProjectHandler", () => {
       isApiME: true,
       isSPFx: false,
       isApiBasedMe: true,
-      isPlugin: false,
     };
     const parseManifestStub = sandbox.stub(ManifestUtil, "parseCommonProperties").returns(parseRes);
     VsCodeLogInstance.outputChannel = {


### PR DESCRIPTION
![image](https://github.com/OfficeDev/TeamsFx/assets/86260893/742a03e8-5af0-4e8c-811b-4d0aa47a2906)


[Bug 27604780](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/27604780): [Pre-Release]The preview in cli and vscode does not display consistently in Teams browser for Copilot Plugin project