### PR TITLE
fix: API ME Launch url in VS

### DIFF
--- a/templates/csharp/api-message-extension-sso/.{{NewProjectTypeName}}/launchSettings.json.tpl
+++ b/templates/csharp/api-message-extension-sso/.{{NewProjectTypeName}}/launchSettings.json.tpl
@@ -3,7 +3,7 @@
     // Launch project within Teams
     "Microsoft Teams (browser)": {
       "commandName": "Project",
-      "launchUrl": "https://teams.microsoft.com?appTenantId=${{TEAMS_APP_TENANT_ID}}&login_hint=${{TEAMSFX_M365_USER_NAME}}",
+      "launchUrl": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&appTenantId=${{TEAMS_APP_TENANT_ID}}&login_hint=${{TEAMSFX_M365_USER_NAME}}",
     }
   }
 }

--- a/templates/csharp/api-message-extension-sso/GettingStarted.md
+++ b/templates/csharp/api-message-extension-sso/GettingStarted.md
@@ -13,7 +13,7 @@
 2. Right-click your project and select `Teams Toolkit > Prepare Teams App Dependencies`.
 3. If prompted, sign in with a Microsoft 365 account for the Teams organization you want to install the app to.
 4. Press F5, or select the `Debug > Start Debugging` menu in Visual Studio
