### PR TITLE
fix: playground installation error message

### DIFF
--- a/packages/fx-core/src/component/deps-checker/internal/testToolChecker.ts
+++ b/packages/fx-core/src/component/deps-checker/internal/testToolChecker.ts
@@ -469,8 +469,8 @@ export class TestToolChecker implements DepsChecker {
       await cleanup(prefix);
       // @ is incorrectly identified as an email format.
       this.telemetryProperties[TelemetryProperties.InstallTestToolError] = (error.message as string)
-        ?.split(pkg)
-        ?.join(pkg);
+        ?.split(`${this.npmPackageName}@${versionRange}`)
+        ?.join(`${this.npmPackageName}{at}${versionRange}`);
       throw new DepsCheckerError(
         {
           default: getDefaultString("error.common.InstallSoftwareError", this.name),


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/34475076

Install error message in telemetry is redacted as user email and not able to recognize the real issue.