### PR TITLE
fix(tsp): downgrade dependency version for tsp template

### DIFF
--- a/templates/common/declarative-agent-typespec/package.json.tpl
+++ b/templates/common/declarative-agent-typespec/package.json.tpl
@@ -3,9 +3,9 @@
   "version": "1.0.0",
   "devDependencies": {
     "@microsoft/typespec-m365-copilot": "1.0.0-rc.3",
-    "@typespec/compiler": "1.0.0",
-    "@typespec/http": "1.0.1",
-    "@typespec/openapi": "1.0.0",
-    "@typespec/openapi3": "1.0.0"
+    "@typespec/compiler": "1.0.0-rc.1",
+    "@typespec/http": "1.0.0-rc.1",
+    "@typespec/openapi": "1.0.0-rc.1",
+    "@typespec/openapi3": "1.0.0-rc.1"
   }
 }


### PR DESCRIPTION
bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_sprints/taskboard/AuthAndData/Microsoft%20Teams%20Extensibility/Bromine/CY25Q2/2Wk/2Wk04%20(May%2018%20-%20May%2031)?workitem=33035401
issue: https://github.com/OfficeDev/microsoft-365-agents-toolkit/issues/14065