### PR TITLE
feat: remove preview tag from debug in test tool option

### DIFF
--- a/templates/js/ai-assistant-bot/.vscode/launch.json.tpl
+++ b/templates/js/ai-assistant-bot/.vscode/launch.json.tpl
@@ -102,7 +102,7 @@
             "stopAll": true
         },
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Attach to Local Service"
             ],

--- a/templates/js/ai-assistant-bot/README.md.tpl
+++ b/templates/js/ai-assistant-bot/README.md.tpl
@@ -64,7 +64,7 @@ Before running or debugging your bot, please follow these steps to setup your ow
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
 {{#enableTestToolByDefault}}
-1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
+1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool`.
 1. You will receive a welcome message from the bot, or send any message to get a response.
 
 **Congratulations**! You are running an application that can now interact with users in Teams App Test Tool:

--- a/templates/js/ai-bot/.vscode/launch.json.tpl
+++ b/templates/js/ai-bot/.vscode/launch.json.tpl
@@ -102,7 +102,7 @@
             "stopAll": true
         },
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Attach to Local Service"
             ],

--- a/templates/js/ai-bot/README.md.tpl
+++ b/templates/js/ai-bot/README.md.tpl
@@ -29,7 +29,7 @@ The app template is built using the Teams AI library, which provides the capabil
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
 {{#enableTestToolByDefault}}
 1. In file *env/.env.testtool.user*, fill in your OpenAI key `SECRET_OPENAI_API_KEY=<your-key>`.
-1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
+1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool`.
 1. You will receive a welcome message from the bot, or send any message to get a response.
 
 **Congratulations**! You are running an application that can now interact with users in Teams App Test Tool:

--- a/templates/js/command-and-response/.vscode/launch.json.tpl
+++ b/templates/js/command-and-response/.vscode/launch.json.tpl
@@ -102,7 +102,7 @@
             "stopAll": true
         },
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Attach to Local Service"
             ],

--- a/templates/js/command-and-response/README.md.tpl
+++ b/templates/js/command-and-response/README.md.tpl
@@ -23,7 +23,7 @@ The app template is built using the TeamsFx SDK, which provides a simple set of 
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
 {{#enableTestToolByDefault}}
-2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
+2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool`.
 3. The browser will pop up to open Teams App Test Tool.
 4. Type or select `helloWorld` in the chat to send it to your bot - this is the default command provided by the template.
 {{/enableTestToolByDefault}}

--- a/templates/js/custom-copilot-assistant-assistants-api/.vscode/launch.json.tpl
+++ b/templates/js/custom-copilot-assistant-assistants-api/.vscode/launch.json.tpl
@@ -102,7 +102,7 @@
             "stopAll": true
         },
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Attach to Local Service"
             ],

--- a/templates/js/custom-copilot-assistant-assistants-api/README.md.tpl
+++ b/templates/js/custom-copilot-assistant-assistants-api/README.md.tpl
@@ -59,7 +59,7 @@ Before running or debugging your bot, please follow these steps to setup your ow
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
 {{#enableTestToolByDefault}}
-1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
+1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool`.
 1. You can send any message to get a response from the bot.
 
 **Congratulations**! You are running an application that can now interact with users in Teams App Test Tool:

--- a/templates/js/custom-copilot-assistant-new/.vscode/launch.json.tpl
+++ b/templates/js/custom-copilot-assistant-new/.vscode/launch.json.tpl
@@ -102,7 +102,7 @@
             "stopAll": true
         },
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Attach to Local Service"
             ],

