### PR TITLE
fix: cli cannot scroll down if multiple selections

### DIFF
--- a/packages/cli/src/prompts/utils.ts
+++ b/packages/cli/src/prompts/utils.ts
@@ -47,7 +47,8 @@ export function computePrefixWidth(
   const middle = Math.floor(pageSize / 2);
   let pageStart;
   if (current < middle) pageStart = 0;
-  else if (current > choices.length - middle) pageStart = choices.length - pageSize;
+  else if (current > choices.length - middle)
+    pageStart = choices.length < pageSize ? 0 : choices.length - pageSize;
   else pageStart = current - middle;
   let prefixWidth = 1;
   choices.slice(pageStart, pageStart + pageSize).forEach((choice) => {

--- a/packages/cli/tests/unit/prompts/customizedListPrompt.tests.ts
+++ b/packages/cli/tests/unit/prompts/customizedListPrompt.tests.ts
@@ -120,6 +120,40 @@ describe("select prompt", () => {
     expect(await answer).equal("id1");
   });
 
+  it("allow setting the page size larger than choices length", async () => {
+    const { answer, events, getScreen } = await render(select, {
+      message: "Select a string",
+      choices,
+      pageSize: 14,
+    });
+
+    expect(getScreen()).equal(
+      trimOutput(`
+        ? Select a string
+        (*) title 1  detail 1
+        ( ) title 2  detail 2
+        ( ) title 3  detail 3
+        ( ) title 4  detail 4
+        ( ) title 5  detail 5
+        ( ) title 6  detail 6
+        ( ) title 7  detail 7
+        ( ) title 8  detail 8
+        ( ) title 9  detail 9
+        ( ) title 10 detail 10
+        ( ) title 11 detail 11
+        ( ) title 12 detail 12`)
+    );
+    events.keypress("down");
+    events.keypress("down");
+    events.keypress("down");
+    events.keypress("down");
+    events.keypress("down");
+    events.keypress("down");
+
+    events.keypress("enter");
+    expect(await answer).equal("id7");
+  });
+
   it("cycles through options", async () => {
     const { answer, events, getScreen } = await render(select, {
       message: "Select a string",

--- a/packages/cli/tests/unit/prompts/customizedListPrompt.tests.ts
+++ b/packages/cli/tests/unit/prompts/customizedListPrompt.tests.ts
@@ -116,8 +116,12 @@ describe("select prompt", () => {
         (Use arrow keys to reveal more choices)`)
     );
 
+    for (let i = 0; i < 8; i++) {
+      events.keypress("down");
+    }
+
     events.keypress("enter");
-    expect(await answer).equal("id1");
+    expect(await answer).equal("id9");
   });
 
   it("allow setting the page size larger than choices length", async () => {
@@ -143,12 +147,10 @@ describe("select prompt", () => {
         ( ) title 11 detail 11
         ( ) title 12 detail 12`)
     );
-    events.keypress("down");
-    events.keypress("down");
-    events.keypress("down");
-    events.keypress("down");
-    events.keypress("down");
-    events.keypress("down");
+
+    for (let i = 0; i < 6; i++) {
+      events.keypress("down");
+    }
 
     events.keypress("enter");
     expect(await answer).equal("id7");

--- a/packages/cli/tests/unit/prompts/customizedListPrompt.tests.ts
+++ b/packages/cli/tests/unit/prompts/customizedListPrompt.tests.ts
@@ -148,12 +148,12 @@ describe("select prompt", () => {
         ( ) title 12 detail 12`)
     );
 
-    for (let i = 0; i < 6; i++) {
+    for (let i = 0; i < 7; i++) {
       events.keypress("down");
     }
 
     events.keypress("enter");
-    expect(await answer).equal("id7");
+    expect(await answer).equal("id8");
   });
 
   it("cycles through options", async () => {


### PR DESCRIPTION
[Bug 27955155](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/27955155): [CLI] Scroll down will error when single select an item of large index from a list
choices.length could be smaller than page size, leading to pageStarter <0.
After fix:
![image](https://github.com/OfficeDev/TeamsFx/assets/86260893/faab7fb9-f4cb-498e-93b2-b7525257b316)

