### PR TITLE
build(deps): update teamsapp-cli to latest atk cli

### DIFF
--- a/templates/vsc/common/declarative-agent-meta-os-new-project/package.json.tpl
+++ b/templates/vsc/common/declarative-agent-meta-os-new-project/package.json.tpl
@@ -50,7 +50,7 @@
     "html-loader": "^5.0.0",
     "html-webpack-plugin": "^5.6.0",
     "office-addin-cli": "^1.6.3",
-    "office-addin-debugging": "6.0.4",
+    "office-addin-debugging": "6.0.6",
     "office-addin-dev-settings": "3.0.4",
     "office-addin-dev-certs": "^1.13.3",
     "office-addin-lint": "^2.3.3",


### PR DESCRIPTION
For the bug : https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/35934231

Updated the legacy `teamsapp-cli` dependency to the `latest atk cli`. Previously, the Office Add-in script relied on the outdated teamsapp-cli. Updated to v6.0.6 of `office-addin-debugging`.

<img width="1534" height="546" alt="image" src="https://github.com/user-attachments/assets/660ef03a-33f6-4c06-8c8c-acac2ca97897" />

