### PR TITLE
fix: space in spec-parser

### DIFF
--- a/packages/spec-parser/src/specParser.ts
+++ b/packages/spec-parser/src/specParser.ts
@@ -292,8 +292,8 @@ export class SpecParser {
         authInfo
       );
 
-      await fs.outputJSON(manifestPath, updatedManifest, { spaces: 2 });
-      await fs.outputJSON(pluginFilePath, apiPlugin, { spaces: 2 });
+      await fs.outputJSON(manifestPath, updatedManifest, { spaces: 4 });
+      await fs.outputJSON(pluginFilePath, apiPlugin, { spaces: 4 });
     } catch (err) {
       if (err instanceof SpecParserError) {
         throw err;


### PR DESCRIPTION
[Bug 27996070](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/27996070): Inconsistent space when writing manifest