### PR TITLE
refactor: Proposed refactoring of API Plugin from Scratch with OAuth

### DIFF
--- a/templates/ts/api-plugin-from-scratch-oauth/src/functions/middleware/authMiddleware.ts
+++ b/templates/ts/api-plugin-from-scratch-oauth/src/functions/middleware/authMiddleware.ts
@@ -11,7 +11,11 @@ export { EntraJwtPayload } from "./tokenValidator";
  * Middleware function to handle authorization using JWT.
  *
  * @param {HttpRequest} req - The HTTP request.
- * @returns {Promise<EntraJwtPayload | false>} - A promise that resolves to an array of JWT claims or false if authentication failed
+ * @param {string | [string]} scope - The required scope(s) for the request.
+ * @param {string[]} allowedTenants - The allowed tenant IDs for the request.
+ * @param {CloudType} cloud - The Microsoft Entra cloud type.
+ * @param {string} issuer - The JWT issuer.
+ * @returns {Promise<EntraJwtPayload | false>} - A promise that resolves to an object containing JWT claims or false if authentication failed
  */
 export async function authMiddleware(req: HttpRequest,
                                      scope: string | [string],

--- a/templates/ts/api-plugin-from-scratch-oauth/src/functions/middleware/tokenValidator.ts
+++ b/templates/ts/api-plugin-from-scratch-oauth/src/functions/middleware/tokenValidator.ts
@@ -27,6 +27,10 @@ export interface EntraJwtPayload extends JwtPayload {
   roles?: string[];
   scp?: string[];
   ver?: string;
+  name?: string;
+  oid?: string;
+  preferred_username?: string;
+  tid?: string;
 }
 
 export class TokenValidator {

--- a/templates/ts/api-plugin-from-scratch-oauth/src/functions/repairs.ts
+++ b/templates/ts/api-plugin-from-scratch-oauth/src/functions/repairs.ts
@@ -6,7 +6,7 @@
 import { app, HttpRequest, HttpResponseInit, InvocationContext } from "@azure/functions";
 
 import repairRecords from "../repairsData.json";
-import { authMiddleware } from "./middleware/authMiddleware";
+import { authMiddleware, EntraJwtPayload } from "./middleware/authMiddleware";
 
 /**
  * This function handles the HTTP request and returns the repair information.
@@ -55,13 +55,15 @@ app.http("repairs", {
   authLevel: "anonymous",
   handler: async (req: HttpRequest, context: InvocationContext) => {
     // Check if the request is authenticated
-    const isAuthenticated = await authMiddleware(req);
-    if (!isAuthenticated) {
+    const entraIdClaims = await authMiddleware(req, "repairs_read");
+    if (!entraIdClaims) {
       return {
         status: 401,
         body: "Unauthorized",
       };
     }
+    console.log(`Authenticated ${req.method} request for ${entraIdClaims.name} (${entraIdClaims.oid})`);
+
     // Call the actual handler function
     return repairs(req, context);
   },

--- a/templates/ts/api-plugin-from-scratch-oauth/src/functions/repairs.ts
+++ b/templates/ts/api-plugin-from-scratch-oauth/src/functions/repairs.ts
@@ -6,7 +6,7 @@
 import { app, HttpRequest, HttpResponseInit, InvocationContext } from "@azure/functions";
 
 import repairRecords from "../repairsData.json";
-import { authMiddleware, EntraJwtPayload } from "./middleware/authMiddleware";
+import { authMiddleware } from "./middleware/authMiddleware";
 
 /**
  * This function handles the HTTP request and returns the repair information.


### PR DESCRIPTION
## Proposed changes to TTK Scaffolding for Declarative Agent with OAuth

The currently generated code requires modifying the middleware to meet application needs; this is not ideal because:

    * it causes the developer to do extra work to understand and modify the middleware
    * it will cause the middleware to vary between projects
    * it will make it harder to replace the middleware with a supported token validation library in the future

These changes are proposed to better separate the API code (Azure functions) from the "middleware".
**It was my intent not to change the logic or default settings at all** - these changes should only rearrange things to make it less necessary for agent developers to modify the middleware.

IF accepted, I will submit a similar PR for the JavaScript version.

## Summary of changes

1. Instead of hard-coding, pass arguments to the authMiddleware function for things that are likely to vary in different apps. The default values for optional arguments will be the same as the current hard-coded values, which are indeed the most commonly needed.

    a. scope (mandatory) - the authorization scope, currently hard coded to "repairs_read". The proposed argument supports either a single scope (string) or an array of scopes ([string]) since some apps will support many scopes for different permissions.

    b. allowedTenants (optional) - an array of tenant IDs that are authorized to use the app

    c. cloudType (optional) - the cloud type which is used to retrieve the correct JWKS URI to handle common, government, and national clouds

    d. issuer (optional) - the issuer, which will vary for multi-tenant apps and different clouds

2. Return claims from authMiddleware so the API can access the user ID, name, upn, tenant ID, etc. that are commonly used to organize data for each user and/or tenant

3. Other changes:

    a. Made the req argument on authMiddleWare mandatory; it was optional but the code would fail if it wasn't specified

    b. Expose the CloudType enum and EntraJwtPayload interface from authMiddlweare.ts so developers don't take dependencies on the libry functions, which may change

    c. Added commonly needed claims such as name and oid to the EntraJwtPayload interface in tokenValidator.ts

Thanks!
