### PR TITLE
The E2E pipeline totally failure due to the azure-function-core upgrade.

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -207,7 +207,11 @@ jobs:
           sudo mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg
           sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-$(lsb_release -cs)-prod $(lsb_release -cs) main" > /etc/apt/sources.list.d/dotnetdev.list'
           sudo apt-get update
-          sudo apt-get install azure-functions-core-tools-4
+          # sudo apt-get install azure-functions-core-tools-4
+          # As a temporary solution
+          sudo apt-get remove azure-functions-core-tools-4
+          rm -rf /usr/lib/azure-functions-core-tools-4
+          npm i -g azure-functions-core-tools@4
           which func
           func --version
         timeout-minutes: 5


### PR DESCRIPTION
According to the previous pipeline result:
https://github.com/OfficeDev/microsoft-365-agents-toolkit/actions/runs/17756471326

<img width="1653" height="1275" alt="image" src="https://github.com/user-attachments/assets/778a564b-dc91-406a-8476-606be15743da" />



And we found a workaround according to the issue: 
https://github.com/Azure/azure-functions-core-tools/issues/4649