### PR TITLE
ci: upgrade upload and download artifacts GitHub action to v4

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -303,7 +303,7 @@ jobs:
           find ./packages/vscode-extension -type f -name '*.vsix' -exec mv {} . \;
 
       - name: upload release info to artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: release
           path: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,7 +39,7 @@ jobs:
           done <<< $links
 
       - name: Upload akas to artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.repo }}
           path: akas.data
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: aka-validation
     steps:
-      - uses: actions/download-artifact@v4.1.7
+      - uses: actions/download-artifact@v4
         with:
           path: artifacts
       - name: List akas
@@ -90,7 +90,7 @@ jobs:
           done
 
       - name: upload result to artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: result
           path: artifacts/result.txt
@@ -99,7 +99,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: aka-validation
     steps:
-      - uses: actions/download-artifact@v4.1.7
+      - uses: actions/download-artifact@v4
         with:
           path: artifacts
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -125,7 +125,7 @@ jobs:
   
       - name: Upload testplan to artifact
         if: ${{ github.event.inputs.target-testplan-name != '' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: testplan
           path: |
@@ -300,7 +300,7 @@ jobs:
           echo "name=$name" >> $GITHUB_OUTPUT
 
       - name: Upload test report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ github.event_name != 'schedule' || success() || (failure() && github.run_attempt >= 5) }}
         with:
           name: test-result-${{ steps.get-report-name.outputs.name }}
@@ -309,7 +309,7 @@ jobs:
       
       - name: Download TestPlan
         if: ${{ always() && github.event.inputs.target-testplan-name != '' }}
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4
         with:
           name: testplan
           path: ./packages/tests
@@ -376,7 +376,7 @@ jobs:
         run: |
           sudo apt install dateutils
 
-      - uses: actions/download-artifact@v4.1.7
+      - uses: actions/download-artifact@v4
         with:
           path: ~/artifacts
 
@@ -588,7 +588,7 @@ jobs:
           zip -r out1.zip .nyc_output/
           zip -r out2.zip coverage/
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: coverage

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -145,7 +145,7 @@ jobs:
           echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: Upload TTK to artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ttk
           path: |
@@ -336,7 +336,7 @@ jobs:
           npx playwright install
 
       - name: Download TTK
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4
         with:
           name: ttk
           path: ./packages/tests
@@ -464,21 +464,21 @@ jobs:
           npx extest run-tests --storage .test-resources --extensions_dir .test-resources --type stable --code_settings ./settings.json ./out/ui-test/**/${{ matrix.test-case }}.test.js
       
       - name: Upload test result json file
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ github.event_name != 'schedule' || success() || (failure() && github.run_attempt >= 5) }}
         with:
           name: test-result-${{ matrix.test-case }}-${{ matrix.os }}
           path: ./packages/tests/mochawesome-report/mochawesome.json
 
       - name: Upload screenshots
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: screenshots ${{ matrix.test-case }} ${{ matrix.os }}
           path: ./packages/tests/.test-resources/screenshots/
 
       - name: Upload source code
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: source code ${{ matrix.test-case }} ${{ matrix.os }}
@@ -487,7 +487,7 @@ jobs:
             !./packages/tests/**/node_modules/*
 
       - name: Upload telemetry
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always() && startsWith(matrix.test-case, 'telemetry')
         with:
           name: telemetry ${{ matrix.test-case }} ${{ matrix.os }}
@@ -528,7 +528,7 @@ jobs:
           npx ts-node src/scripts/testPlan.ts archive $testplanid
       
       - name: Download TestPlan
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4
         with:
           path: ./packages/tests/mocha-results
 


### PR DESCRIPTION
v3 version will deprecate on end of 2024
https://github.com/[actions/upload-artifact](https://github.com/actions/upload-artifact)
