### PR TITLE
fix: add help link when user meet error for uploading da package

### DIFF
--- a/packages/fx-core/src/component/m365/constants.ts
+++ b/packages/fx-core/src/component/m365/constants.ts
@@ -11,3 +11,4 @@ export const outlookCopilotAppId = "d870f6cd-4aa5-4d42-9626-ab690c041429";
 export const outlookBaseUrl = "https://outlook.office.com";
 export const officeBaseUrl = "https://www.office.com";
 export const advancedDASettingUrl = "https://aka.ms/atk-actions/teamsapp-extendToM365";
+export const M365HelpLink = "https://aka.ms/teamsfx-actions/teamsapp-extendToM365";

--- a/packages/fx-core/src/component/m365/errors.ts
+++ b/packages/fx-core/src/component/m365/errors.ts
@@ -4,6 +4,7 @@
 import { UserError } from "@microsoft/teamsfx-api";
 
 import { getDefaultString, getLocalizedString } from "../../common/localizeUtils";
+import { M365HelpLink } from "./constants";
 
 export class NotExtendedToM365Error extends UserError {
   constructor(source: string) {
@@ -12,7 +13,7 @@ export class NotExtendedToM365Error extends UserError {
       name: "NotExtendedToM365Error",
       message: getDefaultString("error.m365.NotExtendedToM365Error"),
       displayMessage: getLocalizedString("error.m365.NotExtendedToM365Error"),
-      helpLink: "https://aka.ms/teamsfx-actions/teamsapp-extendToM365",
+      helpLink: M365HelpLink,
     });
   }
 }

--- a/packages/fx-core/src/component/m365/packageService.ts
+++ b/packages/fx-core/src/component/m365/packageService.ts
@@ -35,7 +35,7 @@ import { NotExtendedToM365Error } from "./errors";
 import { M365AppDefinition, M365AppEntity } from "./interface";
 import { MosServiceEndpoint } from "./serviceConstant";
 import { getDefaultString, getLocalizedString } from "../../common/localizeUtils";
-import { advancedDASettingUrl } from "./constants";
+import { advancedDASettingUrl, M365HelpLink } from "./constants";
 
 const M365ErrorSource = "M365";
 const M365ErrorComponent = "PackageService";
@@ -257,7 +257,11 @@ export class PackageService {
       if (error.response) {
         error = this.traceError(error);
       }
-      throw assembleError(error, M365ErrorSource);
+      const err = assembleError(error, M365ErrorSource);
+      if (err instanceof UserError) {
+        err.helpLink = M365HelpLink;
+      }
+      throw err;
     }
   }
 


### PR DESCRIPTION
Provide help link when user failed to upload package. Reuse the existing aka link and I'll update the wiki content later
ADO: fix #2.1 in https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/34648353/?view=edit
Screenshot:
<img width="3006" height="850" alt="image" src="https://github.com/user-attachments/assets/da0e5103-c6a4-47d5-8abb-62e34cb08898" />
