### PR TITLE
fix: only setup MCP for teamsfx project

### DIFF
--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -1448,7 +1448,9 @@ async function runBackgroundAsyncTasks(
 
   await recommendACPExtension();
 
-  await Correlator.run(setupMCPServer);
+  if (isTeamsFxProject) {
+    await Correlator.run(setupMCPServer);
+  }
 
   await checkProjectTypeAndSendTelemetry();
 }


### PR DESCRIPTION
fix: only setup MCP for teamsfx project

https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/33886591