### PR TITLE
fix: sync to dev (da metaos app name and fix the wrong yaml content formate which cause lib yaml failed)

### DIFF
--- a/templates/common/declarative-agent-meta-os-new-project/m365agents.yml
+++ b/templates/common/declarative-agent-meta-os-new-project/m365agents.yml
@@ -5,7 +5,7 @@ version: v1.7
 
 environmentFolderPath: ./env
 
-# Triggered when 'teamsapp provision' is executed
+# Triggered when 'atk provision' is executed
 provision:
   
   # Creates a Teams app
@@ -51,7 +51,7 @@ provision:
       titleId: M365_TITLE_ID
       appId: M365_APP_ID
 
-# Triggered when 'teamsapp publish' is executed
+# Triggered when 'atk publish' is executed
 publish:
 # Build Teams app package with latest env value
   - uses: teamsApp/zipAppPackage

--- a/templates/common/declarative-agent-meta-os-new-project/m365agents.yml
+++ b/templates/common/declarative-agent-meta-os-new-project/m365agents.yml
@@ -12,7 +12,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}${{APP_NAME_SUFFIX}}
+      name: Declarative Agent ${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:

--- a/templates/common/declarative-agent-meta-os-new-project/m365agents.yml
+++ b/templates/common/declarative-agent-meta-os-new-project/m365agents.yml
@@ -12,7 +12,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: My Agent 3${{APP_NAME_SUFFIX}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:

--- a/templates/common/declarative-agent-meta-os-upgrade-project/m365agents.yml
+++ b/templates/common/declarative-agent-meta-os-upgrade-project/m365agents.yml
@@ -5,7 +5,7 @@ version: v1.7
 
 environmentFolderPath: ./env
 
-# Triggered when 'teamsapp provision' is executed
+# Triggered when 'atk provision' is executed
 provision:
   
   # Creates a Teams app
@@ -51,7 +51,7 @@ provision:
       titleId: M365_TITLE_ID
       appId: M365_APP_ID
 
-# Triggered when 'teamsapp publish' is executed
+# Triggered when 'atk publish' is executed
 publish:
 # Build Teams app package with latest env value
   - uses: teamsApp/zipAppPackage

--- a/templates/common/declarative-agent-meta-os-upgrade-project/m365agents.yml
+++ b/templates/common/declarative-agent-meta-os-upgrade-project/m365agents.yml
@@ -12,7 +12,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: {{appName}}${{APP_NAME_SUFFIX}}
+      name: Declarative Agent ${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:

--- a/templates/common/declarative-agent-meta-os-upgrade-project/m365agents.yml
+++ b/templates/common/declarative-agent-meta-os-upgrade-project/m365agents.yml
@@ -12,7 +12,7 @@ provision:
   - uses: teamsApp/create
     with:
       # Teams app name
-      name: My Agent 3${{APP_NAME_SUFFIX}}
+      name: {{appName}}${{APP_NAME_SUFFIX}}
     # Write the information of created resources into environment file for
     # the specified environment variable(s).
     writeToEnvironmentFile:


### PR DESCRIPTION
This PR sync the following PR to branch `dev`:
- https://github.com/OfficeDev/microsoft-365-agents-toolkit/pull/14058
- https://github.com/OfficeDev/microsoft-365-agents-toolkit/pull/14086

There are three commits cherry-picked from above:
- PR 14058:
  - picked: 4f0a00adbc8f3e18e20bdb316f352fe71329d553
  - picked: 68d73cee0773dbc339a39aa62db35eeab246d906
  - no need to pick: 53b08d9c7ae4afb2b861ff628ce0b06f5964e68c
- PR 14086:
  - picked: 0872e22ed54fd4126f298ef221c754b9fe413fa4

---

The above PR solve the following issues:
- https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/33034464/?view=edit
- https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/33082819/?view=edit