### PR TITLE
fix(da): regenerate plugin telemetry not work

### DIFF
--- a/packages/vscode-extension/src/telemetry/extTelemetry.ts
+++ b/packages/vscode-extension/src/telemetry/extTelemetry.ts
@@ -84,6 +84,8 @@ export namespace ExtTelemetry {
         return TelemetryEvent.SyncManifest;
       case Stage.addPlugin:
         return TelemetryEvent.AddPlugin;
+      case Stage.RegeneratePlugin:
+        return TelemetryEvent.RegenerateAction;
       case Stage.metaOSExtendToDA:
         return TelemetryEvent.MetaOSExtendToDA;
       case Stage.addAuthAction:

--- a/packages/vscode-extension/test/extTelemetry/extTelemetry.test.ts
+++ b/packages/vscode-extension/test/extTelemetry/extTelemetry.test.ts
@@ -97,6 +97,11 @@ describe("ExtTelemetry", () => {
       chai.expect(ExtTelemetry.stageToEvent(stage)).equals(TelemetryEvent.SyncManifest);
     });
 
+    it("Stage.RegeneratePlugin", () => {
+      const stage = Stage.RegeneratePlugin;
+      chai.expect(ExtTelemetry.stageToEvent(stage)).equals(TelemetryEvent.RegenerateAction);
+    });
+
     it("unknown", () => {
       const stage = "unknown";
       chai.expect(ExtTelemetry.stageToEvent(stage as Stage)).equals(undefined);


### PR DESCRIPTION
[Task 32945656](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/32945656): Fix regenerate plugin telemetry not triggered