### PR TITLE
fix(kiota): fix kiota binary could not find error

### DIFF
--- a/packages/fx-core/src/common/kiotaClient.ts
+++ b/packages/fx-core/src/common/kiotaClient.ts
@@ -65,7 +65,10 @@ export async function listAPITreeInfo(
   includeFilters?: string[],
   excludeFilters?: string[]
 ): Promise<KiotaTreeResult> {
-  setKiotaBinaryPath();
+  if (process.env.KIOTA_BINARY_PATH) {
+    setKiotaBinaryPath();
+  }
+
   const treeInfo = await getKiotaTree({
     includeFilters: includeFilters,
     descriptionPath: specPath,

--- a/packages/fx-core/src/common/kiotaClient.ts
+++ b/packages/fx-core/src/common/kiotaClient.ts
@@ -65,9 +65,7 @@ export async function listAPITreeInfo(
   includeFilters?: string[],
   excludeFilters?: string[]
 ): Promise<KiotaTreeResult> {
-  if (process.env.KIOTA_BINARY_PATH) {
-    setKiotaBinaryPath();
-  }
+  setKiotaBinaryPath();
   const treeInfo = await getKiotaTree({
     includeFilters: includeFilters,
     descriptionPath: specPath,

--- a/packages/fx-core/tests/common/kiotaClient.test.ts
+++ b/packages/fx-core/tests/common/kiotaClient.test.ts
@@ -36,8 +36,8 @@ describe("kiotaClient", () => {
       process.env.KIOTA_BINARY_PATH = "/custom/path/to/kiota";
       delete (process as any).pkg;
 
-      const setKiotaConfigStub = sinon.stub().resolves();
-      const searchDescriptionStub = sinon.stub().resolves({});
+      const setKiotaConfigStub = sandbox.stub().resolves();
+      const searchDescriptionStub = sandbox.stub().resolves({});
 
       const { searchOpenAPISpec } = proxyquire("../../src/common/kiotaClient", {
         "@microsoft/kiota": {
@@ -57,8 +57,8 @@ describe("kiotaClient", () => {
       delete process.env.KIOTA_BINARY_PATH;
       (process as any).pkg = {};
 
-      const setKiotaConfigStub = sinon.stub().resolves();
-      const searchDescriptionStub = sinon.stub().resolves({});
+      const setKiotaConfigStub = sandbox.stub().resolves();
+      const searchDescriptionStub = sandbox.stub().resolves({});
 
       const { searchOpenAPISpec } = proxyquire("../../src/common/kiotaClient", {
         "@microsoft/kiota": {
@@ -67,11 +67,11 @@ describe("kiotaClient", () => {
           "@noCallThru": true,
         },
         path: {
-          join: sinon.stub().returns("/home/user/kiota-bin"),
+          join: sandbox.stub().returns("/home/user/kiota-bin"),
           "@noCallThru": true,
         },
         os: {
-          homedir: sinon.stub().returns("/home/user"),
+          homedir: sandbox.stub().returns("/home/user"),
           "@noCallThru": true,
         },
       });
@@ -86,8 +86,8 @@ describe("kiotaClient", () => {
       delete process.env.KIOTA_BINARY_PATH;
       delete (process as any).pkg;
 
-      const setKiotaConfigStub = sinon.stub().resolves();
-      const searchDescriptionStub = sinon.stub().resolves({});
+      const setKiotaConfigStub = sandbox.stub().resolves();
+      const searchDescriptionStub = sandbox.stub().resolves({});
 
       const { searchOpenAPISpec } = proxyquire("../../src/common/kiotaClient", {
         "@microsoft/kiota": {
@@ -106,8 +106,8 @@ describe("kiotaClient", () => {
       process.env.KIOTA_BINARY_PATH = "/env/path/to/kiota";
       (process as any).pkg = {};
 
-      const setKiotaConfigStub = sinon.stub().resolves();
-      const searchDescriptionStub = sinon.stub().resolves({});
+      const setKiotaConfigStub = sandbox.stub().resolves();
+      const searchDescriptionStub = sandbox.stub().resolves({});
 
       const { searchOpenAPISpec } = proxyquire("../../src/common/kiotaClient", {
         "@microsoft/kiota": {
@@ -135,8 +135,8 @@ describe("kiotaClient", () => {
 
     process.env.KIOTA_BINARY_PATH = "mock/path/to/kiota";
 
-    const setKiotaConfigStub = sinon.stub().resolves();
-    const searchDescriptionStub = sinon.stub().resolves(mockSearchResult);
+    const setKiotaConfigStub = sandbox.stub().resolves();
+    const searchDescriptionStub = sandbox.stub().resolves(mockSearchResult);
 
     const { searchOpenAPISpec } = proxyquire("../../src/common/kiotaClient", {
       "@microsoft/kiota": {
@@ -174,8 +174,8 @@ describe("kiotaClient", () => {
       delete process.env.KIOTA_BINARY_PATH;
     }
 
-    const setKiotaConfigStub = sinon.stub().resolves();
-    const searchDescriptionStub = sinon.stub().resolves(mockSearchResult);
+    const setKiotaConfigStub = sandbox.stub().resolves();
+    const searchDescriptionStub = sandbox.stub().resolves(mockSearchResult);
 
     const { searchOpenAPISpec } = proxyquire("../../src/common/kiotaClient", {
       "@microsoft/kiota": {
@@ -195,8 +195,8 @@ describe("kiotaClient", () => {
       delete process.env.KIOTA_BINARY_PATH;
     }
 
-    const setKiotaConfigStub = sinon.stub().resolves();
-    const searchDescriptionStub = sinon.stub().resolves(undefined);
+    const setKiotaConfigStub = sandbox.stub().resolves();
+    const searchDescriptionStub = sandbox.stub().resolves(undefined);
 
     const { searchOpenAPISpec } = proxyquire("../../src/common/kiotaClient", {
       "@microsoft/kiota": {
@@ -212,7 +212,7 @@ describe("kiotaClient", () => {
   });
 
   describe("listAPITreeInfo", () => {
-    const sandbox = sinon.createSandbox();
+    const sandbox = sandbox.createSandbox();
     afterEach(async () => {
       sandbox.restore();
     });
@@ -234,8 +234,8 @@ describe("kiotaClient", () => {
 
       process.env.KIOTA_BINARY_PATH = "mock/path/to/kiota";
 
-      const setKiotaConfigStub = sinon.stub().resolves();
-      const getKiotaTreeStub = sinon.stub().resolves(mockTreeResult);
+      const setKiotaConfigStub = sandbox.stub().resolves();
+      const getKiotaTreeStub = sandbox.stub().resolves(mockTreeResult);
 
       const { listAPITreeInfo } = proxyquire("../../src/common/kiotaClient", {
         "@microsoft/kiota": {
@@ -290,8 +290,8 @@ describe("kiotaClient", () => {
       const includeFilters = ["GET /users"];
       const excludeFilters = ["DELETE /users"];
 
-      const getKiotaTreeStub = sinon.stub().resolves(mockTreeResult);
-      const setKiotaConfigStub = sinon.stub().resolves();
+      const getKiotaTreeStub = sandbox.stub().resolves(mockTreeResult);
+      const setKiotaConfigStub = sandbox.stub().resolves();
 
       const { listAPITreeInfo } = proxyquire("../../src/common/kiotaClient", {
         "@microsoft/kiota": {
@@ -347,8 +347,8 @@ describe("kiotaClient", () => {
 
       process.env.KIOTA_BINARY_PATH = "mock/path/to/kiota";
 
-      const setKiotaConfigStub = sinon.stub().resolves();
-      const getKiotaTreeStub = sinon.stub().resolves(mockTreeResult);
+      const setKiotaConfigStub = sandbox.stub().resolves();
+      const getKiotaTreeStub = sandbox.stub().resolves(mockTreeResult);
 
       const { listAPITreeInfo } = proxyquire("../../src/common/kiotaClient", {
         "@microsoft/kiota": {
@@ -385,8 +385,8 @@ describe("kiotaClient", () => {
       process.env.TestEnv = "test-env";
       process.env.operationId = "test-operation-id";
 
-      const setKiotaConfigStub = sinon.stub().resolves();
-      const getKiotaTreeStub = sinon.stub().resolves(mockTreeResult);
+      const setKiotaConfigStub = sandbox.stub().resolves();
+      const getKiotaTreeStub = sandbox.stub().resolves(mockTreeResult);
 
       const { listAPITreeInfo } = proxyquire("../../src/common/kiotaClient", {
         "@microsoft/kiota": {
@@ -412,9 +412,9 @@ describe("kiotaClient", () => {
     });
 
     it("edge case: listAPITreeInfo returns undefined", async () => {
-      const getKiotaTreeStub = sinon.stub().resolves(undefined);
+      const getKiotaTreeStub = sandbox.stub().resolves(undefined);
 
-      const setKiotaConfigStub = sinon.stub().resolves();
+      const setKiotaConfigStub = sandbox.stub().resolves();
 
       const { listAPITreeInfo } = proxyquire("../../src/common/kiotaClient", {
         "@microsoft/kiota": {
@@ -439,9 +439,9 @@ describe("kiotaClient", () => {
 
     it("error path: listAPITreeInfo throws exception", async () => {
       const errorMessage = "Failed to parse OpenAPI spec";
-      const getKiotaTreeStub = sinon.stub().rejects(new Error(errorMessage));
+      const getKiotaTreeStub = sandbox.stub().rejects(new Error(errorMessage));
 
-      const setKiotaConfigStub = sinon.stub().resolves();
+      const setKiotaConfigStub = sandbox.stub().resolves();
 
       const { listAPITreeInfo } = proxyquire("../../src/common/kiotaClient", {
         "@microsoft/kiota": {

--- a/packages/fx-core/tests/common/kiotaClient.test.ts
+++ b/packages/fx-core/tests/common/kiotaClient.test.ts
@@ -212,7 +212,7 @@ describe("kiotaClient", () => {
   });
 
   describe("listAPITreeInfo", () => {
-    const sandbox = sandbox.createSandbox();
+    const sandbox = sinon.createSandbox();
     afterEach(async () => {
       sandbox.restore();
     });


### PR DESCRIPTION
bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_sprints/taskboard/AuthAndData/Microsoft%20Teams%20Extensibility/Bromine/CY25Q3/2Wk/2Wk07%20(Jun%2029%20-%20Jul%2012)?workitem=33656004

This pull request modifies the `listAPITreeInfo` function in `kiotaClient.ts` to streamline the handling of the Kiota binary path configuration. The most notable change is the removal of the conditional check for `KIOTA_BINARY_PATH` in favor of always invoking the `setKiotaBinaryPath` function.

Code simplification:

* [`packages/fx-core/src/common/kiotaClient.ts`](diffhunk://#diff-3bc619bbafa7271336e4af7b1d0ca11cf6ae850081d9db083aff7a8864aec110L68-L70): Removed the conditional check for `process.env.KIOTA_BINARY_PATH` and ensured `setKiotaBinaryPath` is called unconditionally to simplify the code and improve maintainability.