### PR TITLE
fix: debug in test tool is broken

### DIFF
--- a/templates/csharp/command-and-response/Program.cs.tpl
+++ b/templates/csharp/command-and-response/Program.cs.tpl
@@ -66,7 +66,7 @@ app.MapPost("/api/messages", async (HttpRequest request, HttpResponse response, 
     await adapter.ProcessAsync(request, response, agent, cancellationToken);
 });
 
-if (app.Environment.IsDevelopment() || app.Environment.EnvironmentName == "TestTool")
+if (app.Environment.IsDevelopment() || app.Environment.EnvironmentName == "Playground")
 {
     app.MapGet("/", () => "Command and Response Bot");
     app.MapControllers().AllowAnonymous();

--- a/templates/csharp/command-and-response/Properties/launchSettings.json.tpl
+++ b/templates/csharp/command-and-response/Properties/launchSettings.json.tpl
@@ -11,7 +11,7 @@
       "launchUrl": "http://localhost:56150",
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -40,7 +40,7 @@
       "launchUrl": "http://localhost:56150",
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -67,7 +67,7 @@
       "dotnetRunMessages": true,
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -91,7 +91,7 @@
       "dotnetRunMessages": true,
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },

--- a/templates/csharp/custom-copilot-assistant-assistants-api/Properties/launchSettings.json.tpl
+++ b/templates/csharp/custom-copilot-assistant-assistants-api/Properties/launchSettings.json.tpl
@@ -11,7 +11,7 @@
       "launchUrl": "http://localhost:56150",
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -40,7 +40,7 @@
       "launchUrl": "http://localhost:56150",
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -66,7 +66,7 @@
       "dotnetRunMessages": true,
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -88,7 +88,7 @@
       "dotnetRunMessages": true,
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },

--- a/templates/csharp/custom-copilot-assistant-new/Properties/launchSettings.json.tpl
+++ b/templates/csharp/custom-copilot-assistant-new/Properties/launchSettings.json.tpl
@@ -11,7 +11,7 @@
       "launchUrl": "http://localhost:56150",
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -40,7 +40,7 @@
       "launchUrl": "http://localhost:56150",
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -66,7 +66,7 @@
       "dotnetRunMessages": true,
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -88,7 +88,7 @@
       "dotnetRunMessages": true,
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },

--- a/templates/csharp/custom-copilot-basic/Properties/launchSettings.json.tpl
+++ b/templates/csharp/custom-copilot-basic/Properties/launchSettings.json.tpl
@@ -11,7 +11,7 @@
       "launchUrl": "http://localhost:56150",
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -40,7 +40,7 @@
       "launchUrl": "http://localhost:56150",
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -66,7 +66,7 @@
       "dotnetRunMessages": true,
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -88,7 +88,7 @@
       "dotnetRunMessages": true,
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },

--- a/templates/csharp/custom-copilot-rag-azure-ai-search/Properties/launchSettings.json.tpl
+++ b/templates/csharp/custom-copilot-rag-azure-ai-search/Properties/launchSettings.json.tpl
@@ -11,7 +11,7 @@
       "launchUrl": "http://localhost:56150",
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -40,7 +40,7 @@
       "launchUrl": "http://localhost:56150",
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -66,7 +66,7 @@
       "dotnetRunMessages": true,
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -88,7 +88,7 @@
       "dotnetRunMessages": true,
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },

--- a/templates/csharp/custom-copilot-rag-custom-api/Properties/launchSettings.json.tpl
+++ b/templates/csharp/custom-copilot-rag-custom-api/Properties/launchSettings.json.tpl
@@ -11,7 +11,7 @@
       "launchUrl": "http://localhost:56150",
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -40,7 +40,7 @@
       "launchUrl": "http://localhost:56150",
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -66,7 +66,7 @@
       "dotnetRunMessages": true,
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -88,7 +88,7 @@
       "dotnetRunMessages": true,
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },

--- a/templates/csharp/custom-copilot-rag-customize/Properties/launchSettings.json.tpl
+++ b/templates/csharp/custom-copilot-rag-customize/Properties/launchSettings.json.tpl
@@ -11,7 +11,7 @@
       "launchUrl": "http://localhost:56150",
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -40,7 +40,7 @@
       "launchUrl": "http://localhost:56150",
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -66,7 +66,7 @@
       "dotnetRunMessages": true,
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -88,7 +88,7 @@
       "dotnetRunMessages": true,
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },

