### PR TITLE
fix: remove bot-plugin option from message extension templates

### DIFF
--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -295,7 +295,6 @@
   "core.createProjectQuestion.option.description.preview": "Preview",
   "core.createProjectQuestion.option.description.worksInOutlook": "Works in Teams and Outlook",
   "core.createProjectQuestion.option.description.worksInOutlookM365": "Works in Teams, Outlook, and the Microsoft 365 application",
-  "core.createProjectQuestion.option.description.worksInOutlookCopilot": "Works in Teams, Outlook and Copilot",
   "core.createProjectQuestion.projectType.bot.detail": "Create instant, engaging chat experiences that automate tasks seamlessly",
   "core.createProjectQuestion.projectType.bot.label": "Bot",
   "core.createProjectQuestion.projectType.bot.title": "App Features Using a Bot",

--- a/packages/fx-core/src/component/generator/templates/templateNames.ts
+++ b/packages/fx-core/src/component/generator/templates/templateNames.ts
@@ -33,7 +33,6 @@ export enum TemplateNames {
   MessageExtension = "message-extension",
   MessageExtensionAction = "message-extension-action",
   MessageExtensionSearch = "message-extension-search",
-  MessageExtensionCopilot = "message-extension-copilot",
   M365MessageExtension = "m365-message-extension",
   TabAndDefaultBot = "non-sso-tab-default-bot",
   BotAndMessageExtension = "default-bot-message-extension",
@@ -85,8 +84,6 @@ export const Feature2TemplateName = {
   [`${CapabilityOptions.me().id}:undefined`]: TemplateNames.MessageExtension,
   [`${CapabilityOptions.collectFormMe().id}:undefined`]: TemplateNames.MessageExtensionAction,
   [`${CapabilityOptions.SearchMe().id}:undefined`]: TemplateNames.MessageExtensionSearch,
-  [`${CapabilityOptions.m365SearchMe().id}:undefined:${MeArchitectureOptions.botPlugin().id}`]:
-    TemplateNames.MessageExtensionCopilot,
   [`${CapabilityOptions.m365SearchMe().id}:undefined:${MeArchitectureOptions.botMe().id}`]:
     TemplateNames.M365MessageExtension,
   [`${CapabilityOptions.nonSsoTabAndBot().id}:undefined`]: TemplateNames.TabAndDefaultBot,
@@ -203,13 +200,6 @@ export const inputsToTemplateName: Map<{ [key: string]: any }, TemplateNames> = 
   [
     { [QuestionNames.Capabilities]: CapabilityOptions.SearchMe().id },
     TemplateNames.MessageExtensionSearch,
-  ],
-  [
-    {
-      [QuestionNames.Capabilities]: CapabilityOptions.m365SearchMe().id,
-      [QuestionNames.MeArchitectureType]: MeArchitectureOptions.botPlugin().id,
-    },
-    TemplateNames.MessageExtensionCopilot,
   ],
   [
     {

--- a/packages/fx-core/src/question/constants.ts
+++ b/packages/fx-core/src/question/constants.ts
@@ -835,19 +835,6 @@ export class MeArchitectureOptions {
     };
   }
 
-  static botPlugin(): OptionItem {
-    return {
-      id: "bot-plugin",
-      label: getLocalizedString("core.createProjectQuestion.capability.botMessageExtension.label"),
-      detail: getLocalizedString(
-        "core.createProjectQuestion.capability.botMessageExtension.detail"
-      ),
-      description: getLocalizedString(
-        "core.createProjectQuestion.option.description.worksInOutlookCopilot"
-      ),
-    };
-  }
-
   static newApi(): OptionItem {
     return {
       id: "new-api",
@@ -876,7 +863,7 @@ export class MeArchitectureOptions {
     return [
       MeArchitectureOptions.newApi(),
       MeArchitectureOptions.apiSpec(),
-      MeArchitectureOptions.botPlugin(),
+      MeArchitectureOptions.botMe(),
     ];
   }
 
@@ -884,7 +871,6 @@ export class MeArchitectureOptions {
     return [
       MeArchitectureOptions.newApi(),
       MeArchitectureOptions.apiSpec(),
-      MeArchitectureOptions.botPlugin(),
       MeArchitectureOptions.botMe(),
     ];
   }

--- a/packages/fx-core/src/question/inputs/CreateProjectInputs.ts
+++ b/packages/fx-core/src/question/inputs/CreateProjectInputs.ts
@@ -57,7 +57,7 @@ export interface CreateProjectInputs extends Inputs {
   /** @description SPFx solution folder */
   "spfx-folder"?: string;
   /** @description Architecture of Search Based Message Extension */
-  "me-architecture"?: "new-api" | "api-spec" | "bot-plugin" | "bot";
+  "me-architecture"?: "new-api" | "api-spec" | "bot";
   /** @description Create Declarative Agent */
   "with-plugin"?: "no" | "yes";
   /** @description Create API Plugin */

--- a/packages/fx-core/src/question/options/CreateProjectOptions.ts
+++ b/packages/fx-core/src/question/options/CreateProjectOptions.ts
@@ -106,7 +106,7 @@ export const CreateProjectOptions: CLICommandOption[] = [
     shortName: "m",
     description: "Architecture of Search Based Message Extension.",
     default: "new-api",
-    choices: ["new-api", "api-spec", "bot-plugin", "bot"],
+    choices: ["new-api", "api-spec", "bot"],
   },
   {
     name: "with-plugin",

--- a/packages/fx-core/tests/question/create.test.ts
+++ b/packages/fx-core/tests/question/create.test.ts
@@ -3932,7 +3932,7 @@ describe("scaffold question", () => {
           const select = question as SingleSelectQuestion;
           const options = await select.dynamicOptions!(inputs);
           assert.isTrue(options.length === 3);
-          return ok({ type: "success", result: MeArchitectureOptions.botPlugin().id });
+          return ok({ type: "success", result: MeArchitectureOptions.botMe().id });
         } else if (question.name === QuestionNames.ProgrammingLanguage) {
           const select = question as SingleSelectQuestion;
           const options = await select.dynamicOptions!(inputs);


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/30668746
Remove the Bot-ME template option. The Bot-based message extension is no longer recommended for use as a Copilot extension.