### PR TITLE
perf(spec-parser): update separate ac handling for add plugin

### DIFF
--- a/packages/spec-parser/src/specParser.ts
+++ b/packages/spec-parser/src/specParser.ts
@@ -622,7 +622,7 @@ export class SpecParser {
     let cardName = defaultName;
     let counter = 1;
     while (true) {
-      if (!fs.existsSync(path.join(cardFolder, cardName))) {
+      if (!fs.existsSync(path.join(cardFolder, cardName + ".json"))) {
         break;
       }
       cardName = `${defaultName}${counter}`;

--- a/packages/spec-parser/src/specParser.ts
+++ b/packages/spec-parser/src/specParser.ts
@@ -385,13 +385,14 @@ export class SpecParser {
             const responseSemantic = func.capabilities.response_semantics;
             const card = responseSemantic.static_template;
             if (card && Object.keys(card).length !== 0) {
-              const cardPath = path.join(adaptiveCardFolder, `${func.name}.json`);
-              const dataPath = path.join(adaptiveCardFolder, `${func.name}.data.json`);
+              const cardName = this.findUniqueCardName(func.name, adaptiveCardFolder);
+              const cardPath = path.join(adaptiveCardFolder, `${cardName}.json`);
+              const dataPath = path.join(adaptiveCardFolder, `${cardName}.data.json`);
               responseSemantic.static_template = {
-                file: `adaptiveCards/${func.name}.json`,
+                file: `adaptiveCards/${cardName}.json`,
               };
               await fs.outputJSON(cardPath, card, { spaces: 4 });
-              const data = jsonDataSet[func.name] ?? {};
+              const data = jsonDataSet[cardName] ?? {};
               await fs.outputJSON(dataPath, data, { spaces: 4 });
             }
           }
@@ -615,5 +616,18 @@ export class SpecParser {
     const specString = JSON.stringify(spec);
     const specResolved = Utils.resolveEnv(specString);
     return JSON.parse(specResolved) as OpenAPIV3.Document;
+  }
+
+  private findUniqueCardName(defaultName: string, cardFolder: string) {
+    let cardName = defaultName;
+    let counter = 1;
+    while (true) {
+      if (!fs.existsSync(path.join(cardFolder, cardName))) {
+        break;
+      }
+      cardName = `${defaultName}${counter}`;
+      counter++;
+    }
+    return cardName;
   }
 }

--- a/packages/spec-parser/test/specParser.test.ts
+++ b/packages/spec-parser/test/specParser.test.ts
@@ -1477,6 +1477,11 @@ describe("SpecParser", () => {
       // Stub fs.outputJSON to capture calls
       const outputJSONStub = sinon.stub(fs, "outputJSON").resolves();
 
+      // Stub fs.existsSync to only return true for testFunc1
+      const fsExistsSyncStub = sinon.stub(fs, "existsSync").callsFake((path) => {
+        return path.toString().endsWith("testFunc1");
+      });
+
       // Use a dummy instance (other flows will be stubbed so they are not executed)
       const specParser = new SpecParser("path/to/spec.yaml");
 
@@ -1504,7 +1509,7 @@ describe("SpecParser", () => {
             response_semantics: {
               data_path: "$.results",
               static_template: {
-                file: "adaptiveCards/testFunc1.json",
+                file: "adaptiveCards/testFunc11.json",
               },
             },
           },

--- a/packages/spec-parser/test/specParser.test.ts
+++ b/packages/spec-parser/test/specParser.test.ts
@@ -1479,7 +1479,7 @@ describe("SpecParser", () => {
 
       // Stub fs.existsSync to only return true for testFunc1
       const fsExistsSyncStub = sinon.stub(fs, "existsSync").callsFake((path) => {
-        return path.toString().endsWith("testFunc1");
+        return path.toString().endsWith("testFunc1.json");
       });
 
       // Use a dummy instance (other flows will be stubbed so they are not executed)


### PR DESCRIPTION
When adding a plugin, avoid overwriting existing adaptive card files. For duplicate operationIds, generated files will be named operationId.json, operationId1.json, operationId2.json, etc.