### PR TITLE
feat(cli): add share access removal entry

### DIFF
--- a/packages/cli/src/commands/models/shareRemove.ts
+++ b/packages/cli/src/commands/models/shareRemove.ts
@@ -1,11 +1,30 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { CLICommand, InputsWithProjectPath } from "@microsoft/teamsfx-api";
+import { CLICommand, CLICommandOption, InputsWithProjectPath } from "@microsoft/teamsfx-api";
+// import { removeSharedAccessOptions } from "@microsoft/teamsfx-core";
+import { QuestionNames, ShareOperationOption } from "@microsoft/teamsfx-core";
 import { getFxCore } from "../../activate";
 import { commands } from "../../resource";
 import { TelemetryEvent } from "../../telemetry/cliTelemetryEvents";
 import { EnvOption, IgnoreLoadEnvOption, ProjectFolderOption } from "../common";
-import { removeSharedAccessOptions } from "@microsoft/teamsfx-core";
+
+// Use customized option to temporarily keep owner access removal before moving to collaborator
+const removeSharedAccessOptions: CLICommandOption[] = [
+  {
+    name: "users",
+    type: "string",
+    description: "Remove access for selected user(s)",
+    required: false,
+    skipValidation: true,
+  },
+  {
+    name: "owners",
+    type: "array",
+    description: "Select owners to remove access",
+    required: false,
+    skipValidation: true,
+  },
+];
 
 export const shareRemoveCommand: CLICommand = {
   name: "remove",
@@ -21,13 +40,23 @@ export const shareRemoveCommand: CLICommand = {
     },
     {
       command: `${process.env.TEAMSFX_CLI_BIN_NAME} share remove --users 'a@example.com,b@example.com' -i false`,
-      description: "Remove shared owner access from users",
+      description: "Remove shared access from users",
+    },
+    {
+      command: `${process.env.TEAMSFX_CLI_BIN_NAME} share remove --owners 'a@example.com,b@example.com' -i false`,
+      description: "Remove shared ownership from users",
     },
   ],
   handler: async (ctx) => {
     const inputs = ctx.optionValues as InputsWithProjectPath;
     const core = getFxCore();
-    const res = await core.removeSharedAccess(inputs);
-    return res;
+    if (inputs["users"]) {
+      inputs[QuestionNames.ShareOperation] = ShareOperationOption.RemoveShareAccessFromUsers;
+      inputs[QuestionNames.UserEmail] = inputs["users"];
+      return await core.shareApplication(inputs);
+    } else {
+      inputs["users"] = inputs["owners"];
+      return await core.removeSharedAccess(inputs);
+    }
   },
 };

--- a/packages/cli/tests/unit/commands.tests.ts
+++ b/packages/cli/tests/unit/commands.tests.ts
@@ -584,11 +584,23 @@ describe("CLI commands", () => {
     });
   });
   describe("shareRemoveCommand", async () => {
-    it("success", async () => {
+    it("share with owners", async () => {
       sandbox.stub(FxCore.prototype, "removeSharedAccess").resolves(ok(undefined));
       const ctx: CLIContext = {
         command: { ...shareRemoveCommand, fullName: "teamsfx" },
         optionValues: { env: "dev" },
+        globalOptionValues: {},
+        argumentValues: [],
+        telemetryProperties: {},
+      };
+      const res = await shareRemoveCommand.handler!(ctx);
+      assert.isTrue(res.isOk());
+    });
+    it("share with users", async () => {
+      sandbox.stub(FxCore.prototype, "shareApplication").resolves(ok(undefined));
+      const ctx: CLIContext = {
+        command: { ...shareRemoveCommand, fullName: "teamsfx" },
+        optionValues: { env: "dev", users: "test@example.com" },
         globalOptionValues: {},
         argumentValues: [],
         telemetryProperties: {},


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/33835755

Related: #14342 

Reuse `atk share remove` to remove shared access and owner before owner management is moved to collaborator.