### PR TITLE
feat: show sni help doc for MS users

### DIFF
--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -690,6 +690,7 @@
   "driver.aadApp.error.appNameTooLong": "The name for this Microsoft Entra app is too long. The maximum length is 120.",
   "driver.aadApp.error.credentialInvalidLifetimeAsPerAppPolicy": "The client secret lifetime is too long for your tenant. Use a shorter value with the clientSecretExpireDays parameter.",
   "driver.aadApp.error.credentialTypeNotAllowedAsPerAppPolicy": "Your tenant doesn't allow creating a client secret for Microsoft Entra app. Create and configure the app manually.",
+  "driver.aadApp.error.signInAudienceNotAllowedAsPerAppPolicy": "Your tenant doesn't allow creating a Microsoft Entra app with specified signInAudience value. Error: %s.",
   "driver.aadApp.progressBar.createAadAppTitle": "Creating Microsoft Entra application...",
   "driver.aadApp.progressBar.updateAadAppTitle": "Updating Microsoft Entra application...",
   "driver.aadApp.log.startExecuteDriver": "Executing action %s",

--- a/packages/fx-core/src/component/driver/aad/create.ts
+++ b/packages/fx-core/src/component/driver/aad/create.ts
@@ -88,6 +88,13 @@ export class CreateAadAppDriver implements StepDriver {
 
       this.validateArgs(args);
 
+      const tokenJson = await context.m365TokenProvider.getJsonObject({ scopes: GraphScopes });
+      const isMsftAccount: boolean =
+        tokenJson.isOk() &&
+        tokenJson.value &&
+        typeof tokenJson.value.unique_name === "string" &&
+        tokenJson.value.unique_name.endsWith("@microsoft.com");
+
       const aadAppClient = new AadAppClient(context.m365TokenProvider, context.logProvider);
       if (!aadAppState.clientId) {
         context.logProvider?.info(
@@ -97,12 +104,6 @@ export class CreateAadAppDriver implements StepDriver {
           )
         );
         context.addTelemetryProperties({ [telemetryKeys.newAadApp]: "true" });
-
-        const tokenJson = await context.m365TokenProvider.getJsonObject({ scopes: GraphScopes });
-        const isMsftAccount =
-          tokenJson.isOk() &&
-          tokenJson.value.unique_name &&
-          (tokenJson.value.unique_name as string).endsWith("@microsoft.com");
 
         // Create new Microsoft Entra app if no client id exists
         const signInAudience = args.signInAudience
@@ -116,7 +117,8 @@ export class CreateAadAppDriver implements StepDriver {
         const aadApp = await aadAppClient.createAadApp(
           args.name,
           signInAudience,
-          serviceManagementReference
+          serviceManagementReference,
+          isMsftAccount
         );
         aadAppState.clientId = aadApp.appId!;
         aadAppState.objectId = aadApp.id!;
@@ -163,7 +165,8 @@ export class CreateAadAppDriver implements StepDriver {
           aadAppState.clientSecret = await aadAppClient.generateClientSecret(
             aadAppState.objectId,
             clientSecretExpireDays,
-            clientSecretDescription
+            clientSecretDescription,
+            isMsftAccount
           );
           outputs.set(outputEnvVarNames.get(OutputKeys.clientSecret)!, aadAppState.clientSecret);
 

--- a/packages/fx-core/src/component/driver/aad/error/clientSecretNotAllowedError.ts
+++ b/packages/fx-core/src/component/driver/aad/error/clientSecretNotAllowedError.ts
@@ -9,13 +9,13 @@ const errorCode = "ClientSecretNotAllowed";
 const messageKey = "driver.aadApp.error.credentialTypeNotAllowedAsPerAppPolicy";
 
 export class ClientSecretNotAllowedError extends UserError {
-  constructor(actionName: string) {
+  constructor(actionName: string, isMicrosoftUser = false) {
     super({
       source: actionName,
       name: errorCode,
       message: getDefaultString(messageKey),
       displayMessage: getLocalizedString(messageKey),
-      helpLink: constants.defaultHelpLink,
+      helpLink: isMicrosoftUser ? constants.sniHelpLink : constants.defaultHelpLink,
     });
   }
 }

--- a/packages/fx-core/src/component/driver/aad/error/signInAudienceNotAllowedError.ts
+++ b/packages/fx-core/src/component/driver/aad/error/signInAudienceNotAllowedError.ts
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { UserError } from "@microsoft/teamsfx-api";
+import { getDefaultString, getLocalizedString } from "../../../../common/localizeUtils";
+import { constants } from "../utility/constants";
+
+const errorCode = "SignInAudienceNotAllowed";
+const messageKey = "driver.aadApp.error.signInAudienceNotAllowedAsPerAppPolicy";
+
+export class SignInAudienceNotAllowedError extends UserError {
+  constructor(source: string, errorDetail?: string, isMicrosoftUser = false) {
+    const helpLink = isMicrosoftUser ? constants.sniHelpLink : constants.defaultHelpLink;
+    super({
+      source: source,
+      name: errorCode,
+      message: getDefaultString(messageKey, errorDetail),
+      displayMessage: getLocalizedString(messageKey, errorDetail),
+      helpLink: helpLink,
+    });
+  }
+}

--- a/packages/fx-core/src/component/driver/aad/utility/aadAppClient.ts
+++ b/packages/fx-core/src/component/driver/aad/utility/aadAppClient.ts
@@ -15,6 +15,7 @@ import {
 } from "../error/aadManifestError";
 import { ClientSecretNotAllowedError } from "../error/clientSecretNotAllowedError";
 import { CredentialInvalidLifetimeError } from "../error/credentialInvalidLifetimeError";
+import { SignInAudienceNotAllowedError } from "../error/signInAudienceNotAllowedError";
 import { AADApplication } from "../interface/AADApplication";
 import { AADManifest } from "../interface/AADManifest";
 import { IAADDefinition } from "../interface/IAADDefinition";
@@ -81,7 +82,8 @@ export class AadAppClient {
   public async createAadApp(
     displayName: string,
     signInAudience: SignInAudience = SignInAudience.AzureADMyOrg,
-    serviceManagementReference?: string
+    serviceManagementReference?: string,
+    isMicrosoftUser = false
   ): Promise<AADApplication> {
     const requestBody: IAADDefinition = {
       displayName: displayName,
@@ -89,9 +91,23 @@ export class AadAppClient {
       serviceManagementReference: serviceManagementReference,
     }; // Create a Microsoft Entra app and optionally set service tree id
 
-    const response = await this.axios.post("applications", requestBody);
-
-    return <AADApplication>response.data;
+    try {
+      const response = await this.axios.post("applications", requestBody);
+      return <AADApplication>response.data;
+    } catch (err) {
+      if (axios.isAxiosError(err) && err.response) {
+        if (
+          err.response.data?.error?.code === aadErrorCode.signInAudienceNotAllowedAsPerAppPolicy
+        ) {
+          throw new SignInAudienceNotAllowedError(
+            AadAppClient.name,
+            err.response.data.error?.message,
+            isMicrosoftUser
+          );
+        }
+      }
+      throw err;
+    }
   }
 
   @hooks([ErrorContextMW({ source: "Graph", component: "AadAppClient" })])
@@ -103,7 +119,8 @@ export class AadAppClient {
   public async generateClientSecret(
     objectId: string,
     clientSecretExpireDays = 180, // Recommended lifetime from Azure Portal
-    clientSecretDescription = "default"
+    clientSecretDescription = "default",
+    isMicrosoftUser = false
   ): Promise<string> {
     const startDate = new Date();
     const endDate = new Date(startDate.getTime());
@@ -139,7 +156,7 @@ export class AadAppClient {
         if (
           err.response.data?.error?.code === aadErrorCode.credentialTypeNotAllowedAsPerAppPolicy
         ) {
-          throw new ClientSecretNotAllowedError(AadAppClient.name);
+          throw new ClientSecretNotAllowedError(AadAppClient.name, isMicrosoftUser);
         }
       }
       throw err;

--- a/packages/fx-core/src/component/driver/aad/utility/constants.ts
+++ b/packages/fx-core/src/component/driver/aad/utility/constants.ts
@@ -43,12 +43,14 @@ export const aadErrorCode = {
   hostNameNotOnVerifiedDomain: "HostNameNotOnVerifiedDomain", // Using unverified domain in multi tenant scenario
   credentialInvalidLifetimeAsPerAppPolicy: "CredentialInvalidLifetimeAsPerAppPolicy",
   credentialTypeNotAllowedAsPerAppPolicy: "CredentialTypeNotAllowedAsPerAppPolicy",
+  signInAudienceNotAllowedAsPerAppPolicy: "SignInAudienceNotAllowedAsPerAppPolicy",
 };
 
 export const constants = {
   aadAppPasswordDisplayName: "default",
   oauthAuthorityPrefix: "https://login.microsoftonline.com",
   defaultHelpLink: "https://aka.ms/teamsfx-actions/aadapp-create",
+  sniHelpLink: "https://aka.ms/teams-toolkit-sni-guide",
   insufficientPermissionErrorMessage: "Insufficient privileges to complete the operation.",
 };
 

--- a/packages/fx-core/src/component/driver/botAadApp/create.ts
+++ b/packages/fx-core/src/component/driver/botAadApp/create.ts
@@ -101,8 +101,8 @@ export class CreateBotAadAppDriver implements StepDriver {
       const tokenJson = await context.m365TokenProvider.getJsonObject({ scopes: GraphScopes });
       const isMsftAccount =
         tokenJson.isOk() &&
-        tokenJson.value.unique_name &&
-        (tokenJson.value.unique_name as string).endsWith("@microsoft.com");
+        typeof tokenJson.value.unique_name == "string" &&
+        tokenJson.value.unique_name.endsWith("@microsoft.com");
 
       const startTime = performance.now();
       if (!botAadAppState.botId) {
@@ -114,11 +114,17 @@ export class CreateBotAadAppDriver implements StepDriver {
         const aadApp = await aadAppClient.createAadApp(
           args.name,
           SignInAudience.AzureADMultipleOrgs,
-          serviceManagementReference
+          serviceManagementReference,
+          isMsftAccount
         );
         botAadAppState.botId = aadApp.appId!;
         AadSet.add(aadApp.appId!);
-        botAadAppState.botPassword = await aadAppClient.generateClientSecret(aadApp.id!);
+        botAadAppState.botPassword = await aadAppClient.generateClientSecret(
+          aadApp.id!,
+          undefined,
+          undefined,
+          isMsftAccount
+        );
         context.logProvider?.info(getLocalizedString(logMessageKeys.successCreateBotAadApp));
       } else {
         context.logProvider?.info(getLocalizedString(logMessageKeys.skipCreateBotAadApp));

--- a/packages/fx-core/tests/component/driver/aad/aadAppClient.test.ts
+++ b/packages/fx-core/tests/component/driver/aad/aadAppClient.test.ts
@@ -20,6 +20,7 @@ import {
 import { CredentialInvalidLifetimeError } from "../../../../src/component/driver/aad/error/credentialInvalidLifetimeError";
 import { ClientSecretNotAllowedError } from "../../../../src/component/driver/aad/error/clientSecretNotAllowedError";
 import { MockedM365Provider } from "../../../core/utils";
+import { SignInAudienceNotAllowedError } from "../../../../src/component/driver/aad/error/signInAudienceNotAllowedError";
 chai.use(chaiAsPromised);
 const expect = chai.expect;
 
@@ -217,6 +218,52 @@ describe("AadAppClient", async () => {
       expect(debugLogs[0].includes("Sending API request")).to.be.true;
       expect(debugLogs[1].includes("Received API response")).to.be.true;
     });
+
+    it("should throw SignInAudienceNotAllowedError with proper help link for Microsoft user", async () => {
+      const expectedError = {
+        error: {
+          code: "signInAudienceNotAllowedAsPerAppPolicy",
+          message:
+            "The tenant admin has disabled creation of apps with multi-tenant sign-in audience",
+        },
+      };
+
+      const mock = new MockAdapter(axiosInstance);
+      mock.onPost(`https://graph.microsoft.com/v1.0/applications`).reply(400, expectedError);
+
+      await expect(
+        aadAppClient.createAadApp("test", SignInAudience.AzureADMultipleOrgs, undefined, true)
+      ).to.eventually.be.rejected.then((err) => {
+        expect(err instanceof SignInAudienceNotAllowedError).to.be.true;
+        expect(err.source).equals("AadAppClient");
+        expect(err.name).equals("SignInAudienceNotAllowed");
+        expect(err.message).equals(expectedError.error.message);
+        expect(err.helpLink).equals("https://aka.ms/teams-toolkit-sni-guide");
+      });
+    });
+
+    it("should throw SignInAudienceNotAllowedError with default help link for non-Microsoft user", async () => {
+      const expectedError = {
+        error: {
+          code: "signInAudienceNotAllowedAsPerAppPolicy",
+          message:
+            "The tenant admin has disabled creation of apps with multi-tenant sign-in audience",
+        },
+      };
+
+      const mock = new MockAdapter(axiosInstance);
+      mock.onPost(`https://graph.microsoft.com/v1.0/applications`).reply(400, expectedError);
+
+      await expect(
+        aadAppClient.createAadApp("test", SignInAudience.AzureADMultipleOrgs, undefined, false)
+      ).to.eventually.be.rejected.then((err) => {
+        expect(err instanceof SignInAudienceNotAllowedError).to.be.true;
+        expect(err.source).equals("AadAppClient");
+        expect(err.name).equals("SignInAudienceNotAllowed");
+        expect(err.message).equals(expectedError.error.message);
+        expect(err.helpLink).equals("https://aka.ms/teamsfx-actions/aadapp-create");
+      });
+    });
   });
 
   describe("deleteAadApp", async () => {
@@ -354,6 +401,56 @@ describe("AadAppClient", async () => {
 
       await expect(
         aadAppClient.generateClientSecret(expectedObjectId)
+      ).to.eventually.be.rejected.then((err) => {
+        expect(err instanceof ClientSecretNotAllowedError).to.be.true;
+        expect(err.source).equals("AadAppClient");
+        expect(err.name).equals("ClientSecretNotAllowed");
+        expect(err.message).equals(
+          "Your tenant doesn't allow creating a client secret for Microsoft Entra app. Create and configure the app manually."
+        );
+        expect(err.helpLink).equals("https://aka.ms/teamsfx-actions/aadapp-create");
+      });
+    });
+
+    it("should throw ClientSecretNotAllowedError with proper help link when Microsoft user and CredentialTypeNotAllowedAsPerAppPolicy error happens", async () => {
+      const expectedError = {
+        error: {
+          code: "CredentialTypeNotAllowedAsPerAppPolicy",
+        },
+      };
+
+      const mock = new MockAdapter(axiosInstance);
+      mock
+        .onPost(`https://graph.microsoft.com/v1.0/applications/${expectedObjectId}/addPassword`)
+        .reply(400, expectedError);
+
+      await expect(
+        aadAppClient.generateClientSecret(expectedObjectId, undefined, undefined, true)
+      ).to.eventually.be.rejected.then((err) => {
+        expect(err instanceof ClientSecretNotAllowedError).to.be.true;
+        expect(err.source).equals("AadAppClient");
+        expect(err.name).equals("ClientSecretNotAllowed");
+        expect(err.message).equals(
+          "Your tenant doesn't allow creating a client secret for Microsoft Entra app. Create and configure the app manually."
+        );
+        expect(err.helpLink).equals("https://aka.ms/teams-toolkit-sni-guide");
+      });
+    });
+
+    it("should throw ClientSecretNotAllowedError with default help link when non-Microsoft user and CredentialTypeNotAllowedAsPerAppPolicy error happens", async () => {
+      const expectedError = {
+        error: {
+          code: "CredentialTypeNotAllowedAsPerAppPolicy",
+        },
+      };
+
+      const mock = new MockAdapter(axiosInstance);
+      mock
+        .onPost(`https://graph.microsoft.com/v1.0/applications/${expectedObjectId}/addPassword`)
+        .reply(400, expectedError);
+
+      await expect(
+        aadAppClient.generateClientSecret(expectedObjectId, undefined, undefined, false)
       ).to.eventually.be.rejected.then((err) => {
         expect(err instanceof ClientSecretNotAllowedError).to.be.true;
         expect(err.source).equals("AadAppClient");

--- a/packages/fx-core/tests/component/driver/aad/aadAppClient.test.ts
+++ b/packages/fx-core/tests/component/driver/aad/aadAppClient.test.ts
@@ -222,7 +222,7 @@ describe("AadAppClient", async () => {
     it("should throw SignInAudienceNotAllowedError with proper help link for Microsoft user", async () => {
       const expectedError = {
         error: {
-          code: "signInAudienceNotAllowedAsPerAppPolicy",
+          code: "SignInAudienceNotAllowedAsPerAppPolicy",
           message:
             "The tenant admin has disabled creation of apps with multi-tenant sign-in audience",
         },
@@ -237,7 +237,9 @@ describe("AadAppClient", async () => {
         expect(err instanceof SignInAudienceNotAllowedError).to.be.true;
         expect(err.source).equals("AadAppClient");
         expect(err.name).equals("SignInAudienceNotAllowed");
-        expect(err.message).equals(expectedError.error.message);
+        expect(err.message).equals(
+          "Your tenant doesn't allow creating a Microsoft Entra app with specified signInAudience value. Error: The tenant admin has disabled creation of apps with multi-tenant sign-in audience."
+        );
         expect(err.helpLink).equals("https://aka.ms/teams-toolkit-sni-guide");
       });
     });
@@ -245,7 +247,7 @@ describe("AadAppClient", async () => {
     it("should throw SignInAudienceNotAllowedError with default help link for non-Microsoft user", async () => {
       const expectedError = {
         error: {
-          code: "signInAudienceNotAllowedAsPerAppPolicy",
+          code: "SignInAudienceNotAllowedAsPerAppPolicy",
           message:
             "The tenant admin has disabled creation of apps with multi-tenant sign-in audience",
         },
@@ -260,7 +262,9 @@ describe("AadAppClient", async () => {
         expect(err instanceof SignInAudienceNotAllowedError).to.be.true;
         expect(err.source).equals("AadAppClient");
         expect(err.name).equals("SignInAudienceNotAllowed");
-        expect(err.message).equals(expectedError.error.message);
+        expect(err.message).equals(
+          "Your tenant doesn't allow creating a Microsoft Entra app with specified signInAudience value. Error: The tenant admin has disabled creation of apps with multi-tenant sign-in audience."
+        );
         expect(err.helpLink).equals("https://aka.ms/teamsfx-actions/aadapp-create");
       });
     });

--- a/packages/fx-core/tests/component/driver/botAadApp/create.test.ts
+++ b/packages/fx-core/tests/component/driver/botAadApp/create.test.ts
@@ -21,6 +21,8 @@ import { AADApplication } from "../../../../src/component/driver/aad/interface/A
 import { OutputEnvironmentVariableUndefinedError } from "../../../../src/component/driver/error/outputEnvironmentVariableUndefinedError";
 import { AadAppNameTooLongError } from "../../../../src/component/driver/aad/error/aadAppNameTooLongError";
 import { MockedM365Provider } from "../../../core/utils";
+import { ClientSecretNotAllowedError } from "../../../../src/component/driver/aad/error/clientSecretNotAllowedError";
+import { SignInAudienceNotAllowedError } from "../../../../src/component/driver/aad/error/signInAudienceNotAllowedError";
 
 chai.use(chaiAsPromised);
 const expect = chai.expect;
@@ -437,5 +439,153 @@ describe("botAadAppCreate", async () => {
     expect(result.summaries[0]).not.includes(
       "Teams toolkit will delete the Microsoft Entra application after debugging"
     );
+  });
+
+  it("should throw ClientSecretNotAllowedError with proper help link for Microsoft user", async () => {
+    sinon
+      .stub(mockedDriverContext.m365TokenProvider, "getJsonObject")
+      .resolves(ok({ unique_name: "test@microsoft.com" }));
+
+    sinon.stub(AadAppClient.prototype, "createAadApp").resolves({
+      id: expectedObjectId,
+      displayName: expectedDisplayName,
+      appId: expectedClientId,
+    } as AADApplication);
+
+    sinon.stub(AadAppClient.prototype, "generateClientSecret").rejects({
+      isAxiosError: true,
+      response: {
+        status: 400,
+        data: {
+          error: {
+            code: "CredentialTypeNotAllowedAsPerAppPolicy",
+          },
+        },
+      },
+    });
+
+    const args: any = {
+      name: expectedDisplayName,
+    };
+
+    await expect(createBotAadAppDriver.handler(args, mockedDriverContext, outputEnvVarNames))
+      .to.be.rejectedWith(
+        "Your tenant doesn't allow creating a client secret for Microsoft Entra app. Create and configure the app manually."
+      )
+      .then((error) => {
+        expect(error instanceof ClientSecretNotAllowedError).to.be.true;
+        expect(error.source).equals("botAadApp/create");
+        expect(error.name).equals("ClientSecretNotAllowed");
+        expect(error.helpLink).equals("https://aka.ms/teams-toolkit-sni-guide");
+      });
+  });
+
+  it("should throw ClientSecretNotAllowedError with default help link for non-Microsoft user", async () => {
+    sinon
+      .stub(mockedDriverContext.m365TokenProvider, "getJsonObject")
+      .resolves(ok({ unique_name: "test@test.com" }));
+
+    sinon.stub(AadAppClient.prototype, "createAadApp").resolves({
+      id: expectedObjectId,
+      displayName: expectedDisplayName,
+      appId: expectedClientId,
+    } as AADApplication);
+
+    sinon.stub(AadAppClient.prototype, "generateClientSecret").rejects({
+      isAxiosError: true,
+      response: {
+        status: 400,
+        data: {
+          error: {
+            code: "CredentialTypeNotAllowedAsPerAppPolicy",
+          },
+        },
+      },
+    });
+
+    const args: any = {
+      name: expectedDisplayName,
+    };
+
+    await expect(createBotAadAppDriver.handler(args, mockedDriverContext, outputEnvVarNames))
+      .to.be.rejectedWith(
+        "Your tenant doesn't allow creating a client secret for Microsoft Entra app. Create and configure the app manually."
+      )
+      .then((error) => {
+        expect(error instanceof ClientSecretNotAllowedError).to.be.true;
+        expect(error.source).equals("botAadApp/create");
+        expect(error.name).equals("ClientSecretNotAllowed");
+        expect(error.helpLink).equals("https://aka.ms/teamsfx-actions/aadapp-create");
+      });
+  });
+
+  it("should throw SignInAudienceNotAllowedError with proper help link for Microsoft user", async () => {
+    sinon
+      .stub(mockedDriverContext.m365TokenProvider, "getJsonObject")
+      .resolves(ok({ unique_name: "test@microsoft.com" }));
+
+    sinon.stub(AadAppClient.prototype, "createAadApp").rejects({
+      isAxiosError: true,
+      response: {
+        status: 400,
+        data: {
+          error: {
+            code: "signInAudienceNotAllowedAsPerAppPolicy",
+            message:
+              "The tenant admin has disabled creation of apps with multi-tenant sign-in audience",
+          },
+        },
+      },
+    });
+
+    const args: any = {
+      name: expectedDisplayName,
+    };
+
+    await expect(createBotAadAppDriver.handler(args, mockedDriverContext, outputEnvVarNames))
+      .to.be.rejectedWith(
+        "The tenant admin has disabled creation of apps with multi-tenant sign-in audience"
+      )
+      .then((error) => {
+        expect(error instanceof SignInAudienceNotAllowedError).to.be.true;
+        expect(error.source).equals("botAadApp/create");
+        expect(error.name).equals("SignInAudienceNotAllowed");
+        expect(error.helpLink).equals("https://aka.ms/teams-toolkit-sni-guide");
+      });
+  });
+
+  it("should throw SignInAudienceNotAllowedError with default help link for non-Microsoft user", async () => {
+    sinon
+      .stub(mockedDriverContext.m365TokenProvider, "getJsonObject")
+      .resolves(ok({ unique_name: "test@test.com" }));
+
+    sinon.stub(AadAppClient.prototype, "createAadApp").rejects({
+      isAxiosError: true,
+      response: {
+        status: 400,
+        data: {
+          error: {
+            code: "signInAudienceNotAllowedAsPerAppPolicy",
+            message:
+              "The tenant admin has disabled creation of apps with multi-tenant sign-in audience",
+          },
+        },
+      },
+    });
+
+    const args: any = {
+      name: expectedDisplayName,
+    };
+
+    await expect(createBotAadAppDriver.handler(args, mockedDriverContext, outputEnvVarNames))
+      .to.be.rejectedWith(
+        "The tenant admin has disabled creation of apps with multi-tenant sign-in audience"
+      )
+      .then((error) => {
+        expect(error instanceof SignInAudienceNotAllowedError).to.be.true;
+        expect(error.source).equals("botAadApp/create");
+        expect(error.name).equals("SignInAudienceNotAllowed");
+        expect(error.helpLink).equals("https://aka.ms/teamsfx-actions/aadapp-create");
+      });
   });
 });

--- a/packages/fx-core/tests/component/driver/botAadApp/create.test.ts
+++ b/packages/fx-core/tests/component/driver/botAadApp/create.test.ts
@@ -452,17 +452,11 @@ describe("botAadAppCreate", async () => {
       appId: expectedClientId,
     } as AADApplication);
 
-    sinon.stub(AadAppClient.prototype, "generateClientSecret").rejects({
-      isAxiosError: true,
-      response: {
-        status: 400,
-        data: {
-          error: {
-            code: "CredentialTypeNotAllowedAsPerAppPolicy",
-          },
-        },
-      },
-    });
+    sinon
+      .stub(AadAppClient.prototype, "generateClientSecret")
+      .callsFake(async (objectId, days, description, isMicrosoftUser) => {
+        throw new ClientSecretNotAllowedError("botAadApp/create", isMicrosoftUser);
+      });
 
     const args: any = {
       name: expectedDisplayName,
@@ -491,17 +485,11 @@ describe("botAadAppCreate", async () => {
       appId: expectedClientId,
     } as AADApplication);
 
-    sinon.stub(AadAppClient.prototype, "generateClientSecret").rejects({
-      isAxiosError: true,
-      response: {
-        status: 400,
-        data: {
-          error: {
-            code: "CredentialTypeNotAllowedAsPerAppPolicy",
-          },
-        },
-      },
-    });
+    sinon
+      .stub(AadAppClient.prototype, "generateClientSecret")
+      .callsFake(async (objectId, days, description, isMicrosoftUser) => {
+        throw new ClientSecretNotAllowedError("botAadApp/create", isMicrosoftUser);
+      });
 
     const args: any = {
       name: expectedDisplayName,
@@ -524,19 +512,17 @@ describe("botAadAppCreate", async () => {
       .stub(mockedDriverContext.m365TokenProvider, "getJsonObject")
       .resolves(ok({ unique_name: "test@microsoft.com" }));
 
-    sinon.stub(AadAppClient.prototype, "createAadApp").rejects({
-      isAxiosError: true,
-      response: {
-        status: 400,
-        data: {
-          error: {
-            code: "signInAudienceNotAllowedAsPerAppPolicy",
-            message:
-              "The tenant admin has disabled creation of apps with multi-tenant sign-in audience",
-          },
-        },
-      },
-    });
+    sinon
+      .stub(AadAppClient.prototype, "createAadApp")
+      .callsFake(
+        async (displayName, signInAudience, serviceManagementReference, isMicrosoftUser) => {
+          throw new SignInAudienceNotAllowedError(
+            "botAadApp/create",
+            "The tenant admin has disabled creation of apps with multi-tenant sign-in audience",
+            isMicrosoftUser
+          );
+        }
+      );
 
     const args: any = {
       name: expectedDisplayName,
@@ -559,19 +545,17 @@ describe("botAadAppCreate", async () => {
       .stub(mockedDriverContext.m365TokenProvider, "getJsonObject")
       .resolves(ok({ unique_name: "test@test.com" }));
 
-    sinon.stub(AadAppClient.prototype, "createAadApp").rejects({
-      isAxiosError: true,
-      response: {
-        status: 400,
-        data: {
-          error: {
-            code: "signInAudienceNotAllowedAsPerAppPolicy",
-            message:
-              "The tenant admin has disabled creation of apps with multi-tenant sign-in audience",
-          },
-        },
-      },
-    });
+    sinon
+      .stub(AadAppClient.prototype, "createAadApp")
+      .callsFake(
+        async (displayName, signInAudience, serviceManagementReference, isMicrosoftUser) => {
+          throw new SignInAudienceNotAllowedError(
+            "botAadApp/create",
+            "The tenant admin has disabled creation of apps with multi-tenant sign-in audience",
+            isMicrosoftUser
+          );
+        }
+      );
 
     const args: any = {
       name: expectedDisplayName,


### PR DESCRIPTION
Show SNI help doc when MS users meet the client secret not allowed error or signin audience not allowed error, to help them continue debug their apps locally.

![image](https://github.com/user-attachments/assets/a2a5e7a9-1bd0-456e-9c7e-35548310e832)

![image](https://github.com/user-attachments/assets/34d1d3fd-6d78-4954-9e53-4e081a4265c1)

https://dev.azure.com/msazure/Microsoft%20Teams%20Extensibility/_workitems/edit/31634384