### PR TITLE
fix: zip app package action will throw error if plugin manifest in a sub folder

### DIFF
--- a/packages/fx-core/src/component/driver/teamsApp/createAppPackage.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/createAppPackage.ts
@@ -659,6 +659,7 @@ export class CreateAppPackageDriver implements StepDriver {
     if (await fs.pathExists(jsonFileName)) {
       await fs.chmod(jsonFileName, 0o777);
     }
+    await fs.ensureDir(path.dirname(jsonFileName));
     await fs.writeFile(jsonFileName, content);
     await fs.chmod(jsonFileName, 0o444);
   }


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/31638064