### PR TITLE
feat: troubleshoot UI

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -558,6 +558,10 @@
         {
           "command": "fx-extension.teamsAgentTroubleshootSelectedText",
           "when": "false"
+        },
+        {
+          "command": "fx-extension.teamsAgentTroubleshootError",
+          "when": "false"
         }
       ]
     },
@@ -921,8 +925,14 @@
       },
       {
         "command": "fx-extension.teamsAgentTroubleshootSelectedText",
-        "title": "Troubleshoot with @teamsapp",
-        "enablement": "editor.hasSelection",
+        "title": "Troubleshoot selection with @teamsapp",
+        "enablement": "editor.hasSelection && fx-extension.isChatParticipantUIEntriesEnabled",
+        "category": "Teams"
+      },
+      {
+        "command": "fx-extension.teamsAgentTroubleshootError",
+        "title": "Troubleshoot error with @teamsapp",
+        "enablement": "fx-extension.isChatParticipantUIEntriesEnabled",
         "category": "Teams"
       }
     ],

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -389,7 +389,7 @@
         {
           "command": "fx-extension.teamsAgentTroubleshootSelectedText",
           "group": "navigation",
-          "when": "(resourceFilename =~ /.*Teams Toolkit\\.log$/ || (activeOutputChannel =~ /^extension-output-TeamsDevApp\\.ms-teams-vscode-extension.*/ && view == 'workbench.panel.output'))"
+          "when": "(fx-extension.isChatParticipantUIEntriesEnabled && (resourceFilename =~ /.*Teams Toolkit\\.log$/ || (activeOutputChannel =~ /^extension-output-TeamsDevApp\\.ms-teams-vscode-extension.*/ && view == 'workbench.panel.output')))"
         }
       ],
       "editor/title/run": [

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -385,6 +385,13 @@
           "group": "inline"
         }
       ],
+      "editor/context": [
+        {
+          "command": "fx-extension.teamsGitHubCopilotTroubleshoot",
+          "group": "navigation",
+          "when": "(resourceFilename =~ /.*Teams Toolkit\\.log$/ || (activeOutputChannel =~ /^extension-output-TeamsDevApp\\.ms-teams-vscode-extension.*/ && view == 'workbench.panel.output'))"
+        }
+      ],
       "editor/title/run": [
         {
           "command": "fx-extension.selectAndDebug",
@@ -907,6 +914,12 @@
         "title": "%teamstoolkit.commandsTreeViewProvider.syncManifest%",
         "category": "Teams",
         "enablement": "fx-extension.isSyncManifestEnabled"
+      },
+      {
+        "command": "fx-extension.teamsGitHubCopilotTroubleshoot",
+        "title": "Troubleshoot with @teamsapp",
+        "enablement": "editor.hasSelection",
+        "category": "Teams"
       }
     ],
     "taskDefinitions": [

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -387,7 +387,7 @@
       ],
       "editor/context": [
         {
-          "command": "fx-extension.teamsGitHubCopilotTroubleshoot",
+          "command": "fx-extension.teamsAgentTroubleshootSelectedText",
           "group": "navigation",
           "when": "(resourceFilename =~ /.*Teams Toolkit\\.log$/ || (activeOutputChannel =~ /^extension-output-TeamsDevApp\\.ms-teams-vscode-extension.*/ && view == 'workbench.panel.output'))"
         }
@@ -553,6 +553,10 @@
         },
         {
           "command": "fx-extension.openOfficeDevHelpFeedbackLink",
+          "when": "false"
+        },
+        {
+          "command": "fx-extension.teamsAgentTroubleshootSelectedText",
           "when": "false"
         }
       ]
