### PR TITLE
feat: upgrade test tool version to 0.2.1

### DIFF
--- a/templates/js/ai-assistant-bot/teamsapp.testtool.yml
+++ b/templates/js/ai-assistant-bot/teamsapp.testtool.yml
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
 
   # Run npm command

--- a/templates/js/ai-bot/teamsapp.testtool.yml
+++ b/templates/js/ai-bot/teamsapp.testtool.yml
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
 
   # Run npm command

--- a/templates/js/command-and-response/teamsapp.testtool.yml
+++ b/templates/js/command-and-response/teamsapp.testtool.yml
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
 
   # Run npm command

--- a/templates/js/custom-copilot-assistant-assistants-api/teamsapp.testtool.yml
+++ b/templates/js/custom-copilot-assistant-assistants-api/teamsapp.testtool.yml
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
 
   # Run npm command

--- a/templates/js/custom-copilot-assistant-new/teamsapp.testtool.yml.tpl
+++ b/templates/js/custom-copilot-assistant-new/teamsapp.testtool.yml.tpl
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
 
   # Run npm command

--- a/templates/js/custom-copilot-basic/teamsapp.testtool.yml.tpl
+++ b/templates/js/custom-copilot-basic/teamsapp.testtool.yml.tpl
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
 
   # Run npm command

--- a/templates/js/custom-copilot-rag-azure-ai-search/teamsapp.testtool.yml.tpl
+++ b/templates/js/custom-copilot-rag-azure-ai-search/teamsapp.testtool.yml.tpl
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
 
   # Run npm command

--- a/templates/js/custom-copilot-rag-custom-api/teamsapp.testtool.yml.tpl
+++ b/templates/js/custom-copilot-rag-custom-api/teamsapp.testtool.yml.tpl
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
 
   # Run npm command

--- a/templates/js/custom-copilot-rag-customize/teamsapp.testtool.yml.tpl
+++ b/templates/js/custom-copilot-rag-customize/teamsapp.testtool.yml.tpl
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
 
   # Run npm command

--- a/templates/js/default-bot/teamsapp.testtool.yml
+++ b/templates/js/default-bot/teamsapp.testtool.yml
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
 
   # Run npm command

--- a/templates/js/link-unfurling/teamsapp.testtool.yml
+++ b/templates/js/link-unfurling/teamsapp.testtool.yml
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
 
   # Run npm command

--- a/templates/js/m365-message-extension/teamsapp.testtool.yml
+++ b/templates/js/m365-message-extension/teamsapp.testtool.yml
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
 
   # Run npm command

--- a/templates/js/message-extension-action/teamsapp.testtool.yml
+++ b/templates/js/message-extension-action/teamsapp.testtool.yml
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
 
   # Run npm command

--- a/templates/js/message-extension-copilot/teamsapp.testtool.yml
+++ b/templates/js/message-extension-copilot/teamsapp.testtool.yml
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
 
   # Run npm command

--- a/templates/js/message-extension/teamsapp.testtool.yml
+++ b/templates/js/message-extension/teamsapp.testtool.yml
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
 
   # Run npm command

--- a/templates/js/notification-http-timer-trigger/teamsapp.testtool.yml
+++ b/templates/js/notification-http-timer-trigger/teamsapp.testtool.yml
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
       func:
         version: ~4.0.5174

--- a/templates/js/notification-http-trigger/teamsapp.testtool.yml
+++ b/templates/js/notification-http-trigger/teamsapp.testtool.yml
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
       func:
         version: ~4.0.5174

--- a/templates/js/notification-restify/teamsapp.testtool.yml
+++ b/templates/js/notification-restify/teamsapp.testtool.yml
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
 
   # Run npm command

--- a/templates/js/notification-timer-trigger/teamsapp.testtool.yml
+++ b/templates/js/notification-timer-trigger/teamsapp.testtool.yml
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
       func:
         version: ~4.0.5174

--- a/templates/js/workflow/teamsapp.testtool.yml
+++ b/templates/js/workflow/teamsapp.testtool.yml
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
 
   # Run npm command

--- a/templates/python/custom-copilot-assistant-new/teamsapp.testtool.yml.tpl
+++ b/templates/python/custom-copilot-assistant-new/teamsapp.testtool.yml.tpl
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
 
   # Generate runtime environment variables

--- a/templates/python/custom-copilot-basic/teamsapp.testtool.yml.tpl
+++ b/templates/python/custom-copilot-basic/teamsapp.testtool.yml.tpl
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
 
   # Generate runtime environment variables

--- a/templates/python/custom-copilot-rag-azure-ai-search/teamsapp.testtool.yml.tpl
+++ b/templates/python/custom-copilot-rag-azure-ai-search/teamsapp.testtool.yml.tpl
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
 
   # Generate runtime environment variables

