### PR TITLE
test: fix azure func core version issue

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -204,11 +204,7 @@ jobs:
           sudo mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg
           sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-$(lsb_release -cs)-prod $(lsb_release -cs) main" > /etc/apt/sources.list.d/dotnetdev.list'
           sudo apt-get update
-          # sudo apt-get install azure-functions-core-tools-4
-          # As a temporary solution
-          sudo apt-get remove azure-functions-core-tools-4
-          rm -rf /usr/lib/azure-functions-core-tools-4
-          npm i -g azure-functions-core-tools@4
+          sudo apt-get install azure-functions-core-tools-4
           which func
           func --version
         timeout-minutes: 5


### PR DESCRIPTION
The original issue has been resolved: https://github.com/OfficeDev/microsoft-365-agents-toolkit/actions/runs/18400660127
So we can change the version back:

Here is the test result:  https://github.com/OfficeDev/microsoft-365-agents-toolkit/actions/runs/18400660127
