### PR TITLE
fix: update TDP publish to org URL

### DIFF
--- a/packages/fx-core/src/component/coordinator/index.ts
+++ b/packages/fx-core/src/component/coordinator/index.ts
@@ -925,9 +925,11 @@ class Coordinator {
       loginHint = accountRes.value.unique_name as string;
     }
     await ctx.userInteraction.openUrl(
-      `https://dev.teams.microsoft.com/apps/${
+      `https://dev.teams.cloud.microsoft/apps/${
         updateRes.value as string
-      }/distributions/app-catalog?login_hint=${loginHint}&referrer=teamstoolkit_${inputs.platform}`
+      }/distributions/app-catalog?login_hint=${loginHint}&referrer=teamstoolkit_${
+        inputs.platform
+      }&client-preference=classic`
     );
     return ok(undefined);
   }


### PR DESCRIPTION
[Bug 33933856](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/33933856): [VSC] trigger command "publish to store in Developer Portal" won't jump to a specific page "Publish to your org"