### PR TITLE
feat: display tenant name when user specify tenant id

### DIFF
--- a/packages/cli/src/commands/models/accountLoginM365.ts
+++ b/packages/cli/src/commands/models/accountLoginM365.ts
@@ -25,10 +25,7 @@ export const accountLoginM365Command: CLICommand = {
   },
   handler: async (ctx) => {
     await M365TokenProvider.signout();
-    const res = await accountUtils.outputM365Info("login", ctx.optionValues.tenant as string);
-    if (res && ctx.optionValues.tenant) {
-      await M365TokenProvider.switchTenant(ctx.optionValues.tenant as string);
-    }
+    await accountUtils.outputM365Info("login", ctx.optionValues.tenant as string);
     return ok(undefined);
   },
 };

--- a/packages/cli/src/commands/models/accountShow.ts
+++ b/packages/cli/src/commands/models/accountShow.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 import { CLICommand, err, ok } from "@microsoft/teamsfx-api";
-import { AppStudioScopes, featureFlagManager, FeatureFlags } from "@microsoft/teamsfx-core";
+import {
+  AppStudioScopes,
+  AzureScopes,
+  featureFlagManager,
+  FeatureFlags,
+} from "@microsoft/teamsfx-core";
 import { TextType, colorize } from "../../colorize";
 import AzureTokenProvider, { getAzureProvider } from "../../commonlib/azureLogin";
 import AzureTokenCIProvider from "../../commonlib/azureLoginCI";
@@ -11,6 +16,7 @@ import { logger } from "../../commonlib/logger";
 import M365TokenProvider from "../../commonlib/m365Login";
 import { commands, strings } from "../../resource";
 import { TelemetryEvent } from "../../telemetry/cliTelemetryEvents";
