### PR TITLE
feat: update API key handling in templates to use a custom header

### DIFF
--- a/packages/fx-core/src/component/generator/templates/templateNames.ts
+++ b/packages/fx-core/src/component/generator/templates/templateNames.ts
@@ -110,7 +110,7 @@ export const Feature2TemplateName = {
     ApiAuthOptions.none().id
   }`]: TemplateNames.CopilotPluginFromScratch,
   [`${CapabilityOptions.m365SearchMe().id}:undefined:${MeArchitectureOptions.newApi().id}:${
-    ApiAuthOptions.apiKey().id
+    ApiAuthOptions.bearerToken().id
   }`]: TemplateNames.CopilotPluginFromScratchApiKey,
   [`${CapabilityOptions.m365SearchMe().id}:undefined:${MeArchitectureOptions.newApi().id}:${
     ApiAuthOptions.microsoftEntra().id
@@ -286,7 +286,7 @@ export const inputsToTemplateName: Map<{ [key: string]: any }, TemplateNames> = 
     {
       [QuestionNames.Capabilities]: CapabilityOptions.m365SearchMe().id,
       [QuestionNames.MeArchitectureType]: MeArchitectureOptions.newApi().id,
-      [QuestionNames.ApiAuth]: ApiAuthOptions.apiKey().id,
+      [QuestionNames.ApiAuth]: ApiAuthOptions.bearerToken().id,
     },
     TemplateNames.CopilotPluginFromScratchApiKey,
   ],

