### PR TITLE
fix: reame link to teams ai v2

### DIFF
--- a/templates/vsc/js/command-and-response/README.md.tpl
+++ b/templates/vsc/js/command-and-response/README.md.tpl
@@ -223,5 +223,5 @@ Adaptive cards can be updated on user action to allow user progress through a se
 - [Collaborate with others](https://docs.microsoft.com/microsoftteams/platform/toolkit/teamsfx-collaboration)
 - [Microsoft 365 Agents Toolkit Documentations](https://docs.microsoft.com/microsoftteams/platform/toolkit/teams-toolkit-fundamentals)
 - [Microsoft 365 Agents Toolkit CLI](https://aka.ms/teamsfx-toolkit-cli)
-- [Teams AI SDK V2](https://learn.microsoft.com/en-us/microsoftteams/platform/teams-ai-library/welcome)
+- [Teams AI SDK V2](https://aka.ms/teams-ai-library-v2)
 - [Microsoft 365 Agents Toolkit Samples](https://github.com/OfficeDev/TeamsFx-Samples)

--- a/templates/vsc/js/custom-copilot-rag-azure-ai-search/README.md.tpl
+++ b/templates/vsc/js/custom-copilot-rag-azure-ai-search/README.md.tpl
@@ -4,7 +4,7 @@ This app template showcases how to build one of the most powerful applications e
 This app template also demonstrates usage of techniques like: 
 - [Retrieval Augmented Generation](https://python.langchain.com/docs/use_cases/question_answering/#what-is-rag), or RAG.
 - [Azure AI Search](https://learn.microsoft.com/azure/search/search-what-is-azure-search)
-- [Teams AI library V2](https://learn.microsoft.com/microsoftteams/platform/bots/how-to/teams%20conversational%20ai/teams-conversation-ai-overview)
+- [Teams AI library V2](https://aka.ms/teams-ai-library-v2)
 
 ## Get started with the template
 

--- a/templates/vsc/ts/workflow/README.md.tpl
+++ b/templates/vsc/ts/workflow/README.md.tpl
@@ -232,5 +232,5 @@ The command and response feature adds the ability for your application to "liste
 - [Collaborate with others](https://docs.microsoft.com/microsoftteams/platform/toolkit/teamsfx-collaboration)
 - [Microsoft 365 Agents Toolkit Documentations](https://docs.microsoft.com/microsoftteams/platform/toolkit/teams-toolkit-fundamentals)
 - [Microsoft 365 Agents Toolkit CLI](https://aka.ms/teamsfx-toolkit-cli)
-- [Teams AI SDK](https://learn.microsoft.com/en-us/microsoftteams/platform/teams-ai-library/welcome)
+- [Teams AI SDK](https://aka.ms/teams-ai-library-v2)
 - [Microsoft 365 Agents Toolkit Samples](https://github.com/OfficeDev/TeamsFx-Samples)


### PR DESCRIPTION
[Bug 34903446](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/34903446): [VSC] Teams AI V2 page not updated in some template readme files