--- a/templates/js/custom-copilot-assistant-new/README.md.tpl
+++ b/templates/js/custom-copilot-assistant-new/README.md.tpl
@@ -31,7 +31,7 @@ It showcases how to build an AI agent in Teams capable of chatting with users an
 {{#useAzureOpenAI}}
 1. In file *env/.env.testtool.user*, fill in your Azure OpenAI key `SECRET_AZURE_OPENAI_API_KEY=<your-key>`, endpoint `AZURE_OPENAI_ENDPOINT=<your-endpoint>`, and deployment name `AZURE_OPENAI_DEPLOYMENT_NAME=<your-deployment>`.
 {{/useAzureOpenAI}}
-1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
+1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool`.
 1. You can send any message to get a response from the bot.
 
 **Congratulations**! You are running an application that can now interact with users in Teams App Test Tool:

--- a/templates/js/custom-copilot-basic/.vscode/launch.json.tpl
+++ b/templates/js/custom-copilot-basic/.vscode/launch.json.tpl
@@ -102,7 +102,7 @@
             "stopAll": true
         },
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Attach to Local Service"
             ],

--- a/templates/js/custom-copilot-basic/README.md.tpl
+++ b/templates/js/custom-copilot-basic/README.md.tpl
@@ -31,7 +31,7 @@ It showcases a bot app that responds to user questions like ChatGPT, which enabl
 {{#useAzureOpenAI}}
 1. In file *env/.env.testtool.user*, fill in your Azure OpenAI key `SECRET_AZURE_OPENAI_API_KEY=<your-key>`, endpoint `AZURE_OPENAI_ENDPOINT=<your-endpoint>`, and deployment name `AZURE_OPENAI_DEPLOYMENT_NAME=<your-deployment>`.
 {{/useAzureOpenAI}}
-1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
+1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool`.
 1. You can send any message to get a response from the bot.
 
 **Congratulations**! You are running an application that can now interact with users in Teams App Test Tool:

--- a/templates/js/custom-copilot-rag-azure-ai-search/.vscode/launch.json.tpl
+++ b/templates/js/custom-copilot-rag-azure-ai-search/.vscode/launch.json.tpl
@@ -102,7 +102,7 @@
             "stopAll": true
         },
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Attach to Local Service"
             ],

--- a/templates/js/custom-copilot-rag-azure-ai-search/README.md.tpl
+++ b/templates/js/custom-copilot-rag-azure-ai-search/README.md.tpl
@@ -31,7 +31,7 @@ This app template also demonstrates usage of techniques like:
 1. In file *env/.env.testtool.user*, fill in your Azure OpenAI key `SECRET_AZURE_OPENAI_API_KEY=<your-key>`, endpoint `AZURE_OPENAI_ENDPOINT=<your-endpoint>`, deployment name `AZURE_OPENAI_DEPLOYMENT_NAME=<your-deployment>`, and embedding deployment name `AZURE_OPENAI_EMBEDDING_DEPLOYMENT_NAME=<your-embedding-deployment>`. And fill in your Azure AI search key `SECRET_AZURE_SEARCH_KEY=<your-ai-search-key>` and endpoint `AZURE_SEARCH_ENDPOINT=<your-ai-search-endpoint>`.
 {{/useAzureOpenAI}}
 1. Do `npm install` and `npm run indexer:create` to create the my documents index. Once you're done using the sample it's good practice to delete the index. You can do so with the `npm run indexer:delete` command.
-1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
+1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool`.
 1. You can send any message to get a response from the bot.
 
 **Congratulations**! You are running an application that can now interact with users in Teams App Test Tool:

--- a/templates/js/custom-copilot-rag-custom-api/.vscode/launch.json.tpl
+++ b/templates/js/custom-copilot-rag-custom-api/.vscode/launch.json.tpl
@@ -102,7 +102,7 @@
             "stopAll": true
         },
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Attach to Local Service"
             ],

--- a/templates/js/custom-copilot-rag-custom-api/README.md.tpl
+++ b/templates/js/custom-copilot-rag-custom-api/README.md.tpl
@@ -31,7 +31,7 @@ The app template is built using the Teams AI library, which provides the capabil
 {{#useAzureOpenAI}}
 1. In file *env/.env.testtool.user*, fill in your Azure OpenAI key `SECRET_AZURE_OPENAI_ENDPOINT=<your-key>`, endpoint `SECRET_AZURE_OPENAI_ENDPOINT=<your-endpoint>` and deployment name `AZURE_OPENAI_MODEL_DEPLOYMENT_NAME=<your-deployment-name>`.
 {{/useAzureOpenAI}}
-1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
+1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool`.
 1. You can send any message to get a response from the bot.
 
 **Congratulations**! You are running an application that can now interact with users in Teams App Test Tool:

--- a/templates/js/custom-copilot-rag-customize/.vscode/launch.json.tpl
+++ b/templates/js/custom-copilot-rag-customize/.vscode/launch.json.tpl
@@ -102,7 +102,7 @@
             "stopAll": true
         },
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Attach to Local Service"
             ],