--- a/templates/python/custom-copilot-rag-customize/teamsapp.testtool.yml.tpl
+++ b/templates/python/custom-copilot-rag-customize/teamsapp.testtool.yml.tpl
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
 
   # Generate runtime environment variables

--- a/templates/ts/ai-assistant-bot/teamsapp.testtool.yml
+++ b/templates/ts/ai-assistant-bot/teamsapp.testtool.yml
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
 
   # Run npm command

--- a/templates/ts/ai-bot/teamsapp.testtool.yml
+++ b/templates/ts/ai-bot/teamsapp.testtool.yml
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
 
   # Run npm command

--- a/templates/ts/command-and-response/teamsapp.testtool.yml
+++ b/templates/ts/command-and-response/teamsapp.testtool.yml
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
 
   # Run npm command

--- a/templates/ts/custom-copilot-assistant-assistants-api/teamsapp.testtool.yml
+++ b/templates/ts/custom-copilot-assistant-assistants-api/teamsapp.testtool.yml
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
 
   # Run npm command

--- a/templates/ts/custom-copilot-assistant-new/teamsapp.testtool.yml.tpl
+++ b/templates/ts/custom-copilot-assistant-new/teamsapp.testtool.yml.tpl
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
 
   # Run npm command

--- a/templates/ts/custom-copilot-basic/teamsapp.testtool.yml.tpl
+++ b/templates/ts/custom-copilot-basic/teamsapp.testtool.yml.tpl
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
 
   # Run npm command

--- a/templates/ts/custom-copilot-rag-azure-ai-search/teamsapp.testtool.yml.tpl
+++ b/templates/ts/custom-copilot-rag-azure-ai-search/teamsapp.testtool.yml.tpl
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
 
   # Run npm command

--- a/templates/ts/custom-copilot-rag-custom-api/teamsapp.testtool.yml.tpl
+++ b/templates/ts/custom-copilot-rag-custom-api/teamsapp.testtool.yml.tpl
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
 
   # Run npm command

--- a/templates/ts/custom-copilot-rag-customize/teamsapp.testtool.yml.tpl
+++ b/templates/ts/custom-copilot-rag-customize/teamsapp.testtool.yml.tpl
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
 
   # Run npm command

--- a/templates/ts/default-bot/teamsapp.testtool.yml
+++ b/templates/ts/default-bot/teamsapp.testtool.yml
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
 
   # Run npm command

--- a/templates/ts/link-unfurling/teamsapp.testtool.yml
+++ b/templates/ts/link-unfurling/teamsapp.testtool.yml
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
 
   # Run npm command

--- a/templates/ts/m365-message-extension/teamsapp.testtool.yml
+++ b/templates/ts/m365-message-extension/teamsapp.testtool.yml
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
 
   # Run npm command

--- a/templates/ts/message-extension-action/teamsapp.testtool.yml
+++ b/templates/ts/message-extension-action/teamsapp.testtool.yml
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
 
   # Run npm command

--- a/templates/ts/message-extension-copilot/teamsapp.testtool.yml
+++ b/templates/ts/message-extension-copilot/teamsapp.testtool.yml
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
 
   # Run npm command

--- a/templates/ts/message-extension/teamsapp.testtool.yml
+++ b/templates/ts/message-extension/teamsapp.testtool.yml
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
 
   # Run npm command

--- a/templates/ts/notification-http-timer-trigger/teamsapp.testtool.yml
+++ b/templates/ts/notification-http-timer-trigger/teamsapp.testtool.yml
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
       func:
         version: ~4.0.5174

--- a/templates/ts/notification-http-trigger/teamsapp.testtool.yml
+++ b/templates/ts/notification-http-trigger/teamsapp.testtool.yml
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
       func:
         version: ~4.0.5174

--- a/templates/ts/notification-restify/teamsapp.testtool.yml
+++ b/templates/ts/notification-restify/teamsapp.testtool.yml
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
 
   # Run npm command

--- a/templates/ts/notification-timer-trigger/teamsapp.testtool.yml
+++ b/templates/ts/notification-timer-trigger/teamsapp.testtool.yml
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
       func:
         version: ~4.0.5174

--- a/templates/ts/workflow/teamsapp.testtool.yml
+++ b/templates/ts/workflow/teamsapp.testtool.yml
@@ -8,7 +8,7 @@ deploy:
   - uses: devTool/install
     with:
       testTool:
-        version: ~0.2.1-beta
+        version: ~0.2.1
         symlinkDir: ./devTools/teamsapptester
 
   # Run npm command


### PR DESCRIPTION
Upgrade Test Tool version from `0.2.1-beta` to `0.2.1` in Bot/ME app template.

work item: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/25153944/