### PR TITLE
refactor: upgrade VS templates manifest to 1.21

### DIFF
--- a/templates/csharp/command-and-response/appPackage/manifest.json.tpl
+++ b/templates/csharp/command-and-response/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/csharp/custom-copilot-assistant-assistants-api/appPackage/manifest.json.tpl
+++ b/templates/csharp/custom-copilot-assistant-assistants-api/appPackage/manifest.json.tpl
@@ -5,8 +5,8 @@
     "version": "1.0.0",
 {{/CEAEnabled}}
 {{^CEAEnabled}} 
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
 {{/CEAEnabled}}
     "id": "${{TEAMS_APP_ID}}",

--- a/templates/csharp/custom-copilot-assistant-new/appPackage/manifest.json.tpl
+++ b/templates/csharp/custom-copilot-assistant-new/appPackage/manifest.json.tpl
@@ -5,8 +5,8 @@
     "version": "1.0.0",
 {{/CEAEnabled}}
 {{^CEAEnabled}} 
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
 {{/CEAEnabled}}
     "id": "${{TEAMS_APP_ID}}",

--- a/templates/csharp/custom-copilot-basic/appPackage/manifest.json.tpl
+++ b/templates/csharp/custom-copilot-basic/appPackage/manifest.json.tpl
@@ -5,8 +5,8 @@
     "version": "1.0.0",
 {{/CEAEnabled}}
 {{^CEAEnabled}} 
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
 {{/CEAEnabled}}
     "id": "${{TEAMS_APP_ID}}",

--- a/templates/csharp/custom-copilot-rag-azure-ai-search/appPackage/manifest.json.tpl
+++ b/templates/csharp/custom-copilot-rag-azure-ai-search/appPackage/manifest.json.tpl
@@ -5,8 +5,8 @@
     "version": "1.0.0",
     {{/CEAEnabled}}
     {{^CEAEnabled}} 
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     {{/CEAEnabled}}
     "id": "${{TEAMS_APP_ID}}",

--- a/templates/csharp/custom-copilot-rag-custom-api/appPackage/manifest.json.tpl
+++ b/templates/csharp/custom-copilot-rag-custom-api/appPackage/manifest.json.tpl
@@ -5,8 +5,8 @@
     "version": "1.0.0",
     {{/CEAEnabled}}
     {{^CEAEnabled}} 
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     {{/CEAEnabled}}
     "id": "${{TEAMS_APP_ID}}",

--- a/templates/csharp/custom-copilot-rag-customize/appPackage/manifest.json.tpl
+++ b/templates/csharp/custom-copilot-rag-customize/appPackage/manifest.json.tpl
@@ -5,8 +5,8 @@
     "version": "1.0.0",
     {{/CEAEnabled}}
     {{^CEAEnabled}} 
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     {{/CEAEnabled}}
     "id": "${{TEAMS_APP_ID}}",

--- a/templates/csharp/custom-copilot-rag-microsoft365/appPackage/manifest.json.tpl
+++ b/templates/csharp/custom-copilot-rag-microsoft365/appPackage/manifest.json.tpl
@@ -5,8 +5,8 @@
     "version": "1.0.0",
     {{/CEAEnabled}}
     {{^CEAEnabled}} 
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     {{/CEAEnabled}}
     "id": "${{TEAMS_APP_ID}}",

--- a/templates/csharp/custom-copilot-weather-agent/appPackage/manifest.json.tpl
+++ b/templates/csharp/custom-copilot-weather-agent/appPackage/manifest.json.tpl
@@ -36,8 +36,7 @@
             "scopes": [
                 "copilot",
                 "personal",
-                "team",
-                "groupChat"
+                "team"
             ],
             "supportsFiles": false,
             "isNotificationOnly": false,

--- a/templates/csharp/custom-copilot-weather-agent/appPackage/manifest.json.tpl
+++ b/templates/csharp/custom-copilot-weather-agent/appPackage/manifest.json.tpl
@@ -35,8 +35,7 @@
             "botId": "${{BOT_ID}}",
             "scopes": [
                 "copilot",
-                "personal",
-                "team"
+                "personal"
             ],
             "supportsFiles": false,
             "isNotificationOnly": false,

