### PR TITLE
fix: read label followed by description for tree view items

### DIFF
--- a/packages/vscode-extension/src/treeview/commandsTreeViewProvider.ts
+++ b/packages/vscode-extension/src/treeview/commandsTreeViewProvider.ts
@@ -23,6 +23,19 @@ export class CommandsTreeViewProvider implements vscode.TreeDataProvider<TreeVie
   }
 
   public getTreeItem(element: TreeViewCommand): vscode.TreeItem {
+    const label = element.label
+      ? typeof element.label === "string"
+        ? element.label
+        : element.label.label
+      : "";
+    const tooltip = element.tooltip
+      ? typeof element.tooltip === "string"
+        ? element.tooltip
+        : element.tooltip.value
+      : "";
+    element.accessibilityInformation = {
+      label: `${label}. ${tooltip}`.trim(),
+    };
     return element;
   }
 

--- a/packages/vscode-extension/test/treeview/commandsTreeViewProvider.test.ts
+++ b/packages/vscode-extension/test/treeview/commandsTreeViewProvider.test.ts
@@ -33,4 +33,22 @@ describe("CommandsTreeViewProvider", () => {
     chai.assert.equal(commands.length, 1);
     chai.assert.equal(commands[0].label, "test");
   });
+
+  it("accessibility tests", async () => {
+    const provider = new CommandsTreeViewProvider([]);
+    const command = new TreeViewCommand("testLabel", "testTooltip");
+    let treeItem = provider.getTreeItem(command);
+
+    chai.assert.equal(treeItem.accessibilityInformation?.label, "testLabel. testTooltip");
+
+    command.label = undefined;
+    command.tooltip = undefined;
+    treeItem = provider.getTreeItem(command);
+    chai.assert.equal(treeItem.accessibilityInformation?.label, ".");
+
+    command.label = { label: "testLabel" };
+    command.tooltip = { value: "testTooltip" } as any;
+    treeItem = provider.getTreeItem(command);
+    chai.assert.equal(treeItem.accessibilityInformation?.label, "testLabel. testTooltip");
+  });
 });


### PR DESCRIPTION
ADO: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/34659131

Let screen reader read label followed by description of the tree view items as suggested by Accessibility team