### PR TITLE
fix: hot fix for Python templates to remove Test Tool from the default debug choice

### DIFF
--- a/templates/python/custom-copilot-assistant-new/.vscode/launch.json
+++ b/templates/python/custom-copilot-assistant-new/.vscode/launch.json
@@ -59,7 +59,7 @@
             "request": "launch",
             "program": "${workspaceFolder}/devTools/teamsapptester/node_modules/@microsoft/teams-app-test-tool/cli.js",
             "args": [
-                "start",
+                "start"
             ],
             "cwd": "${workspaceFolder}",
             "console": "integratedTerminal",
@@ -78,12 +78,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
-                "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
                 "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true
@@ -99,12 +94,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
-                "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
                 "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 2
             },
             "stopAll": true
@@ -113,19 +103,14 @@
             "name": "Debug in Test Tool",
             "configurations": [
                 "Start Python",
-                "Start Test Tool",
+                "Start Test Tool"
             ],
             "cascadeTerminateToConfigurations": [
                 "Start Test Tool"
             ],
             "preLaunchTask": "Deploy (Test Tool)",
             "presentation": {
-{{#enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true

--- a/templates/python/custom-copilot-assistant-new/teamsapp.local.yml.tpl
+++ b/templates/python/custom-copilot-assistant-new/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile: 

--- a/templates/python/custom-copilot-assistant-new/teamsapp.yml.tpl
+++ b/templates/python/custom-copilot-assistant-new/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:

--- a/templates/python/custom-copilot-basic/.vscode/launch.json
+++ b/templates/python/custom-copilot-basic/.vscode/launch.json
@@ -59,7 +59,7 @@
             "request": "launch",
             "program": "${workspaceFolder}/devTools/teamsapptester/node_modules/@microsoft/teams-app-test-tool/cli.js",
             "args": [
-                "start",
+                "start"
             ],
             "cwd": "${workspaceFolder}",
             "console": "integratedTerminal",
@@ -78,12 +78,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
-                "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
                 "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true
@@ -99,12 +94,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
-                "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
                 "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 2
             },
             "stopAll": true
@@ -113,19 +103,14 @@
             "name": "Debug in Test Tool",
             "configurations": [
                 "Start Python",
-                "Start Test Tool",
+                "Start Test Tool"
             ],
             "cascadeTerminateToConfigurations": [
                 "Start Test Tool"
             ],
             "preLaunchTask": "Deploy (Test Tool)",
             "presentation": {
-{{#enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true

--- a/templates/python/custom-copilot-basic/teamsapp.local.yml.tpl
+++ b/templates/python/custom-copilot-basic/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile: 

--- a/templates/python/custom-copilot-basic/teamsapp.yml.tpl
+++ b/templates/python/custom-copilot-basic/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:

--- a/templates/python/custom-copilot-rag-azure-ai-search/.vscode/launch.json
+++ b/templates/python/custom-copilot-rag-azure-ai-search/.vscode/launch.json
@@ -59,7 +59,7 @@
             "request": "launch",
             "program": "${workspaceFolder}/devTools/teamsapptester/node_modules/@microsoft/teams-app-test-tool/cli.js",
             "args": [
-                "start",
+                "start"
             ],
             "cwd": "${workspaceFolder}",
             "console": "integratedTerminal",
@@ -78,12 +78,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
-                "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
                 "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true
@@ -99,12 +94,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
-                "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
                 "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 2
             },
             "stopAll": true
@@ -113,19 +103,14 @@
             "name": "Debug in Test Tool",
             "configurations": [
                 "Start Python",
-                "Start Test Tool",
+                "Start Test Tool"
             ],
             "cascadeTerminateToConfigurations": [
                 "Start Test Tool"
             ],
             "preLaunchTask": "Deploy (Test Tool)",
             "presentation": {
-{{#enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true

--- a/templates/python/custom-copilot-rag-azure-ai-search/teamsapp.local.yml.tpl
+++ b/templates/python/custom-copilot-rag-azure-ai-search/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile: 

--- a/templates/python/custom-copilot-rag-azure-ai-search/teamsapp.yml.tpl
+++ b/templates/python/custom-copilot-rag-azure-ai-search/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}-${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:

--- a/templates/python/custom-copilot-rag-customize/.vscode/launch.json
+++ b/templates/python/custom-copilot-rag-customize/.vscode/launch.json
@@ -59,7 +59,7 @@
             "request": "launch",
             "program": "${workspaceFolder}/devTools/teamsapptester/node_modules/@microsoft/teams-app-test-tool/cli.js",
             "args": [
-                "start",
+                "start"
             ],
             "cwd": "${workspaceFolder}",
             "console": "integratedTerminal",
@@ -78,12 +78,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
-                "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
                 "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true
@@ -99,12 +94,7 @@
             ],
             "preLaunchTask": "Start Teams App Locally",
             "presentation": {
-{{#enableTestToolByDefault}}
-                "group": "2-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
                 "group": "1-local",
-{{/enableTestToolByDefault}}
                 "order": 2
             },
             "stopAll": true
@@ -113,19 +103,14 @@
             "name": "Debug in Test Tool",
             "configurations": [
                 "Start Python",
-                "Start Test Tool",
+                "Start Test Tool"
             ],
             "cascadeTerminateToConfigurations": [
                 "Start Test Tool"
             ],
             "preLaunchTask": "Deploy (Test Tool)",
             "presentation": {
-{{#enableTestToolByDefault}}
-                "group": "1-local",
-{{/enableTestToolByDefault}}
-{{^enableTestToolByDefault}}
                 "group": "2-local",
-{{/enableTestToolByDefault}}
                 "order": 1
             },
             "stopAll": true

--- a/templates/python/custom-copilot-rag-customize/teamsapp.local.yml.tpl
+++ b/templates/python/custom-copilot-rag-customize/teamsapp.local.yml.tpl
@@ -8,7 +8,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile: 

--- a/templates/python/custom-copilot-rag-customize/teamsapp.yml.tpl
+++ b/templates/python/custom-copilot-rag-customize/teamsapp.yml.tpl
@@ -11,7 +11,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}${{TEAMSFX_ENV}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:


### PR DESCRIPTION
workitem: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/27894013

E2E TEST: N/A

PR: https://github.com/OfficeDev/TeamsFx/pull/11554 is merged into main branch, while this fix needs to be merged into release branch. Need your review again.