### PR TITLE
fix: spfx static tab content url

### DIFF
--- a/packages/fx-core/src/component/driver/add/utility/constants.ts
+++ b/packages/fx-core/src/component/driver/add/utility/constants.ts
@@ -5,7 +5,7 @@ export class Constants {
   static readonly ActionName = "spfx/add";
 
   static readonly LOCAL_CONTENT_URL =
-    "https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest=/_layouts/15/teamshostedapp.aspx%3Fteams%26personal%26componentId=%s%26forceLocale={locale}%26loadSPFX%3Dtrue%26debugManifestsFile%3Dhttps%3A%2F%2Flocalhost%3A4321%2Ftemp%2Fmanifests.js";
+    "https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest=/_layouts/15/TeamsWorkBench.aspx%3Fteams%26personal%26componentId=%s%26forceLocale={locale}%26loadSPFX%3Dtrue%26debugManifestsFile%3Dhttps%3A%2F%2Flocalhost%3A4321%2Ftemp%2Fmanifests.js";
   static readonly REMOTE_CONTENT_URL =
     "https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest=/_layouts/15/teamshostedapp.aspx%3Fteams%26personal%26componentId=%s%26forceLocale={locale}";
   static readonly YO_RC_FILE = ".yo-rc.json";

--- a/packages/fx-core/src/component/driver/add/utility/constants.ts
+++ b/packages/fx-core/src/component/driver/add/utility/constants.ts
@@ -5,7 +5,7 @@ export class Constants {
   static readonly ActionName = "spfx/add";
 
   static readonly LOCAL_CONTENT_URL =
-    "https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest={teamSitePath}/_layouts/15/TeamsWorkBench.aspx%3FcomponentId=%s%26teams%26personal%26forceLocale={locale}%26loadSPFX%3Dtrue%26debugManifestsFile%3Dhttps%3A%2F%2Flocalhost%3A4321%2Ftemp%2Fmanifests.js";
+    "https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest=/_layouts/15/teamshostedapp.aspx%3Fteams%26personal%26componentId=%s%26forceLocale={locale}%26loadSPFX%3Dtrue%26debugManifestsFile%3Dhttps%3A%2F%2Flocalhost%3A4321%2Ftemp%2Fmanifests.js";
   static readonly REMOTE_CONTENT_URL =
     "https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest=/_layouts/15/teamshostedapp.aspx%3Fteams%26personal%26componentId=%s%26forceLocale={locale}";
   static readonly YO_RC_FILE = ".yo-rc.json";

--- a/packages/fx-core/src/component/generator/spfx/utils/constants.ts
+++ b/packages/fx-core/src/component/generator/spfx/utils/constants.ts
@@ -46,7 +46,7 @@ export class ScaffoldProgressMessage {
 
 export class ManifestTemplate {
   static readonly LOCAL_CONTENT_URL =
-    "https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest={teamSitePath}/_layouts/15/TeamsWorkBench.aspx%3FcomponentId=%s%26teams%26personal%26forceLocale={locale}%26loadSPFX%3Dtrue%26debugManifestsFile%3Dhttps%3A%2F%2Flocalhost%3A4321%2Ftemp%2Fmanifests.js";
+    "https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest=/_layouts/15/teamshostedapp.aspx%3Fteams%26personal%26componentId=%s%26forceLocale={locale}%26loadSPFX%3Dtrue%26debugManifestsFile%3Dhttps%3A%2F%2Flocalhost%3A4321%2Ftemp%2Fmanifests.js";
   static readonly LOCAL_CONFIGURATION_URL =
     "https://{teamSiteDomain}{teamSitePath}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest={teamSitePath}/_layouts/15/TeamsWorkBench.aspx%3FcomponentId=%s%26openPropertyPane=true%26teams%26forceLocale={locale}%26loadSPFX%3Dtrue%26debugManifestsFile%3Dhttps%3A%2F%2Flocalhost%3A4321%2Ftemp%2Fmanifests.js";
   static readonly REMOTE_CONTENT_URL =

--- a/packages/fx-core/src/component/generator/spfx/utils/constants.ts
+++ b/packages/fx-core/src/component/generator/spfx/utils/constants.ts
@@ -46,7 +46,7 @@ export class ScaffoldProgressMessage {
 
 export class ManifestTemplate {
   static readonly LOCAL_CONTENT_URL =
-    "https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest=/_layouts/15/teamshostedapp.aspx%3Fteams%26personal%26componentId=%s%26forceLocale={locale}%26loadSPFX%3Dtrue%26debugManifestsFile%3Dhttps%3A%2F%2Flocalhost%3A4321%2Ftemp%2Fmanifests.js";
+    "https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest=/_layouts/15/TeamsWorkBench.aspx%3Fteams%26personal%26componentId=%s%26forceLocale={locale}%26loadSPFX%3Dtrue%26debugManifestsFile%3Dhttps%3A%2F%2Flocalhost%3A4321%2Ftemp%2Fmanifests.js";
   static readonly LOCAL_CONFIGURATION_URL =
     "https://{teamSiteDomain}{teamSitePath}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest={teamSitePath}/_layouts/15/TeamsWorkBench.aspx%3FcomponentId=%s%26openPropertyPane=true%26teams%26forceLocale={locale}%26loadSPFX%3Dtrue%26debugManifestsFile%3Dhttps%3A%2F%2Flocalhost%3A4321%2Ftemp%2Fmanifests.js";
   static readonly REMOTE_CONTENT_URL =

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/manifestsHappyPathSpfx/expected/manifest.local.json
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/manifestsHappyPathSpfx/expected/manifest.local.json
@@ -27,7 +27,7 @@
       {
           "entityId": "64f41b18-9e9b-453f-a004-cdafe3b4a5e9",
           "name": "helloworld",
-          "contentUrl": "https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest=/_layouts/15/teamshostedapp.aspx%3Fteams%26personal%26componentId=64f41b18-9e9b-453f-a004-cdafe3b4a5e9%26forceLocale={locale}%26loadSPFX%3Dtrue%26debugManifestsFile%3Dhttps%3A%2F%2Flocalhost%3A4321%2Ftemp%2Fmanifests.js",
+          "contentUrl": "https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest=/_layouts/15/TeamsWorkBench.aspx%3Fteams%26personal%26componentId=64f41b18-9e9b-453f-a004-cdafe3b4a5e9%26forceLocale={locale}%26loadSPFX%3Dtrue%26debugManifestsFile%3Dhttps%3A%2F%2Flocalhost%3A4321%2Ftemp%2Fmanifests.js",
           "websiteUrl": "https://products.office.com/en-us/sharepoint/collaboration",
           "scopes": [
               "personal"

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/manifestsHappyPathSpfx/expected/manifest.local.json
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/manifestsHappyPathSpfx/expected/manifest.local.json
@@ -27,7 +27,7 @@
       {
           "entityId": "64f41b18-9e9b-453f-a004-cdafe3b4a5e9",
           "name": "helloworld",
-          "contentUrl": "https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest={teamSitePath}/_layouts/15/TeamsWorkBench.aspx%3FcomponentId=64f41b18-9e9b-453f-a004-cdafe3b4a5e9%26teams%26personal%26forceLocale={locale}%26loadSPFX%3Dtrue%26debugManifestsFile%3Dhttps%3A%2F%2Flocalhost%3A4321%2Ftemp%2Fmanifests.js",
+          "contentUrl": "https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest=/_layouts/15/teamshostedapp.aspx%3Fteams%26personal%26componentId=64f41b18-9e9b-453f-a004-cdafe3b4a5e9%26forceLocale={locale}%26loadSPFX%3Dtrue%26debugManifestsFile%3Dhttps%3A%2F%2Flocalhost%3A4321%2Ftemp%2Fmanifests.js",
           "websiteUrl": "https://products.office.com/en-us/sharepoint/collaboration",
           "scopes": [
               "personal"

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/manifestsHappyPathSpfx/templates/appPackage/manifest.template.json
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/manifestsHappyPathSpfx/templates/appPackage/manifest.template.json
@@ -27,7 +27,7 @@
       {
           "entityId": "64f41b18-9e9b-453f-a004-cdafe3b4a5e9",
           "name": "helloworld",
-          "contentUrl": "{{^config.isLocalDebug}}https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest=/_layouts/15/teamshostedapp.aspx%3Fteams%26personal%26componentId=64f41b18-9e9b-453f-a004-cdafe3b4a5e9%26forceLocale={locale}{{/config.isLocalDebug}}{{#config.isLocalDebug}}https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest=/_layouts/15/teamshostedapp.aspx%3Fteams%26personal%26componentId=64f41b18-9e9b-453f-a004-cdafe3b4a5e9%26forceLocale={locale}%26loadSPFX%3Dtrue%26debugManifestsFile%3Dhttps%3A%2F%2Flocalhost%3A4321%2Ftemp%2Fmanifests.js{{/config.isLocalDebug}}",
+          "contentUrl": "{{^config.isLocalDebug}}https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest=/_layouts/15/teamshostedapp.aspx%3Fteams%26personal%26componentId=64f41b18-9e9b-453f-a004-cdafe3b4a5e9%26forceLocale={locale}{{/config.isLocalDebug}}{{#config.isLocalDebug}}https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest=/_layouts/15/TeamsWorkBench.aspx%3Fteams%26personal%26componentId=64f41b18-9e9b-453f-a004-cdafe3b4a5e9%26forceLocale={locale}%26loadSPFX%3Dtrue%26debugManifestsFile%3Dhttps%3A%2F%2Flocalhost%3A4321%2Ftemp%2Fmanifests.js{{/config.isLocalDebug}}",
           "websiteUrl": "https://products.office.com/en-us/sharepoint/collaboration",
           "scopes": [
               "personal"

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/manifestsHappyPathSpfx/templates/appPackage/manifest.template.json
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/manifestsHappyPathSpfx/templates/appPackage/manifest.template.json
@@ -27,7 +27,7 @@
       {
           "entityId": "64f41b18-9e9b-453f-a004-cdafe3b4a5e9",
           "name": "helloworld",
-          "contentUrl": "{{^config.isLocalDebug}}https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest=/_layouts/15/teamshostedapp.aspx%3Fteams%26personal%26componentId=64f41b18-9e9b-453f-a004-cdafe3b4a5e9%26forceLocale={locale}{{/config.isLocalDebug}}{{#config.isLocalDebug}}https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest={teamSitePath}/_layouts/15/TeamsWorkBench.aspx%3FcomponentId=64f41b18-9e9b-453f-a004-cdafe3b4a5e9%26teams%26personal%26forceLocale={locale}%26loadSPFX%3Dtrue%26debugManifestsFile%3Dhttps%3A%2F%2Flocalhost%3A4321%2Ftemp%2Fmanifests.js{{/config.isLocalDebug}}",
+          "contentUrl": "{{^config.isLocalDebug}}https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest=/_layouts/15/teamshostedapp.aspx%3Fteams%26personal%26componentId=64f41b18-9e9b-453f-a004-cdafe3b4a5e9%26forceLocale={locale}{{/config.isLocalDebug}}{{#config.isLocalDebug}}https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest=/_layouts/15/teamshostedapp.aspx%3Fteams%26personal%26componentId=64f41b18-9e9b-453f-a004-cdafe3b4a5e9%26forceLocale={locale}%26loadSPFX%3Dtrue%26debugManifestsFile%3Dhttps%3A%2F%2Flocalhost%3A4321%2Ftemp%2Fmanifests.js{{/config.isLocalDebug}}",
           "websiteUrl": "https://products.office.com/en-us/sharepoint/collaboration",
           "scopes": [
               "personal"

--- a/packages/fx-core/tests/plugins/resource/appstudio/spfx-resources/appPackage/manifest.local.template.json
+++ b/packages/fx-core/tests/plugins/resource/appstudio/spfx-resources/appPackage/manifest.local.template.json
@@ -26,7 +26,7 @@
         {
             "entityId": "<%= componentId %>",
             "name": "<%= componentNameUnescaped %>",
-            "contentUrl": "https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest=/_layouts/15/teamshostedapp.aspx%3Fteams%26personal%26componentId=<%= componentId %>%26forceLocale={locale}%26loadSPFX%3Dtrue%26debugManifestsFile%3Dhttps%3A%2F%2Flocalhost%3A4321%2Ftemp%2Fmanifests.jss",
+            "contentUrl": "https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest=/_layouts/15/TeamsWorkBench.aspx%3Fteams%26personal%26componentId=<%= componentId %>%26forceLocale={locale}%26loadSPFX%3Dtrue%26debugManifestsFile%3Dhttps%3A%2F%2Flocalhost%3A4321%2Ftemp%2Fmanifests.jss",
             "websiteUrl": "https://products.office.com/en-us/sharepoint/collaboration",
             "scopes": [
                 "personal"

--- a/packages/fx-core/tests/plugins/resource/appstudio/spfx-resources/appPackage/manifest.local.template.json
+++ b/packages/fx-core/tests/plugins/resource/appstudio/spfx-resources/appPackage/manifest.local.template.json
@@ -26,7 +26,7 @@
         {
             "entityId": "<%= componentId %>",
             "name": "<%= componentNameUnescaped %>",
-            "contentUrl": "https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest={teamSitePath}/_layouts/15/TeamsWorkBench.aspx%3FcomponentId=<%= componentId %>%26teams%26personal%26forceLocale={locale}%26loadSPFX%3Dtrue%26debugManifestsFile%3Dhttps%3A%2F%2Flocalhost%3A4321%2Ftemp%2Fmanifests.js",
+            "contentUrl": "https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest=/_layouts/15/teamshostedapp.aspx%3Fteams%26personal%26componentId=<%= componentId %>%26forceLocale={locale}%26loadSPFX%3Dtrue%26debugManifestsFile%3Dhttps%3A%2F%2Flocalhost%3A4321%2Ftemp%2Fmanifests.jss",
             "websiteUrl": "https://products.office.com/en-us/sharepoint/collaboration",
             "scopes": [
                 "personal"

--- a/packages/fx-core/tests/plugins/resource/appstudio/spfx-resources/appPackage/manifest.local.template.json
+++ b/packages/fx-core/tests/plugins/resource/appstudio/spfx-resources/appPackage/manifest.local.template.json
@@ -26,7 +26,7 @@
         {
             "entityId": "<%= componentId %>",
             "name": "<%= componentNameUnescaped %>",
-            "contentUrl": "https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest=/_layouts/15/TeamsWorkBench.aspx%3Fteams%26personal%26componentId=<%= componentId %>%26forceLocale={locale}%26loadSPFX%3Dtrue%26debugManifestsFile%3Dhttps%3A%2F%2Flocalhost%3A4321%2Ftemp%2Fmanifests.jss",
+            "contentUrl": "https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest=/_layouts/15/TeamsWorkBench.aspx%3Fteams%26personal%26componentId=<%= componentId %>%26forceLocale={locale}%26loadSPFX%3Dtrue%26debugManifestsFile%3Dhttps%3A%2F%2Flocalhost%3A4321%2Ftemp%2Fmanifests.js",
             "websiteUrl": "https://products.office.com/en-us/sharepoint/collaboration",
             "scopes": [
                 "personal"

--- a/packages/fx-core/tests/plugins/resource/appstudio/spfx-resources/appPackage/manifest.template.json
+++ b/packages/fx-core/tests/plugins/resource/appstudio/spfx-resources/appPackage/manifest.template.json
@@ -27,7 +27,7 @@
     {
       "entityId": "<%= componentId %>",
       "name": "<%= componentNameUnescaped %>",
-      "contentUrl": "{{^config.isLocalDebug}}https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest=/_layouts/15/teamshostedapp.aspx%3Fteams%26personal%26componentId=<%= componentId %>%26forceLocale={locale}{{/config.isLocalDebug}}{{#config.isLocalDebug}}https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest={teamSitePath}/_layouts/15/TeamsWorkBench.aspx%3FcomponentId=<%= componentId %>%26teams%26personal%26forceLocale={locale}%26loadSPFX%3Dtrue%26debugManifestsFile%3Dhttps%3A%2F%2Flocalhost%3A4321%2Ftemp%2Fmanifests.js{{/config.isLocalDebug}}",
+      "contentUrl": "{{^config.isLocalDebug}}https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest=/_layouts/15/teamshostedapp.aspx%3Fteams%26personal%26componentId=<%= componentId %>%26forceLocale={locale}{{/config.isLocalDebug}}{{#config.isLocalDebug}}https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest=/_layouts/15/teamshostedapp.aspx%3Fteams%26personal%26componentId=<%= componentId %>%26forceLocale={locale}%26loadSPFX%3Dtrue%26debugManifestsFile%3Dhttps%3A%2F%2Flocalhost%3A4321%2Ftemp%2Fmanifests.js{{/config.isLocalDebug}}",
       "websiteUrl": "https://products.office.com/en-us/sharepoint/collaboration",
       "scopes": ["personal"]
     }

--- a/packages/fx-core/tests/plugins/resource/appstudio/spfx-resources/appPackage/manifest.template.json
+++ b/packages/fx-core/tests/plugins/resource/appstudio/spfx-resources/appPackage/manifest.template.json
@@ -27,7 +27,7 @@
     {
       "entityId": "<%= componentId %>",
       "name": "<%= componentNameUnescaped %>",
-      "contentUrl": "{{^config.isLocalDebug}}https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest=/_layouts/15/teamshostedapp.aspx%3Fteams%26personal%26componentId=<%= componentId %>%26forceLocale={locale}{{/config.isLocalDebug}}{{#config.isLocalDebug}}https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest=/_layouts/15/teamshostedapp.aspx%3Fteams%26personal%26componentId=<%= componentId %>%26forceLocale={locale}%26loadSPFX%3Dtrue%26debugManifestsFile%3Dhttps%3A%2F%2Flocalhost%3A4321%2Ftemp%2Fmanifests.js{{/config.isLocalDebug}}",
+      "contentUrl": "{{^config.isLocalDebug}}https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest=/_layouts/15/teamshostedapp.aspx%3Fteams%26personal%26componentId=<%= componentId %>%26forceLocale={locale}{{/config.isLocalDebug}}{{#config.isLocalDebug}}https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest=/_layouts/15/TeamsWorkBench.aspx%3Fteams%26personal%26componentId=<%= componentId %>%26forceLocale={locale}%26loadSPFX%3Dtrue%26debugManifestsFile%3Dhttps%3A%2F%2Flocalhost%3A4321%2Ftemp%2Fmanifests.js{{/config.isLocalDebug}}",
       "websiteUrl": "https://products.office.com/en-us/sharepoint/collaboration",
       "scopes": ["personal"]
     }

--- a/packages/manifest/test/manifest.json
+++ b/packages/manifest/test/manifest.json
@@ -26,7 +26,7 @@
         {
             "entityId": "ee0ab78d-284e-4275-b720-fc084f80a0a3",
             "name": "helloworld",
-            "contentUrl": "https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest={teamSitePath}/_layouts/15/TeamsWorkBench.aspx%3FcomponentId=ee0ab78d-284e-4275-b720-fc084f80a0a3%26teams%26personal%26forceLocale={locale}%26loadSPFX%3Dtrue%26debugManifestsFile%3Dhttps%3A%2F%2Flocalhost%3A4321%2Ftemp%2Fmanifests.js",
+            "contentUrl": "https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest=/_layouts/15/teamshostedapp.aspx%3Fteams%26personal%26componentId=ee0ab78d-284e-4275-b720-fc084f80a0a3%26forceLocale={locale}%26loadSPFX%3Dtrue%26debugManifestsFile%3Dhttps%3A%2F%2Flocalhost%3A4321%2Ftemp%2Fmanifests.js",
             "websiteUrl": "https://products.office.com/en-us/sharepoint/collaboration",
             "scopes": [
                 "personal"

--- a/packages/manifest/test/manifest.json
+++ b/packages/manifest/test/manifest.json
@@ -26,7 +26,7 @@
         {
             "entityId": "ee0ab78d-284e-4275-b720-fc084f80a0a3",
             "name": "helloworld",
-            "contentUrl": "https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest=/_layouts/15/teamshostedapp.aspx%3Fteams%26personal%26componentId=ee0ab78d-284e-4275-b720-fc084f80a0a3%26forceLocale={locale}%26loadSPFX%3Dtrue%26debugManifestsFile%3Dhttps%3A%2F%2Flocalhost%3A4321%2Ftemp%2Fmanifests.js",
+            "contentUrl": "https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest=/_layouts/15/TeamsWorkBench.aspx%3Fteams%26personal%26componentId=ee0ab78d-284e-4275-b720-fc084f80a0a3%26forceLocale={locale}%26loadSPFX%3Dtrue%26debugManifestsFile%3Dhttps%3A%2F%2Flocalhost%3A4321%2Ftemp%2Fmanifests.js",
             "websiteUrl": "https://products.office.com/en-us/sharepoint/collaboration",
             "scopes": [
                 "personal"

--- a/packages/vscode-extension/.vscode/launch.json
+++ b/packages/vscode-extension/.vscode/launch.json
@@ -13,8 +13,8 @@
       "env": {
         "NODE_ENV": "development",
         "TEAMSFX_SAMPLE_CONFIG_BRANCH": "dev"
-      }
-      //"preLaunchTask": "watch"
+      },
+      "preLaunchTask": "watch"
     },
     {
       "name": "Extension Unit Tests",

--- a/packages/vscode-extension/.vscode/launch.json
+++ b/packages/vscode-extension/.vscode/launch.json
@@ -13,8 +13,8 @@
       "env": {
         "NODE_ENV": "development",
         "TEAMSFX_SAMPLE_CONFIG_BRANCH": "dev"
-      },
-      "preLaunchTask": "watch"
+      }
+      //"preLaunchTask": "watch"
     },
     {
       "name": "Extension Unit Tests",

--- a/templates/ts/spfx-tab/appPackage/manifest.local.json.tpl
+++ b/templates/ts/spfx-tab/appPackage/manifest.local.json.tpl
@@ -26,7 +26,7 @@
         {
             "entityId": "{{componentId}}",
             "name": "{{webpartName}}",
-            "contentUrl": "https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest={teamSitePath}/_layouts/15/TeamsWorkBench.aspx%3FcomponentId={{componentId}}%26teams%26personal%26forceLocale={locale}%26loadSPFX%3Dtrue%26debugManifestsFile%3Dhttps%3A%2F%2Flocalhost%3A4321%2Ftemp%2Fmanifests.js",
+            "contentUrl": "https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest=/_layouts/15/teamshostedapp.aspx%3Fteams%26personal%26componentId={{componentId}}%26forceLocale={locale}%26loadSPFX%3Dtrue%26debugManifestsFile%3Dhttps%3A%2F%2Flocalhost%3A4321%2Ftemp%2Fmanifests.js",
             "websiteUrl": "https://products.office.com/en-us/sharepoint/collaboration",
             "scopes": [
                 "personal"

--- a/templates/ts/spfx-tab/appPackage/manifest.local.json.tpl
+++ b/templates/ts/spfx-tab/appPackage/manifest.local.json.tpl
@@ -26,7 +26,7 @@
         {
             "entityId": "{{componentId}}",
             "name": "{{webpartName}}",
-            "contentUrl": "https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest=/_layouts/15/teamshostedapp.aspx%3Fteams%26personal%26componentId={{componentId}}%26forceLocale={locale}%26loadSPFX%3Dtrue%26debugManifestsFile%3Dhttps%3A%2F%2Flocalhost%3A4321%2Ftemp%2Fmanifests.js",
+            "contentUrl": "https://{teamSiteDomain}/_layouts/15/TeamsLogon.aspx?SPFX=true&dest=/_layouts/15/TeamsWorkBench.aspx%3Fteams%26personal%26componentId={{componentId}}%26forceLocale={locale}%26loadSPFX%3Dtrue%26debugManifestsFile%3Dhttps%3A%2F%2Flocalhost%3A4321%2Ftemp%2Fmanifests.js",
             "websiteUrl": "https://products.office.com/en-us/sharepoint/collaboration",
             "scopes": [
                 "personal"


### PR DESCRIPTION
teams: 
![image](https://github.com/user-attachments/assets/3c9fcf0a-db94-4754-8905-8c4a58d0e453)

outlook:
![image](https://github.com/user-attachments/assets/d5682c24-9e1a-4f00-b240-1eae0ba1a3c9)

365:
![image](https://github.com/user-attachments/assets/06145d0e-9f1d-474d-806c-1440cd8f5b89)


add web part:
![image](https://github.com/user-attachments/assets/86c92b02-ce92-4e61-ab5d-d2bbe898e5f6)

import:
![image](https://github.com/user-attachments/assets/a7427aa7-9d87-4183-9c55-1db089639ddb)


[Bug 30489950](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/30489950): SPFX: local debug for outlook failed with showing error page