--- a/templates/js/custom-copilot-rag-customize/README.md.tpl
+++ b/templates/js/custom-copilot-rag-customize/README.md.tpl
@@ -29,7 +29,7 @@ This app template also demonstrates usage of techniques like:
 {{#useAzureOpenAI}}
 1. In file *env/.env.testtool.user*, fill in your Azure OpenAI key `SECRET_AZURE_OPENAI_API_KEY=<your-key>`, endpoint `AZURE_OPENAI_ENDPOINT=<your-endpoint>` and deployment name `AZURE_OPENAI_DEPLOYMENT_NAME=<your-deployment>`.
 {{/useAzureOpenAI}}
-1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
+1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool`.
 1. You can send any message to get a response from the bot.
 
 **Congratulations**! You are running an application that can now interact with users in Teams App Test Tool:

--- a/templates/js/default-bot/.vscode/launch.json.tpl
+++ b/templates/js/default-bot/.vscode/launch.json.tpl
@@ -102,7 +102,7 @@
             "stopAll": true
         },
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Attach to Local Service"
             ],

--- a/templates/js/default-bot/README.md.tpl
+++ b/templates/js/default-bot/README.md.tpl
@@ -24,7 +24,7 @@ A bot interaction can be a quick question and answer, or it can be a complex con
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
 {{#enableTestToolByDefault}}
-2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
+2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool`.
 3. The browser will pop up to open Teams App Test Tool.
 4. You will receive a welcome message from the bot, and you can send anything to the bot to get an echoed response.
 

--- a/templates/js/link-unfurling/.vscode/launch.json.tpl
+++ b/templates/js/link-unfurling/.vscode/launch.json.tpl
@@ -116,7 +116,7 @@
     ],
     "compounds": [
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Attach to Local Service"
             ],

--- a/templates/js/m365-message-extension/.vscode/launch.json.tpl
+++ b/templates/js/m365-message-extension/.vscode/launch.json.tpl
@@ -116,7 +116,7 @@
     ],
     "compounds": [
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Attach to Local Service"
             ],

