### PR TITLE
perf: add da properties in metadata telemetry

### DIFF
--- a/packages/fx-core/src/common/telemetry.ts
+++ b/packages/fx-core/src/common/telemetry.ts
@@ -187,6 +187,11 @@ export enum ProjectTypeProps {
   TeamsJs = "teams-js",
   Lauguages = "languages",
   OfficeAddinProjectType = "office-addin-project-type",
+
+  DeclarativeAgentCapabilitiesCount = "declarative-agent-capabilities-count",
+  DeclarativeAgentCapabilities = "declarative-agent-capabilities",
+  DeclarativeAgentActionsCount = "declarative-agent-actions-count",
+  DeclarativeAgentPluginAuthTypes = "declarative-agent-plugin-auth-types",
 }
 
 export enum TelemetrySuccess {

--- a/packages/fx-core/src/component/utils/metadataDAProperties.ts
+++ b/packages/fx-core/src/component/utils/metadataDAProperties.ts
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import path from "path";
+import fs from "fs-extra";
+import { MetadataV3 } from "../../common/versionMetadata";
+import { ProjectModel } from "../configManager/interface";
+import { ProjectTypeProps } from "../../common/telemetry";
+import { manifestUtils } from "../driver/teamsApp/utils/ManifestUtils";
+import { DeclarativeCopilotManifestSchema, PluginManifestSchema } from "@microsoft/teamsfx-api";
+
+class MetadataDAPropertiesUtil {
+  async parseManifest(
+    ymlPath: string,
+    model: ProjectModel,
+    props: { [key: string]: string }
+  ): Promise<void> {
+    let manifestName = path.join(MetadataV3.teamsManifestFolder, MetadataV3.teamsManifestFileName);
+    const action = model.provision?.driverDefs.find(
+      (def) => def.uses === "teamsApp/validateManifest"
+    );
+    // if teamsApp/validateManifest action is defined, use the manifest file in the action
+    if (action) {
+      const parameters = action.with as { [key: string]: string };
+      if (parameters && parameters["manifestPath"]) {
+        manifestName = parameters["manifestPath"];
+      }
+    }
+
+    const projectRoot = path.dirname(ymlPath);
+    const manifestPath = path.join(projectRoot, manifestName);
+    if (!(await fs.pathExists(manifestPath))) {
+      return;
+    }
+
+    try {
+      const result = await manifestUtils._readAppManifest(manifestPath);
+      if (result.isErr()) {
+        return;
+      }
+      const manifest = result.value;
+      const declarativeAgentRelativePath = manifest.copilotAgents?.declarativeAgents?.[0].file;
+
+      if (declarativeAgentRelativePath) {
+        const manifestFolder = path.dirname(manifestPath);
+        const declarativeAgentJsonPath = path.join(manifestFolder, declarativeAgentRelativePath);
+        const declarativeAgentJson = (await fs.readJSON(
+          declarativeAgentJsonPath
+        )) as DeclarativeCopilotManifestSchema;
+
+        const capabilitiesCount = declarativeAgentJson.capabilities?.length ?? 0;
+        props[ProjectTypeProps.DeclarativeAgentCapabilitiesCount] = capabilitiesCount.toString();
+
+        if (declarativeAgentJson.capabilities) {
+          props[ProjectTypeProps.DeclarativeAgentCapabilities] = declarativeAgentJson.capabilities
+            ?.map((capability: any) => capability.name)
+            .join(",");
+        } else {
+          props[ProjectTypeProps.DeclarativeAgentCapabilities] = "";
+        }
+
+        const actionsCount = declarativeAgentJson.actions?.length ?? 0;
+        props[ProjectTypeProps.DeclarativeAgentActionsCount] = actionsCount.toString();
+
+        if (declarativeAgentJson.actions) {
+          const pluginPaths = declarativeAgentJson.actions.map((action: any) => action.file);
+
+          const declarativeAgentFolder = path.dirname(declarativeAgentJsonPath);
+          const authInfo = [];
+          for (const pluginPath of pluginPaths ?? []) {
+            const pluginJsonPath = path.join(declarativeAgentFolder, pluginPath);
+            if (await fs.pathExists(pluginJsonPath)) {
+              const pluginJson = (await fs.readJSON(pluginJsonPath)) as PluginManifestSchema;
+              const runtimes = pluginJson.runtimes;
+              if (runtimes) {
+                const authStr = runtimes
+                  .filter((runtime) => runtime.type === "OpenApi")
+                  .map((runtime: any) => runtime.auth?.type)
+                  .filter((type) => type !== undefined)
+                  .join(",");
+                authInfo.push(authStr);
+              }
+            }
+          }
+          props[ProjectTypeProps.DeclarativeAgentPluginAuthTypes] = authInfo.join(";");
+        } else {
+          props[ProjectTypeProps.DeclarativeAgentPluginAuthTypes] = "";
+        }
+      }
+    } catch (error) {
+      return;
+    }
+  }
+}
+
+export const metadataDAPropertiesUtil = new MetadataDAPropertiesUtil();

--- a/packages/fx-core/src/component/utils/metadataDAProperties.ts
+++ b/packages/fx-core/src/component/utils/metadataDAProperties.ts
@@ -16,10 +16,7 @@ class MetadataDAPropertiesUtil {
     props: { [key: string]: string }
   ): Promise<void> {
     let manifestName = path.join(MetadataV3.teamsManifestFolder, MetadataV3.teamsManifestFileName);
-    const action = model.provision?.driverDefs.find(
-      (def) => def.uses === "teamsApp/validateManifest"
-    );
-    // if teamsApp/validateManifest action is defined, use the manifest file in the action
+    const action = model.provision?.driverDefs.find((def) => def.uses === "teamsApp/zipAppPackage");
     if (action) {
       const parameters = action.with as { [key: string]: string };
       if (parameters && parameters["manifestPath"]) {
@@ -29,10 +26,6 @@ class MetadataDAPropertiesUtil {
 
     const projectRoot = path.dirname(ymlPath);
     const manifestPath = path.join(projectRoot, manifestName);
-    if (!(await fs.pathExists(manifestPath))) {
-      return;
-    }
-
     try {
       const result = await manifestUtils._readAppManifest(manifestPath);
       if (result.isErr()) {
@@ -53,7 +46,7 @@ class MetadataDAPropertiesUtil {
 
         if (declarativeAgentJson.capabilities) {
           props[ProjectTypeProps.DeclarativeAgentCapabilities] = declarativeAgentJson.capabilities
-            ?.map((capability: any) => capability.name)
+            .map((capability: any) => capability.name)
             .join(",");
         } else {
           props[ProjectTypeProps.DeclarativeAgentCapabilities] = "";

--- a/packages/fx-core/src/component/utils/metadataUtil.ts
+++ b/packages/fx-core/src/component/utils/metadataUtil.ts
@@ -10,6 +10,7 @@ import { yamlParser } from "../configManager/parser";
 import { createHash } from "crypto";
 import { metadataGraphPermissionUtil } from "./metadataGraphPermssion";
 import { metadataRscPermissionUtil } from "./metadataRscPermission";
+import { metadataDAPropertiesUtil } from "./metadataDAProperties";
 
 class MetadataUtil {
   async parse(path: string, env: string | undefined): Promise<Result<ProjectModel, FxError>> {
@@ -35,6 +36,7 @@ class MetadataUtil {
       );
       await metadataGraphPermissionUtil.parseAadManifest(path, res.value, props);
       await metadataRscPermissionUtil.parseManifest(path, res.value, props);
+      await metadataDAPropertiesUtil.parseManifest(path, res.value, props);
 
       TOOLS.telemetryReporter?.sendTelemetryEvent(TelemetryEvent.MetaData, props);
     }

--- a/packages/fx-core/tests/component/util/metadataDAPropertiesUtil.test.ts
+++ b/packages/fx-core/tests/component/util/metadataDAPropertiesUtil.test.ts
@@ -1,0 +1,185 @@
+import { err, FxError, LogProvider, ok, Result } from "@microsoft/teamsfx-api";
+import { assert } from "chai";
+import "mocha";
+import sinon from "sinon";
+import fs from "fs-extra";
+import {
+  DriverInstance,
+  ExecutionResult,
+  ProjectModel,
+} from "../../../src/component/configManager/interface";
+import { DriverContext } from "../../../src/component/driver/interface/commonArgs";
+import { setTools } from "../../../src/common/globalVars";
+import { MockTools } from "../../core/utils";
+import { ExecutionResult as DriverResult } from "../../../src/component/driver/interface/stepDriver";
+import {
+  ProjectTypeProps,
+  TelemetryProperty,
+  WebApplicationIdValue,
+} from "../../../src/common/telemetry";
+import { metadataDAPropertiesUtil } from "../../../src/component/utils/metadataDAProperties";
+import { manifestUtils } from "../../../src/component/driver/teamsApp/utils/ManifestUtils";
+
+function mockedResolveDriverInstances(log: LogProvider): Result<DriverInstance[], FxError> {
+  return ok([
+    {
+      uses: "arm/deploy",
+      with: undefined,
+      instance: {
+        execute: async (args: unknown, context: DriverContext): Promise<DriverResult> => {
+          return { result: ok(new Map<string, string>()), summaries: [] };
+        },
+      },
+    },
+  ]);
+}
+
+describe("metadata rsc permission util", () => {
+  const manifestContent = `
+  
+  `;
+  const sandbox = sinon.createSandbox();
+
+  const readAppManifestRes = {
+    $schema: "https://developer.microsoft.com/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
+    manifestVersion: "1.19",
+    version: "1.0.0",
+    id: "TEAMS_APP_ID",
+    developer: {
+      name: "Teams App, Inc.",
+      websiteUrl: "https://www.example.com",
+      privacyUrl: "https://www.example.com/privacy",
+      termsOfUseUrl: "https://www.example.com/termofuse",
+    },
+    icons: {
+      color: "color.png",
+      outline: "outline.png",
+    },
+    name: {
+      short: "test_NAME_SUFFIX",
+      full: "Full name for ddfdfdddd",
+    },
+    description: {
+      short: "Short description for test",
+      full: "Full description for test",
+    },
+    accentColor: "#FFFFFF",
+    copilotAgents: {
+      declarativeAgents: [
+        {
+          id: "declarativeAgent",
+          file: "declarativeAgent.json",
+        },
+      ],
+    },
+    permissions: ["identity", "messageTeamMembers"],
+    validDomains: [],
+  };
+
+  const mockProjectModel: ProjectModel = {
+    version: "1.0.0",
+    provision: {
+      name: "provision",
+      driverDefs: [
+        {
+          uses: "teamsApp/validateManifest",
+          with: {
+            manifestPath: "./appPackage/manifest.json",
+          },
+        },
+      ],
+      resolvePlaceholders: () => {
+        return ["AZURE_SUBSCRIPTION_ID", "AZURE_RESOURCE_GROUP_NAME"];
+      },
+      execute: async (ctx: DriverContext): Promise<ExecutionResult> => {
+        return { result: ok(new Map()), summaries: [] };
+      },
+      resolveDriverInstances: mockedResolveDriverInstances,
+    },
+    environmentFolderPath: "./envs",
+  };
+  let tools: MockTools;
+  const ymlPath = "teamsapp.yml";
+
+  beforeEach(() => {
+    tools = new MockTools();
+    setTools(tools);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("parseManifest happy path", async () => {
+    sandbox.stub(fs, "pathExists").resolves(true);
+    sandbox.stub(manifestUtils, "_readAppManifest").resolves(ok(readAppManifestRes as any));
+
+    sandbox.stub(fs, "readJSON").callsFake(async (path: string) => {
+      if (path.endsWith("declarativeAgent.json")) {
+        return {
+          capabilities: [
+            {
+              name: "capability1",
+            },
+            {
+              name: "capability2",
+            },
+          ],
+          actions: [
+            {
+              file: "action1.json",
+            },
+            {
+              file: "action2.json",
+            },
+          ],
+        };
+      } else if (path.endsWith("action1.json")) {
+        return {
+          runtimes: [
+            {
+              type: "OpenApi",
+              auth: {
+                type: "None",
+              },
+              spec: {
+                url: "apiSpecificationFile/openapi.yaml",
+              },
+              run_for_functions: ["deletePet"],
+            },
+          ],
+        };
+      } else if (path.endsWith("action2.json")) {
+        return {
+          runtimes: [
+            {
+              type: "OpenApi",
+              auth: {
+                type: "ApiKeyPluginVault",
+              },
+              spec: {
+                url: "apiSpecificationFile/openapi.yaml",
+              },
+              run_for_functions: ["deletePet"],
+            },
+          ],
+        };
+      }
+    });
+
+    const props: any = {};
+    await metadataDAPropertiesUtil.parseManifest(ymlPath, mockProjectModel, props);
+
+    assert(props[ProjectTypeProps.DeclarativeAgentCapabilitiesCount] === "2");
+    assert(props[ProjectTypeProps.DeclarativeAgentActionsCount] === "2");
+    assert(props[ProjectTypeProps.DeclarativeAgentCapabilities] === "capability1,capability2");
+    assert(props[ProjectTypeProps.DeclarativeAgentPluginAuthTypes] === "None;ApiKeyPluginVault");
+  });
+
+  it("parseManifest no manifest", async () => {
+    sandbox.stub(fs, "pathExists").resolves(false);
+    const props: any = {};
+    await metadataDAPropertiesUtil.parseManifest(ymlPath, mockProjectModel, props);
+    assert(props[ProjectTypeProps.TeamsManifestVersion] === undefined);
+  });
+});

--- a/packages/fx-core/tests/component/util/metadataDAPropertiesUtil.test.ts
+++ b/packages/fx-core/tests/component/util/metadataDAPropertiesUtil.test.ts
@@ -1,4 +1,4 @@
-import { err, FxError, LogProvider, ok, Result } from "@microsoft/teamsfx-api";
+import { FxError, LogProvider, ok, Result } from "@microsoft/teamsfx-api";
 import { assert } from "chai";
 import "mocha";
 import sinon from "sinon";
@@ -12,11 +12,7 @@ import { DriverContext } from "../../../src/component/driver/interface/commonArg
 import { setTools } from "../../../src/common/globalVars";
 import { MockTools } from "../../core/utils";
 import { ExecutionResult as DriverResult } from "../../../src/component/driver/interface/stepDriver";
-import {
-  ProjectTypeProps,
-  TelemetryProperty,
-  WebApplicationIdValue,
-} from "../../../src/common/telemetry";
+import { ProjectTypeProps } from "../../../src/common/telemetry";
 import { metadataDAPropertiesUtil } from "../../../src/component/utils/metadataDAProperties";
 import { manifestUtils } from "../../../src/component/driver/teamsApp/utils/ManifestUtils";
 
@@ -44,26 +40,6 @@ describe("metadata rsc permission util", () => {
     $schema: "https://developer.microsoft.com/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
     manifestVersion: "1.19",
     version: "1.0.0",
-    id: "TEAMS_APP_ID",
-    developer: {
-      name: "Teams App, Inc.",
-      websiteUrl: "https://www.example.com",
-      privacyUrl: "https://www.example.com/privacy",
-      termsOfUseUrl: "https://www.example.com/termofuse",
-    },
-    icons: {
-      color: "color.png",
-      outline: "outline.png",
-    },
-    name: {
-      short: "test_NAME_SUFFIX",
-      full: "Full name for ddfdfdddd",
-    },
-    description: {
-      short: "Short description for test",
-      full: "Full description for test",
-    },
-    accentColor: "#FFFFFF",
     copilotAgents: {
       declarativeAgents: [
         {
@@ -72,8 +48,6 @@ describe("metadata rsc permission util", () => {
         },
       ],
     },
-    permissions: ["identity", "messageTeamMembers"],
-    validDomains: [],
   };
 
   const mockProjectModel: ProjectModel = {
@@ -82,7 +56,7 @@ describe("metadata rsc permission util", () => {
       name: "provision",
       driverDefs: [
         {
-          uses: "teamsApp/validateManifest",
+          uses: "teamsApp/zipAppPackage",
           with: {
             manifestPath: "./appPackage/manifest.json",
           },
@@ -179,7 +153,89 @@ describe("metadata rsc permission util", () => {
   it("parseManifest no manifest", async () => {
     sandbox.stub(fs, "pathExists").resolves(false);
     const props: any = {};
+    await metadataDAPropertiesUtil.parseManifest(
+      ymlPath,
+      {
+        version: "1.0.0",
+        provision: {
+          name: "provision",
+          driverDefs: [
+            {
+              uses: "teamsApp/zipAppPackage",
+              with: {},
+            },
+          ],
+          resolvePlaceholders: () => {
+            return ["AZURE_SUBSCRIPTION_ID", "AZURE_RESOURCE_GROUP_NAME"];
+          },
+          execute: async (ctx: DriverContext): Promise<ExecutionResult> => {
+            return { result: ok(new Map()), summaries: [] };
+          },
+          resolveDriverInstances: mockedResolveDriverInstances,
+        },
+        environmentFolderPath: "./envs",
+      },
+      props
+    );
+    assert(props[ProjectTypeProps.TeamsManifestVersion] === undefined);
+  });
+
+  it("parseManifest read manfiest error", async () => {
+    sandbox.stub(fs, "pathExists").resolves(false);
+    const props: any = {};
     await metadataDAPropertiesUtil.parseManifest(ymlPath, mockProjectModel, props);
     assert(props[ProjectTypeProps.TeamsManifestVersion] === undefined);
+  });
+
+  it("parseManifest no capabilities and actions", async () => {
+    sandbox.stub(fs, "pathExists").resolves(true);
+    sandbox.stub(manifestUtils, "_readAppManifest").resolves(ok(readAppManifestRes as any));
+
+    sandbox.stub(fs, "readJSON").callsFake(async (path: string) => {
+      if (path.endsWith("declarativeAgent.json")) {
+        return {};
+      }
+    });
+
+    const props: any = {};
+    await metadataDAPropertiesUtil.parseManifest(ymlPath, mockProjectModel, props);
+
+    assert(props[ProjectTypeProps.DeclarativeAgentCapabilitiesCount] === "0");
+    assert(props[ProjectTypeProps.DeclarativeAgentActionsCount] === "0");
+    assert(props[ProjectTypeProps.DeclarativeAgentCapabilities] === "");
+    assert(props[ProjectTypeProps.DeclarativeAgentPluginAuthTypes] === "");
+  });
+
+  it("parseManifest no copilotAgents", async () => {
+    sandbox.stub(fs, "pathExists").resolves(true);
+    sandbox.stub(manifestUtils, "_readAppManifest").resolves(
+      ok({
+        $schema:
+          "https://developer.microsoft.com/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
+        manifestVersion: "1.19",
+      } as any)
+    );
+
+    const props: any = {};
+    await metadataDAPropertiesUtil.parseManifest(ymlPath, mockProjectModel, props);
+
+    assert.deepEqual(props, {});
+  });
+
+  it("parseManifest no declarativeAgents", async () => {
+    sandbox.stub(fs, "pathExists").resolves(true);
+    sandbox.stub(manifestUtils, "_readAppManifest").resolves(
+      ok({
+        $schema:
+          "https://developer.microsoft.com/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
+        manifestVersion: "1.19",
+        copilotAgents: {},
+      } as any)
+    );
+
+    const props: any = {};
+    await metadataDAPropertiesUtil.parseManifest(ymlPath, mockProjectModel, props);
+
+    assert.deepEqual(props, {});
   });
 });


### PR DESCRIPTION
Add additional properties for DA project
```json
{
  "declarative-agent-capabilities-count": "2",
  "declarative-agent-capabilities": "WebSearch,GraphConnectors",
  "declarative-agent-actions-count": "9",
  "declarative-agent-plugin-auth-types": "None;ApiKeyPluginVault"
}
```
