### PR TITLE
fix: load tenant id when getting user login status

### DIFF
--- a/packages/vscode-extension/src/commonlib/azureLogin.ts
+++ b/packages/vscode-extension/src/commonlib/azureLogin.ts
@@ -111,6 +111,9 @@ export class AzureAccountManager extends login implements AzureAccountProvider {
   }
 
   private async isUserLogin(tenantId?: string): Promise<boolean> {
+    if (featureFlagManager.getBooleanValue(FeatureFlags.MultiTenant) && !tenantId) {
+      tenantId = await loadTenantId(azureCacheName);
+    }
     const session = await getSessionFromVSCode(AzureScopes, tenantId, {
       createIfNone: false,
       silent: true,


### PR DESCRIPTION
If user login to specific tenant, while credential for other tenants exist, TTK will try to get token since login status is logged in. Need to load tenant cache and get related status.