### PR TITLE
fix: local debug launch without error before preparing dependencies i…

### DIFF
--- a/packages/fx-core/src/component/coordinator/index.ts
+++ b/packages/fx-core/src/component/coordinator/index.ts
@@ -365,6 +365,16 @@ class Coordinator {
     if (unresolvedPlaceholders.length > 0) {
       return err(new LifeCycleUndefinedError(unresolvedPlaceholders.join(",")));
     }
+
+    for (const action of projectModel.provision?.driverDefs ?? []) {
+      if (action.uses === "teamsApp/create") {
+        const teamsAppIdKeyName = action.writeToEnvironmentFile?.teamsAppId || "TEAMS_APP_ID";
+        if (!process.env[teamsAppIdKeyName]) {
+          return err(new LifeCycleUndefinedError(unresolvedPlaceholders.join(",")));
+        }
+        break;
+      }
+    }
     return ok(undefined);
   }
 

--- a/packages/fx-core/tests/component/coordinator/coordinator.test.ts
+++ b/packages/fx-core/tests/component/coordinator/coordinator.test.ts
@@ -213,6 +213,62 @@ describe("component coordinator test", () => {
     assert.isTrue(res.isOk());
   });
 
+  it("preCheckYmlAndEnvForVS - happy pass with empty provision actions", async () => {
+    const mockProjectModel: ProjectModel = {
+      version: "1.0.0",
+    };
+    sandbox.stub(metadataUtil, "parse").resolves(ok(mockProjectModel));
+    sandbox.stub(envUtil, "readEnv").resolves(ok({}));
+    sandbox.stub(envUtil, "writeEnv").resolves(ok(undefined));
+    sandbox.stub(pathUtils, "getEnvFilePath").resolves(ok("."));
+    sandbox.stub(fs, "pathExistsSync").returns(true);
+    const inputs: Inputs = {
+      platform: Platform.VSCode,
+      projectPath: ".",
+      env: "local",
+      ignoreLockByUT: true,
+    };
+    const fxCore = new FxCore(tools);
+    const res = await fxCore.preCheckYmlAndEnvForVS(inputs);
+    assert.isTrue(res.isOk());
+  });
+
+  it("preCheckYmlAndEnvForVS - happy pass without teamsApp/create action", async () => {
+    const mockProjectModel: ProjectModel = {
+      version: "1.0.0",
+      provision: {
+        name: "configureApp",
+        driverDefs: [
+          {
+            uses: "botFramework/create",
+            with: undefined,
+          },
+        ],
+        resolvePlaceholders: () => {
+          return [];
+        },
+        execute: async (ctx: DriverContext): Promise<ExecutionResult> => {
+          return { result: ok(new Map()), summaries: [] };
+        },
+        resolveDriverInstances: mockedResolveDriverInstances,
+      },
+    };
+    sandbox.stub(metadataUtil, "parse").resolves(ok(mockProjectModel));
+    sandbox.stub(envUtil, "readEnv").resolves(ok({}));
+    sandbox.stub(envUtil, "writeEnv").resolves(ok(undefined));
+    sandbox.stub(pathUtils, "getEnvFilePath").resolves(ok("."));
+    sandbox.stub(fs, "pathExistsSync").returns(true);
+    const inputs: Inputs = {
+      platform: Platform.VSCode,
+      projectPath: ".",
+      env: "local",
+      ignoreLockByUT: true,
+    };
+    const fxCore = new FxCore(tools);
+    const res = await fxCore.preCheckYmlAndEnvForVS(inputs);
+    assert.isTrue(res.isOk());
+  });
+
   it("fail to get project model in preCheckYmlAndEnvForVS", async () => {
     sandbox.stub(metadataUtil, "parse").resolves(err(new UserError({})));
     sandbox.stub(envUtil, "readEnv").resolves(ok({}));

--- a/packages/fx-core/tests/component/coordinator/coordinator.test.ts
+++ b/packages/fx-core/tests/component/coordinator/coordinator.test.ts
@@ -201,6 +201,7 @@ describe("component coordinator test", () => {
     sandbox.stub(envUtil, "writeEnv").resolves(ok(undefined));
     sandbox.stub(pathUtils, "getEnvFilePath").resolves(ok("."));
     sandbox.stub(fs, "pathExistsSync").returns(true);
+    sandbox.stub(process, "env").value({ TEAMS_APP_ID: "faked_id" });
     const inputs: Inputs = {
       platform: Platform.VSCode,
       projectPath: ".",
@@ -244,6 +245,43 @@ describe("component coordinator test", () => {
         ],
         resolvePlaceholders: () => {
           return ["BotId"];
+        },
+        execute: async (ctx: DriverContext): Promise<ExecutionResult> => {
+          return { result: ok(new Map()), summaries: [] };
+        },
+        resolveDriverInstances: mockedResolveDriverInstances,
+      },
+    };
+    sandbox.stub(metadataUtil, "parse").resolves(ok(mockProjectModel));
+    sandbox.stub(envUtil, "readEnv").resolves(ok({}));
+    sandbox.stub(envUtil, "writeEnv").resolves(ok(undefined));
+    sandbox.stub(pathUtils, "getEnvFilePath").resolves(ok("."));
+    sandbox.stub(fs, "pathExistsSync").returns(true);
+    const inputs: Inputs = {
+      platform: Platform.VSCode,
+      projectPath: ".",
+      env: "local",
+      ignoreLockByUT: true,
+    };
+    const fxCore = new FxCore(tools);
+    const res = await fxCore.preCheckYmlAndEnvForVS(inputs);
+    assert.isTrue(res.isErr());
+  });
+
+  it("empty teams app id in preCheckYmlAndEnvForVS", async () => {
+    const mockProjectModel: ProjectModel = {
+      version: "1.0.0",
+      provision: {
+        name: "configureApp",
+        driverDefs: [
+          {
+            uses: "teamsApp/create",
+            with: undefined,
+            writeToEnvironmentFile: { teamsAppId: "CUSTOMIZED_TEAMS_APP_ID" },
+          },
+        ],
+        resolvePlaceholders: () => {
+          return [];
         },
         execute: async (ctx: DriverContext): Promise<ExecutionResult> => {
           return { result: ok(new Map()), summaries: [] };


### PR DESCRIPTION
…n vs for non-sso tab

Ensure teams app id exists before VS local debug

ADO:
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/30763931