### PR TITLE
fix: hide add web part command for non-spfx project

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -920,7 +920,7 @@
       {
         "command": "fx-extension.addWebpart",
         "title": "%teamstoolkit.commmands.addWebpart.title%",
-        "enablement": "fx-extension.isTeamsFx && isWorkspaceTrusted && !fx-extension.commandLocked",
+        "enablement": "fx-extension.isTeamsFx && isWorkspaceTrusted && !fx-extension.commandLocked && fx-extension.isSPFx",
         "category": "Teams"
       },
       {


### PR DESCRIPTION
Cherry-pick https://github.com/OfficeDev/teams-toolkit/pull/13474
ADO: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/31814762