### PR TITLE
refactor(generator): mapping user inputs to template names

### DIFF
--- a/packages/fx-core/src/component/generator/generatorProvider.ts
+++ b/packages/fx-core/src/component/generator/generatorProvider.ts
@@ -1,6 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 import { OfficeAddinGeneratorNew } from "./officeAddin/generator";
+import { SsrTabGenerator } from "./templates/ssrTabGenerator";
 import { DefaultTemplateGenerator } from "./templates/templateGenerator";
 
-export const Generators = [new DefaultTemplateGenerator(), new OfficeAddinGeneratorNew()];
+// When multiple generators are activated, only the top one will be executed.
+export const Generators = [
+  new OfficeAddinGeneratorNew(),
+  new SsrTabGenerator(),
+  new DefaultTemplateGenerator(),
+];

--- a/packages/fx-core/src/component/generator/officeAddin/generator.ts
+++ b/packages/fx-core/src/component/generator/officeAddin/generator.ts
@@ -245,8 +245,7 @@ export class OfficeAddinGeneratorNew extends DefaultTemplateGenerator {
       inputs[QuestionNames.Capabilities] === CapabilityOptions.officeAddinImport().id
         ? ProgrammingLanguage.TS
         : lang;
-    const replaceMap = {};
-    return Promise.resolve(ok([{ templateName: tplName, language: lang, replaceMap }]));
+    return Promise.resolve(ok([{ templateName: tplName, language: lang }]));
   }
 
   public async post(

--- a/packages/fx-core/src/component/generator/templates/ssrTabGenerator.ts
+++ b/packages/fx-core/src/component/generator/templates/ssrTabGenerator.ts
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { Context, FxError, Inputs, Result, ok } from "@microsoft/teamsfx-api";
+import { DefaultTemplateGenerator } from "./templateGenerator";
+import { TemplateInfo } from "./templateInfo";
+import { CapabilityOptions, ProgrammingLanguage, QuestionNames } from "../../../question";
+import { getTemplateReplaceMap } from "./templateReplaceMap";
+import { TemplateNames } from "./templateNames";
+
+export class SsrTabGenerator extends DefaultTemplateGenerator {
+  capabilities2TemplateNames = {
+    [CapabilityOptions.nonSsoTab().id]: TemplateNames.TabSSR,
+    [CapabilityOptions.tab().id]: TemplateNames.SsoTabSSR,
+  };
+  public activate(context: Context, inputs: Inputs): boolean {
+    const capability = inputs.capabilities as string;
+    return (
+      this.capabilities2TemplateNames[capability] !== undefined &&
+      inputs[QuestionNames.ProgrammingLanguage] === ProgrammingLanguage.CSharp &&
+      inputs.targetFramework !== "net6.0" &&
+      inputs.targetFramework !== "net7.0"
+    );
+  }
+  public getTemplateInfos(
+    context: Context,
+    inputs: Inputs
+  ): Promise<Result<TemplateInfo[], FxError>> {
+    return Promise.resolve(
+      ok([
+        {
+          templateName: this.capabilities2TemplateNames[inputs.capabilities as string],
+          language: ProgrammingLanguage.CSharp,
+          replaceMap: getTemplateReplaceMap(inputs),
+        },
+      ])
+    );
+  }
+}

--- a/packages/fx-core/src/component/generator/templates/ssrTabGenerator.ts
+++ b/packages/fx-core/src/component/generator/templates/ssrTabGenerator.ts
@@ -5,15 +5,15 @@ import { Context, FxError, Inputs, Result, ok } from "@microsoft/teamsfx-api";
 import { DefaultTemplateGenerator } from "./templateGenerator";
 import { TemplateInfo } from "./templateInfo";
 import { CapabilityOptions, ProgrammingLanguage, QuestionNames } from "../../../question";
-import { getTemplateReplaceMap } from "./templateReplaceMap";
 import { TemplateNames } from "./templateNames";
 
+// For the APS.NET server-side rendering tab
 export class SsrTabGenerator extends DefaultTemplateGenerator {
   capabilities2TemplateNames = {
     [CapabilityOptions.nonSsoTab().id]: TemplateNames.TabSSR,
     [CapabilityOptions.tab().id]: TemplateNames.SsoTabSSR,
   };
-  public activate(context: Context, inputs: Inputs): boolean {
+  override activate(context: Context, inputs: Inputs): boolean {
     const capability = inputs.capabilities as string;
     return (
       this.capabilities2TemplateNames[capability] !== undefined &&
@@ -22,7 +22,7 @@ export class SsrTabGenerator extends DefaultTemplateGenerator {
       inputs.targetFramework !== "net7.0"
     );
   }
-  public getTemplateInfos(
+  override getTemplateInfos(
     context: Context,
     inputs: Inputs
   ): Promise<Result<TemplateInfo[], FxError>> {
@@ -31,7 +31,6 @@ export class SsrTabGenerator extends DefaultTemplateGenerator {
         {
           templateName: this.capabilities2TemplateNames[inputs.capabilities as string],
           language: ProgrammingLanguage.CSharp,
-          replaceMap: getTemplateReplaceMap(inputs),
         },
       ])
     );

--- a/packages/fx-core/src/component/generator/templates/templateGenerator.ts
+++ b/packages/fx-core/src/component/generator/templates/templateGenerator.ts
@@ -7,18 +7,13 @@ import { TelemetryEvent, TelemetryProperty } from "../../../common/telemetry";
 import { ProgressMessages, ProgressTitles } from "../../messages";
 import { ActionContext, ActionExecutionMW } from "../../middleware/actionExecutionMW";
 import { commonTemplateName, componentName } from "../constant";
-import {
-  CapabilityOptions,
-  MeArchitectureOptions,
-  ProgrammingLanguage,
-  QuestionNames,
-} from "../../../question";
+import { ProgrammingLanguage, QuestionNames } from "../../../question";
 import { Generator, templateDefaultOnActionError } from "../generator";
 import { convertToLangKey, renderTemplateFileData, renderTemplateFileName } from "../utils";
 import { merge } from "lodash";
 import { GeneratorContext, TemplateActionSeq } from "../generatorAction";
 import { TemplateInfo } from "./templateInfo";
-import { Feature2TemplateName } from "./templateNames";
+import { getTemplateName, tryGetTemplateName } from "./templateNames";
 import { getTemplateReplaceMap } from "./templateReplaceMap";
 
 export class DefaultTemplateGenerator {
@@ -27,9 +22,7 @@ export class DefaultTemplateGenerator {
 
   // override this method to determine whether to run this generator
   public activate(context: Context, inputs: Inputs): boolean {
-    return Object.keys(Feature2TemplateName).some((feature) =>
-      feature.startsWith(inputs.capabilities)
-    );
+    return tryGetTemplateName(inputs) !== undefined;
   }
 
   // The main entry of the generator. Do not override this method.
@@ -68,7 +61,7 @@ export class DefaultTemplateGenerator {
     inputs: Inputs,
     actionContext?: ActionContext
   ): Promise<Result<TemplateInfo[], FxError>> {
-    const templateName = this.getTemplateName(inputs);
+    const templateName = getTemplateName(inputs);
     const language = inputs[QuestionNames.ProgrammingLanguage] as ProgrammingLanguage;
     const replaceMap = getTemplateReplaceMap(inputs);
     return Promise.resolve(ok([{ templateName, language, replaceMap }]));
@@ -82,56 +75,6 @@ export class DefaultTemplateGenerator {
     actionContext?: ActionContext
   ): Promise<Result<undefined, FxError>> {
     return Promise.resolve(ok(undefined));
-  }
-
-  private getTemplateName(inputs: Inputs) {
-    const language = inputs[QuestionNames.ProgrammingLanguage];
-    const capability = inputs.capabilities as string;
-    const meArchitecture = inputs[QuestionNames.MeArchitectureType] as string;
-    const apiMEAuthType = inputs[QuestionNames.ApiMEAuth] as string;
-    const trigger = inputs[QuestionNames.BotTrigger] as string;
-    let feature = `${capability}:${trigger}`;
-    if (
-      capability === CapabilityOptions.m365SsoLaunchPage().id ||
-      capability === CapabilityOptions.m365SearchMe().id
-    ) {
-      inputs.isM365 = true;
-    }
-
-    if (
-      language === "csharp" &&
-      capability === CapabilityOptions.notificationBot().id &&
-      inputs.isIsolated === true
-    ) {
-      feature += "-isolated";
-    }
-
-    if (meArchitecture) {
-      feature = `${feature}:${meArchitecture}`;
-    }
-    if (
-      inputs.targetFramework &&
-      inputs.targetFramework !== "net6.0" &&
-      inputs.targetFramework !== "net7.0" &&
-      (capability === CapabilityOptions.nonSsoTab().id || capability === CapabilityOptions.tab().id)
-    ) {
-      feature = `${capability}:ssr`;
-    }
-
-    if (
-      capability === CapabilityOptions.m365SearchMe().id &&
-      meArchitecture === MeArchitectureOptions.newApi().id
-    ) {
-      feature = `${feature}:${apiMEAuthType}`;
-    }
-
-    if (capability === CapabilityOptions.customCopilotRag().id) {
-      feature = `${feature}:${inputs[QuestionNames.CustomCopilotRag] as string}`;
-    } else if (capability === CapabilityOptions.customCopilotAssistant().id) {
-      feature = `${feature}:${inputs[QuestionNames.CustomCopilotAssistant] as string}`;
-    }
-
-    return Feature2TemplateName[feature];
   }
 
   private async scaffolding(

--- a/packages/fx-core/src/component/generator/templates/templateGenerator.ts
+++ b/packages/fx-core/src/component/generator/templates/templateGenerator.ts
@@ -46,6 +46,7 @@ export class DefaultTemplateGenerator {
 
     const templateInfos = preResult.value;
     for (const templateInfo of templateInfos) {
+      templateInfo.replaceMap = { ...getTemplateReplaceMap(inputs), ...templateInfo.replaceMap };
       await this.scaffolding(context, templateInfo, destinationPath, actionContext);
     }
 
@@ -63,8 +64,7 @@ export class DefaultTemplateGenerator {
   ): Promise<Result<TemplateInfo[], FxError>> {
     const templateName = getTemplateName(inputs);
     const language = inputs[QuestionNames.ProgrammingLanguage] as ProgrammingLanguage;
-    const replaceMap = getTemplateReplaceMap(inputs);
-    return Promise.resolve(ok([{ templateName, language, replaceMap }]));
+    return Promise.resolve(ok([{ templateName, language }]));
   }
 
   // override this method to do post process

--- a/packages/fx-core/src/component/generator/templates/templateInfo.ts
+++ b/packages/fx-core/src/component/generator/templates/templateInfo.ts
@@ -5,6 +5,6 @@ import { ProgrammingLanguage } from "../../../question";
 export interface TemplateInfo {
   templateName: string;
   language: ProgrammingLanguage;
-  replaceMap: { [key: string]: string }; // key is the placeholder in the template file, value is the value to replace
+  replaceMap?: { [key: string]: string }; // key is the placeholder in the template file, value is the value to replace
   filterFn?: (fileName: string) => boolean; // return true to include the file, false to exclude
 }

--- a/packages/fx-core/src/component/generator/templates/templateNames.ts
+++ b/packages/fx-core/src/component/generator/templates/templateNames.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+import { Inputs } from "@microsoft/teamsfx-api";
 import {
   ApiMessageExtensionAuthOptions,
   CapabilityOptions,
@@ -7,6 +8,8 @@ import {
   CustomCopilotRagOptions,
   MeArchitectureOptions,
   NotificationTriggerOptions,
+  ProgrammingLanguage,
+  QuestionNames,
 } from "../../../question";
 
 export enum TemplateNames {
@@ -18,12 +21,12 @@ export enum TemplateNames {
   DashboardTab = "dashboard-tab",
   NotificationRestify = "notification-restify",
   NotificationWebApi = "notification-webapi",
-  NotificationHttpTrigger = "notification-http-trigger",
   NotificationHttpTriggerIsolated = "notification-http-trigger-isolated",
-  NotificationTimerTrigger = "notification-timer-trigger",
+  NotificationHttpTrigger = "notification-http-trigger",
   NotificationTimerTriggerIsolated = "notification-timer-trigger-isolated",
-  NotificationHttpTimerTrigger = "notification-http-timer-trigger",
+  NotificationTimerTrigger = "notification-timer-trigger",
   NotificationHttpTimerTriggerIsolated = "notification-http-timer-trigger-isolated",
+  NotificationHttpTimerTrigger = "notification-http-timer-trigger",
   CommandAndResponse = "command-and-response",
   Workflow = "workflow",
   DefaultBot = "default-bot",
@@ -50,6 +53,7 @@ export enum TemplateNames {
   CustomCopilotAssistantAssistantsApi = "custom-copilot-assistant-assistants-api",
 }
 
+// TODO: remove this mapping after all generators are migrated to new generator pattern
 export const Feature2TemplateName = {
   [`${CapabilityOptions.nonSsoTab().id}:undefined`]: TemplateNames.Tab,
   [`${CapabilityOptions.tab().id}:undefined`]: TemplateNames.SsoTab,
@@ -124,3 +128,254 @@ export const Feature2TemplateName = {
     CustomCopilotAssistantOptions.assistantsApi().id
   }`]: TemplateNames.CustomCopilotAssistantAssistantsApi,
 };
+
+export function tryGetTemplateName(inputs: Inputs): TemplateNames | undefined {
+  return inputs2TemplateName.find((item) =>
+    Object.keys(item.inputs).every((key) => item.inputs[key] === inputs[key])
+  )?.name;
+}
+
+export function getTemplateName(inputs: Inputs): TemplateNames {
+  const templateName = tryGetTemplateName(inputs);
+  if (!templateName) {
+    throw new Error("Template name not found");
+  }
+  return templateName;
+}
+
+// When multiple template name matches, only the top one will be picked.
+export const inputs2TemplateName: { inputs: { [key: string]: any }; name: TemplateNames }[] = [
+  {
+    inputs: { [QuestionNames.Capabilities]: CapabilityOptions.nonSsoTab().id },
+    name: TemplateNames.Tab,
+  },
+  {
+    inputs: { [QuestionNames.Capabilities]: CapabilityOptions.tab().id },
+    name: TemplateNames.SsoTab,
+  },
+  {
+    inputs: { [QuestionNames.Capabilities]: CapabilityOptions.m365SsoLaunchPage().id },
+    name: TemplateNames.SsoTabObo,
+  },
+  {
+    inputs: { [QuestionNames.Capabilities]: CapabilityOptions.dashboardTab().id },
+    name: TemplateNames.DashboardTab,
+  },
+  {
+    inputs: {
+      [QuestionNames.Capabilities]: CapabilityOptions.notificationBot().id,
+      [QuestionNames.BotTrigger]: NotificationTriggerOptions.appService().id,
+    },
+    name: TemplateNames.NotificationRestify,
+  },
+  {
+    inputs: {
+      [QuestionNames.ProgrammingLanguage]: ProgrammingLanguage.CSharp,
+      [QuestionNames.Capabilities]: CapabilityOptions.notificationBot().id,
+      [QuestionNames.BotTrigger]: NotificationTriggerOptions.appServiceForVS().id,
+    },
+    name: TemplateNames.NotificationWebApi,
+  },
+  {
+    inputs: {
+      [QuestionNames.ProgrammingLanguage]: ProgrammingLanguage.CSharp,
+      [QuestionNames.Capabilities]: CapabilityOptions.notificationBot().id,
+      [QuestionNames.BotTrigger]: NotificationTriggerOptions.functionsHttpTrigger().id,
+      ["isIsolated"]: true,
+    },
+    name: TemplateNames.NotificationHttpTriggerIsolated,
+  },
+  {
+    inputs: {
+      [QuestionNames.Capabilities]: CapabilityOptions.notificationBot().id,
+      [QuestionNames.BotTrigger]: NotificationTriggerOptions.functionsHttpTrigger().id,
+    },
+    name: TemplateNames.NotificationHttpTrigger,
+  },
+  {
+    inputs: {
+      [QuestionNames.ProgrammingLanguage]: ProgrammingLanguage.CSharp,
+      [QuestionNames.Capabilities]: CapabilityOptions.notificationBot().id,
+      [QuestionNames.BotTrigger]: NotificationTriggerOptions.functionsTimerTrigger().id,
+      ["isIsolated"]: true,
+    },
+    name: TemplateNames.NotificationTimerTriggerIsolated,
+  },
+  {
+    inputs: {
+      [QuestionNames.Capabilities]: CapabilityOptions.notificationBot().id,
+      [QuestionNames.BotTrigger]: NotificationTriggerOptions.functionsTimerTrigger().id,
+    },
+    name: TemplateNames.NotificationTimerTrigger,
+  },
+  {
+    inputs: {
+      [QuestionNames.ProgrammingLanguage]: ProgrammingLanguage.CSharp,
+      [QuestionNames.Capabilities]: CapabilityOptions.notificationBot().id,
+      [QuestionNames.BotTrigger]: NotificationTriggerOptions.functionsHttpAndTimerTrigger().id,
+      ["isIsolated"]: true,
+    },
+    name: TemplateNames.NotificationHttpTimerTriggerIsolated,
+  },
+  {
+    inputs: {
+      [QuestionNames.Capabilities]: CapabilityOptions.notificationBot().id,
+      [QuestionNames.BotTrigger]: NotificationTriggerOptions.functionsHttpAndTimerTrigger().id,
+    },
+    name: TemplateNames.NotificationHttpTimerTrigger,
+  },
+  {
+    inputs: {
+      [QuestionNames.Capabilities]: CapabilityOptions.commandBot().id,
+    },
+    name: TemplateNames.CommandAndResponse,
+  },
+  {
+    inputs: {
+      [QuestionNames.Capabilities]: CapabilityOptions.workflowBot().id,
+    },
+    name: TemplateNames.Workflow,
+  },
+  {
+    inputs: {
+      [QuestionNames.Capabilities]: CapabilityOptions.basicBot().id,
+    },
+    name: TemplateNames.DefaultBot,
+  },
+  {
+    inputs: {
+      [QuestionNames.Capabilities]: CapabilityOptions.me().id,
+    },
+    name: TemplateNames.MessageExtension,
+  },
+  {
+    inputs: {
+      [QuestionNames.Capabilities]: CapabilityOptions.collectFormMe().id,
+    },
+    name: TemplateNames.MessageExtensionAction,
+  },
+  {
+    inputs: { [QuestionNames.Capabilities]: CapabilityOptions.SearchMe().id },
+    name: TemplateNames.MessageExtensionSearch,
+  },
+  {
+    inputs: {
+      [QuestionNames.Capabilities]: CapabilityOptions.m365SearchMe().id,
+      [QuestionNames.MeArchitectureType]: MeArchitectureOptions.botPlugin().id,
+    },
+    name: TemplateNames.MessageExtensionCopilot,
+  },
+  {
+    inputs: {
+      [QuestionNames.Capabilities]: CapabilityOptions.m365SearchMe().id,
+      [QuestionNames.MeArchitectureType]: MeArchitectureOptions.botMe().id,
+    },
+    name: TemplateNames.M365MessageExtension,
+  },
+  {
+    inputs: {
+      [QuestionNames.Capabilities]: CapabilityOptions.nonSsoTabAndBot().id,
+    },
+    name: TemplateNames.TabAndDefaultBot,
+  },
+  {
+    inputs: {
+      [QuestionNames.Capabilities]: CapabilityOptions.botAndMe().id,
+    },
+    name: TemplateNames.BotAndMessageExtension,
+  },
+  {
+    inputs: {
+      [QuestionNames.Capabilities]: CapabilityOptions.linkUnfurling().id,
+    },
+    name: TemplateNames.LinkUnfurling,
+  },
+  {
+    inputs: {
+      [QuestionNames.Capabilities]: CapabilityOptions.aiBot().id,
+    },
+    name: TemplateNames.AIBot,
+  },
+  {
+    inputs: {
+      [QuestionNames.Capabilities]: CapabilityOptions.aiAssistantBot().id,
+    },
+    name: TemplateNames.AIAssistantBot,
+  },
+  {
+    inputs: {
+      [QuestionNames.Capabilities]: CapabilityOptions.copilotPluginNewApi().id,
+    },
+    name: TemplateNames.ApiPluginFromScratch,
+  },
+  {
+    inputs: {
+      [QuestionNames.Capabilities]: CapabilityOptions.m365SearchMe().id,
+      [QuestionNames.MeArchitectureType]: MeArchitectureOptions.newApi().id,
+      [QuestionNames.ApiMEAuth]: ApiMessageExtensionAuthOptions.none().id,
+    },
+    name: TemplateNames.CopilotPluginFromScratch,
+  },
+  {
+    inputs: {
+      [QuestionNames.Capabilities]: CapabilityOptions.m365SearchMe().id,
+      [QuestionNames.MeArchitectureType]: MeArchitectureOptions.newApi().id,
+      [QuestionNames.ApiMEAuth]: ApiMessageExtensionAuthOptions.apiKey().id,
+    },
+    name: TemplateNames.CopilotPluginFromScratchApiKey,
+  },
+  {
+    inputs: {
+      [QuestionNames.Capabilities]: CapabilityOptions.m365SearchMe().id,
+      [QuestionNames.MeArchitectureType]: MeArchitectureOptions.newApi().id,
+      [QuestionNames.ApiMEAuth]: ApiMessageExtensionAuthOptions.microsoftEntra().id,
+    },
+    name: TemplateNames.ApiMessageExtensionSso,
+  },
+  {
+    inputs: { [QuestionNames.Capabilities]: CapabilityOptions.customCopilotBasic().id },
+    name: TemplateNames.CustomCopilotBasic,
+  },
+  {
+    inputs: {
+      [QuestionNames.Capabilities]: CapabilityOptions.customCopilotRag().id,
+      [QuestionNames.CustomCopilotRag]: CustomCopilotRagOptions.customize().id,
+    },
+    name: TemplateNames.CustomCopilotRagCustomize,
+  },
+  {
+    inputs: {
+      [QuestionNames.Capabilities]: CapabilityOptions.customCopilotRag().id,
+      [QuestionNames.CustomCopilotRag]: CustomCopilotRagOptions.azureAISearch().id,
+    },
+    name: TemplateNames.CustomCopilotRagAzureAISearch,
+  },
+  {
+    inputs: {
+      [QuestionNames.Capabilities]: CapabilityOptions.customCopilotRag().id,
+      [QuestionNames.CustomCopilotRag]: CustomCopilotRagOptions.customApi().id,
+    },
+    name: TemplateNames.CustomCopilotRagCustomApi,
+  },
+  {
+    inputs: {
+      [QuestionNames.Capabilities]: CapabilityOptions.customCopilotRag().id,
+      [QuestionNames.CustomCopilotRag]: CustomCopilotRagOptions.microsoft365().id,
+    },
+    name: TemplateNames.CustomCopilotRagMicrosoft365,
+  },
+  {
+    inputs: {
+      [QuestionNames.Capabilities]: CapabilityOptions.customCopilotAssistant().id,
+      [QuestionNames.CustomCopilotAssistant]: CustomCopilotAssistantOptions.new().id,
+    },
+    name: TemplateNames.CustomCopilotAssistantNew,
+  },
+  {
+    inputs: {
+      [QuestionNames.Capabilities]: CapabilityOptions.customCopilotAssistant().id,
+      [QuestionNames.CustomCopilotAssistant]: CustomCopilotAssistantOptions.assistantsApi().id,
+    },
+    name: TemplateNames.CustomCopilotAssistantAssistantsApi,
+  },
+];

--- a/packages/fx-core/src/component/generator/templates/templateNames.ts
+++ b/packages/fx-core/src/component/generator/templates/templateNames.ts
@@ -130,7 +130,7 @@ export const Feature2TemplateName = {
 };
 
 export function tryGetTemplateName(inputs: Inputs): TemplateNames | undefined {
-  return inputs2TemplateName.find((item) =>
+  return inputsToTemplateName.find((item) =>
     Object.keys(item.inputs).every((key) => item.inputs[key] === inputs[key])
   )?.name;
 }
@@ -144,7 +144,7 @@ export function getTemplateName(inputs: Inputs): TemplateNames {
 }
 
 // When multiple template name matches, only the top one will be picked.
-export const inputs2TemplateName: { inputs: { [key: string]: any }; name: TemplateNames }[] = [
+export const inputsToTemplateName: { inputs: { [key: string]: any }; name: TemplateNames }[] = [
   {
     inputs: { [QuestionNames.Capabilities]: CapabilityOptions.nonSsoTab().id },
     name: TemplateNames.Tab,

--- a/packages/fx-core/src/component/generator/templates/templateNames.ts
+++ b/packages/fx-core/src/component/generator/templates/templateNames.ts
@@ -130,9 +130,11 @@ export const Feature2TemplateName = {
 };
 
 export function tryGetTemplateName(inputs: Inputs): TemplateNames | undefined {
-  return inputsToTemplateName.find((item) =>
-    Object.keys(item.inputs).every((key) => item.inputs[key] === inputs[key])
-  )?.name;
+  for (const [key, value] of inputsToTemplateName) {
+    if (Object.keys(key).every((k) => key[k] === inputs[k])) {
+      return value;
+    }
+  }
 }
 
 export function getTemplateName(inputs: Inputs): TemplateNames {
@@ -144,238 +146,198 @@ export function getTemplateName(inputs: Inputs): TemplateNames {
 }
 
 // When multiple template name matches, only the top one will be picked.
-export const inputsToTemplateName: { inputs: { [key: string]: any }; name: TemplateNames }[] = [
-  {
-    inputs: { [QuestionNames.Capabilities]: CapabilityOptions.nonSsoTab().id },
-    name: TemplateNames.Tab,
-  },
-  {
-    inputs: { [QuestionNames.Capabilities]: CapabilityOptions.tab().id },
-    name: TemplateNames.SsoTab,
-  },
-  {
-    inputs: { [QuestionNames.Capabilities]: CapabilityOptions.m365SsoLaunchPage().id },
-    name: TemplateNames.SsoTabObo,
-  },
-  {
-    inputs: { [QuestionNames.Capabilities]: CapabilityOptions.dashboardTab().id },
-    name: TemplateNames.DashboardTab,
-  },
-  {
-    inputs: {
+export const inputsToTemplateName: Map<{ [key: string]: any }, TemplateNames> = new Map([
+  [{ [QuestionNames.Capabilities]: CapabilityOptions.nonSsoTab().id }, TemplateNames.Tab],
+  [{ [QuestionNames.Capabilities]: CapabilityOptions.tab().id }, TemplateNames.SsoTab],
+  [
+    { [QuestionNames.Capabilities]: CapabilityOptions.m365SsoLaunchPage().id },
+    TemplateNames.SsoTabObo,
+  ],
+  [
+    { [QuestionNames.Capabilities]: CapabilityOptions.dashboardTab().id },
+    TemplateNames.DashboardTab,
+  ],
+  [
+    {
       [QuestionNames.Capabilities]: CapabilityOptions.notificationBot().id,
       [QuestionNames.BotTrigger]: NotificationTriggerOptions.appService().id,
     },
-    name: TemplateNames.NotificationRestify,
-  },
-  {
-    inputs: {
+    TemplateNames.NotificationRestify,
+  ],
+  [
+    {
       [QuestionNames.ProgrammingLanguage]: ProgrammingLanguage.CSharp,
       [QuestionNames.Capabilities]: CapabilityOptions.notificationBot().id,
       [QuestionNames.BotTrigger]: NotificationTriggerOptions.appServiceForVS().id,
     },
-    name: TemplateNames.NotificationWebApi,
-  },
-  {
-    inputs: {
+    TemplateNames.NotificationWebApi,
+  ],
+  [
+    {
       [QuestionNames.ProgrammingLanguage]: ProgrammingLanguage.CSharp,
       [QuestionNames.Capabilities]: CapabilityOptions.notificationBot().id,
       [QuestionNames.BotTrigger]: NotificationTriggerOptions.functionsHttpTrigger().id,
       ["isIsolated"]: true,
     },
-    name: TemplateNames.NotificationHttpTriggerIsolated,
-  },
-  {
-    inputs: {
+    TemplateNames.NotificationHttpTriggerIsolated,
+  ],
+  [
+    {
       [QuestionNames.Capabilities]: CapabilityOptions.notificationBot().id,
       [QuestionNames.BotTrigger]: NotificationTriggerOptions.functionsHttpTrigger().id,
     },
-    name: TemplateNames.NotificationHttpTrigger,
-  },
-  {
-    inputs: {
+    TemplateNames.NotificationHttpTrigger,
+  ],
+  [
+    {
       [QuestionNames.ProgrammingLanguage]: ProgrammingLanguage.CSharp,
       [QuestionNames.Capabilities]: CapabilityOptions.notificationBot().id,
       [QuestionNames.BotTrigger]: NotificationTriggerOptions.functionsTimerTrigger().id,
       ["isIsolated"]: true,
     },
-    name: TemplateNames.NotificationTimerTriggerIsolated,
-  },
-  {
-    inputs: {
+    TemplateNames.NotificationTimerTriggerIsolated,
+  ],
+  [
+    {
       [QuestionNames.Capabilities]: CapabilityOptions.notificationBot().id,
       [QuestionNames.BotTrigger]: NotificationTriggerOptions.functionsTimerTrigger().id,
     },
-    name: TemplateNames.NotificationTimerTrigger,
-  },
-  {
-    inputs: {
+    TemplateNames.NotificationTimerTrigger,
+  ],
+  [
+    {
       [QuestionNames.ProgrammingLanguage]: ProgrammingLanguage.CSharp,
       [QuestionNames.Capabilities]: CapabilityOptions.notificationBot().id,
       [QuestionNames.BotTrigger]: NotificationTriggerOptions.functionsHttpAndTimerTrigger().id,
       ["isIsolated"]: true,
     },
-    name: TemplateNames.NotificationHttpTimerTriggerIsolated,
-  },
-  {
-    inputs: {
+    TemplateNames.NotificationHttpTimerTriggerIsolated,
+  ],
+  [
+    {
       [QuestionNames.Capabilities]: CapabilityOptions.notificationBot().id,
       [QuestionNames.BotTrigger]: NotificationTriggerOptions.functionsHttpAndTimerTrigger().id,
     },
-    name: TemplateNames.NotificationHttpTimerTrigger,
-  },
-  {
-    inputs: {
-      [QuestionNames.Capabilities]: CapabilityOptions.commandBot().id,
-    },
-    name: TemplateNames.CommandAndResponse,
-  },
-  {
-    inputs: {
-      [QuestionNames.Capabilities]: CapabilityOptions.workflowBot().id,
-    },
-    name: TemplateNames.Workflow,
-  },
-  {
-    inputs: {
-      [QuestionNames.Capabilities]: CapabilityOptions.basicBot().id,
-    },
-    name: TemplateNames.DefaultBot,
-  },
-  {
-    inputs: {
-      [QuestionNames.Capabilities]: CapabilityOptions.me().id,
-    },
-    name: TemplateNames.MessageExtension,
-  },
-  {
-    inputs: {
-      [QuestionNames.Capabilities]: CapabilityOptions.collectFormMe().id,
-    },
-    name: TemplateNames.MessageExtensionAction,
-  },
-  {
-    inputs: { [QuestionNames.Capabilities]: CapabilityOptions.SearchMe().id },
-    name: TemplateNames.MessageExtensionSearch,
-  },
-  {
-    inputs: {
+    TemplateNames.NotificationHttpTimerTrigger,
+  ],
+  [
+    { [QuestionNames.Capabilities]: CapabilityOptions.commandBot().id },
+    TemplateNames.CommandAndResponse,
+  ],
+  [{ [QuestionNames.Capabilities]: CapabilityOptions.workflowBot().id }, TemplateNames.Workflow],
+  [{ [QuestionNames.Capabilities]: CapabilityOptions.basicBot().id }, TemplateNames.DefaultBot],
+  [{ [QuestionNames.Capabilities]: CapabilityOptions.me().id }, TemplateNames.MessageExtension],
+  [
+    { [QuestionNames.Capabilities]: CapabilityOptions.collectFormMe().id },
+    TemplateNames.MessageExtensionAction,
+  ],
+  [
+    { [QuestionNames.Capabilities]: CapabilityOptions.SearchMe().id },
+    TemplateNames.MessageExtensionSearch,
+  ],
+  [
+    {
       [QuestionNames.Capabilities]: CapabilityOptions.m365SearchMe().id,
       [QuestionNames.MeArchitectureType]: MeArchitectureOptions.botPlugin().id,
     },
-    name: TemplateNames.MessageExtensionCopilot,
-  },
-  {
-    inputs: {
+    TemplateNames.MessageExtensionCopilot,
+  ],
+  [
+    {
       [QuestionNames.Capabilities]: CapabilityOptions.m365SearchMe().id,
       [QuestionNames.MeArchitectureType]: MeArchitectureOptions.botMe().id,
     },
-    name: TemplateNames.M365MessageExtension,
-  },
-  {
-    inputs: {
-      [QuestionNames.Capabilities]: CapabilityOptions.nonSsoTabAndBot().id,
-    },
-    name: TemplateNames.TabAndDefaultBot,
-  },
-  {
-    inputs: {
-      [QuestionNames.Capabilities]: CapabilityOptions.botAndMe().id,
-    },
-    name: TemplateNames.BotAndMessageExtension,
-  },
-  {
-    inputs: {
-      [QuestionNames.Capabilities]: CapabilityOptions.linkUnfurling().id,
-    },
-    name: TemplateNames.LinkUnfurling,
-  },
-  {
-    inputs: {
-      [QuestionNames.Capabilities]: CapabilityOptions.aiBot().id,
-    },
-    name: TemplateNames.AIBot,
-  },
-  {
-    inputs: {
-      [QuestionNames.Capabilities]: CapabilityOptions.aiAssistantBot().id,
-    },
-    name: TemplateNames.AIAssistantBot,
-  },
-  {
-    inputs: {
-      [QuestionNames.Capabilities]: CapabilityOptions.copilotPluginNewApi().id,
-    },
-    name: TemplateNames.ApiPluginFromScratch,
-  },
-  {
-    inputs: {
+    TemplateNames.M365MessageExtension,
+  ],
+  [
+    { [QuestionNames.Capabilities]: CapabilityOptions.nonSsoTabAndBot().id },
+    TemplateNames.TabAndDefaultBot,
+  ],
+  [
+    { [QuestionNames.Capabilities]: CapabilityOptions.botAndMe().id },
+    TemplateNames.BotAndMessageExtension,
+  ],
+  [
+    { [QuestionNames.Capabilities]: CapabilityOptions.linkUnfurling().id },
+    TemplateNames.LinkUnfurling,
+  ],
+  [{ [QuestionNames.Capabilities]: CapabilityOptions.aiBot().id }, TemplateNames.AIBot],
+  [
+    { [QuestionNames.Capabilities]: CapabilityOptions.aiAssistantBot().id },
+    TemplateNames.AIAssistantBot,
+  ],
+  [
+    { [QuestionNames.Capabilities]: CapabilityOptions.copilotPluginNewApi().id },
+    TemplateNames.ApiPluginFromScratch,
+  ],
+  [
+    {
       [QuestionNames.Capabilities]: CapabilityOptions.m365SearchMe().id,
       [QuestionNames.MeArchitectureType]: MeArchitectureOptions.newApi().id,
       [QuestionNames.ApiMEAuth]: ApiMessageExtensionAuthOptions.none().id,
     },
-    name: TemplateNames.CopilotPluginFromScratch,
-  },
-  {
-    inputs: {
+    TemplateNames.CopilotPluginFromScratch,
+  ],
+  [
+    {
       [QuestionNames.Capabilities]: CapabilityOptions.m365SearchMe().id,
       [QuestionNames.MeArchitectureType]: MeArchitectureOptions.newApi().id,
       [QuestionNames.ApiMEAuth]: ApiMessageExtensionAuthOptions.apiKey().id,
     },
-    name: TemplateNames.CopilotPluginFromScratchApiKey,
-  },
-  {
-    inputs: {
+    TemplateNames.CopilotPluginFromScratchApiKey,
+  ],
+  [
+    {
       [QuestionNames.Capabilities]: CapabilityOptions.m365SearchMe().id,
       [QuestionNames.MeArchitectureType]: MeArchitectureOptions.newApi().id,
       [QuestionNames.ApiMEAuth]: ApiMessageExtensionAuthOptions.microsoftEntra().id,
     },
-    name: TemplateNames.ApiMessageExtensionSso,
-  },
-  {
-    inputs: { [QuestionNames.Capabilities]: CapabilityOptions.customCopilotBasic().id },
-    name: TemplateNames.CustomCopilotBasic,
-  },
-  {
-    inputs: {
+    TemplateNames.ApiMessageExtensionSso,
+  ],
+  [
+    { [QuestionNames.Capabilities]: CapabilityOptions.customCopilotBasic().id },
+    TemplateNames.CustomCopilotBasic,
+  ],
+  [
+    {
       [QuestionNames.Capabilities]: CapabilityOptions.customCopilotRag().id,
       [QuestionNames.CustomCopilotRag]: CustomCopilotRagOptions.customize().id,
     },
-    name: TemplateNames.CustomCopilotRagCustomize,
-  },
-  {
-    inputs: {
+    TemplateNames.CustomCopilotRagCustomize,
+  ],
+  [
+    {
       [QuestionNames.Capabilities]: CapabilityOptions.customCopilotRag().id,
       [QuestionNames.CustomCopilotRag]: CustomCopilotRagOptions.azureAISearch().id,
     },
-    name: TemplateNames.CustomCopilotRagAzureAISearch,
-  },
-  {
-    inputs: {
+    TemplateNames.CustomCopilotRagAzureAISearch,
+  ],
+  [
+    {
       [QuestionNames.Capabilities]: CapabilityOptions.customCopilotRag().id,
       [QuestionNames.CustomCopilotRag]: CustomCopilotRagOptions.customApi().id,
     },
-    name: TemplateNames.CustomCopilotRagCustomApi,
-  },
-  {
-    inputs: {
+    TemplateNames.CustomCopilotRagCustomApi,
+  ],
+  [
+    {
       [QuestionNames.Capabilities]: CapabilityOptions.customCopilotRag().id,
       [QuestionNames.CustomCopilotRag]: CustomCopilotRagOptions.microsoft365().id,
     },
-    name: TemplateNames.CustomCopilotRagMicrosoft365,
-  },
-  {
-    inputs: {
+    TemplateNames.CustomCopilotRagMicrosoft365,
+  ],
+  [
+    {
       [QuestionNames.Capabilities]: CapabilityOptions.customCopilotAssistant().id,
       [QuestionNames.CustomCopilotAssistant]: CustomCopilotAssistantOptions.new().id,
     },
-    name: TemplateNames.CustomCopilotAssistantNew,
-  },
-  {
-    inputs: {
+    TemplateNames.CustomCopilotAssistantNew,
+  ],
+  [
+    {
       [QuestionNames.Capabilities]: CapabilityOptions.customCopilotAssistant().id,
       [QuestionNames.CustomCopilotAssistant]: CustomCopilotAssistantOptions.assistantsApi().id,
     },
-    name: TemplateNames.CustomCopilotAssistantAssistantsApi,
-  },
-];
+    TemplateNames.CustomCopilotAssistantAssistantsApi,
+  ],
+]);

--- a/packages/fx-core/tests/component/generator/templateGenerator.test.ts
+++ b/packages/fx-core/tests/component/generator/templateGenerator.test.ts
@@ -6,276 +6,52 @@ import { createContextV3 } from "../../../src/component/utils";
 import path from "path";
 import { createSandbox } from "sinon";
 import { Generators } from "../../../src/component/generator/generatorProvider";
-import {
-  CapabilityOptions,
-  CustomCopilotAssistantOptions,
-  CustomCopilotRagOptions,
-  MeArchitectureOptions,
-  NotificationTriggerOptions,
-  ProgrammingLanguage,
-} from "../../../src/question/create";
-import { ApiMessageExtensionAuthOptions, QuestionNames } from "../../../src/question";
+import { ProgrammingLanguage } from "../../../src/question/create";
+import { CapabilityOptions, QuestionNames } from "../../../src/question";
 import { MockTools, randomAppName } from "../../core/utils";
 import { Generator } from "../../../src/component/generator/generator";
-import { TemplateNames } from "../../../src/component/generator/templates/templateNames";
+import {
+  TemplateNames,
+  inputs2TemplateName,
+} from "../../../src/component/generator/templates/templateNames";
 import { setTools } from "../../../src/core/globalVars";
 import { DefaultTemplateGenerator } from "../../../src/component/generator/templates/templateGenerator";
 import { TemplateInfo } from "../../../src/component/generator/templates/templateInfo";
 
 describe("TemplateGenerator", () => {
-  const inputs2TemplateName = [
+  const testInputs2TemplateName = [
+    ...inputs2TemplateName,
     {
-      inputs: { [QuestionNames.Capabilities]: CapabilityOptions.nonSsoTab().id },
-      name: TemplateNames.Tab,
-    },
-    {
-      inputs: { [QuestionNames.Capabilities]: CapabilityOptions.tab().id },
-      name: TemplateNames.SsoTab,
-    },
-    {
-      inputs: { [QuestionNames.Capabilities]: CapabilityOptions.m365SsoLaunchPage().id },
-      name: TemplateNames.SsoTabObo,
-    },
-    {
-      inputs: {
-        platform: Platform.VS,
-        [QuestionNames.ProgrammingLanguage]: ProgrammingLanguage.CSharp,
-        [QuestionNames.Capabilities]: CapabilityOptions.nonSsoTab().id,
-        targetFramework: "net8.0",
-      },
       name: TemplateNames.TabSSR,
-    },
-    {
       inputs: {
-        platform: Platform.VS,
+        capabilities: CapabilityOptions.nonSsoTab().id,
         [QuestionNames.ProgrammingLanguage]: ProgrammingLanguage.CSharp,
-        [QuestionNames.Capabilities]: CapabilityOptions.tab().id,
         targetFramework: "net8.0",
       },
+    },
+    {
       name: TemplateNames.SsoTabSSR,
-    },
-    {
-      inputs: { [QuestionNames.Capabilities]: CapabilityOptions.dashboardTab().id },
-      name: TemplateNames.DashboardTab,
-    },
-    {
       inputs: {
-        [QuestionNames.Capabilities]: CapabilityOptions.notificationBot().id,
-        [QuestionNames.BotTrigger]: NotificationTriggerOptions.appService().id,
-      },
-      name: TemplateNames.NotificationRestify,
-    },
-    {
-      inputs: {
-        platform: Platform.VS,
+        capabilities: CapabilityOptions.tab().id,
         [QuestionNames.ProgrammingLanguage]: ProgrammingLanguage.CSharp,
-        [QuestionNames.Capabilities]: CapabilityOptions.notificationBot().id,
-        [QuestionNames.BotTrigger]: NotificationTriggerOptions.appServiceForVS().id,
+        targetFramework: "net8.0",
       },
-      name: TemplateNames.NotificationWebApi,
     },
     {
+      name: TemplateNames.Tab,
       inputs: {
-        [QuestionNames.Capabilities]: CapabilityOptions.notificationBot().id,
-        [QuestionNames.BotTrigger]: NotificationTriggerOptions.functionsHttpTrigger().id,
-      },
-      name: TemplateNames.NotificationHttpTrigger,
-    },
-    {
-      inputs: {
-        platform: Platform.VS,
+        capabilities: CapabilityOptions.nonSsoTab().id,
         [QuestionNames.ProgrammingLanguage]: ProgrammingLanguage.CSharp,
-        [QuestionNames.Capabilities]: CapabilityOptions.notificationBot().id,
-        [QuestionNames.BotTrigger]: NotificationTriggerOptions.functionsHttpTriggerIsolated().id,
+        targetFramework: "net6.0",
       },
-      name: TemplateNames.NotificationHttpTriggerIsolated,
     },
     {
+      name: TemplateNames.SsoTab,
       inputs: {
-        [QuestionNames.Capabilities]: CapabilityOptions.notificationBot().id,
-        [QuestionNames.BotTrigger]: NotificationTriggerOptions.functionsTimerTrigger().id,
-      },
-      name: TemplateNames.NotificationTimerTrigger,
-    },
-    {
-      inputs: {
-        platform: Platform.VS,
+        capabilities: CapabilityOptions.tab().id,
         [QuestionNames.ProgrammingLanguage]: ProgrammingLanguage.CSharp,
-        [QuestionNames.Capabilities]: CapabilityOptions.notificationBot().id,
-        [QuestionNames.BotTrigger]: NotificationTriggerOptions.functionsTimerTriggerIsolated().id,
+        targetFramework: "net6.0",
       },
-      name: TemplateNames.NotificationTimerTriggerIsolated,
-    },
-    {
-      inputs: {
-        [QuestionNames.Capabilities]: CapabilityOptions.notificationBot().id,
-        [QuestionNames.BotTrigger]: NotificationTriggerOptions.functionsHttpAndTimerTrigger().id,
-      },
-      name: TemplateNames.NotificationHttpTimerTrigger,
-    },
-    {
-      inputs: {
-        platform: Platform.VS,
-        [QuestionNames.ProgrammingLanguage]: ProgrammingLanguage.CSharp,
-        [QuestionNames.Capabilities]: CapabilityOptions.notificationBot().id,
-        [QuestionNames.BotTrigger]:
-          NotificationTriggerOptions.functionsHttpAndTimerTriggerIsolated().id,
-      },
-      name: TemplateNames.NotificationHttpTimerTriggerIsolated,
-    },
-    {
-      inputs: {
-        [QuestionNames.Capabilities]: CapabilityOptions.commandBot().id,
-      },
-      name: TemplateNames.CommandAndResponse,
-    },
-    {
-      inputs: {
-        [QuestionNames.Capabilities]: CapabilityOptions.workflowBot().id,
-      },
-      name: TemplateNames.Workflow,
-    },
-    {
-      inputs: {
-        [QuestionNames.Capabilities]: CapabilityOptions.basicBot().id,
-      },
-      name: TemplateNames.DefaultBot,
-    },
-    {
-      inputs: {
-        [QuestionNames.Capabilities]: CapabilityOptions.me().id,
-      },
-      name: TemplateNames.MessageExtension,
-    },
-    {
-      inputs: {
-        [QuestionNames.Capabilities]: CapabilityOptions.collectFormMe().id,
-      },
-      name: TemplateNames.MessageExtensionAction,
-    },
-    {
-      inputs: { [QuestionNames.Capabilities]: CapabilityOptions.SearchMe().id },
-      name: TemplateNames.MessageExtensionSearch,
-    },
-    {
-      inputs: {
-        [QuestionNames.Capabilities]: CapabilityOptions.m365SearchMe().id,
-        [QuestionNames.MeArchitectureType]: MeArchitectureOptions.botPlugin().id,
-      },
-      name: TemplateNames.MessageExtensionCopilot,
-    },
-    {
-      inputs: {
-        [QuestionNames.Capabilities]: CapabilityOptions.m365SearchMe().id,
-        [QuestionNames.MeArchitectureType]: MeArchitectureOptions.botMe().id,
-      },
-      name: TemplateNames.M365MessageExtension,
-    },
-    {
-      inputs: {
-        [QuestionNames.Capabilities]: CapabilityOptions.nonSsoTabAndBot().id,
-      },
-      name: TemplateNames.TabAndDefaultBot,
-    },
-    {
-      inputs: {
-        [QuestionNames.Capabilities]: CapabilityOptions.botAndMe().id,
-      },
-      name: TemplateNames.BotAndMessageExtension,
-    },
-    {
-      inputs: {
-        [QuestionNames.Capabilities]: CapabilityOptions.linkUnfurling().id,
-      },
-      name: TemplateNames.LinkUnfurling,
-    },
-    {
-      inputs: {
-        [QuestionNames.Capabilities]: CapabilityOptions.aiBot().id,
-      },
-      name: TemplateNames.AIBot,
-    },
-    {
-      inputs: {
-        [QuestionNames.Capabilities]: CapabilityOptions.aiAssistantBot().id,
-      },
-      name: TemplateNames.AIAssistantBot,
-    },
-    {
-      inputs: {
-        [QuestionNames.Capabilities]: CapabilityOptions.copilotPluginNewApi().id,
-      },
-      name: TemplateNames.ApiPluginFromScratch,
-    },
-    {
-      inputs: {
-        [QuestionNames.Capabilities]: CapabilityOptions.m365SearchMe().id,
-        [QuestionNames.MeArchitectureType]: MeArchitectureOptions.newApi().id,
-        [QuestionNames.ApiMEAuth]: ApiMessageExtensionAuthOptions.none().id,
-      },
-      name: TemplateNames.CopilotPluginFromScratch,
-    },
-    {
-      inputs: {
-        [QuestionNames.Capabilities]: CapabilityOptions.m365SearchMe().id,
-        [QuestionNames.MeArchitectureType]: MeArchitectureOptions.newApi().id,
-        [QuestionNames.ApiMEAuth]: ApiMessageExtensionAuthOptions.apiKey().id,
-      },
-      name: TemplateNames.CopilotPluginFromScratchApiKey,
-    },
-    {
-      inputs: {
-        [QuestionNames.Capabilities]: CapabilityOptions.m365SearchMe().id,
-        [QuestionNames.MeArchitectureType]: MeArchitectureOptions.newApi().id,
-        [QuestionNames.ApiMEAuth]: ApiMessageExtensionAuthOptions.microsoftEntra().id,
-      },
-      name: TemplateNames.ApiMessageExtensionSso,
-    },
-    {
-      inputs: { [QuestionNames.Capabilities]: CapabilityOptions.customCopilotBasic().id },
-      name: TemplateNames.CustomCopilotBasic,
-    },
-    {
-      inputs: {
-        [QuestionNames.Capabilities]: CapabilityOptions.customCopilotRag().id,
-        [QuestionNames.CustomCopilotRag]: CustomCopilotRagOptions.customize().id,
-      },
-      name: TemplateNames.CustomCopilotRagCustomize,
-    },
-    {
-      inputs: {
-        [QuestionNames.Capabilities]: CapabilityOptions.customCopilotRag().id,
-        [QuestionNames.CustomCopilotRag]: CustomCopilotRagOptions.azureAISearch().id,
-      },
-      name: TemplateNames.CustomCopilotRagAzureAISearch,
-    },
-    {
-      inputs: {
-        [QuestionNames.Capabilities]: CapabilityOptions.customCopilotRag().id,
-        [QuestionNames.CustomCopilotRag]: CustomCopilotRagOptions.customApi().id,
-      },
-      name: TemplateNames.CustomCopilotRagCustomApi,
-    },
-    {
-      inputs: {
-        [QuestionNames.Capabilities]: CapabilityOptions.customCopilotRag().id,
-        [QuestionNames.CustomCopilotRag]: CustomCopilotRagOptions.microsoft365().id,
-      },
-      name: TemplateNames.CustomCopilotRagMicrosoft365,
-    },
-    {
-      inputs: {
-        [QuestionNames.Capabilities]: CapabilityOptions.customCopilotAssistant().id,
-        [QuestionNames.CustomCopilotAssistant]: CustomCopilotAssistantOptions.new().id,
-      },
-      name: TemplateNames.CustomCopilotAssistantNew,
-    },
-    {
-      inputs: {
-        [QuestionNames.Capabilities]: CapabilityOptions.customCopilotAssistant().id,
-        [QuestionNames.CustomCopilotAssistant]: CustomCopilotAssistantOptions.assistantsApi().id,
-      },
-      name: TemplateNames.CustomCopilotAssistantAssistantsApi,
     },
   ];
 
@@ -300,7 +76,7 @@ describe("TemplateGenerator", () => {
     sandbox.restore();
   });
 
-  inputs2TemplateName.forEach(async (pair) => {
+  testInputs2TemplateName.forEach(async (pair) => {
     it(`scaffolding ${pair.name}`, async () => {
       inputs = { ...inputs, ...pair.inputs };
       const res = await Generators.find((g) => g.activate(ctx, inputs))?.run(

--- a/packages/fx-core/tests/component/generator/templateGenerator.test.ts
+++ b/packages/fx-core/tests/component/generator/templateGenerator.test.ts
@@ -12,15 +12,15 @@ import { MockTools, randomAppName } from "../../core/utils";
 import { Generator } from "../../../src/component/generator/generator";
 import {
   TemplateNames,
-  inputs2TemplateName,
+  inputsToTemplateName,
 } from "../../../src/component/generator/templates/templateNames";
 import { setTools } from "../../../src/core/globalVars";
 import { DefaultTemplateGenerator } from "../../../src/component/generator/templates/templateGenerator";
 import { TemplateInfo } from "../../../src/component/generator/templates/templateInfo";
 
 describe("TemplateGenerator", () => {
-  const testInputs2TemplateName = [
-    ...inputs2TemplateName,
+  const testInputsToTemplateName = [
+    ...inputsToTemplateName,
     {
       name: TemplateNames.TabSSR,
       inputs: {
@@ -76,7 +76,7 @@ describe("TemplateGenerator", () => {
     sandbox.restore();
   });
 
-  testInputs2TemplateName.forEach(async (pair) => {
+  testInputsToTemplateName.forEach(async (pair) => {
     it(`scaffolding ${pair.name}`, async () => {
       inputs = { ...inputs, ...pair.inputs };
       const res = await Generators.find((g) => g.activate(ctx, inputs))?.run(

--- a/packages/fx-core/tests/component/generator/templateGenerator.test.ts
+++ b/packages/fx-core/tests/component/generator/templateGenerator.test.ts
@@ -19,41 +19,41 @@ import { DefaultTemplateGenerator } from "../../../src/component/generator/templ
 import { TemplateInfo } from "../../../src/component/generator/templates/templateInfo";
 
 describe("TemplateGenerator", () => {
-  const testInputsToTemplateName = [
+  const testInputsToTemplateName = new Map([
     ...inputsToTemplateName,
-    {
-      name: TemplateNames.TabSSR,
-      inputs: {
-        capabilities: CapabilityOptions.nonSsoTab().id,
+    [
+      {
+        [QuestionNames.Capabilities]: CapabilityOptions.tab().id,
         [QuestionNames.ProgrammingLanguage]: ProgrammingLanguage.CSharp,
         targetFramework: "net8.0",
       },
-    },
-    {
-      name: TemplateNames.SsoTabSSR,
-      inputs: {
-        capabilities: CapabilityOptions.tab().id,
+      TemplateNames.SsoTabSSR,
+    ],
+    [
+      {
+        [QuestionNames.Capabilities]: CapabilityOptions.tab().id,
+        [QuestionNames.ProgrammingLanguage]: ProgrammingLanguage.CSharp,
+        targetFramework: "net6.0",
+      },
+      TemplateNames.SsoTab,
+    ],
+    [
+      {
+        [QuestionNames.Capabilities]: CapabilityOptions.nonSsoTab().id,
         [QuestionNames.ProgrammingLanguage]: ProgrammingLanguage.CSharp,
         targetFramework: "net8.0",
       },
-    },
-    {
-      name: TemplateNames.Tab,
-      inputs: {
-        capabilities: CapabilityOptions.nonSsoTab().id,
+      TemplateNames.TabSSR,
+    ],
+    [
+      {
+        [QuestionNames.Capabilities]: CapabilityOptions.nonSsoTab().id,
         [QuestionNames.ProgrammingLanguage]: ProgrammingLanguage.CSharp,
         targetFramework: "net6.0",
       },
-    },
-    {
-      name: TemplateNames.SsoTab,
-      inputs: {
-        capabilities: CapabilityOptions.tab().id,
-        [QuestionNames.ProgrammingLanguage]: ProgrammingLanguage.CSharp,
-        targetFramework: "net6.0",
-      },
-    },
-  ];
+      TemplateNames.Tab,
+    ],
+  ]);
 
   setTools(new MockTools());
   const ctx = createContextV3();
@@ -76,9 +76,9 @@ describe("TemplateGenerator", () => {
     sandbox.restore();
   });
 
-  testInputsToTemplateName.forEach(async (pair) => {
-    it(`scaffolding ${pair.name}`, async () => {
-      inputs = { ...inputs, ...pair.inputs };
+  testInputsToTemplateName.forEach(async (templateName, _inputs) => {
+    it(`scaffolding ${templateName}`, async () => {
+      inputs = { ...inputs, ..._inputs };
       const res = await Generators.find((g) => g.activate(ctx, inputs))?.run(
         ctx,
         inputs,
@@ -87,10 +87,10 @@ describe("TemplateGenerator", () => {
 
       assert.isTrue(res?.isOk());
       assert.isTrue(scaffoldingSpy.calledOnce);
-      assert.equal((scaffoldingSpy.args[0][1] as TemplateInfo).templateName, pair.name);
+      assert.equal((scaffoldingSpy.args[0][1] as TemplateInfo).templateName, templateName);
       assert.equal(
         (scaffoldingSpy.args[0][1] as TemplateInfo).language,
-        pair.inputs?.[QuestionNames.ProgrammingLanguage] || ProgrammingLanguage.JS
+        inputs?.[QuestionNames.ProgrammingLanguage] || ProgrammingLanguage.JS
       );
     });
   });


### PR DESCRIPTION
1. Mapping inputs to template names. Templates onboarding process is simplified to registering new item in the map.
2. Customizing generator for ASP.NET SSR tab templates to keep default template generator simple.