### PR TITLE
fix: delete title id after removing acquisiations for shared scope DA

### DIFF
--- a/packages/fx-core/src/component/m365/packageService.ts
+++ b/packages/fx-core/src/component/m365/packageService.ts
@@ -437,6 +437,23 @@ export class PackageService {
           Authorization: `Bearer ${token}`,
         },
       });
+
+      if (featureFlagManager.getBooleanValue(FeatureFlags.BuilderAPIEnabled)) {
+        try {
+          await this.axiosInstance.delete(`/builder/v1/users/titles/${titleId}`, {
+            baseURL: serviceUrl,
+            headers: {
+              Authorization: `Bearer ${token}`,
+            },
+          });
+        } catch (error: any) {
+          if (error.response && error.response.status === 404) {
+            this.logger?.debug(`TitleId ${titleId} not found, skip deleting.`);
+          } else {
+            throw error;
+          }
+        }
+      }
       this.logger?.verbose("Unacquiring done.");
     } catch (error: any) {
       if (error.response) {

--- a/packages/fx-core/tests/component/m365/packageService.test.ts
+++ b/packages/fx-core/tests/component/m365/packageService.test.ts
@@ -952,6 +952,36 @@ describe("Package Service", () => {
     chai.assert.isUndefined(actualError);
   });
 
+  it("unacquire happy path - Builder API OFF", async () => {
+    process.env["TEAMSFX_BUILDER_API"] = "0";
+    axiosGetResponses["/config/v1/environment"] = {
+      data: {
+        titlesServiceUrl: "https://test-url",
+      },
+    };
+    axiosDeleteResponses["/catalog/v1/users/acquisitions/test-title-id"] = {};
+
+    let packageService = new PackageService("https://test-endpoint");
+    let actualError: Error | undefined;
+    try {
+      await packageService.unacquire("test-token", "test-title-id");
+    } catch (error: any) {
+      actualError = error;
+    }
+
+    chai.assert.isUndefined(actualError);
+
+    packageService = new PackageService("https://test-endpoint", logger);
+    actualError = undefined;
+    try {
+      await packageService.unacquire("test-token", "test-title-id");
+    } catch (error: any) {
+      actualError = error;
+    }
+
+    chai.assert.isUndefined(actualError);
+  });
+
   it("unacquire happy path for personal scope DA", async () => {
     axiosGetResponses["/config/v1/environment"] = {
       data: {

--- a/packages/fx-core/tests/component/m365/packageService.test.ts
+++ b/packages/fx-core/tests/component/m365/packageService.test.ts
@@ -966,7 +966,7 @@ describe("Package Service", () => {
       message: "test-delete-error",
     };
 
-    const packageService = new PackageService("https://test-endpoint");
+    let packageService = new PackageService("https://test-endpoint");
     let actualError: Error | undefined;
     try {
       await packageService.unacquire("test-token", "test-title-id");
@@ -975,6 +975,41 @@ describe("Package Service", () => {
     }
 
     chai.assert.isUndefined(actualError);
+
+    packageService = new PackageService("https://test-endpoint", logger);
+    actualError = undefined;
+    try {
+      await packageService.unacquire("test-token", "test-title-id");
+    } catch (error: any) {
+      actualError = error;
+    }
+
+    chai.assert.isUndefined(actualError);
+  });
+
+  it("unacquire throws error for shared scope DA", async () => {
+    axiosGetResponses["/config/v1/environment"] = {
+      data: {
+        titlesServiceUrl: "https://test-url",
+      },
+    };
+    axiosDeleteResponses["/catalog/v1/users/acquisitions/test-title-id"] = {};
+    axiosDeleteResponses["/builder/v1/users/titles/test-title-id"] = {
+      response: {
+        status: 401,
+      },
+      message: "test-delete-error",
+    };
+
+    const packageService = new PackageService("https://test-endpoint");
+    let actualError: Error | undefined;
+    try {
+      await packageService.unacquire("test-token", "test-title-id");
+    } catch (error: any) {
+      actualError = error;
+    }
+
+    chai.assert.isDefined(actualError);
   });
 
   it("unacquire throws expected error", async () => {

--- a/packages/fx-core/tests/component/m365/packageService.test.ts
+++ b/packages/fx-core/tests/component/m365/packageService.test.ts
@@ -929,6 +929,7 @@ describe("Package Service", () => {
       },
     };
     axiosDeleteResponses["/catalog/v1/users/acquisitions/test-title-id"] = {};
+    axiosDeleteResponses["/builder/v1/users/titles/test-title-id"] = {};
 
     let packageService = new PackageService("https://test-endpoint");
     let actualError: Error | undefined;
@@ -950,6 +951,32 @@ describe("Package Service", () => {
 
     chai.assert.isUndefined(actualError);
   });
+
+  it("unacquire happy path for personal scope DA", async () => {
+    axiosGetResponses["/config/v1/environment"] = {
+      data: {
+        titlesServiceUrl: "https://test-url",
+      },
+    };
+    axiosDeleteResponses["/catalog/v1/users/acquisitions/test-title-id"] = {};
+    axiosDeleteResponses["/builder/v1/users/titles/test-title-id"] = {
+      response: {
+        status: 404,
+      },
+      message: "test-delete-error",
+    };
+
+    const packageService = new PackageService("https://test-endpoint");
+    let actualError: Error | undefined;
+    try {
+      await packageService.unacquire("test-token", "test-title-id");
+    } catch (error: any) {
+      actualError = error;
+    }
+
+    chai.assert.isUndefined(actualError);
+  });
+
   it("unacquire throws expected error", async () => {
     axiosGetResponses["/config/v1/environment"] = {
       data: {


### PR DESCRIPTION
ADO: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/33952994

For shared scope DA, need to delete acquisition first and then delete title id;
For personal scope DA and apps created with sideloading API, only need to delete acquisition since the title id will be removed when acquisition is deleted;
Safely ignore the 404 error for personal scope DA and apps created with sideloading API as confirmed with MOS team.