--- a/templates/csharp/custom-copilot-weather-agent/Program.cs.tpl
+++ b/templates/csharp/custom-copilot-weather-agent/Program.cs.tpl
@@ -73,7 +73,7 @@ app.MapPost("/api/messages", async (HttpRequest request, HttpResponse response, 
     await adapter.ProcessAsync(request, response, agent, cancellationToken);
 });
 
-if (app.Environment.IsDevelopment() || app.Environment.EnvironmentName == "TestTool")
+if (app.Environment.IsDevelopment() || app.Environment.EnvironmentName == "Playground")
 {
     app.MapGet("/", () => "Weather Bot");
     app.UseDeveloperExceptionPage();

--- a/templates/csharp/custom-copilot-weather-agent/Properties/launchSettings.json.tpl
+++ b/templates/csharp/custom-copilot-weather-agent/Properties/launchSettings.json.tpl
@@ -11,7 +11,7 @@
       "launchUrl": "http://localhost:56150",
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -40,7 +40,7 @@
       "launchUrl": "http://localhost:56150",
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -66,7 +66,7 @@
       "dotnetRunMessages": true,
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -88,7 +88,7 @@
       "dotnetRunMessages": true,
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },

--- a/templates/csharp/default-bot/Program.cs.tpl
+++ b/templates/csharp/default-bot/Program.cs.tpl
@@ -45,7 +45,7 @@ app.MapPost("/api/messages", async (HttpRequest request, HttpResponse response, 
     await adapter.ProcessAsync(request, response, agent, cancellationToken);
 });
 
-if (app.Environment.IsDevelopment() || app.Environment.EnvironmentName == "TestTool")
+if (app.Environment.IsDevelopment() || app.Environment.EnvironmentName == "Playground")
 {
     app.MapGet("/", () => "Echo Agent");
     app.UseDeveloperExceptionPage();

--- a/templates/csharp/default-bot/Properties/launchSettings.json.tpl
+++ b/templates/csharp/default-bot/Properties/launchSettings.json.tpl
@@ -11,7 +11,7 @@
       "launchUrl": "http://localhost:56150",
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -40,7 +40,7 @@
       "launchUrl": "http://localhost:56150",
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -67,7 +67,7 @@
       "dotnetRunMessages": true,
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -91,7 +91,7 @@
       "dotnetRunMessages": true,
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },

