### PR TITLE
refactor: upgrade Blazor templates from FluentUI v3 to v4

### DIFF
--- a/templates/csharp/non-sso-tab-ssr/Components/_Imports.razor.tpl
+++ b/templates/csharp/non-sso-tab-ssr/Components/_Imports.razor.tpl
@@ -9,6 +9,6 @@
 @using {{SafeProjectName}}
 @using {{SafeProjectName}}.Interop.TeamsSDK;
 @using {{SafeProjectName}}.Components
-@using Microsoft.Fast.Components.FluentUI;
+@using Microsoft.FluentUI.AspNetCore.Components
 @using Microsoft.TeamsFx
 @using static Microsoft.AspNetCore.Components.Web.RenderMode

--- a/templates/csharp/non-sso-tab-ssr/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/non-sso-tab-ssr/{{ProjectName}}.csproj.tpl
@@ -18,7 +18,7 @@
 {{/isNewProjectTypeEnabled}}
   <ItemGroup>
     <PackageReference Include="Microsoft.Graph" Version="5.56.0" />
-    <PackageReference Include="Microsoft.Fast.Components.FluentUI" Version="3.7.8" />
+    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.11.6" />
     <PackageReference Include="Microsoft.TeamsFx" Version="2.5.*" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>

--- a/templates/csharp/sso-tab-ssr/Components/_Imports.razor.tpl
+++ b/templates/csharp/sso-tab-ssr/Components/_Imports.razor.tpl
@@ -9,6 +9,6 @@
 @using {{SafeProjectName}}
 @using {{SafeProjectName}}.Interop.TeamsSDK;
 @using {{SafeProjectName}}.Components
-@using Microsoft.Fast.Components.FluentUI;
+@using Microsoft.FluentUI.AspNetCore.Components
 @using Microsoft.TeamsFx
 @using static Microsoft.AspNetCore.Components.Web.RenderMode

--- a/templates/csharp/sso-tab-ssr/Program.cs.tpl
+++ b/templates/csharp/sso-tab-ssr/Program.cs.tpl
@@ -1,6 +1,7 @@
 using {{SafeProjectName}};
 using {{SafeProjectName}}.Components;
 using {{SafeProjectName}}.Interop.TeamsSDK;
+using Microsoft.FluentUI.AspNetCore.Components;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -15,6 +16,8 @@ builder.Services.AddControllers();
 builder.Services.AddHttpClient("WebClient", client => client.Timeout = TimeSpan.FromSeconds(600));
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddAntiforgery(o => o.SuppressXFrameOptionsHeader = true);
+
+builder.Services.AddSingleton<LibraryConfiguration>();
 
 var app = builder.Build();
 

--- a/templates/csharp/sso-tab-ssr/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/sso-tab-ssr/{{ProjectName}}.csproj.tpl
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.12.0" />
     <PackageReference Include="Microsoft.Graph" Version="5.56.0" />
-    <PackageReference Include="Microsoft.Fast.Components.FluentUI" Version="3.7.8" />
+    <PackageReference Include="Microsoft.FluentUI.AspNetCore.Components" Version="4.11.6" />
     <PackageReference Include="Microsoft.TeamsFx" Version="2.5.*" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>


### PR DESCRIPTION
[Update Blazor samples to use latest Fluent UI library version](https://github.com/OfficeDev/teams-toolkit/issues/13361)