### PR TITLE
fix: update plugin name to agent in readme

### DIFF
--- a/templates/js/api-plugin-from-scratch-bearer/README.md.tpl
+++ b/templates/js/api-plugin-from-scratch-bearer/README.md.tpl
@@ -88,7 +88,7 @@ The following files can be customized and demonstrate an example implementation 
 | `src/repairsData.json`                       | The data source for the repair API.                                                               |
 | `src/keyGen.js`                              | Designed to generate a API key used for authorization.                                            |
 | `appPackage/apiSpecificationFile/repair.yml` | A file that describes the structure and behavior of the repair API.                               |
-| `appPackage/manifest.json`                   | Teams application manifest that defines metadata for your plugin inside Microsoft Teams.          |
+| `appPackage/manifest.json`                   | Teams application manifest that defines metadata for your agent inside Microsoft Teams.          |
 | `appPackage/ai-plugin.json`                  | The manifest file for your API Plugin that contains information for your API and used by LLM. |
 {{#DeclarativeCopilot}}
 | `appPackage/repairDeclarativeAgent.json` | Define the behaviour and configurations of the declarative agent. |

--- a/templates/js/api-plugin-from-scratch-oauth/README.md.tpl
+++ b/templates/js/api-plugin-from-scratch-oauth/README.md.tpl
@@ -74,7 +74,7 @@ The following files can be customized and demonstrate an example implementation 
 | `src/functions/middleware/config.js`            | Configuration file that exports Microsoft Entra app settings from environment variables.                                      |
 | `src/repairsData.json`                          | The data source for the repair API.                                                                                           |
 | `appPackage/apiSpecificationFile/repairs.yml`    | A file that describes the structure and behavior of the repair API.                                                           |
-| `appPackage/manifest.json`                      | Teams application manifest that defines metadata for your plugin inside Microsoft Teams.                                      |
+| `appPackage/manifest.json`                      | Teams application manifest that defines metadata for your agent inside Microsoft Teams.                                      |
 | `appPackage/ai-plugin.json`                     | The manifest file for your API Plugin that contains information for your API and used by LLM.                                 |
 {{#DeclarativeCopilot}}
 | `appPackage/repairDeclarativeAgent.json`        | Define the behaviour and configurations of the declarative agent.                                                             |

--- a/templates/js/api-plugin-from-scratch/README.md.tpl
+++ b/templates/js/api-plugin-from-scratch/README.md.tpl
@@ -70,7 +70,7 @@ The following files can be customized and demonstrate an example implementation 
 | `src/functions/repairs.js`                   | The main file of a function in Azure Functions.                                                   |
 | `src/repairsData.json`                       | The data source for the repair API.                                                               |
 | `appPackage/apiSpecificationFile/repair.yml` | A file that describes the structure and behavior of the repair API.                               |
-| `appPackage/manifest.json`                   | Teams application manifest that defines metadata for your plugin inside Microsoft Teams.          |
+| `appPackage/manifest.json`                   | Teams application manifest that defines metadata for your agent inside Microsoft Teams.          |
 | `appPackage/ai-plugin.json`                  | The manifest file for your API Plugin that contains information for your API and used by LLM. |
 {{#DeclarativeCopilot}}
 | `appPackage/repairDeclarativeAgent.json` | Define the behaviour and configurations of the declarative agent. |

--- a/templates/ts/api-plugin-from-scratch-bearer/README.md.tpl
+++ b/templates/ts/api-plugin-from-scratch-bearer/README.md.tpl
@@ -88,7 +88,7 @@ The following files can be customized and demonstrate an example implementation 
 | `src/repairsData.json`                       | The data source for the repair API.                                                               |
 | `src/keyGen.ts`                              | Designed to generate a API key used for authorization.                                            |
 | `appPackage/apiSpecificationFile/repair.yml` | A file that describes the structure and behavior of the repair API.                               |
-| `appPackage/manifest.json`                   | Teams application manifest that defines metadata for your plugin inside Microsoft Teams.          |
+| `appPackage/manifest.json`                   | Teams application manifest that defines metadata for your agent inside Microsoft Teams.          |
 | `appPackage/ai-plugin.json`                  | The manifest file for your API plugin that contains information for your API and used by LLM. |
 {{#DeclarativeCopilot}}
 | `appPackage/repairDeclarativeAgent.json` | Define the behaviour and configurations of the declarative agent. |

--- a/templates/ts/api-plugin-from-scratch-oauth/README.md.tpl
+++ b/templates/ts/api-plugin-from-scratch-oauth/README.md.tpl
@@ -74,7 +74,7 @@ The following files can be customized and demonstrate an example implementation 
 | `src/functions/middleware/config.ts`            | Configuration file that exports Microsoft Entra app settings from environment variables.                                     |
 | `src/repairsData.json`                          | The data source for the repair API.                                                                                          |
 | `appPackage/apiSpecificationFile/repair.yml`    | A file that describes the structure and behavior of the repair API.                                                          |
-| `appPackage/manifest.json`                      | Teams application manifest that defines metadata for your plugin inside Microsoft Teams.                                     |
+| `appPackage/manifest.json`                      | Teams application manifest that defines metadata for your agent inside Microsoft Teams.                                     |
 | `appPackage/ai-plugin.json`                     | The manifest file for your API plugin that contains information for your API and used by LLM.                                |
 {{#DeclarativeCopilot}}
 | `appPackage/repairDeclarativeAgent.json` | Define the behaviour and configurations of the declarative agent. |

--- a/templates/ts/api-plugin-from-scratch/README.md.tpl
+++ b/templates/ts/api-plugin-from-scratch/README.md.tpl
@@ -69,7 +69,7 @@ The following files can be customized and demonstrate an example implementation 
 | `src/functions/repairs.ts`                   | The main file of a function in Azure Functions.                                                   |
 | `src/repairsData.json`                       | The data source for the repair API.                                                               |
 | `appPackage/apiSpecificationFile/repair.yml` | A file that describes the structure and behavior of the repair API.                               |
-| `appPackage/manifest.json`                   | Teams application manifest that defines metadata for your plugin inside Microsoft Teams.          |
+| `appPackage/manifest.json`                   | Teams application manifest that defines metadata for your agent inside Microsoft Teams.          |
 | `appPackage/ai-plugin.json`                  | The manifest file for your API Plugin that contains information for your API and used by LLM. |
 {{#DeclarativeCopilot}}
 | `appPackage/repairDeclarativeAgent.json` | Define the behaviour and configurations of the declarative agent. |


### PR DESCRIPTION
Minor change to fix the terminology in the README files to use agent instead of plugin.