### PR TITLE
fix: add suffix for files generated when add plugin

### DIFF
--- a/packages/fx-core/src/core/FxCore.ts
+++ b/packages/fx-core/src/core/FxCore.ts
@@ -1586,16 +1586,19 @@ export class FxCore {
     const openApiSpecFileNamePrefix = openApiSpecFileName.split(".")[0];
     const openApiSpecFileType = openApiSpecFileName.split(".")[1];
     let apiSpecFileNameSuffix = 1;
+    openApiSpecFileName = `${openApiSpecFileNamePrefix}_${apiSpecFileNameSuffix}.${openApiSpecFileType}`;
+
     while (await fs.pathExists(path.join(apiSpecFolder, openApiSpecFileName))) {
-      openApiSpecFileName = `${openApiSpecFileNamePrefix}_${apiSpecFileNameSuffix++}.${openApiSpecFileType}`;
+      openApiSpecFileName = `${openApiSpecFileNamePrefix}_${++apiSpecFileNameSuffix}.${openApiSpecFileType}`;
     }
     const openApiSpecFilePath = path.join(apiSpecFolder, openApiSpecFileName);
 
     let pluginManifestName = defaultPluginManifestFileName;
     const pluginManifestNamePrefix = defaultPluginManifestFileName.split(".")[0];
     let pluginFileNameSuffix = 1;
+    pluginManifestName = `${pluginManifestNamePrefix}_${pluginFileNameSuffix}.json`;
     while (await fs.pathExists(path.join(appPackageFolder, pluginManifestName))) {
-      pluginManifestName = `${pluginManifestNamePrefix}_${pluginFileNameSuffix++}.json`;
+      pluginManifestName = `${pluginManifestNamePrefix}_${++pluginFileNameSuffix}.json`;
     }
     const pluginManifestFilePath = path.join(appPackageFolder, pluginManifestName);
 

--- a/packages/fx-core/tests/core/FxCore.test.ts
+++ b/packages/fx-core/tests/core/FxCore.test.ts
@@ -4106,16 +4106,16 @@ describe("addPlugin", async () => {
     sandbox.stub(manifestUtils, "_readAppManifest").resolves(ok(manifest));
     sandbox.stub(manifestUtils, "_writeAppManifest").resolves(ok(undefined));
     sandbox.stub(fs, "pathExists").callsFake(async (path: string) => {
-      if (path.endsWith("openapi.json")) {
-        return true;
-      }
-      if (path.endsWith("ai-plugin.json")) {
-        return true;
-      }
       if (path.endsWith("openapi_1.json")) {
-        return false;
+        return true;
       }
       if (path.endsWith("ai-plugin_1.json")) {
+        return true;
+      }
+      if (path.endsWith("openapi_2.json")) {
+        return false;
+      }
+      if (path.endsWith("ai-plugin_2.json")) {
         return false;
       }
       return true;
@@ -4164,16 +4164,16 @@ describe("addPlugin", async () => {
     sandbox.stub(manifestUtils, "_readAppManifest").resolves(ok(manifest));
     sandbox.stub(manifestUtils, "_writeAppManifest").resolves(ok(undefined));
     sandbox.stub(fs, "pathExists").callsFake(async (path: string) => {
-      if (path.endsWith("openapi.yaml")) {
-        return true;
-      }
-      if (path.endsWith("ai-plugin.json")) {
-        return true;
-      }
       if (path.endsWith("openapi_1.yaml")) {
-        return false;
+        return true;
       }
       if (path.endsWith("ai-plugin_1.json")) {
+        return true;
+      }
+      if (path.endsWith("openapi_2.yaml")) {
+        return false;
+      }
+      if (path.endsWith("ai-plugin_2.json")) {
         return false;
       }
       return true;
@@ -4222,16 +4222,16 @@ describe("addPlugin", async () => {
     sandbox.stub(manifestUtils, "_readAppManifest").resolves(ok(manifest));
     sandbox.stub(manifestUtils, "_writeAppManifest").resolves(ok(undefined));
     sandbox.stub(fs, "pathExists").callsFake(async (path: string) => {
-      if (path.endsWith("openapi.json")) {
-        return true;
-      }
-      if (path.endsWith("ai-plugin.json")) {
-        return true;
-      }
       if (path.endsWith("openapi_1.json")) {
-        return false;
+        return true;
       }
       if (path.endsWith("ai-plugin_1.json")) {
+        return true;
+      }
+      if (path.endsWith("openapi_2.json")) {
+        return false;
+      }
+      if (path.endsWith("ai-plugin_2.json")) {
         return false;
       }
       return true;
@@ -4426,6 +4426,15 @@ describe("addPlugin", async () => {
         file: "test.json",
       },
     ];
+    sandbox.stub(fs, "pathExists").callsFake(async (path: string) => {
+      if (path.endsWith("openapi_1.json")) {
+        return false;
+      }
+      if (path.endsWith("ai-plugin_1.json")) {
+        return false;
+      }
+      return true;
+    });
     sandbox.stub(validationUtils, "validateInputs").resolves(undefined);
     sandbox.stub(manifestUtils, "_readAppManifest").resolves(ok(manifest));
     sandbox
@@ -4456,6 +4465,15 @@ describe("addPlugin", async () => {
         file: "test.json",
       },
     ];
+    sandbox.stub(fs, "pathExists").callsFake(async (path: string) => {
+      if (path.endsWith("openapi_1.json")) {
+        return false;
+      }
+      if (path.endsWith("ai-plugin_1.json")) {
+        return false;
+      }
+      return true;
+    });
     sandbox.stub(validationUtils, "validateInputs").resolves(undefined);
     sandbox.stub(manifestUtils, "_readAppManifest").resolves(ok(manifest));
     sandbox
@@ -4494,18 +4512,13 @@ describe("addPlugin", async () => {
       .stub(manifestUtils, "_writeAppManifest")
       .resolves(err(new SystemError("writeError", "writeError", "", "")));
     sandbox.stub(fs, "pathExists").callsFake(async (path: string) => {
-      if (path.endsWith("openapi.json")) {
-        return true;
-      }
-      if (path.endsWith("ai-plugin.json")) {
-        return true;
-      }
       if (path.endsWith("openapi_1.json")) {
         return false;
       }
       if (path.endsWith("ai-plugin_1.json")) {
         return false;
       }
+
       return true;
     });
     sandbox
@@ -4552,12 +4565,6 @@ describe("addPlugin", async () => {
     sandbox.stub(manifestUtils, "_readAppManifest").resolves(ok(manifest));
     sandbox.stub(manifestUtils, "_writeAppManifest").resolves(ok(undefined));
     sandbox.stub(fs, "pathExists").callsFake(async (path: string) => {
-      if (path.endsWith("openapi.json")) {
-        return true;
-      }
-      if (path.endsWith("ai-plugin.json")) {
-        return true;
-      }
       if (path.endsWith("openapi_1.json")) {
         return false;
       }


### PR DESCRIPTION
[Bug 27986092](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/27986092): Generate Copilot Plugin manifest & OpenAPI desc files names uniquely