### PR TITLE
fix: naming of 'regenerate action' command

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -960,7 +960,7 @@
       },
       {
         "command": "fx-extension.regeneratePlugin",
-        "title": "Regenerate Plugin",
+        "title": "Regenerate Action",
         "enablement": "fx-extension.isTeamsFx && isWorkspaceTrusted && !fx-extension.commandLocked && fx-extension.isDeclarativeCopilotApp && fx-extension.isKiotaNPMIntegrationEnabled",
         "category": "Microsoft 365 Agents"
       },


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/35815212
<img width="899" height="120" alt="{77CEB491-6D35-4FC5-B369-2113919E54D7}" src="https://github.com/user-attachments/assets/ecd020f5-992b-4c09-90d2-5027fbf6908e" />
