### PR TITLE
fix: remove packageName

### DIFF
--- a/templates/common/api-plugin-existing-api/appPackage/manifest.json.tpl
+++ b/templates/common/api-plugin-existing-api/appPackage/manifest.json.tpl
@@ -3,7 +3,6 @@
     "manifestVersion": "devPreview",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
-    "packageName": "com.microsoft.teams.extension",
     "developer": {
         "name": "Teams App, Inc.",
         "websiteUrl": "https://www.example.com",

--- a/templates/common/copilot-gpt-basic/appPackage/manifest.json.tpl
+++ b/templates/common/copilot-gpt-basic/appPackage/manifest.json.tpl
@@ -3,7 +3,6 @@
     "manifestVersion": "devPreview",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
-    "packageName": "com.microsoft.teams.extension",
     "developer": {
         "name": "Teams App, Inc.",
         "websiteUrl": "https://www.example.com",

--- a/templates/common/copilot-plugin-existing-api-api-key/appPackage/manifest.json.tpl
+++ b/templates/common/copilot-plugin-existing-api-api-key/appPackage/manifest.json.tpl
@@ -3,7 +3,6 @@
     "manifestVersion": "devPreview",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
-    "packageName": "com.microsoft.teams.extension",
     "developer": {
         "name": "Teams App, Inc.",
         "websiteUrl": "https://www.example.com",

--- a/templates/common/copilot-plugin-existing-api/appPackage/manifest.json.tpl
+++ b/templates/common/copilot-plugin-existing-api/appPackage/manifest.json.tpl
@@ -3,7 +3,6 @@
     "manifestVersion": "devPreview",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
-    "packageName": "com.microsoft.teams.extension",
     "developer": {
         "name": "Teams App, Inc.",
         "websiteUrl": "https://www.example.com",

--- a/templates/common/copilot-plugin-from-oai-plugin/appPackage/manifest.json.tpl
+++ b/templates/common/copilot-plugin-from-oai-plugin/appPackage/manifest.json.tpl
@@ -3,7 +3,6 @@
     "manifestVersion": "devPreview",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
-    "packageName": "com.microsoft.teams.extension",
     "developer": {
         "name": "Teams App, Inc.",
         "websiteUrl": "https://www.example.com",

--- a/templates/csharp/api-message-extension-sso/appPackage/manifest.json.tpl
+++ b/templates/csharp/api-message-extension-sso/appPackage/manifest.json.tpl
@@ -2,7 +2,6 @@
     "$schema": "https://developer.microsoft.com/json-schemas/teams/vDevPreview/MicrosoftTeams.schema.json",
     "manifestVersion": "devPreview",
     "id": "${{TEAMS_APP_ID}}",
-    "packageName": "com.microsoft.teams.extension",
     "version": "1.0.0",
     "developer": {
         "name": "Teams App, Inc.",

--- a/templates/csharp/api-plugin-existing-api/appPackage/manifest.json.tpl
+++ b/templates/csharp/api-plugin-existing-api/appPackage/manifest.json.tpl
@@ -3,7 +3,6 @@
     "manifestVersion": "devPreview",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
-    "packageName": "com.microsoft.teams.extension",
     "developer": {
         "name": "Teams App, Inc.",
         "websiteUrl": "https://www.example.com",

--- a/templates/csharp/api-plugin-from-scratch/appPackage/manifest.json.tpl
+++ b/templates/csharp/api-plugin-from-scratch/appPackage/manifest.json.tpl
@@ -2,7 +2,6 @@
   "$schema": "https://developer.microsoft.com/json-schemas/teams/vDevPreview/MicrosoftTeams.schema.json",
   "manifestVersion": "devPreview",
   "id": "${{TEAMS_APP_ID}}",
-  "packageName": "com.microsoft.teams.extension",
   "version": "1.0.0",
   "developer": {
     "name": "Teams App, Inc.",

--- a/templates/csharp/copilot-plugin-existing-api-api-key/appPackage/manifest.json.tpl
+++ b/templates/csharp/copilot-plugin-existing-api-api-key/appPackage/manifest.json.tpl
@@ -3,7 +3,6 @@
     "manifestVersion": "devPreview",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
-    "packageName": "com.microsoft.teams.extension",
     "developer": {
         "name": "Teams App, Inc.",
         "websiteUrl": "https://www.example.com",

--- a/templates/csharp/copilot-plugin-existing-api/appPackage/manifest.json.tpl
+++ b/templates/csharp/copilot-plugin-existing-api/appPackage/manifest.json.tpl
@@ -3,7 +3,6 @@
     "manifestVersion": "devPreview",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
-    "packageName": "com.microsoft.teams.extension",
     "developer": {
         "name": "Teams App, Inc.",
         "websiteUrl": "https://www.example.com",

--- a/templates/csharp/copilot-plugin-from-oai-plugin/appPackage/manifest.json.tpl
+++ b/templates/csharp/copilot-plugin-from-oai-plugin/appPackage/manifest.json.tpl
@@ -3,7 +3,6 @@
     "manifestVersion": "devPreview",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
-    "packageName": "com.microsoft.teams.extension",
     "developer": {
         "name": "Teams App, Inc.",
         "websiteUrl": "https://www.example.com",

--- a/templates/csharp/copilot-plugin-from-scratch-api-key/appPackage/manifest.json.tpl
+++ b/templates/csharp/copilot-plugin-from-scratch-api-key/appPackage/manifest.json.tpl
@@ -2,7 +2,6 @@
   "$schema": "https://developer.microsoft.com/json-schemas/teams/vDevPreview/MicrosoftTeams.schema.json",
   "manifestVersion": "devPreview",
   "id": "${{TEAMS_APP_ID}}",
-  "packageName": "com.microsoft.teams.extension",
   "version": "1.0.0",
   "developer": {
     "name": "Teams App, Inc.",

--- a/templates/csharp/copilot-plugin-from-scratch/appPackage/manifest.json.tpl
+++ b/templates/csharp/copilot-plugin-from-scratch/appPackage/manifest.json.tpl
@@ -2,7 +2,6 @@
     "$schema": "https://developer.microsoft.com/json-schemas/teams/vDevPreview/MicrosoftTeams.schema.json",
     "manifestVersion": "devPreview",
     "id": "${{TEAMS_APP_ID}}",
-    "packageName": "com.microsoft.teams.extension",
     "version": "1.0.0",
     "developer": {
         "name": "Teams App, Inc.",

--- a/templates/csharp/message-extension-copilot/appPackage/manifest.json.tpl
+++ b/templates/csharp/message-extension-copilot/appPackage/manifest.json.tpl
@@ -3,7 +3,6 @@
     "manifestVersion": "devPreview",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
-    "packageName": "com.microsoft.teams.extension",
     "developer": {
         "name": "Teams App, Inc.",
         "websiteUrl": "https://www.example.com",

--- a/templates/js/api-message-extension-sso/appPackage/manifest.json.tpl
+++ b/templates/js/api-message-extension-sso/appPackage/manifest.json.tpl
@@ -2,7 +2,6 @@
     "$schema": "https://developer.microsoft.com/json-schemas/teams/vDevPreview/MicrosoftTeams.schema.json",
     "manifestVersion": "devPreview",
     "id": "${{TEAMS_APP_ID}}",
-    "packageName": "com.microsoft.teams.extension",
     "version": "1.0.0",
     "developer": {
         "name": "Teams App, Inc.",

--- a/templates/js/api-plugin-from-scratch/appPackage/manifest.json.tpl
+++ b/templates/js/api-plugin-from-scratch/appPackage/manifest.json.tpl
@@ -2,7 +2,6 @@
   "$schema": "https://developer.microsoft.com/json-schemas/teams/vDevPreview/MicrosoftTeams.schema.json",
   "manifestVersion": "devPreview",
   "id": "${{TEAMS_APP_ID}}",
-  "packageName": "com.microsoft.teams.extension",
   "version": "1.0.0",
   "developer": {
     "name": "Teams App, Inc.",

--- a/templates/js/copilot-gpt-from-scratch-plugin/appPackage/manifest.json.tpl
+++ b/templates/js/copilot-gpt-from-scratch-plugin/appPackage/manifest.json.tpl
@@ -2,7 +2,6 @@
   "$schema": "https://developer.microsoft.com/json-schemas/teams/vDevPreview/MicrosoftTeams.schema.json",
   "manifestVersion": "devPreview",
   "id": "${{TEAMS_APP_ID}}",
-  "packageName": "com.microsoft.teams.extension",
   "version": "1.0.0",
   "developer": {
     "name": "Teams App, Inc.",

--- a/templates/js/copilot-plugin-from-scratch-api-key/appPackage/manifest.json.tpl
+++ b/templates/js/copilot-plugin-from-scratch-api-key/appPackage/manifest.json.tpl
@@ -2,7 +2,6 @@
   "$schema": "https://developer.microsoft.com/json-schemas/teams/vDevPreview/MicrosoftTeams.schema.json",
   "manifestVersion": "devPreview",
   "id": "${{TEAMS_APP_ID}}",
-  "packageName": "com.microsoft.teams.extension",
   "version": "1.0.0",
   "developer": {
     "name": "Teams App, Inc.",

--- a/templates/js/copilot-plugin-from-scratch/appPackage/manifest.json.tpl
+++ b/templates/js/copilot-plugin-from-scratch/appPackage/manifest.json.tpl
@@ -2,7 +2,6 @@
     "$schema": "https://developer.microsoft.com/json-schemas/teams/vDevPreview/MicrosoftTeams.schema.json",
     "manifestVersion": "devPreview",
     "id": "${{TEAMS_APP_ID}}",
-    "packageName": "com.microsoft.teams.extension",
     "version": "1.0.0",
     "developer": {
         "name": "Teams App, Inc.",

--- a/templates/js/message-extension-copilot/appPackage/manifest.json.tpl
+++ b/templates/js/message-extension-copilot/appPackage/manifest.json.tpl
@@ -3,7 +3,6 @@
     "manifestVersion": "devPreview",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
-    "packageName": "com.microsoft.teams.extension",
     "developer": {
         "name": "Teams App, Inc.",
         "websiteUrl": "https://www.example.com",

--- a/templates/ts/api-message-extension-sso/appPackage/manifest.json.tpl
+++ b/templates/ts/api-message-extension-sso/appPackage/manifest.json.tpl
@@ -2,7 +2,6 @@
     "$schema": "https://developer.microsoft.com/json-schemas/teams/vDevPreview/MicrosoftTeams.schema.json",
     "manifestVersion": "devPreview",
     "id": "${{TEAMS_APP_ID}}",
-    "packageName": "com.microsoft.teams.extension",
     "version": "1.0.0",
     "developer": {
         "name": "Teams App, Inc.",

--- a/templates/ts/api-plugin-from-scratch/appPackage/manifest.json.tpl
+++ b/templates/ts/api-plugin-from-scratch/appPackage/manifest.json.tpl
@@ -2,7 +2,6 @@
   "$schema": "https://developer.microsoft.com/json-schemas/teams/vDevPreview/MicrosoftTeams.schema.json",
   "manifestVersion": "devPreview",
   "id": "${{TEAMS_APP_ID}}",
-  "packageName": "com.microsoft.teams.extension",
   "version": "1.0.0",
   "developer": {
     "name": "Teams App, Inc.",

--- a/templates/ts/copilot-gpt-from-scratch-plugin/appPackage/manifest.json.tpl
+++ b/templates/ts/copilot-gpt-from-scratch-plugin/appPackage/manifest.json.tpl
@@ -2,7 +2,6 @@
   "$schema": "https://developer.microsoft.com/json-schemas/teams/vDevPreview/MicrosoftTeams.schema.json",
   "manifestVersion": "devPreview",
   "id": "${{TEAMS_APP_ID}}",
-  "packageName": "com.microsoft.teams.extension",
   "version": "1.0.0",
   "developer": {
     "name": "Teams App, Inc.",

--- a/templates/ts/copilot-plugin-from-scratch-api-key/appPackage/manifest.json.tpl
+++ b/templates/ts/copilot-plugin-from-scratch-api-key/appPackage/manifest.json.tpl
@@ -2,7 +2,6 @@
   "$schema": "https://developer.microsoft.com/json-schemas/teams/vDevPreview/MicrosoftTeams.schema.json",
   "manifestVersion": "devPreview",
   "id": "${{TEAMS_APP_ID}}",
-  "packageName": "com.microsoft.teams.extension",
   "version": "1.0.0",
   "developer": {
     "name": "Teams App, Inc.",

--- a/templates/ts/copilot-plugin-from-scratch/appPackage/manifest.json.tpl
+++ b/templates/ts/copilot-plugin-from-scratch/appPackage/manifest.json.tpl
@@ -2,7 +2,6 @@
     "$schema": "https://developer.microsoft.com/json-schemas/teams/vDevPreview/MicrosoftTeams.schema.json",
     "manifestVersion": "devPreview",
     "id": "${{TEAMS_APP_ID}}",
-    "packageName": "com.microsoft.teams.extension",
     "version": "1.0.0",
     "developer": {
         "name": "Teams App, Inc.",

--- a/templates/ts/message-extension-copilot/appPackage/manifest.json.tpl
+++ b/templates/ts/message-extension-copilot/appPackage/manifest.json.tpl
@@ -3,7 +3,6 @@
     "manifestVersion": "devPreview",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
-    "packageName": "com.microsoft.teams.extension",
     "developer": {
         "name": "Teams App, Inc.",
         "websiteUrl": "https://www.example.com",


### PR DESCRIPTION
[Bug 28026372](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/28026372): PackageName property in manifest is deprecated