### PR TITLE
feat(tsp): run npm/install and typeSpec/compile before package for TSP projects

### DIFF
--- a/packages/fx-core/src/common/projectTypeChecker.ts
+++ b/packages/fx-core/src/common/projectTypeChecker.ts
@@ -13,6 +13,7 @@ import {
   MetadataV3,
   MetadataV4,
 } from "./versionMetadata";
+import { pathUtils } from "../component/utils/pathUtils";
 
 export const TeamsJsModule = "@microsoft/teams-js";
 
@@ -304,4 +305,15 @@ export function IsDeclarativeAgentManifest(manifest: any): boolean {
     manifest.copilotAgents?.declarativeAgents && manifest.copilotAgents.declarativeAgents.length > 0
   );
 }
+
+export function isTypeSpecProject(projectPath: string): boolean {
+  const yamlFilePath = pathUtils.getYmlFilePath(projectPath);
+  if (!yamlFilePath) {
+    return false;
+  }
+
+  const yamlContent = fs.readFileSync(yamlFilePath, "utf8");
+  return yamlContent.includes("typeSpec/compile");
+}
+
 export const projectTypeChecker = new ProjectTypeChecker();

--- a/packages/fx-core/src/common/tools.ts
+++ b/packages/fx-core/src/common/tools.ts
@@ -13,6 +13,9 @@ import { GraphReadUserScopes, SPFxScopes } from "./constants";
 import fs from "fs-extra";
 import path from "path";
 import { MetadataV3, MetadataV4 } from "./versionMetadata";
+import { pathUtils } from "../component/utils/pathUtils";
+import { TypeSpecCompileArgs } from "../component/driver/typeSpec/interface/typeSpecCompileArgs";
+import { parseDocument } from "yaml";
 
 export async function getSideloadingStatus(token: string): Promise<boolean | undefined> {
   return teamsDevPortalClient.getSideloadingStatus(token);
@@ -113,4 +116,49 @@ export function isTestToolEnabledProject(projectPath: string): boolean {
     return true;
   }
   return false;
+}
+
+export function isTypeSpecProject(projectPath: string): boolean {
+  const yamlFilePath = pathUtils.getYmlFilePath(projectPath);
+  if (!yamlFilePath) {
+    return false;
+  }
+
+  const yamlContent = fs.readFileSync(yamlFilePath, "utf8");
+  return yamlContent.includes("typeSpec/compile");
+}
+
+export function getTypeSpecArgs(projectPath: string): TypeSpecCompileArgs {
+  const defaultArgs = {
+    path: "./main.tsp",
+    manifestPath: "./appPackage/manifest.json",
+    outputDir: "./appPackage/.generated",
+    typeSpecConfigPath: "./tspconfig.yaml",
+  };
+  const yamlFilePath = pathUtils.getYmlFilePath(projectPath);
+  if (!yamlFilePath) {
+    return defaultArgs;
+  }
+
+  const yamlContent = fs.readFileSync(yamlFilePath, "utf8");
+  const document = parseDocument(yamlContent);
+  const provisionNode = document.get("provision") as any;
+  if (!provisionNode) {
+    return defaultArgs;
+  }
+
+  const tspCompileAction = provisionNode.items.find(
+    (item: any) => item.get("uses") === "typeSpec/compile"
+  );
+  if (!tspCompileAction) {
+    return defaultArgs;
+  }
+
+  const args = tspCompileAction.get("with");
+  return {
+    path: args.get("path") ?? defaultArgs.path,
+    manifestPath: args.get("manifestPath") ?? defaultArgs.manifestPath,
+    outputDir: args.get("outputDir") ?? defaultArgs.outputDir,
+    typeSpecConfigPath: args.get("typeSpecConfigPath") ?? defaultArgs.typeSpecConfigPath,
+  };
 }

--- a/packages/fx-core/src/common/tools.ts
+++ b/packages/fx-core/src/common/tools.ts
@@ -118,16 +118,6 @@ export function isTestToolEnabledProject(projectPath: string): boolean {
   return false;
 }
 
