### PR TITLE
perf: add npm/install and typeSpec/compile in publish stage

### DIFF
--- a/templates/vsc/common/declarative-agent-typespec/m365agents.yml.tpl
+++ b/templates/vsc/common/declarative-agent-typespec/m365agents.yml.tpl
@@ -66,6 +66,23 @@ provision:
 
 # Triggered when 'teamsapp publish' is executed
 publish:
+  - uses: cli/runNpmCommand
+    name: install dependencies
+    with:
+      args: install --no-audit --progress=false
+
+  # Compile typespec files and generate necessary files for agent.
+  # If you want to update the outputDir, please make sure the following paths are also updated.
+  # 1. File paths in tspconfig.yaml.
+  # 2. manifestPath in this action. Please make sure there is manifest.json under root folder of your outputDir and set the value to the path of this manifest.json.
+  # 3. manifestPath in teamsApp/zipAppPackage action. Please set the value to the same as manifestPath in this action.
+  - uses: typeSpec/compile
+    with:
+      path: ./main.tsp
+      manifestPath: ./appPackage/manifest.json
+      outputDir: ./appPackage/.generated
+      typeSpecConfigPath: ./tspconfig.yaml
+
   # Build app package with latest env value
   - uses: teamsApp/zipAppPackage
     with:


### PR DESCRIPTION
This pull request updates the `publish` section of the `m365agents.yml.tpl` file to enhance the build process for Teams apps. The changes include installing dependencies and compiling TypeSpec files to generate necessary files for the agent.

**Enhancements to the build process:**

* Added a step to install dependencies using the `cli/runNpmCommand` action with specific arguments to ensure a streamlined installation process.
* Introduced a new step to compile TypeSpec files using the `typeSpec/compile` action. This step includes configuration for paths such as `manifestPath`, `outputDir`, and `typeSpecConfigPath`, ensuring proper file generation and compatibility with subsequent actions.