### PR TITLE
fix: extend retry duration to avoid 429 error

### DIFF
--- a/packages/fx-core/src/component/m365/packageService.ts
+++ b/packages/fx-core/src/component/m365/packageService.ts
@@ -250,7 +250,7 @@ export class PackageService {
           this.logger?.verbose("Sideloading done.");
           return [titleId, appId];
         } else {
-          await waitSeconds(2);
+          await waitSeconds(7);
         }
       } while (true);
     } catch (error: any) {
@@ -323,7 +323,7 @@ export class PackageService {
           this.logger?.verbose("Sideloading done.");
           return [titleId, appId];
         } else {
-          await waitSeconds(2);
+          await waitSeconds(7);
         }
       } while (true);
     } catch (error: any) {

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 > Note: This changelog only includes the changes for the stable versions of Microsoft 365 Agents Toolkit (evolved from Teams Toolkit). For the changelog of pre-released versions, please refer to the [Microsoft 365 Agents Toolkit Pre-release Changelog](https://github.com/OfficeDev/TeamsFx/blob/dev/packages/vscode-extension/PRERELEASE.md).
 
+## 6.4.1 - Nov 17, 2025
+
+Hotfix Version.
+
+### Enhancement
+Increased retry duration for the Check Status API to reduce 429 (Too Many Requests) errors during local debugging or provisioning.
+
 ## 6.4.0 - Nov 14, 2025
 
 Building on the incremental enhancements previously introduced in the [prerelease version](https://github.com/OfficeDev/microsoft-365-agents-toolkit/blob/dev/packages/vscode-extension/PRERELEASE.md), this release brings a streamlined developer experience, deeper Teams integration, and expanded AI capabilities. Below you’ll find a comprehensive list of new features and enhancements included in this release:


### PR DESCRIPTION
Workaround for https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/35750729/?view=edit