-5. When Teams launches in the browser, you can navigate to a chat message and [trigger your search commands from compose message area](https://learn.microsoft.com/microsoftteams/platform/messaging-extensions/what-are-messaging-extensions?tabs=dotnet#search-commands).
+5. To trigger the Message Extension, you can click the `+` under compose message area to find your message extension.
 
 ## Learn more
 

--- a/templates/csharp/api-message-extension-sso/Properties/launchSettings.json.tpl
+++ b/templates/csharp/api-message-extension-sso/Properties/launchSettings.json.tpl
@@ -6,7 +6,7 @@
       "commandLineArgs": "host start --port 5130 --pause-on-error",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "launchUrl": "https://teams.microsoft.com?appTenantId=${{TEAMS_APP_TENANT_ID}}&login_hint=${{TEAMSFX_M365_USER_NAME}}",
+      "launchUrl": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&appTenantId=${{TEAMS_APP_TENANT_ID}}&login_hint=${{TEAMSFX_M365_USER_NAME}}",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },

--- a/templates/csharp/api-message-extension-sso/teamsapp.local.yml.tpl
+++ b/templates/csharp/api-message-extension-sso/teamsapp.local.yml.tpl
@@ -104,7 +104,7 @@ provision:
             commandLineArgs: "host start --port 5130 --pause-on-error"
             dotnetRunMessages: true
             launchBrowser: true
-            launchUrl: "https://teams.microsoft.com?appTenantId=${{TEAMS_APP_TENANT_ID}}&login_hint=${{TEAMSFX_M365_USER_NAME}}"
+            launchUrl: "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&appTenantId=${{TEAMS_APP_TENANT_ID}}&login_hint=${{TEAMSFX_M365_USER_NAME}}"
             environmentVariables:
               ASPNETCORE_ENVIRONMENT: "Development"
             hotReloadProfile: "aspnetcore"

--- a/templates/csharp/copilot-plugin-existing-api-api-key/GettingStarted.md
+++ b/templates/csharp/copilot-plugin-existing-api-api-key/GettingStarted.md
@@ -13,7 +13,7 @@
 2. If prompted, sign in with a Microsoft 365 account for the Teams organization you want 
 to install the app to.
 3. Right-click your project and select `Teams Toolkit > Preview in > Teams`.
-4. When Teams launches in the browser, you can navigate to a chat message and [trigger your search commands from compose message area](https://learn.microsoft.com/microsoftteams/platform/messaging-extensions/what-are-messaging-extensions?tabs=dotnet#search-commands).
+4. To trigger the Message Extension, you can click the `+` under compose message area to find your message extension.
 
 > [!NOTE]
 > Teams Toolkit will ask you for your API key during provision. The API key will be securely stored with [Teams Developer Portal](https://dev.teams.microsoft.com/home) and used by Teams client to access your API in runtime. Teams Toolkit will not store your API key.

--- a/templates/csharp/copilot-plugin-existing-api/GettingStarted.md
+++ b/templates/csharp/copilot-plugin-existing-api/GettingStarted.md
@@ -13,7 +13,7 @@
 2. If prompted, sign in with a Microsoft 365 account for the Teams organization you want 
 to install the app to.
 3. Right-click your project and select `Teams Toolkit > Preview in > Teams`.
-4. When Teams launches in the browser, you can navigate to a chat message and [trigger your search commands from compose message area](https://learn.microsoft.com/microsoftteams/platform/messaging-extensions/what-are-messaging-extensions?tabs=dotnet#search-commands).
+4. To trigger the Message Extension, you can click the `+` under compose message area to find your message extension.
 
 ## Learn more
 

--- a/templates/csharp/copilot-plugin-from-scratch-api-key/.{{NewProjectTypeName}}/launchSettings.json.tpl
+++ b/templates/csharp/copilot-plugin-from-scratch-api-key/.{{NewProjectTypeName}}/launchSettings.json.tpl
@@ -3,7 +3,7 @@
     // Launch project within Teams
     "Microsoft Teams (browser)": {
       "commandName": "Project",
-      "launchUrl": "https://teams.microsoft.com?appTenantId=${{TEAMS_APP_TENANT_ID}}&login_hint=${{TEAMSFX_M365_USER_NAME}}",
+      "launchUrl": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&appTenantId=${{TEAMS_APP_TENANT_ID}}&login_hint=${{TEAMSFX_M365_USER_NAME}}",
     }
   }
 }

--- a/templates/csharp/copilot-plugin-from-scratch-api-key/GettingStarted.md
+++ b/templates/csharp/copilot-plugin-from-scratch-api-key/GettingStarted.md
@@ -29,7 +29,7 @@
 3. Right-click your project and select `Teams Toolkit > Prepare Teams App Dependencies`.
 4. If prompted, sign in with a Microsoft 365 account for the Teams organization you want to install the app to.
 5. Press F5, or select the `Debug > Start Debugging` menu in Visual Studio
-6. When Teams launches in the browser, you can navigate to a chat message and [trigger your search commands from compose message area](https://learn.microsoft.com/microsoftteams/platform/messaging-extensions/what-are-messaging-extensions?tabs=dotnet#search-commands).
+6. To trigger the Message Extension, you can click the `+` under compose message area to find your message extension..
 
 
 ## Learn more

--- a/templates/csharp/copilot-plugin-from-scratch-api-key/Properties/launchSettings.json.tpl
+++ b/templates/csharp/copilot-plugin-from-scratch-api-key/Properties/launchSettings.json.tpl
@@ -6,7 +6,7 @@
       "commandLineArgs": "host start --port 5130 --pause-on-error",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "launchUrl": "https://teams.microsoft.com?appTenantId=${{TEAMS_APP_TENANT_ID}}&login_hint=${{TEAMSFX_M365_USER_NAME}}",
+      "launchUrl": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&appTenantId=${{TEAMS_APP_TENANT_ID}}&login_hint=${{TEAMSFX_M365_USER_NAME}}",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },

--- a/templates/csharp/copilot-plugin-from-scratch-api-key/teamsapp.local.yml.tpl
+++ b/templates/csharp/copilot-plugin-from-scratch-api-key/teamsapp.local.yml.tpl
@@ -107,7 +107,7 @@ provision:
             commandLineArgs: "host start --port 5130 --pause-on-error"
             dotnetRunMessages: true
             launchBrowser: true
-            launchUrl: "https://teams.microsoft.com?appTenantId=${{TEAMS_APP_TENANT_ID}}&login_hint=${{TEAMSFX_M365_USER_NAME}}"
+            launchUrl: "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&appTenantId=${{TEAMS_APP_TENANT_ID}}&login_hint=${{TEAMSFX_M365_USER_NAME}}"
             environmentVariables:
               ASPNETCORE_ENVIRONMENT: "Development"
             hotReloadProfile: "aspnetcore"

--- a/templates/csharp/copilot-plugin-from-scratch/.{{NewProjectTypeName}}/launchSettings.json.tpl
+++ b/templates/csharp/copilot-plugin-from-scratch/.{{NewProjectTypeName}}/launchSettings.json.tpl
@@ -3,7 +3,7 @@
     // Launch project within Teams
     "Microsoft Teams (browser)": {
       "commandName": "Project",
-      "launchUrl": "https://teams.microsoft.com?appTenantId=${{TEAMS_APP_TENANT_ID}}&login_hint=${{TEAMSFX_M365_USER_NAME}}",
+      "launchUrl": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&appTenantId=${{TEAMS_APP_TENANT_ID}}&login_hint=${{TEAMSFX_M365_USER_NAME}}",
     }
   }
 }

--- a/templates/csharp/copilot-plugin-from-scratch/GettingStarted.md
+++ b/templates/csharp/copilot-plugin-from-scratch/GettingStarted.md
@@ -13,8 +13,7 @@
 2. Right-click your project and select `Teams Toolkit > Prepare Teams App Dependencies`.
 3. If prompted, sign in with a Microsoft 365 account for the Teams organization you want to install the app to.
 4. Press F5, or select the `Debug > Start Debugging` menu in Visual Studio
-5. When Teams launches in the browser, you can navigate to a chat message and [trigger your search commands from compose message area](https://learn.microsoft.com/microsoftteams/platform/messaging-extensions/what-are-messaging-extensions?tabs=dotnet#search-commands).
-
+5. To trigger the Message Extension, you can click the `+` under compose message area to find your message extension.
 ## Learn more
 
 - [Extend Teams platform with APIs](https://aka.ms/teamsfx-api-plugin)

--- a/templates/csharp/copilot-plugin-from-scratch/Properties/launchSettings.json.tpl
+++ b/templates/csharp/copilot-plugin-from-scratch/Properties/launchSettings.json.tpl
@@ -6,7 +6,7 @@
       "commandLineArgs": "host start --port 5130 --pause-on-error",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "launchUrl": "https://teams.microsoft.com?appTenantId=${{TEAMS_APP_TENANT_ID}}&login_hint=${{TEAMSFX_M365_USER_NAME}}",
+      "launchUrl": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&appTenantId=${{TEAMS_APP_TENANT_ID}}&login_hint=${{TEAMSFX_M365_USER_NAME}}",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },

--- a/templates/csharp/copilot-plugin-from-scratch/teamsapp.local.yml.tpl
+++ b/templates/csharp/copilot-plugin-from-scratch/teamsapp.local.yml.tpl
@@ -71,7 +71,7 @@ provision:
             commandLineArgs: "host start --port 5130 --pause-on-error"
             dotnetRunMessages: true
             launchBrowser: true
-            launchUrl: "https://teams.microsoft.com?appTenantId=${{TEAMS_APP_TENANT_ID}}&login_hint=${{TEAMSFX_M365_USER_NAME}}"
+            launchUrl: "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&appTenantId=${{TEAMS_APP_TENANT_ID}}&login_hint=${{TEAMSFX_M365_USER_NAME}}"
             environmentVariables:
               ASPNETCORE_ENVIRONMENT: "Development"
             hotReloadProfile: "aspnetcore"


### PR DESCRIPTION
[Bug 27777602](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/27777602): Debugging API ME shouldn't go to the home page of Teams