--- a/templates/js/m365-message-extension/README.md.tpl
+++ b/templates/js/m365-message-extension/README.md.tpl
@@ -20,7 +20,7 @@ This app template is a search-based [message extension](https://docs.microsoft.c
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
 {{#enableMETestToolByDefault}}
-2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
+2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool`.
 3. To trigger the Message Extension, you can click the `+` in compose message area and select `Search Command`
 
 **Congratulations**! You are running an application that can now search npm registries in Teams App Test Tool.

--- a/templates/js/message-extension-action/.vscode/launch.json.tpl
+++ b/templates/js/message-extension-action/.vscode/launch.json.tpl
@@ -66,7 +66,7 @@
     ],
     "compounds": [
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Attach to Local Service"
             ],

--- a/templates/js/message-extension-copilot/.vscode/launch.json.tpl
+++ b/templates/js/message-extension-copilot/.vscode/launch.json.tpl
@@ -166,7 +166,7 @@
     ],
     "compounds": [
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Attach to Local Service"
             ],

--- a/templates/js/message-extension/.vscode/launch.json.tpl
+++ b/templates/js/message-extension/.vscode/launch.json.tpl
@@ -116,7 +116,7 @@
     ],
     "compounds": [
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Attach to Local Service"
             ],

--- a/templates/js/notification-http-timer-trigger/.vscode/launch.json.tpl
+++ b/templates/js/notification-http-timer-trigger/.vscode/launch.json.tpl
@@ -102,7 +102,7 @@
             "stopAll": true
         },
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Attach to Local Service"
             ],

--- a/templates/js/notification-http-timer-trigger/README.md.tpl
+++ b/templates/js/notification-http-timer-trigger/README.md.tpl
@@ -24,7 +24,7 @@ The app template is built using the TeamsFx SDK, which provides a simple set of 
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
 {{#enableTestToolByDefault}}
-2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
+2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool`.
 3. The browser will pop up to open Teams App Test Tool.
 4. If you select `Timer Trigger`, wait for 30 seconds. If you select `HTTP Trigger`, send a POST request to `http://<endpoint>/api/notification` with your favorite tool (like `Postman`)
 {{/enableTestToolByDefault}}

--- a/templates/js/notification-http-trigger/.vscode/launch.json.tpl
+++ b/templates/js/notification-http-trigger/.vscode/launch.json.tpl
@@ -102,7 +102,7 @@
             "stopAll": true
         },
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Attach to Local Service"
             ],

--- a/templates/js/notification-http-trigger/README.md.tpl
+++ b/templates/js/notification-http-trigger/README.md.tpl
@@ -24,7 +24,7 @@ The app template is built using the TeamsFx SDK, which provides a simple set of 
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
 {{#enableTestToolByDefault}}
-2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
+2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool`.
 3. The browser will pop up to open Teams App Test Tool.
 4. If you select `Timer Trigger`, wait for 30 seconds. If you select `HTTP Trigger`, send a POST request to `http://<endpoint>/api/notification` with your favorite tool (like `Postman`)
 {{/enableTestToolByDefault}}

--- a/templates/js/notification-restify/.vscode/launch.json.tpl
+++ b/templates/js/notification-restify/.vscode/launch.json.tpl
@@ -102,7 +102,7 @@
             "stopAll": true
         },
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Attach to Local Service"
             ],

--- a/templates/js/notification-restify/README.md.tpl
+++ b/templates/js/notification-restify/README.md.tpl
@@ -24,7 +24,7 @@ The app template is built using the TeamsFx SDK, which provides a simple set of 
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
 {{#enableTestToolByDefault}}
-2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
+2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool`.
 3. The browser will pop up to open Teams App Test Tool.
 4. Send a POST request to `http://<endpoint>/api/notification` with your favorite tool (like `Postman`)
 {{/enableTestToolByDefault}}

--- a/templates/js/notification-timer-trigger/.vscode/launch.json.tpl
+++ b/templates/js/notification-timer-trigger/.vscode/launch.json.tpl
@@ -102,7 +102,7 @@
             "stopAll": true
         },
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Attach to Local Service"
             ],

--- a/templates/js/notification-timer-trigger/README.md.tpl
+++ b/templates/js/notification-timer-trigger/README.md.tpl
@@ -25,7 +25,7 @@ The app template is built using the TeamsFx SDK, which provides a simple set of 
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
 {{#enableTestToolByDefault}}
-2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
+2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool`.
 3. The browser will pop up to open Teams App Test Tool.
 4. If you select `Timer Trigger`, wait for 30 seconds. If you select `HTTP Trigger`, send a POST request to `http://<endpoint>/api/notification` with your favorite tool (like `Postman`)
 {{/enableTestToolByDefault}}

--- a/templates/js/workflow/.vscode/launch.json.tpl
+++ b/templates/js/workflow/.vscode/launch.json.tpl
@@ -102,7 +102,7 @@
             "stopAll": true
         },
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Attach to Local Service"
             ],

--- a/templates/js/workflow/README.md.tpl
+++ b/templates/js/workflow/README.md.tpl
@@ -23,7 +23,7 @@ The app template is built using the TeamsFx SDK, which provides a simple set of 
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
 {{#enableTestToolByDefault}}
-2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
+2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool`.
 3. The browser will pop up to open Teams App Test Tool.
 4. Type or select `helloWorld` in the chat to send it to your bot - this is the default command provided by the template.
 5. In the response from the bot, select the **DoStuff** button.

--- a/templates/python/custom-copilot-assistant-new/.vscode/launch.json.tpl
+++ b/templates/python/custom-copilot-assistant-new/.vscode/launch.json.tpl
@@ -110,7 +110,7 @@
             "stopAll": true
         },
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Start Python",
                 "Start Test Tool",

--- a/templates/python/custom-copilot-assistant-new/README.md.tpl
+++ b/templates/python/custom-copilot-assistant-new/README.md.tpl
@@ -49,7 +49,7 @@ It showcases how to build an AI agent in Teams capable of chatting with users an
 ### Conversation with bot
 1. Select the Teams Toolkit icon on the left in the VS Code toolbar.
 {{#enableTestToolByDefault}}
-1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
+1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool`.
 {{/enableTestToolByDefault}}
 {{^enableTestToolByDefault}}
 1. In the Account section, sign in with your [Microsoft 365 account](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts) if you haven't already.

--- a/templates/python/custom-copilot-basic/.vscode/launch.json.tpl
+++ b/templates/python/custom-copilot-basic/.vscode/launch.json.tpl
@@ -110,7 +110,7 @@
             "stopAll": true
         },
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Start Python",
                 "Start Test Tool",

--- a/templates/python/custom-copilot-basic/README.md.tpl
+++ b/templates/python/custom-copilot-basic/README.md.tpl
@@ -50,7 +50,7 @@ This template showcases a bot app that responds to user questions like an AI ass
 ### Conversation with bot
 1. Select the Teams Toolkit icon on the left in the VS Code toolbar.
 {{#enableTestToolByDefault}}
-1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
+1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool`.
 {{/enableTestToolByDefault}}
 {{^enableTestToolByDefault}}
 1. In the Account section, sign in with your [Microsoft 365 account](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts) if you haven't already.

--- a/templates/python/custom-copilot-rag-azure-ai-search/.vscode/launch.json.tpl
+++ b/templates/python/custom-copilot-rag-azure-ai-search/.vscode/launch.json.tpl
@@ -110,7 +110,7 @@
             "stopAll": true
         },
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Start Python",
                 "Start Test Tool",

--- a/templates/python/custom-copilot-rag-azure-ai-search/README.md.tpl
+++ b/templates/python/custom-copilot-rag-azure-ai-search/README.md.tpl
@@ -76,7 +76,7 @@ This app template also demonstrates usage of techniques like:
 1. When Teams launches in the browser, select the Add button in the dialog to install your app to Teams.
 {{/enableTestToolByDefault}}
 {{#enableTestToolByDefault}}
-1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
+1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool`.
 {{/enableTestToolByDefault}}
 1. You will receive a welcome message from the bot, or send any message to get a response.
 

--- a/templates/python/custom-copilot-rag-customize/.vscode/launch.json.tpl
+++ b/templates/python/custom-copilot-rag-customize/.vscode/launch.json.tpl
@@ -110,7 +110,7 @@
             "stopAll": true
         },
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Start Python",
                 "Start Test Tool",

--- a/templates/python/custom-copilot-rag-customize/README.md.tpl
+++ b/templates/python/custom-copilot-rag-customize/README.md.tpl
@@ -56,7 +56,7 @@ This app template also demonstrates usage of techniques like:
 1. When Teams launches in the browser, select the Add button in the dialog to install your app to Teams.
 {{/enableTestToolByDefault}}
 {{#enableTestToolByDefault}}
-1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
+1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool`.
 {{/enableTestToolByDefault}}
 1. You will receive a welcome message from the bot, or send any message to get a response.
 

--- a/templates/ts/ai-assistant-bot/.vscode/launch.json.tpl
+++ b/templates/ts/ai-assistant-bot/.vscode/launch.json.tpl
@@ -102,7 +102,7 @@
             "stopAll": true
         },
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Attach to Local Service"
             ],

--- a/templates/ts/ai-assistant-bot/README.md.tpl
+++ b/templates/ts/ai-assistant-bot/README.md.tpl
@@ -66,7 +66,7 @@ Before running or debugging your bot, please follow these steps to setup your ow
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
 {{#enableTestToolByDefault}}
-1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
+1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool`.
 1. You will receive a welcome message from the bot, or send any message to get a response.
 
 **Congratulations**! You are running an application that can now interact with users in Teams App Test Tool:

--- a/templates/ts/ai-bot/.vscode/launch.json.tpl
+++ b/templates/ts/ai-bot/.vscode/launch.json.tpl
@@ -102,7 +102,7 @@
             "stopAll": true
         },
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Attach to Local Service"
             ],

--- a/templates/ts/ai-bot/README.md.tpl
+++ b/templates/ts/ai-bot/README.md.tpl
@@ -29,7 +29,7 @@ The app template is built using the Teams AI library, which provides the capabil
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
 {{#enableTestToolByDefault}}
 1. In file *env/.env.testtool.user*, fill in your OpenAI key `SECRET_OPENAI_API_KEY=<your-key>`.
-1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
+1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool`.
 1. You will receive a welcome message from the bot, or send any message to get a response.
 
 **Congratulations**! You are running an application that can now interact with users in Teams App Test Tool:

--- a/templates/ts/command-and-response/.vscode/launch.json.tpl
+++ b/templates/ts/command-and-response/.vscode/launch.json.tpl
@@ -102,7 +102,7 @@
             "stopAll": true
         },
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Attach to Local Service"
             ],

--- a/templates/ts/command-and-response/README.md.tpl
+++ b/templates/ts/command-and-response/README.md.tpl
@@ -23,7 +23,7 @@ The app template is built using the TeamsFx SDK, which provides a simple set of 
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
 {{#enableTestToolByDefault}}
-2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
+2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool`.
 3. The browser will pop up to open Teams App Test Tool.
 4. Type or select `helloWorld` in the chat to send it to your bot - this is the default command provided by the template.
 {{/enableTestToolByDefault}}

--- a/templates/ts/custom-copilot-assistant-assistants-api/.vscode/launch.json.tpl
+++ b/templates/ts/custom-copilot-assistant-assistants-api/.vscode/launch.json.tpl
@@ -102,7 +102,7 @@
             "stopAll": true
         },
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Attach to Local Service"
             ],

--- a/templates/ts/custom-copilot-assistant-assistants-api/README.md.tpl
+++ b/templates/ts/custom-copilot-assistant-assistants-api/README.md.tpl
@@ -60,7 +60,7 @@ Before running or debugging your bot, please follow these steps to setup your ow
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
 {{#enableTestToolByDefault}}
-1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
+1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool`.
 1. You can send any message to get a response from the bot.
 
 **Congratulations**! You are running an application that can now interact with users in Teams App Test Tool:

--- a/templates/ts/custom-copilot-assistant-new/.vscode/launch.json.tpl
+++ b/templates/ts/custom-copilot-assistant-new/.vscode/launch.json.tpl
@@ -102,7 +102,7 @@
             "stopAll": true
         },
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Attach to Local Service"
             ],

--- a/templates/ts/custom-copilot-assistant-new/README.md.tpl
+++ b/templates/ts/custom-copilot-assistant-new/README.md.tpl
@@ -31,7 +31,7 @@ It showcases how to build an AI agent in Teams capable of chatting with users an
 {{#useAzureOpenAI}}
 1. In file *env/.env.testtool.user*, fill in your Azure OpenAI key `SECRET_AZURE_OPENAI_API_KEY=<your-key>`, endpoint `AZURE_OPENAI_ENDPOINT=<your-endpoint>`, and deployment name `AZURE_OPENAI_DEPLOYMENT_NAME=<your-deployment>`.
 {{/useAzureOpenAI}}
-1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
+1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool`.
 1. You can send any message to get a response from the bot.
 
 **Congratulations**! You are running an application that can now interact with users in Teams App Test Tool:

--- a/templates/ts/custom-copilot-basic/.vscode/launch.json.tpl
+++ b/templates/ts/custom-copilot-basic/.vscode/launch.json.tpl
@@ -102,7 +102,7 @@
             "stopAll": true
         },
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Attach to Local Service"
             ],

--- a/templates/ts/custom-copilot-basic/README.md.tpl
+++ b/templates/ts/custom-copilot-basic/README.md.tpl
@@ -31,7 +31,7 @@ It showcases a bot app that responds to user questions like ChatGPT. This enable
 {{#useAzureOpenAI}}
 1. In file *env/.env.testtool.user*, fill in your Azure OpenAI key `SECRET_AZURE_OPENAI_API_KEY=<your-key>`, endpoint `AZURE_OPENAI_ENDPOINT=<your-endpoint>`, and deployment name `AZURE_OPENAI_DEPLOYMENT_NAME=<your-deployment>`.
 {{/useAzureOpenAI}}
-1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
+1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool`.
 1. You can send any message to get a response from the bot.
 
 **Congratulations**! You are running an application that can now interact with users in Teams App Test Tool:

--- a/templates/ts/custom-copilot-rag-azure-ai-search/.vscode/launch.json.tpl
+++ b/templates/ts/custom-copilot-rag-azure-ai-search/.vscode/launch.json.tpl
@@ -102,7 +102,7 @@
             "stopAll": true
         },
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Attach to Local Service"
             ],

--- a/templates/ts/custom-copilot-rag-azure-ai-search/README.md.tpl
+++ b/templates/ts/custom-copilot-rag-azure-ai-search/README.md.tpl
@@ -31,7 +31,7 @@ This app template also demonstrates usage of techniques like:
 1. In file *env/.env.testtool.user*, fill in your Azure OpenAI key `SECRET_AZURE_OPENAI_API_KEY=<your-key>`, endpoint `AZURE_OPENAI_ENDPOINT=<your-endpoint>`, deployment name `AZURE_OPENAI_DEPLOYMENT_NAME=<your-deployment>`, and embedding deployment name `AZURE_OPENAI_EMBEDDING_DEPLOYMENT_NAME=<your-embedding-deployment>`. And fill in your Azure AI search key `SECRET_AZURE_SEARCH_KEY=<your-ai-search-key>` and endpoint `AZURE_SEARCH_ENDPOINT=<your-ai-search-endpoint>`.
 {{/useAzureOpenAI}}
 1. Do `npm install` and `npm run indexer:create` to create the my documents index. Once you're done using the sample it's good practice to delete the index. You can do so with the `npm run indexer:delete` command.
-1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
+1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool`.
 1. You can send any message to get a response from the bot.
 
 **Congratulations**! You are running an application that can now interact with users in Teams App Test Tool:

--- a/templates/ts/custom-copilot-rag-custom-api/.vscode/launch.json.tpl
+++ b/templates/ts/custom-copilot-rag-custom-api/.vscode/launch.json.tpl
@@ -102,7 +102,7 @@
             "stopAll": true
         },
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Attach to Local Service"
             ],

--- a/templates/ts/custom-copilot-rag-custom-api/README.md.tpl
+++ b/templates/ts/custom-copilot-rag-custom-api/README.md.tpl
@@ -31,7 +31,7 @@ The app template is built using the Teams AI library, which provides the capabil
 {{#useAzureOpenAI}}
 1. In file *env/.env.testtool.user*, fill in your Azure OpenAI key `SECRET_AZURE_OPENAI_ENDPOINT=<your-key>`, endpoint `SECRET_AZURE_OPENAI_ENDPOINT=<your-endpoint>` and deployment name `AZURE_OPENAI_MODEL_DEPLOYMENT_NAME=<your-deployment-name>`.
 {{/useAzureOpenAI}}
-1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
+1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool`.
 1. You can send any message to get a response from the bot.
 
 **Congratulations**! You are running an application that can now interact with users in Teams App Test Tool:

--- a/templates/ts/custom-copilot-rag-customize/.vscode/launch.json.tpl
+++ b/templates/ts/custom-copilot-rag-customize/.vscode/launch.json.tpl
@@ -102,7 +102,7 @@
             "stopAll": true
         },
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Attach to Local Service"
             ],

--- a/templates/ts/custom-copilot-rag-customize/README.md.tpl
+++ b/templates/ts/custom-copilot-rag-customize/README.md.tpl
@@ -29,7 +29,7 @@ This app template also demonstrates usage of techniques like:
 {{#useAzureOpenAI}}
 1. In file *env/.env.testtool.user*, fill in your Azure OpenAI key `SECRET_AZURE_OPENAI_API_KEY=<your-key>`, endpoint `AZURE_OPENAI_ENDPOINT=<your-endpoint>` and deployment name `AZURE_OPENAI_DEPLOYMENT_NAME=<your-deployment>`.
 {{/useAzureOpenAI}}
-1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
+1. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool`.
 1. You can send any message to get a response from the bot.
 
 **Congratulations**! You are running an application that can now interact with users in Teams App Test Tool:

--- a/templates/ts/default-bot/.vscode/launch.json.tpl
+++ b/templates/ts/default-bot/.vscode/launch.json.tpl
@@ -102,7 +102,7 @@
             "stopAll": true
         },
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Attach to Local Service"
             ],

--- a/templates/ts/default-bot/README.md.tpl
+++ b/templates/ts/default-bot/README.md.tpl
@@ -24,7 +24,7 @@ A bot interaction can be a quick question and answer, or it can be a complex con
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
 {{#enableTestToolByDefault}}
-2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
+2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool`.
 3. The browser will pop up to open Teams App Test Tool.
 4. You will receive a welcome message from the bot, and you can send anything to the bot to get an echoed response.
 

--- a/templates/ts/link-unfurling/.vscode/launch.json.tpl
+++ b/templates/ts/link-unfurling/.vscode/launch.json.tpl
@@ -116,7 +116,7 @@
     ],
     "compounds": [
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Attach to Local Service"
             ],

--- a/templates/ts/m365-message-extension/.vscode/launch.json.tpl
+++ b/templates/ts/m365-message-extension/.vscode/launch.json.tpl
@@ -116,7 +116,7 @@
     ],
     "compounds": [
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Attach to Local Service"
             ],

--- a/templates/ts/m365-message-extension/README.md.tpl
+++ b/templates/ts/m365-message-extension/README.md.tpl
@@ -20,7 +20,7 @@ This app template is a search-based [message extension](https://docs.microsoft.c
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
 {{#enableMETestToolByDefault}}
-2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
+2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool`.
 3. To trigger the Message Extension, you can click the `+` in compose message area and select `Search Command`
 
 **Congratulations**! You are running an application that can now search npm registries in Teams App Test Tool.

--- a/templates/ts/message-extension-action/.vscode/launch.json.tpl
+++ b/templates/ts/message-extension-action/.vscode/launch.json.tpl
@@ -66,7 +66,7 @@
     ],
     "compounds": [
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Attach to Local Service"
             ],

--- a/templates/ts/message-extension-copilot/.vscode/launch.json.tpl
+++ b/templates/ts/message-extension-copilot/.vscode/launch.json.tpl
@@ -166,7 +166,7 @@
     ],
     "compounds": [
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Attach to Local Service"
             ],

--- a/templates/ts/message-extension/.vscode/launch.json.tpl
+++ b/templates/ts/message-extension/.vscode/launch.json.tpl
@@ -116,7 +116,7 @@
     ],
     "compounds": [
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Attach to Local Service"
             ],

--- a/templates/ts/notification-http-timer-trigger/.vscode/launch.json.tpl
+++ b/templates/ts/notification-http-timer-trigger/.vscode/launch.json.tpl
@@ -102,7 +102,7 @@
             "stopAll": true
         },
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Attach to Local Service"
             ],

