### PR TITLE
fix: aad.manifest.json file in csharp template using old schema

### DIFF
--- a/templates/csharp/declarative-agent-with-action-from-scratch-oauth/aad.manifest.json.tpl
+++ b/templates/csharp/declarative-agent-with-action-from-scratch-oauth/aad.manifest.json.tpl
@@ -1,9 +1,46 @@
 {
     "id": "${{AAD_APP_OBJECT_ID}}",
     "appId": "${{AAD_APP_CLIENT_ID}}",
-    "name": "{{appName}}-aad",
-    "accessTokenAcceptedVersion": 2,
+    "displayName": "{{appName}}-aad",
+    "identifierUris": [
+{{#MicrosoftEntra}}
+        "api://${{OPENAPI_SERVER_DOMAIN}}/${{AAD_APP_CLIENT_ID}}",
+        "${{AADAUTHCODE_APPLICATION_ID_URI}}"
+{{/MicrosoftEntra}}
+{{^MicrosoftEntra}}
+        "api://${{AAD_APP_CLIENT_ID}}"
+{{/MicrosoftEntra}}
+    ],
     "signInAudience": "AzureADMyOrg",
+        "api": {
+        "requestedAccessTokenVersion": 2,
+        "oauth2PermissionScopes": [
+            {
+                "adminConsentDescription": "Allows Copilot to read repair records on your behalf.",
+                "adminConsentDisplayName": "Read repairs",
+                "id": "${{AAD_APP_ACCESS_AS_USER_PERMISSION_ID}}",
+                "isEnabled": true,
+                "type": "User",
+                "userConsentDescription": "Allows Copilot to read repair records.",
+                "userConsentDisplayName": "Read repairs",
+                "value": "repairs_read"
+            }
+{{^MicrosoftEntra}}
+        ]
+{{/MicrosoftEntra}}
+{{#MicrosoftEntra}}
+        ],
+        "preAuthorizedApplications": [
+            {
+                "appId": "ab3be6b7-f5df-413d-ac2d-abf1e3fd9c0b",
+                "delegatedPermissionIds": [
+                    "${{AAD_APP_ACCESS_AS_USER_PERMISSION_ID}}"
+                ]
+            }
+        ]
+{{/MicrosoftEntra}}
+    },
+    "info": {},
     "optionalClaims": {
         "idToken": [],
         "accessToken": [
@@ -16,46 +53,21 @@
         ],
         "saml2Token": []
     },
-    "oauth2Permissions": [
-        {
-            "adminConsentDescription": "Allows Copilot to read repair records on your behalf.",
-            "adminConsentDisplayName": "Read repairs",
-            "id": "${{AAD_APP_ACCESS_AS_USER_PERMISSION_ID}}",
-            "isEnabled": true,
-            "type": "User",
-            "userConsentDescription": "Allows Copilot to read repair records.",
-            "userConsentDisplayName": "Read repairs",
-            "value": "repairs_read"
-        }
-    ],
+    "publicClient": {
+        "redirectUris": []
+    },
+    "web": {
+        "redirectUris": [
 {{#MicrosoftEntra}}
-    "preAuthorizedApplications": [
-        {
-            "appId": "ab3be6b7-f5df-413d-ac2d-abf1e3fd9c0b",
-            "permissionIds": [
-                "${{AAD_APP_ACCESS_AS_USER_PERMISSION_ID}}"
-            ]
-        }
-    ],
-{{/MicrosoftEntra}}
-    "replyUrlsWithType": [
-        {
-{{#MicrosoftEntra}}
-           "url": "https://teams.microsoft.com/api/platform/v1.0/oAuthConsentRedirect",
+            "https://teams.microsoft.com/api/platform/v1.0/oAuthConsentRedirect"
 {{/MicrosoftEntra}}
 {{^MicrosoftEntra}}
-           "url": "https://teams.microsoft.com/api/platform/v1.0/oAuthRedirect",
+            "https://teams.microsoft.com/api/platform/v1.0/oAuthRedirect"
 {{/MicrosoftEntra}}
-           "type": "Web"
-        }
-    ],
-    "identifierUris": [
-{{#MicrosoftEntra}}
-        "api://${{OPENAPI_SERVER_DOMAIN}}/${{AAD_APP_CLIENT_ID}}",
-        "${{AADAUTHCODE_APPLICATION_ID_URI}}"
-{{/MicrosoftEntra}}
-{{^MicrosoftEntra}}
-        "api://${{AAD_APP_CLIENT_ID}}"
-{{/MicrosoftEntra}}
-    ]
+        ],
+        "implicitGrantSettings": {}
+    },
+    "spa": {
+        "redirectUris": []
+    }
 }


### PR DESCRIPTION
[Bug 32066763](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/32066763): [VS] Declarative agent is still using old schema for Microsoft Entra app manifest