### PR TITLE
refactor: upgrade vsc templates to v1.21

### DIFF
--- a/templates/common/declarative-agent-basic/appPackage/manifest.json.tpl
+++ b/templates/common/declarative-agent-basic/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/common/declarative-agent-typespec/appPackage/manifest.json.tpl
+++ b/templates/common/declarative-agent-typespec/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/common/declarative-agent-with-action-from-existing-api/appPackage/manifest.json.tpl
+++ b/templates/common/declarative-agent-with-action-from-existing-api/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/common/message-extension-with-existing-api/appPackage/manifest.json.tpl
+++ b/templates/common/message-extension-with-existing-api/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/js/ai-assistant-bot/appPackage/manifest.json.tpl
+++ b/templates/js/ai-assistant-bot/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/js/ai-bot/appPackage/manifest.json.tpl
+++ b/templates/js/ai-bot/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/js/command-and-response/appPackage/manifest.json.tpl
+++ b/templates/js/command-and-response/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/js/custom-copilot-assistant-assistants-api/appPackage/manifest.json.tpl
+++ b/templates/js/custom-copilot-assistant-assistants-api/appPackage/manifest.json.tpl
@@ -1,14 +1,7 @@
 {
-    {{#CEAEnabled}} 
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/vdevPreview/MicrosoftTeams.schema.json",
-    "manifestVersion": "devPreview",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
-    {{/CEAEnabled}}
-    {{^CEAEnabled}} 
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
-    "version": "1.0.0",
-    {{/CEAEnabled}}
     "id": "${{TEAMS_APP_ID}}",
     "developer": {
         "name": "My App, Inc.",
@@ -43,8 +36,12 @@
         {
             "botId": "${{BOT_ID}}",
             "scopes": [
-                {{#CEAEnabled}} 
+                {{#CEAEnabled}}
                 "copilot",
+                {{/CEAEnabled}}
+                {{^CEAEnabled}}
+                "team",
+                "groupChat",
                 {{/CEAEnabled}}
                 "personal"
             ],

--- a/templates/js/custom-copilot-assistant-new/appPackage/manifest.json.tpl
+++ b/templates/js/custom-copilot-assistant-new/appPackage/manifest.json.tpl
@@ -1,14 +1,7 @@
 {
-    {{#CEAEnabled}} 
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/vdevPreview/MicrosoftTeams.schema.json",
-    "manifestVersion": "devPreview",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
-    {{/CEAEnabled}}
-    {{^CEAEnabled}} 
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
-    "version": "1.0.0",
-    {{/CEAEnabled}}
     "id": "${{TEAMS_APP_ID}}",
     "developer": {
         "name": "My App, Inc.",
@@ -43,8 +36,12 @@
         {
             "botId": "${{BOT_ID}}",
             "scopes": [
-                {{#CEAEnabled}} 
+                {{#CEAEnabled}}
                 "copilot",
+                {{/CEAEnabled}}
+                {{^CEAEnabled}}
+                "team",
+                "groupChat",
                 {{/CEAEnabled}}
                 "personal"
             ],

--- a/templates/js/custom-copilot-basic/appPackage/manifest.json.tpl
+++ b/templates/js/custom-copilot-basic/appPackage/manifest.json.tpl
@@ -1,14 +1,7 @@
 {
-    {{#CEAEnabled}} 
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/vdevPreview/MicrosoftTeams.schema.json",
-    "manifestVersion": "devPreview",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
-    {{/CEAEnabled}}
-    {{^CEAEnabled}} 
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
-    "version": "1.0.0",
-    {{/CEAEnabled}}
     "id": "${{TEAMS_APP_ID}}",
     "developer": {
         "name": "My App, Inc.",
@@ -43,12 +36,14 @@
         {
             "botId": "${{BOT_ID}}",
             "scopes": [
-                {{#CEAEnabled}} 
+                {{#CEAEnabled}}
                 "copilot",
                 {{/CEAEnabled}}
-                "personal",
+                {{^CEAEnabled}}
                 "team",
-                "groupChat"
+                "groupChat",
+                {{/CEAEnabled}}
+                "personal"
             ],
             "supportsFiles": false,
             "isNotificationOnly": false,

--- a/templates/js/custom-copilot-rag-azure-ai-search/appPackage/manifest.json.tpl
+++ b/templates/js/custom-copilot-rag-azure-ai-search/appPackage/manifest.json.tpl
@@ -1,14 +1,7 @@
 {
-    {{#CEAEnabled}} 
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/vdevPreview/MicrosoftTeams.schema.json",
-    "manifestVersion": "devPreview",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
-    {{/CEAEnabled}}
-    {{^CEAEnabled}} 
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
-    "version": "1.0.0",
-    {{/CEAEnabled}}
     "id": "${{TEAMS_APP_ID}}",
     "developer": {
         "name": "My App, Inc.",
@@ -43,12 +36,14 @@
         {
             "botId": "${{BOT_ID}}",
             "scopes": [
-                {{#CEAEnabled}} 
+                {{#CEAEnabled}}
                 "copilot",
                 {{/CEAEnabled}}
-                "personal",
+                {{^CEAEnabled}}
                 "team",
-                "groupChat"
+                "groupChat",
+                {{/CEAEnabled}}
+                "personal"
             ],
             "supportsFiles": false,
             "isNotificationOnly": false,

--- a/templates/js/custom-copilot-rag-custom-api/appPackage/manifest.json.tpl
+++ b/templates/js/custom-copilot-rag-custom-api/appPackage/manifest.json.tpl
@@ -1,14 +1,7 @@
 {
-    {{#CEAEnabled}}
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/vdevPreview/MicrosoftTeams.schema.json",
-    "manifestVersion": "devPreview",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
-    {{/CEAEnabled}}
-    {{^CEAEnabled}}
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
-    "version": "1.0.0",
-    {{/CEAEnabled}}
     "id": "${{TEAMS_APP_ID}}",
     "developer": {
         "name": "My App, Inc.",
@@ -43,12 +36,14 @@
         {
             "botId": "${{BOT_ID}}",
             "scopes": [
-                {{#CEAEnabled}} 
+                {{#CEAEnabled}}
                 "copilot",
                 {{/CEAEnabled}}
-                "personal",
+                {{^CEAEnabled}}
                 "team",
-                "groupChat"
+                "groupChat",
+                {{/CEAEnabled}}
+                "personal"
             ],
             "supportsFiles": false,
             "isNotificationOnly": false

--- a/templates/js/custom-copilot-rag-customize/appPackage/manifest.json.tpl
+++ b/templates/js/custom-copilot-rag-customize/appPackage/manifest.json.tpl
@@ -1,14 +1,7 @@
 {
-    {{#CEAEnabled}} 
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/vdevPreview/MicrosoftTeams.schema.json",
-    "manifestVersion": "devPreview",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
-    {{/CEAEnabled}}
-    {{^CEAEnabled}} 
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
-    "version": "1.0.0",
-    {{/CEAEnabled}}
     "id": "${{TEAMS_APP_ID}}",
     "developer": {
         "name": "My App, Inc.",
@@ -43,12 +36,14 @@
         {
             "botId": "${{BOT_ID}}",
             "scopes": [
-                {{#CEAEnabled}} 
+                {{#CEAEnabled}}
                 "copilot",
                 {{/CEAEnabled}}
-                "personal",
+                {{^CEAEnabled}}
                 "team",
-                "groupChat"
+                "groupChat",
+                {{/CEAEnabled}}
+                "personal"
             ],
             "supportsFiles": false,
             "isNotificationOnly": false,

--- a/templates/js/custom-copilot-rag-microsoft365/appPackage/manifest.json.tpl
+++ b/templates/js/custom-copilot-rag-microsoft365/appPackage/manifest.json.tpl
@@ -1,14 +1,7 @@
 {
-    {{#CEAEnabled}} 
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/vdevPreview/MicrosoftTeams.schema.json",
-    "manifestVersion": "devPreview",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
-    {{/CEAEnabled}}
-    {{^CEAEnabled}} 
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
-    "version": "1.0.0",
-    {{/CEAEnabled}}
     "id": "${{TEAMS_APP_ID}}",
     "developer": {
         "name": "My App, Inc.",
@@ -43,12 +36,14 @@
         {
             "botId": "${{BOT_ID}}",
             "scopes": [
-                {{#CEAEnabled}} 
+                {{#CEAEnabled}}
                 "copilot",
                 {{/CEAEnabled}}
-                "personal",
+                {{^CEAEnabled}}
                 "team",
-                "groupChat"
+                "groupChat",
+                {{/CEAEnabled}}
+                "personal"
             ],
             "supportsFiles": false,
             "isNotificationOnly": false,

--- a/templates/js/dashboard-tab/appPackage/manifest.json.tpl
+++ b/templates/js/dashboard-tab/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/js/declarative-agent-with-action-from-scratch-bearer/appPackage/manifest.json.tpl
+++ b/templates/js/declarative-agent-with-action-from-scratch-bearer/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-  "manifestVersion": "1.19",
+  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+  "manifestVersion": "1.21",
   "id": "${{TEAMS_APP_ID}}",
   "version": "1.0.0",
   "developer": {

--- a/templates/js/declarative-agent-with-action-from-scratch-oauth/appPackage/manifest.json.tpl
+++ b/templates/js/declarative-agent-with-action-from-scratch-oauth/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-  "manifestVersion": "1.19",
+  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+  "manifestVersion": "1.21",
   "id": "${{TEAMS_APP_ID}}",
   "version": "1.0.0",
   "developer": {

--- a/templates/js/declarative-agent-with-action-from-scratch/appPackage/manifest.json.tpl
+++ b/templates/js/declarative-agent-with-action-from-scratch/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-  "manifestVersion": "1.19",
+  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+  "manifestVersion": "1.21",
   "id": "${{TEAMS_APP_ID}}",
   "version": "1.0.0",
   "developer": {

--- a/templates/js/default-bot-message-extension/appPackage/manifest.json.tpl
+++ b/templates/js/default-bot-message-extension/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/js/default-bot/appPackage/manifest.json.tpl
+++ b/templates/js/default-bot/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/js/link-unfurling/appPackage/manifest.json.tpl
+++ b/templates/js/link-unfurling/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/js/m365-message-extension/appPackage/manifest.json.tpl
+++ b/templates/js/m365-message-extension/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/js/message-extension-action/appPackage/manifest.json.tpl
+++ b/templates/js/message-extension-action/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/js/message-extension-with-api-from-scratch-api-key/appPackage/manifest.json.tpl
+++ b/templates/js/message-extension-with-api-from-scratch-api-key/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-  "manifestVersion": "1.19",
+  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+  "manifestVersion": "1.21",
   "id": "${{TEAMS_APP_ID}}",
   "version": "1.0.0",
   "developer": {

--- a/templates/js/message-extension-with-api-from-scratch-sso/appPackage/manifest.json.tpl
+++ b/templates/js/message-extension-with-api-from-scratch-sso/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "id": "${{TEAMS_APP_ID}}",
     "version": "1.0.0",
     "developer": {

--- a/templates/js/message-extension-with-api-from-scratch/appPackage/manifest.json.tpl
+++ b/templates/js/message-extension-with-api-from-scratch/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "id": "${{TEAMS_APP_ID}}",
     "version": "1.0.0",
     "developer": {

--- a/templates/js/message-extension/appPackage/manifest.json.tpl
+++ b/templates/js/message-extension/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/js/non-sso-tab-default-bot/appPackage/manifest.json.tpl
+++ b/templates/js/non-sso-tab-default-bot/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/js/non-sso-tab/appPackage/manifest.json.tpl
+++ b/templates/js/non-sso-tab/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/js/notification-express/appPackage/manifest.json.tpl
+++ b/templates/js/notification-express/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/js/notification-http-timer-trigger/appPackage/manifest.json.tpl
+++ b/templates/js/notification-http-timer-trigger/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/js/notification-http-trigger/appPackage/manifest.json.tpl
+++ b/templates/js/notification-http-trigger/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/js/notification-timer-trigger/appPackage/manifest.json.tpl
+++ b/templates/js/notification-timer-trigger/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/js/sso-tab-with-obo-flow/appPackage/manifest.json.tpl
+++ b/templates/js/sso-tab-with-obo-flow/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/js/workflow/appPackage/manifest.json.tpl
+++ b/templates/js/workflow/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/python/custom-copilot-assistant-assistants-api/appPackage/manifest.json.tpl
+++ b/templates/python/custom-copilot-assistant-assistants-api/appPackage/manifest.json.tpl
@@ -1,14 +1,7 @@
 {
-    {{#CEAEnabled}}
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/vdevPreview/MicrosoftTeams.schema.json",
-    "manifestVersion": "devPreview",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
-    {{/CEAEnabled}}
-    {{^CEAEnabled}}
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
-    "version": "1.0.0",
-    {{/CEAEnabled}}
     "id": "${{TEAMS_APP_ID}}",
     "developer": {
         "name": "My App, Inc.",
@@ -46,9 +39,11 @@
                 {{#CEAEnabled}}
                 "copilot",
                 {{/CEAEnabled}}
-                "personal",
+                {{^CEAEnabled}}
                 "team",
-                "groupChat"
+                "groupChat",
+                {{/CEAEnabled}}
+                "personal"
             ],
             "supportsFiles": false,
             "isNotificationOnly": false,

--- a/templates/python/custom-copilot-assistant-new/appPackage/manifest.json.tpl
+++ b/templates/python/custom-copilot-assistant-new/appPackage/manifest.json.tpl
@@ -1,14 +1,7 @@
 {
-    {{#CEAEnabled}}
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/vdevPreview/MicrosoftTeams.schema.json",
-    "manifestVersion": "devPreview",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
-    {{/CEAEnabled}}
-    {{^CEAEnabled}}
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
-    "version": "1.0.0",
-    {{/CEAEnabled}}
     "id": "${{TEAMS_APP_ID}}",
     "developer": {
         "name": "My App, Inc.",
@@ -46,9 +39,11 @@
                 {{#CEAEnabled}}
                 "copilot",
                 {{/CEAEnabled}}
-                "personal",
+                {{^CEAEnabled}}
                 "team",
-                "groupChat"
+                "groupChat",
+                {{/CEAEnabled}}
+                "personal"
             ],
             "supportsFiles": false,
             "isNotificationOnly": false,

--- a/templates/python/custom-copilot-basic/appPackage/manifest.json.tpl
+++ b/templates/python/custom-copilot-basic/appPackage/manifest.json.tpl
@@ -1,14 +1,7 @@
 {
-    {{#CEAEnabled}}
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/vdevPreview/MicrosoftTeams.schema.json",
-    "manifestVersion": "devPreview",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
-    {{/CEAEnabled}}
-    {{^CEAEnabled}}
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
-    "version": "1.0.0",
-    {{/CEAEnabled}}
     "id": "${{TEAMS_APP_ID}}",
     "developer": {
         "name": "My App, Inc.",
@@ -46,9 +39,11 @@
                 {{#CEAEnabled}}
                 "copilot",
                 {{/CEAEnabled}}
-                "personal",
+                {{^CEAEnabled}}
                 "team",
-                "groupChat"
+                "groupChat",
+                {{/CEAEnabled}}
+                "personal"
             ],
             "supportsFiles": false,
             "isNotificationOnly": false,

--- a/templates/python/custom-copilot-rag-azure-ai-search/appPackage/manifest.json.tpl
+++ b/templates/python/custom-copilot-rag-azure-ai-search/appPackage/manifest.json.tpl
@@ -1,14 +1,7 @@
 {
-    {{#CEAEnabled}}
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/vdevPreview/MicrosoftTeams.schema.json",
-    "manifestVersion": "devPreview",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
-    {{/CEAEnabled}}
-    {{^CEAEnabled}}
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
-    "version": "1.0.0",
-    {{/CEAEnabled}}
     "id": "${{TEAMS_APP_ID}}",
     "developer": {
         "name": "My App, Inc.",
@@ -46,9 +39,11 @@
                 {{#CEAEnabled}}
                 "copilot",
                 {{/CEAEnabled}}
-                "personal",
+                {{^CEAEnabled}}
                 "team",
-                "groupChat"
+                "groupChat",
+                {{/CEAEnabled}}
+                "personal"
             ],
             "supportsFiles": false,
             "isNotificationOnly": false,

--- a/templates/python/custom-copilot-rag-custom-api/appPackage/manifest.json.tpl
+++ b/templates/python/custom-copilot-rag-custom-api/appPackage/manifest.json.tpl
@@ -1,14 +1,7 @@
 {
-    {{#CEAEnabled}}
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/vdevPreview/MicrosoftTeams.schema.json",
-    "manifestVersion": "devPreview",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
-    {{/CEAEnabled}}
-    {{^CEAEnabled}}
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
-    "version": "1.0.0",
-    {{/CEAEnabled}}
     "id": "${{TEAMS_APP_ID}}",
     "developer": {
         "name": "My App, Inc.",
@@ -46,9 +39,11 @@
                 {{#CEAEnabled}}
                 "copilot",
                 {{/CEAEnabled}}
-                "personal",
+                {{^CEAEnabled}}
                 "team",
-                "groupChat"
+                "groupChat",
+                {{/CEAEnabled}}
+                "personal"
             ],
             "supportsFiles": false,
             "isNotificationOnly": false

--- a/templates/python/custom-copilot-rag-customize/appPackage/manifest.json.tpl
+++ b/templates/python/custom-copilot-rag-customize/appPackage/manifest.json.tpl
@@ -1,14 +1,7 @@
 {
-    {{#CEAEnabled}}
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/vdevPreview/MicrosoftTeams.schema.json",
-    "manifestVersion": "devPreview",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
-    {{/CEAEnabled}}
-    {{^CEAEnabled}}
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
-    "version": "1.0.0",
-    {{/CEAEnabled}}
     "id": "${{TEAMS_APP_ID}}",
     "developer": {
         "name": "My App, Inc.",
@@ -46,9 +39,11 @@
                 {{#CEAEnabled}}
                 "copilot",
                 {{/CEAEnabled}}
-                "personal",
+                {{^CEAEnabled}}
                 "team",
-                "groupChat"
+                "groupChat",
+                {{/CEAEnabled}}
+                "personal"
             ],
             "supportsFiles": false,
             "isNotificationOnly": false,

--- a/templates/ts/ai-assistant-bot/appPackage/manifest.json.tpl
+++ b/templates/ts/ai-assistant-bot/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/ts/ai-bot/appPackage/manifest.json.tpl
+++ b/templates/ts/ai-bot/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/ts/command-and-response/appPackage/manifest.json.tpl
+++ b/templates/ts/command-and-response/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/ts/custom-copilot-assistant-assistants-api/appPackage/manifest.json.tpl
+++ b/templates/ts/custom-copilot-assistant-assistants-api/appPackage/manifest.json.tpl
@@ -1,14 +1,7 @@
 {
-    {{#CEAEnabled}} 
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/vdevPreview/MicrosoftTeams.schema.json",
-    "manifestVersion": "devPreview",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
-    {{/CEAEnabled}}
-    {{^CEAEnabled}} 
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
-    "version": "1.0.0",
-    {{/CEAEnabled}}
     "id": "${{TEAMS_APP_ID}}",
     "developer": {
         "name": "My App, Inc.",
@@ -43,8 +36,12 @@
         {
             "botId": "${{BOT_ID}}",
             "scopes": [
-                {{#CEAEnabled}} 
+                {{#CEAEnabled}}
                 "copilot",
+                {{/CEAEnabled}}
+                {{^CEAEnabled}}
+                "team",
+                "groupChat",
                 {{/CEAEnabled}}
                 "personal"
             ],

--- a/templates/ts/custom-copilot-assistant-new/appPackage/manifest.json.tpl
+++ b/templates/ts/custom-copilot-assistant-new/appPackage/manifest.json.tpl
@@ -1,14 +1,7 @@
 {
-    {{#CEAEnabled}} 
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/vdevPreview/MicrosoftTeams.schema.json",
-    "manifestVersion": "devPreview",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
-    {{/CEAEnabled}}
-    {{^CEAEnabled}} 
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
-    "version": "1.0.0",
-    {{/CEAEnabled}}
     "id": "${{TEAMS_APP_ID}}",
     "developer": {
         "name": "My App, Inc.",
@@ -43,12 +36,14 @@
         {
             "botId": "${{BOT_ID}}",
             "scopes": [
-                {{#CEAEnabled}} 
+                {{#CEAEnabled}}
                 "copilot",
                 {{/CEAEnabled}}
-                "personal",
+                {{^CEAEnabled}}
                 "team",
-                "groupChat"
+                "groupChat",
+                {{/CEAEnabled}}
+                "personal"
             ],
             "supportsFiles": false,
             "isNotificationOnly": false,

--- a/templates/ts/custom-copilot-basic/appPackage/manifest.json.tpl
+++ b/templates/ts/custom-copilot-basic/appPackage/manifest.json.tpl
@@ -1,14 +1,7 @@
 {
-    {{#CEAEnabled}} 
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/vdevPreview/MicrosoftTeams.schema.json",
-    "manifestVersion": "devPreview",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
-    {{/CEAEnabled}}
-    {{^CEAEnabled}} 
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
-    "version": "1.0.0",
-    {{/CEAEnabled}}
     "id": "${{TEAMS_APP_ID}}",
     "developer": {
         "name": "My App, Inc.",
@@ -43,12 +36,14 @@
         {
             "botId": "${{BOT_ID}}",
             "scopes": [
-                {{#CEAEnabled}} 
+                {{#CEAEnabled}}
                 "copilot",
                 {{/CEAEnabled}}
-                "personal",
+                {{^CEAEnabled}}
                 "team",
-                "groupChat"
+                "groupChat",
+                {{/CEAEnabled}}
+                "personal"
             ],
             "supportsFiles": false,
             "isNotificationOnly": false,

--- a/templates/ts/custom-copilot-rag-azure-ai-search/appPackage/manifest.json.tpl
+++ b/templates/ts/custom-copilot-rag-azure-ai-search/appPackage/manifest.json.tpl
@@ -1,14 +1,7 @@
 {
-    {{#CEAEnabled}} 
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/vdevPreview/MicrosoftTeams.schema.json",
-    "manifestVersion": "devPreview",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
-    {{/CEAEnabled}}
-    {{^CEAEnabled}} 
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
-    "version": "1.0.0",
-    {{/CEAEnabled}}
     "id": "${{TEAMS_APP_ID}}",
     "developer": {
         "name": "My App, Inc.",
@@ -43,12 +36,14 @@
         {
             "botId": "${{BOT_ID}}",
             "scopes": [
-                {{#CEAEnabled}} 
+                {{#CEAEnabled}}
                 "copilot",
                 {{/CEAEnabled}}
-                "personal",
+                {{^CEAEnabled}}
                 "team",
-                "groupChat"
+                "groupChat",
+                {{/CEAEnabled}}
+                "personal"
             ],
             "supportsFiles": false,
             "isNotificationOnly": false,

--- a/templates/ts/custom-copilot-rag-custom-api/appPackage/manifest.json.tpl
+++ b/templates/ts/custom-copilot-rag-custom-api/appPackage/manifest.json.tpl
@@ -1,14 +1,7 @@
 {
-    {{#CEAEnabled}}
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/vdevPreview/MicrosoftTeams.schema.json",
-    "manifestVersion": "devPreview",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
-    {{/CEAEnabled}}
-    {{^CEAEnabled}}
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
-    "version": "1.0.0",
-    {{/CEAEnabled}}
     "id": "${{TEAMS_APP_ID}}",
     "developer": {
         "name": "My App, Inc.",
@@ -43,12 +36,14 @@
         {
             "botId": "${{BOT_ID}}",
             "scopes": [
-                {{#CEAEnabled}} 
+                {{#CEAEnabled}}
                 "copilot",
                 {{/CEAEnabled}}
-                "personal",
+                {{^CEAEnabled}}
                 "team",
-                "groupChat"
+                "groupChat",
+                {{/CEAEnabled}}
+                "personal"
             ],
             "supportsFiles": false,
             "isNotificationOnly": false

--- a/templates/ts/custom-copilot-rag-customize/appPackage/manifest.json.tpl
+++ b/templates/ts/custom-copilot-rag-customize/appPackage/manifest.json.tpl
@@ -1,14 +1,7 @@
 {
-    {{#CEAEnabled}} 
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/vdevPreview/MicrosoftTeams.schema.json",
-    "manifestVersion": "devPreview",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
-    {{/CEAEnabled}}
-    {{^CEAEnabled}} 
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
-    "version": "1.0.0",
-    {{/CEAEnabled}}
     "id": "${{TEAMS_APP_ID}}",
     "developer": {
         "name": "My App, Inc.",
@@ -43,12 +36,14 @@
         {
             "botId": "${{BOT_ID}}",
             "scopes": [
-                {{#CEAEnabled}} 
+                {{#CEAEnabled}}
                 "copilot",
                 {{/CEAEnabled}}
-                "personal",
+                {{^CEAEnabled}}
                 "team",
-                "groupChat"
+                "groupChat",
+                {{/CEAEnabled}}
+                "personal"
             ],
             "supportsFiles": false,
             "isNotificationOnly": false,

--- a/templates/ts/custom-copilot-rag-microsoft365/appPackage/manifest.json.tpl
+++ b/templates/ts/custom-copilot-rag-microsoft365/appPackage/manifest.json.tpl
@@ -1,14 +1,7 @@
 {
-    {{#CEAEnabled}} 
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/vdevPreview/MicrosoftTeams.schema.json",
-    "manifestVersion": "devPreview",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
-    {{/CEAEnabled}}
-    {{^CEAEnabled}} 
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
-    "version": "1.0.0",
-    {{/CEAEnabled}}
     "id": "${{TEAMS_APP_ID}}",
     "developer": {
         "name": "My App, Inc.",
@@ -43,12 +36,14 @@
         {
             "botId": "${{BOT_ID}}",
             "scopes": [
-                {{#CEAEnabled}} 
+                {{#CEAEnabled}}
                 "copilot",
                 {{/CEAEnabled}}
-                "personal",
+                {{^CEAEnabled}}
                 "team",
-                "groupChat"
+                "groupChat",
+                {{/CEAEnabled}}
+                "personal"
             ],
             "supportsFiles": false,
             "isNotificationOnly": false,

--- a/templates/ts/dashboard-tab/appPackage/manifest.json.tpl
+++ b/templates/ts/dashboard-tab/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/ts/declarative-agent-with-action-from-scratch-bearer/appPackage/manifest.json.tpl
+++ b/templates/ts/declarative-agent-with-action-from-scratch-bearer/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-  "manifestVersion": "1.19",
+  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+  "manifestVersion": "1.21",
   "id": "${{TEAMS_APP_ID}}",
   "version": "1.0.0",
   "developer": {

--- a/templates/ts/declarative-agent-with-action-from-scratch-oauth/appPackage/manifest.json.tpl
+++ b/templates/ts/declarative-agent-with-action-from-scratch-oauth/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-  "manifestVersion": "1.19",
+  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+  "manifestVersion": "1.21",
   "id": "${{TEAMS_APP_ID}}",
   "version": "1.0.0",
   "developer": {

--- a/templates/ts/declarative-agent-with-action-from-scratch/appPackage/manifest.json.tpl
+++ b/templates/ts/declarative-agent-with-action-from-scratch/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-  "manifestVersion": "1.19",
+  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+  "manifestVersion": "1.21",
   "id": "${{TEAMS_APP_ID}}",
   "version": "1.0.0",
   "developer": {

--- a/templates/ts/default-bot-message-extension/appPackage/manifest.json.tpl
+++ b/templates/ts/default-bot-message-extension/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/ts/default-bot/appPackage/manifest.json.tpl
+++ b/templates/ts/default-bot/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/ts/link-unfurling/appPackage/manifest.json.tpl
+++ b/templates/ts/link-unfurling/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/ts/m365-message-extension/appPackage/manifest.json.tpl
+++ b/templates/ts/m365-message-extension/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/ts/message-extension-action/appPackage/manifest.json.tpl
+++ b/templates/ts/message-extension-action/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/ts/message-extension-with-api-from-scratch-api-key/appPackage/manifest.json.tpl
+++ b/templates/ts/message-extension-with-api-from-scratch-api-key/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-  "manifestVersion": "1.19",
+  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+  "manifestVersion": "1.21",
   "id": "${{TEAMS_APP_ID}}",
   "version": "1.0.0",
   "developer": {

--- a/templates/ts/message-extension-with-api-from-scratch-sso/appPackage/manifest.json.tpl
+++ b/templates/ts/message-extension-with-api-from-scratch-sso/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "id": "${{TEAMS_APP_ID}}",
     "version": "1.0.0",
     "developer": {

--- a/templates/ts/message-extension-with-api-from-scratch/appPackage/manifest.json.tpl
+++ b/templates/ts/message-extension-with-api-from-scratch/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "id": "${{TEAMS_APP_ID}}",
     "version": "1.0.0",
     "developer": {

--- a/templates/ts/message-extension/appPackage/manifest.json.tpl
+++ b/templates/ts/message-extension/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/ts/non-sso-tab-default-bot/appPackage/manifest.json.tpl
+++ b/templates/ts/non-sso-tab-default-bot/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/ts/non-sso-tab/appPackage/manifest.json.tpl
+++ b/templates/ts/non-sso-tab/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/ts/notification-express/appPackage/manifest.json.tpl
+++ b/templates/ts/notification-express/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/ts/notification-http-timer-trigger/appPackage/manifest.json.tpl
+++ b/templates/ts/notification-http-timer-trigger/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/ts/notification-http-trigger/appPackage/manifest.json.tpl
+++ b/templates/ts/notification-http-trigger/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/ts/notification-timer-trigger/appPackage/manifest.json.tpl
+++ b/templates/ts/notification-timer-trigger/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/ts/office-addin-outlook-taskpane/appPackage/manifest.json.tpl
+++ b/templates/ts/office-addin-outlook-taskpane/appPackage/manifest.json.tpl
@@ -1,7 +1,7 @@
 {
-    "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
+    "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
     "id": "{{manifestId}}",
-    "manifestVersion": "1.19",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "name": {
         "short": "{{appName}}",

--- a/templates/ts/spfx-tab/appPackage/manifest.json.tpl
+++ b/templates/ts/spfx-tab/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "id": "${{TEAMS_APP_ID}}",
     "version": "1.0.0",
     "developer": {

--- a/templates/ts/sso-tab-with-obo-flow/appPackage/manifest.json.tpl
+++ b/templates/ts/sso-tab-with-obo-flow/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {

--- a/templates/ts/workflow/appPackage/manifest.json.tpl
+++ b/templates/ts/workflow/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.19/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.19",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.21/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.21",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/32769619

For Agents for Teams, whose names start with "custom-copilot-", we decide to defaultly use 1.21 version of manifest but keep the feature flag control for other features.