### PR TITLE
feat(vsc): show count in sample gallery type filter

### DIFF
--- a/packages/vscode-extension/src/controls/sampleGallery/sampleFilter.tsx
+++ b/packages/vscode-extension/src/controls/sampleGallery/sampleFilter.tsx
@@ -29,7 +29,10 @@ export default class SampleFilter extends React.Component<SampleFilterProps, unk
     const sampleTechniques = this.props.filterOptions.technologies;
     const typeOptions: IDropdownOption[] = sampleTypes.map((type) => {
       const selected = this.props.filterTags.indexOf(type) >= 0;
-      return { key: type, text: type, selected };
+      const count = this.props.samples.filter((sample) => {
+        return sample.tags && sample.tags.indexOf(type) >= 0;
+      }).length;
+      return { key: type, text: `${type} (${count})`, selected };
     });
     const languageOptions: IDropdownOption[] = sampleLanguages.map((type) => {
       const selected = this.props.filterTags.indexOf(type) >= 0;


### PR DESCRIPTION
Effect:
<img width="195" alt="image" src="https://github.com/user-attachments/assets/dacdba98-a54c-47db-8da9-9573dd918362" />

Feature: https://dev.azure.com/msazure/Microsoft%20Teams%20Extensibility/_workitems/edit/33259089