### PR TITLE
fix: mismatched feature in DA from existing API spec

### DIFF
--- a/templates/vs/csharp/declarative-agent-with-action-from-existing-api/README.md.tpl
+++ b/templates/vs/csharp/declarative-agent-with-action-from-existing-api/README.md.tpl
@@ -17,7 +17,11 @@ to install the app to.
 
 {{#ApiKey}}
 > [!NOTE]
-> Microsoft 365 Agents Toolkit will ask you for your API key during provision. The API key will be securely stored with [Developer Portal](https://dev.teams.microsoft.com/home) and used by Teams client to access your API in runtime. Microsoft 365 Agents Toolkit will not store your API key.
+> Fill in API Key into `env/.env.*.user`.
+    ```
+    SECRET_API_KEY=<your-api-key>
+    ```
+> The API key will be securely stored with [Developer Portal](https://dev.teams.microsoft.com/home) and used by Teams client to access your API in runtime. Microsoft 365 Agents Toolkit will not store your API key.
 {{/ApiKey}}
 
 {{#OAuth}}

--- a/templates/vs/csharp/declarative-agent-with-action-from-existing-api/env/.env.dev.user.tpl
+++ b/templates/vs/csharp/declarative-agent-with-action-from-existing-api/env/.env.dev.user.tpl
@@ -1,0 +1,6 @@
+# This file includes environment variables that will not be committed to git by default. You can set these environment variables in your CI/CD system for your project.
+
+# Secrets. Keys prefixed with `SECRET_` will be masked in Microsoft 365 Agents Toolkit logs.
+{{#ApiKey}}
+SECRET_API_KEY=
+{{/ApiKey}}

--- a/templates/vs/csharp/declarative-agent-with-action-from-existing-api/m365agents.yml.tpl
+++ b/templates/vs/csharp/declarative-agent-with-action-from-existing-api/m365agents.yml.tpl
@@ -23,6 +23,8 @@ provision:
     with:
       # Name of the API Key
       name: {{ApiSpecAuthName}}
+      # Value of the API Key
+      primaryClientSecret: ${{SECRET_API_KEY}}
       # Teams app ID
       appId: ${{TEAMS_APP_ID}}
       # Path to OpenAPI description document


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/34490269

When not setting `SECRET_API_KEY`, provisioning will raise:
```bash
Failed to Execute lifecycle provision because there are unresolved placeholders ["SECRET_API_KEY"] for action: apiKey/register. Env output: {"TEAMS_APP_ID":"22dea25b-0c91-45ec-a50c-040a93d72273","TEAMS_APP_TENANT_ID":"72f988bf-86f1-41af-91ab-2d7cd011db47"}
Execution summary:

Summary:
(×) Error: Lifecycle stage provision failed.
  (√) Done: teamsApp/create executed successfully.
    (√) Done: app 22dea25b-0c91-45ec-a50c-040a93d72273 created successfully
  (×) Error: apiKey/register failed.
    (×) Error: Unresolved placeholders: SECRET_API_KEY
  (!) Warning: teamsApp/zipAppPackage was not executed.
  (!) Warning: teamsApp/validateAppPackage was not executed.
  (!) Warning: teamsApp/update was not executed.
  (!) Warning: teamsApp/extendToM365 was not executed.

{
  "errorType": "UserError",
  "source": "apiKeyRegister",
  "name": "MissingEnvironmentVariablesError",
  "message": "Missing environment variables 'SECRET_API_KEY' for file: C:\\Users\\zhiyou\\source\\repos\\MyM365Agent24\\MyM365Agent24\\m365agents.yml. Please edit the .env file 'C:\\Users\\zhiyou\\source\\repos\\MyM365Agent24\\MyM365Agent24\\env\\.env.dev' or 'C:\\Users\\zhiyou\\source\\repos\\MyM365Agent24\\MyM365Agent24\\env\\.env.dev.user', or adjust system environment variables. For new Microsoft 365 Agents Toolkit projects, make sure you've run provision or debug to set these variables correctly.",
  "stack": "MissingEnvironmentVariablesError: Missing environment variables 'SECRET_API_KEY' for file: C:\\Users\\zhiyou\\source\\repos\\MyM365Agent24\\MyM365Agent24\\m365agents.yml. Please edit the .env file 'C:\\Users\\zhiyou\\source\\repos\\MyM365Agent24\\MyM365Agent24\\env\\.env.dev' or 'C:\\Users\\zhiyou\\source\\repos\\MyM365Agent24\\MyM365Agent24\\env\\.env.dev.user', or adjust system environment variables. For new Microsoft 365 Agents Toolkit projects, make sure you've run provision or debug to set ...
  "innerError": null,
  "userData": null,
  "timestamp": "2025-09-04T07:31:06.934Z",
  "displayMessage": "Missing environment variables 'SECRET_API_KEY' for file: C:\\Users\\zhiyou\\source\\repos\\MyM365Agent24\\MyM365Agent24\\m365agents.yml. Please edit the .env file 'C:\\Users\\zhiyou\\source\\repos\\MyM365Agent24\\MyM365Agent24\\env\\.env.dev' or 'C:\\Users\\zhiyou\\source\\repos\\MyM365Agent24\\MyM365Agent24\\env\\.env.dev.user', or adjust system environment variables. For new Microsoft 365 Agents Toolkit projects, make sure you've run provision or debug to set these variables correctly...
  "helpLink": "https://aka.ms/teamsfx-v5.0-guide#environments",
  "issueLink": null
}
```

When setting `SECRET_API_KEY`, provisioning will succeed.