### PR TITLE
fix(vs): update template dependencies

### DIFF
--- a/templates/vs/csharp/notification-http-timer-trigger/{{ProjectName}}.csproj.tpl
+++ b/templates/vs/csharp/notification-http-timer-trigger/{{ProjectName}}.csproj.tpl
@@ -30,7 +30,7 @@
   <ItemGroup>
     <PackageReference Include="AdaptiveCards.Templating" Version="2.0.5" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.5" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
     <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="1.*" />

--- a/templates/vs/csharp/notification-http-timer-trigger/{{ProjectName}}.csproj.tpl
+++ b/templates/vs/csharp/notification-http-timer-trigger/{{ProjectName}}.csproj.tpl
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AdaptiveCards.Templating" Version="1.3.1" />
+    <PackageReference Include="AdaptiveCards.Templating" Version="2.0.5" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.0" />

--- a/templates/vs/csharp/notification-http-trigger/{{ProjectName}}.csproj.tpl
+++ b/templates/vs/csharp/notification-http-trigger/{{ProjectName}}.csproj.tpl
@@ -28,9 +28,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AdaptiveCards.Templating" Version="1.3.1" />
+    <PackageReference Include="AdaptiveCards.Templating" Version="2.0.5" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.5" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.0" />
     <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="1.*" />
     <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="1.*" />

--- a/templates/vs/csharp/notification-timer-trigger/{{ProjectName}}.csproj.tpl
+++ b/templates/vs/csharp/notification-timer-trigger/{{ProjectName}}.csproj.tpl
@@ -30,7 +30,7 @@
   <ItemGroup>
     <PackageReference Include="AdaptiveCards.Templating" Version="2.0.5" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.5" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
     <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="1.*" />

--- a/templates/vs/csharp/notification-timer-trigger/{{ProjectName}}.csproj.tpl
+++ b/templates/vs/csharp/notification-timer-trigger/{{ProjectName}}.csproj.tpl
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AdaptiveCards.Templating" Version="1.3.1" />
+    <PackageReference Include="AdaptiveCards.Templating" Version="2.0.5" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.0" />

--- a/templates/vs/csharp/notification-webapi/{{ProjectName}}.csproj.tpl
+++ b/templates/vs/csharp/notification-webapi/{{ProjectName}}.csproj.tpl
@@ -24,7 +24,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AdaptiveCards.Templating" Version="1.3.1" />
+    <PackageReference Include="AdaptiveCards.Templating" Version="2.0.5" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="1.*" />
     <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="1.*" />
     <PackageReference Include="Microsoft.Agents.Extensions.Teams" Version="1.*" />


### PR DESCRIPTION
- Update `AdaptiveCards.Templating` to 2.0.5, resolve 2 bugs:
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/33819785
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/33819790
<img width="600" height="161" alt="image" src="https://github.com/user-attachments/assets/ae56c8a2-9750-49dd-99eb-b5aeb733e75d" />

- Update `Microsoft.Azure.Functions.Worker.Sdk` to 2.0.5, to support .net 10
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/33805863
