### PR TITLE
fix(template): enable cea by default with preview tag

### DIFF
--- a/templates/js/basic-custom-engine-agent/.vscode/launch.json.tpl
+++ b/templates/js/basic-custom-engine-agent/.vscode/launch.json.tpl
@@ -90,10 +90,9 @@
                 "order": 6
             },
             "internalConsoleOptions": "neverOpen",
-        {{#CEAEnabled}}
         },
         {
-            "name": "Launch Remote in Copilot (Edge)",
+            "name": "(Preview) Launch Remote in Copilot (Edge)",
             "type": "msedge",
             "request": "launch",
             "url": "https://m365.cloud.microsoft/chat/entity1-d870f6cd-4aa5-4d42-9626-ab690c041429/${agent-hint}?auth=2&${account-hint}&developerMode=Basic",
@@ -109,7 +108,7 @@
             ]
             },
             {
-            "name": "Launch Remote in Copilot (Chrome)",
+            "name": "(Preview) Launch Remote in Copilot (Chrome)",
             "type": "chrome",
             "request": "launch",
             "url": "https://m365.cloud.microsoft/chat/entity1-d870f6cd-4aa5-4d42-9626-ab690c041429/${agent-hint}?auth=2&${account-hint}&developerMode=Basic",
@@ -155,7 +154,6 @@
                 "--remote-debugging-port=9223",
                 "--no-first-run"
             ]
