### PR TITLE
fix: template version bump

### DIFF
--- a/packages/fx-core/src/common/templates-config.json
+++ b/packages/fx-core/src/common/templates-config.json
@@ -1,6 +1,6 @@
 {
-    "version": "~6.0",
-    "localVersion": "6.0.0",
+    "version": "~6.2",
+    "localVersion": "6.2.0",
     "tagPrefix": "templates@",
     "vstagPrefix": "templates-vs@",
     "vsversion": "18.0.0",

--- a/templates/package.json
+++ b/templates/package.json
@@ -1,6 +1,6 @@
 {
     "name": "templates",
-    "version": "6.0.0",
+    "version": "6.2.0-alpha",
     "private": "true",
     "license": "MIT",
     "vsversion": "18.0.0",


### PR DESCRIPTION
template version should bump because some templates may not work in ATK 6.0 in the future.