--- a/templates/ts/notification-http-timer-trigger/README.md.tpl
+++ b/templates/ts/notification-http-timer-trigger/README.md.tpl
@@ -24,7 +24,7 @@ The app template is built using the TeamsFx SDK, which provides a simple set of 
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
 {{#enableTestToolByDefault}}
-2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
+2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool`.
 3. The browser will pop up to open Teams App Test Tool.
 4. If you select `Timer Trigger`, wait for 30 seconds. If you select `HTTP Trigger`, send a POST request to `http://<endpoint>/api/notification` with your favorite tool (like `Postman`)
 {{/enableTestToolByDefault}}

--- a/templates/ts/notification-http-trigger/.vscode/launch.json.tpl
+++ b/templates/ts/notification-http-trigger/.vscode/launch.json.tpl
@@ -102,7 +102,7 @@
             "stopAll": true
         },
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Attach to Local Service"
             ],

--- a/templates/ts/notification-http-trigger/README.md.tpl
+++ b/templates/ts/notification-http-trigger/README.md.tpl
@@ -24,7 +24,7 @@ The app template is built using the TeamsFx SDK, which provides a simple set of 
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
 {{#enableTestToolByDefault}}
-2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
+2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool`.
 3. The browser will pop up to open Teams App Test Tool.
 4. If you select `Timer Trigger`, wait for 30 seconds. If you select `HTTP Trigger`, send a POST request to `http://<endpoint>/api/notification` with your favorite tool (like `Postman`)
 {{/enableTestToolByDefault}}

--- a/templates/ts/notification-restify/.vscode/launch.json.tpl
+++ b/templates/ts/notification-restify/.vscode/launch.json.tpl
@@ -102,7 +102,7 @@
             "stopAll": true
         },
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Attach to Local Service"
             ],

