### PR TITLE
perf(spec-parser): do not generate response_semantics when response is empty

### DIFF
--- a/packages/spec-parser/src/manifestUpdater.ts
+++ b/packages/spec-parser/src/manifestUpdater.ts
@@ -240,11 +240,15 @@ export class ManifestUpdater {
               }
 
               if (options.allowResponseSemantics) {
-                const [card, jsonPath] = AdaptiveCardGenerator.generateAdaptiveCard(operationItem);
-                const responseSemantic = wrapResponseSemantics(card, jsonPath);
-                funcObj.capabilities = {
-                  response_semantics: responseSemantic,
-                };
+                const { json } = Utils.getResponseJson(operationItem);
+                if (json.schema) {
+                  const [card, jsonPath] =
+                    AdaptiveCardGenerator.generateAdaptiveCard(operationItem);
+                  const responseSemantic = wrapResponseSemantics(card, jsonPath);
+                  funcObj.capabilities = {
+                    response_semantics: responseSemantic,
+                  };
+                }
               }
 
               if (options.allowConfirmation && method !== ConstantString.GetMethod) {

--- a/packages/spec-parser/test/manifestUpdater.test.ts
+++ b/packages/spec-parser/test/manifestUpdater.test.ts
@@ -19,7 +19,7 @@ describe("updateManifestWithAiPlugin", () => {
   });
 
   describe("responseSemantics", () => {
-    it("should generate default response semantics", async () => {
+    it("should not generate response semantics when response is empty", async () => {
       const spec: any = {
         openapi: "3.0.2",
         info: {
@@ -88,23 +88,6 @@ describe("updateManifestWithAiPlugin", () => {
                 },
               },
               required: ["limit"],
-            },
-            capabilities: {
-              response_semantics: {
-                data_path: "$",
-                static_template: {
-                  $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
-                  body: [
-                    {
-                      text: "success",
-                      type: "TextBlock",
-                      wrap: true,
-                    },
-                  ],
-                  type: "AdaptiveCard",
-                  version: "1.5",
-                },
-              },
             },
           },
         ],
@@ -1209,23 +1192,6 @@ describe("updateManifestWithAiPlugin", () => {
               },
               required: ["limit"],
             },
-            capabilities: {
-              response_semantics: {
-                data_path: "$",
-                static_template: {
-                  $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
-                  type: "AdaptiveCard",
-                  version: "1.5",
-                  body: [
-                    {
-                      type: "TextBlock",
-                      text: "success",
-                      wrap: true,
-                    },
-                  ],
-                },
-              },
-            },
           },
           {
             name: "createPet",
@@ -1245,21 +1211,6 @@ describe("updateManifestWithAiPlugin", () => {
                 type: "AdaptiveCard",
                 title: "Create a pet",
                 body: "* **Name**: {{function.parameters.name}}",
-              },
-              response_semantics: {
-                data_path: "$",
-                static_template: {
-                  $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
-                  type: "AdaptiveCard",
-                  version: "1.5",
-                  body: [
-                    {
-                      type: "TextBlock",
-                      text: "success",
-                      wrap: true,
-                    },
-                  ],
-                },
               },
             },
           },

--- a/packages/spec-parser/test/manifestUpdater.test.ts
+++ b/packages/spec-parser/test/manifestUpdater.test.ts
@@ -1150,6 +1150,22 @@ describe("updateManifestWithAiPlugin", () => {
                   },
                 },
               },
+              responses: {
+                200: {
+                  content: {
+                    "application/json": {
+                      schema: {
+                        type: "object",
+                        properties: {
+                          name: {
+                            type: "string",
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
             },
           },
         },
@@ -1211,6 +1227,24 @@ describe("updateManifestWithAiPlugin", () => {
                 type: "AdaptiveCard",
                 title: "Create a pet",
                 body: "* **Name**: {{function.parameters.name}}",
+              },
+              response_semantics: {
+                data_path: "$",
+                properties: {
+                  title: "$.name",
+                },
+                static_template: {
+                  $schema: "http://adaptivecards.io/schemas/adaptive-card.json",
+                  body: [
+                    {
+                      text: "name: ${if(name, name, 'N/A')}",
+                      type: "TextBlock",
+                      wrap: true,
+                    },
+                  ],
+                  type: "AdaptiveCard",
+                  version: "1.5",
+                },
               },
             },
           },


### PR DESCRIPTION
[Bug 27787556](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/27787556): Don't generate response_semantics when response is empty