### PR TITLE
fix: update env variable default value for vs

### DIFF
--- a/packages/fx-core/src/component/generator/generator.ts
+++ b/packages/fx-core/src/component/generator/generator.ts
@@ -103,8 +103,8 @@ export class Generator {
       isNewProjectTypeEnabled: featureFlagManager.getBooleanValue(FeatureFlags.NewProjectType)
         ? "true"
         : "",
-      NewProjectTypeName: process.env.TEAMSFX_NEW_PROJECT_TYPE_NAME ?? "TeamsApp",
-      NewProjectTypeExt: process.env.TEAMSFX_NEW_PROJECT_TYPE_EXTENSION ?? "ttkproj",
+      NewProjectTypeName: process.env.TEAMSFX_NEW_PROJECT_TYPE_NAME ?? "M365Agent",
+      NewProjectTypeExt: process.env.TEAMSFX_NEW_PROJECT_TYPE_EXTENSION ?? "atkproj",
       CEAEnabled: featureFlagManager.getBooleanValue(FeatureFlags.CEAEnabled) ? "true" : "",
       EmbeddedKnowledgeEnabled: featureFlagManager.getBooleanValue(
         FeatureFlags.EmbeddedKnowledgeEnabled

--- a/packages/fx-core/src/component/generator/templates/templateReplaceMap.ts
+++ b/packages/fx-core/src/component/generator/templates/templateReplaceMap.ts
@@ -74,8 +74,8 @@ export function getTemplateReplaceMap(inputs: Inputs): { [key: string]: string }
     isNewProjectTypeEnabled: featureFlagManager.getBooleanValue(FeatureFlags.NewProjectType)
       ? "true"
       : "",
-    NewProjectTypeName: process.env.TEAMSFX_NEW_PROJECT_TYPE_NAME ?? "TeamsApp",
-    NewProjectTypeExt: process.env.TEAMSFX_NEW_PROJECT_TYPE_EXTENSION ?? "ttkproj",
+    NewProjectTypeName: process.env.TEAMSFX_NEW_PROJECT_TYPE_NAME ?? "M365Agent",
+    NewProjectTypeExt: process.env.TEAMSFX_NEW_PROJECT_TYPE_EXTENSION ?? "atkproj",
     CEAEnabled: featureFlagManager.getBooleanValue(FeatureFlags.CEAEnabled) ? "true" : "",
     EmbeddedKnowledgeEnabled: featureFlagManager.getBooleanValue(
       FeatureFlags.EmbeddedKnowledgeEnabled


### PR DESCRIPTION
These variables have been renamed in VS side. So for production, the actual value comes from VS and doesn't have problem; but for local debug, the old values will cause issue.