-        {{/CEAEnabled}}
 {{#SandBoxedTeam}}
         },
         {
@@ -260,10 +258,9 @@
                 "order": 1
             },
             "stopAll": true
-        {{#CEAEnabled}}
         },
         {
-            "name": "Debug in Copilot (Edge)",
+            "name": "(Preview) Debug in Copilot (Edge)",
             "configurations": [
                 "Launch in Copilot (Edge)",
                 "Attach to Local Service"
@@ -276,7 +273,7 @@
             "stopAll": true
             },
             {
-            "name": "Debug in Copilot (Chrome)",
+            "name": "(Preview) Debug in Copilot (Chrome)",
             "configurations": [
                 "Launch in Copilot (Chrome)",
                 "Attach to Local Service"
@@ -287,7 +284,6 @@
                 "order": 2
             },
             "stopAll": true
-        {{/CEAEnabled}}
         }
     ]
 }

--- a/templates/js/basic-custom-engine-agent/README.md.tpl
+++ b/templates/js/basic-custom-engine-agent/README.md.tpl
@@ -87,8 +87,6 @@ The following are Microsoft 365 Agents Toolkit specific project files. You can [
 - [Microsoft 365 Agents Toolkit Documentations](https://docs.microsoft.com/microsoftteams/platform/toolkit/teams-toolkit-fundamentals)
 - [Microsoft 365 Agents Toolkit CLI](https://aka.ms/teamsfx-toolkit-cli)
 - [Microsoft 365 Agents Toolkit Samples](https://github.com/OfficeDev/TeamsFx-Samples)
-{{#CEAEnabled}}
 
 ## Known issue
 - The agent is currently not working in any Teams group chats or Teams channels when the stream response is enabled.
-{{/CEAEnabled}}

--- a/templates/js/basic-custom-engine-agent/appPackage/manifest.json.tpl
+++ b/templates/js/basic-custom-engine-agent/appPackage/manifest.json.tpl
@@ -1,14 +1,7 @@
 {
-    {{#CEAEnabled}} 
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/vdevPreview/MicrosoftTeams.schema.json",
-    "manifestVersion": "devPreview",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
-    {{/CEAEnabled}}
-    {{^CEAEnabled}} 
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
-    "version": "1.0.0",
-    {{/CEAEnabled}}
     "id": "${{TEAMS_APP_ID}}",
     "developer": {
         "name": "My App, Inc.",
@@ -29,7 +22,6 @@
         "full": "full description for {{appName}}"
     },
     "accentColor": "#FFFFFF",
-    {{#CEAEnabled}} 
     "copilotAgents": {
         "customEngineAgents": [
             {
@@ -38,26 +30,20 @@
             }
         ]
     },
-    {{/CEAEnabled}}
     "bots": [
         {
             "botId": "${{BOT_ID}}",
             "scopes": [
-                {{#CEAEnabled}} 
                 "copilot",
-                {{/CEAEnabled}}
                 "personal",
-                "team",
-                "groupChat"
+                "team"
             ],
             "supportsFiles": false,
             "isNotificationOnly": false,
             "commandLists": [
                 {
                     "scopes": [
-                        {{#CEAEnabled}} 
                         "copilot",
-                        {{/CEAEnabled}}
                         "personal"
                     ],
                     "commands": [

--- a/templates/js/basic-custom-engine-agent/m365agents.local.yml.tpl
+++ b/templates/js/basic-custom-engine-agent/m365agents.local.yml.tpl
@@ -39,13 +39,11 @@ provision:
       channels:
         - name: msteams
 
-  {{^CEAEnabled}}
   # Validate using manifest schema
   - uses: teamsApp/validateManifest
     with:
       # Path to manifest template
       manifestPath: ./appPackage/manifest.json
-  {{/CEAEnabled}}
 
   # Build app package with latest env value
   - uses: teamsApp/zipAppPackage
@@ -68,7 +66,6 @@ provision:
       # Relative path to this file. This is the path for built zip file.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
 
-{{#CEAEnabled}}
   - uses: teamsApp/extendToM365
     with:
       # Relative path to the build app package.
@@ -78,7 +75,6 @@ provision:
     writeToEnvironmentFile:
       titleId: M365_TITLE_ID
       appId: M365_APP_ID
-{{/CEAEnabled}}
 
 deploy:
   # Run npm command

--- a/templates/js/basic-custom-engine-agent/m365agents.sandbox.yml.tpl
+++ b/templates/js/basic-custom-engine-agent/m365agents.sandbox.yml.tpl
@@ -52,13 +52,11 @@ provision:
       channels:
         - name: msteams
 
-  {{^CEAEnabled}}
   # Validate using manifest schema
   - uses: teamsApp/validateManifest
     with:
       # Path to manifest template
       manifestPath: ./appPackage/manifest.json
-  {{/CEAEnabled}}
 
   # Build app package with latest env value
   - uses: teamsApp/zipAppPackage
@@ -81,7 +79,6 @@ provision:
       # Relative path to this file. This is the path for built zip file.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
 
-{{#CEAEnabled}}
   - uses: teamsApp/extendToM365
     with:
       # Relative path to the build app package.
@@ -91,7 +88,6 @@ provision:
     writeToEnvironmentFile:
       titleId: M365_TITLE_ID
       appId: M365_APP_ID
-{{/CEAEnabled}}
 
 deploy:
 {{#SandBoxedTeam}}

--- a/templates/js/basic-custom-engine-agent/m365agents.yml.tpl
+++ b/templates/js/basic-custom-engine-agent/m365agents.yml.tpl
@@ -42,13 +42,11 @@ provision:
       # will use bicep CLI in PATH if you remove this config.
       bicepCliVersion: v0.9.1
       
-  {{^CEAEnabled}}
   # Validate using manifest schema
   - uses: teamsApp/validateManifest
     with:
       # Path to manifest template
       manifestPath: ./appPackage/manifest.json
-  {{/CEAEnabled}}
   # Build app package with latest env value
   - uses: teamsApp/zipAppPackage
     with:
@@ -68,7 +66,6 @@ provision:
     with:
       # Relative path to this file. This is the path for built zip file.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
-  {{#CEAEnabled}}
   - uses: teamsApp/extendToM365
     with:
       # Relative path to the build app package.
@@ -78,7 +75,6 @@ provision:
     writeToEnvironmentFile:
       titleId: M365_TITLE_ID
       appId: M365_APP_ID
-  {{/CEAEnabled}}
 
 # Triggered when 'teamsapp deploy' is executed
 deploy:
@@ -107,13 +103,11 @@ deploy:
 
 # Triggered when 'teamsapp publish' is executed
 publish:
-  {{^CEAEnabled}}
   # Validate using manifest schema
   - uses: teamsApp/validateManifest
     with:
       # Path to manifest template
       manifestPath: ./appPackage/manifest.json
-  {{/CEAEnabled}}
   # Build app package with latest env value
   - uses: teamsApp/zipAppPackage
     with:

--- a/templates/js/weather-agent/.vscode/launch.json.tpl
+++ b/templates/js/weather-agent/.vscode/launch.json.tpl
@@ -90,10 +90,9 @@
                 "order": 6
             },
             "internalConsoleOptions": "neverOpen",
-        {{#CEAEnabled}}
         },
         {
-            "name": "Launch Remote in Copilot (Edge)",
+            "name": "(Preview) Launch Remote in Copilot (Edge)",
             "type": "msedge",
             "request": "launch",
             "url": "https://m365.cloud.microsoft/chat/entity1-d870f6cd-4aa5-4d42-9626-ab690c041429/${agent-hint}?auth=2&${account-hint}&developerMode=Basic",
@@ -109,7 +108,7 @@
             ]
             },
             {
-            "name": "Launch Remote in Copilot (Chrome)",
+            "name": "(Preview) Launch Remote in Copilot (Chrome)",
             "type": "chrome",
             "request": "launch",
             "url": "https://m365.cloud.microsoft/chat/entity1-d870f6cd-4aa5-4d42-9626-ab690c041429/${agent-hint}?auth=2&${account-hint}&developerMode=Basic",
@@ -125,7 +124,7 @@
             ]
         },
         {
-            "name": "Launch in Copilot (Edge)",
+            "name": "(Preview) Launch in Copilot (Edge)",
             "type": "msedge",
             "request": "launch",
             "url": "https://m365.cloud.microsoft/chat/entity1-d870f6cd-4aa5-4d42-9626-ab690c041429/${local:agent-hint}?auth=2&${account-hint}&developerMode=Basic",
@@ -141,7 +140,7 @@
             ]
         },
         {
-            "name": "Launch in Copilot (Chrome)",
+            "name": "(Preview) Launch in Copilot (Chrome)",
             "type": "chrome",
             "request": "launch",
             "url": "https://m365.cloud.microsoft/chat/entity1-d870f6cd-4aa5-4d42-9626-ab690c041429/${local:agent-hint}?auth=2&${account-hint}&developerMode=Basic",
@@ -155,7 +154,6 @@
                 "--remote-debugging-port=9223",
                 "--no-first-run"
             ]
-        {{/CEAEnabled}}
 {{#SandBoxedTeam}}
         },
         {
@@ -260,10 +258,9 @@
                 "order": 1
             },
             "stopAll": true
-        {{#CEAEnabled}}
         },
         {
-            "name": "Debug in Copilot (Edge)",
+            "name": "(Preview) Debug in Copilot (Edge)",
             "configurations": [
                 "Launch in Copilot (Edge)",
                 "Attach to Local Service"
@@ -276,7 +273,7 @@
             "stopAll": true
             },
             {
-            "name": "Debug in Copilot (Chrome)",
+            "name": "(Preview) Debug in Copilot (Chrome)",
             "configurations": [
                 "Launch in Copilot (Chrome)",
                 "Attach to Local Service"
@@ -287,7 +284,6 @@
                 "order": 2
             },
             "stopAll": true
-        {{/CEAEnabled}}
         }
     ]
 }

--- a/templates/js/weather-agent/README.md.tpl
+++ b/templates/js/weather-agent/README.md.tpl
@@ -88,8 +88,6 @@ The following are Microsoft 365 Agents Toolkit specific project files. You can [
 - [Microsoft 365 Agents Toolkit Documentations](https://docs.microsoft.com/microsoftteams/platform/toolkit/teams-toolkit-fundamentals)
 - [Microsoft 365 Agents Toolkit CLI](https://aka.ms/teamsfx-toolkit-cli)
 - [Microsoft 365 Agents Toolkit Samples](https://github.com/OfficeDev/TeamsFx-Samples)
-{{#CEAEnabled}}
 
 ## Known issue
 - The agent is currently not working in any Teams group chats or Teams channels when the stream response is enabled.
-{{/CEAEnabled}}

--- a/templates/js/weather-agent/appPackage/manifest.json.tpl
+++ b/templates/js/weather-agent/appPackage/manifest.json.tpl
@@ -1,14 +1,7 @@
 {
-    {{#CEAEnabled}} 
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/vdevPreview/MicrosoftTeams.schema.json",
-    "manifestVersion": "devPreview",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
-    {{/CEAEnabled}}
-    {{^CEAEnabled}} 
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
-    "version": "1.0.0",
-    {{/CEAEnabled}}
     "id": "${{TEAMS_APP_ID}}",
     "developer": {
         "name": "My App, Inc.",
@@ -29,7 +22,6 @@
         "full": "full description for {{appName}}"
     },
     "accentColor": "#FFFFFF",
-    {{#CEAEnabled}} 
     "copilotAgents": {
         "customEngineAgents": [
             {
@@ -38,26 +30,20 @@
             }
         ]
     },
-    {{/CEAEnabled}}
     "bots": [
         {
             "botId": "${{BOT_ID}}",
             "scopes": [
-                {{#CEAEnabled}} 
                 "copilot",
-                {{/CEAEnabled}}
                 "personal",
-                "team",
-                "groupChat"
+                "team"
             ],
             "supportsFiles": false,
             "isNotificationOnly": false,
             "commandLists": [
                 {
                     "scopes": [
-                        {{#CEAEnabled}} 
                         "copilot",
-                        {{/CEAEnabled}}
                         "personal"
                     ],
                     "commands": [

--- a/templates/js/weather-agent/m365agents.local.yml.tpl
+++ b/templates/js/weather-agent/m365agents.local.yml.tpl
@@ -39,13 +39,11 @@ provision:
       channels:
         - name: msteams
 
-  {{^CEAEnabled}}
   # Validate using manifest schema
   - uses: teamsApp/validateManifest
     with:
       # Path to manifest template
       manifestPath: ./appPackage/manifest.json
-  {{/CEAEnabled}}
 
   # Build app package with latest env value
   - uses: teamsApp/zipAppPackage
@@ -68,7 +66,6 @@ provision:
       # Relative path to this file. This is the path for built zip file.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
 
-{{#CEAEnabled}}
   - uses: teamsApp/extendToM365
     with:
       # Relative path to the build app package.
@@ -78,7 +75,6 @@ provision:
     writeToEnvironmentFile:
       titleId: M365_TITLE_ID
       appId: M365_APP_ID
-{{/CEAEnabled}}
 
 deploy:
   # Run npm command

--- a/templates/js/weather-agent/m365agents.sandbox.yml.tpl
+++ b/templates/js/weather-agent/m365agents.sandbox.yml.tpl
@@ -52,13 +52,11 @@ provision:
       channels:
         - name: msteams
 
-  {{^CEAEnabled}}
   # Validate using manifest schema
   - uses: teamsApp/validateManifest
     with:
       # Path to manifest template
       manifestPath: ./appPackage/manifest.json
-  {{/CEAEnabled}}
 
   # Build app package with latest env value
   - uses: teamsApp/zipAppPackage
@@ -81,7 +79,6 @@ provision:
       # Relative path to this file. This is the path for built zip file.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
 
-{{#CEAEnabled}}
   - uses: teamsApp/extendToM365
     with:
       # Relative path to the build app package.
@@ -91,7 +88,6 @@ provision:
     writeToEnvironmentFile:
       titleId: M365_TITLE_ID
       appId: M365_APP_ID
-{{/CEAEnabled}}
 
 deploy:
 {{#SandBoxedTeam}}

--- a/templates/js/weather-agent/m365agents.yml.tpl
+++ b/templates/js/weather-agent/m365agents.yml.tpl
@@ -42,13 +42,11 @@ provision:
       # will use bicep CLI in PATH if you remove this config.
       bicepCliVersion: v0.9.1
       
-  {{^CEAEnabled}}
   # Validate using manifest schema
   - uses: teamsApp/validateManifest
     with:
       # Path to manifest template
       manifestPath: ./appPackage/manifest.json
-  {{/CEAEnabled}}
   # Build app package with latest env value
   - uses: teamsApp/zipAppPackage
     with:
@@ -68,7 +66,6 @@ provision:
     with:
       # Relative path to this file. This is the path for built zip file.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
-  {{#CEAEnabled}}
   - uses: teamsApp/extendToM365
     with:
       # Relative path to the build app package.
@@ -78,7 +75,6 @@ provision:
     writeToEnvironmentFile:
       titleId: M365_TITLE_ID
       appId: M365_APP_ID
-  {{/CEAEnabled}}
 
 # Triggered when 'teamsapp deploy' is executed
 deploy:
@@ -107,13 +103,11 @@ deploy:
 
 # Triggered when 'teamsapp publish' is executed
 publish:
-  {{^CEAEnabled}}
   # Validate using manifest schema
   - uses: teamsApp/validateManifest
     with:
       # Path to manifest template
       manifestPath: ./appPackage/manifest.json
-  {{/CEAEnabled}}
   # Build app package with latest env value
   - uses: teamsApp/zipAppPackage
     with:

--- a/templates/ts/basic-custom-engine-agent/.vscode/launch.json.tpl
+++ b/templates/ts/basic-custom-engine-agent/.vscode/launch.json.tpl
@@ -90,10 +90,9 @@
                 "order": 6
             },
             "internalConsoleOptions": "neverOpen",
-        {{#CEAEnabled}}
         },
         {
-            "name": "Launch Remote in Copilot (Edge)",
+            "name": "(Preview) Launch Remote in Copilot (Edge)",
             "type": "msedge",
             "request": "launch",
             "url": "https://m365.cloud.microsoft/chat/entity1-d870f6cd-4aa5-4d42-9626-ab690c041429/${agent-hint}?auth=2&${account-hint}&developerMode=Basic",
@@ -109,7 +108,7 @@
             ]
             },
             {
-            "name": "Launch Remote in Copilot (Chrome)",
+            "name": "(Preview) Launch Remote in Copilot (Chrome)",
             "type": "chrome",
             "request": "launch",
             "url": "https://m365.cloud.microsoft/chat/entity1-d870f6cd-4aa5-4d42-9626-ab690c041429/${agent-hint}?auth=2&${account-hint}&developerMode=Basic",
@@ -125,7 +124,7 @@
             ]
         },
         {
-            "name": "Launch in Copilot (Edge)",
+            "name": "(Preview) Launch in Copilot (Edge)",
             "type": "msedge",
             "request": "launch",
             "url": "https://m365.cloud.microsoft/chat/entity1-d870f6cd-4aa5-4d42-9626-ab690c041429/${local:agent-hint}?auth=2&${account-hint}&developerMode=Basic",
@@ -141,7 +140,7 @@
             ]
         },
         {
-            "name": "Launch in Copilot (Chrome)",
+            "name": "(Preview) Launch in Copilot (Chrome)",
             "type": "chrome",
             "request": "launch",
             "url": "https://m365.cloud.microsoft/chat/entity1-d870f6cd-4aa5-4d42-9626-ab690c041429/${local:agent-hint}?auth=2&${account-hint}&developerMode=Basic",
@@ -155,7 +154,6 @@
                 "--remote-debugging-port=9223",
                 "--no-first-run"
             ]
-        {{/CEAEnabled}}
 {{#SandBoxedTeam}}
         },
         {
@@ -260,10 +258,9 @@
                 "order": 1
             },
             "stopAll": true
-        {{#CEAEnabled}}
         },
         {
-            "name": "Debug in Copilot (Edge)",
+            "name": "(Preview) Debug in Copilot (Edge)",
             "configurations": [
                 "Launch in Copilot (Edge)",
                 "Attach to Local Service"
@@ -276,7 +273,7 @@
             "stopAll": true
             },
             {
-            "name": "Debug in Copilot (Chrome)",
+            "name": "(Preview) Debug in Copilot (Chrome)",
             "configurations": [
                 "Launch in Copilot (Chrome)",
                 "Attach to Local Service"
@@ -287,7 +284,6 @@
                 "order": 2
             },
             "stopAll": true
-        {{/CEAEnabled}}
         }
     ]
 }

--- a/templates/ts/basic-custom-engine-agent/README.md.tpl
+++ b/templates/ts/basic-custom-engine-agent/README.md.tpl
@@ -87,8 +87,6 @@ The following are Microsoft 365 Agents Toolkit specific project files. You can [
 - [Microsoft 365 Agents Toolkit Documentations](https://docs.microsoft.com/microsoftteams/platform/toolkit/teams-toolkit-fundamentals)
 - [Microsoft 365 Agents Toolkit CLI](https://aka.ms/teamsfx-toolkit-cli)
 - [Microsoft 365 Agents Toolkit Samples](https://github.com/OfficeDev/TeamsFx-Samples)
-{{#CEAEnabled}}
 
 ## Known issue
 - The agent is currently not working in any Teams group chats or Teams channels when the stream response is enabled.
-{{/CEAEnabled}}

--- a/templates/ts/basic-custom-engine-agent/appPackage/manifest.json.tpl
+++ b/templates/ts/basic-custom-engine-agent/appPackage/manifest.json.tpl
@@ -1,14 +1,7 @@
 {
-    {{#CEAEnabled}} 
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/vdevPreview/MicrosoftTeams.schema.json",
-    "manifestVersion": "devPreview",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
-    {{/CEAEnabled}}
-    {{^CEAEnabled}} 
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
-    "version": "1.0.0",
-    {{/CEAEnabled}}
     "id": "${{TEAMS_APP_ID}}",
     "developer": {
         "name": "My App, Inc.",
@@ -29,7 +22,6 @@
         "full": "full description for {{appName}}"
     },
     "accentColor": "#FFFFFF",
-    {{#CEAEnabled}} 
     "copilotAgents": {
         "customEngineAgents": [
             {
@@ -38,26 +30,20 @@
             }
         ]
     },
-    {{/CEAEnabled}}
     "bots": [
         {
             "botId": "${{BOT_ID}}",
             "scopes": [
-                {{#CEAEnabled}} 
                 "copilot",
-                {{/CEAEnabled}}
                 "personal",
-                "team",
-                "groupChat"
+                "team"
             ],
             "supportsFiles": false,
             "isNotificationOnly": false,
             "commandLists": [
                 {
                     "scopes": [
-                        {{#CEAEnabled}} 
                         "copilot",
-                        {{/CEAEnabled}}
                         "personal"
                     ],
                     "commands": [

--- a/templates/ts/basic-custom-engine-agent/m365agents.local.yml.tpl
+++ b/templates/ts/basic-custom-engine-agent/m365agents.local.yml.tpl
@@ -39,13 +39,11 @@ provision:
       channels:
         - name: msteams
 
-  {{^CEAEnabled}}
   # Validate using manifest schema
   - uses: teamsApp/validateManifest
     with:
       # Path to manifest template
       manifestPath: ./appPackage/manifest.json
-  {{/CEAEnabled}}
 
   # Build app package with latest env value
   - uses: teamsApp/zipAppPackage
@@ -68,7 +66,6 @@ provision:
       # Relative path to this file. This is the path for built zip file.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
 
-{{#CEAEnabled}}
   - uses: teamsApp/extendToM365
     with:
       # Relative path to the build app package.
@@ -78,7 +75,6 @@ provision:
     writeToEnvironmentFile:
       titleId: M365_TITLE_ID
       appId: M365_APP_ID
-{{/CEAEnabled}}
 
 deploy:
   # Run npm command

--- a/templates/ts/basic-custom-engine-agent/m365agents.sandbox.yml.tpl
+++ b/templates/ts/basic-custom-engine-agent/m365agents.sandbox.yml.tpl
@@ -52,13 +52,11 @@ provision:
       channels:
         - name: msteams
 
-  {{^CEAEnabled}}
   # Validate using manifest schema
   - uses: teamsApp/validateManifest
     with:
       # Path to manifest template
       manifestPath: ./appPackage/manifest.json
-  {{/CEAEnabled}}
 
   # Build app package with latest env value
   - uses: teamsApp/zipAppPackage
@@ -81,7 +79,6 @@ provision:
       # Relative path to this file. This is the path for built zip file.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
 
-{{#CEAEnabled}}
   - uses: teamsApp/extendToM365
     with:
       # Relative path to the build app package.
@@ -91,7 +88,6 @@ provision:
     writeToEnvironmentFile:
       titleId: M365_TITLE_ID
       appId: M365_APP_ID
-{{/CEAEnabled}}
 
 deploy:
   # Run npm command

--- a/templates/ts/basic-custom-engine-agent/m365agents.yml.tpl
+++ b/templates/ts/basic-custom-engine-agent/m365agents.yml.tpl
@@ -41,14 +41,12 @@ provision:
       # Microsoft 365 Agents Toolkit will download this bicep CLI version from github for you,
       # will use bicep CLI in PATH if you remove this config.
       bicepCliVersion: v0.9.1
-      
-  {{^CEAEnabled}}
+
   # Validate using manifest schema
   - uses: teamsApp/validateManifest
     with:
       # Path to manifest template
       manifestPath: ./appPackage/manifest.json
-  {{/CEAEnabled}}
   # Build app package with latest env value
   - uses: teamsApp/zipAppPackage
     with:
@@ -68,7 +66,6 @@ provision:
     with:
       # Relative path to this file. This is the path for built zip file.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
-  {{#CEAEnabled}}
   - uses: teamsApp/extendToM365
     with:
       # Relative path to the build app package.
@@ -78,7 +75,6 @@ provision:
     writeToEnvironmentFile:
       titleId: M365_TITLE_ID
       appId: M365_APP_ID
-  {{/CEAEnabled}}
 
 # Triggered when 'teamsapp deploy' is executed
 deploy:
@@ -107,13 +103,11 @@ deploy:
 
 # Triggered when 'teamsapp publish' is executed
 publish:
-  {{^CEAEnabled}}
   # Validate using manifest schema
   - uses: teamsApp/validateManifest
     with:
       # Path to manifest template
       manifestPath: ./appPackage/manifest.json
-  {{/CEAEnabled}}
   # Build app package with latest env value
   - uses: teamsApp/zipAppPackage
     with:

--- a/templates/ts/weather-agent/.vscode/launch.json.tpl
+++ b/templates/ts/weather-agent/.vscode/launch.json.tpl
@@ -90,10 +90,9 @@
                 "order": 6
             },
             "internalConsoleOptions": "neverOpen",
-        {{#CEAEnabled}}
         },
         {
-            "name": "Launch Remote in Copilot (Edge)",
+            "name": "(Preview) Launch Remote in Copilot (Edge)",
             "type": "msedge",
             "request": "launch",
             "url": "https://m365.cloud.microsoft/chat/entity1-d870f6cd-4aa5-4d42-9626-ab690c041429/${agent-hint}?auth=2&${account-hint}&developerMode=Basic",
@@ -109,7 +108,7 @@
             ]
             },
             {
-            "name": "Launch Remote in Copilot (Chrome)",
+            "name": "(Preview) Launch Remote in Copilot (Chrome)",
             "type": "chrome",
             "request": "launch",
             "url": "https://m365.cloud.microsoft/chat/entity1-d870f6cd-4aa5-4d42-9626-ab690c041429/${agent-hint}?auth=2&${account-hint}&developerMode=Basic",
@@ -125,7 +124,7 @@
             ]
         },
         {
-            "name": "Launch in Copilot (Edge)",
+            "name": "(Preview) Launch in Copilot (Edge)",
             "type": "msedge",
             "request": "launch",
             "url": "https://m365.cloud.microsoft/chat/entity1-d870f6cd-4aa5-4d42-9626-ab690c041429/${local:agent-hint}?auth=2&${account-hint}&developerMode=Basic",
@@ -141,7 +140,7 @@
             ]
         },
         {
-            "name": "Launch in Copilot (Chrome)",
+            "name": "(Preview) Launch in Copilot (Chrome)",
             "type": "chrome",
             "request": "launch",
             "url": "https://m365.cloud.microsoft/chat/entity1-d870f6cd-4aa5-4d42-9626-ab690c041429/${local:agent-hint}?auth=2&${account-hint}&developerMode=Basic",
@@ -155,7 +154,6 @@
                 "--remote-debugging-port=9223",
                 "--no-first-run"
             ]
-        {{/CEAEnabled}}
 {{#SandBoxedTeam}}
         },
         {
@@ -260,10 +258,9 @@
                 "order": 1
             },
             "stopAll": true
-        {{#CEAEnabled}}
         },
         {
-            "name": "Debug in Copilot (Edge)",
+            "name": "(Preview) Debug in Copilot (Edge)",
             "configurations": [
                 "Launch in Copilot (Edge)",
                 "Attach to Local Service"
@@ -276,7 +273,7 @@
             "stopAll": true
             },
             {
-            "name": "Debug in Copilot (Chrome)",
+            "name": "(Preview) Debug in Copilot (Chrome)",
             "configurations": [
                 "Launch in Copilot (Chrome)",
                 "Attach to Local Service"
@@ -287,7 +284,6 @@
                 "order": 2
             },
             "stopAll": true
-        {{/CEAEnabled}}
         }
     ]
 }

--- a/templates/ts/weather-agent/README.md.tpl
+++ b/templates/ts/weather-agent/README.md.tpl
@@ -88,8 +88,6 @@ The following are Microsoft 365 Agents Toolkit specific project files. You can [
 - [Microsoft 365 Agents Toolkit Documentations](https://docs.microsoft.com/microsoftteams/platform/toolkit/teams-toolkit-fundamentals)
 - [Microsoft 365 Agents Toolkit CLI](https://aka.ms/teamsfx-toolkit-cli)
 - [Microsoft 365 Agents Toolkit Samples](https://github.com/OfficeDev/TeamsFx-Samples)
-{{#CEAEnabled}}
 
 ## Known issue
 - The agent is currently not working in any Teams group chats or Teams channels when the stream response is enabled.
-{{/CEAEnabled}}

--- a/templates/ts/weather-agent/appPackage/manifest.json.tpl
+++ b/templates/ts/weather-agent/appPackage/manifest.json.tpl
@@ -1,14 +1,7 @@
 {
-    {{#CEAEnabled}} 
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/vdevPreview/MicrosoftTeams.schema.json",
-    "manifestVersion": "devPreview",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
-    {{/CEAEnabled}}
-    {{^CEAEnabled}} 
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
-    "version": "1.0.0",
-    {{/CEAEnabled}}
     "id": "${{TEAMS_APP_ID}}",
     "developer": {
         "name": "My App, Inc.",
@@ -29,7 +22,6 @@
         "full": "full description for {{appName}}"
     },
     "accentColor": "#FFFFFF",
-    {{#CEAEnabled}} 
     "copilotAgents": {
         "customEngineAgents": [
             {
@@ -38,26 +30,20 @@
             }
         ]
     },
-    {{/CEAEnabled}}
     "bots": [
         {
             "botId": "${{BOT_ID}}",
             "scopes": [
-                {{#CEAEnabled}} 
                 "copilot",
-                {{/CEAEnabled}}
                 "personal",
-                "team",
-                "groupChat"
+                "team"
             ],
             "supportsFiles": false,
             "isNotificationOnly": false,
             "commandLists": [
                 {
                     "scopes": [
-                        {{#CEAEnabled}} 
                         "copilot",
-                        {{/CEAEnabled}}
                         "personal"
                     ],
                     "commands": [

--- a/templates/ts/weather-agent/m365agents.local.yml.tpl
+++ b/templates/ts/weather-agent/m365agents.local.yml.tpl
@@ -39,13 +39,11 @@ provision:
       channels:
         - name: msteams
 
-  {{^CEAEnabled}}
   # Validate using manifest schema
   - uses: teamsApp/validateManifest
     with:
       # Path to manifest template
       manifestPath: ./appPackage/manifest.json
-  {{/CEAEnabled}}
 
   # Build app package with latest env value
   - uses: teamsApp/zipAppPackage
@@ -68,7 +66,6 @@ provision:
       # Relative path to this file. This is the path for built zip file.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
 
-{{#CEAEnabled}}
   - uses: teamsApp/extendToM365
     with:
       # Relative path to the build app package.
@@ -78,7 +75,6 @@ provision:
     writeToEnvironmentFile:
       titleId: M365_TITLE_ID
       appId: M365_APP_ID
-{{/CEAEnabled}}
 
 deploy:
   # Run npm command

--- a/templates/ts/weather-agent/m365agents.sandbox.yml.tpl
+++ b/templates/ts/weather-agent/m365agents.sandbox.yml.tpl
@@ -52,13 +52,11 @@ provision:
       channels:
         - name: msteams
 
-  {{^CEAEnabled}}
   # Validate using manifest schema
   - uses: teamsApp/validateManifest
     with:
       # Path to manifest template
       manifestPath: ./appPackage/manifest.json
-  {{/CEAEnabled}}
 
   # Build app package with latest env value
   - uses: teamsApp/zipAppPackage
@@ -81,7 +79,6 @@ provision:
       # Relative path to this file. This is the path for built zip file.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
 
-{{#CEAEnabled}}
   - uses: teamsApp/extendToM365
     with:
       # Relative path to the build app package.
@@ -91,7 +88,6 @@ provision:
     writeToEnvironmentFile:
       titleId: M365_TITLE_ID
       appId: M365_APP_ID
-{{/CEAEnabled}}
 
 deploy:
 {{#SandBoxedTeam}}

--- a/templates/ts/weather-agent/m365agents.yml.tpl
+++ b/templates/ts/weather-agent/m365agents.yml.tpl
@@ -41,14 +41,12 @@ provision:
       # Microsoft 365 Agents Toolkit will download this bicep CLI version from github for you,
       # will use bicep CLI in PATH if you remove this config.
       bicepCliVersion: v0.9.1
-      
-  {{^CEAEnabled}}
+
   # Validate using manifest schema
   - uses: teamsApp/validateManifest
     with:
       # Path to manifest template
       manifestPath: ./appPackage/manifest.json
-  {{/CEAEnabled}}
   # Build app package with latest env value
   - uses: teamsApp/zipAppPackage
     with:
@@ -68,7 +66,6 @@ provision:
     with:
       # Relative path to this file. This is the path for built zip file.
       appPackagePath: ./appPackage/build/appPackage.${{TEAMSFX_ENV}}.zip
-  {{#CEAEnabled}}
   - uses: teamsApp/extendToM365
     with:
       # Relative path to the build app package.
@@ -78,7 +75,6 @@ provision:
     writeToEnvironmentFile:
       titleId: M365_TITLE_ID
       appId: M365_APP_ID
-  {{/CEAEnabled}}
 
 # Triggered when 'teamsapp deploy' is executed
 deploy:
@@ -107,13 +103,11 @@ deploy:
 
 # Triggered when 'teamsapp publish' is executed
 publish:
-  {{^CEAEnabled}}
   # Validate using manifest schema
   - uses: teamsApp/validateManifest
     with:
       # Path to manifest template
       manifestPath: ./appPackage/manifest.json
-  {{/CEAEnabled}}
   # Build app package with latest env value
   - uses: teamsApp/zipAppPackage
     with:


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/32769663

Changes on CEA templates:
1. Use app manifest v1.21.
2. Remove feature flag and enable CEA by default.
3. Add Preview tag to debug option title.
4. Ensure manifest property `bots[0].scopes` count is no more than 3 to pass action "teamsApp/validateManifest".