### PR TITLE
fix: cli test lack llm-service param

### DIFF
--- a/packages/tests/src/e2e/vs/TeamsCollaboratorAgent.dotnet.tests.ts
+++ b/packages/tests/src/e2e/vs/TeamsCollaboratorAgent.dotnet.tests.ts
@@ -80,6 +80,7 @@ describe("Teams Collaborator Agent for csharp version", function () {
       myRecordAzOpenAI["azure-openai-key"] = "fake";
       myRecordAzOpenAI["azure-openai-deployment-name"] = "fake";
       myRecordAzOpenAI["azure-openai-endpoint"] = "https://test.com";
+      myRecordAzOpenAI["llm-service"] = "llm-service-azure-openai";
       const options = Object.entries(myRecordAzOpenAI)
         .map(([key, value]) => "--" + key + " " + value)
         .join(" ");


### PR DESCRIPTION
C# Collaborator agent template: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/35037307

fix e2e test: src/e2e/vs/TeamsCollaboratorAgent.dotnet.tests.ts
e2e test lacks cli option: --llm-service llm-service-azure-openai
the template support azure OpenAI endpoint and OpenAI endpoint.