### PR TITLE
fix: fallback devPreview version to 1.19 to fix MetaOS DA validate

### DIFF
--- a/packages/fx-core/src/component/driver/teamsApp/createAppPackage.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/createAppPackage.ts
@@ -120,7 +120,7 @@ export class CreateAppPackageDriver implements StepDriver {
     const relativeFiles = [manifest.icons.color, manifest.icons.outline];
     const manifestVersion =
       manifest.manifestVersion === "devPreview"
-        ? semver.coerce("1.19.0") // for MetaOS and MetaOS DA, handle the `devPreview` version as `1.19.0`
+        ? semver.coerce("1.19.0") // for MetaOS WXP, fallback the `devPreview` ver as `1.19.0` to enable following logics
         : semver.coerce(manifest.manifestVersion); // ensure manifestVersion is a valid semver
     if (manifestVersion && semver.gte(manifestVersion, "1.21.0")) {
       const color32x32 = (manifest as TeamsManifestV1D21.TeamsManifestV1D21).icons.color32x32;

--- a/packages/fx-core/src/component/driver/teamsApp/validate.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/validate.ts
@@ -120,7 +120,10 @@ export class ValidateManifestDriver implements StepDriver {
     telemetryProperties[TelemetryPropertyKey.localizationValidationErrors] =
       localizationFilesValidationRes.value.error.map((r: string) => r.replace(/\//g, "")).join(";");
 
-    const manifestVersion = semver.coerce(manifest.manifestVersion);
+    const manifestVersion =
+      manifest.manifestVersion === "devPreview"
+        ? semver.coerce("1.19.0") // for MetaOS WXP, fallback the `devPreview` ver as `1.19.0` to enable following logics
+        : semver.coerce(manifest.manifestVersion); // ensure manifestVersion is a valid semver
     let declarativeAgents: TeamsManifestV1D19.DeclarativeAgentRef[] | undefined;
     if (manifestVersion && semver.gte(manifestVersion, "1.19.0")) {
       declarativeAgents = (manifest as TeamsManifestV1D19.TeamsManifestV1D19).copilotAgents

--- a/packages/fx-core/tests/component/driver/teamsApp/validate.test.ts
+++ b/packages/fx-core/tests/component/driver/teamsApp/validate.test.ts
@@ -484,6 +484,8 @@ describe("teamsApp/validateManifest", async () => {
 
     it("validate with errors returned - MetaOS DA", async () => {
       const teamsManifest = {
+        $schema:
+          "https://developer.microsoft.com/json-schemas/teams/vDevPreview/MicrosoftTeams.schema.json",
         manifestVersion: "devPreview",
       } as TeamsManifestVDevPreview.TeamsManifestVDevPreview;
       teamsManifest.copilotAgents = {

--- a/packages/fx-core/tests/component/driver/teamsApp/validate.test.ts
+++ b/packages/fx-core/tests/component/driver/teamsApp/validate.test.ts
@@ -8,6 +8,7 @@ import {
   Platform,
   SystemError,
   TeamsManifestV1D19,
+  TeamsManifestVDevPreview,
 } from "@microsoft/teamsfx-api";
 import chai from "chai";
 import "mocha";
@@ -429,6 +430,62 @@ describe("teamsApp/validateManifest", async () => {
       const teamsManifest = {
         manifestVersion: "1.19",
       } as TeamsManifestV1D19.TeamsManifestV1D19;
+      teamsManifest.copilotAgents = {
+        declarativeAgents: [
+          {
+            id: "fakeId",
+            file: "fakeFile",
+          },
+        ],
+      };
+
+      sinon.stub(manifestUtils, "getManifestV3").resolves(ok(teamsManifest));
+      sinon.stub(ManifestUtil, "validateManifest").resolves([]);
+      sinon.stub(pluginManifestUtils, "validateAgainstSchema").resolves(
+        ok({
+          id: "fakeId",
+          filePath: "fakeFile",
+          validationResult: ["error1"],
+        })
+      );
+      sinon.stub(pluginManifestUtils, "logValidationErrors").returns("errorMessage1");
+
+      sinon.stub(copilotGptManifestUtils, "validateAgainstSchema").resolves(
+        ok({
+          id: "fakeId",
+          filePath: "fakeFile",
+          validationResult: ["error2"],
+          actionValidationResult: [
+            {
+              id: "fakeId",
+              filePath: "fakeFile",
+              validationResult: ["error3"],
+            },
+          ],
+        })
+      );
+      sinon.stub(copilotGptManifestUtils, "logValidationErrors").returns("errorMessage2");
+
+      const args: ValidateManifestArgs = {
+        manifestPath:
+          "./tests/plugins/resource/appstudio/resources-multi-env/templates/appPackage/v3.manifest.template.json",
+        showMessage: true,
+      };
+
+      mockedDriverContext.platform = Platform.VSCode;
+      mockedDriverContext.projectPath = "test";
+
+      const result = (await teamsAppDriver.execute(args, mockedDriverContext)).result;
+      chai.assert(result.isErr());
+      if (result.isErr()) {
+        chai.assert.equal(result.error.name, AppStudioError.ValidationFailedError.name);
+      }
+    });
+
+    it("validate with errors returned - MetaOS DA", async () => {
+      const teamsManifest = {
+        manifestVersion: "devPreview",
+      } as TeamsManifestVDevPreview.TeamsManifestVDevPreview;
       teamsManifest.copilotAgents = {
         declarativeAgents: [
           {


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/33035312

Fall back version devPreview to 1.19 to enable following logic.