### PR TITLE
feat: update api key register logic to support new schema

### DIFF
--- a/packages/fx-core/src/component/driver/apiKey/create.ts
+++ b/packages/fx-core/src/component/driver/apiKey/create.ts
@@ -25,7 +25,7 @@ import { ApiKeyNameTooLongError } from "./error/apiKeyNameTooLong";
 import { CreateApiKeyArgs } from "./interface/createApiKeyArgs";
 import { CreateApiKeyOutputs, OutputKeys } from "./interface/createApiKeyOutputs";
 import { logMessageKeys, maxSecretLength, minSecretLength } from "./utility/constants";
-import { getDomain, loadStateFromEnv, validateDomain } from "./utility/utility";
+import { getDomain, loadStateFromEnv, validateDomain, validateUrl } from "./utility/utility";
 import { apiKeyFromScratchClientSecretInvalid } from "./error/apiKeyFromScratchClientSecretInvalid";
 import { WrapDriverContext } from "../util/wrapUtil";
 
@@ -100,8 +100,13 @@ export class CreateApiKeyDriver implements StepDriver {
 
         this.validateArgs(args);
 
-        const domains = await getDomain(args, context, actionName);
-        validateDomain(domains, actionName);
+        let domains: string[] = [];
+        if (args.baseUrl) {
+          domains = [args.baseUrl];
+        } else {
+          domains = await getDomain(args, context, actionName);
+          validateDomain(domains, actionName);
+        }
 
         const apiKey = await this.mapArgsToApiSecretRegistration(
           context.m365TokenProvider,
@@ -190,7 +195,16 @@ export class CreateApiKeyDriver implements StepDriver {
       throw new ApiKeyClientSecretInvalidError(actionName);
     }
 
-    if (typeof args.apiSpecPath !== "string" || !args.apiSpecPath) {
+    if (args.baseUrl && (typeof args.baseUrl !== "string" || !validateUrl(args.baseUrl))) {
+      invalidParameters.push("baseUrl");
+    }
+
+    if (args.apiSpecPath && typeof args.apiSpecPath !== "string") {
+      invalidParameters.push("apiSpecPath");
+    }
+
+    if (!args.baseUrl && !args.apiSpecPath) {
+      invalidParameters.push("baseUrl");
       invalidParameters.push("apiSpecPath");
     }
 

--- a/packages/fx-core/src/component/driver/apiKey/interface/createApiKeyArgs.ts
+++ b/packages/fx-core/src/component/driver/apiKey/interface/createApiKeyArgs.ts
@@ -6,7 +6,8 @@ export interface CreateApiKeyArgs {
   appId: string; // Teams app id
   primaryClientSecret?: string; // The primary api secret
   secondaryClientSecret?: string; // The secondary api secret
-  apiSpecPath: string; // The location of api spec file
+  apiSpecPath?: string; // The location of api spec file
   applicableToApps?: string; // What app can access the api key. Values can be "SpecificApp" or "AnyApp". Default is "AnyApp".
   targetAudience?: string; // What tenant can access the api key. Values can be "HomeTenant" or "AnyTenant". Default is "HomeTenant".
+  baseUrl?: string; // The base url of the api spec. If not provided, the base url will be extracted from the api spec file.
 }

--- a/packages/fx-core/src/component/driver/apiKey/interface/updateApiKeyArgs.ts
+++ b/packages/fx-core/src/component/driver/apiKey/interface/updateApiKeyArgs.ts
@@ -5,7 +5,8 @@ export interface UpdateApiKeyArgs {
   registrationId: string; // The registration id of the api key
   name: string; // The name of Api Secret
   appId: string; // Teams app id
-  apiSpecPath: string; // The location of api spec file
+  apiSpecPath?: string; // The location of api spec file
   applicableToApps?: string; // Which app can access the API key? Values can be "SpecificApp" or "AnyApp". Default is "AnyApp".
   targetAudience?: string; // Which tenant can access the API key? Values can be "HomeTenant" or "AnyTenant". Default is "AnyTenant".
+  baseUrl?: string; // The base url of the api spec. If not provided, the base url will be extracted from the api spec file.
 }

--- a/packages/fx-core/src/component/driver/apiKey/update.ts
+++ b/packages/fx-core/src/component/driver/apiKey/update.ts
@@ -20,7 +20,7 @@ import {
 import { ApiKeyNameTooLongError } from "./error/apiKeyNameTooLong";
 import { UpdateApiKeyArgs } from "./interface/updateApiKeyArgs";
 import { logMessageKeys } from "./utility/constants";
-import { getDomain, validateDomain } from "./utility/utility";
+import { getDomain, validateDomain, validateUrl } from "./utility/utility";
 import { WrapDriverContext } from "../util/wrapUtil";
 
 const actionName = "apiKey/update"; // DO NOT MODIFY the name
@@ -46,8 +46,13 @@ export class UpdateApiKeyDriver implements StepDriver {
       context.logProvider?.info(getLocalizedString(logMessageKeys.startExecuteDriver, actionName));
       this.validateArgs(args);
 
-      const domain = await getDomain(args, context, actionName);
-      validateDomain(domain, actionName);
+      let domain: string[] = [];
+      if (args.baseUrl) {
+        domain = [args.baseUrl];
+      } else {
+        domain = await getDomain(args, context, actionName);
+        validateDomain(domain, actionName);
+      }
 
       const appStudioTokenRes = await context.m365TokenProvider.getAccessToken({
         scopes: AppStudioScopes,
@@ -147,7 +152,16 @@ export class UpdateApiKeyDriver implements StepDriver {
       invalidParameters.push("appId");
     }
 
-    if (typeof args.apiSpecPath !== "string" || !args.apiSpecPath) {
+    if (args.baseUrl && (typeof args.baseUrl !== "string" || !validateUrl(args.baseUrl))) {
+      invalidParameters.push("baseUrl");
+    }
+
+    if (args.apiSpecPath && typeof args.apiSpecPath !== "string") {
+      invalidParameters.push("apiSpecPath");
+    }
+
+    if (!args.baseUrl && !args.apiSpecPath) {
+      invalidParameters.push("baseUrl");
       invalidParameters.push("apiSpecPath");
     }
 

--- a/packages/fx-core/src/component/driver/apiKey/utility/utility.ts
+++ b/packages/fx-core/src/component/driver/apiKey/utility/utility.ts
@@ -29,7 +29,7 @@ export async function getDomain(
   context: WrapDriverContext,
   actionName: string
 ): Promise<string[]> {
-  const absolutePath = getAbsolutePath(args.apiSpecPath, context.projectPath);
+  const absolutePath = getAbsolutePath(args.apiSpecPath!, context.projectPath);
   const parser = new SpecParser(absolutePath, {
     allowBearerTokenAuth: true, // Currently, API key auth support is actually bearer token auth
     allowMultipleParameters: true,
@@ -71,5 +71,14 @@ export function validateDomain(domain: string[], actionName: string): void {
 
   if (domain.length === 0 || domain.includes("")) {
     throw new ApiKeyFailedToGetDomainError(actionName);
+  }
+}
+
+export function validateUrl(baseUrl: string): boolean {
+  try {
+    const url = new URL(baseUrl);
+    return url.protocol === "https:";
+  } catch (error) {
+    return false;
   }
 }

--- a/packages/fx-core/tests/component/driver/apiKey/create.test.ts
+++ b/packages/fx-core/tests/component/driver/apiKey/create.test.ts
@@ -100,6 +100,82 @@ describe("CreateApiKeyDriver", () => {
     }
   });
 
+  it("happy path: create registraionid, read domain from baseURL, clientSecret from input", async () => {
+    sinon.stub(teamsDevPortalClient, "createApiKeyRegistration").resolves({
+      id: "mockedRegistrationId",
+      clientSecrets: [],
+      targetUrlsShouldStartWith: [],
+      applicableToApps: ApiSecretRegistrationAppType.SpecificApp,
+    });
+
+    const args: any = {
+      name: "test",
+      appId: "mockedAppId",
+      primaryClientSecret: "mockedClientSecret",
+      apiSpecPath: "mockedPath",
+      baseUrl: "https://test",
+    };
+    const result = await createApiKeyDriver.execute(args, mockedDriverContext, outputEnvVarNames);
+    expect(result.result.isOk()).to.be.true;
+    if (result.result.isOk()) {
+      expect(result.result.value.get(outputKeys.registrationId)).to.equal("mockedRegistrationId");
+      expect(result.summaries.length).to.equal(1);
+    }
+  });
+
+  it("should throw error if baseURL is not a valid https URL", async () => {
+    sinon.stub(teamsDevPortalClient, "createApiKeyRegistration").resolves({
+      id: "mockedRegistrationId",
+      clientSecrets: [],
+      targetUrlsShouldStartWith: [],
+      applicableToApps: ApiSecretRegistrationAppType.SpecificApp,
+    });
+
+    const args: any = {
+      name: "test",
+      appId: "mockedAppId",
+      primaryClientSecret: "mockedClientSecret",
+      apiSpecPath: "mockedPath",
+      baseUrl: "http://test",
+    };
+    const result1 = await createApiKeyDriver.execute(args, mockedDriverContext, outputEnvVarNames);
+    expect(result1.result.isErr()).to.be.true;
+    if (result1.result.isErr()) {
+      expect(result1.result.error.name).to.equal("InvalidActionInputError");
+      expect(result1.result.error.message).contains("baseUrl");
+    }
+
+    args.baseUrl = "invalidURL";
+    const result2 = await createApiKeyDriver.execute(args, mockedDriverContext, outputEnvVarNames);
+    expect(result2.result.isErr()).to.be.true;
+    if (result2.result.isErr()) {
+      expect(result2.result.error.name).to.equal("InvalidActionInputError");
+      expect(result2.result.error.message).contains("baseUrl");
+    }
+  });
+
+  it("should throw error if baseURL and apiSpecPath are both missing", async () => {
+    sinon.stub(teamsDevPortalClient, "createApiKeyRegistration").resolves({
+      id: "mockedRegistrationId",
+      clientSecrets: [],
+      targetUrlsShouldStartWith: [],
+      applicableToApps: ApiSecretRegistrationAppType.SpecificApp,
+    });
+
+    const args: any = {
+      name: "test",
+      appId: "mockedAppId",
+      primaryClientSecret: "mockedClientSecret",
+    };
+    const result = await createApiKeyDriver.execute(args, mockedDriverContext, outputEnvVarNames);
+    expect(result.result.isErr()).to.be.true;
+    if (result.result.isErr()) {
+      expect(result.result.error.name).to.equal("InvalidActionInputError");
+      expect(result.result.error.message).contains("baseUrl");
+      expect(result.result.error.message).contains("apiSpecPath");
+    }
+  });
+
   it("happy path: create registraionid, read domain from api spec, clientSecret and secondaryClientSecret from input", async () => {
     sinon.stub(teamsDevPortalClient, "createApiKeyRegistration").resolves({
       id: "mockedRegistrationId",

--- a/packages/fx-core/tests/component/driver/apiKey/update.test.ts
+++ b/packages/fx-core/tests/component/driver/apiKey/update.test.ts
@@ -126,6 +126,48 @@ describe("UpdateApiKeyDriver", () => {
     }
   });
 
+  it("happy path: update all fields with baseURL", async () => {
+    sinon.stub(teamsDevPortalClient, "updateApiKeyRegistration").resolves({
+      description: "mockedDescription",
+      targetUrlsShouldStartWith: ["https://test2"],
+      applicableToApps: ApiSecretRegistrationAppType.SpecificApp,
+      targetAudience: ApiSecretRegistrationTargetAudience.HomeTenant,
+      specificAppId: "mockedAppId",
+    });
+    sinon.stub(teamsDevPortalClient, "getApiKeyRegistrationById").resolves({
+      id: "mockedRegistrationId",
+      description: "mockedDescription",
+      clientSecrets: [],
+      targetUrlsShouldStartWith: ["https://test"],
+      applicableToApps: ApiSecretRegistrationAppType.AnyApp,
+      targetAudience: ApiSecretRegistrationTargetAudience.AnyTenant,
+    });
+
+    sinon.stub(mockedDriverContext.ui, "confirm").callsFake(async (config) => {
+      expect((config as ConfirmConfig).title.includes("description")).to.be.true;
+      expect((config as ConfirmConfig).title.includes("applicableToApps")).to.be.true;
+      expect((config as ConfirmConfig).title.includes("specificAppId")).to.be.true;
+      expect((config as ConfirmConfig).title.includes("targetAudience")).to.be.true;
+      return ok({ type: "success", value: true });
+    });
+
+    const args: UpdateApiKeyArgs = {
+      name: "test2",
+      appId: "mockedAppId",
+      targetAudience: "HomeTenant",
+      applicableToApps: "SpecificApp",
+      registrationId: "mockedRegistrationId",
+      baseUrl: "https://test",
+    };
+
+    const result = await updateApiKeyDriver.execute(args, mockedDriverContext);
+    expect(result.result.isOk()).to.be.true;
+    if (result.result.isOk()) {
+      expect(result.result.value.size).to.equal(0);
+      expect(result.summaries.length).to.equal(1);
+    }
+  });
+
   it("happy path: does not update when no changes", async () => {
     sinon.stub(teamsDevPortalClient, "getApiKeyRegistrationById").resolves({
       id: "test",
@@ -348,7 +390,7 @@ describe("UpdateApiKeyDriver", () => {
     }
   });
 
-  it("should throw error if missing apiSpecPath", async () => {
+  it("should throw error if missing both baseUrl and apiSpecPath", async () => {
     const args: any = {
       name: "name",
       appId: "mockedAppId",
@@ -358,6 +400,38 @@ describe("UpdateApiKeyDriver", () => {
     expect(result.result.isErr()).to.be.true;
     if (result.result.isErr()) {
       expect(result.result.error.name).to.equal("InvalidActionInputError");
+      expect(result.result.error.message).to.include("baseUrl");
+      expect(result.result.error.message).to.include("apiSpecPath");
+    }
+  });
+
+  it("should throw error if apiSpecPath is not string", async () => {
+    const args: any = {
+      name: "name",
+      appId: "mockedAppId",
+      regirstrationid: "mockedRegistrationId",
+      apiSpecPath: ["invalidPathType"],
+    };
+    const result = await updateApiKeyDriver.execute(args, mockedDriverContext);
+    expect(result.result.isErr()).to.be.true;
+    if (result.result.isErr()) {
+      expect(result.result.error.name).to.equal("InvalidActionInputError");
+      expect(result.result.error.message).to.include("apiSpecPath");
+    }
+  });
+
+  it("should throw error if baseURL is not valid https url", async () => {
+    const args: any = {
+      name: "name",
+      appId: "mockedAppId",
+      regirstrationid: "mockedRegistrationId",
+      baseUrl: "http://test",
+    };
+    const result = await updateApiKeyDriver.execute(args, mockedDriverContext);
+    expect(result.result.isErr()).to.be.true;
+    if (result.result.isErr()) {
+      expect(result.result.error.name).to.equal("InvalidActionInputError");
+      expect(result.result.error.message).to.include("baseUrl");
     }
   });
 


### PR DESCRIPTION
[Task 32016815](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/32016815): Update apikey action logic to use new schema