### PR TITLE
fix: ado 33039505 remove the old readme pic

### DIFF
--- a/templates/common/declarative-agent-meta-os-upgrade-project/README.md
+++ b/templates/common/declarative-agent-meta-os-upgrade-project/README.md
@@ -13,8 +13,6 @@ With the declarative agent, you can build a custom version of Copilot that can b
 > - [Microsoft 365 Agents Toolkit Visual Studio Code Extension](https://aka.ms/teams-toolkit) version 5.0.0 and higher or [Microsoft 365 Agents Toolkit CLI](https://aka.ms/teamsfx-toolkit-cli)
 > - [Microsoft 365 Copilot license](https://learn.microsoft.com/microsoft-365-copilot/extensibility/prerequisites#prerequisites)
 
-![image](https://github.com/user-attachments/assets/e1c2a3b3-2e59-4e9b-8335-19315e92ba30)
-
 1. First, select the Microsoft 365 Agents Toolkit icon on the left in the VS Code toolbar.
 2. In the Account section, sign in with your [Microsoft 365 account](https://docs.microsoft.com/microsoftteams/platform/toolkit/accounts) if you haven't already.
 3. Create Microsoft 365 Agents app by clicking `Provision` in "Lifecycle" section.


### PR DESCRIPTION
This PR aims to fix the 33039505 by remove the old picture.

ADO Link: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/33039505/?view=edit