--- a/packages/fx-core/src/question/constants.ts
+++ b/packages/fx-core/src/question/constants.ts
@@ -783,6 +783,13 @@ export class ApiAuthOptions {
   static apiKey(): OptionItem {
     return {
       id: "api-key",
+      label: "API Key",
+    };
+  }
+
+  static bearerToken(): OptionItem {
+    return {
+      id: "bearer-token",
       label: "API Key (Bearer Token Auth)",
     };
   }
@@ -805,6 +812,7 @@ export class ApiAuthOptions {
     return [
       ApiAuthOptions.none(),
       ApiAuthOptions.apiKey(),
+      ApiAuthOptions.bearerToken(),
       ApiAuthOptions.microsoftEntra(),
       ApiAuthOptions.oauth(),
     ];

--- a/packages/fx-core/src/question/create.ts
+++ b/packages/fx-core/src/question/create.ts
@@ -951,7 +951,7 @@ export function apiAuthQuestion(): SingleSelectQuestion {
     dynamicOptions: (inputs: Inputs) => {
       const options: OptionItem[] = [ApiAuthOptions.none()];
       if (inputs[QuestionNames.MeArchitectureType] === MeArchitectureOptions.newApi().id) {
-        options.push(ApiAuthOptions.apiKey(), ApiAuthOptions.microsoftEntra());
+        options.push(ApiAuthOptions.bearerToken(), ApiAuthOptions.microsoftEntra());
       } else if (inputs[QuestionNames.ApiPluginType] === ApiPluginStartOptions.newApi().id) {
         options.push(ApiAuthOptions.apiKey());
         if (featureFlagManager.getBooleanValue(FeatureFlags.ApiPluginAAD)) {

--- a/packages/fx-core/src/question/inputs/CreateProjectInputs.ts
+++ b/packages/fx-core/src/question/inputs/CreateProjectInputs.ts
@@ -67,7 +67,7 @@ export interface CreateProjectInputs extends Inputs {
   /** @description Import OpenAPI Description Document */
   "plugin-opeanapi-spec-path"?: string;
   /** @description Authentication Type */
-  "api-auth"?: "none" | "api-key" | "microsoft-entra" | "oauth";
+  "api-auth"?: "none" | "api-key" | "bearer-token" | "microsoft-entra" | "oauth";
   /** @description Chat With Your Data */
   "custom-copilot-rag"?:
     | "custom-copilot-rag-customize"

--- a/packages/fx-core/src/question/options/CreateProjectOptions.ts
+++ b/packages/fx-core/src/question/options/CreateProjectOptions.ts
@@ -137,7 +137,7 @@ export const CreateProjectOptions: CLICommandOption[] = [
     type: "string",
     description: "The authentication type for the API.",
     default: "none",
-    choices: ["none", "api-key", "microsoft-entra", "oauth"],
+    choices: ["none", "api-key", "bearer-token", "microsoft-entra", "oauth"],
   },
   {
     name: "custom-copilot-rag",

--- a/packages/fx-core/tests/component/coordinator/coordinator.create.test.ts
+++ b/packages/fx-core/tests/component/coordinator/coordinator.create.test.ts
@@ -475,7 +475,7 @@ describe("coordinator create", () => {
         [QuestionNames.ProjectType]: ProjectTypeOptions.me().id,
         [QuestionNames.Capabilities]: CapabilityOptions.m365SearchMe().id,
         [QuestionNames.MeArchitectureType]: MeArchitectureOptions.newApi().id,
-        [QuestionNames.ApiAuth]: ApiAuthOptions.apiKey().id,
+        [QuestionNames.ApiAuth]: ApiAuthOptions.bearerToken().id,
         [QuestionNames.AppName]: randomAppName(),
         [QuestionNames.Scratch]: ScratchOptions.yes().id,
       };

--- a/packages/fx-core/tests/question/create.test.ts
+++ b/packages/fx-core/tests/question/create.test.ts
@@ -4085,7 +4085,7 @@ describe("scaffold question", () => {
         const options = (await question.dynamicOptions(inputs)) as OptionItem[];
         assert.deepEqual(options, [
           ApiAuthOptions.none(),
-          ApiAuthOptions.apiKey(),
+          ApiAuthOptions.bearerToken(),
           ApiAuthOptions.microsoftEntra(),
         ]);
       }

--- a/templates/csharp/api-plugin-from-scratch-bearer/Repairs.cs.tpl
+++ b/templates/csharp/api-plugin-from-scratch-bearer/Repairs.cs.tpl
@@ -72,13 +72,13 @@ namespace {{SafeProjectName}}
         {
             // Try to get the value of the 'Authorization' header from the request.
             // If the header is not present, return false.
-            if (!req.Headers.TryGetValues("Authorization", out var authValue))
+            if (!req.Headers.TryGetValues("X-API-Key", out var authValue))
             {
                 return false;
             }
 
             // Get the api key value from the 'Authorization' header.
-            var apiKey = authValue.FirstOrDefault().Replace("Bearer", "").Trim();
+            var apiKey = authValue.FirstOrDefault().Trim();
 
             // Get the API key from the configuration.
             var configApiKey = _configuration["API_KEY"];

--- a/templates/csharp/api-plugin-from-scratch-bearer/appPackage/apiSpecificationFile/repair.yml
+++ b/templates/csharp/api-plugin-from-scratch-bearer/appPackage/apiSpecificationFile/repair.yml
@@ -9,8 +9,9 @@ servers:
 components:
   securitySchemes:
     apiKey:
-      type: http
-      scheme: bearer
+      type: apiKey
+      in: header
+      name: X-API-Key
 paths:
   /repairs:
     get:

--- a/templates/js/api-plugin-from-scratch-bearer/appPackage/apiSpecificationFile/repair.yml
+++ b/templates/js/api-plugin-from-scratch-bearer/appPackage/apiSpecificationFile/repair.yml
@@ -9,8 +9,9 @@ servers:
 components:
   securitySchemes:
     apiKey:
-      type: http
-      scheme: bearer
+      type: apiKey
+      in: header
+      name: X-API-Key
 paths:
   /repairs:
     get:

--- a/templates/js/api-plugin-from-scratch-bearer/src/functions/repair.js
+++ b/templates/js/api-plugin-from-scratch-bearer/src/functions/repair.js
@@ -62,7 +62,7 @@ async function repairs(req, context) {
  * @param req - The HTTP request.
  */
 function isApiKeyValid(req) {
-  const apiKey = req.headers.get("Authorization")?.replace("Bearer ", "").trim();
+  const apiKey = req.headers.get("X-API-Key")?.trim();
   return apiKey === process.env.API_KEY;
 }
 

--- a/templates/ts/api-plugin-from-scratch-bearer/appPackage/apiSpecificationFile/repair.yml
+++ b/templates/ts/api-plugin-from-scratch-bearer/appPackage/apiSpecificationFile/repair.yml
@@ -9,8 +9,9 @@ servers:
 components:
   securitySchemes:
     apiKey:
-      type: http
-      scheme: bearer
+      type: apiKey
+      in: header
+      name: X-API-Key
 paths:
   /repairs:
     get:

--- a/templates/ts/api-plugin-from-scratch-bearer/src/functions/repairs.ts
+++ b/templates/ts/api-plugin-from-scratch-bearer/src/functions/repairs.ts
@@ -66,7 +66,7 @@ export async function repairs(
  * @returns {boolean} - True if the request is authorized, false otherwise.
  */
 function isApiKeyValid(req: HttpRequest): boolean {
-  const apiKey = req.headers.get("Authorization")?.replace("Bearer ", "").trim();
+  const apiKey = req.headers.get("X-API-Key")?.trim();
   return apiKey === process.env.API_KEY;
 }
 


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/30544962

- Removed `Bearer Token Auth` from the API Key authentication option for Declarative Agent.
- Kept `API Key (Bearer Token Auth)` for API ME as it is.
- Updated the API key configurations in Declarative Agent templates.