### PR TITLE
perf(da): use latest kiota npm package, fix bugs

### DIFF
--- a/packages/fx-core/package.json
+++ b/packages/fx-core/package.json
@@ -105,7 +105,7 @@
     "@feathersjs/hooks": "^0.6.5",
     "@microsoft/dev-tunnels-contracts": "1.1.9",
     "@microsoft/dev-tunnels-management": "1.1.9",
-    "@microsoft/kiota": "1.25.1-preview.202504170001",
+    "@microsoft/kiota": "1.25.1-preview.202504240001",
     "@microsoft/m365-spec-parser": "workspace:^",
     "@microsoft/teamsfx-api": "workspace:*",
     "adm-zip": "^0.5.10",

--- a/packages/fx-core/pnpm-lock.yaml
+++ b/packages/fx-core/pnpm-lock.yaml
@@ -42,8 +42,8 @@ dependencies:
     specifier: 1.1.9
     version: 1.1.9
   '@microsoft/kiota':
-    specifier: 1.25.1-preview.202504170001
-    version: 1.25.1-preview.202504170001
+    specifier: 1.25.1-preview.202504240001
+    version: 1.25.1-preview.202504240001
   '@microsoft/m365-spec-parser':
     specifier: workspace:^
     version: link:../spec-parser
@@ -1020,8 +1020,8 @@ packages:
       - supports-color
     dev: false
 
-  /@microsoft/kiota@1.25.1-preview.202504170001:
-    resolution: {integrity: sha512-PaQekaThLmUeImtkU+pvAzaJZNtCliLURt8gbGiBXl98XAcA8oEw3HIPJ6FEA4S9uYbBa94omMSKB7hM5zwGzg==}
+  /@microsoft/kiota@1.25.1-preview.202504240001:
+    resolution: {integrity: sha512-LKI6fsLO7GRYXRiF4t0xIk9noHOWWGin0atzPqaI3pjTu0oljTZ3J0Q8h4/H4AURX7xv5eNH6pTt6CAbi7XvuQ==}
     dependencies:
       adm-zip: 0.5.16
       original-fs: 1.2.0

