### PR TITLE
fix: fix the wrong yaml content formate which cause lib yaml failed

### DIFF
--- a/templates/common/declarative-agent-meta-os-new-project/m365agents.yml
+++ b/templates/common/declarative-agent-meta-os-new-project/m365agents.yml
@@ -12,7 +12,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}${{APP_NAME_SUFFIX}}
+      name: Declarative Agent ${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:

--- a/templates/common/declarative-agent-meta-os-upgrade-project/m365agents.yml
+++ b/templates/common/declarative-agent-meta-os-upgrade-project/m365agents.yml
@@ -12,7 +12,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}${{APP_NAME_SUFFIX}}
+      name: Declarative Agent ${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:


### PR DESCRIPTION
This pr aims to fix the issue: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/33082819/?view=edit

the issue is caused by wrong yaml content formate which lead the lib yaml failed.