### PR TITLE
refactor: add help link to cli debug in desktop client

### DIFF
--- a/packages/cli/src/cmds/preview/launch.ts
+++ b/packages/cli/src/cmds/preview/launch.ts
@@ -103,7 +103,7 @@ async function _openTeamsDesktopClient(
 
   const desktopDebugHelpMessage = [
     {
-      content: `Before proceeding, make sure your Teams desktop login matches your current Microsoft 365 account${username} used in Teams Toolkit.`,
+      content: `Before proceeding, make sure your Teams desktop login matches your current Microsoft 365 account${username} used in Teams Toolkit. Please visit https://aka.ms/teamsfx-debug-in-desktop-client to get more info.`,
       color: Colors.WHITE,
     },
   ];

--- a/packages/vscode-extension/package.nls.json
+++ b/packages/vscode-extension/package.nls.json
@@ -322,7 +322,7 @@
   "teamstoolkit.localDebug.useTestTool": "Alternatively, you can skip this step by choosing the %s option.",
   "teamstoolkit.localDebug.launchTeamsDesktopClientError": "Unable to launch Teams desktop client.",
   "teamstoolkit.localDebug.launchTeamsDesktopClientStoppedError": "Task to launch Teams desktop client stopped with exit code '%s'.",
-  "teamstoolkit.localDebug.launchTeamsDesktopClientMessage": "Before proceeding, make sure your Teams desktop login matches your current Microsoft 365 account %s used in Teams Toolkit.",
+  "teamstoolkit.localDebug.launchTeamsDesktopClientMessage": "Before proceeding, make sure your Teams desktop login matches your current Microsoft 365 account%s used in Teams Toolkit.",
   "teamstoolkit.migrateTeamsManifest.progressTitle": "Upgrade Teams Manifest to extend in Outlook and the Microsoft 365 app",
   "teamstoolkit.migrateTeamsManifest.selectFileConfig.name": "Select Teams Manifest to Upgrade",
   "teamstoolkit.migrateTeamsManifest.selectFileConfig.title": "Select Teams Manifest to Upgrade",

--- a/packages/vscode-extension/src/debug/taskTerminal/launchDesktopClientTerminal.ts
+++ b/packages/vscode-extension/src/debug/taskTerminal/launchDesktopClientTerminal.ts
@@ -71,7 +71,7 @@ export class LaunchDesktopClientTerminal extends BaseTaskTerminal {
       });
       let username = "";
       if (accountInfo.isOk() && accountInfo.value["unique_name"]) {
-        username = "(" + (accountInfo.value["unique_name"] as string) + ")";
+        username = " (" + (accountInfo.value["unique_name"] as string) + ")";
       }
       if (config.obj[showDebugDesktopClientWizard] === "false") {
         void vscode.window


### PR DESCRIPTION
Show help link to cli debug in desktop client.

![image](https://github.com/OfficeDev/teams-toolkit/assets/13211513/d8c6beb8-3bf6-4309-bcee-7a0e6eec919f)