--- a/templates/ts/notification-restify/README.md.tpl
+++ b/templates/ts/notification-restify/README.md.tpl
@@ -24,7 +24,7 @@ The app template is built using the TeamsFx SDK, which provides a simple set of 
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
 {{#enableTestToolByDefault}}
-2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
+2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool`.
 3. The browser will pop up to open Teams App Test Tool.
 4. Send a POST request to `http://<endpoint>/api/notification` with your favorite tool (like `Postman`)
 {{/enableTestToolByDefault}}

--- a/templates/ts/notification-timer-trigger/.vscode/launch.json.tpl
+++ b/templates/ts/notification-timer-trigger/.vscode/launch.json.tpl
@@ -102,7 +102,7 @@
             "stopAll": true
         },
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Attach to Local Service"
             ],

--- a/templates/ts/notification-timer-trigger/README.md.tpl
+++ b/templates/ts/notification-timer-trigger/README.md.tpl
@@ -24,7 +24,7 @@ The app template is built using the TeamsFx SDK, which provides a simple set of 
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
 {{#enableTestToolByDefault}}
-2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
+2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool`.
 3. The browser will pop up to open Teams App Test Tool.
 4. If you select `Timer Trigger`, wait for 30 seconds. If you select `HTTP Trigger`, send a POST request to `http://<endpoint>/api/notification` with your favorite tool (like `Postman`)
 {{/enableTestToolByDefault}}

--- a/templates/ts/workflow/.vscode/launch.json.tpl
+++ b/templates/ts/workflow/.vscode/launch.json.tpl
@@ -102,7 +102,7 @@
             "stopAll": true
         },
         {
-            "name": "Debug in Test Tool (Preview)",
+            "name": "Debug in Test Tool",
             "configurations": [
                 "Attach to Local Service"
             ],

--- a/templates/ts/workflow/README.md.tpl
+++ b/templates/ts/workflow/README.md.tpl
@@ -23,7 +23,7 @@ The app template is built using the TeamsFx SDK, which provides a simple set of 
 
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
 {{#enableTestToolByDefault}}
-2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool (Preview)`.
+2. Press F5 to start debugging which launches your app in Teams App Test Tool using a web browser. Select `Debug in Test Tool`.
 3. The browser will pop up to open Teams App Test Tool.
 4. Type or select `helloWorld` in the chat to send it to your bot - this is the default command provided by the template.
 5. In the response from the bot, select the **DoStuff** button.


### PR DESCRIPTION
Remove `(Preview)` tag from the debug option `Debug in Test Tool`.
<img src='https://github.com/OfficeDev/TeamsFx/assets/15644078/3f736a1d-9ef2-4809-a029-8ad805f5a8e7' height='200px' />


work item: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/25153944/