### PR TITLE
fix: rag m365 template readme and launch.json

### DIFF
--- a/templates/js/custom-copilot-rag-microsoft365/.vscode/launch.json.tpl
+++ b/templates/js/custom-copilot-rag-microsoft365/.vscode/launch.json.tpl
@@ -111,7 +111,7 @@
             ],
             "preLaunchTask": "Start Teams App in Desktop Client",
             "presentation": {
-                "group": "2-local",
+                "group": "1-local",
                 "order": 3
             },
             "stopAll": true

--- a/templates/js/custom-copilot-rag-microsoft365/README.md.tpl
+++ b/templates/js/custom-copilot-rag-microsoft365/README.md.tpl
@@ -39,8 +39,6 @@ This app template also demonstrates usage of techniques like:
 1. When Teams launches in the browser, select the Add button in the dialog to install your app to Teams.
 1. You can send any message to get a response from the bot.
 
-**Congratulations**! You are running an application that can now interact with users in Teams App Test Tool:
-
 ![M365 RAG Bot](https://github.com/OfficeDev/TeamsFx/assets/13211513/c2fff68c-53ce-445a-a101-97f0c127b825)
 
 ## What's included in the template
@@ -73,7 +71,6 @@ The following are Teams Toolkit specific project files. You can [visit a complet
 | - | - |
 |`teamsapp.yml`|This is the main Teams Toolkit project file. The project file defines two primary things:  Properties and configuration Stage definitions. |
 |`teamsapp.local.yml`|This overrides `teamsapp.yml` with actions that enable local execution and debugging.|
-|`teamsapp.testtool.yml`| This overrides `teamsapp.yml` with actions that enable local execution and debugging in Teams App Test Tool.|
 
 ## Extend the template
 

--- a/templates/ts/custom-copilot-rag-microsoft365/.vscode/launch.json.tpl
+++ b/templates/ts/custom-copilot-rag-microsoft365/.vscode/launch.json.tpl
@@ -111,7 +111,7 @@
             ],
             "preLaunchTask": "Start Teams App in Desktop Client",
             "presentation": {
-                "group": "2-local",
+                "group": "1-local",
                 "order": 3
             },
             "stopAll": true

--- a/templates/ts/custom-copilot-rag-microsoft365/README.md.tpl
+++ b/templates/ts/custom-copilot-rag-microsoft365/README.md.tpl
@@ -39,8 +39,6 @@ This app template also demonstrates usage of techniques like:
 1. When Teams launches in the browser, select the Add button in the dialog to install your app to Teams.
 1. You can send any message to get a response from the bot.
 
-**Congratulations**! You are running an application that can now interact with users in Teams App Test Tool:
-
 ![M365 RAG Bot](https://github.com/OfficeDev/TeamsFx/assets/13211513/c2fff68c-53ce-445a-a101-97f0c127b825)
 
 ## What's included in the template
@@ -73,7 +71,6 @@ The following are Teams Toolkit specific project files. You can [visit a complet
 | - | - |
 |`teamsapp.yml`|This is the main Teams Toolkit project file. The project file defines two primary things:  Properties and configuration Stage definitions. |
 |`teamsapp.local.yml`|This overrides `teamsapp.yml` with actions that enable local execution and debugging.|
-|`teamsapp.testtool.yml`| This overrides `teamsapp.yml` with actions that enable local execution and debugging in Teams App Test Tool.|
 
 ## Extend the template
 


### PR DESCRIPTION
Fix launch.json and readme issues.

Fix: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/28711111/