### PR TITLE
fix: default bot readme & manifest improvement 

### DIFF
--- a/packages/fx-core/src/component/generator/openApiSpec/helper.ts
+++ b/packages/fx-core/src/component/generator/openApiSpec/helper.ts
@@ -1514,7 +1514,7 @@ module.exports = { {{operationId}}Handler };`,
 ):
   path = getattr(parameters, "path", {})
   body = getattr(parameters, "body", None)
-  query = getattr(parameters, "query", {})
+  query = getattr(parameters, "query", {}) or {}
   resp = client.{{operationId}}(**path, json=body, _headers={}, _params=query, _cookies={})
 
   if resp.status_code != 200:

--- a/templates/vsc/python/default-bot/README.md
+++ b/templates/vsc/python/default-bot/README.md
@@ -28,7 +28,9 @@ This template showcases a simple bot designed to respond to user messages within
 
 > For local debugging using Microsoft 365 Agents Toolkit CLI, you need to do some extra steps described in [Set up your Microsoft 365 Agents Toolkit CLI for local debugging](https://aka.ms/teamsfx-cli-debugging).
 
-![echo bot](https://github.com/user-attachments/assets/41b6cf00-bb1e-42b3-af62-022c92844707)
+![echo bot](https://github.com/user-attachments/assets/e0e64bdf-3982-4abf-ae5c-dfc886f0dd82"
+<img width="777" height="153" alt="Screenshot 2025-10-23 144438" src="https://github.com/user-attachments/assets/e0e64bdf-3982-4abf-ae5c-dfc886f0dd82" />
+
 
 ## What's included in the template
 

--- a/templates/vsc/python/default-bot/README.md.tpl
+++ b/templates/vsc/python/default-bot/README.md.tpl
@@ -28,9 +28,7 @@ This template showcases a simple bot designed to respond to user messages within
 
 > For local debugging using Microsoft 365 Agents Toolkit CLI, you need to do some extra steps described in [Set up your Microsoft 365 Agents Toolkit CLI for local debugging](https://aka.ms/teamsfx-cli-debugging).
 
-![echo bot](https://github.com/user-attachments/assets/e0e64bdf-3982-4abf-ae5c-dfc886f0dd82"
-<img width="777" height="153" alt="Screenshot 2025-10-23 144438" src="https://github.com/user-attachments/assets/e0e64bdf-3982-4abf-ae5c-dfc886f0dd82" />
-
+![echo bot](https://github.com/user-attachments/assets/e0e64bdf-3982-4abf-ae5c-dfc886f0dd82)
 
 ## What's included in the template
 

--- a/templates/vsc/python/default-bot/appPackage/manifest.json.tpl
+++ b/templates/vsc/python/default-bot/appPackage/manifest.json.tpl
@@ -29,7 +29,18 @@
         "isNotificationOnly": false,
         "supportsCalling": false,
         "supportsVideo": false,
-        "supportsFiles": false
+        "supportsFiles": false,
+        "commandLists": [
+                {
+                  "scopes": ["personal", "team", "groupChat"],
+                  "commands": [
+                      {
+                          "title": "hi",
+                          "description": "Say hi to the bot."
+                      }
+                  ]
+                }
+            ]
         }
     ],
     "composeExtensions": [],


### PR DESCRIPTION
[Bug 35680578](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/35680578): An image in readme is missing for Bot Python project and no recommended commands