### PR TITLE
fix: unify url telemetry property for MOS API failure

### DIFF
--- a/packages/fx-core/src/common/wrappedAxiosClient.ts
+++ b/packages/fx-core/src/common/wrappedAxiosClient.ts
@@ -140,7 +140,6 @@ export class WrappedAxiosClient {
       }: ${innerError.message as string} `;
       properties[TelemetryProperty.ErrorMessage] = finalMessage;
       properties[TelemetryProperty.MOSTraceId] = tracingId;
-      properties.url = apiName;
     }
 
     TOOLS?.telemetryReporter?.sendTelemetryErrorEvent(eventName, properties);


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/32998591