### PR TITLE
fix: avoid debug event for DA projects

### DIFF
--- a/packages/fx-core/src/component/driver/file/createOrUpdateEnvironmentFile.ts
+++ b/packages/fx-core/src/component/driver/file/createOrUpdateEnvironmentFile.ts
@@ -129,7 +129,7 @@ export class CreateOrUpdateEnvironmentFileDriver implements StepDriver {
     args: GenerateEnvArgs,
     envOutput: Map<string, string>
   ): Promise<Result<Void, FxError>> {
-    const placeHolderReg = /\${{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*}}/g;
+    const placeHolderReg = /\${{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*}}/;
     if (args.envs[OpenAIEnvironmentVariables.AZURE_OPENAI_API_KEY]) {
       const matches = placeHolderReg.exec(
         args.envs[OpenAIEnvironmentVariables.AZURE_OPENAI_API_KEY]

--- a/packages/vscode-extension/src/debug/teamsfxDebugProvider.ts
+++ b/packages/vscode-extension/src/debug/teamsfxDebugProvider.ts
@@ -109,7 +109,8 @@ export class TeamsfxDebugProvider implements vscode.DebugConfigurationProvider {
 
       const isLocal =
         (env && !environmentNameManager.isRemoteEnvironment(env)) ||
-        !debugConfiguration.name.startsWith("Launch Remote");
+        (!debugConfiguration.name.startsWith("Launch Remote") &&
+          !debugConfiguration.name.startsWith("Preview in Copilot"));
       telemetryIsRemote = !isLocal;
 
       // Put env and hub in `debugConfiguration` so debug handlers can retrieve it and send telemetry
@@ -207,7 +208,9 @@ export class TeamsfxDebugProvider implements vscode.DebugConfigurationProvider {
       await vscode.debug.stopDebugging();
       // not for undefined
       if (telemetryIsRemote === false) {
-        await sendDebugAllEvent(error);
+        await sendDebugAllEvent(error, {
+          [TelemetryProperty.DebugConfigName]: debugConfiguration.name,
+        });
       }
       endLocalDebugSession();
     }


### PR DESCRIPTION
1) Fix the issue: As DA project doesn't have placeholders, it won't pop up select env. And the name doesn't begin with "Launch remote", so it's treated as local env. Then the failure debug-all events will be sent out. 
Example launch.json
```
 {
            "name": "Preview in Copilot (Edge)",
            "type": "msedge",
            "request": "launch",
            "url": "https://m365.cloud.microsoft/chat/entity1-d870f6cd-4aa5-4d42-9626-ab690c041429/${agent-hint}?auth=2&developerMode=Basic",
            "presentation": {
                "group": "remote",
                "order": 1
            },
            "internalConsoleOptions": "neverOpen",
            "runtimeArgs": [
                "--remote-debugging-port=9222",
                "--no-first-run",
                "--user-data-dir=${env:TEMP}/copilot-msedge-user-data-dir"
            ]
        }
```

2) Add telemetry property debug-config-name for later investigation:
```
[2025-02-10T14:43:48.807] [DEBUG] TelemTest - debug-all {
  success: 'no',
  'debug-config-name': 'Test Launch Remote in Teams (Edge)',
  'debug-prelaunch-task-info': '{"Start Teams App Locally":[{"label":"Validate prerequisites","type":"teamsfx","command":"debug-check-prerequisites"},{"label":"Start local tunnel","type":"teamsfx","command":"debug-start-local-tunnel"},{"label":"Provision","type":"teamsfx","command":"provision"},{"label":"Deploy","type":"teamsfx","command":"deploy"},{"label":"Start application","type":"<unknown>","command":"npm run dev:teamsfx"}],"Start Teams App (Test Tool)":[{"label":"Validate prerequisites (Test Tool)","type":"teamsfx","command":"debug-check-prerequisites"},{"label":"Deploy (Test Tool)","type":"teamsfx","command":"deploy"},{"label":"<unknown>","type":"<unknown>","command":"npm run dev:teamsfx:testtool"},{"label":"Start Test Tool","type":"<unknown>","command":"npm run dev:teamsfx:launch-testtool"}]}',
}
```

3) Remove global flag from regular expression, to avoid matching error. When the global flag is used, exec() method maintains a state about the last index it matched.