### PR TITLE
feat: support package command in cli

### DIFF
--- a/packages/fx-core/src/common/projectTypeChecker.ts
+++ b/packages/fx-core/src/common/projectTypeChecker.ts
@@ -306,7 +306,10 @@ export function IsDeclarativeAgentManifest(manifest: any): boolean {
   );
 }
 
-export function isTypeSpecProject(projectPath: string): boolean {
+export function isTypeSpecProject(projectPath: string | undefined): boolean {
+  if (!projectPath) {
+    return false;
+  }
   const yamlFilePath = pathUtils.getYmlFilePath(projectPath);
   if (!yamlFilePath) {
     return false;

--- a/packages/fx-core/src/common/tools.ts
+++ b/packages/fx-core/src/common/tools.ts
@@ -16,6 +16,11 @@ import { MetadataV3, MetadataV4 } from "./versionMetadata";
 import { pathUtils } from "../component/utils/pathUtils";
 import { TypeSpecCompileArgs } from "../component/driver/typeSpec/interface/typeSpecCompileArgs";
 import { parseDocument } from "yaml";
+import { TypeSpecCompileDriver } from "../component/driver/typeSpec/compile";
+import { NpmBuildDriver } from "../component/driver/script/npmBuildDriver";
+import { DriverContext } from "../component/driver/interface/commonArgs";
+import { isTypeSpecProject } from "./projectTypeChecker";
+import Container from "typedi";
 
 export async function getSideloadingStatus(token: string): Promise<boolean | undefined> {
   return teamsDevPortalClient.getSideloadingStatus(token);
@@ -151,4 +156,32 @@ export function getTypeSpecArgs(projectPath: string): TypeSpecCompileArgs {
     outputDir: args.get("outputDir") ?? defaultArgs.outputDir,
     typeSpecConfigPath: args.get("typeSpecConfigPath") ?? defaultArgs.typeSpecConfigPath,
   };
+}
+
+export async function runForTypeSpecProject(
+  projectPath: string | undefined,
+  context: DriverContext
+): Promise<void> {
+  const isTspProject = isTypeSpecProject(projectPath);
+  if (isTspProject) {
+    // Call npm/install
+    const npmInstallDriver: NpmBuildDriver = Container.get("cli/runNpmCommand");
+    const npmInstallArgs = {
+      args: "install --no-audit --progress=false",
+    };
+    const npmInstallResult = (await npmInstallDriver.execute(npmInstallArgs, context)).result;
+    if (npmInstallResult.isErr()) {
+      throw err(npmInstallResult.error);
+    }
+
+    // call typespec/compile
+    const typeSpecCompileDriver: TypeSpecCompileDriver = Container.get("typeSpec/compile");
+    const typeSpecCompileArgs: TypeSpecCompileArgs = getTypeSpecArgs(projectPath!);
+    const typeSpecCompileResult = (
+      await typeSpecCompileDriver.execute(typeSpecCompileArgs, context)
+    ).result;
+    if (typeSpecCompileResult.isErr()) {
+      throw err(typeSpecCompileResult.error);
+    }
+  }
 }

--- a/packages/fx-core/src/component/driver/teamsApp/teamsappMgr.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/teamsappMgr.ts
@@ -42,6 +42,7 @@ import { manifestUtils } from "./utils/ManifestUtils";
 import { ValidateManifestDriver } from "./validate";
 import { ValidateAppPackageDriver } from "./validateAppPackage";
 import { ValidateWithTestCasesDriver } from "./validateTestCases";
+import { runForTypeSpecProject } from "../../../common/tools";
 
 class TeamsAppMgr {
   async ensureAppPackageFile(inputs: TeamsAppInputs): Promise<Result<undefined, FxError>> {
@@ -169,6 +170,8 @@ class TeamsAppMgr {
     const buildDriver: CreateAppPackageDriver = Container.get(createAppPackageActionName);
     const driverContext: DriverContext = createDriverContext(inputs);
 
+    // For TSP projects
+    await runForTypeSpecProject(inputs.projectPath, driverContext);
     const res = (await buildDriver.execute(packageArgs, driverContext)).result;
     if (res.isErr()) {
       return err(res.error);

--- a/packages/fx-core/src/core/FxCore.ts
+++ b/packages/fx-core/src/core/FxCore.ts
@@ -69,7 +69,6 @@ import {
 import {
   IsDeclarativeAgentManifest,
   ProjectTypeResult,
-  isTypeSpecProject,
   projectTypeChecker,
 } from "../common/projectTypeChecker";
 import { TelemetryEvent, TelemetryProperty, telemetryUtils } from "../common/telemetry";
@@ -206,10 +205,7 @@ import { CoreTelemetryEvent, CoreTelemetryProperty } from "./telemetry";
 import { CoreHookContext, PreProvisionResForVS, VersionCheckRes } from "./types";
 import { InstallAppArgs } from "../component/driver/devChannel/interfaces/InstallAppArgs";
 import { TemplateNames } from "../component/generator/templates/templateNames";
-import { getTypeSpecArgs } from "../common/tools";
-import { NpmBuildDriver } from "../component/driver/script/npmBuildDriver";
-import { TypeSpecCompileDriver } from "../component/driver/typeSpec/compile";
-import { TypeSpecCompileArgs } from "../component/driver/typeSpec/interface/typeSpecCompileArgs";
+import { runForTypeSpecProject } from "../common/tools";
 
 export class FxCore {
   constructor(tools: Tools) {
@@ -1265,28 +1261,7 @@ export class FxCore {
     const context: DriverContext = createDriverContext(inputs);
 
     // For TSP projects
-    const isTspProject = isTypeSpecProject(inputs.projectPath!);
-    if (isTspProject) {
-      // Call npm/install
-      const npmInstallDriver: NpmBuildDriver = Container.get("cli/runNpmCommand");
-      const npmInstallArgs = {
-        args: "install --no-audit --progress=false",
-      };
-      const npmInstallResult = (await npmInstallDriver.execute(npmInstallArgs, context)).result;
-      if (npmInstallResult.isErr()) {
-        throw err(npmInstallResult.error);
-      }
-
-      // call typespec/compile
-      const typeSpecCompileDriver: TypeSpecCompileDriver = Container.get("typeSpec/compile");
-      const typeSpecCompileArgs: TypeSpecCompileArgs = getTypeSpecArgs(inputs.projectPath!);
-      const typeSpecCompileResult = (
-        await typeSpecCompileDriver.execute(typeSpecCompileArgs, context)
-      ).result;
-      if (typeSpecCompileResult.isErr()) {
-        throw err(typeSpecCompileResult.error);
-      }
-    }
+    await runForTypeSpecProject(inputs.projectPath, context);
 
     const teamsAppManifestFilePath = inputs?.[QuestionNames.TeamsAppManifestFilePath] as string;
 

--- a/packages/fx-core/tests/common/projectTypeChecker.test.ts
+++ b/packages/fx-core/tests/common/projectTypeChecker.test.ts
@@ -564,6 +564,11 @@ describe("ProjectTypeChecker", () => {
       chai.expect(result).to.be.true;
     });
 
+    it("should return false if no project path", () => {
+      const result = isTypeSpecProject(undefined);
+      chai.expect(result).to.be.false;
+    });
+
     it("should return false if no yaml file", () => {
       sandbox.stub(pathUtils, "getYmlFilePath").returns(undefined);
       const result = isTypeSpecProject("test-project-path");

--- a/packages/fx-core/tests/common/tools.test.ts
+++ b/packages/fx-core/tests/common/tools.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { ok } from "@microsoft/teamsfx-api";
+import { err, ok, UserError } from "@microsoft/teamsfx-api";
 import axios, { AxiosResponse } from "axios";
 import * as chai from "chai";
 import chaiAsPromised from "chai-as-promised";
@@ -583,12 +583,15 @@ projectId: 00000000-0000-0000-0000-000000000000`;
       const typeSpecCompileStub = sandbox
         .stub(TypeSpecCompileDriver.prototype, "execute")
         .resolves({ result: ok(new Map()), summaries: [] });
-      const npmInstallStub = sandbox
-        .stub(NpmBuildDriver.prototype, "execute")
-        .rejects(new Error("NPM install failed"));
-      await chai
-        .expect(runForTypeSpecProject(mockProjectPath, mockContext))
-        .to.be.rejectedWith("NPM install failed");
+      const npmInstallStub = sandbox.stub(NpmBuildDriver.prototype, "execute").resolves({
+        result: err(new UserError("source", "NpmInstallError", "NPM install failed")),
+        summaries: [],
+      });
+      try {
+        await runForTypeSpecProject(mockProjectPath, mockContext);
+      } catch (error) {
+        chai.expect(error.error.name).to.equal("NpmInstallError");
+      }
     });
 
     it("should throw error if typespec compile fails", async () => {
@@ -602,13 +605,18 @@ projectId: 00000000-0000-0000-0000-000000000000`;
         );
       const typeSpecCompileStub = sandbox
         .stub(TypeSpecCompileDriver.prototype, "execute")
-        .rejects(new Error("TSP compile failed"));
+        .resolves({
+          result: err(new UserError("source", "TypeSpecCompileError", "TypeSpec compile failed")),
+          summaries: [],
+        });
       const npmInstallStub = sandbox
         .stub(NpmBuildDriver.prototype, "execute")
         .resolves({ result: ok(new Map()), summaries: [] });
-      await chai
-        .expect(runForTypeSpecProject(mockProjectPath, mockContext))
-        .to.be.rejectedWith("TSP compile failed");
+      try {
+        await runForTypeSpecProject(mockProjectPath, mockContext);
+      } catch (error) {
+        chai.expect(error.error.name).to.equal("TypeSpecCompileError");
+      }
     });
   });
 });

--- a/packages/fx-core/tests/common/tools.test.ts
+++ b/packages/fx-core/tests/common/tools.test.ts
@@ -20,14 +20,19 @@ import {
   isTestToolEnabledProject,
   isSandboxedEnabled,
   getTypeSpecArgs,
+  runForTypeSpecProject,
 } from "../../src/common/tools";
 import { PackageService } from "../../src/component/m365/packageService";
 import { isVideoFilterProject } from "../../src/core/middleware/videoFilterAppBlocker";
 import { isUserCancelError } from "../../src/error/common";
-import { MockedM365Provider, MockTools } from "../core/utils";
+import { MockedM365Provider, MockLogProvider, MockTools } from "../core/utils";
 import { GraphClient } from "../../src/client/graphClient";
 import { setTools } from "../../src/common/globalVars";
 import { pathUtils } from "../../src";
+import { WrapDriverContext } from "../../src/component/driver/util/wrapUtil";
+import { NpmBuildDriver } from "../../src/component/driver/script/npmBuildDriver";
+import { TypeSpecCompileDriver } from "../../src/component/driver/typeSpec/compile";
+import * as ProjecTypeChecker from "../../src/common/projectTypeChecker";
 
 chai.use(chaiAsPromised);
 
@@ -520,6 +525,90 @@ projectId: 00000000-0000-0000-0000-000000000000`;
         outputDir: "./appPackage/.generated",
         typeSpecConfigPath: "./tspconfig.yaml",
       });
+    });
+  });
+
+  describe("runForTypeSpecProject", () => {
+    const sandbox = sinon.createSandbox();
+    let mockContext: WrapDriverContext;
+    beforeEach(() => {
+      mockContext = {
+        m365TokenProvider: new MockedM365Provider(),
+        logProvider: new MockLogProvider(),
+        addSummary: sandbox.stub(),
+        summaries: [],
+      } as unknown as WrapDriverContext;
+    });
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it("should call npm install and typeSpec compile for TypeSpec project", async () => {
+      const mockProjectPath = "mock-project-path";
+      const npmInstallStub = sandbox
+        .stub(NpmBuildDriver.prototype, "execute")
+        .resolves({ result: ok(new Map()), summaries: [] });
+      const typeSpecCompileStub = sandbox
+        .stub(TypeSpecCompileDriver.prototype, "execute")
+        .resolves({ result: ok(new Map()), summaries: [] });
+      sandbox.stub(ProjecTypeChecker, "isTypeSpecProject").returns(true);
+      sandbox.stub(pathUtils, "getYmlFilePath").returns("m365agents.yml");
+      sandbox
+        .stub(fs, "readFileSync")
+        .returns(
+          "provision:\n  - uses: typeSpec/compile\n    with:\n      path: ./custom.tsp\n      manifestPath: ./customManifest.json\n      outputDir: ./customOutputDir\n      typeSpecConfigPath: ./customTspconfig.yaml"
+        );
+      await runForTypeSpecProject(mockProjectPath, mockContext);
+      chai.expect(npmInstallStub.calledOnce).to.be.true;
+      chai.expect(typeSpecCompileStub.calledOnce).to.be.true;
+    });
+
+    it("should skip for not TypeSpec project", async () => {
+      const mockProjectPath = "mock-project-path";
+      const npmInstallStub = sandbox
+        .stub(NpmBuildDriver.prototype, "execute")
+        .resolves({ result: ok(new Map()), summaries: [] });
+      const typeSpecCompileStub = sandbox
+        .stub(TypeSpecCompileDriver.prototype, "execute")
+        .resolves({ result: ok(new Map()), summaries: [] });
+      sandbox.stub(ProjecTypeChecker, "isTypeSpecProject").returns(false);
+      await runForTypeSpecProject(mockProjectPath, mockContext);
+      chai.expect(npmInstallStub.notCalled).to.be.true;
+      chai.expect(typeSpecCompileStub.notCalled).to.be.true;
+    });
+
+    it("should throw error if npm install fails", async () => {
+      const mockProjectPath = "mock-project-path";
+      sandbox.stub(ProjecTypeChecker, "isTypeSpecProject").returns(true);
+      const typeSpecCompileStub = sandbox
+        .stub(TypeSpecCompileDriver.prototype, "execute")
+        .resolves({ result: ok(new Map()), summaries: [] });
+      const npmInstallStub = sandbox
+        .stub(NpmBuildDriver.prototype, "execute")
+        .rejects(new Error("NPM install failed"));
+      await chai
+        .expect(runForTypeSpecProject(mockProjectPath, mockContext))
+        .to.be.rejectedWith("NPM install failed");
+    });
+
+    it("should throw error if typespec compile fails", async () => {
+      const mockProjectPath = "mock-project-path";
+      sandbox.stub(ProjecTypeChecker, "isTypeSpecProject").returns(true);
+      sandbox.stub(pathUtils, "getYmlFilePath").returns("m365agents.yml");
+      sandbox
+        .stub(fs, "readFileSync")
+        .returns(
+          "provision:\n  - uses: typeSpec/compile\n    with:\n      path: ./custom.tsp\n      manifestPath: ./customManifest.json\n      outputDir: ./customOutputDir\n      typeSpecConfigPath: ./customTspconfig.yaml"
+        );
+      const typeSpecCompileStub = sandbox
+        .stub(TypeSpecCompileDriver.prototype, "execute")
+        .rejects(new Error("TSP compile failed"));
+      const npmInstallStub = sandbox
+        .stub(NpmBuildDriver.prototype, "execute")
+        .resolves({ result: ok(new Map()), summaries: [] });
+      await chai
+        .expect(runForTypeSpecProject(mockProjectPath, mockContext))
+        .to.be.rejectedWith("TSP compile failed");
     });
   });
 });

--- a/packages/fx-core/tests/component/driver/teamsApp/teamsappMgr.test.ts
+++ b/packages/fx-core/tests/component/driver/teamsApp/teamsappMgr.test.ts
@@ -21,6 +21,7 @@ import { ValidateManifestDriver } from "../../../../src/component/driver/teamsAp
 import { ValidateAppPackageDriver } from "../../../../src/component/driver/teamsApp/validateAppPackage";
 import { ConfigureTeamsAppDriver } from "../../../../src/component/driver/teamsApp/configure";
 import { PublishAppPackageDriver } from "../../../../src/component/driver/teamsApp/publishAppPackage";
+import * as CommonTools from "../../../../src/common/tools";
 
 describe("TeamsAppMgr", async () => {
   const sandbox = sinon.createSandbox();
@@ -241,6 +242,7 @@ describe("TeamsAppMgr", async () => {
     it("driver fail", async () => {
       sandbox.stub(fs, "pathExists").resolves(true);
       sandbox.stub(teamsappMgr, "checkAndTryToLoadEnv").resolves(ok("dev"));
+      sandbox.stub(CommonTools, "runForTypeSpecProject").resolves();
       sandbox
         .stub(CreateAppPackageDriver.prototype, "execute")
         .resolves({ result: err(new UserCancelError()), summaries: [] });
@@ -254,6 +256,7 @@ describe("TeamsAppMgr", async () => {
     it("driver success", async () => {
       sandbox.stub(fs, "pathExists").resolves(true);
       sandbox.stub(teamsappMgr, "checkAndTryToLoadEnv").resolves(ok(undefined));
+      sandbox.stub(CommonTools, "runForTypeSpecProject").resolves();
       sandbox
         .stub(CreateAppPackageDriver.prototype, "execute")
         .resolves({ result: ok(new Map()), summaries: [] });

--- a/packages/fx-core/tests/core/FxCore.test.ts
+++ b/packages/fx-core/tests/core/FxCore.test.ts
@@ -127,9 +127,6 @@ import { MockTools, MockUserInteraction, randomAppName } from "./utils";
 import { TabCapabilityOptions } from "../../src/question/scaffold/vsc/CapabilityOptions";
 import { InstallAppToChannelDriver } from "../../src/component/driver/devChannel/installApp";
 import * as CommonTools from "../../src/common/tools";
-import * as ProjecTypeChecker from "../../src/common/projectTypeChecker";
-import { NpmBuildDriver } from "../../src/component/driver/script/npmBuildDriver";
-import { TypeSpecCompileDriver } from "../../src/component/driver/typeSpec/compile";
 
 const tools = new MockTools();
 
@@ -2278,6 +2275,7 @@ describe("Teams app APIs", async () => {
     };
 
     sinon.stub(process, "platform").value("win32");
+    sinon.stub(CommonTools, "runForTypeSpecProject").resolves();
     const runStub = sinon
       .stub(CreateAppPackageDriver.prototype, "execute")
       .resolves({ result: ok(new Map()), summaries: [] });
@@ -2285,43 +2283,6 @@ describe("Teams app APIs", async () => {
     await core.createAppPackage(inputs);
     sinon.assert.calledOnce(runStub);
     sinon.assert.calledOnce(showMessageStub);
-  });
-
-  it("create app package with TypeSpec project", async () => {
-    setTools(tools);
-    const appName = await mockV3Project();
-    const inputs: Inputs = {
-      platform: Platform.VSCode,
-      [QuestionNames.Folder]: os.tmpdir(),
-      [QuestionNames.TeamsAppManifestFilePath]: ".\\appPackage\\manifest.json",
-      projectPath: path.join(os.tmpdir(), appName),
-      [QuestionNames.OutputZipPathParamName]: ".\\build\\appPackage\\appPackage.dev.zip",
-    };
-    const isTypeSpecProjectStub = sinon.stub(ProjecTypeChecker, "isTypeSpecProject").returns(true);
-    const getTypeSpecArgsStub = sinon.stub(CommonTools, "getTypeSpecArgs").returns({
-      path: "./main.tsp",
-      manifestPath: "./appPackage/manifest.json",
-      outputDir: "./appPackage/.generated",
-      typeSpecConfigPath: "./tspconfig.yaml",
-    });
-    const npmInstallStub = sinon
-      .stub(NpmBuildDriver.prototype, "execute")
-      .resolves({ result: ok(new Map()), summaries: [] });
-    const typeSpecCompileStub = sinon
-      .stub(TypeSpecCompileDriver.prototype, "execute")
-      .resolves({ result: ok(new Map()), summaries: [] });
-    sinon.stub(process, "platform").value("win32");
-    const runStub = sinon
-      .stub(CreateAppPackageDriver.prototype, "execute")
-      .resolves({ result: ok(new Map()), summaries: [] });
-    const showMessageStub = sinon.stub(tools.ui, "showMessage");
-    await core.createAppPackage(inputs);
-    sinon.assert.calledOnce(runStub);
-    sinon.assert.calledOnce(showMessageStub);
-    sinon.assert.calledOnce(isTypeSpecProjectStub);
-    sinon.assert.calledOnce(getTypeSpecArgsStub);
-    sinon.assert.calledOnce(npmInstallStub);
-    sinon.assert.calledOnce(typeSpecCompileStub);
   });
 
   it("publish application", async () => {


### PR DESCRIPTION
task: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_sprints/taskboard/AuthAndData/Microsoft%20Teams%20Extensibility/Bromine/CY25Q2/2Wk/2Wk06%20(Jun%2015%20-%20Jun%2028)?workitem=33517905
This pull request introduces a new utility function, `runForTypeSpecProject`, to centralize the handling of TypeSpec projects, replacing duplicated logic across the codebase. It also includes updates to the `isTypeSpecProject` function, refactoring of related code, and the addition of unit tests for the new functionality.

### Refactoring and Centralization:

* **New utility function**: Added `runForTypeSpecProject` in `packages/fx-core/src/common/tools.ts` to handle npm installation and TypeSpec compilation for TypeSpec projects. This replaces duplicated logic in `FxCore` and `TeamsAppMgr` classes. (`[[1]](diffhunk://#diff-61cad5bd6ae66dab772819dad61d881421fca050fa57ef11afcde2db4894a5aaR160-R187)`, `[[2]](diffhunk://#diff-865e74985eb295565c44f290e73f980bcb360d8019e4cb8f6c6728af9b6fdf41R173-R174)`, `[[3]](diffhunk://#diff-10159345d62a8197aef7d191bf8684f26090bd4954b855df89eca115bc59a76eL1268-R1264)`)
* **Refactored `isTypeSpecProject`**: Updated `isTypeSpecProject` to handle `undefined` project paths and return `false` in such cases. (`[packages/fx-core/src/common/projectTypeChecker.tsL309-R312](diffhunk://#diff-28a530b89a9f9770e3784005443a4a0c6210729cb84f9aaca89f7af16053ddf3L309-R312)`)

### Codebase Updates:

* **Code cleanup**: Removed redundant imports and logic related to TypeSpec handling from `FxCore` and `TeamsAppMgr` classes, replacing them with calls to `runForTypeSpecProject`. (`[[1]](diffhunk://#diff-10159345d62a8197aef7d191bf8684f26090bd4954b855df89eca115bc59a76eL209-R208)`, `[[2]](diffhunk://#diff-10159345d62a8197aef7d191bf8684f26090bd4954b855df89eca115bc59a76eL1268-R1264)`, `[[3]](diffhunk://#diff-865e74985eb295565c44f290e73f980bcb360d8019e4cb8f6c6728af9b6fdf41R173-R174)`)
* **New imports**: Added necessary imports for `runForTypeSpecProject` in relevant files. (`[[1]](diffhunk://#diff-61cad5bd6ae66dab772819dad61d881421fca050fa57ef11afcde2db4894a5aaR19-R23)`, `[[2]](diffhunk://#diff-865e74985eb295565c44f290e73f980bcb360d8019e4cb8f6c6728af9b6fdf41R45)`)

### Testing Enhancements:

* **Unit tests for `isTypeSpecProject`**: Added a test case to verify it returns `false` when the project path is `undefined`. (`[packages/fx-core/tests/common/projectTypeChecker.test.tsR567-R571](diffhunk://#diff-09303432ed17412e1c90bbaae451556eb4cc38787f3fdc02d1e66dffe61bfc88R567-R571)`)
* **Unit tests for `runForTypeSpecProject`**: Added comprehensive tests to validate its behavior, including success scenarios, skipping for non-TypeSpec projects, and error handling for npm install and TypeSpec compile failures. (`[packages/fx-core/tests/common/tools.test.tsR530-R613](diffhunk://#diff-8197adeda2f197eacf78577aecf2d5db32f1d163af4d00dc8455c7b2641133ffR530-R613)`)
* **Integration tests**: Updated existing tests in `TeamsAppMgr` and `FxCore` to include stubs for `runForTypeSpecProject`. Removed outdated TypeSpec-related test logic. (`[[1]](diffhunk://#diff-8a90064d7323221ebe62bb4828a56f71593b717703567b67735001abf9041353R245)`, `[[2]](diffhunk://#diff-0f3ad673b061b5d314e0a6e21baaf3a4259a961b8be3c5bf854fb0791566b00eR2278)`, `[[3]](diffhunk://#diff-0f3ad673b061b5d314e0a6e21baaf3a4259a961b8be3c5bf854fb0791566b00eL2290-L2326)`)