### PR TITLE
fix(core): bump sample tag version

### DIFF
--- a/packages/fx-core/src/common/samples.ts
+++ b/packages/fx-core/src/common/samples.ts
@@ -15,7 +15,7 @@ const packageJson = require("../../package.json");
 const SampleConfigOwner = "OfficeDev";
 const SampleConfigRepo = "TeamsFx-Samples";
 const SampleConfigFile = ".config/samples-config-v3.json";
-export const SampleConfigTag = "v2.4.0";
+export const SampleConfigTag = "v2.5.0";
 // prerelease tag is always using a branch.
 export const SampleConfigBranchForPrerelease = "main";
 


### PR DESCRIPTION
Need to bump version because of new image URL support: https://github.com/OfficeDev/TeamsFx/pull/11160
Related: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/27194270