### PR TITLE
refactor: update Microsoft.Agents package versions to 1.* across project templates

### DIFF
--- a/packages/dotnet-sdk/src/TeamsFx/Microsoft.TeamsFx.csproj
+++ b/packages/dotnet-sdk/src/TeamsFx/Microsoft.TeamsFx.csproj
@@ -27,9 +27,9 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
       <_Parameter1>Microsoft.TeamsFx.Test</_Parameter1>
     </AssemblyAttribute>
-    <PackageReference Include="Microsoft.Agents.Builder.Dialogs" Version="0.2.*-*" />
-    <PackageReference Include="Microsoft.Agents.Extensions.Teams" Version="0.2.*-*" />
-    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="0.2.*-*" />
+    <PackageReference Include="Microsoft.Agents.Builder.Dialogs" Version="1.*" />
+    <PackageReference Include="Microsoft.Agents.Extensions.Teams" Version="1.*" />
+    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="1.*" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.14" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.1" />

--- a/templates/csharp/command-and-response/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/command-and-response/{{ProjectName}}.csproj.tpl
@@ -20,8 +20,8 @@
 {{/isNewProjectTypeEnabled}}
   <ItemGroup>
     <PackageReference Include="AdaptiveCards.Templating" Version="2.0.5" />
-    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="0.2.*-*" />
-    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="0.2.*-*" />
+    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="1.*" />
+    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="1.*" />
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.14" />
     <PackageReference Include="Microsoft.TeamsFx" Version="3.0.*-*" >
       <!-- Exclude TeamsFx wwwroot static files which are for frontend only. -->

--- a/templates/csharp/custom-copilot-weather-agent/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/custom-copilot-weather-agent/{{ProjectName}}.csproj.tpl
@@ -28,8 +28,8 @@
     <PackageReference Include="Microsoft.SemanticKernel.Agents.Core" Version="1.45.0" />
     <PackageReference Include="Microsoft.SemanticKernel.Connectors.AzureOpenAI" Version="1.45.0" />
     <PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.45.0" />
-    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="0.2.*-*" />
-    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="0.2.*-*" />
+    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="1.*" />
+    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="1.*" />
   </ItemGroup>
 
   <!-- Exclude local settings from publish -->

--- a/templates/csharp/default-bot/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/default-bot/{{ProjectName}}.csproj.tpl
@@ -19,8 +19,8 @@
 
 {{/isNewProjectTypeEnabled}}
   <ItemGroup>
-    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="0.2.*-*" />
-    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="0.2.*-*" />
+    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="1.*" />
+    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="1.*" />
   </ItemGroup>
 
 </Project>

--- a/templates/csharp/link-unfurling/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/link-unfurling/{{ProjectName}}.csproj.tpl
@@ -18,9 +18,9 @@
 {{/isNewProjectTypeEnabled}}
   <ItemGroup>
 	  <PackageReference Include="AdaptiveCards" Version="3.1.0" />
-	  <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="0.2.*-*" />
-	  <PackageReference Include="Microsoft.Agents.Extensions.Teams" Version="0.2.*-*" />
-	  <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="0.2.*-*" />
+	  <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="1.*" />
+	  <PackageReference Include="Microsoft.Agents.Extensions.Teams" Version="1.*" />
+	  <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="1.*" />
   </ItemGroup>
 
 </Project>

--- a/templates/csharp/message-extension-action/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/message-extension-action/{{ProjectName}}.csproj.tpl
@@ -19,9 +19,9 @@
   <ItemGroup>
     <PackageReference Include="AdaptiveCards" Version="3.1.0" />
     <PackageReference Include="AdaptiveCards.Templating" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="0.2.*-*" />
-    <PackageReference Include="Microsoft.Agents.Extensions.Teams" Version="0.2.*-*" />
-    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="0.2.*-*" />
+    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="1.*" />
+    <PackageReference Include="Microsoft.Agents.Extensions.Teams" Version="1.*" />
+    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="1.*" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/templates/csharp/message-extension-search/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/message-extension-search/{{ProjectName}}.csproj.tpl
@@ -19,9 +19,9 @@
   <ItemGroup>
     <PackageReference Include="AdaptiveCards" Version="3.1.0" />
     <PackageReference Include="AdaptiveCards.Templating" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="0.2.*-*" />
-    <PackageReference Include="Microsoft.Agents.Extensions.Teams" Version="0.2.*-*" />
-    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="0.2.*-*" />
+    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="1.*" />
+    <PackageReference Include="Microsoft.Agents.Extensions.Teams" Version="1.*" />
+    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="1.*" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/templates/csharp/message-extension/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/message-extension/{{ProjectName}}.csproj.tpl
@@ -19,9 +19,9 @@
   <ItemGroup>
     <PackageReference Include="AdaptiveCards" Version="3.1.0" />
     <PackageReference Include="AdaptiveCards.Templating" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="0.2.*-*" />
