### PR TITLE
feat(SDK): add obsolete message for TeamsFx SDK

### DIFF
--- a/packages/dotnet-sdk/CHANGELOG.md
+++ b/packages/dotnet-sdk/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.0.1
+- Deprecation notice: This package will be deprecated by 2026-09. Users can follow the migration guide to migrate their apps.
+
 # 3.0.0
 - Breaking: Migrate dependencies from Bot Framework SDK to Microsoft Agents SDK.
 - Breaking: Upgrade target framework to .NET 8.0.

--- a/packages/dotnet-sdk/CHANGELOG.md
+++ b/packages/dotnet-sdk/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 3.0.1
+# 3.1.0
 - Deprecation notice: This package will be deprecated by 2026-09. Users can follow the migration guide to migrate their apps.
 
 # 3.0.0

--- a/packages/dotnet-sdk/MIGRATION.md
+++ b/packages/dotnet-sdk/MIGRATION.md
@@ -1,0 +1,204 @@
+# TeamsFx .NET SDK
+
+## Notification Bot
+
+TeamsFx SDK provides `ConversationBot.Notification` to send proactive notification message to Bot installations, such as personal installations, channels and groupChats.
+
+The main thing to note is listen to `ConversationUpdateEvents.MembersAdded` event, store `ConversationReference` somewhere, then you can use it to send proactive notification later.
+
+With Microsoft.TeamsFx SDK, you can simply create a ConversationBot:
+
+```csharp
+// In Program.cs
+builder.Services.AddSingleton(sp =>
+{
+    var options = new ConversationOptions()
+    {
+        Adapter = sp.GetService<CloudAdapter>(),
+        Notification = new NotificationOptions
+        {
+            BotAppId = builder.Configuration["Connections:BotServiceConnection:Settings:ClientId"],
+        },
+    };
+
+    return new ConversationBot(options);
+});
+
+// In Trigger.cs
+var pagedInstallations = await _conversation.Notification.GetPagedInstallationsAsync(pageSize, continuationToken, req.HttpContext.RequestAborted);
+```
+
+Without TeamsFx SDK, you can put key classes `NotificationBot.cs`, `NotificationMiddleware.cs`, and other notification-related classes into your Teams app source code, use `LocalFileStorage` or implement your own persistent storage.
+
+```csharp
+builder.Services.AddSingleton(sp =>
+{
+    var adapter = sp.GetService<CloudAdapter>();
+    var botAppId = builder.Configuration["Connections:BotServiceConnection:Settings:ClientId"];
+    return new NotificationBot(adapter, botAppId, null);
+});
+
+// In Program.cs
+builder.Services.AddSingleton(sp =>
+{
+    var options = new ConversationOptions()
+    {
+        Adapter = sp.GetService<CloudAdapter>(),
+        Notification = new NotificationOptions
+        {
+            BotAppId = builder.Configuration["Connections:BotServiceConnection:Settings:ClientId"],
+        },
+    };
+
+    return new ConversationBot(options);
+});
+
+// In Trigger.cs
+var pagedInstallations = await _notification.GetPagedInstallationsAsync(pageSize, continuationToken, cancellationToken);
+```
+
+You can refer to [notification-http-trigger template](https://github.com/OfficeDev/microsoft-365-agents-toolkit/tree/dev/templates/vs/csharp/notification-http-trigger).
+
+## Command Bot and Workflow Bot
+
+With TeamsFx SDK, you can define a ConversationBot with commands.
+
+```csharp
+// In Program.cs
+builder.Services.AddSingleton<HelloWorldCommandHandler>();
+
+builder.Services.AddSingleton(sp =>
+{
+    var options = new ConversationOptions()
+    {
+        Adapter = sp.GetService<CloudAdapter>(),
+        Command = new CommandOptions()
+        {
+            Commands = new List<ITeamsCommandHandler> { 
+                sp.GetService<HelloWorldCommandHandler>()
+            }
+        },
+        CardAction = new CardActionOptions()
+        {
+            Actions = new List<IAdaptiveCardActionHandler> { sp.GetService<DoStuffActionHandler>() }
+        }
+    };
+    return new ConversationBot(options);
+});
+
+// Command handler implementation
+public class HelloWorldCommandHandler : ITeamsCommandHandler
+{
+    public IEnumerable<ITriggerPattern> TriggerPatterns => new List<ITriggerPattern>
+    {
+        new RegExpTrigger("helloworld")
+    };
+
+    public async Task<ICommandResponse> HandleCommandAsync(ITurnContext context, CommandMessage message, CancellationToken cancellationToken = default)
+    {
+        // Your logic here
+    }
+}
+```
+
+### Option: Use Microsoft Agents SDK
+
+[Microsoft Agents SDK](https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) provides a simple set of functions over the Microsoft Bot Framework to implement this scenario.
+
+```csharp
+// In TeamsBot.cs
+public class TeamsBot : AgentApplication
+{
+    public TeamsBot(AgentApplicationOptions options) : base(options)
+    {
+        OnConversationUpdate(ConversationUpdateEvents.MembersAdded, OnMembersAddedAsync);
+        OnActivity(ActivityTypes.Message, OnMessageReceivedAsync);
+        AdaptiveCards.OnActionExecute(DoStuffActionHandler.TriggerVerb, DoStuffActionHandler.handler);
+    }
+
+    protected async Task OnMessageReceivedAsync(ITurnContext turnContext, ITurnState turnState, CancellationToken cancellationToken)
+    {
+        var messageText = turnContext.Activity.Text?.Trim().ToLowerInvariant();
+        
+        if (messageText == "helloworld")
+        {
+            await turnContext.SendActivityAsync(MessageFactory.Text("Hello World!"), cancellationToken);
+        }
+        else if (messageText == "help")
+        {
+            await turnContext.SendActivityAsync(MessageFactory.Text("Available commands: helloworld, help"), cancellationToken);
+        }
+    }
+}
+
+// In DoStuffActionHandler.cs
+public class DoStuffActionHandler
+    {
+        public static string TriggerVerb => "doStuff";
+
+        public static ActionExecuteHandler handler = HandleActionInvokedAsync;
+
+        private static async Task<AdaptiveCardInvokeResponse> HandleActionInvokedAsync(ITurnContext turnContext, ITurnState state, object cardData, CancellationToken cancellationToken = default)
+        {
+            // Render adaptive card content
+            var cardContent = new AdaptiveCardTemplate(cardTemplate).Expand
+            (
+                new HelloWorldModel
+                {
+                    Title = "Hello World Bot",
+                    Body = $"Congratulations! Your {TriggerVerb} action is processed successfully!",
+                }
+            );
+
+            // Send invoke response with adaptive card
+            return  AdaptiveCardInvokeResponseFactory.AdaptiveCard(cardContent);
+        }
+    }
+```
+
+You can refer to [command and response template](https://github.com/OfficeDev/microsoft-365-agents-toolkit/tree/dev/templates/vs/csharp/command-and-response) and [workflow template](https://github.com/OfficeDev/microsoft-365-agents-toolkit/tree/dev/templates/vs/csharp/workflow).
+
+## Bot SSO
+
+### Option: Use Teams AI Library
+
+[Teams AI Library](https://www.nuget.org/packages/Microsoft.Teams.AI) integrates with `TeamsBotSsoPrompt`. You can add authentication configurations to Application.
+
+```csharp
+// Program.cs
+    IConfidentialClientApplication msal = sp.GetService<IConfidentialClientApplication>();
+    string signInLink = $"https://{config.BOT_DOMAIN}/auth-start.html";
+
+    AuthenticationOptions<AppState> options = new();
+    options.AddAuthentication("graph", new TeamsSsoSettings(new string[]{"User.Read"}, signInLink, msal));
+
+    Application<AppState> app = new ApplicationBuilder<AppState>()
+        .WithStorage(storage)
+        .WithTurnStateFactory(() => new AppState())
+        .WithAuthentication(adapter, options)
+        .Build();
+
+
+    app.Authentication.Get("graph").OnUserSignInSuccess(async (context, state) =>
+    {
+        await context.SendActivityAsync("Successfully logged in");
+        // Get token from state
+        await context.SendActivityAsync($"Token string length: {state.Temp.AuthTokens["graph"].Length}");
+        await context.SendActivityAsync($"This is what you said before the AuthFlow started: {context.Activity.Text}");
+    });
+
+```
+
+You can refer to [Teams AI bot sso sample](https://github.com/microsoft/teams-ai/blob/main/dotnet/samples/06.auth.teamsSSO.bot)
+
+## Tab SSO
+
+### Option 1: Move TeamsUserCredential.cs into source code
+
+`TeamsUserCredential` represents Teams current user's identity. Using this credential will request user consent at the first time. It leverages the Teams SSO and On-Behalf-Of flow to do token exchange. SDK uses this credential when developer choose "User" identity in browser environment. You can copy this `TeamsUserCredential.cs` into your source code.
+
+### Option 2: NAA
+
+We recommend [Nested App Auth](https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/authentication/nested-authentication) to implement SSO.
+
+You can refer to [NAA sample](https://github.com/OfficeDev/Microsoft-Teams-Samples/tree/main/samples/tab-nested-auth/csharp).

--- a/packages/dotnet-sdk/README.md
+++ b/packages/dotnet-sdk/README.md
@@ -1,5 +1,7 @@
 # TeamsFx .NET SDK
 
+This package will be deprecated by 2026-09.
+
 A NuGet package for Blazor projects which aims to reduce the developer tasks of implementing identity and access to cloud resources.
 
 [TeamsFx SDK for JavaScript/TypeScript](https://github.com/OfficeDev/TeamsFx/tree/main/packages/sdk) |

--- a/packages/dotnet-sdk/src/TeamsFx/Bot/TeamsBotSsoPrompt.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Bot/TeamsBotSsoPrompt.cs
@@ -73,7 +73,7 @@ namespace Microsoft.TeamsFx.Bot;
 /// </code>
 /// 
 /// </example>
-[Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+[Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
 public class TeamsBotSsoPrompt : Dialog
 {
     private readonly TeamsBotSsoPromptSettings _settings;
@@ -90,7 +90,7 @@ public class TeamsBotSsoPrompt : Dialog
     /// <remarks>The value of <paramref name="dialogId"/> must be unique within the
     /// <see cref="DialogSet"/> or <see cref="ComponentDialog"/> to which the prompt is added.</remarks>
     /// <exception cref="ExceptionCode.InvalidParameter">When input parameters is null.</exception>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public TeamsBotSsoPrompt(string dialogId, TeamsBotSsoPromptSettings settings): base(dialogId)
     {
         if (string.IsNullOrWhiteSpace(dialogId))
@@ -115,7 +115,7 @@ public class TeamsBotSsoPrompt : Dialog
     /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
     /// <returns> A System.Threading.Tasks.Task representing the asynchronous operation.</returns>
     /// <exception cref="ExceptionCode.InvalidParameter">if dialog context argument is null</exception>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dialogContext, object options = null, CancellationToken cancellationToken = default)
     {
         if (dialogContext == null)
@@ -145,7 +145,7 @@ public class TeamsBotSsoPrompt : Dialog
     /// <para>The prompt generally ends on invalid message from user's reply.</para></remarks>
     /// <exception cref="ExceptionCode.InternalError">When failed to login with unknown error.</exception>
     /// <exception cref="ExceptionCode.ServiceError">When failed to get access token from identity server(AAD).</exception>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public override async Task<DialogTurnResult> ContinueDialogAsync(DialogContext dc, CancellationToken cancellationToken = default(CancellationToken))
     {
         EnsureMsTeamsChannel(dc);

--- a/packages/dotnet-sdk/src/TeamsFx/Bot/TeamsBotSsoPrompt.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Bot/TeamsBotSsoPrompt.cs
@@ -73,6 +73,7 @@ namespace Microsoft.TeamsFx.Bot;
 /// </code>
 /// 
 /// </example>
+[Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
 public class TeamsBotSsoPrompt : Dialog
 {
     private readonly TeamsBotSsoPromptSettings _settings;
@@ -89,6 +90,7 @@ public class TeamsBotSsoPrompt : Dialog
     /// <remarks>The value of <paramref name="dialogId"/> must be unique within the
     /// <see cref="DialogSet"/> or <see cref="ComponentDialog"/> to which the prompt is added.</remarks>
     /// <exception cref="ExceptionCode.InvalidParameter">When input parameters is null.</exception>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public TeamsBotSsoPrompt(string dialogId, TeamsBotSsoPromptSettings settings): base(dialogId)
     {
         if (string.IsNullOrWhiteSpace(dialogId))
@@ -113,6 +115,7 @@ public class TeamsBotSsoPrompt : Dialog
     /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
     /// <returns> A System.Threading.Tasks.Task representing the asynchronous operation.</returns>
     /// <exception cref="ExceptionCode.InvalidParameter">if dialog context argument is null</exception>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dialogContext, object options = null, CancellationToken cancellationToken = default)
     {
         if (dialogContext == null)
@@ -142,6 +145,7 @@ public class TeamsBotSsoPrompt : Dialog
     /// <para>The prompt generally ends on invalid message from user's reply.</para></remarks>
     /// <exception cref="ExceptionCode.InternalError">When failed to login with unknown error.</exception>
     /// <exception cref="ExceptionCode.ServiceError">When failed to get access token from identity server(AAD).</exception>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public override async Task<DialogTurnResult> ContinueDialogAsync(DialogContext dc, CancellationToken cancellationToken = default(CancellationToken))
     {
         EnsureMsTeamsChannel(dc);

--- a/packages/dotnet-sdk/src/TeamsFx/Bot/TeamsBotSsoPrompt.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Bot/TeamsBotSsoPrompt.cs
@@ -73,7 +73,7 @@ namespace Microsoft.TeamsFx.Bot;
 /// </code>
 /// 
 /// </example>
-[Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+[Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
 public class TeamsBotSsoPrompt : Dialog
 {
     private readonly TeamsBotSsoPromptSettings _settings;
@@ -90,7 +90,7 @@ public class TeamsBotSsoPrompt : Dialog
     /// <remarks>The value of <paramref name="dialogId"/> must be unique within the
     /// <see cref="DialogSet"/> or <see cref="ComponentDialog"/> to which the prompt is added.</remarks>
     /// <exception cref="ExceptionCode.InvalidParameter">When input parameters is null.</exception>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public TeamsBotSsoPrompt(string dialogId, TeamsBotSsoPromptSettings settings): base(dialogId)
     {
         if (string.IsNullOrWhiteSpace(dialogId))
@@ -115,7 +115,7 @@ public class TeamsBotSsoPrompt : Dialog
     /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
     /// <returns> A System.Threading.Tasks.Task representing the asynchronous operation.</returns>
     /// <exception cref="ExceptionCode.InvalidParameter">if dialog context argument is null</exception>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dialogContext, object options = null, CancellationToken cancellationToken = default)
     {
         if (dialogContext == null)
@@ -145,7 +145,7 @@ public class TeamsBotSsoPrompt : Dialog
     /// <para>The prompt generally ends on invalid message from user's reply.</para></remarks>
     /// <exception cref="ExceptionCode.InternalError">When failed to login with unknown error.</exception>
     /// <exception cref="ExceptionCode.ServiceError">When failed to get access token from identity server(AAD).</exception>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public override async Task<DialogTurnResult> ContinueDialogAsync(DialogContext dc, CancellationToken cancellationToken = default(CancellationToken))
     {
         EnsureMsTeamsChannel(dc);

--- a/packages/dotnet-sdk/src/TeamsFx/Bot/TeamsBotSsoPromptSettings.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Bot/TeamsBotSsoPromptSettings.cs
@@ -8,12 +8,14 @@ namespace Microsoft.TeamsFx.Bot;
 /// <summary>
 /// Contains settings for an <see cref="TeamsBotSsoPrompt"/>.
 /// </summary>
+[Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
 public class TeamsBotSsoPromptSettings
 {
 
     /// <summary>
     /// Constructor of TeamsBotSsoPromptSettings
     /// </summary>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public TeamsBotSsoPromptSettings(BotAuthenticationOptions botAuthOptions, string[] scopes, int timeout = 900000)
     {
         BotAuthOptions = botAuthOptions;
@@ -25,6 +27,7 @@ public class TeamsBotSsoPromptSettings
     /// Gets or sets the array of strings that declare the desired permissions and the resources requested.
     /// </summary>
     /// <value>The array of strings that declare the desired permissions and the resources requested.</value>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public string[] Scopes { get; set; }
 
     /// <summary>
@@ -32,10 +35,12 @@ public class TeamsBotSsoPromptSettings
     /// Default is 900,000 (15 minutes).
     /// </summary>
     /// <value>The number of milliseconds the prompt waits for the user to authenticate.</value>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public int Timeout { get; set; }
 
     /// <summary>
     /// Gets or sets bot related authentication options.
     /// </summary>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public BotAuthenticationOptions BotAuthOptions { get; set; }
 }

--- a/packages/dotnet-sdk/src/TeamsFx/Bot/TeamsBotSsoPromptTokenResponse.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Bot/TeamsBotSsoPromptTokenResponse.cs
@@ -7,15 +7,18 @@ namespace Microsoft.TeamsFx.Bot;
 /// <summary>
 /// Token response provided by Teams Bot SSO prompt
 /// </summary>
+[Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
 public class TeamsBotSsoPromptTokenResponse: TokenResponse
 {
     /// <summary>
     /// SSO token for user
     /// </summary>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public string SsoToken { get; set; }
 
     /// <summary>
     /// Expiration time of SSO token
     /// </summary>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public string SsoTokenExpiration { get; set; }
 }

--- a/packages/dotnet-sdk/src/TeamsFx/Configuration/AuthenticationOption.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Configuration/AuthenticationOption.cs
@@ -8,7 +8,7 @@ namespace Microsoft.TeamsFx.Configuration;
 /// <summary>
 /// Authentication related configuration.
 /// </summary>
-[Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+[Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
 public class AuthenticationOptions
 {
     /// <summary>
@@ -20,7 +20,7 @@ public class AuthenticationOptions
     /// The client (application) ID of an App Registration in the tenant.
     /// </summary>
     [RegularExpression(@"^[0-9A-Fa-f\-]{36}$")]
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public string ClientId { get; set; }
 
     /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Configuration/AuthenticationOption.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Configuration/AuthenticationOption.cs
@@ -8,7 +8,7 @@ namespace Microsoft.TeamsFx.Configuration;
 /// <summary>
 /// Authentication related configuration.
 /// </summary>
-[Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+[Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
 public class AuthenticationOptions
 {
     /// <summary>
@@ -20,7 +20,7 @@ public class AuthenticationOptions
     /// The client (application) ID of an App Registration in the tenant.
     /// </summary>
     [RegularExpression(@"^[0-9A-Fa-f\-]{36}$")]
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public string ClientId { get; set; }
 
     /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Configuration/AuthenticationOption.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Configuration/AuthenticationOption.cs
@@ -8,6 +8,7 @@ namespace Microsoft.TeamsFx.Configuration;
 /// <summary>
 /// Authentication related configuration.
 /// </summary>
+[Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
 public class AuthenticationOptions
 {
     /// <summary>
@@ -19,45 +20,53 @@ public class AuthenticationOptions
     /// The client (application) ID of an App Registration in the tenant.
     /// </summary>
     [RegularExpression(@"^[0-9A-Fa-f\-]{36}$")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public string ClientId { get; set; }
 
     /// <summary>
     /// The secret of an App Registration in the tenant. (Created by Teams extension in user secrets)
     /// </summary>
     [Required(ErrorMessage = "Client secret is required")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public string ClientSecret { get; set; }
 
     /// <summary>
     /// Login page for Teams to redirect to.
     /// </summary>
     [RegularExpression(@"^http(s)?://[-a-zA-Z0-9@:%._\+~#=/]{1,256}$")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public string InitiateLoginEndpoint { get; set; }
 
     /// <summary>
     /// Application ID URI.
     /// </summary>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public string ApplicationIdUri { get; set; }
 
     /// <summary>
     /// Authority URL that is used in OAuth On-behalf-of flow.
     /// </summary>
     [RegularExpression(@"^http(s)?://[-a-zA-Z0-9@:%._\+~#=/]{1,100}$")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public string OAuthAuthority { get; set; }
 
     /// <summary>
     /// Bot specific authentication configurations.
     /// </summary>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public BotAuthenticationConfigurations Bot { get; set; }
 }
 
 /// <summary>
 /// Bot specific authentication configurations.
 /// </summary>
+[Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
 public class BotAuthenticationConfigurations
 {
     /// <summary>
     /// Initiate login start page endpoint.
     /// </summary>
     [Required(ErrorMessage = "login start page endpoint uri is required")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public string InitiateLoginEndpoint { get; set; }
 }

--- a/packages/dotnet-sdk/src/TeamsFx/Configuration/BotAuthenticationOption.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Configuration/BotAuthenticationOption.cs
@@ -8,6 +8,7 @@ namespace Microsoft.TeamsFx.Configuration;
 /// <summary>
 /// Bot related authentication configuration.
 /// </summary>
+[Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
 public class BotAuthenticationOptions
 {
     /// <summary>
@@ -15,12 +16,14 @@ public class BotAuthenticationOptions
     /// </summary>
     [Required(ErrorMessage = "Client id is required")]
     [RegularExpression(@"^[0-9A-Fa-f\-]{36}$")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public string ClientId { get; set; }
 
     /// <summary>
     /// The client (application) Secret of an App Registration in the tenant.
     /// </summary>
     [Required(ErrorMessage = "Client secret is required")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public string ClientSecret { get; set; }
 
     /// <summary>
@@ -28,17 +31,20 @@ public class BotAuthenticationOptions
     /// </summary>
     [Required(ErrorMessage = "OAuth authority is required")]
     [RegularExpression(@"^http(s)?://[-a-zA-Z0-9@:%._\+~#=/]{1,100}$")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public string OAuthAuthority { get; set; }
 
     /// <summary>
     /// Application ID URI.
     /// </summary>
     [Required(ErrorMessage = "Application id uri is required")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public string ApplicationIdUri { get; set; }
 
     /// <summary>
     /// Login authentication start page endpoint.
     /// </summary>
     [Required(ErrorMessage = "Login authentication start page endpoint is required")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public string InitiateLoginEndpoint  { get; set; }
 }

--- a/packages/dotnet-sdk/src/TeamsFx/Configuration/ConfigurationMethods.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Configuration/ConfigurationMethods.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Extensions.DependencyInjection;
 /// <summary>
 /// Service Registration
 /// </summary>
+[Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
 public static class TeamsFxConfigurationMethods
 {
     /// <summary>
@@ -21,6 +22,7 @@ public static class TeamsFxConfigurationMethods
     /// <param name="services">service collection for DI</param>
     /// <param name="namedConfigurationSection">configuration instance</param>
     /// <returns></returns>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public static IServiceCollection AddTeamsFx(
         this IServiceCollection services,
         IConfiguration namedConfigurationSection)
@@ -50,6 +52,7 @@ public static class TeamsFxConfigurationMethods
     /// <param name="services">service collection for DI</param>
     /// <param name="configureOptions">customized action to configure option</param>
     /// <returns></returns>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public static IServiceCollection AddTeamsFx(
         this IServiceCollection services,
         Action<AuthenticationOptions> configureOptions)
@@ -82,6 +85,7 @@ public static class TeamsFxConfigurationMethods
     /// <param name="services">service collection for DI</param>
     /// <param name="userOptions">customized option instance</param>
     /// <returns></returns>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public static IServiceCollection AddTeamsFx(
         this IServiceCollection services,
         AuthenticationOptions userOptions)

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/ActivityCommandResponse.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/ActivityCommandResponse.cs
@@ -9,7 +9,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Represents a message activity for a command response.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public class ActivityCommandResponse : ICommandResponse
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/ActivityCommandResponse.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/ActivityCommandResponse.cs
@@ -9,7 +9,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Represents a message activity for a command response.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public class ActivityCommandResponse : ICommandResponse
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/ActivityCommandResponse.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/ActivityCommandResponse.cs
@@ -9,6 +9,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Represents a message activity for a command response.
     /// </summary>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public class ActivityCommandResponse : ICommandResponse
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/AdaptiveCardResponse.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/AdaptiveCardResponse.cs
@@ -6,7 +6,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Options used to control how the response card will be sent to users.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public enum AdaptiveCardResponse
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/AdaptiveCardResponse.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/AdaptiveCardResponse.cs
@@ -6,7 +6,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Options used to control how the response card will be sent to users.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public enum AdaptiveCardResponse
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/AdaptiveCardResponse.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/AdaptiveCardResponse.cs
@@ -6,6 +6,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Options used to control how the response card will be sent to users.
     /// </summary>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public enum AdaptiveCardResponse
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/CardActionBot.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/CardActionBot.cs
@@ -8,7 +8,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Represents a bot to handle Adaptive Card Action Execute invoke activities.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public class CardActionBot
     {
         private readonly CloudAdapter _adapter;

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/CardActionBot.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/CardActionBot.cs
@@ -8,6 +8,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Represents a bot to handle Adaptive Card Action Execute invoke activities.
     /// </summary>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public class CardActionBot
     {
         private readonly CloudAdapter _adapter;

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/CardActionBot.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/CardActionBot.cs
@@ -8,7 +8,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Represents a bot to handle Adaptive Card Action Execute invoke activities.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public class CardActionBot
     {
         private readonly CloudAdapter _adapter;

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/CardActionOptions.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/CardActionOptions.cs
@@ -6,7 +6,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Options to initialize a <see cref="CommandBot"/>.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public class CardActionOptions
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/CardActionOptions.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/CardActionOptions.cs
@@ -6,7 +6,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Options to initialize a <see cref="CommandBot"/>.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public class CardActionOptions
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/CardActionOptions.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/CardActionOptions.cs
@@ -6,6 +6,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Options to initialize a <see cref="CommandBot"/>.
     /// </summary>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public class CardActionOptions
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/Channel.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/Channel.cs
@@ -10,6 +10,7 @@
     /// <remarks>
     /// It's recommended to get channels from <see cref="TeamsBotInstallation.GetChannelsAsync"/>.
     /// </remarks>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public class Channel : INotificationTarget
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/Channel.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/Channel.cs
@@ -10,7 +10,7 @@
     /// <remarks>
     /// It's recommended to get channels from <see cref="TeamsBotInstallation.GetChannelsAsync"/>.
     /// </remarks>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public class Channel : INotificationTarget
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/Channel.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/Channel.cs
@@ -10,7 +10,7 @@
     /// <remarks>
     /// It's recommended to get channels from <see cref="TeamsBotInstallation.GetChannelsAsync"/>.
     /// </remarks>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public class Channel : INotificationTarget
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/CommandBot.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/CommandBot.cs
@@ -8,7 +8,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Represents a command bot to handle commands received from Teams.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public class CommandBot
     {
         private readonly CloudAdapter _adapter;

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/CommandBot.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/CommandBot.cs
@@ -8,7 +8,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Represents a command bot to handle commands received from Teams.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public class CommandBot
     {
         private readonly CloudAdapter _adapter;

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/CommandBot.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/CommandBot.cs
@@ -8,6 +8,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Represents a command bot to handle commands received from Teams.
     /// </summary>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public class CommandBot
     {
         private readonly CloudAdapter _adapter;

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/CommandMessage.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/CommandMessage.cs
@@ -8,7 +8,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Represents the command message received from Teams.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public class CommandMessage
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/CommandMessage.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/CommandMessage.cs
@@ -8,6 +8,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Represents the command message received from Teams.
     /// </summary>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public class CommandMessage
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/CommandMessage.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/CommandMessage.cs
@@ -8,7 +8,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Represents the command message received from Teams.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public class CommandMessage
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/CommandOptions.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/CommandOptions.cs
@@ -6,7 +6,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Options to initialize a <see cref="CommandBot"/>.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public class CommandOptions
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/CommandOptions.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/CommandOptions.cs
@@ -6,6 +6,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Options to initialize a <see cref="CommandBot"/>.
     /// </summary>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public class CommandOptions
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/CommandOptions.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/CommandOptions.cs
@@ -6,7 +6,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Options to initialize a <see cref="CommandBot"/>.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public class CommandOptions
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/CommandResponseMiddleware.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/CommandResponseMiddleware.cs
@@ -10,6 +10,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Middleware to handle message activity from Teams.
     /// </summary>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public class CommandResponseMiddleware : IMiddleware
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/CommandResponseMiddleware.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/CommandResponseMiddleware.cs
@@ -10,7 +10,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Middleware to handle message activity from Teams.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public class CommandResponseMiddleware : IMiddleware
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/CommandResponseMiddleware.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/CommandResponseMiddleware.cs
@@ -10,7 +10,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Middleware to handle message activity from Teams.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public class CommandResponseMiddleware : IMiddleware
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/ConversationBot.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/ConversationBot.cs
@@ -24,7 +24,7 @@
     /// For command, set <c>Command.Commands</c> in <see cref="CommandOptions"/> to register your command handlers.
     /// </para>
     /// </remarks>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public class ConversationBot
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/ConversationBot.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/ConversationBot.cs
@@ -24,6 +24,7 @@
     /// For command, set <c>Command.Commands</c> in <see cref="CommandOptions"/> to register your command handlers.
     /// </para>
     /// </remarks>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public class ConversationBot
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/ConversationBot.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/ConversationBot.cs
@@ -24,7 +24,7 @@
     /// For command, set <c>Command.Commands</c> in <see cref="CommandOptions"/> to register your command handlers.
     /// </para>
     /// </remarks>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public class ConversationBot
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/ConversationOptions.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/ConversationOptions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Represents the options used to initialize a <see cref="ConversationBot"/>.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public class ConversationOptions
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/ConversationOptions.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/ConversationOptions.cs
@@ -8,6 +8,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Represents the options used to initialize a <see cref="ConversationBot"/>.
     /// </summary>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public class ConversationOptions
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/ConversationOptions.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/ConversationOptions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Represents the options used to initialize a <see cref="ConversationBot"/>.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public class ConversationOptions
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/DefaultConversationReferenceStore.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/DefaultConversationReferenceStore.cs
@@ -5,7 +5,6 @@ namespace Microsoft.TeamsFx.Conversation
 {
     using Microsoft.Agents.Core.Models;
 
-    [Obsolete]
     internal sealed class DefaultConversationReferenceStore : IConversationReferenceStore
     {
         private readonly INotificationTargetStorage _storage;

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/IAdaptiveCardActionHandler.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/IAdaptiveCardActionHandler.cs
@@ -9,7 +9,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Represents an adaptive card action handler to respond to an adaptiveCard/action invoke activity.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public interface IAdaptiveCardActionHandler
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/IAdaptiveCardActionHandler.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/IAdaptiveCardActionHandler.cs
@@ -9,6 +9,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Represents an adaptive card action handler to respond to an adaptiveCard/action invoke activity.
     /// </summary>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public interface IAdaptiveCardActionHandler
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/IAdaptiveCardActionHandler.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/IAdaptiveCardActionHandler.cs
@@ -9,7 +9,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Represents an adaptive card action handler to respond to an adaptiveCard/action invoke activity.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public interface IAdaptiveCardActionHandler
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/ICommandResponse.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/ICommandResponse.cs
@@ -8,6 +8,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Defines a contract that represents a command response.
     /// </summary>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public interface ICommandResponse
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/ICommandResponse.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/ICommandResponse.cs
@@ -8,7 +8,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Defines a contract that represents a command response.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public interface ICommandResponse
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/ICommandResponse.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/ICommandResponse.cs
@@ -8,7 +8,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Defines a contract that represents a command response.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public interface ICommandResponse
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/IConversationReferenceStore.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/IConversationReferenceStore.cs
@@ -8,6 +8,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Interface for a store provider that manages notification target references.
     /// </summary>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public interface IConversationReferenceStore
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/IConversationReferenceStore.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/IConversationReferenceStore.cs
@@ -8,7 +8,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Interface for a store provider that manages notification target references.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public interface IConversationReferenceStore
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/IConversationReferenceStore.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/IConversationReferenceStore.cs
@@ -8,7 +8,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Interface for a store provider that manages notification target references.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public interface IConversationReferenceStore
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/IConversationReferenceStoreAddOptions.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/IConversationReferenceStoreAddOptions.cs
@@ -6,7 +6,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// The options to add a conversation reference.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public class ConversationReferenceStoreAddOptions
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/IConversationReferenceStoreAddOptions.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/IConversationReferenceStoreAddOptions.cs
@@ -6,7 +6,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// The options to add a conversation reference.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public class ConversationReferenceStoreAddOptions
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/IConversationReferenceStoreAddOptions.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/IConversationReferenceStoreAddOptions.cs
@@ -6,6 +6,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// The options to add a conversation reference.
     /// </summary>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public class ConversationReferenceStoreAddOptions
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/INotificationTarget.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/INotificationTarget.cs
@@ -6,7 +6,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Represent a notification target.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public interface INotificationTarget
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/INotificationTarget.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/INotificationTarget.cs
@@ -6,6 +6,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Represent a notification target.
     /// </summary>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public interface INotificationTarget
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/INotificationTarget.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/INotificationTarget.cs
@@ -6,7 +6,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Represent a notification target.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public interface INotificationTarget
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/INotificationTargetStorage.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/INotificationTargetStorage.cs
@@ -5,7 +5,7 @@
     /// <summary>
     /// Interface for a storage provider that stores and retrieves notification target references.
     /// </summary>
-    [Obsolete($"Use {nameof(IConversationReferenceStore)} to customize the way to persist bot notification connections instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public interface INotificationTargetStorage
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/INotificationTargetStorage.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/INotificationTargetStorage.cs
@@ -5,7 +5,7 @@
     /// <summary>
     /// Interface for a storage provider that stores and retrieves notification target references.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public interface INotificationTargetStorage
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/INotificationTargetStorage.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/INotificationTargetStorage.cs
@@ -5,7 +5,7 @@
     /// <summary>
     /// Interface for a storage provider that stores and retrieves notification target references.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public interface INotificationTargetStorage
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/ITeamsCommandHandler.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/ITeamsCommandHandler.cs
@@ -8,6 +8,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Defines a contract that represents a command handler that can handle commands received from Teams.
     /// </summary>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public interface ITeamsCommandHandler
     {
 

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/ITeamsCommandHandler.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/ITeamsCommandHandler.cs
@@ -8,7 +8,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Defines a contract that represents a command handler that can handle commands received from Teams.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public interface ITeamsCommandHandler
     {
 

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/ITeamsCommandHandler.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/ITeamsCommandHandler.cs
@@ -8,7 +8,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Defines a contract that represents a command handler that can handle commands received from Teams.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public interface ITeamsCommandHandler
     {
 

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/ITriggerPattern.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/ITriggerPattern.cs
@@ -6,7 +6,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Defines a contract that represents a trigger used to trigger command handler.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public interface ITriggerPattern
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/ITriggerPattern.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/ITriggerPattern.cs
@@ -6,6 +6,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Defines a contract that represents a trigger used to trigger command handler.
     /// </summary>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public interface ITriggerPattern
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/ITriggerPattern.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/ITriggerPattern.cs
@@ -6,7 +6,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Defines a contract that represents a trigger used to trigger command handler.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public interface ITriggerPattern
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/InvokeResponseContentType.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/InvokeResponseContentType.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.TeamsFx.Conversation
 {
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     internal static class InvokeResponseContentType
     {
         public const string AdaptiveCard = "application/vnd.microsoft.card.adaptive";

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/InvokeResponseContentType.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/InvokeResponseContentType.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.TeamsFx.Conversation
 {
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     internal static class InvokeResponseContentType
     {
         public const string AdaptiveCard = "application/vnd.microsoft.card.adaptive";

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/InvokeResponseContentType.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/InvokeResponseContentType.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.TeamsFx.Conversation
 {
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     internal static class InvokeResponseContentType
     {
         public const string AdaptiveCard = "application/vnd.microsoft.card.adaptive";

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/InvokeResponseErrorCode.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/InvokeResponseErrorCode.cs
@@ -6,6 +6,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Status code for an application/vnd.microsoft.error invoke response.
     /// </summary>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public enum InvokeResponseErrorCode
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/InvokeResponseErrorCode.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/InvokeResponseErrorCode.cs
@@ -6,7 +6,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Status code for an application/vnd.microsoft.error invoke response.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public enum InvokeResponseErrorCode
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/InvokeResponseErrorCode.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/InvokeResponseErrorCode.cs
@@ -6,7 +6,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Status code for an application/vnd.microsoft.error invoke response.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public enum InvokeResponseErrorCode
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/InvokeResponseFactory.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/InvokeResponseFactory.cs
@@ -9,7 +9,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Contains utility methods for various invoke response types for an adaptiveCard/action invoke response.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public static class InvokeResponseFactory
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/InvokeResponseFactory.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/InvokeResponseFactory.cs
@@ -9,6 +9,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Contains utility methods for various invoke response types for an adaptiveCard/action invoke response.
     /// </summary>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public static class InvokeResponseFactory
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/InvokeResponseFactory.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/InvokeResponseFactory.cs
@@ -9,7 +9,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Contains utility methods for various invoke response types for an adaptiveCard/action invoke response.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public static class InvokeResponseFactory
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/LocalFileStorage.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/LocalFileStorage.cs
@@ -6,7 +6,6 @@ namespace Microsoft.TeamsFx.Conversation
     using Microsoft.Agents.Core.Models;
     using System.Text.Json;
 
-    [Obsolete]
     internal sealed class LocalFileStorage : INotificationTargetStorage
     {
         private readonly string _filePath;

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/Member.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/Member.cs
@@ -11,7 +11,7 @@
     /// <remarks>
     /// It's recommended to get members from <see cref="TeamsBotInstallation.GetMembersAsync"/>.
     /// </remarks>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public class Member : INotificationTarget
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/Member.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/Member.cs
@@ -11,7 +11,7 @@
     /// <remarks>
     /// It's recommended to get members from <see cref="TeamsBotInstallation.GetMembersAsync"/>.
     /// </remarks>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public class Member : INotificationTarget
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/Member.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/Member.cs
@@ -11,6 +11,7 @@
     /// <remarks>
     /// It's recommended to get members from <see cref="TeamsBotInstallation.GetMembersAsync"/>.
     /// </remarks>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public class Member : INotificationTarget
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/MessageResponse.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/MessageResponse.cs
@@ -7,7 +7,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// Defines a contract that represents a message response.
     /// E.g., returned by <see cref="INotificationTarget.SendAdaptiveCard"/> or <see cref="INotificationTarget.SendMessage"/>.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public class MessageResponse
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/MessageResponse.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/MessageResponse.cs
@@ -7,7 +7,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// Defines a contract that represents a message response.
     /// E.g., returned by <see cref="INotificationTarget.SendAdaptiveCard"/> or <see cref="INotificationTarget.SendMessage"/>.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public class MessageResponse
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/MessageResponse.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/MessageResponse.cs
@@ -7,6 +7,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// Defines a contract that represents a message response.
     /// E.g., returned by <see cref="INotificationTarget.SendAdaptiveCard"/> or <see cref="INotificationTarget.SendMessage"/>.
     /// </summary>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public class MessageResponse
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/NotificationBot.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/NotificationBot.cs
@@ -12,7 +12,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Provide utilities to send notification to varies targets (e.g., member, group, channel).
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public class NotificationBot
     {
         private readonly CloudAdapter _adapter;

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/NotificationBot.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/NotificationBot.cs
@@ -12,7 +12,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Provide utilities to send notification to varies targets (e.g., member, group, channel).
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public class NotificationBot
     {
         private readonly CloudAdapter _adapter;

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/NotificationBot.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/NotificationBot.cs
@@ -12,6 +12,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Provide utilities to send notification to varies targets (e.g., member, group, channel).
     /// </summary>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public class NotificationBot
     {
         private readonly CloudAdapter _adapter;

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/NotificationOptions.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/NotificationOptions.cs
@@ -6,7 +6,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Options to initialize <see cref="NotificationBot"/>.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public class NotificationOptions
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/NotificationOptions.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/NotificationOptions.cs
@@ -6,7 +6,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Options to initialize <see cref="NotificationBot"/>.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public class NotificationOptions
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/NotificationOptions.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/NotificationOptions.cs
@@ -6,6 +6,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Options to initialize <see cref="NotificationBot"/>.
     /// </summary>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public class NotificationOptions
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/NotificationTargetType.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/NotificationTargetType.cs
@@ -6,7 +6,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// The target type where the notification will be sent to.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public enum NotificationTargetType
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/NotificationTargetType.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/NotificationTargetType.cs
@@ -6,6 +6,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// The target type where the notification will be sent to.
     /// </summary>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public enum NotificationTargetType
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/NotificationTargetType.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/NotificationTargetType.cs
@@ -6,7 +6,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// The target type where the notification will be sent to.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public enum NotificationTargetType
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/PagedData.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/PagedData.cs
@@ -6,6 +6,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Represents a page of data.
     /// </summary>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public class PagedData<T>
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/PagedData.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/PagedData.cs
@@ -6,7 +6,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Represents a page of data.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public class PagedData<T>
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/PagedData.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/PagedData.cs
@@ -6,7 +6,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Represents a page of data.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public class PagedData<T>
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/RegExpTrigger.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/RegExpTrigger.cs
@@ -9,7 +9,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// Represents a command trigger that triggered by regular expression match.
     /// </summary>
     /// <seealso cref="ITeamsCommandHandler"/>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public class RegExpTrigger : ITriggerPattern
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/RegExpTrigger.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/RegExpTrigger.cs
@@ -9,7 +9,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// Represents a command trigger that triggered by regular expression match.
     /// </summary>
     /// <seealso cref="ITeamsCommandHandler"/>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public class RegExpTrigger : ITriggerPattern
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/RegExpTrigger.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/RegExpTrigger.cs
@@ -9,6 +9,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// Represents a command trigger that triggered by regular expression match.
     /// </summary>
     /// <seealso cref="ITeamsCommandHandler"/>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public class RegExpTrigger : ITriggerPattern
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/SearchScope.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/SearchScope.cs
@@ -9,6 +9,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// For example, to search from personal chat and group chat, use `SearchScope.Person | SearchScope.Group`.
     /// </summary>
     [Flags]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public enum SearchScope
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/SearchScope.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/SearchScope.cs
@@ -9,7 +9,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// For example, to search from personal chat and group chat, use `SearchScope.Person | SearchScope.Group`.
     /// </summary>
     [Flags]
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public enum SearchScope
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/SearchScope.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/SearchScope.cs
@@ -9,7 +9,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// For example, to search from personal chat and group chat, use `SearchScope.Person | SearchScope.Group`.
     /// </summary>
     [Flags]
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public enum SearchScope
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/StringTrigger.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/StringTrigger.cs
@@ -7,7 +7,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// Represents a command trigger that triggered by string match.
     /// </summary>
     ///  <seealso cref="ITeamsCommandHandler"/>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public class StringTrigger : ITriggerPattern
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/StringTrigger.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/StringTrigger.cs
@@ -7,7 +7,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// Represents a command trigger that triggered by string match.
     /// </summary>
     ///  <seealso cref="ITeamsCommandHandler"/>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public class StringTrigger : ITriggerPattern
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/StringTrigger.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/StringTrigger.cs
@@ -7,6 +7,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// Represents a command trigger that triggered by string match.
     /// </summary>
     ///  <seealso cref="ITeamsCommandHandler"/>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public class StringTrigger : ITriggerPattern
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/TeamsBotInstallation.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/TeamsBotInstallation.cs
@@ -27,7 +27,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <remarks>
     /// It's recommended to get bot installations from <c>ConversationBot.Notification.GetInstallationsAsync</c>.
     /// </remarks>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public class TeamsBotInstallation : INotificationTarget
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/TeamsBotInstallation.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/TeamsBotInstallation.cs
@@ -27,7 +27,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <remarks>
     /// It's recommended to get bot installations from <c>ConversationBot.Notification.GetInstallationsAsync</c>.
     /// </remarks>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public class TeamsBotInstallation : INotificationTarget
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/TeamsBotInstallation.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/TeamsBotInstallation.cs
@@ -27,6 +27,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <remarks>
     /// It's recommended to get bot installations from <c>ConversationBot.Notification.GetInstallationsAsync</c>.
     /// </remarks>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public class TeamsBotInstallation : INotificationTarget
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/TextCommandResponse.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/TextCommandResponse.cs
@@ -8,6 +8,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Represents a simple text message for a command response.
     /// </summary>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public class TextCommandResponse : ICommandResponse
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Conversation/TextCommandResponse.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Conversation/TextCommandResponse.cs
@@ -8,7 +8,7 @@ namespace Microsoft.TeamsFx.Conversation
     /// <summary>
     /// Represents a simple text message for a command response.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public class TextCommandResponse : ICommandResponse
     {
         /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Credential/TeamsUserCredential.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Credential/TeamsUserCredential.cs
@@ -20,7 +20,7 @@ namespace Microsoft.TeamsFx;
 /// <remarks>
 /// Can only be used within Blazor server for security reason.
 /// </remarks>
-[Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+[Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
 public class TeamsUserCredential : TokenCredential, IAsyncDisposable
 {
     internal bool _initialized;
@@ -46,7 +46,7 @@ public class TeamsUserCredential : TokenCredential, IAsyncDisposable
     /// <param name="logger">Logger of TeamsUserCredential Class.</param>
     /// <param name="identityClientAdapter">Global instance of adaptor to call MSAL.NET library</param>
     /// <exception cref="ExceptionCode.InvalidConfiguration">When client id, client secret, initiate login endpoint or OAuth authority is missing or invalid in config.</exception>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public TeamsUserCredential(
         IOptions<AuthenticationOptions> authenticationOptions,
         IJSRuntime jsRuntime,
@@ -82,7 +82,7 @@ public class TeamsUserCredential : TokenCredential, IAsyncDisposable
     /// <returns>Basic user info with user displayName, objectId and preferredUserName.</returns>
     /// <exception cref="ExceptionCode.InternalError">When SSO token from Teams client is not valid.</exception>
     /// <exception cref="ExceptionCode.InvalidParameter">When SSO token from Teams client is empty.</exception>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public async ValueTask<UserInfo> GetUserInfoAsync()
     {
         _logger.LogInformation("Get basic user info from SSO token");
@@ -121,7 +121,7 @@ public class TeamsUserCredential : TokenCredential, IAsyncDisposable
     ///
     /// <exception cref="ExceptionCode.InternalError">When failed to login with unknown error.</exception>
     /// <exception cref="ExceptionCode.ConsentFailed">When user canceled or failed to consent.</exception>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public async Task LoginAsync(string scopes)
     {
         _logger.LogInformation($"Popup consent page to get user's access token with scopes: {scopes}");
@@ -167,7 +167,7 @@ public class TeamsUserCredential : TokenCredential, IAsyncDisposable
     ///
     /// <exception cref="ExceptionCode.InternalError">When failed to login with unknown error.</exception>
     /// <exception cref="ExceptionCode.ConsentFailed">When user canceled or failed to consent.</exception>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public async Task LoginAsync(string[] scopes)
     {
         var scopeString = string.Join(' ', scopes);
@@ -197,7 +197,7 @@ public class TeamsUserCredential : TokenCredential, IAsyncDisposable
     /// <remarks>
     /// Can only be used within Teams.
     /// </remarks>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public async override ValueTask<global::Azure.Core.AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
     {
         await EnsureTeamsSdkInitialized().ConfigureAwait(false);
@@ -219,7 +219,7 @@ public class TeamsUserCredential : TokenCredential, IAsyncDisposable
     /// <summary>
     /// Sync version is not supported now. Please use GetTokenAsync instead.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public override global::Azure.Core.AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
     {
         throw new NotImplementedException();
@@ -229,7 +229,7 @@ public class TeamsUserCredential : TokenCredential, IAsyncDisposable
     /// Dispose.
     /// </summary>
     /// <returns></returns>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public async ValueTask DisposeAsync()
     {
         if (_teamsSdkTask.IsValueCreated)

--- a/packages/dotnet-sdk/src/TeamsFx/Credential/TeamsUserCredential.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Credential/TeamsUserCredential.cs
@@ -20,6 +20,7 @@ namespace Microsoft.TeamsFx;
 /// <remarks>
 /// Can only be used within Blazor server for security reason.
 /// </remarks>
+[Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
 public class TeamsUserCredential : TokenCredential, IAsyncDisposable
 {
     internal bool _initialized;
@@ -45,6 +46,7 @@ public class TeamsUserCredential : TokenCredential, IAsyncDisposable
     /// <param name="logger">Logger of TeamsUserCredential Class.</param>
     /// <param name="identityClientAdapter">Global instance of adaptor to call MSAL.NET library</param>
     /// <exception cref="ExceptionCode.InvalidConfiguration">When client id, client secret, initiate login endpoint or OAuth authority is missing or invalid in config.</exception>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public TeamsUserCredential(
         IOptions<AuthenticationOptions> authenticationOptions,
         IJSRuntime jsRuntime,
@@ -80,6 +82,7 @@ public class TeamsUserCredential : TokenCredential, IAsyncDisposable
     /// <returns>Basic user info with user displayName, objectId and preferredUserName.</returns>
     /// <exception cref="ExceptionCode.InternalError">When SSO token from Teams client is not valid.</exception>
     /// <exception cref="ExceptionCode.InvalidParameter">When SSO token from Teams client is empty.</exception>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public async ValueTask<UserInfo> GetUserInfoAsync()
     {
         _logger.LogInformation("Get basic user info from SSO token");
@@ -118,6 +121,7 @@ public class TeamsUserCredential : TokenCredential, IAsyncDisposable
     ///
     /// <exception cref="ExceptionCode.InternalError">When failed to login with unknown error.</exception>
     /// <exception cref="ExceptionCode.ConsentFailed">When user canceled or failed to consent.</exception>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public async Task LoginAsync(string scopes)
     {
         _logger.LogInformation($"Popup consent page to get user's access token with scopes: {scopes}");
@@ -163,6 +167,7 @@ public class TeamsUserCredential : TokenCredential, IAsyncDisposable
     ///
     /// <exception cref="ExceptionCode.InternalError">When failed to login with unknown error.</exception>
     /// <exception cref="ExceptionCode.ConsentFailed">When user canceled or failed to consent.</exception>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public async Task LoginAsync(string[] scopes)
     {
         var scopeString = string.Join(' ', scopes);
@@ -192,6 +197,7 @@ public class TeamsUserCredential : TokenCredential, IAsyncDisposable
     /// <remarks>
     /// Can only be used within Teams.
     /// </remarks>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public async override ValueTask<global::Azure.Core.AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
     {
         await EnsureTeamsSdkInitialized().ConfigureAwait(false);
@@ -213,6 +219,7 @@ public class TeamsUserCredential : TokenCredential, IAsyncDisposable
     /// <summary>
     /// Sync version is not supported now. Please use GetTokenAsync instead.
     /// </summary>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public override global::Azure.Core.AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
     {
         throw new NotImplementedException();
@@ -222,6 +229,7 @@ public class TeamsUserCredential : TokenCredential, IAsyncDisposable
     /// Dispose.
     /// </summary>
     /// <returns></returns>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public async ValueTask DisposeAsync()
     {
         if (_teamsSdkTask.IsValueCreated)

--- a/packages/dotnet-sdk/src/TeamsFx/Credential/TeamsUserCredential.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Credential/TeamsUserCredential.cs
@@ -20,7 +20,7 @@ namespace Microsoft.TeamsFx;
 /// <remarks>
 /// Can only be used within Blazor server for security reason.
 /// </remarks>
-[Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+[Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
 public class TeamsUserCredential : TokenCredential, IAsyncDisposable
 {
     internal bool _initialized;
@@ -46,7 +46,7 @@ public class TeamsUserCredential : TokenCredential, IAsyncDisposable
     /// <param name="logger">Logger of TeamsUserCredential Class.</param>
     /// <param name="identityClientAdapter">Global instance of adaptor to call MSAL.NET library</param>
     /// <exception cref="ExceptionCode.InvalidConfiguration">When client id, client secret, initiate login endpoint or OAuth authority is missing or invalid in config.</exception>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public TeamsUserCredential(
         IOptions<AuthenticationOptions> authenticationOptions,
         IJSRuntime jsRuntime,
@@ -82,7 +82,7 @@ public class TeamsUserCredential : TokenCredential, IAsyncDisposable
     /// <returns>Basic user info with user displayName, objectId and preferredUserName.</returns>
     /// <exception cref="ExceptionCode.InternalError">When SSO token from Teams client is not valid.</exception>
     /// <exception cref="ExceptionCode.InvalidParameter">When SSO token from Teams client is empty.</exception>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public async ValueTask<UserInfo> GetUserInfoAsync()
     {
         _logger.LogInformation("Get basic user info from SSO token");
@@ -121,7 +121,7 @@ public class TeamsUserCredential : TokenCredential, IAsyncDisposable
     ///
     /// <exception cref="ExceptionCode.InternalError">When failed to login with unknown error.</exception>
     /// <exception cref="ExceptionCode.ConsentFailed">When user canceled or failed to consent.</exception>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public async Task LoginAsync(string scopes)
     {
         _logger.LogInformation($"Popup consent page to get user's access token with scopes: {scopes}");
@@ -167,7 +167,7 @@ public class TeamsUserCredential : TokenCredential, IAsyncDisposable
     ///
     /// <exception cref="ExceptionCode.InternalError">When failed to login with unknown error.</exception>
     /// <exception cref="ExceptionCode.ConsentFailed">When user canceled or failed to consent.</exception>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public async Task LoginAsync(string[] scopes)
     {
         var scopeString = string.Join(' ', scopes);
@@ -197,7 +197,7 @@ public class TeamsUserCredential : TokenCredential, IAsyncDisposable
     /// <remarks>
     /// Can only be used within Teams.
     /// </remarks>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public async override ValueTask<global::Azure.Core.AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
     {
         await EnsureTeamsSdkInitialized().ConfigureAwait(false);
@@ -219,7 +219,7 @@ public class TeamsUserCredential : TokenCredential, IAsyncDisposable
     /// <summary>
     /// Sync version is not supported now. Please use GetTokenAsync instead.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public override global::Azure.Core.AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
     {
         throw new NotImplementedException();
@@ -229,7 +229,7 @@ public class TeamsUserCredential : TokenCredential, IAsyncDisposable
     /// Dispose.
     /// </summary>
     /// <returns></returns>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public async ValueTask DisposeAsync()
     {
         if (_teamsSdkTask.IsValueCreated)

--- a/packages/dotnet-sdk/src/TeamsFx/ExceptionWithCode.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/ExceptionWithCode.cs
@@ -5,7 +5,7 @@ namespace Microsoft.TeamsFx;
 /// <summary>
 /// Exception code to trace the exception types.
 /// </summary>
-[Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+[Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
 public enum ExceptionCode
 {
     /// <summary>
@@ -57,7 +57,7 @@ public enum ExceptionCode
 /// <summary>
 /// Exception class with code and message thrown by the SDK.
 /// </summary>
-[Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+[Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
 public class ExceptionWithCode : Exception
 {
     /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/ExceptionWithCode.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/ExceptionWithCode.cs
@@ -5,6 +5,7 @@ namespace Microsoft.TeamsFx;
 /// <summary>
 /// Exception code to trace the exception types.
 /// </summary>
+[Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
 public enum ExceptionCode
 {
     /// <summary>
@@ -56,6 +57,7 @@ public enum ExceptionCode
 /// <summary>
 /// Exception class with code and message thrown by the SDK.
 /// </summary>
+[Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
 public class ExceptionWithCode : Exception
 {
     /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/ExceptionWithCode.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/ExceptionWithCode.cs
@@ -5,7 +5,7 @@ namespace Microsoft.TeamsFx;
 /// <summary>
 /// Exception code to trace the exception types.
 /// </summary>
-[Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+[Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
 public enum ExceptionCode
 {
     /// <summary>
@@ -57,7 +57,7 @@ public enum ExceptionCode
 /// <summary>
 /// Exception class with code and message thrown by the SDK.
 /// </summary>
-[Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+[Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
 public class ExceptionWithCode : Exception
 {
     /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Helper/IIdentityClientAdapter.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Helper/IIdentityClientAdapter.cs
@@ -8,7 +8,7 @@ namespace Microsoft.TeamsFx.Helper
     /// <summary>
     /// Adapter of IConfidentialClientApplication On-behalf-of flow.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public interface IIdentityClientAdapter
     {
         /// <summary>
@@ -17,7 +17,7 @@ namespace Microsoft.TeamsFx.Helper
         /// <param name="ssoToken">token from Teams client</param>
         /// <param name="scopes">required scopes</param>
         /// <returns></returns>
-        [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+        [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
         Task<AuthenticationResult> GetAccessToken(string ssoToken, IEnumerable<string> scopes);
     }
 }

--- a/packages/dotnet-sdk/src/TeamsFx/Helper/IIdentityClientAdapter.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Helper/IIdentityClientAdapter.cs
@@ -8,7 +8,7 @@ namespace Microsoft.TeamsFx.Helper
     /// <summary>
     /// Adapter of IConfidentialClientApplication On-behalf-of flow.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public interface IIdentityClientAdapter
     {
         /// <summary>
@@ -17,7 +17,7 @@ namespace Microsoft.TeamsFx.Helper
         /// <param name="ssoToken">token from Teams client</param>
         /// <param name="scopes">required scopes</param>
         /// <returns></returns>
-        [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+        [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
         Task<AuthenticationResult> GetAccessToken(string ssoToken, IEnumerable<string> scopes);
     }
 }

--- a/packages/dotnet-sdk/src/TeamsFx/Helper/IIdentityClientAdapter.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Helper/IIdentityClientAdapter.cs
@@ -8,6 +8,7 @@ namespace Microsoft.TeamsFx.Helper
     /// <summary>
     /// Adapter of IConfidentialClientApplication On-behalf-of flow.
     /// </summary>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public interface IIdentityClientAdapter
     {
         /// <summary>
@@ -16,6 +17,7 @@ namespace Microsoft.TeamsFx.Helper
         /// <param name="ssoToken">token from Teams client</param>
         /// <param name="scopes">required scopes</param>
         /// <returns></returns>
+        [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
         Task<AuthenticationResult> GetAccessToken(string ssoToken, IEnumerable<string> scopes);
     }
 }

--- a/packages/dotnet-sdk/src/TeamsFx/Helper/ITeamsInfo.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Helper/ITeamsInfo.cs
@@ -9,7 +9,7 @@ namespace Microsoft.TeamsFx.Helper
     /// <summary>
     /// provides utility methods for interactions that occur within Microsoft Teams.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
     public interface ITeamsInfo
     {
         /// <summary>
@@ -20,7 +20,7 @@ namespace Microsoft.TeamsFx.Helper
         /// <param name="userId"> ID of the user in question. </param>
         /// <param name="cancellationToken"> cancellation token. </param>
         /// <returns>Team Account Details.</returns>
-        [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+        [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
         Task<TeamsChannelAccount> GetTeamsMemberAsync(ITurnContext context, string userId, CancellationToken cancellationToken = default);
     }
 }

--- a/packages/dotnet-sdk/src/TeamsFx/Helper/ITeamsInfo.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Helper/ITeamsInfo.cs
@@ -9,6 +9,7 @@ namespace Microsoft.TeamsFx.Helper
     /// <summary>
     /// provides utility methods for interactions that occur within Microsoft Teams.
     /// </summary>
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
     public interface ITeamsInfo
     {
         /// <summary>
@@ -19,6 +20,7 @@ namespace Microsoft.TeamsFx.Helper
         /// <param name="userId"> ID of the user in question. </param>
         /// <param name="cancellationToken"> cancellation token. </param>
         /// <returns>Team Account Details.</returns>
+        [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
         Task<TeamsChannelAccount> GetTeamsMemberAsync(ITurnContext context, string userId, CancellationToken cancellationToken = default);
     }
 }

--- a/packages/dotnet-sdk/src/TeamsFx/Helper/ITeamsInfo.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Helper/ITeamsInfo.cs
@@ -9,7 +9,7 @@ namespace Microsoft.TeamsFx.Helper
     /// <summary>
     /// provides utility methods for interactions that occur within Microsoft Teams.
     /// </summary>
-    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+    [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
     public interface ITeamsInfo
     {
         /// <summary>
@@ -20,7 +20,7 @@ namespace Microsoft.TeamsFx.Helper
         /// <param name="userId"> ID of the user in question. </param>
         /// <param name="cancellationToken"> cancellation token. </param>
         /// <returns>Team Account Details.</returns>
-        [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+        [Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
         Task<TeamsChannelAccount> GetTeamsMemberAsync(ITurnContext context, string userId, CancellationToken cancellationToken = default);
     }
 }

--- a/packages/dotnet-sdk/src/TeamsFx/Microsoft.TeamsFx.csproj
+++ b/packages/dotnet-sdk/src/TeamsFx/Microsoft.TeamsFx.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Microsoft.TeamsFx</AssemblyName>
     <RootNamespace>Microsoft.TeamsFx</RootNamespace>
-    <Version>3.1.0-alpha.0</Version>
+    <Version>3.1.0</Version>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
     <RepositoryUrl>https://github.com/OfficeDev/TeamsFx</RepositoryUrl>

--- a/packages/dotnet-sdk/src/TeamsFx/Microsoft.TeamsFx.csproj
+++ b/packages/dotnet-sdk/src/TeamsFx/Microsoft.TeamsFx.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Microsoft.TeamsFx</AssemblyName>
     <RootNamespace>Microsoft.TeamsFx</RootNamespace>
-    <Version>3.0.0</Version>
+    <Version>3.1.0-alpha.0</Version>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
     <RepositoryUrl>https://github.com/OfficeDev/TeamsFx</RepositoryUrl>

--- a/packages/dotnet-sdk/src/TeamsFx/Model/UserInfo.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Model/UserInfo.cs
@@ -5,6 +5,7 @@ namespace Microsoft.TeamsFx;
 /// <summary>
 /// UserInfo with user displayName, objectId and preferredUserName.
 /// </summary>
+[Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
 public class UserInfo
 {
     /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Model/UserInfo.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Model/UserInfo.cs
@@ -5,7 +5,7 @@ namespace Microsoft.TeamsFx;
 /// <summary>
 /// UserInfo with user displayName, objectId and preferredUserName.
 /// </summary>
-[Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Core) instead.")]
+[Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
 public class UserInfo
 {
     /// <summary>

--- a/packages/dotnet-sdk/src/TeamsFx/Model/UserInfo.cs
+++ b/packages/dotnet-sdk/src/TeamsFx/Model/UserInfo.cs
@@ -5,7 +5,7 @@ namespace Microsoft.TeamsFx;
 /// <summary>
 /// UserInfo with user displayName, objectId and preferredUserName.
 /// </summary>
-[Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://www.nuget.org/packages/Microsoft.Agents.Hosting.AspNetCore) instead.")]
+[Obsolete("This package will be deprecated by 2026-09. Please use Microsoft 365 Agents SDK (https://github.com/microsoft/Agents-for-net) instead.")]
 public class UserInfo
 {
     /// <summary>


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/32852703

- Add Obsolete message for all classes/methods.
- Update Readme and Changelog, add migration guide
- Bump SDK version to 3.1.0