### PR TITLE
feat: notify if AAD manifest is already in new schema

### DIFF
--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -492,6 +492,7 @@
   "core.convertAadToNewSchema.continue": "Continue",
   "core.convertAadToNewSchema.warning": "Converting Microsoft Entra app manifest file to new schema will replace the original file. Do you still want to continue?",
   "core.convertAadToNewSchema.success": "Microsoft Entra app manifest file successfully converted to new schema.",
+  "core.convertAadToNewSchema.alreadyNewSchema": "Microsoft Entra app manifest file you selected is already in the new schema.",
   "core.teamsAppQuestion.label": "Teams app",
   "core.teamsAppQuestion.description": "Your Teams app",
   "core.M365SsoLaunchPageOptionItem.label": "React with Fluent UI",

--- a/packages/fx-core/src/core/FxCore.ts
+++ b/packages/fx-core/src/core/FxCore.ts
@@ -850,6 +850,16 @@ export class FxCore {
 
     const manifest = await fs.readJson(manifestTemplatePath);
     const context = createContext();
+
+    if (AadManifestHelper.isNewAADManifestSchema(manifest)) {
+      void (await context.userInteraction.showMessage(
+        "info",
+        getLocalizedString("core.convertAadToNewSchema.alreadyNewSchema"),
+        false
+      ));
+      return ok(undefined);
+    }
+
     const confirmRes = await context.userInteraction.showMessage(
       "warn",
       getLocalizedString("core.convertAadToNewSchema.warning"),

--- a/packages/fx-core/tests/core/FxCore.test.ts
+++ b/packages/fx-core/tests/core/FxCore.test.ts
@@ -681,6 +681,38 @@ describe("Core basic APIs", () => {
     }
   });
 
+  it("convertAadToNewSchema show message when manifest is in new schema", async () => {
+    const restore = mockedEnv({
+      TEAMSFX_DEBUG_TEMPLATE: "true", // workaround test failure that when local template not released to GitHub
+      NODE_ENV: "development", // workaround test failure that when local template not released to GitHub
+    });
+
+    try {
+      const core = new FxCore(tools);
+      const appName = await mockV3Project();
+      const projectPath = path.join(os.tmpdir(), appName);
+      const inputs: Inputs = {
+        platform: Platform.VSCode,
+        projectPath: projectPath,
+        [QuestionNames.AadAppManifestFilePath]: `${projectPath}/aad.manifest.json`,
+      };
+
+      sandbox.stub(fs, "readJson").resolves({ displayName: "displayName" });
+      const showMessageStub = sandbox.stub(tools.ui, "showMessage");
+
+      const result = await core.convertAadToNewSchema(inputs);
+      sandbox.assert.calledOnceWithExactly(
+        showMessageStub,
+        "info",
+        getLocalizedString("core.convertAadToNewSchema.alreadyNewSchema") as any,
+        false
+      );
+      assert.isTrue(result.isOk());
+    } finally {
+      restore();
+    }
+  });
+
   it("addSso method should exist", async () => {
     const restore = mockedEnv({
       TEAMSFX_DEBUG_TEMPLATE: "true", // workaround test failures when template changed but not release to GitHub alpha template


### PR DESCRIPTION
[Task 30544933](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/30544933): Show message when aad manifest already in new schema when convert