### PR TITLE
fix: entra and oauth vs DA template local debug failed

### DIFF
--- a/packages/fx-core/src/common/kiotaClient.ts
+++ b/packages/fx-core/src/common/kiotaClient.ts
@@ -15,13 +15,27 @@ import {
 import { KiotaGeneratePluginError } from "../error";
 import { getLocalizedString } from "./localizeUtils";
 import { Utils } from "@microsoft/m365-spec-parser";
+import path from "path";
+import * as os from "os";
 
 const ERROR_LOG_LEVEL = 4;
 
-export async function searchOpenAPISpec(query: string): Promise<SearchOpenAPISpecResult[]> {
+function setKiotaBinaryPath() {
   if (process.env.KIOTA_BINARY_PATH) {
     setKiotaConfig({ binaryLocation: process.env.KIOTA_BINARY_PATH });
+  } else {
+    // If running inside pkg package used by VS, set the binary location to a specific directory to avoid issues.
+    const isInsidePkg = typeof (process as any).pkg !== "undefined";
+
+    if (isInsidePkg) {
+      const kiotaBinDir = path.join(os.homedir(), "kiota-bin");
+      setKiotaConfig({ binaryLocation: kiotaBinDir });
+    }
   }
+}
+
+export async function searchOpenAPISpec(query: string): Promise<SearchOpenAPISpecResult[]> {
+  setKiotaBinaryPath();
 
   const searchResult: Record<string, KiotaSearchResultItem> | undefined = await searchDescription({
     searchTerm: query,
@@ -52,7 +66,7 @@ export async function listAPITreeInfo(
   excludeFilters?: string[]
 ): Promise<KiotaTreeResult> {
   if (process.env.KIOTA_BINARY_PATH) {
-    setKiotaConfig({ binaryLocation: process.env.KIOTA_BINARY_PATH });
+    setKiotaBinaryPath();
   }
   const treeInfo = await getKiotaTree({
     includeFilters: includeFilters,
@@ -90,9 +104,7 @@ export async function kiotageneratePlugin(
   excludePatterns?: string[],
   noWorkspace?: boolean
 ): Promise<GeneratePluginResult> {
-  if (process.env.KIOTA_BINARY_PATH) {
-    setKiotaConfig({ binaryLocation: process.env.KIOTA_BINARY_PATH });
-  }
+  setKiotaBinaryPath();
 
   const config = {
     descriptionPath: specPath,

--- a/packages/fx-core/tests/common/kiotaClient.test.ts
+++ b/packages/fx-core/tests/common/kiotaClient.test.ts
@@ -16,6 +16,114 @@ describe("kiotaClient", () => {
     sandbox.restore();
   });
 
+  describe("setKiotaBinaryPath", () => {
+    let originalPkg: any;
+
+    beforeEach(() => {
+      originalPkg = (process as any).pkg;
+    });
+
+    afterEach(() => {
+      if (originalPkg !== undefined) {
+        (process as any).pkg = originalPkg;
+      } else {
+        delete (process as any).pkg;
+      }
+      delete process.env.KIOTA_BINARY_PATH;
+    });
+
+    it("should set binary location from KIOTA_BINARY_PATH environment variable", async () => {
+      process.env.KIOTA_BINARY_PATH = "/custom/path/to/kiota";
+      delete (process as any).pkg;
+
+      const setKiotaConfigStub = sinon.stub().resolves();
+      const searchDescriptionStub = sinon.stub().resolves({});
+
+      const { searchOpenAPISpec } = proxyquire("../../src/common/kiotaClient", {
+        "@microsoft/kiota": {
+          setKiotaConfig: setKiotaConfigStub,
+          searchDescription: searchDescriptionStub,
+          "@noCallThru": true,
+        },
+      });
+
+      await searchOpenAPISpec("test-query");
+
+      assert(setKiotaConfigStub.calledOnce);
+      assert(setKiotaConfigStub.calledWith({ binaryLocation: "/custom/path/to/kiota" }));
+    });
+
+    it("should set binary location to kiota-bin directory when running inside pkg", async () => {
+      delete process.env.KIOTA_BINARY_PATH;
+      (process as any).pkg = {};
+
+      const setKiotaConfigStub = sinon.stub().resolves();
+      const searchDescriptionStub = sinon.stub().resolves({});
+
+      const { searchOpenAPISpec } = proxyquire("../../src/common/kiotaClient", {
+        "@microsoft/kiota": {
+          setKiotaConfig: setKiotaConfigStub,
+          searchDescription: searchDescriptionStub,
+          "@noCallThru": true,
+        },
+        path: {
+          join: sinon.stub().returns("/home/user/kiota-bin"),
+          "@noCallThru": true,
+        },
+        os: {
+          homedir: sinon.stub().returns("/home/user"),
+          "@noCallThru": true,
+        },
+      });
+
+      await searchOpenAPISpec("test-query");
+
+      assert(setKiotaConfigStub.calledOnce);
+      assert(setKiotaConfigStub.calledWith({ binaryLocation: "/home/user/kiota-bin" }));
+    });
+
+    it("should not call setKiotaConfig when not in pkg and no env var set", async () => {
+      delete process.env.KIOTA_BINARY_PATH;
+      delete (process as any).pkg;
+
+      const setKiotaConfigStub = sinon.stub().resolves();
+      const searchDescriptionStub = sinon.stub().resolves({});
+
+      const { searchOpenAPISpec } = proxyquire("../../src/common/kiotaClient", {
+        "@microsoft/kiota": {
+          setKiotaConfig: setKiotaConfigStub,
+          searchDescription: searchDescriptionStub,
+          "@noCallThru": true,
+        },
+      });
+
+      await searchOpenAPISpec("test-query");
+
+      assert(setKiotaConfigStub.notCalled);
+    });
+
+    it("should prioritize KIOTA_BINARY_PATH over pkg detection", async () => {
+      process.env.KIOTA_BINARY_PATH = "/env/path/to/kiota";
+      (process as any).pkg = {};
+
+      const setKiotaConfigStub = sinon.stub().resolves();
+      const searchDescriptionStub = sinon.stub().resolves({});
+
+      const { searchOpenAPISpec } = proxyquire("../../src/common/kiotaClient", {
+        "@microsoft/kiota": {
+          setKiotaConfig: setKiotaConfigStub,
+          searchDescription: searchDescriptionStub,
+          "@noCallThru": true,
+        },
+      });
+
+      await searchOpenAPISpec("test-query");
+
+      assert(setKiotaConfigStub.calledOnce);
+      assert(setKiotaConfigStub.calledWith({ binaryLocation: "/env/path/to/kiota" }));
+    });
+  });
+
   it("happy path: searchOpenAPISpec", async () => {
     const mockSearchResult = {
       "api-spec": {


### PR DESCRIPTION
[Bug 33656004](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/33656004): [VS Daily]Declarative Agent entra and oauth template local debug failed