### PR TITLE
fix: parse access token to get tenant id

### DIFF
--- a/packages/vscode-extension/src/commonlib/azureLogin.ts
+++ b/packages/vscode-extension/src/commonlib/azureLogin.ts
@@ -19,7 +19,7 @@ import {
   err,
 } from "@microsoft/teamsfx-api";
 import { ExtensionErrors } from "../error/error";
-import { LoginFailureError } from "./codeFlowLogin";
+import { ConvertTokenToJson, LoginFailureError } from "./codeFlowLogin";
 import * as vscode from "vscode";
 import {
   azureCacheName,
@@ -154,7 +154,7 @@ export class AzureAccountManager extends login implements AzureAccountProvider {
             }
           });
       }
-      await saveTenantId(azureCacheName, session.id.split("/")[0]);
+      await saveTenantId(azureCacheName, (ConvertTokenToJson(session.accessToken) as any).tid);
 
       const credential: TokenCredential = {
         // eslint-disable-next-line @typescript-eslint/require-await


### PR DESCRIPTION
This is part of fix for https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/31380242. The `session.id` format is different for classic & msal Microsoft-authentication setting. Hence get tid from access token instead of session.id.