### PR TITLE
fix: copilot debug compatibility issue

### DIFF
--- a/packages/vscode-extension/src/pluginDebugger/cdpClient.ts
+++ b/packages/vscode-extension/src/pluginDebugger/cdpClient.ts
@@ -77,7 +77,7 @@ export class CDPClient {
     );
 
     // try to filter on sub target iframe at the same time for compatibility issue,
-    // for some accounts, connect to main iframe does not works, but for some accounts, connect to sub target iframe works
+    // for some accounts, connect to main iframe does not work, connect to sub target iframe works
     logger.debug("CDPClient.subscribeToWebSocketEvents() - start listening to sub target iframe");
     this.enableRetry = true;
     void this.connectToTargetIframeWithRetries(client);

--- a/packages/vscode-extension/src/pluginDebugger/cdpClient.ts
+++ b/packages/vscode-extension/src/pluginDebugger/cdpClient.ts
@@ -66,26 +66,20 @@ export class CDPClient {
     throw recentError;
   }
   async subscribeToWebSocketEvents(client: CDP.Client): Promise<void> {
-    if (this.url.includes("m365.cloud.microsoft/chat")) {
-      logger.debug(
-        "CDPClient.subscribeToWebSocketEvents() - is m365.cloud.microsoft/chat, start listening to sub target iframe"
-      );
-      // only m365.cloud.microsoft need listen to sub target iframe
-      this.enableRetry = true;
-      void this.connectToTargetIframeWithRetries(client);
-    } else {
-      logger.debug(
-        "CDPClient.subscribeToWebSocketEvents() - is not m365.cloud.microsoft/chat, start listening to target directly"
-      );
-      // Enable the necessary domains
-      await client.Network.enable();
-      await client.Page.enable();
-      client.Network.webSocketFrameReceived(this.webSocketFrameReceivedHandler.bind(this));
-      this.client = client;
-      logger.info(
-        `CDPClient.subscribeToWebSocketEvents() - Connected to copilot iframe target: ${this.name}, port: ${this.port}, url: ${this.url}`
-      );
-    }
+    // connect to the main frame first
+    logger.debug("CDPClient.subscribeToWebSocketEvents() - start listening to main frame");
+    await client.Network.enable();
+    await client.Page.enable();
+    client.Network.webSocketFrameReceived(this.webSocketFrameReceivedHandler.bind(this));
+    this.client = client;
+    logger.info(
+      `CDPClient.subscribeToWebSocketEvents() - Connected to copilot iframe target: ${this.name}, port: ${this.port}, url: ${this.url}`
+    );
+
+    // try to filter on sub target iframe at the same time for compatibility issue
+    logger.debug("CDPClient.subscribeToWebSocketEvents() - start listening to sub target iframe");
+    this.enableRetry = true;
+    void this.connectToTargetIframeWithRetries(client);
   }
 
   async connectToTargetIframeWithRetries(

--- a/packages/vscode-extension/src/pluginDebugger/cdpClient.ts
+++ b/packages/vscode-extension/src/pluginDebugger/cdpClient.ts
@@ -66,7 +66,7 @@ export class CDPClient {
     throw recentError;
   }
   async subscribeToWebSocketEvents(client: CDP.Client): Promise<void> {
-    // connect to the main frame first
+    // connect to the main iframe, for some accounts, connect to main iframe works
     logger.debug("CDPClient.subscribeToWebSocketEvents() - start listening to main frame");
     await client.Network.enable();
     await client.Page.enable();
@@ -76,7 +76,8 @@ export class CDPClient {
       `CDPClient.subscribeToWebSocketEvents() - Connected to copilot iframe target: ${this.name}, port: ${this.port}, url: ${this.url}`
     );
 
-    // try to filter on sub target iframe at the same time for compatibility issue
+    // try to filter on sub target iframe at the same time for compatibility issue,
+    // for some accounts, connect to main iframe does not works, but for some accounts, connect to sub target iframe works
     logger.debug("CDPClient.subscribeToWebSocketEvents() - start listening to sub target iframe");
     this.enableRetry = true;
     void this.connectToTargetIframeWithRetries(client);

--- a/packages/vscode-extension/test/pluginDebugger/cdpClient.test.ts
+++ b/packages/vscode-extension/test/pluginDebugger/cdpClient.test.ts
@@ -44,6 +44,7 @@ describe("cdpClient", () => {
     it("happy", async () => {
       const cdpClient = new CDPClient("url", 9222, "name");
       sandbox.stub(cdpClient, "url").value("xxx");
+      sandbox.stub(cdpClient, "connectToTargetIframeWithRetries").resolves();
       const client = {
         Network: { enable: () => {}, webSocketFrameReceived: () => {} },
         Page: { enable: () => {} },
@@ -56,23 +57,6 @@ describe("cdpClient", () => {
       const webSocketFrameReceived = sandbox.stub(client.Network, "webSocketFrameReceived");
       await cdpClient.subscribeToWebSocketEvents(client);
       chai.assert.isTrue(webSocketFrameReceived.called);
-    });
-    it("connect to iframe target", async () => {
-      const cdpClient = new CDPClient("url", 9222, "name");
-      sandbox.stub(cdpClient, "connectToTargetIframeWithRetries").resolves();
-      const client = {
-        Network: { enable: () => {}, webSocketFrameReceived: () => {} },
-        Page: { enable: () => {} },
-        Target: {
-          getTargets: () => {
-            return { targetInfos: [] };
-          },
-        },
-      } as any;
-      sandbox.stub(cdpClient, "url").value("m365.cloud.microsoft/chat");
-      const webSocketFrameReceived = sandbox.stub(client.Network, "webSocketFrameReceived");
-      await cdpClient.subscribeToWebSocketEvents(client);
-      chai.assert.isTrue(webSocketFrameReceived.notCalled);
     });
   });
   describe("start", () => {


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/32835213

For some accounts, the debugging info is subscribed from the main iframe, and for some acounts, the info is subscribed from the sub iframe. The PR covers both two cases, it will subscribe the main frame first and trying to find the target sub iframe at the same time. If the matched sub iframe is found, it will use the sub iframe to get the debugging info.