### PR TITLE
fix: remove unused suggestion prompt for custom engine agent

### DIFF
--- a/packages/fx-core/src/component/generator/apiSpec/helper.ts
+++ b/packages/fx-core/src/component/generator/apiSpec/helper.ts
@@ -1611,14 +1611,6 @@ async function updatePromptSuggestions(specItems: SpecObject[], manifestPath: st
       {
         scopes: ["personal"],
         commands: [
-          {
-            title: "Hello, how can you help me?",
-            description: "How can you help me?",
-          },
-          {
-            title: "How to build apps with TTK?",
-            description: "How can I develop apps with Teams Toolkit?",
-          },
           ...descriptions.map((des) => {
             return {
               title: des.slice(0, 32),

--- a/packages/fx-core/tests/component/generator/apiSpecGenerator.test.ts
+++ b/packages/fx-core/tests/component/generator/apiSpecGenerator.test.ts
@@ -926,15 +926,9 @@ describe("updateForCustomApi", async () => {
       .callsFake(async (updatedManifest, manifestPath) => {
         expect(manifestPath.replace(/\\/g, "/")).to.be.equal("path/appPackage/manifest.json");
         expect(updatedManifest.bots![0].commandLists![0].commands[0].title).to.be.equal(
-          "Hello, how can you help me?"
-        );
-        expect(updatedManifest.bots![0].commandLists![0].commands[1].title).to.be.equal(
-          "How to build apps with TTK?"
-        );
-        expect(updatedManifest.bots![0].commandLists![0].commands[2].title).to.be.equal(
           "Returns a greeting"
         );
-        expect(updatedManifest.bots![0].commandLists![0].commands[3].title).to.be.equal(
+        expect(updatedManifest.bots![0].commandLists![0].commands[1].title).to.be.equal(
           "Create a pet"
         );
         return ok(undefined);


### PR DESCRIPTION
[Bug 31299606](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/31299606): [VSC Daily][CEA Enable]prompt suggestions for bot command returns empty result for Custom Copilot Rag Custom Api