### PR TITLE
fix: not show error when creating DA with Kiota enabled

### DIFF
--- a/packages/vscode-extension/src/handlers/createDeclarativeAgentWithApiSpecHandler.ts
+++ b/packages/vscode-extension/src/handlers/createDeclarativeAgentWithApiSpecHandler.ts
@@ -29,6 +29,7 @@ import {
   TelemetrySuccess,
 } from "../telemetry/extTelemetryEvents";
 import { localize } from "../utils/localizeUtils";
+import { createNewProjectHandler } from "./lifecycleHandlers";
 
 export async function createDeclarativeAgentWithApiSpec(
   args?: any[]
@@ -56,7 +57,7 @@ export async function createDeclarativeAgentWithApiSpec(
   inputs[QuestionNames.WithPlugin] = "yes";
   inputs[QuestionNames.ProjectType] = ProjectTypeOptions.Agent().id;
 
-  const result = await runCommand(Stage.create, inputs);
+  const result = await createNewProjectHandler("", inputs);
 
   if (result.isErr()) {
     ExtTelemetry.sendTelemetryErrorEvent(
@@ -66,9 +67,6 @@ export async function createDeclarativeAgentWithApiSpec(
     return err(result.error);
   }
 
-  const res = result.value as CreateProjectResult;
-  const projectPathUri = vscode.Uri.file(res.projectPath);
-  await openFolder(projectPathUri, true, res.warnings);
   ExtTelemetry.sendTelemetryEvent(TelemetryEvent.CreateDeclarativeAgentWithApiSpec, {
     [TelemetryProperty.Success]: TelemetrySuccess.Yes,
   });

--- a/packages/vscode-extension/src/handlers/lifecycleHandlers.ts
+++ b/packages/vscode-extension/src/handlers/lifecycleHandlers.ts
@@ -54,7 +54,7 @@ export async function createNewProjectHandler(...args: any[]): Promise<Result<an
       inputs.teamsAppFromTdp = args[0].teamsAppFromTdp;
     }
   } else if (args?.length === 2) {
-    // from copilot chat
+    // from copilot chat or createDeclarativeAgentWithApiSpec
     inputs = { ...getSystemInputs(), ...args[1] };
   }
   const result = await runCommand(Stage.create, inputs);


### PR DESCRIPTION
Fix https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/31367677

Demo: https://microsoftapc-my.sharepoint.com/:v:/g/personal/junhan_microsoft_com1/EelQzXJ-HD1JrdCfd18C8yoBThBj_tjFZN28ysZXOq7CrA?e=M0nhWw

Limitation: When Kiota is enabled, user stills need to select an OpenAPI spec manually

TODO: Let Kiota VS Code Command API to respepct the file path of OpenAPI spec