### PR TITLE
fix: do not provide space as value

### DIFF
--- a/templates/js/ai-assistant-bot/env/.env.local.user
+++ b/templates/js/ai-assistant-bot/env/.env.local.user
@@ -3,5 +3,5 @@
 # If you're adding a secret value, add SECRET_ prefix to the name so Teams Toolkit can handle them properly
 # Secrets. Keys prefixed with `SECRET_` will be masked in Teams Toolkit logs.
 SECRET_BOT_PASSWORD=
-SECRET_OPENAI_API_KEY=' '
+SECRET_OPENAI_API_KEY=
 SECRET_OPENAI_ASSISTANT_ID=' ' # See README.md for how to fill in this value.

--- a/templates/js/custom-copilot-rag-custom-api/env/.env.local.user.tpl
+++ b/templates/js/custom-copilot-rag-custom-api/env/.env.local.user.tpl
@@ -8,7 +8,7 @@ SECRET_BOT_PASSWORD=
 SECRET_OPENAI_API_KEY={{{openAIKey}}}
 {{/openAIKey}}
 {{^openAIKey}}
-SECRET_OPENAI_API_KEY=' '
+SECRET_OPENAI_API_KEY=
 {{/openAIKey}}
 {{/useOpenAI}}
 {{#useAzureOpenAI}}
@@ -16,7 +16,7 @@ SECRET_OPENAI_API_KEY=' '
 SECRET_AZURE_OPENAI_API_KEY={{{azureOpenAIKey}}}
 {{/azureOpenAIKey}}
 {{^azureOpenAIKey}}
-SECRET_AZURE_OPENAI_API_KEY=' '
+SECRET_AZURE_OPENAI_API_KEY=
 {{/azureOpenAIKey}}
 {{#azureOpenAIDeploymentName}}
 AZURE_OPENAI_MODEL_DEPLOYMENT_NAME='{{{azureOpenAIDeploymentName}}}'

--- a/templates/python/custom-copilot-rag-custom-api/env/.env.local.user.tpl
+++ b/templates/python/custom-copilot-rag-custom-api/env/.env.local.user.tpl
@@ -8,7 +8,7 @@ SECRET_BOT_PASSWORD=
 SECRET_OPENAI_API_KEY={{{openAIKey}}}
 {{/openAIKey}}
 {{^openAIKey}}
-SECRET_OPENAI_API_KEY=' '
+SECRET_OPENAI_API_KEY=
 {{/openAIKey}}
 {{/useOpenAI}}
 {{#useAzureOpenAI}}
@@ -16,7 +16,7 @@ SECRET_OPENAI_API_KEY=' '
 SECRET_AZURE_OPENAI_API_KEY={{{azureOpenAIKey}}}
 {{/azureOpenAIKey}}
 {{^azureOpenAIKey}}
-SECRET_AZURE_OPENAI_API_KEY=' '
+SECRET_AZURE_OPENAI_API_KEY=
 {{/azureOpenAIKey}}
 {{#azureOpenAIDeploymentName}}
 AZURE_OPENAI_MODEL_DEPLOYMENT_NAME='{{{azureOpenAIDeploymentName}}}'

--- a/templates/ts/ai-assistant-bot/env/.env.local.user
+++ b/templates/ts/ai-assistant-bot/env/.env.local.user
@@ -3,5 +3,5 @@
 # If you're adding a secret value, add SECRET_ prefix to the name so Teams Toolkit can handle them properly
 # Secrets. Keys prefixed with `SECRET_` will be masked in Teams Toolkit logs.
 SECRET_BOT_PASSWORD=
-SECRET_OPENAI_API_KEY=' '
+SECRET_OPENAI_API_KEY=
 SECRET_OPENAI_ASSISTANT_ID=' ' # See README.md for how to fill in this value.

--- a/templates/ts/custom-copilot-rag-custom-api/env/.env.local.user.tpl
+++ b/templates/ts/custom-copilot-rag-custom-api/env/.env.local.user.tpl
@@ -8,7 +8,7 @@ SECRET_BOT_PASSWORD=
 SECRET_OPENAI_API_KEY={{{openAIKey}}}
 {{/openAIKey}}
 {{^openAIKey}}
-SECRET_OPENAI_API_KEY=' '
+SECRET_OPENAI_API_KEY=
 {{/openAIKey}}
 {{/useOpenAI}}
 {{#useAzureOpenAI}}
@@ -16,7 +16,7 @@ SECRET_OPENAI_API_KEY=' '
 SECRET_AZURE_OPENAI_API_KEY={{{azureOpenAIKey}}}
 {{/azureOpenAIKey}}
 {{^azureOpenAIKey}}
-SECRET_AZURE_OPENAI_API_KEY=' '
+SECRET_AZURE_OPENAI_API_KEY=
 {{/azureOpenAIKey}}
 {{#azureOpenAIDeploymentName}}
 AZURE_OPENAI_MODEL_DEPLOYMENT_NAME='{{{azureOpenAIDeploymentName}}}'


### PR DESCRIPTION
Bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/31894173

Should not provide a space as the value, then we will treat this environment variable as provided.