### PR TITLE
fix(core): remove playground support condition

### DIFF
--- a/packages/fx-core/src/component/driver/aad/create.ts
+++ b/packages/fx-core/src/component/driver/aad/create.ts
@@ -5,16 +5,18 @@ import { hooks } from "@feathersjs/hooks/lib";
 import {
   FxError,
   M365TokenProvider,
+  Result,
   SystemError,
   UserError,
   err,
   ok,
-  Result,
 } from "@microsoft/teamsfx-api";
 import axios from "axios";
 import { Service } from "typedi";
 import { GraphScopes } from "../../../common/constants";
+import { AadSet } from "../../../common/globalVars";
 import { getLocalizedString } from "../../../common/localizeUtils";
+import { environmentNameManager } from "../../../core/environmentName";
 import {
   HttpClientError,
   HttpServerError,
@@ -41,9 +43,6 @@ import {
   questionKeys,
   telemetryKeys,
 } from "./utility/constants";
-import { AadSet } from "../../../common/globalVars";
-import { isTestToolEnabledProject } from "../../../common/tools";
-import { environmentNameManager } from "../../../core/environmentName";
 
 const actionName = "aadApp/create"; // DO NOT MODIFY the name
 const helpLink = "https://aka.ms/teamsfx-actions/aadapp-create";
@@ -212,11 +211,10 @@ export class CreateAadAppDriver implements StepDriver {
           getLocalizedString(logMessageKeys.failExecuteDriver, actionName, message)
         );
         if (error.response!.status >= 400 && error.response!.status < 500) {
-          // When user don't have permission to create AAD app, and cannot use Test Tool, we will ask for AAD app id and secret
+          // When user don't have permission to create AAD app, we will ask for AAD app id and secret
           if (
             error.response!.status === 403 &&
             message.includes(constants.insufficientPermissionErrorMessage) &&
-            !isTestToolEnabledProject(context.projectPath) &&
             process.env.TEAMSFX_ENV == environmentNameManager.getLocalEnvName()
           ) {
             context.addTelemetryProperties({

--- a/packages/fx-core/tests/component/driver/script/scriptDriver.test.ts
+++ b/packages/fx-core/tests/component/driver/script/scriptDriver.test.ts
@@ -352,29 +352,30 @@ describe("getStderrHandler", () => {
 
 describe("defaultShell", () => {
   const sandbox = sinon.createSandbox();
-  let restoreEnv: RestoreFn = () => {};
   afterEach(() => {
     sandbox.restore();
-    restoreEnv();
   });
   it("SHELL", async () => {
-    restoreEnv = mockedEnv({ SHELL: "/bin/bash" });
+    sandbox.stub(process, "env").value({ SHELL: "/bin/bash" });
     const result = await defaultShell();
     assert.equal(result, "/bin/bash");
   });
   it("darwin - /bin/zsh", async () => {
+    sandbox.stub(process, "env").value({});
     sandbox.stub(process, "platform").value("darwin");
     sandbox.stub(fs, "pathExists").resolves(true);
     const result = await defaultShell();
     assert.equal(result, "/bin/zsh");
   });
   it("darwin - /bin/bash", async () => {
+    sandbox.stub(process, "env").value({});
     sandbox.stub(process, "platform").value("darwin");
     sandbox.stub(fs, "pathExists").onFirstCall().resolves(false).onSecondCall().resolves(true);
     const result = await defaultShell();
     assert.equal(result, "/bin/bash");
   });
   it("darwin - undefined", async () => {
+    sandbox.stub(process, "env").value({});
     sandbox.stub(process, "platform").value("darwin");
     sandbox.stub(fs, "pathExists").resolves(false);
     const result = await defaultShell();
@@ -383,18 +384,19 @@ describe("defaultShell", () => {
 
   it("win32 - ComSpec", async () => {
     sandbox.stub(process, "platform").value("win32");
-    restoreEnv = mockedEnv({ ComSpec: "cmd.exe" });
+    sandbox.stub(process, "env").value({ ComSpec: "cmd.exe" });
     const result = await defaultShell();
     assert.equal(result, "cmd.exe");
   });
   it("win32 - cmd.exe", async () => {
     sandbox.stub(process, "platform").value("win32");
-    restoreEnv = mockedEnv({ ComSpec: undefined });
+    sandbox.stub(process, "env").value({});
     const result = await defaultShell();
     assert.equal(result, "cmd.exe");
   });
 
   it("other OS - /bin/sh", async () => {
+    sandbox.stub(process, "env").value({});
     sandbox.stub(process, "platform").value("other");
     sandbox.stub(fs, "pathExists").resolves(true);
     const result = await defaultShell();
@@ -402,6 +404,7 @@ describe("defaultShell", () => {
   });
 
   it("other OS - undefined", async () => {
+    sandbox.stub(process, "env").value({});
     sandbox.stub(process, "platform").value("other");
     sandbox.stub(fs, "pathExists").resolves(false);
     const result = await defaultShell();


### PR DESCRIPTION
Trying to ask for app id and secret if user doesn't have permission to create a new one.
The error happens when user debug in Teams even if it has Playground support, so the condition check is removed.