@@ -916,7 +920,7 @@
         "enablement": "fx-extension.isSyncManifestEnabled"
       },
       {
-        "command": "fx-extension.teamsGitHubCopilotTroubleshoot",
+        "command": "fx-extension.teamsAgentTroubleshootSelectedText",
         "title": "Troubleshoot with @teamsapp",
         "enablement": "editor.hasSelection",
         "category": "Teams"

--- a/packages/vscode-extension/src/error/common.ts
+++ b/packages/vscode-extension/src/error/common.ts
@@ -81,11 +81,7 @@ export async function showError(e: UserError | SystemError) {
     VsCodeLogInstance.error(`code:${errorCode}, message: ${e.message}\n Help link: ${e.helpLink}`);
     // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     VsCodeLogInstance.debug(`Call stack: ${e.stack || e.innerError?.stack || ""}`);
-    const buttons = recommendTestTool
-      ? shouldRecommendTeamsAgent
-        ? []
-        : [runTestTool, help]
-      : [help];
+    const buttons = recommendTestTool ? [runTestTool, help] : [help];
     if (shouldRecommendTeamsAgent) {
       buttons.push(troubleshootErrorWithTeamsAgentButton);
     }

--- a/packages/vscode-extension/src/error/common.ts
+++ b/packages/vscode-extension/src/error/common.ts
@@ -2,7 +2,12 @@
 // Licensed under the MIT license.
 
 import { UserError, SystemError, FxError, Result, err, ok } from "@microsoft/teamsfx-api";
-import { isUserCancelError, ConcurrentError } from "@microsoft/teamsfx-core";
+import {
+  isUserCancelError,
+  ConcurrentError,
+  featureFlagManager,
+  FeatureFlags as CoreFeatureFlags,
+} from "@microsoft/teamsfx-core";
 import { Uri, commands, window } from "vscode";
 import {
   RecommendedOperations,
@@ -14,7 +19,11 @@ import { ExtTelemetry } from "../telemetry/extTelemetry";
 import { anonymizeFilePaths } from "../utils/fileSystemUtils";
 import { localize } from "../utils/localizeUtils";
 import { isTestToolEnabledProject } from "../utils/projectChecker";
-import { TelemetryEvent, TelemetryProperty } from "../telemetry/extTelemetryEvents";
+import {
+  TelemetryEvent,
+  TelemetryProperty,
+  TelemetryTriggerFrom,
+} from "../telemetry/extTelemetryEvents";
 import VsCodeLogInstance from "../commonlib/log";
 import { ExtensionSource, ExtensionErrors } from "./error";
 
@@ -33,6 +42,20 @@ export async function showError(e: UserError | SystemError) {
     e.recommendedOperation === RecommendedOperations.DebugInTestTool &&
     workspaceUri?.fsPath &&
     isTestToolEnabledProject(workspaceUri.fsPath);
+
+  const shouldRecommendTeamsAgent = featureFlagManager.getBooleanValue(
+    CoreFeatureFlags.ChatParticipantUIEntries
+  );
+  const troubleshootErrorWithTeamsAgentButton = {
+    title: "Troubleshoot error with @teamsapp", // Localize
+    run: async () => {
+      await commands.executeCommand(
+        "fx-extension.teamsAgentTroubleshootError",
+        TelemetryTriggerFrom.Notification,
+        e
+      );
+    },
+  };
 
   if (recommendTestTool) {
     const recommendTestToolMessage = openTestToolMessage();
@@ -58,7 +81,14 @@ export async function showError(e: UserError | SystemError) {
     VsCodeLogInstance.error(`code:${errorCode}, message: ${e.message}\n Help link: ${e.helpLink}`);
     // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     VsCodeLogInstance.debug(`Call stack: ${e.stack || e.innerError?.stack || ""}`);
-    const buttons = recommendTestTool ? [runTestTool, help] : [help];
+    const buttons = recommendTestTool
+      ? shouldRecommendTeamsAgent
+        ? []
+        : [runTestTool, help]
+      : [help];
+    if (shouldRecommendTeamsAgent) {
+      buttons.push(troubleshootErrorWithTeamsAgentButton);
+    }
     const button = await window.showErrorMessage(
       `[${errorCode}]: ${notificationMessage}`,
       ...buttons
@@ -95,6 +125,9 @@ export async function showError(e: UserError | SystemError) {
     const buttons = recommendTestTool
       ? [runTestTool, issue, similarIssues]
       : [issue, similarIssues];
+    if (shouldRecommendTeamsAgent) {
+      buttons.push(troubleshootErrorWithTeamsAgentButton);
+    }
     const button = await window.showErrorMessage(
       `[${errorCode}]: ${notificationMessage}`,
       ...buttons
@@ -104,7 +137,13 @@ export async function showError(e: UserError | SystemError) {
     if (!(e instanceof ConcurrentError)) {
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       VsCodeLogInstance.debug(`Call stack: ${e.stack || e.innerError?.stack || ""}`);
-      const buttons = recommendTestTool ? [runTestTool] : [];
+      const buttons: {
+        title: string;
+        run: () => void;
+      }[] = recommendTestTool ? [runTestTool] : [];
+      if (shouldRecommendTeamsAgent) {
+        buttons.push(troubleshootErrorWithTeamsAgentButton);
+      }
       const button = await window.showErrorMessage(
         `[${errorCode}]: ${notificationMessage}`,
         ...buttons

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -458,6 +458,12 @@ function registerActivateCommands(context: vscode.ExtensionContext) {
     Correlator.run(copilotChatHandlers.invokeTeamsAgent, args)
   );
   context.subscriptions.push(invokeTeamsAgent);
+
+  const troubleshootWithTeamsAgent = vscode.commands.registerCommand(
+    "fx-extension.teamsAgentTroubleshootSelectedText",
+    (...args) => Correlator.run(copilotChatHandlers.troubleshootSelectedText, args)
+  );
+  context.subscriptions.push(troubleshootWithTeamsAgent);
 }
 
 /**

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -459,11 +459,17 @@ function registerActivateCommands(context: vscode.ExtensionContext) {
   );
   context.subscriptions.push(invokeTeamsAgent);
 
-  const troubleshootWithTeamsAgent = vscode.commands.registerCommand(
+  const troubleshootSelectedText = vscode.commands.registerCommand(
     "fx-extension.teamsAgentTroubleshootSelectedText",
     (...args) => Correlator.run(copilotChatHandlers.troubleshootSelectedText, args)
   );
-  context.subscriptions.push(troubleshootWithTeamsAgent);
+  context.subscriptions.push(troubleshootSelectedText);
+
+  const troubleshootError = vscode.commands.registerCommand(
+    "fx-extension.teamsAgentTroubleshootError",
+    (...args) => Correlator.run(copilotChatHandlers.troubleshootError, args)
+  );
+  context.subscriptions.push(troubleshootError);
 }
 
 /**

--- a/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
@@ -283,6 +283,8 @@ export enum TelemetryEvent {
   InvokeTeamsAgent = "invoke-teams-agent",
   TroubleshootSelectedTextStart = "troubleshoot-selected-text-start",
   TroubleshootSelectedText = "troubleshoot-selected-text",
+  TroubleshootErrorFromNotificationStart = "troubleshoot-error-from-notification-start",
+  TroubleshootErrorFromNotification = "troubleshoot-error-from-notification",
 
   // Copilot Chat
   CopilotChatStart = "copilot-chat-start",

--- a/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetryEvents.ts
@@ -278,8 +278,11 @@ export enum TelemetryEvent {
 
   FindSimilarIssues = "find-similar-issues",
 
+  // Teams Github Copilot UI
   InvokeTeamsAgentStart = "invoke-teams-agent-start",
   InvokeTeamsAgent = "invoke-teams-agent",
+  TroubleshootSelectedTextStart = "troubleshoot-selected-text-start",
+  TroubleshootSelectedText = "troubleshoot-selected-text",
 
   // Copilot Chat
   CopilotChatStart = "copilot-chat-start",
@@ -459,6 +462,7 @@ export enum TelemetryTriggerFrom {
   SampleDetailPage = "SampleDetailPage",
   CopilotChat = "CopilotChat",
   CreateAppQuestionFlow = "CreateAppQuestionFlow",
+  EditorContextMenu = "EditorContextMenu",
   Other = "Other",
   Auto = "Auto",
   Unknow = "Unknow",

--- a/packages/vscode-extension/src/utils/telemetryUtils.ts
+++ b/packages/vscode-extension/src/utils/telemetryUtils.ts
@@ -73,6 +73,8 @@ export function getTriggerFromProperty(args?: any[]) {
       return { [TelemetryProperty.TriggerFrom]: TelemetryTriggerFrom.Other };
     case TelemetryTriggerFrom.CreateAppQuestionFlow:
       return { [TelemetryProperty.TriggerFrom]: TelemetryTriggerFrom.CreateAppQuestionFlow };
+    case TelemetryTriggerFrom.EditorContextMenu:
+      return { [TelemetryProperty.TriggerFrom]: TelemetryTriggerFrom.EditorContextMenu };
     default:
       return { [TelemetryProperty.TriggerFrom]: TelemetryTriggerFrom.Unknow };
   }

--- a/packages/vscode-extension/test/error/common.test.ts
+++ b/packages/vscode-extension/test/error/common.test.ts
@@ -10,6 +10,7 @@ import { SystemError, UserError } from "@microsoft/teamsfx-api";
 import { showError } from "../../src/error/common";
 import { TelemetryEvent } from "../../src/telemetry/extTelemetryEvents";
 import { RecommendedOperations } from "../../src/debug/common/debugConstants";
+import { featureFlagManager } from "@microsoft/teamsfx-core";
 
 describe("common", () => {
   const sandbox = sinon.createSandbox();
@@ -121,9 +122,22 @@ describe("common", () => {
     });
 
     it(`showError - ${type} - recommend test tool`, async () => {
+      sandbox.stub(featureFlagManager, "getBooleanValue").returns(false);
       sandbox.stub(localizeUtils, "localize").returns("");
       const showErrorMessageStub = sandbox.stub(vscode.window, "showErrorMessage");
       sandbox.stub(projectChecker, "isTestToolEnabledProject").returns(true);
+      sandbox.stub(globalVariables, "workspaceUri").value(vscode.Uri.file("path"));
+      sandbox.stub(vscode.commands, "executeCommand");
+      const error = buildError();
+      await showError(error);
+      chai.assert.equal(showErrorMessageStub.firstCall.args.length, buttonNum + 1);
+    });
+
+    it(`showError - ${type} - recommend troubleshoot`, async () => {
+      sandbox.stub(featureFlagManager, "getBooleanValue").returns(true);
+      sandbox.stub(localizeUtils, "localize").returns("");
+      const showErrorMessageStub = sandbox.stub(vscode.window, "showErrorMessage");
+      sandbox.stub(projectChecker, "isTestToolEnabledProject").returns(false);
       sandbox.stub(globalVariables, "workspaceUri").value(vscode.Uri.file("path"));
       sandbox.stub(vscode.commands, "executeCommand");
       const error = buildError();


### PR DESCRIPTION
- All things listed below is behind feature, which means they are not visible if stable release.
- Add command that user can troubleshoot with GitHub Copilot Teams Agent if selecting text in Teams Toolkit output.
![image](https://github.com/user-attachments/assets/9442af15-7611-4658-a793-dcff82979156)

- Will notify user that they can troubleshoot with teamsapp when error notification.
![image](https://github.com/user-attachments/assets/625e219f-e953-403e-b8e0-a7c28b49d5f9)

- TODO: update string and localize once being finalized