### PR TITLE
feat: support env variables in localization.json

### DIFF
--- a/packages/fx-core/src/component/driver/teamsApp/createAppPackage.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/createAppPackage.ts
@@ -175,8 +175,13 @@ export class CreateAppPackageDriver implements StepDriver {
         if (relativePath.startsWith("..")) {
           return err(new InvalidFileOutsideOfTheDirectotryError(fileName));
         }
-        const dir = path.dirname(file);
-        zip.addLocalFile(fileName, dir === "." ? "" : dir);
+        const resolvedLocFileRes = await manifestUtils.resolveLocFile(fileName);
+        if (resolvedLocFileRes.isErr()) {
+          return err(resolvedLocFileRes.error);
+        }
+        if (resolvedLocFileRes.value) {
+          zip.addFile(relativePath, Buffer.from(resolvedLocFileRes.value));
+        }
       }
     }
     if (manifest.localizationInfo && manifest.localizationInfo.defaultLanguageFile) {
@@ -186,8 +191,14 @@ export class CreateAppPackageDriver implements StepDriver {
       if (relativePath.startsWith("..")) {
         return err(new InvalidFileOutsideOfTheDirectotryError(fileName));
       }
-      const dir = path.dirname(file);
-      zip.addLocalFile(fileName, dir === "." ? "" : dir);
+
+      const resolvedLocFileRes = await manifestUtils.resolveLocFile(fileName);
+      if (resolvedLocFileRes.isErr()) {
+        return err(resolvedLocFileRes.error);
+      }
+      if (resolvedLocFileRes.value) {
+        zip.addFile(relativePath, Buffer.from(resolvedLocFileRes.value));
+      }
     }
 
     // API ME, API specification and Adaptive card templates

--- a/packages/fx-core/src/component/driver/teamsApp/validate.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/validate.ts
@@ -431,11 +431,11 @@ export class ValidateManifestDriver implements StepDriver {
       );
       const localizationFilePath = getAbsolutePath(filePath, localizationFileDir);
 
-      const manifestRes = await manifestUtils._readAppManifest(localizationFilePath);
-      if (manifestRes.isErr()) {
-        return err(manifestRes.error);
+      const resolvedLocFileRes = await manifestUtils.resolveLocFile(localizationFilePath);
+      if (resolvedLocFileRes.isErr()) {
+        return err(resolvedLocFileRes.error);
       }
-      const localizationFile = manifestRes.value;
+      const localizationFile = JSON.parse(resolvedLocFileRes.value) as TeamsAppManifest;
       try {
         const schema = await ManifestUtil.fetchSchema(localizationFile);
         // the current localization schema has invalid regex sytax, we need to manually fix the properties temporarily

--- a/packages/fx-core/tests/component/driver/teamsApp/manifestUtils.test.ts
+++ b/packages/fx-core/tests/component/driver/teamsApp/manifestUtils.test.ts
@@ -27,6 +27,7 @@ import {
 } from "../../../../src/component/driver/teamsApp/constants";
 import { AppStudioError } from "../../../../src/component/driver/teamsApp/errors";
 import { FileNotFoundError, JSONSyntaxError, ReadFileError } from "../../../../src/error";
+import mockedEnv, { RestoreFn } from "mocked-env";
 
 const latestManifestVersion = "1.17";
 const oldManifestVersion = "1.16";
@@ -523,7 +524,12 @@ describe("trimManifestShortName", () => {
 
 describe("resolveLocFile", () => {
   const sandbox = sinon.createSandbox();
+  let mockedEnvRestore: RestoreFn;
+
   afterEach(() => {
+    if (mockedEnvRestore) {
+      mockedEnvRestore();
+    }
     sandbox.restore();
   });
 
@@ -556,7 +562,9 @@ describe("resolveLocFile", () => {
     sandbox.stub(fs, "pathExists").resolves(true);
     const fakedLocManifest = new TeamsAppManifest();
     fakedLocManifest.name.short = "shortname ${{APP_NAME_SUFFIX}}";
-    process.env.APP_NAME_SUFFIX = "- hello world";
+    mockedEnvRestore = mockedEnv({
+      ["APP_NAME_SUFFIX"]: "- hello world",
+    });
     sandbox.stub(fs, "readFile").resolves(JSON.stringify(fakedLocManifest) as any);
 
     const locFile = await manifestUtils.resolveLocFile("loc_file_path");

--- a/packages/fx-core/tests/component/driver/teamsApp/validate.test.ts
+++ b/packages/fx-core/tests/component/driver/teamsApp/validate.test.ts
@@ -275,7 +275,7 @@ describe("teamsApp/validateManifest", async () => {
       const manifest = { localizationInfo: { additionalLanguages: [{ file: "filePath" }] } } as any;
 
       sinon
-        .stub(manifestUtils, "_readAppManifest")
+        .stub(manifestUtils, "resolveLocFile")
         .resolves(err(new SystemError("error", "error", "", "")));
 
       const result = await teamsAppDriver.validateLocalizatoinFiles(
@@ -297,7 +297,9 @@ describe("teamsApp/validateManifest", async () => {
           "https://developer.microsoft.com/en-us/json-schemas/teams/v1.16/MicrosoftTeams.Localization.schema.json",
       };
 
-      sinon.stub(manifestUtils, "_readAppManifest").resolves(ok(fakeLocalizationFile as any));
+      sinon
+        .stub(manifestUtils, "resolveLocFile")
+        .resolves(ok(JSON.stringify(fakeLocalizationFile)));
       sinon.stub(ManifestUtil, "validateManifestAgainstSchema").resolves(["Validation error"]);
 
       const result = await teamsAppDriver.validateLocalizatoinFiles(
@@ -365,7 +367,9 @@ describe("teamsApp/validateManifest", async () => {
       const manifest = { localizationInfo: { additionalLanguages: [{ file: "filePath" }] } } as any;
       const fakeLocalizationFile = {};
 
-      sinon.stub(manifestUtils, "_readAppManifest").resolves(ok(fakeLocalizationFile as any));
+      sinon
+        .stub(manifestUtils, "resolveLocFile")
+        .resolves(ok(JSON.stringify(fakeLocalizationFile)));
       sinon
         .stub(ManifestUtil, "validateManifestAgainstSchema")
         .throws(new Error("validation exception"));
@@ -385,7 +389,7 @@ describe("teamsApp/validateManifest", async () => {
       const args: ValidateManifestArgs = { manifestPath: "fakepath" };
       const manifest = { localizationInfo: { additionalLanguages: [{ file: "filePath" }] } } as any;
       sinon.stub(ManifestUtil, "fetchSchema").resolves({} as any);
-      sinon.stub(manifestUtils, "_readAppManifest").resolves(ok({} as any));
+      sinon.stub(manifestUtils, "resolveLocFile").resolves(ok("{}"));
       sinon.stub(ManifestUtil, "validateManifestAgainstSchema").resolves([] as any);
       const result = await teamsAppDriver.validateLocalizatoinFiles(
         args,
@@ -409,7 +413,9 @@ describe("teamsApp/validateManifest", async () => {
         "activities.activityTypes[0].description": "aa",
       };
 
-      sinon.stub(manifestUtils, "_readAppManifest").resolves(ok(fakeLocalizationFile as any));
+      sinon
+        .stub(manifestUtils, "resolveLocFile")
+        .resolves(ok(JSON.stringify(fakeLocalizationFile)));
       const result = await teamsAppDriver.validateLocalizatoinFiles(
         args,
         mockedDriverContext,


### PR DESCRIPTION
ADO:
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/30459175
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/30459177

Screenshots:
create app package and upload
<img width="895" alt="image" src="https://github.com/user-attachments/assets/15efb5af-3742-4186-82a7-fc4518a03fb8">

validate fail when env variables not resolved
<img width="585" alt="env_support_validate" src="https://github.com/user-attachments/assets/0004e31a-b759-4ce6-aada-3760d16f8950">
