### PR TITLE
fix: remove extra scopes

### DIFF
--- a/templates/vs/csharp/custom-copilot-assistant-assistants-api/appPackage/manifest.json.tpl
+++ b/templates/vs/csharp/custom-copilot-assistant-assistants-api/appPackage/manifest.json.tpl
@@ -39,9 +39,11 @@
                 {{#CEAEnabled}} 
                 "copilot",
                 {{/CEAEnabled}}
-                "personal",
+                {{^CEAEnabled}}
                 "team",
-                "groupChat"
+                "groupChat",
+                {{/CEAEnabled}}
+                "personal"
             ],
             "supportsFiles": false,
             "isNotificationOnly": false,

--- a/templates/vs/csharp/custom-copilot-assistant-new/appPackage/manifest.json.tpl
+++ b/templates/vs/csharp/custom-copilot-assistant-new/appPackage/manifest.json.tpl
@@ -39,9 +39,11 @@
                 {{#CEAEnabled}} 
                 "copilot",
                 {{/CEAEnabled}}
-                "personal",
+                {{^CEAEnabled}}
                 "team",
-                "groupChat"
+                "groupChat",
+                {{/CEAEnabled}}
+                "personal"
             ],
             "supportsFiles": false,
             "isNotificationOnly": false,

--- a/templates/vs/csharp/custom-copilot-basic/appPackage/manifest.json.tpl
+++ b/templates/vs/csharp/custom-copilot-basic/appPackage/manifest.json.tpl
@@ -39,9 +39,11 @@
                 {{#CEAEnabled}} 
                 "copilot",
                 {{/CEAEnabled}}
-                "personal",
+                {{^CEAEnabled}}
                 "team",
-                "groupChat"
+                "groupChat",
+                {{/CEAEnabled}}
+                "personal"
             ],
             "supportsFiles": false,
             "isNotificationOnly": false,

--- a/templates/vs/csharp/custom-copilot-rag-azure-ai-search/appPackage/manifest.json.tpl
+++ b/templates/vs/csharp/custom-copilot-rag-azure-ai-search/appPackage/manifest.json.tpl
@@ -39,9 +39,11 @@
                 {{#CEAEnabled}} 
                 "copilot",
                 {{/CEAEnabled}}
-                "personal",
+                {{^CEAEnabled}}
                 "team",
-                "groupChat"
+                "groupChat",
+                {{/CEAEnabled}}
+                "personal"
             ],
             "supportsFiles": false,
             "isNotificationOnly": false,

--- a/templates/vs/csharp/custom-copilot-rag-custom-api/appPackage/manifest.json.tpl
+++ b/templates/vs/csharp/custom-copilot-rag-custom-api/appPackage/manifest.json.tpl
@@ -39,9 +39,11 @@
                 {{#CEAEnabled}} 
                 "copilot",
                 {{/CEAEnabled}}
-                "personal",
+                {{^CEAEnabled}}
                 "team",
-                "groupChat"
+                "groupChat",
+                {{/CEAEnabled}}
+                "personal"
             ],
             "supportsFiles": false,
             "isNotificationOnly": false,

--- a/templates/vs/csharp/custom-copilot-rag-customize/appPackage/manifest.json.tpl
+++ b/templates/vs/csharp/custom-copilot-rag-customize/appPackage/manifest.json.tpl
@@ -39,9 +39,11 @@
                 {{#CEAEnabled}} 
                 "copilot",
                 {{/CEAEnabled}}
-                "personal",
+                {{^CEAEnabled}}
                 "team",
-                "groupChat"
+                "groupChat",
+                {{/CEAEnabled}}
+                "personal"
             ],
             "supportsFiles": false,
             "isNotificationOnly": false,


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/33121722

when CEAEnable flag is closed, there are 4 scopes listed in the manifest.json file, which exceeds the limit of 3 in 1.21 manifest.
Thus, we delete 2 scopes of groupChat and team, as CEA is expected to be a personal agent.