### PR TITLE
fix: account item tooltip is not read by screen reader

### DIFF
--- a/packages/vscode-extension/src/treeview/account/azureNode.ts
+++ b/packages/vscode-extension/src/treeview/account/azureNode.ts
@@ -84,7 +84,12 @@ export class AzureAccountNode extends DynamicNode {
     this.tooltip = new vscode.MarkdownString(
       localize("teamstoolkit.accountTree.azureAccountTooltip")
     );
-
+    this.accessibilityInformation = {
+      label:
+        (this.label ? (typeof this.label === "string" ? this.label : this.label.label) : "") +
+        ". " +
+        localize("teamstoolkit.accountTree.azureAccountTooltip"),
+    };
     return this;
   }
 }

--- a/packages/vscode-extension/src/treeview/account/m365Node.ts
+++ b/packages/vscode-extension/src/treeview/account/m365Node.ts
@@ -143,6 +143,12 @@ export class M365AccountNode extends DynamicNode {
     } else {
       this.iconPath = m365Icon;
     }
+    this.accessibilityInformation = {
+      label:
+        (this.label ? (typeof this.label === "string" ? this.label : this.label.label) : "") +
+        ". " +
+        localize("teamstoolkit.accountTree.m365AccountTooltip"),
+    };
     return this;
   }
 }

--- a/packages/vscode-extension/test/treeview/account/azureNode.test.ts
+++ b/packages/vscode-extension/test/treeview/account/azureNode.test.ts
@@ -8,6 +8,7 @@ import { AccountItemStatus, azureIcon, loadingIcon } from "../../../src/treeview
 import { DynamicNode } from "../../../src/treeview/dynamicNode";
 import { featureFlagManager } from "@microsoft/teamsfx-core";
 import * as tools from "@microsoft/teamsfx-core/build/common/tools";
+import { localize } from "../../../src/utils/localizeUtils";
 
 describe("AzureNode", () => {
   const sandbox = sinon.createSandbox();
@@ -106,5 +107,30 @@ describe("AzureNode", () => {
   it("getChildren", () => {
     const azureNode = new AzureAccountNode(eventEmitter);
     chai.assert.isNull(azureNode.getChildren());
+  });
+
+  it("accessibility test for azure node", async () => {
+    const azureNode = new AzureAccountNode(eventEmitter);
+    await azureNode.setSignedIn("token", "", "test upn");
+    const treeItem = await azureNode.getTreeItem();
+
+    chai.assert.equal(
+      treeItem.accessibilityInformation?.label,
+      "test upn. " + localize("teamstoolkit.accountTree.azureAccountTooltip")
+    );
+
+    azureNode.label = undefined;
+    const treeItem2 = await azureNode.getTreeItem();
+    chai.assert.equal(
+      treeItem2.accessibilityInformation?.label,
+      ". " + localize("teamstoolkit.accountTree.azureAccountTooltip")
+    );
+
+    azureNode.label = { label: "test label" };
+    const treeItem3 = await azureNode.getTreeItem();
+    chai.assert.equal(
+      treeItem3.accessibilityInformation?.label,
+      "test label. " + localize("teamstoolkit.accountTree.azureAccountTooltip")
+    );
   });
 });

--- a/packages/vscode-extension/test/treeview/account/m365Node.test.ts
+++ b/packages/vscode-extension/test/treeview/account/m365Node.test.ts
@@ -9,6 +9,7 @@ import * as tool from "@microsoft/teamsfx-core/build/common/tools";
 import * as globalVariables from "../../../src/globalVariables";
 import { MockTools } from "../../mocks/mockTools";
 import { ok } from "@microsoft/teamsfx-api";
+import { localize } from "../../../src/utils/localizeUtils";
 
 describe("m365Node", () => {
   const sandbox = sinon.createSandbox();
@@ -19,6 +20,7 @@ describe("m365Node", () => {
   });
 
   it("setSignedIn", async () => {
+    sandbox.stub(globalVariables, "tools").value(new MockTools());
     sandbox
       .stub(globalVariables.tools.tokenProvider.m365TokenProvider, "getAccessToken")
       .resolves(ok(""));
@@ -31,6 +33,35 @@ describe("m365Node", () => {
     chai.assert.equal(treeItem.label, "test upn");
     chai.assert.equal(treeItem.contextValue, "signedinM365");
     chai.assert.equal(treeItem.command, undefined);
+  });
+
+  it("accessibility test for m365 node", async () => {
+    sandbox.stub(globalVariables, "tools").value(new MockTools());
+    sandbox
+      .stub(globalVariables.tools.tokenProvider.m365TokenProvider, "getAccessToken")
+      .resolves(ok(""));
+    const m365Node = new M365AccountNode(eventEmitter);
+    await m365Node.setSignedIn("test upn", "");
+    const treeItem = await m365Node.getTreeItem();
+
+    chai.assert.equal(
+      treeItem.accessibilityInformation?.label,
+      "test upn. " + localize("teamstoolkit.accountTree.m365AccountTooltip")
+    );
+
+    m365Node.label = undefined;
+    const treeItem2 = await m365Node.getTreeItem();
+    chai.assert.equal(
+      treeItem2.accessibilityInformation?.label,
+      ". " + localize("teamstoolkit.accountTree.m365AccountTooltip")
+    );
+
+    m365Node.label = { label: "test label" };
+    const treeItem3 = await m365Node.getTreeItem();
+    chai.assert.equal(
+      treeItem3.accessibilityInformation?.label,
+      "test label. " + localize("teamstoolkit.accountTree.m365AccountTooltip")
+    );
   });
 
   it("setSignedIn - multitenant", async () => {


### PR DESCRIPTION
ADO: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/34629506
Manually set the accessibility info to read both the label and the tooltip