### PR TITLE
feat: upgrade vscode api to 1.93

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -21,7 +21,7 @@
     ]
   },
   "engines": {
-    "vscode": "^1.66.0"
+    "vscode": "^1.93.0"
   },
   "license": "MIT",
   "keywords": [
@@ -1801,7 +1801,7 @@
     "@types/tmp": "^0.2.0",
     "@types/uuid": "^8.3.0",
     "@types/validator": "^13.1.1",
-    "@types/vscode": "^1.66.0",
+    "@types/vscode": "^1.93.0",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
     "@vitejs/plugin-react": "^4.3.1",

--- a/packages/vscode-extension/pnpm-lock.yaml
+++ b/packages/vscode-extension/pnpm-lock.yaml
@@ -221,8 +221,8 @@ devDependencies:
     specifier: ^13.1.1
     version: 13.1.1
   '@types/vscode':
-    specifier: ^1.66.0
-    version: 1.66.0
+    specifier: ^1.93.0
+    version: 1.93.0
   '@typescript-eslint/eslint-plugin':
     specifier: ^5.0.0
     version: 5.0.0(@typescript-eslint/parser@5.0.0)(eslint@8.1.0)(typescript@4.7.4)
@@ -3414,8 +3414,8 @@ packages:
     resolution: {integrity: sha512-/39uXOKe1KV4ElXb8cp0RVyeRn9X1QRwllComMMql+FQ9nhmTx0Yhw+kJtccPSShsjma+KXjW/TiXyGUNqNn+w==}
     dev: true
 
-  /@types/vscode@1.66.0:
-    resolution: {integrity: sha512-ZfJck4M7nrGasfs4A4YbUoxis3Vu24cETw3DERsNYtDZmYSYtk6ljKexKFKhImO/ZmY6ZMsmegu2FPkXoUFImA==}
+  /@types/vscode@1.93.0:
+    resolution: {integrity: sha512-kUK6jAHSR5zY8ps42xuW89NLcBpw1kOabah7yv38J8MyiYuOHxLQBi0e7zeXbQgVefDy/mZZetqEFC+Fl5eIEQ==}
     dev: true
 
   /@types/which@2.0.2:

--- a/packages/vscode-extension/test/handlers/officeDevHandler.test.ts
+++ b/packages/vscode-extension/test/handlers/officeDevHandler.test.ts
@@ -237,6 +237,7 @@ describe("OfficeDevTerminal", () => {
 });
 
 class TerminalStub implements vscode.Terminal {
+  shellIntegration: vscode.TerminalShellIntegration | undefined;
   name!: string;
   processId!: Thenable<number | undefined>;
   creationOptions!: Readonly<vscode.TerminalOptions | vscode.ExtensionTerminalOptions>;


### PR DESCRIPTION
- Upgrade to 1.93 (introduced in 2024.8) to use https://code.visualstudio.com/updates/v1_93#_authentication-account-api later