-export function isTypeSpecProject(projectPath: string): boolean {
-  const yamlFilePath = pathUtils.getYmlFilePath(projectPath);
-  if (!yamlFilePath) {
-    return false;
-  }
-
-  const yamlContent = fs.readFileSync(yamlFilePath, "utf8");
-  return yamlContent.includes("typeSpec/compile");
-}
-
 export function getTypeSpecArgs(projectPath: string): TypeSpecCompileArgs {
   const defaultArgs = {
     path: "./main.tsp",

--- a/packages/fx-core/src/core/FxCore.ts
+++ b/packages/fx-core/src/core/FxCore.ts
@@ -205,6 +205,10 @@ import { CoreTelemetryEvent, CoreTelemetryProperty } from "./telemetry";
 import { CoreHookContext, PreProvisionResForVS, VersionCheckRes } from "./types";
 import { InstallAppArgs } from "../component/driver/devChannel/interfaces/InstallAppArgs";
 import { TemplateNames } from "../component/generator/templates/templateNames";
+import { getTypeSpecArgs, isTypeSpecProject } from "../common/tools";
+import { NpmBuildDriver } from "../component/driver/script/npmBuildDriver";
+import { TypeSpecCompileDriver } from "../component/driver/typeSpec/compile";
+import { TypeSpecCompileArgs } from "../component/driver/typeSpec/interface/typeSpecCompileArgs";
 
 export class FxCore {
   constructor(tools: Tools) {
@@ -1258,6 +1262,30 @@ export class FxCore {
     inputs.stage = Stage.createAppPackage;
 
     const context: DriverContext = createDriverContext(inputs);
+
+    // For TSP projects
+    const isTspProject = isTypeSpecProject(inputs.projectPath!);
+    if (isTspProject) {
+      // Call npm/install
+      const npmInstallDriver: NpmBuildDriver = Container.get("cli/runNpmCommand");
+      const npmInstallArgs = {
+        args: "install --no-audit --progress=false",
+      };
+      const npmInstallResult = (await npmInstallDriver.execute(npmInstallArgs, context)).result;
+      if (npmInstallResult.isErr()) {
+        throw err(npmInstallResult.error);
+      }
+
+      // call typespec/compile
+      const typeSpecCompileDriver: TypeSpecCompileDriver = Container.get("typeSpec/compile");
+      const typeSpecCompileArgs: TypeSpecCompileArgs = getTypeSpecArgs(inputs.projectPath!);
+      const typeSpecCompileResult = (
+        await typeSpecCompileDriver.execute(typeSpecCompileArgs, context)
+      ).result;
+      if (typeSpecCompileResult.isErr()) {
+        throw err(typeSpecCompileResult.error);
+      }
+    }
 
     const teamsAppManifestFilePath = inputs?.[QuestionNames.TeamsAppManifestFilePath] as string;
 

--- a/packages/fx-core/src/core/FxCore.ts
+++ b/packages/fx-core/src/core/FxCore.ts
@@ -69,6 +69,7 @@ import {
 import {
   IsDeclarativeAgentManifest,
   ProjectTypeResult,
+  isTypeSpecProject,
   projectTypeChecker,
 } from "../common/projectTypeChecker";
 import { TelemetryEvent, TelemetryProperty, telemetryUtils } from "../common/telemetry";
@@ -205,7 +206,7 @@ import { CoreTelemetryEvent, CoreTelemetryProperty } from "./telemetry";
 import { CoreHookContext, PreProvisionResForVS, VersionCheckRes } from "./types";
 import { InstallAppArgs } from "../component/driver/devChannel/interfaces/InstallAppArgs";
 import { TemplateNames } from "../component/generator/templates/templateNames";
-import { getTypeSpecArgs, isTypeSpecProject } from "../common/tools";
+import { getTypeSpecArgs } from "../common/tools";
 import { NpmBuildDriver } from "../component/driver/script/npmBuildDriver";
 import { TypeSpecCompileDriver } from "../component/driver/typeSpec/compile";
 import { TypeSpecCompileArgs } from "../component/driver/typeSpec/interface/typeSpecCompileArgs";

--- a/packages/fx-core/tests/common/projectTypeChecker.test.ts
+++ b/packages/fx-core/tests/common/projectTypeChecker.test.ts
@@ -11,10 +11,13 @@ import {
   SPFxKey,
   TeamsfxVersionState,
   getCapabilities,
+  isTypeSpecProject,
   projectTypeChecker,
 } from "../../src/common/projectTypeChecker";
 import { MetadataV2, MetadataV3 } from "../../src/common/versionMetadata";
 import { IsDeclarativeAgentManifest } from "../../build/common/projectTypeChecker";
+import { pathUtils } from "../../src/component/utils/pathUtils";
+import * as chai from "chai";
 
 describe("ProjectTypeChecker", () => {
   const sandbox = sinon.createSandbox();
@@ -545,6 +548,33 @@ describe("ProjectTypeChecker", () => {
       };
       isDeclarativeAgent = IsDeclarativeAgentManifest(manifest3);
       assert.isFalse(isDeclarativeAgent);
+    });
+  });
+
+  describe("isTypeSpecProject", () => {
+    const sandbox = sinon.createSandbox();
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it("should return true if TypeSpec project", () => {
+      sandbox.stub(pathUtils, "getYmlFilePath").returns("m365agents.yml");
+      sandbox.stub(fs, "readFileSync").returns("provision: typeSpec/compile with: []");
+      const result = isTypeSpecProject("test-project-path");
+      chai.expect(result).to.be.true;
+    });
+
+    it("should return false if no yaml file", () => {
+      sandbox.stub(pathUtils, "getYmlFilePath").returns(undefined);
+      const result = isTypeSpecProject("test-project-path");
+      chai.expect(result).to.be.false;
+    });
+
+    it("should return false if not TypeSpec project", () => {
+      sandbox.stub(pathUtils, "getYmlFilePath").returns("m365agents.yml");
+      sandbox.stub(fs, "readFileSync").returns("provision: aadApp/create with: []");
+      const result = isTypeSpecProject("test-project-path");
+      chai.expect(result).to.be.false;
     });
   });
 });

--- a/packages/fx-core/tests/common/tools.test.ts
+++ b/packages/fx-core/tests/common/tools.test.ts
@@ -19,7 +19,6 @@ import {
   listDevTunnels,
   isTestToolEnabledProject,
   isSandboxedEnabled,
-  isTypeSpecProject,
   getTypeSpecArgs,
 } from "../../src/common/tools";
 import { PackageService } from "../../src/component/m365/packageService";
@@ -446,33 +445,6 @@ projectId: 00000000-0000-0000-0000-000000000000`;
     it("should return false if test tool YAML file does not exist", () => {
       sandbox.stub(fs, "pathExistsSync").returns(false);
       const result = isTestToolEnabledProject("test-project-path");
-      chai.expect(result).to.be.false;
-    });
-  });
-
-  describe("isTypeSpecProject", () => {
-    const sandbox = sinon.createSandbox();
-    afterEach(() => {
-      sandbox.restore();
-    });
-
-    it("should return true if TypeSpec project", () => {
-      sandbox.stub(pathUtils, "getYmlFilePath").returns("m365agents.yml");
-      sandbox.stub(fs, "readFileSync").returns("provision: typeSpec/compile with: []");
-      const result = isTypeSpecProject("test-project-path");
-      chai.expect(result).to.be.true;
-    });
-
-    it("should return false if no yaml file", () => {
-      sandbox.stub(pathUtils, "getYmlFilePath").returns(undefined);
-      const result = isTypeSpecProject("test-project-path");
-      chai.expect(result).to.be.false;
-    });
-
-    it("should return false if not TypeSpec project", () => {
-      sandbox.stub(pathUtils, "getYmlFilePath").returns("m365agents.yml");
-      sandbox.stub(fs, "readFileSync").returns("provision: aadApp/create with: []");
-      const result = isTypeSpecProject("test-project-path");
       chai.expect(result).to.be.false;
     });
   });

--- a/packages/fx-core/tests/common/tools.test.ts
+++ b/packages/fx-core/tests/common/tools.test.ts
@@ -19,6 +19,8 @@ import {
   listDevTunnels,
   isTestToolEnabledProject,
   isSandboxedEnabled,
+  isTypeSpecProject,
+  getTypeSpecArgs,
 } from "../../src/common/tools";
 import { PackageService } from "../../src/component/m365/packageService";
 import { isVideoFilterProject } from "../../src/core/middleware/videoFilterAppBlocker";
@@ -26,6 +28,7 @@ import { isUserCancelError } from "../../src/error/common";
 import { MockedM365Provider, MockTools } from "../core/utils";
 import { GraphClient } from "../../src/client/graphClient";
 import { setTools } from "../../src/common/globalVars";
+import { pathUtils } from "../../src";
 
 chai.use(chaiAsPromised);
 
@@ -444,6 +447,107 @@ projectId: 00000000-0000-0000-0000-000000000000`;
       sandbox.stub(fs, "pathExistsSync").returns(false);
       const result = isTestToolEnabledProject("test-project-path");
       chai.expect(result).to.be.false;
+    });
+  });
+
+  describe("isTypeSpecProject", () => {
+    const sandbox = sinon.createSandbox();
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it("should return true if TypeSpec project", () => {
+      sandbox.stub(pathUtils, "getYmlFilePath").returns("m365agents.yml");
+      sandbox.stub(fs, "readFileSync").returns("provision: typeSpec/compile with: []");
+      const result = isTypeSpecProject("test-project-path");
+      chai.expect(result).to.be.true;
+    });
+
+    it("should return false if no yaml file", () => {
+      sandbox.stub(pathUtils, "getYmlFilePath").returns(undefined);
+      const result = isTypeSpecProject("test-project-path");
+      chai.expect(result).to.be.false;
+    });
+
+    it("should return false if not TypeSpec project", () => {
+      sandbox.stub(pathUtils, "getYmlFilePath").returns("m365agents.yml");
+      sandbox.stub(fs, "readFileSync").returns("provision: aadApp/create with: []");
+      const result = isTypeSpecProject("test-project-path");
+      chai.expect(result).to.be.false;
+    });
+  });
+
+  describe("getTypeSpecArgs", () => {
+    const sandbox = sinon.createSandbox();
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it("should return default args if no yaml file", () => {
+      sandbox.stub(pathUtils, "getYmlFilePath").returns(undefined);
+      const result = getTypeSpecArgs("test-project-path");
+      chai.expect(result).to.deep.equal({
+        path: "./main.tsp",
+        manifestPath: "./appPackage/manifest.json",
+        outputDir: "./appPackage/.generated",
+        typeSpecConfigPath: "./tspconfig.yaml",
+      });
+    });
+
+    it("should return default args if no provision node", () => {
+      sandbox.stub(pathUtils, "getYmlFilePath").returns("m365agents.yml");
+      sandbox.stub(fs, "readFileSync").returns("version: 1.0.0");
+      const result = getTypeSpecArgs("test-project-path");
+      chai.expect(result).to.deep.equal({
+        path: "./main.tsp",
+        manifestPath: "./appPackage/manifest.json",
+        outputDir: "./appPackage/.generated",
+        typeSpecConfigPath: "./tspconfig.yaml",
+      });
+    });
+
+    it("should return default args if no tspCompileAction", () => {
+      sandbox.stub(pathUtils, "getYmlFilePath").returns("m365agents.yml");
+      sandbox.stub(fs, "readFileSync").returns("provision: []");
+      const result = getTypeSpecArgs("test-project-path");
+      chai.expect(result).to.deep.equal({
+        path: "./main.tsp",
+        manifestPath: "./appPackage/manifest.json",
+        outputDir: "./appPackage/.generated",
+        typeSpecConfigPath: "./tspconfig.yaml",
+      });
+    });
+
+    it("should return args from tspCompileAction", () => {
+      sandbox.stub(pathUtils, "getYmlFilePath").returns("m365agents.yml");
+      sandbox
+        .stub(fs, "readFileSync")
+        .returns(
+          "provision:\n  - uses: typeSpec/compile\n    with:\n      path: ./custom.tsp\n      manifestPath: ./customManifest.json\n      outputDir: ./customOutputDir\n      typeSpecConfigPath: ./customTspconfig.yaml"
+        );
+      const result = getTypeSpecArgs("test-project-path");
+      chai.expect(result).to.deep.equal({
+        path: "./custom.tsp",
+        manifestPath: "./customManifest.json",
+        outputDir: "./customOutputDir",
+        typeSpecConfigPath: "./customTspconfig.yaml",
+      });
+    });
+
+    it("should return args from default if missing parameter", () => {
+      sandbox.stub(pathUtils, "getYmlFilePath").returns("m365agents.yml");
+      sandbox
+        .stub(fs, "readFileSync")
+        .returns(
+          "provision:\n  - uses: typeSpec/compile\n    with:\n      path2: ./custom.tsp\n      manifestPath2: ./customManifest.json\n      outputDir2: ./customOutputDir\n      typeSpecConfigPath2: ./customTspconfig.yaml"
+        );
+      const result = getTypeSpecArgs("test-project-path");
+      chai.expect(result).to.deep.equal({
+        path: "./main.tsp",
+        manifestPath: "./appPackage/manifest.json",
+        outputDir: "./appPackage/.generated",
+        typeSpecConfigPath: "./tspconfig.yaml",
+      });
     });
   });
 });

