### PR TITLE
fix: Update Office.js CDN URL

### DIFF
--- a/packages/tests/src/ui-test/treeview/office-xml-addin/src/commands/commands.html
+++ b/packages/tests/src/ui-test/treeview/office-xml-addin/src/commands/commands.html
@@ -8,7 +8,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
 
     <!-- Office JavaScript API -->
-    <script type="text/javascript" src="https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js"></script>
+    <script type="text/javascript" src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js"></script>
 </head>
 
 <body>

--- a/packages/tests/src/ui-test/treeview/office-xml-addin/src/taskpane/taskpane.html
+++ b/packages/tests/src/ui-test/treeview/office-xml-addin/src/taskpane/taskpane.html
@@ -11,7 +11,7 @@
     <title>Contoso Task Pane Add-in</title>
 
     <!-- Office JavaScript API -->
-    <script type="text/javascript" src="https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js"></script>
+    <script type="text/javascript" src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js"></script>
 
     <!-- For more information on Fluent UI, visit https://developer.microsoft.com/fluentui#/. -->
     <link rel="stylesheet" href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/11.0.0/css/fabric.min.css"/>

--- a/packages/tests/src/ui-test/treeview/word-xml-addin/src/commands/commands.html
+++ b/packages/tests/src/ui-test/treeview/word-xml-addin/src/commands/commands.html
@@ -8,7 +8,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
 
     <!-- Office JavaScript API -->
-    <script type="text/javascript" src="https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js"></script>
+    <script type="text/javascript" src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js"></script>
 </head>
 
 <body>

--- a/packages/tests/src/ui-test/treeview/word-xml-addin/src/taskpane/taskpane.html
+++ b/packages/tests/src/ui-test/treeview/word-xml-addin/src/taskpane/taskpane.html
@@ -11,7 +11,7 @@
     <title>Contoso Task Pane Add-in</title>
 
     <!-- Office JavaScript API -->
-    <script type="text/javascript" src="https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js"></script>
+    <script type="text/javascript" src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js"></script>
 
     <!-- For more information on Fluent UI, visit https://developer.microsoft.com/fluentui#/. -->
     <link rel="stylesheet" href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/11.0.0/css/fabric.min.css"/>

--- a/templates/ts/office-addin-outlook-taskpane/src/commands/commands.html
+++ b/templates/ts/office-addin-outlook-taskpane/src/commands/commands.html
@@ -8,7 +8,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
 
     <!-- Office JavaScript API -->
-    <script type="text/javascript" src="https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js"></script>
+    <script type="text/javascript" src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js"></script>
 </head>
 
 <body>

--- a/templates/ts/office-addin-outlook-taskpane/src/taskpane/taskpane.html
+++ b/templates/ts/office-addin-outlook-taskpane/src/taskpane/taskpane.html
@@ -11,7 +11,7 @@
     <title>Contoso Task Pane Add-in</title>
 
     <!-- Office JavaScript API -->
-    <script type="text/javascript" src="https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js"></script>
+    <script type="text/javascript" src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js"></script>
 
     <!-- For more information on Fluent UI, visit https://developer.microsoft.com/fluentui#/. -->
     <link rel="stylesheet" href="https://res-1.cdn.office.net/files/fabric-cdn-prod_20230815.002/office-ui-fabric-core/11.1.0/css/fabric.min.css"/>

--- a/templates/ts/office-addin-wxpo-taskpane/src/commands/commands.html
+++ b/templates/ts/office-addin-wxpo-taskpane/src/commands/commands.html
@@ -8,7 +8,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
 
     <!-- Office JavaScript API -->
-    <script type="text/javascript" src="https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js"></script>
+    <script type="text/javascript" src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js"></script>
 </head>
 
 <body>

--- a/templates/ts/office-addin-wxpo-taskpane/src/taskpane/taskpane.html
+++ b/templates/ts/office-addin-wxpo-taskpane/src/taskpane/taskpane.html
@@ -11,7 +11,7 @@
     <title>Contoso Task Pane Add-in</title>
 
     <!-- Office JavaScript API -->
-    <script type="text/javascript" src="https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js"></script>
+    <script type="text/javascript" src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js"></script>
 
     <!-- For more information on Fluent UI, visit https://developer.microsoft.com/fluentui#/. -->
     <link rel="stylesheet" href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/11.0.0/css/fabric.min.css"/>


### PR DESCRIPTION
Updates the Office.js CDN URL in applicable template and test files to align with guidance in [Understanding the Office JavaScript API](https://learn.microsoft.com/office/dev/add-ins/develop/understanding-the-javascript-api-for-office).