### PR TITLE
fix: function tool latest version compatibility

### DIFF
--- a/.github/workflows/env-checker-ci-schedule.yml
+++ b/.github/workflows/env-checker-ci-schedule.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
         node-version: [16, 18, 20]
-        func-version: [none, "3", "4", "4.0.4670", "~4.0.5174"]
+        func-version: [none, "3", "4", "4.0.4670", "^4.0.5174"]
       max-parallel: 30
 
     runs-on: ${{ matrix.os }}

--- a/packages/fx-core/src/core/middleware/utils/debug/taskMigrator.ts
+++ b/packages/fx-core/src/core/middleware/utils/debug/taskMigrator.ts
@@ -1129,5 +1129,5 @@ function getLabels(tasks: CommentArray<CommentJSONValue>): string[] {
 
 async function getFuncVersion(): Promise<string> {
   const nodeVersion = (await NodeChecker.getInstalledNodeVersion())?.majorVersion;
-  return !nodeVersion || Number.parseInt(nodeVersion) >= 18 ? "~4.0.5174" : "4";
+  return !nodeVersion || Number.parseInt(nodeVersion) >= 18 ? "^4.0.5174" : "4";
 }

--- a/packages/fx-core/tests/component/deps-checker/cases/funcTool.it.ts
+++ b/packages/fx-core/tests/component/deps-checker/cases/funcTool.it.ts
@@ -57,7 +57,7 @@ describe("FuncToolChecker E2E Test", async () => {
     const installOptions = {
       projectPath: projectPath,
       symlinkDir: "./devTools/func",
-      version: "~4.0.5174",
+      version: "^4.0.5174",
     };
     const res = await funcToolChecker.resolve(installOptions);
     if (res.error) {
@@ -92,7 +92,7 @@ describe("FuncToolChecker E2E Test", async () => {
     const installOptions = {
       projectPath: projectPath,
       symlinkDir: "./devTools/func",
-      version: "~4.0.5174",
+      version: "^4.0.5174",
     };
     const res = await funcToolChecker.resolve(installOptions);
     assert.isFalse(res.isInstalled);
@@ -122,7 +122,7 @@ describe("FuncToolChecker E2E Test", async () => {
     const installOptions = {
       projectPath: projectPath,
       symlinkDir: "./devTools/func",
-      version: "~4.0.5174",
+      version: "^4.0.5174",
     };
     const depsInfo = await funcToolChecker.resolve(installOptions);
 
@@ -140,7 +140,7 @@ describe("FuncToolChecker E2E Test", async () => {
     if (!funcVersion || !isLinux()) {
       this.skip();
     }
-    if (!semver.satisfies(funcVersion, "~4.0.5174")) {
+    if (!semver.satisfies(funcVersion, "^4.0.5174")) {
       this.skip();
     }
 
@@ -151,7 +151,7 @@ describe("FuncToolChecker E2E Test", async () => {
     const installOptions = {
       projectPath: projectPath,
       symlinkDir: "./devTools/func",
-      version: "~4.0.5174",
+      version: "^4.0.5174",
     };
     const depsInfo = await funcToolChecker.resolve(installOptions);
     if (depsInfo.error) {
@@ -167,7 +167,7 @@ describe("FuncToolChecker E2E Test", async () => {
     if (isLinux()) {
       this.skip();
     }
-    if (!funcVersion || semver.satisfies(funcVersion, "~4.0.5174")) {
+    if (!funcVersion || semver.satisfies(funcVersion, "^4.0.5174")) {
       this.skip();
     }
 
@@ -180,7 +180,7 @@ describe("FuncToolChecker E2E Test", async () => {
     const installOptions = {
       projectPath: projectPath,
       symlinkDir: "./devTools/func",
-      version: "~4.0.5174",
+      version: "^4.0.5174",
     };
     const res = await funcToolChecker.resolve(installOptions);
     if (res.error) {
@@ -202,7 +202,7 @@ describe("FuncToolChecker E2E Test", async () => {
     if (isLinux()) {
       this.skip();
     }
-    if (!funcVersion || !semver.satisfies(funcVersion, "~4.0.5174")) {
+    if (!funcVersion || !semver.satisfies(funcVersion, "^4.0.5174")) {
       this.skip();
     }
 
@@ -214,7 +214,7 @@ describe("FuncToolChecker E2E Test", async () => {
     const installOptions = {
       projectPath: projectPath,
       symlinkDir: "./devTools/func",
-      version: "~4.0.5174",
+      version: "^4.0.5174",
     };
     const res = await funcToolChecker.resolve(installOptions);
     if (res.error) {

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/V3.5.0-V4.0.6-tab-bot-func-node18/expected/app.local.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/V3.5.0-V4.0.6-tab-bot-func-node18/expected/app.local.yml
@@ -35,7 +35,7 @@ deploy:
       devCert:
         trust: true
       func:
-        version: ~4.0.5174
+        version: ^4.0.5174
         symlinkDir: ./devTools/func
       dotnet: true
     # Write the information of installed development tool(s) into environment

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/beforeV3.4.0-tab-bot-func-node18/expected/app.local.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/beforeV3.4.0-tab-bot-func-node18/expected/app.local.yml
@@ -35,7 +35,7 @@ deploy:
       devCert:
         trust: true
       func:
-        version: ~4.0.5174
+        version: ^4.0.5174
         symlinkDir: ./devTools/func
       dotnet: true
     # Write the information of installed development tool(s) into environment

--- a/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-notification-node18/expected/app.local.yml
+++ b/packages/fx-core/tests/core/middleware/testAssets/v3Migration/debug/transparent-notification-node18/expected/app.local.yml
@@ -22,7 +22,7 @@ deploy:
   - uses: devTool/install
     with:
       func:
-        version: ~4.0.5174
+        version: ^4.0.5174
         symlinkDir: ./devTools/func
     # Write the information of installed development tool(s) into environment
     # file for the specified environment variable(s).

--- a/templates/vsc/js/declarative-agent-with-action-from-scratch-bearer/m365agents.local.yml.tpl
+++ b/templates/vsc/js/declarative-agent-with-action-from-scratch-bearer/m365agents.local.yml.tpl
@@ -88,7 +88,7 @@ deploy:
   - uses: devTool/install
     with:
       func:
-        version: ~4.0.5530
+        version: ^4.0.5530
         symlinkDir: ./devTools/func
     # Write the information of installed development tool(s) into environment
     # file for the specified environment variable(s).

--- a/templates/vsc/js/declarative-agent-with-action-from-scratch-oauth/m365agents.local.yml.tpl
+++ b/templates/vsc/js/declarative-agent-with-action-from-scratch-oauth/m365agents.local.yml.tpl
@@ -152,7 +152,7 @@ deploy:
   - uses: devTool/install
     with:
       func:
-        version: ~4.0.5530
+        version: ^4.0.5530
         symlinkDir: ./devTools/func
     # Write the information of installed development tool(s) into environment
     # file for the specified environment variable(s).

--- a/templates/vsc/js/declarative-agent-with-action-from-scratch/m365agents.local.yml.tpl
+++ b/templates/vsc/js/declarative-agent-with-action-from-scratch/m365agents.local.yml.tpl
@@ -61,7 +61,7 @@ deploy:
   - uses: devTool/install
     with:
       func:
-        version: ~4.0.5530
+        version: ^4.0.5530
         symlinkDir: ./devTools/func
     # Write the information of installed development tool(s) into environment
     # file for the specified environment variable(s).

--- a/templates/vsc/js/message-extension-with-api-from-scratch-api-key/m365agents.local.yml.tpl
+++ b/templates/vsc/js/message-extension-with-api-from-scratch-api-key/m365agents.local.yml.tpl
@@ -92,7 +92,7 @@ deploy:
   - uses: devTool/install
     with:
       func:
-        version: ~4.0.5455
+        version: ^4.0.5455
         symlinkDir: ./devTools/func
     # Write the information of installed development tool(s) into environment
     # file for the specified environment variable(s).

--- a/templates/vsc/js/message-extension-with-api-from-scratch-sso/m365agents.local.yml.tpl
+++ b/templates/vsc/js/message-extension-with-api-from-scratch-sso/m365agents.local.yml.tpl
@@ -97,7 +97,7 @@ deploy:
   - uses: devTool/install
     with:
       func:
-        version: ~4.0.5455
+        version: ^4.0.5455
         symlinkDir: ./devTools/func
     # Write the information of installed development tool(s) into environment
     # file for the specified environment variable(s).

--- a/templates/vsc/js/message-extension-with-api-from-scratch/m365agents.local.yml.tpl
+++ b/templates/vsc/js/message-extension-with-api-from-scratch/m365agents.local.yml.tpl
@@ -65,7 +65,7 @@ deploy:
   - uses: devTool/install
     with:
       func:
-        version: ~4.0.5455
+        version: ^4.0.5455
         symlinkDir: ./devTools/func
     # Write the information of installed development tool(s) into environment
     # file for the specified environment variable(s).

--- a/templates/vsc/js/notification-http-timer-trigger/m365agents.local.yml.tpl
+++ b/templates/vsc/js/notification-http-timer-trigger/m365agents.local.yml.tpl
@@ -71,7 +71,7 @@ deploy:
   - uses: devTool/install
     with:
       func:
-        version: ~4.0.5174
+        version: ^4.0.5174
         symlinkDir: ./devTools/func
     # Write the information of installed development tool(s) into environment
     # file for the specified environment variable(s).

--- a/templates/vsc/js/notification-http-trigger/m365agents.local.yml.tpl
+++ b/templates/vsc/js/notification-http-trigger/m365agents.local.yml.tpl
@@ -71,7 +71,7 @@ deploy:
   - uses: devTool/install
     with:
       func:
-        version: ~4.0.5174
+        version: ^4.0.5174
         symlinkDir: ./devTools/func
     # Write the information of installed development tool(s) into environment
     # file for the specified environment variable(s).

--- a/templates/vsc/js/notification-timer-trigger/m365agents.local.yml.tpl
+++ b/templates/vsc/js/notification-timer-trigger/m365agents.local.yml.tpl
@@ -71,7 +71,7 @@ deploy:
   - uses: devTool/install
     with:
       func:
-        version: ~4.0.5174
+        version: ^4.0.5174
         symlinkDir: ./devTools/func
     # Write the information of installed development tool(s) into environment
     # file for the specified environment variable(s).

--- a/templates/vsc/js/sso-tab-naa/m365agents.local.yml.tpl
+++ b/templates/vsc/js/sso-tab-naa/m365agents.local.yml.tpl
@@ -102,7 +102,7 @@ deploy:
       devCert:
         trust: true
       func:
-        version: ~4.0.5455
+        version: ^4.0.5455
         symlinkDir: ./devTools/func
     # Write the information of installed development tool(s) into environment
     # file for the specified environment variable(s).

--- a/templates/vsc/ts/declarative-agent-with-action-from-scratch-bearer/m365agents.local.yml.tpl
+++ b/templates/vsc/ts/declarative-agent-with-action-from-scratch-bearer/m365agents.local.yml.tpl
@@ -88,7 +88,7 @@ deploy:
   - uses: devTool/install
     with:
       func:
-        version: ~4.0.5530
+        version: ^4.0.5530
         symlinkDir: ./devTools/func
     # Write the information of installed development tool(s) into environment
     # file for the specified environment variable(s).

--- a/templates/vsc/ts/declarative-agent-with-action-from-scratch-oauth/m365agents.local.yml.tpl
+++ b/templates/vsc/ts/declarative-agent-with-action-from-scratch-oauth/m365agents.local.yml.tpl
@@ -152,7 +152,7 @@ deploy:
   - uses: devTool/install
     with:
       func:
-        version: ~4.0.5530
+        version: ^4.0.5530
         symlinkDir: ./devTools/func
     # Write the information of installed development tool(s) into environment
     # file for the specified environment variable(s).

--- a/templates/vsc/ts/declarative-agent-with-action-from-scratch/m365agents.local.yml.tpl
+++ b/templates/vsc/ts/declarative-agent-with-action-from-scratch/m365agents.local.yml.tpl
@@ -61,7 +61,7 @@ deploy:
   - uses: devTool/install
     with:
       func:
-        version: ~4.0.5530
+        version: ^4.0.5530
         symlinkDir: ./devTools/func
     # Write the information of installed development tool(s) into environment
     # file for the specified environment variable(s).

--- a/templates/vsc/ts/message-extension-with-api-from-scratch-api-key/m365agents.local.yml.tpl
+++ b/templates/vsc/ts/message-extension-with-api-from-scratch-api-key/m365agents.local.yml.tpl
@@ -92,7 +92,7 @@ deploy:
   - uses: devTool/install
     with:
       func:
-        version: ~4.0.5455
+        version: ^4.0.5455
         symlinkDir: ./devTools/func
     # Write the information of installed development tool(s) into environment
     # file for the specified environment variable(s).

--- a/templates/vsc/ts/message-extension-with-api-from-scratch-sso/m365agents.local.yml.tpl
+++ b/templates/vsc/ts/message-extension-with-api-from-scratch-sso/m365agents.local.yml.tpl
@@ -97,7 +97,7 @@ deploy:
   - uses: devTool/install
     with:
       func:
-        version: ~4.0.5455
+        version: ^4.0.5455
         symlinkDir: ./devTools/func
     # Write the information of installed development tool(s) into environment
     # file for the specified environment variable(s).

--- a/templates/vsc/ts/message-extension-with-api-from-scratch/m365agents.local.yml.tpl
+++ b/templates/vsc/ts/message-extension-with-api-from-scratch/m365agents.local.yml.tpl
@@ -65,7 +65,7 @@ deploy:
   - uses: devTool/install
     with:
       func:
-        version: ~4.0.5455
+        version: ^4.0.5455
         symlinkDir: ./devTools/func
     # Write the information of installed development tool(s) into environment
     # file for the specified environment variable(s).

--- a/templates/vsc/ts/notification-http-timer-trigger/m365agents.local.yml.tpl
+++ b/templates/vsc/ts/notification-http-timer-trigger/m365agents.local.yml.tpl
@@ -71,7 +71,7 @@ deploy:
   - uses: devTool/install
     with:
       func:
-        version: ~4.0.5174
+        version: ^4.0.5174
         symlinkDir: ./devTools/func
     # Write the information of installed development tool(s) into environment
     # file for the specified environment variable(s).

--- a/templates/vsc/ts/notification-http-trigger/m365agents.local.yml.tpl
+++ b/templates/vsc/ts/notification-http-trigger/m365agents.local.yml.tpl
@@ -71,7 +71,7 @@ deploy:
   - uses: devTool/install
     with:
       func:
-        version: ~4.0.5174
+        version: ^4.0.5174
         symlinkDir: ./devTools/func
     # Write the information of installed development tool(s) into environment
     # file for the specified environment variable(s).

--- a/templates/vsc/ts/notification-timer-trigger/m365agents.local.yml.tpl
+++ b/templates/vsc/ts/notification-timer-trigger/m365agents.local.yml.tpl
@@ -71,7 +71,7 @@ deploy:
   - uses: devTool/install
     with:
       func:
-        version: ~4.0.5174
+        version: ^4.0.5174
         symlinkDir: ./devTools/func
     # Write the information of installed development tool(s) into environment
     # file for the specified environment variable(s).

--- a/templates/vsc/ts/sso-tab-naa/m365agents.local.yml.tpl
+++ b/templates/vsc/ts/sso-tab-naa/m365agents.local.yml.tpl
@@ -102,7 +102,7 @@ deploy:
       devCert:
         trust: true
       func:
-        version: ~4.0.5455
+        version: ^4.0.5455
         symlinkDir: ./devTools/func
     # Write the information of installed development tool(s) into environment
     # file for the specified environment variable(s).


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/33882570/?view=edit

Latest version is `4.1.0`, which may cause version check error if user manual installs latest.

https://www.npmjs.com/package/azure-functions-core-tools?activeTab=readme