### PR TITLE
fix(cherry-pick): add missing .env.*.user for da vs api key project

### DIFF
--- a/templates/vs/csharp/declarative-agent-with-action-from-scratch-bearer/env/.env.dev.user
+++ b/templates/vs/csharp/declarative-agent-with-action-from-scratch-bearer/env/.env.dev.user
@@ -1,0 +1,4 @@
+# This file includes environment variables that will not be committed to git by default. You can set these environment variables in your CI/CD system for your project.
+
+# Secrets. Keys prefixed with `SECRET_` will be masked in Teams Toolkit logs.
+SECRET_API_KEY=' ' # See README.md for how to fill in this value.

--- a/templates/vs/csharp/declarative-agent-with-action-from-scratch-bearer/env/.env.local.user
+++ b/templates/vs/csharp/declarative-agent-with-action-from-scratch-bearer/env/.env.local.user
@@ -1,0 +1,4 @@
+# This file includes environment variables that will not be committed to git by default. You can set these environment variables in your CI/CD system for your project.
+
+# Secrets. Keys prefixed with `SECRET_` will be masked in Teams Toolkit logs.
+SECRET_API_KEY=' ' # See README.md for how to fill in this value.


### PR DESCRIPTION
[Bug 33737419](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/33737419): [VS] "TeamsApp" is not updated in the Readme in DA with API Key template