### PR TITLE
ci: vs template release rc and stable

### DIFF
--- a/.github/scripts/fxcore-sync-up-version.js
+++ b/.github/scripts/fxcore-sync-up-version.js
@@ -53,7 +53,7 @@ function syncTemplateVersion(templateVersion, templateConfigs) {
 }
 
 function updateUseLocalFlag(templateVersion, templateConfigs) {
-  if (!semver.prerelease(templateVersion) || templateVersion.includes("rc")) {
+  if (!semver.prerelease(templateVersion) || templateVersion.includes("rc") || process.env.VS_RELEASE === "true") {
     templateConfigs.useLocalTemplate = false;
   } else {
     templateConfigs.useLocalTemplate = true;

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -177,15 +177,30 @@ jobs:
           tag: "template-tag-list"
           allowUpdates: true
 
+      - name: Release RC VS templates to GitHub
+        if: ${{ contains(steps.version-change.outputs.CHANGED, 'templates@') && github.event_name == 'workflow_dispatch' && contains(github.events.inputs.pkgs, "server") }}
+        uses: mini-bomba/create-github-release@v1.1.3
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          tag: "templates-vs@0.0.0-rc"
+          name: "templates-vs@0.0.0-rc"
+          body: "VS Templates RC release for templates-vs@0.0.0-rc"
+          target_commit: ${{ github.sha }}
+          prerelease: true
+          clear_attachments: true
+          files: |
+            ${{ github.workspace }}/templates/build/csharp.zip
+      
       - name: Get VS Templates version
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.vsrelease == 'true' }}
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.vsrelease == 'true' && contains(github.events.inputs.pkgs, "templates") }}
         id: vs-template-tag
         run: |
           VS_VERSION=$(node -p "require('./templates/package.json').vsversion")
           echo "VSTAG=templates-vs@$VS_VERSION" >> $GITHUB_OUTPUT
 
-      - uses: mini-bomba/create-github-release@v1.1.3
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.vsrelease == 'true' }}
+      - name: Release stable VS Templates to GitHub
+        uses: mini-bomba/create-github-release@v1.1.3
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.vsrelease == 'true' && contains(github.events.inputs.pkgs, "templates") }}
         with:
           token: ${{ steps.generate-token.outputs.token }}
           tag: ${{ steps.vs-template-tag.outputs.VSTAG }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -178,7 +178,7 @@ jobs:
           allowUpdates: true
 
       - name: Release RC VS templates to GitHub
-        if: ${{ contains(steps.version-change.outputs.CHANGED, 'templates@') && github.event_name == 'workflow_dispatch' && contains(github.events.inputs.pkgs, "server") }}
+        if: ${{ contains(steps.version-change.outputs.CHANGED, 'templates@') && github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/heads/release/vs') }}
         uses: mini-bomba/create-github-release@v1.1.3
         with:
           token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,6 +20,10 @@ on:
         type: boolean
         default: false
         description: "Whether to release vs product"
+      vstemplate:
+        type: boolean
+        default: false
+        description: "Whether to release vs template"
   schedule:
     - cron: "0 16 * * *"
 
@@ -33,7 +37,7 @@ jobs:
     env:
       CI: true
       PREID: ${{ github.event.inputs.preid }}
-      VSC: ${{ github.event.inputs.vsrelease }}
+      VS_RELEASE: ${{ github.event.inputs.vsrelease }}
     steps:
       - name: Validate CD branch
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/dev' && !startsWith(github.ref, 'refs/heads/release/') }}
@@ -178,7 +182,7 @@ jobs:
           allowUpdates: true
 
       - name: Release RC VS templates to GitHub
-        if: ${{ contains(steps.version-change.outputs.CHANGED, 'templates@') && github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/heads/release/vs') }}
+        if: ${{ contains(steps.version-change.outputs.CHANGED, 'templates@') && github.event_name == 'workflow_dispatch' && github.event.inputs.vsrelease == 'true' }}
         uses: mini-bomba/create-github-release@v1.1.3
         with:
           token: ${{ steps.generate-token.outputs.token }}
@@ -192,7 +196,7 @@ jobs:
             ${{ github.workspace }}/templates/build/csharp.zip
       
       - name: Get VS Templates version
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.vsrelease == 'true' && contains(github.events.inputs.pkgs, "templates") }}
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.vsrelease == 'true' && github.event.inputs.vstemplate == 'true' }}
         id: vs-template-tag
         run: |
           VS_VERSION=$(node -p "require('./templates/package.json').vsversion")
@@ -200,7 +204,7 @@ jobs:
 
       - name: Release stable VS Templates to GitHub
         uses: mini-bomba/create-github-release@v1.1.3
-        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.vsrelease == 'true' && contains(github.events.inputs.pkgs, "templates") }}
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.vsrelease == 'true' && github.event.inputs.vstemplate == 'true' }}
         with:
           token: ${{ steps.generate-token.outputs.token }}
           tag: ${{ steps.vs-template-tag.outputs.VSTAG }}


### PR DESCRIPTION
When server fetch vs templates
|version|from|
|--|--|
|alpha| local pack|
|preview|download from tag **templates-vs@0.0.0-rc** with env **TEAMSFX_TEMPLATE_PRERELEASE** setting to **vs**|
|stable| download from tag as **templates-vs@18.0.0**|