### PR TITLE
fix: roll back the launch url in API ME SSO template

### DIFF
--- a/templates/csharp/api-message-extension-sso/.{{NewProjectTypeName}}/launchSettings.json.tpl
+++ b/templates/csharp/api-message-extension-sso/.{{NewProjectTypeName}}/launchSettings.json.tpl
@@ -3,7 +3,7 @@
     // Launch project within Teams
     "Microsoft Teams (browser)": {
       "commandName": "Project",
-      "launchUrl": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&appTenantId=${{TEAMS_APP_TENANT_ID}}&login_hint=${{TEAMSFX_M365_USER_NAME}}",
+      "launchUrl": "https://teams.microsoft.com?appTenantId=${{TEAMS_APP_TENANT_ID}}&login_hint=${{TEAMSFX_M365_USER_NAME}}",
     }
   }
 }

--- a/templates/csharp/api-message-extension-sso/GettingStarted.md
+++ b/templates/csharp/api-message-extension-sso/GettingStarted.md
@@ -13,7 +13,7 @@
 2. Right-click your project and select `Teams Toolkit > Prepare Teams App Dependencies`.
 3. If prompted, sign in with a Microsoft 365 account for the Teams organization you want to install the app to.
 4. Press F5, or select the `Debug > Start Debugging` menu in Visual Studio
-5. To trigger the Message Extension, you can click the `+` under compose message area to find your message extension.
+5. When Teams launches in the browser, you can navigate to a chat message and [trigger your search commands from compose message area](https://learn.microsoft.com/microsoftteams/platform/messaging-extensions/what-are-messaging-extensions?tabs=dotnet#search-commands)
 
 ## Learn more
 

--- a/templates/csharp/api-message-extension-sso/Properties/launchSettings.json.tpl
+++ b/templates/csharp/api-message-extension-sso/Properties/launchSettings.json.tpl
@@ -6,7 +6,7 @@
       "commandLineArgs": "host start --port 5130 --pause-on-error",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "launchUrl": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&appTenantId=${{TEAMS_APP_TENANT_ID}}&login_hint=${{TEAMSFX_M365_USER_NAME}}",
+      "launchUrl": "https://teams.microsoft.com?appTenantId=${{TEAMS_APP_TENANT_ID}}&login_hint=${{TEAMSFX_M365_USER_NAME}}",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },

--- a/templates/csharp/api-message-extension-sso/teamsapp.local.yml.tpl
+++ b/templates/csharp/api-message-extension-sso/teamsapp.local.yml.tpl
@@ -104,7 +104,7 @@ provision:
             commandLineArgs: "host start --port 5130 --pause-on-error"
             dotnetRunMessages: true
             launchBrowser: true
-            launchUrl: "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&appTenantId=${{TEAMS_APP_TENANT_ID}}&login_hint=${{TEAMSFX_M365_USER_NAME}}"
+            launchUrl: "https://teams.microsoft.com?appTenantId=${{TEAMS_APP_TENANT_ID}}&login_hint=${{TEAMSFX_M365_USER_NAME}}"
             environmentVariables:
               ASPNETCORE_ENVIRONMENT: "Development"
             hotReloadProfile: "aspnetcore"

--- a/templates/js/api-message-extension-sso/.vscode/launch.json
+++ b/templates/js/api-message-extension-sso/.vscode/launch.json
@@ -5,7 +5,7 @@
             "name": "Launch App in Teams (Edge)",
             "type": "msedge",
             "request": "launch",
-            "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
+            "url": "https://teams.microsoft.com?${account-hint}",
             "cascadeTerminateToConfigurations": [
                 "Attach to Backend"
             ],
@@ -19,7 +19,7 @@
             "name": "Launch App in Teams (Chrome)",
             "type": "chrome",
             "request": "launch",
-            "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
+            "url": "https://teams.microsoft.com?${account-hint}",
             "cascadeTerminateToConfigurations": [
                 "Attach to Backend"
             ],
@@ -33,7 +33,7 @@
             "name": "Preview in Teams (Edge)",
             "type": "msedge",
             "request": "launch",
