### PR TITLE
fix: debugger data ingestion

### DIFF
--- a/packages/vscode-extension/src/pluginDebugger/copilotDebugLogOutput.ts
+++ b/packages/vscode-extension/src/pluginDebugger/copilotDebugLogOutput.ts
@@ -75,7 +75,17 @@ export class CopilotDebugLog {
   constructor(logAsJson: string) {
     let message: this;
     try {
-      message = JSON.parse(logAsJson) as this;
+      const incomingJson = JSON.parse(logAsJson);
+      if (
+        incomingJson !== null &&
+        typeof incomingJson === "object" &&
+        incomingJson?.pluginDeveloperInfo !== undefined
+      ) {
+        const pluginDeveloperInfo = incomingJson?.pluginDeveloperInfo;
+        message = pluginDeveloperInfo as this;
+      } else {
+        message = incomingJson as this;
+      }
     } catch (error) {
       throw new Error(`Error parsing logAsJson: ${(error as Error).message}`);
     }

--- a/packages/vscode-extension/src/pluginDebugger/copilotDebugLogOutput.ts
+++ b/packages/vscode-extension/src/pluginDebugger/copilotDebugLogOutput.ts
@@ -76,16 +76,7 @@ export class CopilotDebugLog {
     let message: this;
     try {
       const incomingJson = JSON.parse(logAsJson);
-      if (
-        incomingJson !== null &&
-        typeof incomingJson === "object" &&
-        incomingJson?.pluginDeveloperInfo !== undefined
-      ) {
-        const pluginDeveloperInfo = incomingJson?.pluginDeveloperInfo;
-        message = pluginDeveloperInfo as this;
-      } else {
-        message = incomingJson as this;
-      }
+      message = (incomingJson?.pluginDeveloperInfo ?? incomingJson) as this;
     } catch (error) {
       throw new Error(`Error parsing logAsJson: ${(error as Error).message}`);
     }

--- a/packages/vscode-extension/test/pluginDebugger/copilotDebugLogOutput.test.ts
+++ b/packages/vscode-extension/test/pluginDebugger/copilotDebugLogOutput.test.ts
@@ -148,6 +148,125 @@ describe("copilotDebugLogOutput", () => {
       ]);
     });
 
+    it("should parse log JSON with the new format and initialize properties", () => {
+      const logJson = JSON.stringify({
+        capabilitiesDeveloperInfo: {},
+        pluginDeveloperInfo: {
+          enabledPlugins: [{ name: "plugin1", id: "1", version: "1.0" }],
+          matchedFunctionCandidates: [
+            {
+              plugin: { name: "plugin1", id: "1", version: "1.0" },
+              functionDisplayName: "function1",
+            },
+          ],
+          functionsSelectedForInvocation: [
+            {
+              plugin: { name: "plugin1", id: "1", version: "1.0" },
+              functionDisplayName: "function1",
+            },
+          ],
+          functionExecutions: [
+            {
+              function: {
+                plugin: { name: "plugin1", id: "1", version: "1.0" },
+                functionDisplayName: "function1",
+              },
+              executionStatus: { requestStatus: 200, responseStatus: 200, responseType: 1 },
+              parameters: {},
+              requestUri: "http://example.com",
+              requestMethod: "GET",
+              responseContent: "",
+              responseContentType: "",
+              errorMessage: "",
+            },
+          ],
+        },
+      });
+      const copilotDebugLog = new CopilotDebugLog(logJson);
+      chai.assert.deepEqual(copilotDebugLog.enabledPlugins, [
+        { name: "plugin1", id: "1", version: "1.0" },
+      ]);
+      chai.assert.deepEqual(copilotDebugLog.matchedFunctionCandidates, [
+        { plugin: { name: "plugin1", id: "1", version: "1.0" }, functionDisplayName: "function1" },
+      ]);
+      chai.assert.deepEqual(copilotDebugLog.functionsSelectedForInvocation, [
+        { plugin: { name: "plugin1", id: "1", version: "1.0" }, functionDisplayName: "function1" },
+      ]);
+      chai.assert.deepEqual(copilotDebugLog.functionExecutions, [
+        {
+          function: {
+            plugin: { name: "plugin1", id: "1", version: "1.0" },
+            functionDisplayName: "function1",
+          },
+          executionStatus: { requestStatus: 200, responseStatus: 200, responseType: 1 },
+          parameters: {},
+          requestUri: "http://example.com",
+          requestMethod: "GET",
+          responseContent: "",
+          responseContentType: "",
+          errorMessage: "",
+        },
+      ]);
+    });
+
+    it("should parse the original log JSON format and initialize properties", () => {
+      const logJson = JSON.stringify({
+        enabledPlugins: [{ name: "plugin1", id: "1", version: "1.0" }],
+        matchedFunctionCandidates: [
+          {
+            plugin: { name: "plugin1", id: "1", version: "1.0" },
+            functionDisplayName: "function1",
+          },
+        ],
+        functionsSelectedForInvocation: [
+          {
+            plugin: { name: "plugin1", id: "1", version: "1.0" },
+            functionDisplayName: "function1",
+          },
+        ],
+        functionExecutions: [
+          {
+            function: {
+              plugin: { name: "plugin1", id: "1", version: "1.0" },
+              functionDisplayName: "function1",
+            },
+            executionStatus: { requestStatus: 200, responseStatus: 200, responseType: 1 },
+            parameters: {},
+            requestUri: "http://example.com",
+            requestMethod: "GET",
+            responseContent: "",
+            responseContentType: "",
+            errorMessage: "",
+          },
+        ],
+      });
+      const copilotDebugLog = new CopilotDebugLog(logJson);
+      chai.assert.deepEqual(copilotDebugLog.enabledPlugins, [
+        { name: "plugin1", id: "1", version: "1.0" },
+      ]);
+      chai.assert.deepEqual(copilotDebugLog.matchedFunctionCandidates, [
+        { plugin: { name: "plugin1", id: "1", version: "1.0" }, functionDisplayName: "function1" },
+      ]);
+      chai.assert.deepEqual(copilotDebugLog.functionsSelectedForInvocation, [
+        { plugin: { name: "plugin1", id: "1", version: "1.0" }, functionDisplayName: "function1" },
+      ]);
+      chai.assert.deepEqual(copilotDebugLog.functionExecutions, [
+        {
+          function: {
+            plugin: { name: "plugin1", id: "1", version: "1.0" },
+            functionDisplayName: "function1",
+          },
+          executionStatus: { requestStatus: 200, responseStatus: 200, responseType: 1 },
+          parameters: {},
+          requestUri: "http://example.com",
+          requestMethod: "GET",
+          responseContent: "",
+          responseContentType: "",
+          errorMessage: "",
+        },
+      ]);
+    });
+
     it("should throw an error if log JSON is invalid", () => {
       const invalidLogJson = "{ invalid json }";
       chai.assert.throws(() => new CopilotDebugLog(invalidLogJson), /Error parsing logAsJson/);


### PR DESCRIPTION
Fixes data ingestion for the debugging experience.
The new agent debugging experience currently deploying to SDF wraps the plugin debugging data in an object like so:
```json
{
  "capabilitiesDeveloperInfo": {
    "enabledCapabilities": [],
    "capabilityExecutions": []
  },
  "pluginDeveloperInfo": {
    "enabledPlugins": [
      {
        "name": "dc-repairs-100",
        "id": "U_918fd220-44d7-3cda-5faf-78fcfe92da1e.action_1",
        "iconUrl": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMAAAADACAYAAABS3GwHAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAABa4SURBVHgB7Z1rrB3XVcfX2jPnXF8/aiexHddO3KYkadqQRJAgKGopSto0JEKAKvhQoXwoElIQH6ACUQmpEnwAiUcrVaJIICQkVKUfEG1VSEoVigqFEChtIU1Knjh2HBzbsX2da+f6npnZ7Pdjzty…",
        "version": "1.0.0",
        "source": "MOS3"
      }
    ],
    "functionsSelectedForInvocation": [],
    "functionExecutions": []
  }
}
```

while TTK expects this data shape:
```json
{
  "enabledPlugins": [
    {
      "name": "dc-repairs-100",
      "id": "U_918fd220-44d7-3cda-5faf-78fcfe92da1e.action_1",
      "iconUrl": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMAAAADACAYAAABS3GwHAAAACXBIWXMAAAsTAAALEwEAmpwY...",
      "version": "1.0.0",
      "source": "MOS3",
      "functionDisplayName": "createRepair"
    }
  ],
  "functionsSelectedForInvocation": [],
  "functionExecutions": []
}
```

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/31460697