### PR TITLE
fix: update manifest based on latest schema and readme update

### DIFF
--- a/packages/spec-parser/src/manifestUpdater.ts
+++ b/packages/spec-parser/src/manifestUpdater.ts
@@ -220,7 +220,7 @@ export class ManifestUpdater {
       apiPlugin.runtimes.push({
         type: "OpenApi",
         auth: {
-          type: "none",
+          type: "None",
         },
         spec: {
           url: specRelativePath,

--- a/packages/spec-parser/test/manifestUpdater.test.ts
+++ b/packages/spec-parser/test/manifestUpdater.test.ts
@@ -128,7 +128,7 @@ describe("updateManifestWithAiPlugin", () => {
         {
           type: "OpenApi",
           auth: {
-            type: "none",
+            type: "None",
           },
           spec: {
             url: "spec/outputSpec.yaml",
@@ -298,7 +298,7 @@ describe("updateManifestWithAiPlugin", () => {
         {
           type: "OpenApi",
           auth: {
-            type: "none",
+            type: "None",
           },
           spec: {
             url: "spec/outputSpec2.yaml",
@@ -308,7 +308,7 @@ describe("updateManifestWithAiPlugin", () => {
         {
           type: "OpenApi",
           auth: {
-            type: "none",
+            type: "None",
           },
           spec: {
             url: "spec/outputSpec.yaml",
@@ -366,7 +366,7 @@ describe("updateManifestWithAiPlugin", () => {
           {
             type: "OpenApi",
             auth: {
-              type: "none",
+              type: "None",
             },
             spec: {
               url: "spec/outputSpec2.yaml",
@@ -501,7 +501,7 @@ describe("updateManifestWithAiPlugin", () => {
         {
           type: "OpenApi",
           auth: {
-            type: "none",
+            type: "None",
           },
           spec: {
             url: "spec/outputSpec.yaml",
@@ -652,7 +652,7 @@ describe("updateManifestWithAiPlugin", () => {
         {
           type: "OpenApi",
           auth: {
-            type: "none",
+            type: "None",
           },
           spec: {
             url: "spec/outputSpec.yaml",
@@ -710,7 +710,7 @@ describe("updateManifestWithAiPlugin", () => {
           {
             type: "OpenApi",
             auth: {
-              type: "none",
+              type: "None",
             },
             spec: {
               url: "spec/outputSpec.yaml",
@@ -854,7 +854,7 @@ describe("updateManifestWithAiPlugin", () => {
         {
           type: "OpenApi",
           auth: {
-            type: "none",
+            type: "None",
           },
           spec: {
             url: "spec/outputSpec.yaml",
@@ -1005,7 +1005,7 @@ describe("updateManifestWithAiPlugin", () => {
         {
           type: "OpenApi",
           auth: {
-            type: "none",
+            type: "None",
           },
           spec: {
             url: "spec/outputSpec.yaml",
@@ -1079,7 +1079,7 @@ describe("updateManifestWithAiPlugin", () => {
         {
           type: "OpenApi",
           auth: {
-            type: "none",
+            type: "None",
           },
           spec: {
             url: "spec/outputSpec.yaml",

--- a/templates/js/api-plugin-from-scratch/README.md
+++ b/templates/js/api-plugin-from-scratch/README.md
@@ -26,12 +26,12 @@ This app template allows Microsoft Copilot for Microsoft 365 to interact directl
 ## What's included in the template
 
 | Folder       | Contents                                                                                                    |
-| ------------ | ----------------------------------------------------------------------------------------------------------- |
-| `.vscode`    | VSCode files for debugging                                                                                  |
-| `appPackage` | Templates for the Teams application manifest, the API specification and response template for API responses |
-| `env`        | Environment files                                                                                           |
-| `infra`      | Templates for provisioning Azure resources                                                                  |
-| `src`        | The source code for the repair API                                                                          |
+| ------------ | ------------------------------------------------------------------------------------------- |
+| `.vscode`    | VSCode files for debugging                                                                  |
+| `appPackage` | Templates for the Teams application manifest, the plugin manifest and the API specification |
+| `env`        | Environment files                                                                           |
+| `infra`      | Templates for provisioning Azure resources                                                  |
+| `src`        | The source code for the repair API                                                          |
 
 The following files can be customized and demonstrate an example implementation to get you started.
 

--- a/templates/js/api-plugin-from-scratch/appPackage/ai-plugin.json.tpl
+++ b/templates/js/api-plugin-from-scratch/appPackage/ai-plugin.json.tpl
@@ -25,7 +25,7 @@
     {
       "type": "OpenApi",
       "auth": {
-        "type": "none"
+        "type": "None"
       },
       "spec": {
         "url": "apiSpecificationFile/repair.yml",

--- a/templates/ts/api-plugin-from-scratch/README.md
+++ b/templates/ts/api-plugin-from-scratch/README.md
@@ -25,13 +25,13 @@ This app template allows Microsoft Copilot for Microsoft 365 to interact directl
 
 ## What's included in the template
 
-| Folder       | Contents                                                                                                    |
-| ------------ | ----------------------------------------------------------------------------------------------------------- |
-| `.vscode`    | VSCode files for debugging                                                                                  |
-| `appPackage` | Templates for the Teams application manifest, the API specification and response template for API responses |
-| `env`        | Environment files                                                                                           |
-| `infra`      | Templates for provisioning Azure resources                                                                  |
-| `src`        | The source code for the repair API                                                                          |
+| Folder       | Contents                                                                                    |
+| ------------ | ------------------------------------------------------------------------------------------- |
+| `.vscode`    | VSCode files for debugging                                                                  |
+| `appPackage` | Templates for the Teams application manifest, the plugin manifest and the API specification |
+| `env`        | Environment files                                                                           |
+| `infra`      | Templates for provisioning Azure resources                                                  |
+| `src`        | The source code for the repair API                                                          |
 
 The following files can be customized and demonstrate an example implementation to get you started.
 

--- a/templates/ts/api-plugin-from-scratch/appPackage/ai-plugin.json.tpl
+++ b/templates/ts/api-plugin-from-scratch/appPackage/ai-plugin.json.tpl
@@ -25,7 +25,7 @@
     {
       "type": "OpenApi",
       "auth": {
-        "type": "none"
+        "type": "None"
       },
       "spec": {
         "url": "apiSpecificationFile/repair.yml",


### PR DESCRIPTION
[Bug 27673808](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/27673808): [VSC]local debug and provison for Copilot Plugin project not work
[Bug 27673792](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/27673792): update readme content for copilot plugin of scratch template