### PR TITLE
fix: build output encoding

### DIFF
--- a/templates/vs/csharp/basic-tab/{{ProjectName}}.csproj.tpl
+++ b/templates/vs/csharp/basic-tab/{{ProjectName}}.csproj.tpl
@@ -47,12 +47,12 @@
   <!-- Run npm steps -->
   <Target Name="NpmInstall" BeforeTargets="BeforeBuild">
     <Message Text="Running npm install..." Importance="high" />
-    <Exec Command="npm install" WorkingDirectory="Web" />
+    <Exec Command="npm install" WorkingDirectory="Web" StdOutEncoding="UTF-8" StdErrEncoding="UTF-8" />
   </Target>
 
   <Target Name="NpmBuild" AfterTargets="NpmInstall" BeforeTargets="BeforeBuild">
     <Message Text="Running npm run build..." Importance="high" />
-    <Exec Command="npm run build" WorkingDirectory="Web" />
+    <Exec Command="npm run build" WorkingDirectory="Web" StdOutEncoding="UTF-8" StdErrEncoding="UTF-8" />
   </Target>
 
   <!-- Dynamically include built frontend files as embedded resources after npm build -->


### PR DESCRIPTION
[Bug 35564805](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/35564805): [VS] There are garbled characters in the output when building a tab project