### PR TITLE
fix: create incoming webhook sample failed

### DIFF
--- a/packages/fx-core/src/component/coordinator/index.ts
+++ b/packages/fx-core/src/component/coordinator/index.ts
@@ -206,7 +206,7 @@ class Coordinator {
     }
 
     // generate unique projectId in teamsapp.yaml (optional)
-    const ymlPath = pathUtils.getYmlFilePath(projectPath, "dev") as string;
+    const ymlPath = pathUtils.getYmlFilePath(projectPath, "dev", true) as string;
     if (await fs.pathExists(ymlPath)) {
       const ensureRes = await this.ensureTrackingId(projectPath, inputs.projectId);
       if (ensureRes.isErr()) return err(ensureRes.error);


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/33039701

It's introduced by https://github.com/OfficeDev/microsoft-365-agents-toolkit/pull/13682/files#diff-2c83b7d66229574153a445966022d4a63e12bb5876b5b2f23267ceab57e5c932