### PR TITLE
feat: enable feature flag for WXP DA and CF shortcut

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -1883,12 +1883,12 @@
         },
         "M365AgentsToolkit.enableDeclarativeAgentInOfficeAddIn": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "markdownDescription": "Enable Declarative Agent support in Office Add-in project."
         },
         "M365AgentsToolkit.enableCustomFunctionShortcutInOfficeAddIn": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "markdownDescription": "Enable Custom function and Shortcut support in Office Add-in project."
         }
       }


### PR DESCRIPTION
This PR aims to enable the following feature flags:

- M365AgentsToolkit.enableCustomFunctionShortcutInOfficeAddIn

- M365AgentsToolkit.enableDeclarativeAgentInOfficeAddIn
Feature link: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/32064569