### PR TITLE
chore(dotnet-sdk): bump to 3.0.0

### DIFF
--- a/packages/dotnet-sdk/CHANGELOG.md
+++ b/packages/dotnet-sdk/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 3.0.0-rc
+# 3.0.0
 - Breaking: Migrate dependencies from Bot Framework SDK to Microsoft Agents SDK.
 - Breaking: Upgrade target framework to .NET 8.0.
 

--- a/packages/dotnet-sdk/src/TeamsFx/Microsoft.TeamsFx.csproj
+++ b/packages/dotnet-sdk/src/TeamsFx/Microsoft.TeamsFx.csproj
@@ -27,9 +27,9 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
       <_Parameter1>Microsoft.TeamsFx.Test</_Parameter1>
     </AssemblyAttribute>
-    <PackageReference Include="Microsoft.Agents.Builder.Dialogs" Version="0.2.*-*" />
-    <PackageReference Include="Microsoft.Agents.Extensions.Teams" Version="0.2.*-*" />
-    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="0.2.*-*" />
+    <PackageReference Include="Microsoft.Agents.Builder.Dialogs" Version="1.*" />
+    <PackageReference Include="Microsoft.Agents.Extensions.Teams" Version="1.*" />
+    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="1.*" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.14" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.1" />

--- a/packages/dotnet-sdk/src/TeamsFx/Microsoft.TeamsFx.csproj
+++ b/packages/dotnet-sdk/src/TeamsFx/Microsoft.TeamsFx.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Microsoft.TeamsFx</AssemblyName>
     <RootNamespace>Microsoft.TeamsFx</RootNamespace>
-    <Version>3.0.0-rc.2</Version>
+    <Version>3.0.0</Version>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
     <RepositoryUrl>https://github.com/OfficeDev/TeamsFx</RepositoryUrl>

--- a/templates/csharp/command-and-response/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/command-and-response/{{ProjectName}}.csproj.tpl
@@ -20,8 +20,8 @@
 {{/isNewProjectTypeEnabled}}
   <ItemGroup>
     <PackageReference Include="AdaptiveCards.Templating" Version="2.0.5" />
-    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="0.2.*-*" />
-    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="0.2.*-*" />
+    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="1.*" />
+    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="1.*" />
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.14" />
     <PackageReference Include="Microsoft.TeamsFx" Version="3.0.*-*" >
       <!-- Exclude TeamsFx wwwroot static files which are for frontend only. -->

--- a/templates/csharp/custom-copilot-weather-agent/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/custom-copilot-weather-agent/{{ProjectName}}.csproj.tpl
@@ -28,8 +28,8 @@
     <PackageReference Include="Microsoft.SemanticKernel.Agents.Core" Version="1.45.0" />
     <PackageReference Include="Microsoft.SemanticKernel.Connectors.AzureOpenAI" Version="1.45.0" />
     <PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.45.0" />
-    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="0.2.*-*" />
-    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="0.2.*-*" />
+    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="1.*" />
+    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="1.*" />
   </ItemGroup>
 
   <!-- Exclude local settings from publish -->

--- a/templates/csharp/default-bot/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/default-bot/{{ProjectName}}.csproj.tpl
@@ -19,8 +19,8 @@
 
 {{/isNewProjectTypeEnabled}}
   <ItemGroup>
-    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="0.2.*-*" />
-    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="0.2.*-*" />
+    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="1.*" />
+    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="1.*" />
   </ItemGroup>
 
 </Project>

--- a/templates/csharp/link-unfurling/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/link-unfurling/{{ProjectName}}.csproj.tpl
@@ -18,9 +18,9 @@
 {{/isNewProjectTypeEnabled}}
   <ItemGroup>
 	  <PackageReference Include="AdaptiveCards" Version="3.1.0" />
-	  <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="0.2.*-*" />
-	  <PackageReference Include="Microsoft.Agents.Extensions.Teams" Version="0.2.*-*" />
-	  <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="0.2.*-*" />
+	  <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="1.*" />
+	  <PackageReference Include="Microsoft.Agents.Extensions.Teams" Version="1.*" />
+	  <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="1.*" />
   </ItemGroup>
 
 </Project>

--- a/templates/csharp/message-extension-action/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/message-extension-action/{{ProjectName}}.csproj.tpl
@@ -19,9 +19,9 @@
   <ItemGroup>
     <PackageReference Include="AdaptiveCards" Version="3.1.0" />
     <PackageReference Include="AdaptiveCards.Templating" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="0.2.*-*" />
