### PR TITLE
ci: update naa code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -234,7 +234,6 @@
 /templates/**/spfx-* @HuihuiWu-Microsoft @yuqizhou77 @wh-alice
 /templates/**/sso-tab @hund030 @eriolchan @Yimin-Jin @adashen
 /templates/**/sso-tab-ssr @Yimin-Jin @eriolchan @hund030 @adashen
-/templates/**/sso-tab-with-obo-flow @Yimin-Jin @hund030 @huimiu @eriolchan @adashen
 /templates/**/weather-agent @adashen @frankqianms
 /templates/**/workflow @kimizhu @dooriya @swatDong @adashen
 /templates/constraints/yml/actions @hund030 @eriolchan @huimiu @adashen

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -244,3 +244,4 @@
 /templates/vsc/* @adashen @wenytang-ms
 /templates/vsc/common/declarative-agent-typespec @KennethBWSong @SLdragon @adashen
 /templates/vsc/python @adashen @blackchoey @frankqianms
+/templates/vsc/**/sso-tab-naa @KennethBWSong @SLdragon @adashen


### PR DESCRIPTION
This pull request includes a small change to the `.github/CODEOWNERS` file. The change adds ownership for files under the `sso-tab-naa` directory within the `/templates/vsc/` path.