### PR TITLE
fix: add telemetry property

### DIFF
--- a/packages/fx-core/src/error/common.ts
+++ b/packages/fx-core/src/error/common.ts
@@ -14,6 +14,7 @@ import { globalVars } from "../common/globalVars";
 import { ErrorCategory } from "./types";
 import path from "path";
 import { MetadataV3 } from "../common/versionMetadata";
+import { TelemetryProperty } from "../component/configManager/constant";
 
 export class FileNotFoundError extends UserError {
   constructor(source: string, filePath: string, helpLink?: string) {
@@ -55,6 +56,11 @@ export class MissingEnvironmentVariablesError extends UserError {
       ),
       helpLink: helpLink || "https://aka.ms/teamsfx-v5.0-guide#environments",
       categories: [ErrorCategory.Internal],
+      telemetryProperties: {
+        [TelemetryProperty.UnresolvedPlaceholders]: variableNames
+          .replace("SECRET", "S")
+          .replace("PASSWORD", "P"),
+      },
     };
     super(errorOptions);
   }


### PR DESCRIPTION
Sample telemetry:
```
[2025-03-06T17:00:53.528] [DEBUG] TelemTest - debug-all {
  success: 'no',
  'is-existing-user': 'yes',
  'error-code': 'fileCreateOrUpdateEnvironmentFile.MissingEnvironmentVariablesError',
  'error-type': 'user',
  'err-message': "Missing environment variables 'SECRET_BOT_PASSWORD' for file: c:<REDACTED:secret> Please edit the .env file 'c:<REDACTED:secret> or 'c:<REDACTED:secret>, or adjust system environment variables. For new Teams Toolkit projects, make sure you've run provision or debug to set these variables correctly.",
  'err-stack': 'Coordinator.convertExecuteResult | Coordinator.deploy | Coordinator.<anonymous> | FxCore3.deployArtifacts | FxCore3.EnvWriterMW | FxCore3.ContextInjectorMW | FxCore3.ConcurrentLockerMW | envLoaderMWImpl | FxCore3.<anonymous> | FxCore3.ProjectMigratorMWV3 | FxCore3.ErrorHandlerMW | FxCore3.<anonymous> | runCommand | LifecycleTaskTerminal._do | _LocalTelemetryReporter.runWithTelemetryGeneric | _LocalTelemetryReporter.runWithTelemetryProperties',
  'error-name': 'MissingEnvironmentVariablesError',
  unresolved: 'S_BOT_P',
  'is-spfx': 'false',
  'settings-version': 'v1.7',
  'feature-flags': 'TEAMSFX_CHAT_PARTICIPANT;TEAMSFX_CHAT_PARTICIPANT_ENTRIES;TEAMSFX_TELEMETRY_TEST'
}
```
![image](https://github.com/user-attachments/assets/e3bbf3ae-a547-4314-a678-584151a84cba)