-            "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
+            "url": "https://teams.microsoft.com?${account-hint}",
             "presentation": {
                 "group": "remote",
                 "order": 1
@@ -44,7 +44,7 @@
             "name": "Preview in Teams (Chrome)",
             "type": "chrome",
             "request": "launch",
-            "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
+            "url": "https://teams.microsoft.com?${account-hint}",
             "presentation": {
                 "group": "remote",
                 "order": 2

--- a/templates/js/api-message-extension-sso/README.md
+++ b/templates/js/api-message-extension-sso/README.md
@@ -20,7 +20,7 @@ This app template allows Teams to interact directly with third-party data, apps,
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
 2. In the Account section, sign in with your [Microsoft 365 account](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts) if you haven't already.
 3. Select `Debug in Teams (Edge)` or `Debug in Teams (Chrome)` from the launch configuration dropdown.
-4. To trigger the Message Extension, you can click the `+` under compose message area to find your message extension.
+4. When Teams launches in the browser, you can navigate to a chat message and [trigger your search commands from compose message area](https://learn.microsoft.com/microsoftteams/platform/messaging-extensions/what-are-messaging-extensions?tabs=dotnet#search-commands).
 
 ## What's included in the template
 

--- a/templates/ts/copilot-plugin-from-scratch-api-key/.vscode/launch.json
+++ b/templates/ts/copilot-plugin-from-scratch-api-key/.vscode/launch.json
@@ -5,7 +5,7 @@
             "name": "Launch App in Teams (Edge)",
             "type": "msedge",
             "request": "launch",
-            "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
+            "url": "https://teams.microsoft.com?${account-hint}",
             "cascadeTerminateToConfigurations": [
                 "Attach to Backend"
             ],
@@ -19,7 +19,7 @@
             "name": "Launch App in Teams (Chrome)",
             "type": "chrome",
             "request": "launch",
-            "url": "https://teams.microsoft.com/l/app/${{local:TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
+            "url": "https://teams.microsoft.com?${account-hint}",
             "cascadeTerminateToConfigurations": [
                 "Attach to Backend"
             ],
@@ -33,7 +33,7 @@
             "name": "Preview in Teams (Edge)",
             "type": "msedge",
             "request": "launch",
-            "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
+            "url": "https://teams.microsoft.com?${account-hint}",
             "presentation": {
                 "group": "remote",
                 "order": 1
@@ -44,7 +44,7 @@
             "name": "Preview in Teams (Chrome)",
             "type": "chrome",
             "request": "launch",
-            "url": "https://teams.microsoft.com/l/app/${{TEAMS_APP_ID}}?installAppPackage=true&webjoin=true&${account-hint}",
+            "url": "https://teams.microsoft.com?${account-hint}",
             "presentation": {
                 "group": "remote",
                 "order": 2

--- a/templates/ts/copilot-plugin-from-scratch-api-key/README.md
+++ b/templates/ts/copilot-plugin-from-scratch-api-key/README.md
@@ -20,7 +20,7 @@ This app template allows Teams to interact directly with third-party data, apps,
 1. First, select the Teams Toolkit icon on the left in the VS Code toolbar.
 2. In the Account section, sign in with your [Microsoft 365 account](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts) if you haven't already.
 3. Select `Debug in Teams (Edge)` or `Debug in Teams (Chrome)` from the launch configuration dropdown.
-4. To trigger the Message Extension, you can click the `+` under compose message area to find your message extension.
+4. When Teams launches in the browser, you can navigate to a chat message and [trigger your search commands from compose message area](https://learn.microsoft.com/microsoftteams/platform/messaging-extensions/what-are-messaging-extensions?tabs=dotnet#search-commands).
 
 ### How to add your own API Key
 


### PR DESCRIPTION
[[VSC]local debug and remote debug for API Message Extension with Microsoft Entra auth get something went wrong ](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/27997549)

Roll back the change from [this PR](https://github.com/OfficeDev/TeamsFx/pull/11461), once the TDP is ready, we'll update the launch url again.