### PR TITLE
fix: do not upgrade yml schema version when higher than v1.8

### DIFF
--- a/packages/fx-core/src/component/driver/util/utils.ts
+++ b/packages/fx-core/src/component/driver/util/utils.ts
@@ -67,7 +67,7 @@ export async function updateVersionForTeamsAppYamlFile(projectPath: string): Pro
           renameClientSecret(document);
         }
 
-        document.set("version", "1.8");
+        document.set("version", "v1.8");
         const docContent = document.toString();
         // yaml-language-server can be like https://aka.ms/teams-toolkit/1.0.0/yaml.schema.json and https://aka.ms/teams-toolkit/v1.2/yaml.schema.json
         const updatedContent = docContent.replace(

--- a/packages/fx-core/src/component/driver/util/utils.ts
+++ b/packages/fx-core/src/component/driver/util/utils.ts
@@ -4,6 +4,7 @@
 import { Inputs } from "@microsoft/teamsfx-api";
 import fs from "fs-extra";
 import path from "path";
+import semver from "semver";
 import { parseDocument } from "yaml";
 import { TOOLS } from "../../../common/globalVars";
 import { YamlFileNames } from "../../../common/versionMetadata";
@@ -55,17 +56,18 @@ export async function updateVersionForTeamsAppYamlFile(projectPath: string): Pro
     if (await fs.pathExists(ymlPath)) {
       const ymlContent = await fs.readFile(ymlPath, "utf-8");
       const document = parseDocument(ymlContent);
-      const version = document.get("version") as string;
-      if (version <= "v1.7") {
-        if (version <= "v1.6") {
+      const version = (document.get("version") as string).slice(1);
+      const validVersion = semver.coerce(version);
+      if (validVersion && semver.lte(validVersion, "1.7.0")) {
+        if (semver.lte(validVersion, "1.6.0")) {
           convertOutputJsonPathToOutputFolder(document);
         }
 
-        if (version === "v1.3") {
+        if (semver.eq(validVersion, "1.3.0")) {
           renameClientSecret(document);
         }
 
-        document.set("version", "v1.8");
+        document.set("version", "1.8");
         const docContent = document.toString();
         // yaml-language-server can be like https://aka.ms/teams-toolkit/1.0.0/yaml.schema.json and https://aka.ms/teams-toolkit/v1.2/yaml.schema.json
         const updatedContent = docContent.replace(


### PR DESCRIPTION
Description:
The existing logic attempts to set yml schema to v1.8 when lower than v1.8 for templates with adaptive cards. Fix the logic to compare version with semver since there's some problems with curent logic

ADO:
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/34648353/?view=edit