### PR TITLE
fix(da): provision failed for new api project

### DIFF
--- a/packages/fx-core/src/component/driver/apiKey/create.ts
+++ b/packages/fx-core/src/component/driver/apiKey/create.ts
@@ -28,6 +28,7 @@ import { logMessageKeys, maxSecretLength, minSecretLength } from "./utility/cons
 import { getDomain, loadStateFromEnv, validateDomain, validateUrl } from "./utility/utility";
 import { apiKeyFromScratchClientSecretInvalid } from "./error/apiKeyFromScratchClientSecretInvalid";
 import { WrapDriverContext } from "../util/wrapUtil";
+import { Utils } from "@microsoft/m365-spec-parser";
 
 const actionName = "apiKey/register"; // DO NOT MODIFY the name
 const helpLink = "https://aka.ms/teamsfx-actions/apiKey-register";
@@ -107,6 +108,10 @@ export class CreateApiKeyDriver implements StepDriver {
           domains = await getDomain(args, context, actionName);
           validateDomain(domains, actionName);
         }
+
+        domains = domains.map((domain) => {
+          return Utils.resolveEnv(domain);
+        });
 
         const apiKey = await this.mapArgsToApiSecretRegistration(
           context.m365TokenProvider,

--- a/packages/fx-core/src/component/driver/apiKey/update.ts
+++ b/packages/fx-core/src/component/driver/apiKey/update.ts
@@ -22,6 +22,7 @@ import { UpdateApiKeyArgs } from "./interface/updateApiKeyArgs";
 import { logMessageKeys } from "./utility/constants";
 import { getDomain, validateDomain, validateUrl } from "./utility/utility";
 import { WrapDriverContext } from "../util/wrapUtil";
+import { Utils } from "@microsoft/m365-spec-parser";
 
 const actionName = "apiKey/update"; // DO NOT MODIFY the name
 const helpLink = "https://aka.ms/teamsfx-actions/apiKey-update";
@@ -46,13 +47,17 @@ export class UpdateApiKeyDriver implements StepDriver {
       context.logProvider?.info(getLocalizedString(logMessageKeys.startExecuteDriver, actionName));
       this.validateArgs(args);
 
-      let domain: string[] = [];
+      let domains: string[] = [];
       if (args.baseUrl) {
-        domain = [args.baseUrl];
+        domains = [args.baseUrl];
       } else {
-        domain = await getDomain(args, context, actionName);
-        validateDomain(domain, actionName);
+        domains = await getDomain(args, context, actionName);
+        validateDomain(domains, actionName);
       }
+
+      domains = domains.map((domain) => {
+        return Utils.resolveEnv(domain);
+      });
 
       const appStudioTokenRes = await context.m365TokenProvider.getAccessToken({
         scopes: AppStudioScopes,
@@ -66,7 +71,7 @@ export class UpdateApiKeyDriver implements StepDriver {
         appStudioToken,
         args.registrationId
       );
-      const diffMsgs = this.compareApiKeyRegistration(getApiKeyRes, args, domain);
+      const diffMsgs = this.compareApiKeyRegistration(getApiKeyRes, args, domains);
       // If there is no difference, skip the update
       if (!diffMsgs || diffMsgs.length === 0) {
         const summary = getLocalizedString(logMessageKeys.skipUpdateApiKey);
@@ -81,7 +86,7 @@ export class UpdateApiKeyDriver implements StepDriver {
 
       // If there is difference, ask user to confirm the update
       // Skip confirm if only targetUrlsShouldStartWith is different when the url contains devtunnel
-      if (!this.shouldSkipConfirm(diffMsgs, getApiKeyRes.targetUrlsShouldStartWith, domain)) {
+      if (!this.shouldSkipConfirm(diffMsgs, getApiKeyRes.targetUrlsShouldStartWith, domains)) {
         const userConfirm = await context.ui!.confirm!({
           name: "confirm-update-api-key",
           title: getLocalizedString("driver.apiKey.confirm.update", diffMsgs.join(",\n")),
@@ -92,7 +97,7 @@ export class UpdateApiKeyDriver implements StepDriver {
         }
       }
 
-      const apiKey = this.mapArgsToApiSecretRegistration(args, domain);
+      const apiKey = this.mapArgsToApiSecretRegistration(args, domains);
       await teamsDevPortalClient.updateApiKeyRegistration(
         appStudioToken,
         apiKey,

--- a/packages/fx-core/src/component/driver/oauth/utility/utility.ts
+++ b/packages/fx-core/src/component/driver/oauth/utility/utility.ts
@@ -13,6 +13,7 @@ import { OauthAuthInfoInvalid } from "../error/oauthAuthInfoInvalid";
 import { UpdateOauthArgs } from "../interface/updateOauthArgs";
 import { OauthAuthMissingInSpec } from "../error/oauthAuthMissingInSpec";
 import { listAPIInfo } from "../../../../common/daSpecParser";
+import { Utils } from "@microsoft/m365-spec-parser";
 
 export interface OauthInfo {
   domain?: string[];
@@ -82,7 +83,7 @@ async function getandValidateOauthInfoFromSpec(
     throw new OauthAuthMissingInSpec(actionName, args.name);
   }
 
-  const domains = operations
+  let domains = operations
     .map((value) => {
       return value.server;
     })
@@ -90,6 +91,10 @@ async function getandValidateOauthInfoFromSpec(
       return self.indexOf(value) === index;
     });
   validateDomain(domains, actionName);
+
+  domains = domains.map((domain) => {
+    return Utils.resolveEnv(domain);
+  });
 
   // Need to separate the logic for different flows
   const flow = "flow" in args ? args.flow : "authorizationCode";

--- a/packages/fx-core/tests/component/driver/apiKey/create.test.ts
+++ b/packages/fx-core/tests/component/driver/apiKey/create.test.ts
@@ -69,7 +69,7 @@ describe("CreateApiKeyDriver", () => {
       APIs: [
         {
           api: "api",
-          server: "https://test",
+          server: "${{OPENAPI_SERVER_URL}}",
           operationId: "get",
           auth: {
             name: "test",
@@ -86,6 +86,11 @@ describe("CreateApiKeyDriver", () => {
       allAPICount: 1,
       validAPICount: 1,
     });
+
+    envRestore = mockedEnv({
+      ["OPENAPI_SERVER_URL"]: "https://test",
+    });
+
     sinon
       .stub(featureFlagManager, "getBooleanValue")
       .withArgs(FeatureFlags.KiotaNPMIntegration)

--- a/packages/fx-core/tests/component/driver/apiKey/update.test.ts
+++ b/packages/fx-core/tests/component/driver/apiKey/update.test.ts
@@ -518,6 +518,11 @@ describe("UpdateApiKeyDriver", () => {
       allAPICount: 1,
       validAPICount: 1,
     });
+    sinon
+      .stub(featureFlagManager, "getBooleanValue")
+      .withArgs(FeatureFlags.KiotaNPMIntegration)
+      .returns(false);
+
     const args: UpdateApiKeyArgs = {
       name: "test2",
       appId: "mockedAppId",


### PR DESCRIPTION
cherry pick:
fix: [Bug 32790056](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/32790056): [VSC]local and provison are failed for Declarative Copilot project