### PR TITLE
feat: support group email when removing share access for da

### DIFF
--- a/packages/fx-core/src/core/share.ts
+++ b/packages/fx-core/src/core/share.ts
@@ -99,10 +99,15 @@ export async function removeShareAccess(
   }
 
   // remove users from shared access
+  const graphClient = new GraphClient(tokenProvider);
   for (const email of emails) {
     const userInfo = await CollaborationUtil.getUserInfo(tokenProvider, email);
     if (!userInfo) {
-      return err(new InputValidationError("shareWithUser", `Invalid user: ${email}`));
+      const groupInfo = await graphClient.getGroupInfo(email);
+      if (!groupInfo) {
+        return err(new InputValidationError("shareWithUser", `Invalid user or group: ${email}`));
+      }
+      entities.add(groupInfo.id);
     } else {
       entities.add(userInfo.aadId);
     }

--- a/packages/fx-core/tests/core/share.test.ts
+++ b/packages/fx-core/tests/core/share.test.ts
@@ -348,6 +348,39 @@ describe("share", () => {
       assert.isTrue(unshareStub.calledOnce);
     });
 
+    it("should remove group when user info not found but group info is found", async () => {
+      // Arrange
+      const groupEmail = "group@example.com";
+      const mockGroupInfo = {
+        id: "group-id",
+        displayName: "Test Group",
+        mail: groupEmail,
+      };
+      const emailsWithGroup = [mockEmails[0], groupEmail];
+
+      sandbox.stub(mockSharedInstance, "getSharedUsers").resolves(ok(mockExistingEntities));
+
+      const shareWithUsersStub = sandbox
+        .stub(mockSharedInstance, "shareWithUsers")
+        .resolves(ok(undefined));
+
+      const getUserInfoStub = sandbox.stub(CollaborationUtil, "getUserInfo");
+      getUserInfoStub.withArgs(sinon.match.any, mockEmails[0]).resolves(mockUserInfo1);
+      getUserInfoStub.withArgs(sinon.match.any, groupEmail).resolves(undefined);
+
+      const getGroupInfoStub = sandbox.stub(GraphClient.prototype, "getGroupInfo");
+      getGroupInfoStub.withArgs(groupEmail).resolves(mockGroupInfo);
+
+      // Act
+      const result = await removeShareAccess(mockMosToken, mockTitleId, emailsWithGroup);
+
+      // Assert
+      assert.isTrue(result.isOk());
+      assert.isTrue(getUserInfoStub.calledTwice);
+      assert.isTrue(getGroupInfoStub.calledOnce);
+      assert.isTrue(shareWithUsersStub.calledOnce);
+    });
+
     it("should return error when invalid user email is provided", async () => {
       // Arrange
       sandbox.stub(mockSharedInstance, "getSharedUsers").resolves(ok(mockExistingEntities));
@@ -356,6 +389,11 @@ describe("share", () => {
       getUserInfoStub.withArgs(sinon.match.any, mockEmails[0]).resolves(mockUserInfo1);
       getUserInfoStub.withArgs(sinon.match.any, mockEmails[1]).resolves(undefined);
 
+      // Mock GraphClient.getGroupInfo to also return undefined
+      const getGroupInfoStub = sandbox
+        .stub(GraphClient.prototype, "getGroupInfo")
+        .resolves(undefined);
+
       // Act
       const result = await removeShareAccess(mockMosToken, mockTitleId, mockEmails);
 
@@ -363,8 +401,9 @@ describe("share", () => {
       assert.isTrue(result.isErr());
       if (result.isErr()) {
         assert.instanceOf(result.error, InputValidationError);
-        assert.include(result.error.message, "Invalid user: user2@example.com");
+        assert.include(result.error.message, "Invalid user or group: user2@example.com");
       }
+      assert.isTrue(getGroupInfoStub.calledOnce);
     });
 
     it("should return error when getSharedUsers fails", async () => {


### PR DESCRIPTION
user story: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/33835755/?view=edit

This pull request enhances the `removeShareAccess` functionality to support removing group access in addition to user access. If a provided email does not correspond to a user, the code now checks if it matches a group and removes access accordingly. The test suite has also been updated to cover these new scenarios.

**Enhancements to group and user access removal:**

* Updated `removeShareAccess` in `share.ts` to check for group info if user info is not found, allowing removal of group access by email. The error message now reflects invalid users or groups.

**Test coverage improvements:**

* Added a new test in `share.test.ts` to verify that group access is removed when user info isn't found but group info is available.
* Updated an existing test in `share.test.ts` to check that the error message includes "Invalid user or group" and that group info lookup is attempted when both user and group info are missing.