### PR TITLE
fix: properties of undefined (reading 'replace') when add plugin

### DIFF
--- a/packages/fx-core/src/component/generator/openApiSpec/helper.ts
+++ b/packages/fx-core/src/component/generator/openApiSpec/helper.ts
@@ -797,11 +797,12 @@ function formatApiSpecValidationWarningMessage(
 
   specialCharactersWarnings.forEach((warning) => {
     resultWarnings.push(
-      getLocalizedString(
-        "core.copilotPlugin.scaffold.summary.warning.operationIdContainsSpecialCharacters",
-        warning.data.operationId,
-        warning.data.operationId.replace(/[^a-zA-Z0-9]/g, "_")
-      )
+      `${SummaryConstant.NotExecuted} ` +
+        getLocalizedString(
+          "core.copilotPlugin.scaffold.summary.warning.operationIdContainsSpecialCharacters",
+          warning.data,
+          warning.data.replace(/[^a-zA-Z0-9]/g, "_")
+        )
     );
   });
 

--- a/packages/fx-core/tests/component/generator/openApiSpec/helper.test.ts
+++ b/packages/fx-core/tests/component/generator/openApiSpec/helper.test.ts
@@ -161,13 +161,13 @@ describe("generateScaffoldingSummary", async () => {
           type: WarningType.OperationIdContainsSpecialCharacters,
           content:
             "Operation id 'user/repo' contained special characters and was renamed to 'user_repo'.",
-          data: { operationId: "user/repo" },
+          data: "user/repo",
         },
         {
           type: WarningType.OperationIdContainsSpecialCharacters,
           content:
             "Operation id 'user/issue' contained special characters and was renamed to 'user_issue'.",
-          data: { operationId: "user/issue" },
+          data: "user/issue",
         },
       ],
       teamsManifest,


### PR DESCRIPTION
[Bug 31759443](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/31759443): Fix Cannot read properties of undefined (reading 'replace') issue when add plugin