### PR TITLE
fix: click cancel button not work when convert aad to new schema

### DIFF
--- a/packages/fx-core/src/component/driver/aad/utility/aadManifestHelper.ts
+++ b/packages/fx-core/src/component/driver/aad/utility/aadManifestHelper.ts
@@ -370,10 +370,11 @@ export class AadManifestHelper {
       getLocalizedString("core.convertAadToNewSchema.continue")
     );
 
-    if (
-      confirmRes.isOk() &&
-      confirmRes.value !== getLocalizedString("core.convertAadToNewSchema.continue")
-    ) {
+    if (confirmRes.isErr()) {
+      return err(confirmRes.error);
+    }
+
+    if (confirmRes.value !== getLocalizedString("core.convertAadToNewSchema.continue")) {
       return err(new UserCancelError());
     }
 


### PR DESCRIPTION
[Bug 31472925](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/31472925): Clicking "Cancel" button also converted Microsoft Entra app manifest file upgraded