-    <PackageReference Include="Microsoft.Agents.Extensions.Teams" Version="0.2.*-*" />
-    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="0.2.*-*" />
+    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="1.*" />
+    <PackageReference Include="Microsoft.Agents.Extensions.Teams" Version="1.*" />
+    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="1.*" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/templates/csharp/notification-http-timer-trigger/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/notification-http-timer-trigger/{{ProjectName}}.csproj.tpl
@@ -33,8 +33,8 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
-    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="0.2.*-*" />
-    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="0.2.*-*" />
+    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="1.*" />
+    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="1.*" />
     <PackageReference Include="Microsoft.TeamsFx" Version="3.0.*-*">
       <!-- Exclude TeamsFx wwwroot static files which are for frontend only. -->
       <ExcludeAssets>contentFiles</ExcludeAssets>

--- a/templates/csharp/notification-http-trigger/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/notification-http-trigger/{{ProjectName}}.csproj.tpl
@@ -32,8 +32,8 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="0.2.*-*" />
-    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="0.2.*-*" />
+    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="1.*" />
+    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="1.*" />
     <PackageReference Include="Microsoft.TeamsFx" Version="3.0.*-*">
       <!-- Exclude TeamsFx wwwroot static files which are for frontend only. -->
       <ExcludeAssets>contentFiles</ExcludeAssets>

--- a/templates/csharp/notification-timer-trigger/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/notification-timer-trigger/{{ProjectName}}.csproj.tpl
@@ -33,8 +33,8 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
-    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="0.2.*-*" />
-    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="0.2.*-*" />
+    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="1.*" />
+    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="1.*" />
     <PackageReference Include="Microsoft.TeamsFx" Version="3.0.*-*">
       <!-- Exclude TeamsFx wwwroot static files which are for frontend only. -->
       <ExcludeAssets>contentFiles</ExcludeAssets>

--- a/templates/csharp/notification-webapi/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/notification-webapi/{{ProjectName}}.csproj.tpl
@@ -25,8 +25,8 @@
 
   <ItemGroup>
     <PackageReference Include="AdaptiveCards.Templating" Version="1.3.1" />
-    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="0.2.*-*" />
-    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="0.2.*-*" />
+    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="1.*" />
+    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="1.*" />
     <PackageReference Include="Microsoft.TeamsFx" Version="3.0.*-*">
       <!-- Exclude TeamsFx wwwroot static files which are for frontend only. -->
       <ExcludeAssets>contentFiles</ExcludeAssets>

--- a/templates/csharp/workflow/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/workflow/{{ProjectName}}.csproj.tpl
@@ -20,8 +20,8 @@
 {{/isNewProjectTypeEnabled}}
   <ItemGroup>
     <PackageReference Include="AdaptiveCards.Templating" Version="2.0.5" />
-    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="0.2.*-*" />
-    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="0.2.*-*" />
+    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="1.*" />
+    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="1.*" />
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.14" />
     <PackageReference Include="Microsoft.TeamsFx" Version="3.0.*-*">
       <!-- Exclude TeamsFx wwwroot static files which are for frontend only. -->


### PR DESCRIPTION
This pull request updates the package references in the `Microsoft.TeamsFx` project and its associated templates to use stable `1.*` versions of key dependencies. These changes ensure compatibility with the latest stable releases of the `Microsoft.Agents` libraries.

### Updates to Package Versions:

* **Core Project (`Microsoft.TeamsFx.csproj`):**
  - Updated `Microsoft.Agents.Builder.Dialogs`, `Microsoft.Agents.Extensions.Teams`, and `Microsoft.Agents.Hosting.AspNetCore` from pre-release `0.2.*-*` versions to stable `1.*` versions.

* **Template Projects:**
  - Updated `Microsoft.Agents.Authentication.Msal` and `Microsoft.Agents.Hosting.AspNetCore` to `1.*` across all C# templates, replacing the pre-release `0.2.*-*` versions. Additionally, `Microsoft.Agents.Extensions.Teams` was updated in applicable templates.
    - `command-and-response` template (`{{ProjectName}}.csproj.tpl`)
    - `custom-copilot-weather-agent` template (`{{ProjectName}}.csproj.tpl`)
    - `default-bot` template (`{{ProjectName}}.csproj.tpl`)
    - `link-unfurling` template (`{{ProjectName}}.csproj.tpl`)
    - `message-extension-*` templates (`{{ProjectName}}.csproj.tpl`)
    - `notification-*` templates (`{{ProjectName}}.csproj.tpl`) [[1]](diffhunk://#diff-58bcf341fd22d88a54e0dd5e123ecf79b766279ebe2c384342f8b2d46b96a33dL36-R37) [[2]](diffhunk://#diff-f3a47f7cde6d4074424e4582e28f980201fba22021c3007d9d5b5fdb162e2836L35-R36)
    - `workflow` template (`{{ProjectName}}.csproj.tpl`)

These updates standardize the dependency versions across the project and templates, ensuring stability and alignment with the latest supported features.