### PR TITLE
fix: ensure schema version is updated with YAML version

### DIFF
--- a/packages/fx-core/src/component/driver/aad/utility/aadManifestHelper.ts
+++ b/packages/fx-core/src/component/driver/aad/utility/aadManifestHelper.ts
@@ -403,8 +403,13 @@ export class AadManifestHelper {
         const version = document.get("version") as string;
         if (version <= "v1.7") {
           document.set("version", "v1.8");
+          const docContent = document.toString();
+          const updatedContent = docContent.replace(
+            /(yaml-language-server:\s*\$schema=https:\/\/aka\.ms\/teams-toolkit\/)v\d+\.\d+(\/yaml\.schema\.json)/,
+            "$1v1.8$2"
+          );
+          await fs.writeFile(ymlPath, updatedContent, "utf8");
         }
-        await fs.writeFile(ymlPath, document.toString(), "utf8");
       }
     }
   }

--- a/packages/fx-core/tests/component/driver/aad/aadManifestHelper.test.ts
+++ b/packages/fx-core/tests/component/driver/aad/aadManifestHelper.test.ts
@@ -120,6 +120,26 @@ describe("Microsoft Entra manifest helper Test", () => {
     chai.assert.isTrue(writtenContent.includes(expectedTeamsAppYaml));
   });
 
+  it("updateVersionForTeamsAppYamlFile should works fine when yaml contains schema url", async () => {
+    const teamsAppYaml = `# yaml-language-server: $schema=https://aka.ms/teams-toolkit/v1.7/yaml.schema.json
+# Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
+# Visit https://aka.ms/teamsfx-actions for details on actions
+version: v1.7`;
+    const expectedTeamsAppYaml = `# yaml-language-server: $schema=https://aka.ms/teams-toolkit/v1.8/yaml.schema.json
+# Visit https://aka.ms/teamsfx-v5.0-guide for details on this file
+# Visit https://aka.ms/teamsfx-actions for details on actions
+version: v1.8`;
+
+    sinon.stub(fs, "pathExists").resolves(true);
+    sinon.stub(fs, "readFile").resolves(teamsAppYaml as any);
+    const writeFileStub = sinon.stub(fs, "writeFile");
+
+    await AadManifestHelper.updateVersionForTeamsAppYamlFile("fake-project-path");
+
+    const writtenContent = writeFileStub.getCall(0).args[1];
+    chai.assert.isTrue(writtenContent.includes(expectedTeamsAppYaml));
+  });
+
   it("processRequiredResourceAccessInManifest with id", async () => {
     const manifestWithId: any = {
       requiredResourceAccess: [


### PR DESCRIPTION
[Bug 30782627](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/30782627): After update yaml file version, the schema version comment should also update