### PR TITLE
fix: action validation result should be printed out

### DIFF
--- a/packages/fx-core/tests/component/driver/teamsApp/copilotGptManifest.test.ts
+++ b/packages/fx-core/tests/component/driver/teamsApp/copilotGptManifest.test.ts
@@ -286,6 +286,36 @@ describe("copilotGptManifestUtils", () => {
       chai.assert.isTrue(res.includes("errorAction1"));
     });
 
+    it("log if VSC and action error only", () => {
+      const validationRes: DeclarativeCopilotManifestValidationResult = {
+        id: "1",
+        filePath: "testPath",
+        validationResult: [],
+        actionValidationResult: [
+          {
+            id: "1",
+            filePath: "testPath",
+            validationResult: ["errorAction1"],
+          },
+          {
+            id: "2",
+            filePath: "pluginPath",
+            validationResult: ["errorAction2"],
+          },
+        ],
+      };
+
+      const res = copilotGptManifestUtils.logValidationErrors(
+        validationRes,
+        Platform.VSCode,
+        "pluginPath"
+      ) as string;
+
+      console.log(res);
+      chai.assert.isFalse(res.includes("errorActions2"));
+      chai.assert.isTrue(res.includes("errorAction1"));
+    });
+
     it("log if CLI", () => {
       const validationRes: DeclarativeCopilotManifestValidationResult = {
         id: "1",
@@ -313,6 +343,35 @@ describe("copilotGptManifestUtils", () => {
       chai.assert.isTrue(res.find((item) => item.content.includes("error1")) !== undefined);
       chai.assert.isTrue(res.find((item) => item.content.includes("errorAction1")) !== undefined);
       chai.assert.isUndefined(res.find((item) => item.content.includes("errorAction2")));
+    });
+
+    it("log if CLI and action error only", () => {
+      const validationRes: DeclarativeCopilotManifestValidationResult = {
+        id: "1",
+        filePath: "testPath",
+        validationResult: [],
+        actionValidationResult: [
+          {
+            id: "1",
+            filePath: "testPath",
+            validationResult: ["errorAction1"],
+          },
+          {
+            id: "2",
+            filePath: "pluginPath",
+            validationResult: ["errorAction2"],
+          },
+        ],
+      };
+
+      const res = copilotGptManifestUtils.logValidationErrors(
+        validationRes,
+        Platform.CLI,
+        ""
+      ) as Array<{ content: string; color: Colors }>;
+      console.log(res);
+      chai.assert.isTrue(res.find((item) => item.content.includes("error1Action2")) !== undefined);
+      chai.assert.isTrue(res.find((item) => item.content.includes("errorAction1")) !== undefined);
     });
   });
 });

--- a/packages/fx-core/tests/component/driver/teamsApp/copilotGptManifest.test.ts
+++ b/packages/fx-core/tests/component/driver/teamsApp/copilotGptManifest.test.ts
@@ -311,7 +311,6 @@ describe("copilotGptManifestUtils", () => {
         "pluginPath"
       ) as string;
 
-      console.log(res);
       chai.assert.isFalse(res.includes("errorActions2"));
       chai.assert.isTrue(res.includes("errorAction1"));
     });
@@ -369,8 +368,7 @@ describe("copilotGptManifestUtils", () => {
         Platform.CLI,
         ""
       ) as Array<{ content: string; color: Colors }>;
-      console.log(res);
-      chai.assert.isTrue(res.find((item) => item.content.includes("error1Action2")) !== undefined);
+      chai.assert.isTrue(res.find((item) => item.content.includes("errorAction2")) !== undefined);
       chai.assert.isTrue(res.find((item) => item.content.includes("errorAction1")) !== undefined);
     });
   });


### PR DESCRIPTION
[Bug 28045219](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/28045219): Action validation error details are not print if Declarative Copilot has action only