### PR TITLE
fix(dotnet): avoid new agents sdk release causing error

### DIFF
--- a/templates/vs/csharp/command-and-response/{{ProjectName}}.csproj.tpl
+++ b/templates/vs/csharp/command-and-response/{{ProjectName}}.csproj.tpl
@@ -20,8 +20,8 @@
 {{/isNewProjectTypeEnabled}}
   <ItemGroup>
     <PackageReference Include="AdaptiveCards.Templating" Version="2.0.5" />
-    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="1.*" />
-    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="1.*" />
+    <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="1.0.1" />
+    <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="1.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="8.0.14" />
     <PackageReference Include="Microsoft.TeamsFx" Version="3.0.*-*" >
       <!-- Exclude TeamsFx wwwroot static files which are for frontend only. -->


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/33819376

As Agents SDK released a new version 2 weeks ago, the template is broken:
https://github.com/microsoft/Agents-for-net/releases

<img width="1738" height="549" alt="image" src="https://github.com/user-attachments/assets/30270245-13d4-4e3a-82f2-4d190b3e8715" />