--- a/templates/csharp/declarative-agent-basic/appPackage/manifest.json.tpl
+++ b/templates/csharp/declarative-agent-basic/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/csharp/declarative-agent-with-action-from-existing-api/appPackage/manifest.json.tpl
+++ b/templates/csharp/declarative-agent-with-action-from-existing-api/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/csharp/declarative-agent-with-action-from-scratch-bearer/appPackage/manifest.json.tpl
+++ b/templates/csharp/declarative-agent-with-action-from-scratch-bearer/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-  "manifestVersion": "1.19",
+  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+  "manifestVersion": "1.21",
   "id": "${{TEAMS_APP_ID}}",
   "version": "1.0.0",
   "developer": {

--- a/templates/csharp/declarative-agent-with-action-from-scratch-oauth/appPackage/manifest.json.tpl
+++ b/templates/csharp/declarative-agent-with-action-from-scratch-oauth/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-  "manifestVersion": "1.19",
+  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+  "manifestVersion": "1.21",
   "id": "${{TEAMS_APP_ID}}",
   "version": "1.0.0",
   "developer": {

--- a/templates/csharp/declarative-agent-with-action-from-scratch/appPackage/manifest.json.tpl
+++ b/templates/csharp/declarative-agent-with-action-from-scratch/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-  "manifestVersion": "1.19",
+  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+  "manifestVersion": "1.21",
   "id": "${{TEAMS_APP_ID}}",
   "version": "1.0.0",
   "developer": {

--- a/templates/csharp/default-bot/appPackage/manifest.json.tpl
+++ b/templates/csharp/default-bot/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/csharp/empty/appPackage/manifest.json.tpl
+++ b/templates/csharp/empty/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/csharp/link-unfurling/appPackage/manifest.json.tpl
+++ b/templates/csharp/link-unfurling/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/csharp/message-extension-action/appPackage/manifest.json.tpl
+++ b/templates/csharp/message-extension-action/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/csharp/message-extension-search/appPackage/manifest.json.tpl
+++ b/templates/csharp/message-extension-search/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/csharp/message-extension-with-api-from-scratch-api-key/appPackage/manifest.json.tpl
+++ b/templates/csharp/message-extension-with-api-from-scratch-api-key/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-  "manifestVersion": "1.19",
+  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+  "manifestVersion": "1.21",
   "id": "${{TEAMS_APP_ID}}",
   "version": "1.0.0",
   "developer": {

--- a/templates/csharp/message-extension-with-api-from-scratch-api-key/appPackage/responseTemplates/repair.json
+++ b/templates/csharp/message-extension-with-api-from-scratch-api-key/appPackage/responseTemplates/repair.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.19/MicrosoftTeams.ResponseRenderingTemplate.schema.json",
+  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.21/MicrosoftTeams.ResponseRenderingTemplate.schema.json",
   "jsonPath": "results",
   "responseLayout": "list",
   "responseCardTemplate": {

--- a/templates/csharp/message-extension-with-api-from-scratch-api-key/appPackage/responseTemplates/repair.json
+++ b/templates/csharp/message-extension-with-api-from-scratch-api-key/appPackage/responseTemplates/repair.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.21/MicrosoftTeams.ResponseRenderingTemplate.schema.json",
+  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.19/MicrosoftTeams.ResponseRenderingTemplate.schema.json",
   "jsonPath": "results",
   "responseLayout": "list",
   "responseCardTemplate": {

--- a/templates/csharp/message-extension-with-api-from-scratch-sso/appPackage/manifest.json.tpl
+++ b/templates/csharp/message-extension-with-api-from-scratch-sso/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "id": "${{TEAMS_APP_ID}}",
     "version": "1.0.0",
     "developer": {

--- a/templates/csharp/message-extension-with-api-from-scratch-sso/appPackage/responseTemplates/repair.json
+++ b/templates/csharp/message-extension-with-api-from-scratch-sso/appPackage/responseTemplates/repair.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.19/MicrosoftTeams.ResponseRenderingTemplate.schema.json",
+  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.21/MicrosoftTeams.ResponseRenderingTemplate.schema.json",
   "jsonPath": "results",
   "responseLayout": "list",
   "responseCardTemplate": {

--- a/templates/csharp/message-extension-with-api-from-scratch-sso/appPackage/responseTemplates/repair.json
+++ b/templates/csharp/message-extension-with-api-from-scratch-sso/appPackage/responseTemplates/repair.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.21/MicrosoftTeams.ResponseRenderingTemplate.schema.json",
+  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.19/MicrosoftTeams.ResponseRenderingTemplate.schema.json",
   "jsonPath": "results",
   "responseLayout": "list",
   "responseCardTemplate": {

--- a/templates/csharp/message-extension-with-api-from-scratch/appPackage/manifest.json.tpl
+++ b/templates/csharp/message-extension-with-api-from-scratch/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "id": "${{TEAMS_APP_ID}}",
     "version": "1.0.0",
     "developer": {

--- a/templates/csharp/message-extension-with-api-from-scratch/appPackage/responseTemplates/repair.json
+++ b/templates/csharp/message-extension-with-api-from-scratch/appPackage/responseTemplates/repair.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.19/MicrosoftTeams.ResponseRenderingTemplate.schema.json",
+  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.21/MicrosoftTeams.ResponseRenderingTemplate.schema.json",
   "jsonPath": "results",
   "responseLayout": "list",
   "responseCardTemplate": {

--- a/templates/csharp/message-extension-with-api-from-scratch/appPackage/responseTemplates/repair.json
+++ b/templates/csharp/message-extension-with-api-from-scratch/appPackage/responseTemplates/repair.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.21/MicrosoftTeams.ResponseRenderingTemplate.schema.json",
+  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.19/MicrosoftTeams.ResponseRenderingTemplate.schema.json",
   "jsonPath": "results",
   "responseLayout": "list",
   "responseCardTemplate": {

--- a/templates/csharp/message-extension-with-existing-api/appPackage/manifest.json.tpl
+++ b/templates/csharp/message-extension-with-existing-api/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/csharp/message-extension/appPackage/manifest.json.tpl
+++ b/templates/csharp/message-extension/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/csharp/non-sso-tab-ssr/appPackage/manifest.json.tpl
+++ b/templates/csharp/non-sso-tab-ssr/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/csharp/notification-http-timer-trigger/appPackage/manifest.json.tpl
+++ b/templates/csharp/notification-http-timer-trigger/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/csharp/notification-http-trigger/appPackage/manifest.json.tpl
+++ b/templates/csharp/notification-http-trigger/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/csharp/notification-timer-trigger/appPackage/manifest.json.tpl
+++ b/templates/csharp/notification-timer-trigger/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/csharp/notification-webapi/appPackage/manifest.json.tpl
+++ b/templates/csharp/notification-webapi/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/csharp/sso-tab-ssr/appPackage/manifest.json.tpl
+++ b/templates/csharp/sso-tab-ssr/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/csharp/workflow/appPackage/manifest.json.tpl
+++ b/templates/csharp/workflow/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/32786014

need to upgrade manifest version to 1.21 for all C# templates