--- a/packages/fx-core/src/common/daSpecParser.ts
+++ b/packages/fx-core/src/common/daSpecParser.ts
@@ -489,7 +489,7 @@ function isAuthTypeSupported(
   allowOauth2: boolean
 ): boolean {
   return (
-    (allowAPIKeyAuth && Utils.isAPIKeyAuth(authScheme)) ||
+    (allowAPIKeyAuth && Utils.isAPIKeyAuthButNotInCookie(authScheme)) ||
     (allowOauth2 && Utils.isOAuthWithAuthCodeFlow(authScheme)) ||
     (allowBearerTokenAuth && Utils.isBearerTokenAuth(authScheme))
   );

--- a/packages/fx-core/src/component/generator/openApiSpec/helper.ts
+++ b/packages/fx-core/src/component/generator/openApiSpec/helper.ts
@@ -693,7 +693,8 @@ export async function injectAuthAction(
   const relativeSpecPath = `./${path.relative(projectPath, outputApiSpecPath).replace(/\\/g, "/")}`;
 
   if (
-    (!!authScheme && (Utils.isBearerTokenAuth(authScheme) || Utils.isAPIKeyAuth(authScheme))) ||
+    (!!authScheme &&
+      (Utils.isBearerTokenAuth(authScheme) || Utils.isAPIKeyAuthButNotInCookie(authScheme))) ||
     authType === APIKeyAuthType
   ) {
     const res = await ActionInjector.injectCreateAPIKeyAction(

--- a/packages/fx-core/src/core/FxCore.ts
+++ b/packages/fx-core/src/core/FxCore.ts
@@ -3015,7 +3015,7 @@ export class FxCore {
         operation.auth &&
         (Utils.isBearerTokenAuth(operation.auth.authScheme) ||
           Utils.isOAuthWithAuthCodeFlow(operation.auth.authScheme) ||
-          Utils.isAPIKeyAuth(operation.auth.authScheme))
+          Utils.isAPIKeyAuthButNotInCookie(operation.auth.authScheme))
       ) {
         if (result.find((value) => value.authName === operation.auth!.name)) {
           continue;

--- a/packages/fx-core/src/question/create.ts
+++ b/packages/fx-core/src/question/create.ts
@@ -827,7 +827,8 @@ export function apiOperationQuestion(
           input.length < 1 ||
           (input.length > 10 &&
             inputs[QuestionNames.CustomCopilotRag] !== CustomCopilotRagOptions.customApi().id &&
-            inputs[QuestionNames.ProjectType] !== ProjectTypeOptions.copilotAgentOptionId)
+            inputs[QuestionNames.ProjectType] !== ProjectTypeOptions.copilotAgentOptionId &&
+            inputs[QuestionNames.ActionType] !== ActionStartOptions.apiSpec().id)
         ) {
           return getLocalizedString(
             "core.createProjectQuestion.apiSpec.operation.invalidMessage",

--- a/packages/fx-core/tests/common/daSpecParser.test.ts
+++ b/packages/fx-core/tests/common/daSpecParser.test.ts
@@ -9,7 +9,7 @@ import * as daSpecParser from "../../src/common/daSpecParser";
 import * as utils from "../../src/common/utils";
 import { featureFlagManager, FeatureFlags } from "../../src/common/featureFlags";
 import { Platform } from "@microsoft/teamsfx-api";
-import { KiotaOpenApiNode, KiotaTreeResult } from "@microsoft/kiota";
+import { KiotaOpenApiNode, KiotaTreeResult, OpenApiSpecVersion } from "@microsoft/kiota";
 import {
   AdaptiveCardUpdateStrategy,
   ErrorType,
@@ -85,6 +85,7 @@ describe("daSpecParser", () => {
         security: [],
         securitySchemes: {},
         logs: [],
+        specVersion: OpenApiSpecVersion.V3_0,
       };
 
       listAPITreeInfoStub.resolves(mockTreeInfo);
@@ -122,6 +123,7 @@ describe("daSpecParser", () => {
         security: [],
         securitySchemes: {},
         logs: [],
+        specVersion: OpenApiSpecVersion.V3_0,
       };
 
       listAPITreeInfoStub.resolves(mockTreeInfo);
@@ -159,6 +161,7 @@ describe("daSpecParser", () => {
         security: [],
         securitySchemes: {},
         logs: [],
+        specVersion: OpenApiSpecVersion.V3_0,
       };
 
       listAPITreeInfoStub.resolves(mockTreeInfo);
@@ -186,6 +189,7 @@ describe("daSpecParser", () => {
         security: [],
         securitySchemes: {},
         logs: [],
+        specVersion: OpenApiSpecVersion.V3_0,
       };
 
       listAPITreeInfoStub.resolves(mockTreeInfo);
@@ -229,6 +233,7 @@ describe("daSpecParser", () => {
         security: [],
         securitySchemes: {},
         logs: [],
+        specVersion: OpenApiSpecVersion.V3_0,
       };
 
       listAPITreeInfoStub.resolves(mockTreeInfo);
@@ -279,6 +284,7 @@ describe("daSpecParser", () => {
             referenceId: "",
           },
         },
+        specVersion: OpenApiSpecVersion.V3_0,
       };
 
       listAPITreeInfoStub.resolves(mockTreeInfo);
@@ -328,6 +334,7 @@ describe("daSpecParser", () => {
           },
         },
         logs: [],
+        specVersion: OpenApiSpecVersion.V3_0,
       };
 
       listAPITreeInfoStub.resolves(mockTreeInfo);
@@ -373,6 +380,7 @@ describe("daSpecParser", () => {
           },
         },
         logs: [],
+        specVersion: OpenApiSpecVersion.V3_0,
       };
 
       listAPITreeInfoStub.resolves(mockTreeInfo);
@@ -399,6 +407,7 @@ describe("daSpecParser", () => {
         security: [],
         securitySchemes: {},
         logs: [],
+        specVersion: OpenApiSpecVersion.V3_0,
       };
 
       listAPITreeInfoStub.resolves(mockTreeInfo);
@@ -425,6 +434,7 @@ describe("daSpecParser", () => {
         security: [],
         securitySchemes: {},
         logs: [],
+        specVersion: OpenApiSpecVersion.V3_0,
       };
 
       listAPITreeInfoStub.resolves(mockTreeInfo);
@@ -452,6 +462,7 @@ describe("daSpecParser", () => {
         security: undefined,
         securitySchemes: {},
         logs: [],
+        specVersion: OpenApiSpecVersion.V3_0,
       };
 
       listAPITreeInfoStub.resolves(mockTreeInfoNoSecurity);
@@ -473,6 +484,7 @@ describe("daSpecParser", () => {
         security: [],
         securitySchemes: {},
         logs: [],
+        specVersion: OpenApiSpecVersion.V3_0,
       };
 
       listAPITreeInfoStub.resolves(mockTreeInfoEmptySecurity);
@@ -494,6 +506,7 @@ describe("daSpecParser", () => {
         security: [{}],
         securitySchemes: {},
         logs: [],
+        specVersion: OpenApiSpecVersion.V3_0,
       };
 
       listAPITreeInfoStub.resolves(mockTreeInfoEmptyRequirement);
@@ -588,6 +601,7 @@ describe("daSpecParser", () => {
           bearer_auth: { type: "http", scheme: "bearer", referenceId: "" },
         },
         logs: [],
+        specVersion: OpenApiSpecVersion.V3_0,
       };
 
       listAPITreeInfoStub.resolves(mockTreeInfo);
@@ -617,6 +631,7 @@ describe("daSpecParser", () => {
         } as KiotaOpenApiNode,
         security: [],
         logs: [],
+        specVersion: OpenApiSpecVersion.V3_0,
       };
 
       listAPITreeInfoStub.resolves(mockTreeInfo);
@@ -652,6 +667,7 @@ describe("daSpecParser", () => {
           api_key: { type: "apiKey", name: "x-api-key", in: "header", referenceId: "" },
         },
         logs: [],
+        specVersion: OpenApiSpecVersion.V3_0,
       };
 
       listAPITreeInfoStub.resolves(mockTreeInfo);
@@ -681,6 +697,7 @@ describe("daSpecParser", () => {
           auth2: { type: "oauth2", flows: {}, referenceId: "" },
         },
         logs: [],
+        specVersion: OpenApiSpecVersion.V3_0,
       };
 
       listAPITreeInfoStub.resolves(mockTreeInfo);
@@ -729,6 +746,7 @@ describe("daSpecParser", () => {
         security: [],
         securitySchemes: {},
         logs: [],
+        specVersion: OpenApiSpecVersion.V3_0,
       };
 
       listAPITreeInfoStub.resolves(mockTreeInfo);
@@ -762,8 +780,8 @@ describe("daSpecParser", () => {
         security: [],
         securitySchemes: {},
         logs: [],
+        specVersion: OpenApiSpecVersion.V3_0,
       };
-
       listAPITreeInfoStub.resolves(mockTreeInfo);
 
       const checkServerUrlStub = sinon.stub();
@@ -808,6 +826,7 @@ describe("daSpecParser", () => {
         security: [],
         securitySchemes: {},
         logs: [],
+        specVersion: OpenApiSpecVersion.V3_0,
       };
 
       listAPITreeInfoStub.resolves(mockTreeInfo);
@@ -849,6 +868,7 @@ describe("daSpecParser", () => {
         security: [],
         securitySchemes: {},
         logs: [],
+        specVersion: OpenApiSpecVersion.V3_0,
       };
 
       listAPITreeInfoStub.resolves(mockTreeInfo);


### PR DESCRIPTION
Update kiota npm version to 1.25.1-preview.202504170001
Fixes:
- Can only select at most 10 APIs when add plugin
- Make sure API key only exists in header or query