### PR TITLE
fix: help link mismatch for DepsCheckerError

### DIFF
--- a/packages/fx-core/src/component/deps-checker/constant/helpLink.ts
+++ b/packages/fx-core/src/component/deps-checker/constant/helpLink.ts
@@ -4,6 +4,8 @@
 export const v3DefaultHelpLink = "https://aka.ms/teamsfx-actions/devtool-install";
 
 export const functionDepsVersionsLink = "https://aka.ms/functions-node-versions";
+export const playgroundInstallationLink = "https://aka.ms/teamsfx-actions/playground-install";
+export const functionToolInstallationLink = "https://aka.ms/teamsfx-actions/function-tool-install";
 
 // TODO: remove this link after clean the useless code.
 export const nodeNotFoundHelpLink = `https://aka.ms/teamsfx-node`;

--- a/packages/fx-core/src/component/deps-checker/internal/funcToolChecker.ts
+++ b/packages/fx-core/src/component/deps-checker/internal/funcToolChecker.ts
@@ -12,7 +12,7 @@ import semver from "semver";
 import * as uuid from "uuid";
 import { getDefaultString, getLocalizedString } from "../../../common/localizeUtils";
 import { DepsCheckerError, InstallSoftwareError, NodejsNotFoundError } from "../../../error";
-import { v3DefaultHelpLink } from "../constant/helpLink";
+import { functionToolInstallationLink, v3DefaultHelpLink } from "../constant/helpLink";
 import { Messages } from "../constant/message";
 import { TelemetryProperties } from "../constant/telemetry";
 import { DependencyStatus, DepsChecker, DepsType, FuncInstallOptions } from "../depsChecker";
@@ -296,10 +296,10 @@ export class FuncToolChecker implements DepsChecker {
     symlinkDir: string | undefined
   ): Promise<DependencyStatus> {
     if (isLinux()) {
-      throw new InstallSoftwareError(funcToolName, v3DefaultHelpLink);
+      throw new InstallSoftwareError(funcToolName, functionToolInstallationLink);
     }
     if (!(await this.hasNPM())) {
-      throw new DepsCheckerError(Messages.needInstallNpm(), v3DefaultHelpLink);
+      throw new DepsCheckerError(Messages.needInstallNpm(), functionToolInstallationLink);
     }
 
     const tmpVersion = `tmp-${uuid.v4().slice(0, 6)}`;
@@ -315,7 +315,7 @@ export class FuncToolChecker implements DepsChecker {
       this.telemetryProperties[TelemetryProperties.InstallFuncError] = funcVersionRes.error.message;
       throw new DepsCheckerError(
         Messages.failToValidateFuncCoreTool(funcVersionRes.error.message),
-        v3DefaultHelpLink
+        functionToolInstallationLink
       );
     }
     this.telemetryProperties[TelemetryProperties.InstalledFuncVersion] =
@@ -416,7 +416,7 @@ export class FuncToolChecker implements DepsChecker {
           default: getDefaultString("error.common.InstallSoftwareError", funcToolName),
           localized: getLocalizedString("error.common.InstallSoftwareError", funcToolName),
         },
-        v3DefaultHelpLink
+        functionToolInstallationLink
       );
     }
   }

--- a/packages/fx-core/src/component/deps-checker/internal/testToolChecker.ts
+++ b/packages/fx-core/src/component/deps-checker/internal/testToolChecker.ts
@@ -12,7 +12,7 @@ import * as url from "url";
 import * as uuid from "uuid";
 import { getDefaultString, getLocalizedString } from "../../../common/localizeUtils";
 import { DepsCheckerError, NodejsNotFoundError } from "../../../error";
-import { v3DefaultHelpLink } from "../constant/helpLink";
+import { playgroundInstallationLink, v3DefaultHelpLink } from "../constant/helpLink";
 import { Messages } from "../constant/message";
 import { TelemetryProperties } from "../constant/telemetry";
 import {
@@ -190,7 +190,7 @@ export class TestToolChecker implements DepsChecker {
       this.telemetryProperties[TelemetryProperties.InstallTestToolError] = versionRes.error.message;
       throw new DepsCheckerError(
         Messages.failToValidateTestTool(versionRes.error.message),
-        v3DefaultHelpLink
+        playgroundInstallationLink
       );
     }
     const actualVersion = versionRes.value;
@@ -476,7 +476,7 @@ export class TestToolChecker implements DepsChecker {
           default: getDefaultString("error.common.InstallSoftwareError", this.name),
           localized: getLocalizedString("error.common.InstallSoftwareError", this.name),
         },
-        v3DefaultHelpLink
+        playgroundInstallationLink
       );
     }
   }
@@ -517,7 +517,7 @@ export class TestToolChecker implements DepsChecker {
           default: getDefaultString("error.common.VersionError", versionRange),
           localized: getLocalizedString("error.common.VersionError", versionRange),
         },
-        v3DefaultHelpLink
+        playgroundInstallationLink
       );
     }
     const release = releases.find((value) => value.version === targetVersion) as GitHubRelease;

--- a/packages/fx-core/src/error/depCheck.ts
+++ b/packages/fx-core/src/error/depCheck.ts
@@ -143,7 +143,7 @@ export class DepsCheckerError extends UserError {
       message: message.default,
       displayMessage: message.localized,
       categories: [ErrorCategory.External],
-      helpLink: NodejsNotRecommendedHelpLink,
+      helpLink,
     };
     super(errorOptions);
   }

--- a/packages/fx-core/tests/component/deps-checker/cases/funcTool.it.ts
+++ b/packages/fx-core/tests/component/deps-checker/cases/funcTool.it.ts
@@ -130,8 +130,8 @@ describe("FuncToolChecker E2E Test", async () => {
     expect(depsInfo.command).to.be.equal("func");
     expect(depsInfo.details.binFolders).to.be.equal(undefined);
     expect(depsInfo.error?.message).to.contains(
-      "Unable to install https://aka.ms/teamsfx-actions/devtool-install.",
-      `Expect error message contains 'Unable to install https://aka.ms/teamsfx-actions/devtool-install.'. Actual error message: ${depsInfo.error?.message}`
+      "Unable to install https://aka.ms/teamsfx-actions/function-tool-install.",
+      `Expect error message contains 'Unable to install https://aka.ms/teamsfx-actions/function-tool-install.'. Actual error message: ${depsInfo.error?.message}`
     );
   });
 


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/34628356

The help link for different error is not using passed link and it's using the same, which bring difficulty for user self-resolve issues.

<img width="1706" height="209" alt="image" src="https://github.com/user-attachments/assets/72832349-fe2d-43de-a481-27bdfe7e3a54" />