+import { listAllTenants } from "@microsoft/teamsfx-core/build/common/tools";
 
 class AccountUtils {
   outputAccountInfoOffline(accountType: string, username: string): boolean {
@@ -32,11 +38,31 @@ class AccountUtils {
     );
     const result = appStudioTokenJsonRes.isOk() ? appStudioTokenJsonRes.value : undefined;
     if (result) {
+      if (tid) {
+        await M365TokenProvider.switchTenant(tid);
+      }
       const username = (result as any).upn ?? (result as any).unique_name;
       if (commandType === "login") {
         logger.outputSuccess(strings["account.login.m365"]);
       }
-      logger.outputInfo(strings["account.show.m365"], colorize(username, TextType.Important));
+
+      const cachedTenantId = featureFlagManager.getBooleanValue(FeatureFlags.MultiTenant)
+        ? await M365TokenProvider.getTenant()
+        : undefined;
+      if (cachedTenantId) {
+        const listTenantToken = await M365TokenProvider.getAccessToken({ scopes: AzureScopes });
+        if (listTenantToken.isOk()) {
+          const tenants = await listAllTenants(listTenantToken.value);
+          const curTenant = tenants.find((tenant) => tenant.tenantId === cachedTenantId);
+          logger.outputInfo(
+            strings["account.show.m365.tenant"],
+            colorize(username, TextType.Important),
+            colorize(curTenant?.displayName, TextType.Important)
+          );
+        }
+      } else {
+        logger.outputInfo(strings["account.show.m365"], colorize(username, TextType.Important));
+      }
       return Promise.resolve(true);
     } else {
       if (commandType === "login") {
@@ -69,11 +95,32 @@ class AccountUtils {
       if (commandType === "login") {
         logger.outputSuccess(strings["account.login.azure"]);
       }
-      logger.outputInfo(
-        strings["account.show.azure"],
-        colorize(username, TextType.Important),
-        JSON.stringify(subscriptions, null, 2)
-      );
+
+      const cachedTenantId = featureFlagManager.getBooleanValue(FeatureFlags.MultiTenant)
+        ? await azureProvider.getTenant()
+        : undefined;
+      if (cachedTenantId) {
+        const identityCredential = await azureProvider.getIdentityCredentialAsync(false);
+        const listTenantToken = identityCredential
+          ? await identityCredential.getToken(AzureScopes)
+          : undefined;
+        if (listTenantToken && listTenantToken.token) {
+          const tenants = await listAllTenants(listTenantToken.token);
+          const curTenant = tenants.find((tenant) => tenant.tenantId === cachedTenantId);
+          logger.outputInfo(
+            strings["account.show.azure.tenant"],
+            colorize(username, TextType.Important),
+            colorize(curTenant?.displayName, TextType.Important),
+            JSON.stringify(subscriptions, null, 2)
+          );
+        }
+      } else {
+        logger.outputInfo(
+          strings["account.show.azure"],
+          colorize(username, TextType.Important),
+          JSON.stringify(subscriptions, null, 2)
+        );
+      }
       return Promise.resolve(true);
     } else {
       if (commandType === "login") {

--- a/packages/cli/src/commonlib/azureLogin.ts
+++ b/packages/cli/src/commonlib/azureLogin.ts
@@ -186,6 +186,10 @@ export class AzureAccountManager extends login implements AzureAccountProvider {
     return Promise.resolve(ok(AzureAccountManager.teamsFxTokenCredential));
   }
 
+  async getTenant(): Promise<string | undefined> {
+    return await loadTenantId(accountName);
+  }
+
   private async updateLoginStatus(): Promise<void> {
     const checkCodeFlow =
       AzureAccountManager.codeFlowInstance !== undefined &&

--- a/packages/cli/src/commonlib/azureLoginCI.ts
+++ b/packages/cli/src/commonlib/azureLoginCI.ts
@@ -127,6 +127,11 @@ export class AzureAccountManager extends login implements AzureAccountProvider {
     return Promise.resolve(ok(AzureAccountManager.tokenCredential));
   }
 
+  async getTenant(): Promise<string | undefined> {
+    await this.load();
+    return AzureAccountManager.tenantId;
+  }
+
   async getStatus(): Promise<LoginStatus> {
     await this.load();
     if (

--- a/packages/cli/src/commonlib/azureLoginUserPassword.ts
+++ b/packages/cli/src/commonlib/azureLoginUserPassword.ts
@@ -75,6 +75,10 @@ export class AzureAccountProviderUserPassword implements AzureAccountProvider {
     throw new Error("Method not implemented.");
   }
 
+  async getTenant(): Promise<string | undefined> {
+    return Promise.resolve(cfg.AZURE_TENANT_ID);
+  }
+
   public async getStatus(): Promise<LoginStatus> {
     return Promise.resolve({
       status: "SignedIn",

--- a/packages/cli/src/commonlib/m365Login.ts
+++ b/packages/cli/src/commonlib/m365Login.ts
@@ -15,7 +15,7 @@ import {
 } from "@microsoft/teamsfx-api";
 import { AuthSvcScopes, teamsDevPortalClient } from "@microsoft/teamsfx-core";
 import ui from "../userInteraction";
-import { CryptoCachePlugin } from "./cacheAccess";
+import { CryptoCachePlugin, loadTenantId } from "./cacheAccess";
 import { CodeFlowLogin, ConvertTokenToJson, ErrorMessage } from "./codeFlowLogin";
 import { m365CacheName, signedIn, signedOut } from "./common/constant";
 import { LoginStatus } from "./common/login";
@@ -130,6 +130,10 @@ export class M365Login extends BasicLogin implements M365TokenProvider {
     return ok("");
   }
 
+  async getTenant(): Promise<string | undefined> {
+    return await loadTenantId(m365CacheName);
+  }
+
   async getStatus(tokenRequest: TokenRequest): Promise<Result<LoginStatus, FxError>> {
     if (!M365Login.codeFlowInstance.account) {
       await M365Login.codeFlowInstance.reloadCache();
@@ -203,6 +207,9 @@ class MM365TokenProviderWrapper implements M365TokenProvider {
   }
   async switchTenant(tenantId: string): Promise<Result<string, FxError>> {
     return await this.getProvider().switchTenant(tenantId);
+  }
+  async getTenant(): Promise<string | undefined> {
+    return await (this.getProvider() as any).getTenant();
   }
 }
 

--- a/packages/cli/src/commonlib/m365LoginUserPassword.ts
+++ b/packages/cli/src/commonlib/m365LoginUserPassword.ts
@@ -139,6 +139,10 @@ export class M365ProviderUserPassword extends BasicLogin implements M365TokenPro
   switchTenant(tenantId: string): Promise<Result<string, FxError>> {
     throw new Error("Method not implemented.");
   }
+
+  async getTenant(): Promise<string | undefined> {
+    return Promise.resolve(cfg.M365_TENANT_ID);
+  }
 }
 
 export default M365ProviderUserPassword.getInstance();

--- a/packages/cli/src/resource/strings.json
+++ b/packages/cli/src/resource/strings.json
@@ -8,7 +8,9 @@
   "account.logout.m365": "Successfully signed out of Microsoft 365.",
   "account.logout.m365.fail": "Unable to sign out of Microsoft 365.",
   "account.show.azure": "Your Azure account is: %s. Your subscriptions are: %s",
+  "account.show.azure.tenant": "Your Azure account is: %s(%s). Your subscriptions are: %s",
   "account.show.m365": "Your Microsoft 365 account is: %s.",
+  "account.show.m365.tenant": "Your Microsoft 365 account is: %s(%s).",
   "account.show.info": "Your %s account is: %s.",
   "command": {
     "doctor": {

--- a/packages/cli/tests/unit/commands.tests.ts
+++ b/packages/cli/tests/unit/commands.tests.ts
@@ -970,6 +970,15 @@ describe("CLI read-only commands", () => {
       sandbox.stub(AzureTokenCIProvider, "switchTenant").resolves();
       sandbox.stub(AzureTokenCIProvider, "getJsonObject").resolves({ unique_name: "test" });
       sandbox.stub(AzureTokenCIProvider, "listSubscriptions").resolves([]);
+      sandbox.stub(AzureTokenCIProvider, "getTenant").resolves("faked_tenant_id");
+      sandbox.stub(AzureTokenCIProvider, "getIdentityCredentialAsync").resolves({
+        getToken: async () => {
+          return Promise.resolve({ token: "faked_token" });
+        },
+      } as any);
+      sandbox
+        .stub(tools, "listAllTenants")
+        .resolves([{ tenantId: "faked_tid_1" }, { tenantId: "faked_tenant_id" }]);
       const res = await accountUtils.outputAzureInfo("login", "faked_tenant_id", true);
       assert.isTrue(res);
       mockedEnvRestore();

--- a/packages/cli/tests/unit/commands.tests.ts
+++ b/packages/cli/tests/unit/commands.tests.ts
@@ -920,20 +920,50 @@ describe("CLI read-only commands", () => {
     });
     it("outputM365Info login success", async () => {
       sandbox.stub(M365TokenProvider, "getJsonObject").resolves(ok({ upn: "fakename" }));
+      sandbox.stub(M365TokenProvider, "getTenant").resolves(undefined);
       const res = await accountUtils.outputM365Info("login");
       assert.isTrue(res);
     });
-    it("outputM365Info login success under hosting tenant", async () => {
-      const mocks = mockedEnv({ TEAMSFX_MULTI_TENANT: "true" });
-      sandbox.stub(M365TokenProvider, "getJsonObject").resolves(ok({ unique_name: "fakename" }));
-      sandbox.stub(M365TokenProvider, "getTenant").resolves("faked_tenant_id");
-      sandbox.stub(M365TokenProvider, "getAccessToken").resolves(ok("token"));
-      sandbox
-        .stub(tools, "listAllTenants")
-        .resolves([{ tenantId: "faked_tid_1" }, { tenantId: "faked_tenant_id" }]);
-      const res = await accountUtils.outputM365Info("login", "faked_tenant_id");
-      assert.isTrue(res);
-      mocks();
+    context("outputM365Info login under hosting tenant", () => {
+      let mocks: RestoreFn;
+      beforeEach(() => {
+        mocks = mockedEnv({ TEAMSFX_MULTI_TENANT: "true" });
+        sandbox.stub(M365TokenProvider, "getJsonObject").resolves(ok({ unique_name: "fakename" }));
+        sandbox.stub(M365TokenProvider, "getTenant").resolves("faked_tenant_id");
+      });
+
+      afterEach(() => {
+        mocks();
+      });
+
+      it("specified tenant name displayed", async () => {
+        sandbox.stub(M365TokenProvider, "getAccessToken").resolves(ok("token"));
+        sandbox
+          .stub(tools, "listAllTenants")
+          .resolves([
+            { tenantId: "faked_tid_1" },
+            { tenantId: "faked_tenant_id", displayName: "Test tenant" },
+          ]);
+        const res = await accountUtils.outputM365Info("login", "faked_tenant_id");
+        assert.isTrue(res);
+      });
+
+      it("specified tenant not match", async () => {
+        sandbox.stub(M365TokenProvider, "getAccessToken").resolves(ok("token"));
+        sandbox
+          .stub(tools, "listAllTenants")
+          .resolves([{ tenantId: "faked_tid_1" }, { tenantId: "faked_tid_2" }]);
+        const res = await accountUtils.outputM365Info("login", "faked_tenant_id");
+        assert.isTrue(res);
+      });
+
+      it("failed to retrieve access token", async () => {
+        sandbox
+          .stub(M365TokenProvider, "getAccessToken")
+          .resolves(err("failed to get access token" as any));
+        const res = await accountUtils.outputM365Info("login", "faked_tenant_id");
+        assert.isTrue(res);
+      });
     });
     it("outputM365Info login fail", async () => {
       sandbox.stub(M365TokenProvider, "getJsonObject").resolves(err(new UserCancelError()));
@@ -979,6 +1009,39 @@ describe("CLI read-only commands", () => {
       sandbox
         .stub(tools, "listAllTenants")
         .resolves([{ tenantId: "faked_tid_1" }, { tenantId: "faked_tenant_id" }]);
+      const res = await accountUtils.outputAzureInfo("login", "faked_tenant_id", true);
+      assert.isTrue(res);
+      mockedEnvRestore();
+    });
+    it("outputAzureInfo login fail with tenant parameter - invalid token", async () => {
+      const mockedEnvRestore = mockedEnv({ TEAMSFX_MULTI_TENANT: "true" });
+      sandbox.stub(AzureTokenCIProvider, "load").resolves();
+      sandbox.stub(AzureTokenCIProvider, "init").resolves();
+      sandbox.stub(AzureTokenCIProvider, "switchTenant").resolves();
+      sandbox.stub(AzureTokenCIProvider, "getJsonObject").resolves({ unique_name: "test" });
+      sandbox.stub(AzureTokenCIProvider, "listSubscriptions").resolves([]);
+      sandbox.stub(AzureTokenCIProvider, "getTenant").resolves("faked_tenant_id");
+      sandbox.stub(AzureTokenCIProvider, "getIdentityCredentialAsync").resolves(undefined);
+      const res = await accountUtils.outputAzureInfo("login", "faked_tenant_id", true);
+      assert.isTrue(res);
+      mockedEnvRestore();
+    });
+    it("outputAzureInfo login fail with tenant parameter - tenant mismatch", async () => {
+      const mockedEnvRestore = mockedEnv({ TEAMSFX_MULTI_TENANT: "true" });
+      sandbox.stub(AzureTokenCIProvider, "load").resolves();
+      sandbox.stub(AzureTokenCIProvider, "init").resolves();
+      sandbox.stub(AzureTokenCIProvider, "switchTenant").resolves();
+      sandbox.stub(AzureTokenCIProvider, "getJsonObject").resolves({ unique_name: "test" });
+      sandbox.stub(AzureTokenCIProvider, "listSubscriptions").resolves([]);
+      sandbox.stub(AzureTokenCIProvider, "getTenant").resolves("faked_tenant_id");
+      sandbox.stub(AzureTokenCIProvider, "getIdentityCredentialAsync").resolves({
+        getToken: async () => {
+          return Promise.resolve({ token: "faked_token" });
+        },
+      } as any);
+      sandbox
+        .stub(tools, "listAllTenants")
+        .resolves([{ tenantId: "faked_tid_1" }, { tenantId: "faked_tid_2" }]);
       const res = await accountUtils.outputAzureInfo("login", "faked_tenant_id", true);
       assert.isTrue(res);
       mockedEnvRestore();

--- a/packages/cli/tests/unit/commands.tests.ts
+++ b/packages/cli/tests/unit/commands.tests.ts
@@ -212,22 +212,6 @@ describe("CLI commands", () => {
       const res = await accountLoginM365Command.handler!(ctx);
       assert.isTrue(res.isOk());
     });
-
-    it("switch tenant succeed with tenant parameter", async () => {
-      sandbox.stub(M365TokenProvider, "signout");
-      sandbox.stub(accountUtils, "outputM365Info").resolves(true);
-      const switchTenantStub = sandbox.stub(M365TokenProvider, "switchTenant").resolves();
-      const ctx: CLIContext = {
-        command: { ...accountLoginM365Command, fullName: "teamsapp auth login m365" },
-        optionValues: { "service-principal": false, tenant: "faked_tenant_id" },
-        globalOptionValues: {},
-        argumentValues: [],
-        telemetryProperties: {},
-      };
-      const res = await accountLoginM365Command.handler!(ctx);
-      assert.isTrue(res.isOk());
-      assert.isTrue(switchTenantStub.calledOnce);
-    });
   });
 
   describe("addSPFxWebpartCommand", async () => {
@@ -942,6 +926,11 @@ describe("CLI read-only commands", () => {
     it("outputM365Info login success under hosting tenant", async () => {
       const mocks = mockedEnv({ TEAMSFX_MULTI_TENANT: "true" });
       sandbox.stub(M365TokenProvider, "getJsonObject").resolves(ok({ unique_name: "fakename" }));
+      sandbox.stub(M365TokenProvider, "getTenant").resolves("faked_tenant_id");
+      sandbox.stub(M365TokenProvider, "getAccessToken").resolves(ok("token"));
+      sandbox
+        .stub(tools, "listAllTenants")
+        .resolves([{ tenantId: "faked_tid_1" }, { tenantId: "faked_tenant_id" }]);
       const res = await accountUtils.outputM365Info("login", "faked_tenant_id");
       assert.isTrue(res);
       mocks();
@@ -953,6 +942,11 @@ describe("CLI read-only commands", () => {
     });
     it("outputM365Info show success", async () => {
       sandbox.stub(M365TokenProvider, "getJsonObject").resolves(ok({ upn: "fakename" }));
+      sandbox.stub(M365TokenProvider, "getTenant").resolves("faked_tenant_id");
+      sandbox.stub(M365TokenProvider, "getAccessToken").resolves(ok("token"));
+      sandbox
+        .stub(tools, "listAllTenants")
+        .resolves([{ tenantId: "faked_tid_1" }, { tenantId: "faked_tenant_id" }]);
       const res = await accountUtils.outputM365Info("show");
       assert.isTrue(res);
     });


### PR DESCRIPTION
ADO: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/30370091

Screenshots:
Login with specified tenant
<img width="591" alt="image" src="https://github.com/user-attachments/assets/f1261ce4-6e81-4e3e-a395-dd1d0155f4d6">

List accounts
<img width="591" alt="image" src="https://github.com/user-attachments/assets/52f5a033-4a96-4833-8085-87f6d8d788fc">

Login  without tenant
<img width="585" alt="image" src="https://github.com/user-attachments/assets/751318bb-e82c-45e5-a82c-ef617b8c1f00">
List accounts
<img width="525" alt="image" src="https://github.com/user-attachments/assets/f1fd47ae-41d1-4f9b-90d1-d1bf7fc106af">