--- a/templates/csharp/link-unfurling/Program.cs.tpl
+++ b/templates/csharp/link-unfurling/Program.cs.tpl
@@ -43,7 +43,7 @@ app.MapPost("/api/messages", async (HttpRequest request, HttpResponse response, 
 {
     await adapter.ProcessAsync(request, response, agent, cancellationToken);
 });
-if (app.Environment.IsDevelopment() || app.Environment.EnvironmentName == "TestTool")
+if (app.Environment.IsDevelopment() || app.Environment.EnvironmentName == "Playground")
 {
     app.MapGet("/", () => "Link Unfurling Bot");
     app.UseDeveloperExceptionPage();

--- a/templates/csharp/link-unfurling/Properties/launchSettings.json.tpl
+++ b/templates/csharp/link-unfurling/Properties/launchSettings.json.tpl
@@ -11,7 +11,7 @@
       "launchUrl": "http://localhost:56150",
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -51,7 +51,7 @@
       "launchUrl": "http://localhost:56150",
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -78,7 +78,7 @@
       "dotnetRunMessages": true,
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -100,7 +100,7 @@
       "dotnetRunMessages": true,
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },

--- a/templates/csharp/message-extension-action/Program.cs.tpl
+++ b/templates/csharp/message-extension-action/Program.cs.tpl
@@ -42,7 +42,7 @@ app.MapPost("/api/messages", async (HttpRequest request, HttpResponse response, 
 {
     await adapter.ProcessAsync(request, response, agent, cancellationToken);
 });
-if (app.Environment.IsDevelopment() || app.Environment.EnvironmentName == "TestTool")
+if (app.Environment.IsDevelopment() || app.Environment.EnvironmentName == "Playground")
 {
     app.MapGet("/", () => "Message Extension Action Bot");
     app.UseDeveloperExceptionPage();

--- a/templates/csharp/message-extension-action/Properties/launchSettings.json.tpl
+++ b/templates/csharp/message-extension-action/Properties/launchSettings.json.tpl
@@ -11,7 +11,7 @@
       "launchUrl": "http://localhost:56150",
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -40,7 +40,7 @@
       "launchUrl": "http://localhost:56150",
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -67,7 +67,7 @@
       "dotnetRunMessages": true,
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -89,7 +89,7 @@
       "dotnetRunMessages": true,
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },

--- a/templates/csharp/message-extension-search/Program.cs.tpl
+++ b/templates/csharp/message-extension-search/Program.cs.tpl
@@ -44,7 +44,7 @@ app.MapPost("/api/messages", async (HttpRequest request, HttpResponse response, 
     await adapter.ProcessAsync(request, response, agent, cancellationToken);
 });
 
-if (app.Environment.IsDevelopment() || app.Environment.EnvironmentName == "TestTool")
+if (app.Environment.IsDevelopment() || app.Environment.EnvironmentName == "Playground")
 {
     app.MapGet("/", () => "Message Extension Search Bot");
     app.UseDeveloperExceptionPage();

--- a/templates/csharp/message-extension-search/Properties/launchSettings.json.tpl
+++ b/templates/csharp/message-extension-search/Properties/launchSettings.json.tpl
@@ -11,7 +11,7 @@
       "launchUrl": "http://localhost:56150",
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -51,7 +51,7 @@
       "launchUrl": "http://localhost:56150",
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -78,7 +78,7 @@
       "dotnetRunMessages": true,
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -100,7 +100,7 @@
       "dotnetRunMessages": true,
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },

--- a/templates/csharp/message-extension/Program.cs.tpl
+++ b/templates/csharp/message-extension/Program.cs.tpl
@@ -43,7 +43,7 @@ app.MapPost("/api/messages", async (HttpRequest request, HttpResponse response, 
     await adapter.ProcessAsync(request, response, agent, cancellationToken);
 });
 
-if (app.Environment.IsDevelopment() || app.Environment.EnvironmentName == "TestTool")
+if (app.Environment.IsDevelopment() || app.Environment.EnvironmentName == "Playground")
 {
     app.MapGet("/", () => "Message Extension Bot");
     app.UseDeveloperExceptionPage();

--- a/templates/csharp/message-extension/Properties/launchSettings.json.tpl
+++ b/templates/csharp/message-extension/Properties/launchSettings.json.tpl
@@ -11,7 +11,7 @@
       "launchUrl": "http://localhost:56150",
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -51,7 +51,7 @@
       "launchUrl": "http://localhost:56150",
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -78,7 +78,7 @@
       "dotnetRunMessages": true,
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -100,7 +100,7 @@
       "dotnetRunMessages": true,
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },

--- a/templates/csharp/notification-webapi/Program.cs.tpl
+++ b/templates/csharp/notification-webapi/Program.cs.tpl
@@ -52,7 +52,7 @@ app.UseRouting();
 app.UseAuthentication();
 app.UseAuthorization();
 
-if (app.Environment.IsDevelopment() || app.Environment.EnvironmentName == "TestTool")
+if (app.Environment.IsDevelopment() || app.Environment.EnvironmentName == "Playground")
 {
     app.MapGet("/", () => "Notification Bot");
     app.UseDeveloperExceptionPage();

--- a/templates/csharp/workflow/Program.cs.tpl
+++ b/templates/csharp/workflow/Program.cs.tpl
@@ -72,7 +72,7 @@ app.MapPost("/api/messages", async (HttpRequest request, HttpResponse response, 
     await adapter.ProcessAsync(request, response, agent, cancellationToken);
 });
 
-if (app.Environment.IsDevelopment() || app.Environment.EnvironmentName == "TestTool")
+if (app.Environment.IsDevelopment() || app.Environment.EnvironmentName == "Playground")
 {
     app.MapGet("/", () => "Workflow Bot");
     app.MapControllers().AllowAnonymous();

--- a/templates/csharp/workflow/Properties/launchSettings.json.tpl
+++ b/templates/csharp/workflow/Properties/launchSettings.json.tpl
@@ -11,7 +11,7 @@
       "launchUrl": "http://localhost:56150",
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -40,7 +40,7 @@
       "launchUrl": "http://localhost:56150",
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -67,7 +67,7 @@
       "dotnetRunMessages": true,
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },
@@ -91,7 +91,7 @@
       "dotnetRunMessages": true,
       "applicationUrl": "http://localhost:5130",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "TestTool",
+        "ASPNETCORE_ENVIRONMENT": "Playground",
         "TEAMSFX_NOTIFICATION_STORE_FILENAME": ".notification.playgroundstore.json",
         "UPDATE_TEAMS_APP": "false"
       },


### PR DESCRIPTION
Issue: appSettings.{environment}.json can't be read successfully since environment name is not consistent
Fix: update test tool env name so app source code can get valid config
ADO: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/32479744