-    <PackageReference Include="Microsoft.Agents.Extensions.Teams" Version="0.2.*-*" />
-    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="0.2.*-*" />
+    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="1.*" />
+    <PackageReference Include="Microsoft.Agents.Extensions.Teams" Version="1.*" />
+    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="1.*" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/templates/csharp/message-extension-search/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/message-extension-search/{{ProjectName}}.csproj.tpl
@@ -19,9 +19,9 @@
   <ItemGroup>
     <PackageReference Include="AdaptiveCards" Version="3.1.0" />
     <PackageReference Include="AdaptiveCards.Templating" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="0.2.*-*" />
-    <PackageReference Include="Microsoft.Agents.Extensions.Teams" Version="0.2.*-*" />
-    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="0.2.*-*" />
+    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="1.*" />
+    <PackageReference Include="Microsoft.Agents.Extensions.Teams" Version="1.*" />
+    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="1.*" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/templates/csharp/message-extension/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/message-extension/{{ProjectName}}.csproj.tpl
@@ -19,9 +19,9 @@
   <ItemGroup>
     <PackageReference Include="AdaptiveCards" Version="3.1.0" />
     <PackageReference Include="AdaptiveCards.Templating" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="0.2.*-*" />
-    <PackageReference Include="Microsoft.Agents.Extensions.Teams" Version="0.2.*-*" />
-    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="0.2.*-*" />
+    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="1.*" />
+    <PackageReference Include="Microsoft.Agents.Extensions.Teams" Version="1.*" />
+    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="1.*" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 

--- a/templates/csharp/notification-http-timer-trigger/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/notification-http-timer-trigger/{{ProjectName}}.csproj.tpl
@@ -33,8 +33,8 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
-    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="0.2.*-*" />
-    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="0.2.*-*" />
+    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="1.*" />
+    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="1.*" />
     <PackageReference Include="Microsoft.TeamsFx" Version="3.0.*-*">
       <!-- Exclude TeamsFx wwwroot static files which are for frontend only. -->
       <ExcludeAssets>contentFiles</ExcludeAssets>

--- a/templates/csharp/notification-http-trigger/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/notification-http-trigger/{{ProjectName}}.csproj.tpl
@@ -32,8 +32,8 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="0.2.*-*" />
-    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="0.2.*-*" />
+    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="1.*" />
+    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="1.*" />
     <PackageReference Include="Microsoft.TeamsFx" Version="3.0.*-*">
       <!-- Exclude TeamsFx wwwroot static files which are for frontend only. -->
       <ExcludeAssets>contentFiles</ExcludeAssets>

--- a/templates/csharp/notification-timer-trigger/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/notification-timer-trigger/{{ProjectName}}.csproj.tpl
@@ -33,8 +33,8 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
-    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="0.2.*-*" />
-    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="0.2.*-*" />
+    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="1.*" />
+    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="1.*" />
     <PackageReference Include="Microsoft.TeamsFx" Version="3.0.*-*">
       <!-- Exclude TeamsFx wwwroot static files which are for frontend only. -->
       <ExcludeAssets>contentFiles</ExcludeAssets>

--- a/templates/csharp/notification-webapi/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/notification-webapi/{{ProjectName}}.csproj.tpl
@@ -25,8 +25,8 @@
 
   <ItemGroup>
     <PackageReference Include="AdaptiveCards.Templating" Version="1.3.1" />
-    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="0.2.*-*" />
-    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="0.2.*-*" />
+    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="1.*" />
+    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="1.*" />
     <PackageReference Include="Microsoft.TeamsFx" Version="3.0.*-*">
       <!-- Exclude TeamsFx wwwroot static files which are for frontend only. -->
       <ExcludeAssets>contentFiles</ExcludeAssets>

--- a/templates/csharp/workflow/{{ProjectName}}.csproj.tpl
+++ b/templates/csharp/workflow/{{ProjectName}}.csproj.tpl
@@ -20,8 +20,8 @@
 {{/isNewProjectTypeEnabled}}
   <ItemGroup>
     <PackageReference Include="AdaptiveCards.Templating" Version="2.0.5" />
-    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="0.2.*-*" />
-    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="0.2.*-*" />
+    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="1.*" />
+    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="1.*" />
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.14" />
     <PackageReference Include="Microsoft.TeamsFx" Version="3.0.*-*">
       <!-- Exclude TeamsFx wwwroot static files which are for frontend only. -->


### PR DESCRIPTION
Cherry-pick Agents SDK upgrade on release/VS1714P6 and bump .NET SDK.