### PR TITLE
fix(core): match template in corresponding platform

### DIFF
--- a/packages/fx-core/src/component/generator/defaultGenerator.ts
+++ b/packages/fx-core/src/component/generator/defaultGenerator.ts
@@ -14,6 +14,8 @@ import {
   Result,
 } from "@microsoft/teamsfx-api";
 import { merge } from "lodash";
+import * as path from "path";
+import { featureFlagManager, FeatureFlags } from "../../common/featureFlags";
 import { TelemetryEvent, TelemetryProperty } from "../../common/telemetry";
 import { MetadataV3, MetadataV4 } from "../../common/versionMetadata";
 import { ProgrammingLanguage, QuestionNames } from "../../question/constants";
@@ -26,8 +28,6 @@ import { getAllTemplatesOnPlatform, getDefaultTemplatesOnPlatform } from "./temp
 import { TemplateInfo } from "./templates/templateInfo";
 import { getTemplateReplaceMap } from "./templates/templateReplaceMap";
 import { convertToLangKey, renderTemplateFileData, renderTemplateFileName } from "./utils";
-import { featureFlagManager, FeatureFlags } from "../../common/featureFlags";
-import * as path from "path";
 
 export class DefaultTemplateGenerator implements IGenerator {
   // override this property to send telemetry event with different component name
@@ -127,7 +127,9 @@ export class DefaultTemplateGenerator implements IGenerator {
       [TelemetryProperty.TemplateName]: templateName,
     });
 
-    const templateMetadata = getAllTemplatesOnPlatform(Platform.CLI).find((t) => t.name === name);
+    const templateMetadata = getAllTemplatesOnPlatform(inputs?.platform || Platform.CLI).find(
+      (t) => t.name === name
+    );
     const folderName =
       templateMetadata?.language === "common" || templateMetadata?.language === "none"
         ? templateMetadata.id

--- a/packages/fx-core/src/component/generator/defaultGenerator.ts
+++ b/packages/fx-core/src/component/generator/defaultGenerator.ts
@@ -10,7 +10,6 @@ import {
   IGenerator,
   Inputs,
   ok,
-  Platform,
   Result,
 } from "@microsoft/teamsfx-api";
 import { merge } from "lodash";
@@ -66,7 +65,7 @@ export class DefaultTemplateGenerator implements IGenerator {
       const templatePath = templateInfo.subFolder
         ? path.join(destinationPath, templateInfo.subFolder)
         : destinationPath;
-      await this.scaffolding(context, templateInfo, templatePath, actionContext, inputs);
+      await this.scaffolding(context, inputs, templateInfo, templatePath, actionContext);
     }
 
     const postRes = await this.post(context, inputs, destinationPath, actionContext);
@@ -97,10 +96,10 @@ export class DefaultTemplateGenerator implements IGenerator {
 
   private async scaffolding(
     context: Context,
+    inputs: Inputs,
     templateInfo: TemplateInfo,
     destinationPath: string,
-    actionContext?: ActionContext,
-    inputs?: Inputs
+    actionContext?: ActionContext
   ): Promise<void> {
     const name = templateInfo.templateName;
     const language = convertToLangKey(templateInfo.language) ?? commonTemplateName;
@@ -127,7 +126,7 @@ export class DefaultTemplateGenerator implements IGenerator {
       [TelemetryProperty.TemplateName]: templateName,
     });
 
-    const templateMetadata = getAllTemplatesOnPlatform(inputs?.platform || Platform.CLI).find(
+    const templateMetadata = getAllTemplatesOnPlatform(inputs.platform).find(
       (t) => t.name === name
     );
     const folderName =
@@ -140,7 +139,7 @@ export class DefaultTemplateGenerator implements IGenerator {
       language: language,
       destination: destinationPath,
       logProvider: context.logProvider,
-      platform: inputs!.platform,
+      platform: inputs.platform,
       fileNameReplaceFn: (fileName, fileData) =>
         renderTemplateFileName(fileName, fileData, replaceMap)
           .replace(/\\/g, "/")

--- a/packages/fx-core/tests/component/generator/templateGenerator.test.ts
+++ b/packages/fx-core/tests/component/generator/templateGenerator.test.ts
@@ -63,7 +63,7 @@ describe("TemplateGenerator", () => {
     scaffoldingSpy = sandbox.spy(DefaultTemplateGenerator.prototype, <any>"scaffolding");
     sandbox.stub(Generator, "generate").resolves();
     inputs = {
-      platform: Platform.VSCode,
+      platform: Platform.VS,
       [QuestionNames.AppName]: randomAppName(),
       [QuestionNames.ProgrammingLanguage]: ProgrammingLanguage.JS,
     } as Inputs;
@@ -84,9 +84,9 @@ describe("TemplateGenerator", () => {
 
       assert.isTrue(res?.isOk());
       assert.isTrue(scaffoldingSpy.calledOnce);
-      assert.equal((scaffoldingSpy.args[0][1] as TemplateInfo).templateName, templateName);
+      assert.equal((scaffoldingSpy.args[0][2] as TemplateInfo).templateName, templateName);
       assert.equal(
-        (scaffoldingSpy.args[0][1] as TemplateInfo).language,
+        (scaffoldingSpy.args[0][2] as TemplateInfo).language,
         inputs?.[QuestionNames.ProgrammingLanguage] || ProgrammingLanguage.JS
       );
     });


### PR DESCRIPTION
It helps to find more accurate template metadata incase the template folder names are different.
related: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/33653984