### PR TITLE
fix: show error when @teams with empty prompt

### DIFF
--- a/packages/vscode-extension/src/chat/handlers.ts
+++ b/packages/vscode-extension/src/chat/handlers.ts
@@ -65,6 +65,12 @@ async function defaultHandler(
   );
   ExtTelemetry.sendTelemetryEvent(TelemetryEvent.CopilotChatStart, chatTelemetryData.properties);
 
+  if (!request.prompt) {
+    throw new Error(`
+Please specify a question when using this command.
+
+Usage: @teams Ask questions about Teams Development"`);
+  }
   const messages = [
     defaultSystemPrompt(),
     new LanguageModelChatMessage(LanguageModelChatMessageRole.User, request.prompt),

--- a/packages/vscode-extension/test/chat/handlers.test.ts
+++ b/packages/vscode-extension/test/chat/handlers.test.ts
@@ -140,6 +140,43 @@ describe("chat handlers", () => {
 
       chai.expect(result).to.deep.equal(metaDataMock);
     });
+
+    it("call defaultHandler - error", async () => {
+      const request: ChatRequest = {
+        prompt: "",
+        command: "",
+        references: [],
+        location: ChatLocation.Panel,
+        attempt: 0,
+        enableCommandDetection: false,
+      };
+
+      const chatTelemetryDataMock = sandbox.createStubInstance(telemetry.ChatTelemetryData);
+      const metaDataMock = { metadata: { command: undefined, requestId: undefined } };
+      sandbox.stub(chatTelemetryDataMock, "properties").get(function getterFn() {
+        return undefined;
+      });
+      sandbox.stub(chatTelemetryDataMock, "measurements").get(function getterFn() {
+        return undefined;
+      });
+      chatTelemetryDataMock.chatMessages = [];
+      sandbox
+        .stub(telemetry.ChatTelemetryData, "createByParticipant")
+        .returns(chatTelemetryDataMock);
+      sandbox.stub(ExtTelemetry, "sendTelemetryEvent");
+      sandbox.stub(util, "verbatimCopilotInteraction");
+      await chai.expect(
+        handler.chatRequestHandler(
+          request,
+          {} as unknown as ChatContext,
+          response as unknown as ChatResponseStream,
+          token
+        )
+      ).is.rejectedWith(`
+Please specify a question when using this command.
+
+Usage: @teams Ask questions about Teams Development"`);
+    });
   });
 
   describe("chatExecuteCommandHandler()", () => {


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/28055577
![image](https://github.com/OfficeDev/TeamsFx/assets/15262146/241fda63-29f2-4648-bc22-0f705b491113)