--- a/packages/fx-core/tests/core/FxCore.test.ts
+++ b/packages/fx-core/tests/core/FxCore.test.ts
@@ -126,6 +126,11 @@ import { validationUtils } from "../../src/ui/validationUtils";
 import { MockTools, MockUserInteraction, randomAppName } from "./utils";
 import { TabCapabilityOptions } from "../../src/question/scaffold/vsc/CapabilityOptions";
 import { InstallAppToChannelDriver } from "../../src/component/driver/devChannel/installApp";
+import * as CommonTools from "../../src/common/tools";
+import Container from "typedi";
+import { sum } from "lodash";
+import { NpmBuildDriver } from "../../src/component/driver/script/npmBuildDriver";
+import { TypeSpecCompileDriver } from "../../src/component/driver/typeSpec/compile";
 
 const tools = new MockTools();
 
@@ -2281,6 +2286,43 @@ describe("Teams app APIs", async () => {
     await core.createAppPackage(inputs);
     sinon.assert.calledOnce(runStub);
     sinon.assert.calledOnce(showMessageStub);
+  });
+
+  it("create app package with TypeSpec project", async () => {
+    setTools(tools);
+    const appName = await mockV3Project();
+    const inputs: Inputs = {
+      platform: Platform.VSCode,
+      [QuestionNames.Folder]: os.tmpdir(),
+      [QuestionNames.TeamsAppManifestFilePath]: ".\\appPackage\\manifest.json",
+      projectPath: path.join(os.tmpdir(), appName),
+      [QuestionNames.OutputZipPathParamName]: ".\\build\\appPackage\\appPackage.dev.zip",
+    };
+    const isTypeSpecProjectStub = sinon.stub(CommonTools, "isTypeSpecProject").returns(true);
+    const getTypeSpecArgsStub = sinon.stub(CommonTools, "getTypeSpecArgs").returns({
+      path: "./main.tsp",
+      manifestPath: "./appPackage/manifest.json",
+      outputDir: "./appPackage/.generated",
+      typeSpecConfigPath: "./tspconfig.yaml",
+    });
+    const npmInstallStub = sinon
+      .stub(NpmBuildDriver.prototype, "execute")
+      .resolves({ result: ok(new Map()), summaries: [] });
+    const typeSpecCompileStub = sinon
+      .stub(TypeSpecCompileDriver.prototype, "execute")
+      .resolves({ result: ok(new Map()), summaries: [] });
+    sinon.stub(process, "platform").value("win32");
+    const runStub = sinon
+      .stub(CreateAppPackageDriver.prototype, "execute")
+      .resolves({ result: ok(new Map()), summaries: [] });
+    const showMessageStub = sinon.stub(tools.ui, "showMessage");
+    await core.createAppPackage(inputs);
+    sinon.assert.calledOnce(runStub);
+    sinon.assert.calledOnce(showMessageStub);
+    sinon.assert.calledOnce(isTypeSpecProjectStub);
+    sinon.assert.calledOnce(getTypeSpecArgsStub);
+    sinon.assert.calledOnce(npmInstallStub);
+    sinon.assert.calledOnce(typeSpecCompileStub);
   });
 
   it("publish application", async () => {

--- a/packages/fx-core/tests/core/FxCore.test.ts
+++ b/packages/fx-core/tests/core/FxCore.test.ts
@@ -127,8 +127,7 @@ import { MockTools, MockUserInteraction, randomAppName } from "./utils";
 import { TabCapabilityOptions } from "../../src/question/scaffold/vsc/CapabilityOptions";
 import { InstallAppToChannelDriver } from "../../src/component/driver/devChannel/installApp";
 import * as CommonTools from "../../src/common/tools";
-import Container from "typedi";
-import { sum } from "lodash";
+import * as ProjecTypeChecker from "../../src/common/projectTypeChecker";
 import { NpmBuildDriver } from "../../src/component/driver/script/npmBuildDriver";
 import { TypeSpecCompileDriver } from "../../src/component/driver/typeSpec/compile";
 
@@ -2298,7 +2297,7 @@ describe("Teams app APIs", async () => {
       projectPath: path.join(os.tmpdir(), appName),
       [QuestionNames.OutputZipPathParamName]: ".\\build\\appPackage\\appPackage.dev.zip",
     };
-    const isTypeSpecProjectStub = sinon.stub(CommonTools, "isTypeSpecProject").returns(true);
+    const isTypeSpecProjectStub = sinon.stub(ProjecTypeChecker, "isTypeSpecProject").returns(true);
     const getTypeSpecArgsStub = sinon.stub(CommonTools, "getTypeSpecArgs").returns({
       path: "./main.tsp",
       manifestPath: "./appPackage/manifest.json",


### PR DESCRIPTION
task: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_sprints/taskboard/AuthAndData/Microsoft%20Teams%20Extensibility/Bromine/CY25Q2/2Wk/2Wk06%20(Jun%2015%20-%20Jun%2028)?workitem=33235446
This pull request introduces support for handling TypeSpec projects in the `fx-core` module. It adds utility functions to detect TypeSpec projects, parse configuration files, and execute related build and compile steps. The changes also include corresponding unit tests to ensure functionality.

### TypeSpec Project Support:

* **Utility Functions**:
  - Added `isTypeSpecProject` to detect if a project is a TypeSpec project by checking for specific YAML configurations.
  - Added `getTypeSpecArgs` to retrieve TypeSpec compile arguments from a YAML file or use default values if not specified.

* **Integration in `FxCore`**:
  - Integrated TypeSpec project detection and build/compile logic into the `createAppPackage` flow. This includes invoking `npm install` and `typeSpec/compile` commands if the project is identified as a TypeSpec project.

### Testing Enhancements:

* **Unit Tests for Utilities**:
  - Added unit tests for `isTypeSpecProject` and `getTypeSpecArgs` to validate their behavior under various scenarios, such as missing YAML files or incomplete configurations.

* **End-to-End Test for TypeSpec Projects**:
  - Added an end-to-end test for creating app packages with TypeSpec projects, verifying the integration of the new functionality in the `FxCore` class.

These changes ensure that TypeSpec projects are seamlessly supported and tested within the existing framework.