### PR TITLE
fix: fix the missing root folder when converting existing Office add-ins

### DIFF
--- a/packages/fx-core/src/component/generator/officeAddin/generator.ts
+++ b/packages/fx-core/src/component/generator/officeAddin/generator.ts
@@ -63,7 +63,7 @@ export class OfficeAddinGenerator {
         );
         if (manifestFile.endsWith(".xml")) {
           // Need to convert to json project first
-          await convertProject(manifestFile, "./backup.zip", "", true);
+          await convertProject(manifestFile, "./backup.zip", addinRoot, true);
           manifestFile = manifestFile.replace(/\.xml$/, ".json");
         }
         inputs[QuestionNames.OfficeAddinHost] = await getHost(manifestFile);


### PR DESCRIPTION
ADO Link: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/32627450/