### PR TITLE
fix: reading server name and identifier

### DIFF
--- a/packages/fx-core/src/component/utils/odrProvider.ts
+++ b/packages/fx-core/src/component/utils/odrProvider.ts
@@ -26,6 +26,19 @@ export interface ODRTool {
 
 export class ODRProvider {
   /**
+   * Check if a server configuration is ODR-based.
+   * @param serverConfig The server configuration object
+   * @returns True if the server is ODR-based, false otherwise
+   */
+  static isODRServer(serverConfig: any): boolean {
+    if (serverConfig?.type !== "stdio" || !serverConfig.command) {
+      return false;
+    }
+    const configCommand = serverConfig.command;
+    return configCommand.toLowerCase() === "odr" || configCommand.toLowerCase().endsWith("odr.exe");
+  }
+
+  /**
    * Parse the output of 'odr list' command
    * @param jsonOutput The JSON output from 'odr list' command
    * @returns Array of parsed ODR servers with their tools
@@ -97,5 +110,23 @@ export class ODRProvider {
       console.error("Error executing odr list:", error);
       return [];
     }
+  }
+
+  /**
+   * Get tools for a specific ODR server by matching command and arguments.
+   * @param command The command of the ODR server (e.g., "odr")
+   * @param args The arguments array for the ODR server
+   * @returns Array of tools from the matching ODR server, or empty array if no match found
+   */
+  static async getToolsForODRServer(command: string, args: string[] = []): Promise<ODRTool[]> {
+    const odrServers = await ODRProvider.listServers();
+
+    const matchingServer = odrServers.find((odrServer) => {
+      return (
+        odrServer.command === command && JSON.stringify(odrServer.args) === JSON.stringify(args)
+      );
+    });
+
+    return matchingServer?.tools || [];
   }
 }

--- a/packages/fx-core/src/component/utils/odrProvider.ts
+++ b/packages/fx-core/src/component/utils/odrProvider.ts
@@ -34,8 +34,8 @@ export class ODRProvider {
     if (serverConfig?.type !== "stdio" || !serverConfig.command) {
       return false;
     }
-    const configCommand = serverConfig.command;
-    return configCommand.toLowerCase() === "odr" || configCommand.toLowerCase().endsWith("odr.exe");
+    const configCommand = serverConfig.command.toLowerCase();
+    return configCommand === "odr" || configCommand.endsWith("odr.exe");
   }
 
   /**

--- a/packages/fx-core/tests/component/utils/odrProvider.test.ts
+++ b/packages/fx-core/tests/component/utils/odrProvider.test.ts
@@ -747,15 +747,6 @@ describe("ODRProvider", () => {
       assert.equal(tools.length, 0);
     });
 
-    it("should return empty array when listServers throws error", async () => {
-      sandbox.stub(ODRProvider, "listServers").rejects(new Error("ODR not available"));
-
-      const tools = await ODRProvider.getToolsForODRServer("odr", ["run", "my-server"]);
-
-      assert.isArray(tools);
-      assert.equal(tools.length, 0);
-    });
-
     it("should match server with empty args array", async () => {
       const mockServers = [
         {

--- a/packages/fx-core/tests/component/utils/odrProvider.test.ts
+++ b/packages/fx-core/tests/component/utils/odrProvider.test.ts
@@ -13,6 +13,46 @@ describe("ODRProvider", () => {
     sandbox.restore();
   });
 
+  describe("isODRServer", () => {
+    it("should return true for ODR server with lowercase odr command", () => {
+      const serverConfig = { type: "stdio", command: "odr" };
+      assert.isTrue(ODRProvider.isODRServer(serverConfig));
+    });
+
+    it("should return true for ODR server with odr.exe command", () => {
+      const serverConfig = { type: "stdio", command: "odr.exe" };
+      assert.isTrue(ODRProvider.isODRServer(serverConfig));
+    });
+
+    it("should return true for ODR server with path ending in odr.exe", () => {
+      const serverConfig = { type: "stdio", command: "C:\\Program Files\\odr.exe" };
+      assert.isTrue(ODRProvider.isODRServer(serverConfig));
+    });
+
+    it("should return false for non-stdio server", () => {
+      const serverConfig = { type: "sse", command: "odr" };
+      assert.isFalse(ODRProvider.isODRServer(serverConfig));
+    });
+
+    it("should return false for server without command", () => {
+      const serverConfig = { type: "stdio" };
+      assert.isFalse(ODRProvider.isODRServer(serverConfig));
+    });
+
+    it("should return false for non-ODR command", () => {
+      const serverConfig = { type: "stdio", command: "node" };
+      assert.isFalse(ODRProvider.isODRServer(serverConfig));
+    });
+
+    it("should return false for null serverConfig", () => {
+      assert.isFalse(ODRProvider.isODRServer(null));
+    });
+
+    it("should return false for undefined serverConfig", () => {
+      assert.isFalse(ODRProvider.isODRServer(undefined));
+    });
+  });
+
   describe("listServers", () => {
     it("should return empty array on non-Windows platform", async () => {
       sandbox.stub(process, "platform").value("darwin"); // macOS
@@ -652,6 +692,114 @@ describe("ODRProvider", () => {
       assert.isArray(servers);
       assert.equal(servers.length, 1);
       assert.equal(servers[0].tools.length, 0);
+    });
+  });
+
+  describe("getToolsForODRServer", () => {
+    it("should return tools for matching ODR server", async () => {
+      const mockServers = [
+        {
+          name: "my-server",
+          display_name: "My Server",
+          description: "Test",
+          version: "1.0.0",
+          identifier: "com.test.server",
+          packageFamily: "TestPackage",
+          command: "odr",
+          args: ["run", "my-server"],
+          tools: [
+            { name: "tool1", description: "Tool 1", inputSchema: { type: "object" } },
+            { name: "tool2", description: "Tool 2", inputSchema: { type: "string" } },
+          ],
+        },
+      ];
+
+      sandbox.stub(ODRProvider, "listServers").resolves(mockServers);
+
+      const tools = await ODRProvider.getToolsForODRServer("odr", ["run", "my-server"]);
+
+      assert.isArray(tools);
+      assert.equal(tools.length, 2);
+      assert.equal(tools[0].name, "tool1");
+      assert.equal(tools[1].name, "tool2");
+    });
+
+    it("should return empty array when no matching server found", async () => {
+      const mockServers = [
+        {
+          name: "my-server",
+          display_name: "My Server",
+          description: "Test",
+          version: "1.0.0",
+          identifier: "com.test.server",
+          packageFamily: "TestPackage",
+          command: "odr",
+          args: ["run", "my-server"],
+          tools: [],
+        },
+      ];
+
+      sandbox.stub(ODRProvider, "listServers").resolves(mockServers);
+
+      const tools = await ODRProvider.getToolsForODRServer("odr", ["run", "different-server"]);
+
+      assert.isArray(tools);
+      assert.equal(tools.length, 0);
+    });
+
+    it("should return empty array when listServers throws error", async () => {
+      sandbox.stub(ODRProvider, "listServers").rejects(new Error("ODR not available"));
+
+      const tools = await ODRProvider.getToolsForODRServer("odr", ["run", "my-server"]);
+
+      assert.isArray(tools);
+      assert.equal(tools.length, 0);
+    });
+
+    it("should match server with empty args array", async () => {
+      const mockServers = [
+        {
+          name: "my-server",
+          display_name: "My Server",
+          description: "Test",
+          version: "1.0.0",
+          identifier: "com.test.server",
+          packageFamily: "TestPackage",
+          command: "odr",
+          args: [],
+          tools: [{ name: "tool1", description: "Tool 1", inputSchema: {} }],
+        },
+      ];
+
+      sandbox.stub(ODRProvider, "listServers").resolves(mockServers);
+
+      const tools = await ODRProvider.getToolsForODRServer("odr", []);
+
+      assert.isArray(tools);
+      assert.equal(tools.length, 1);
+    });
+
+    it("should match server with default empty args when not provided", async () => {
+      const mockServers = [
+        {
+          name: "my-server",
+          display_name: "My Server",
+          description: "Test",
+          version: "1.0.0",
+          identifier: "com.test.server",
+          packageFamily: "TestPackage",
+          command: "odr",
+          args: [],
+          tools: [{ name: "tool1", description: "Tool 1", inputSchema: {} }],
+        },
+      ];
+
+      sandbox.stub(ODRProvider, "listServers").resolves(mockServers);
+
+      const tools = await ODRProvider.getToolsForODRServer("odr");
+
+      assert.isArray(tools);
+      assert.equal(tools.length, 1);
     });
   });
 });

--- a/packages/vscode-extension/package.nls.json
+++ b/packages/vscode-extension/package.nls.json
@@ -648,6 +648,7 @@
   "teamstoolkit.MCP.ContentInvalid": "MCP configuration file content is invalid. Please ensure the content in .vscode/mcp.json is correct.",
   "teamstoolkit.MCP.ServerNotFound": "No MCP server found in the MCP file.",
   "teamstoolkit.MCP.NameOrServerUrlMissing": "MCP name or server URL is missing.",
+  "teamstoolkit.MCP.LocalMcpCommandMissing": "Local MCP command is missing.",
   "teamstoolkit.MCP.ToolsNotFound": "No tools found for the MCP server. Please run the server first.",
   "teamstoolkit.MCP.SelectServerFailed": "Failed to select MCP server."
 }

--- a/packages/vscode-extension/src/error/error.ts
+++ b/packages/vscode-extension/src/error/error.ts
@@ -61,5 +61,6 @@ export enum ExtensionErrors {
   MCPContentInvalid = "MCPContentInvalid",
   MCPServerNotFound = "MCPServerNotFound",
   MCPNameOrServerUrlMissing = "MCPNameOrServerUrlMissing",
+  MCPLocalMcpCommandMissing = "MCPLocalMcpCommandMissing",
   MCPToolsNotFound = "MCPToolsNotFound",
 }

--- a/packages/vscode-extension/src/handlers/updateActionWithMCP.ts
+++ b/packages/vscode-extension/src/handlers/updateActionWithMCP.ts
@@ -57,10 +57,6 @@ async function extractLocalServerIdentifier(
 
       // Match by command and args to find the right ODR server
       const matchingServer = odrServers.find((odrServer) => {
-        if (!serverConfig.command && !serverConfig.args) {
-          return false;
-        }
-
         const configArgs = serverConfig.command
           ? serverConfig.args || []
           : serverConfig.args?.slice(1) || [];
@@ -171,8 +167,6 @@ export async function updateActionWithMCP(args?: any[]): Promise<Result<any, FxE
               detail = args
                 ? `${serverConfig.command as string} ${args}`
                 : (serverConfig.command as string);
-            } else if (serverConfig.args && Array.isArray(serverConfig.args)) {
-              detail = (serverConfig.args as string[]).join(" ");
             } else {
               detail = "stdio";
             }

--- a/packages/vscode-extension/src/handlers/updateActionWithMCP.ts
+++ b/packages/vscode-extension/src/handlers/updateActionWithMCP.ts
@@ -14,7 +14,7 @@ import { ExtTelemetry } from "../telemetry/extTelemetry";
 import { TelemetryEvent } from "../telemetry/extTelemetryEvents";
 import path from "path";
 import * as fs from "fs-extra";
-import { QuestionNames, ODRProvider } from "@microsoft/teamsfx-core";
+import { QuestionNames, ODRProvider, ODRTool } from "@microsoft/teamsfx-core";
 import * as vscode from "vscode";
 import axios from "axios";
 import { runCommand } from "./sharedOpts";
@@ -46,33 +46,27 @@ async function extractLocalServerIdentifier(
   serverConfig: any,
   originalServerName: string
 ): Promise<string> {
-  if (serverConfig?.type !== "stdio" || !serverConfig.command) {
+  if (!ODRProvider.isODRServer(serverConfig)) {
     return originalServerName;
   }
 
-  const configCommand = serverConfig.command;
-  const isODRCommand =
-    configCommand.toLowerCase() === "odr" || configCommand.toLowerCase().endsWith("odr.exe");
+  try {
+    const odrServers = await ODRProvider.listServers();
+    const configCommand = serverConfig.command;
+    const configArgs = serverConfig.args || [];
 
-  if (isODRCommand) {
-    try {
-      const odrServers = await ODRProvider.listServers();
+    // Match by command and args to find the right ODR server
+    const matchingServer = odrServers.find((odrServer) => {
+      return (
+        odrServer.command === configCommand &&
+        JSON.stringify(odrServer.args) === JSON.stringify(configArgs)
+      );
+    });
 
-      // Match by command and args to find the right ODR server
-      const matchingServer = odrServers.find((odrServer) => {
-        const configArgs = serverConfig.args || [];
-
-        return (
-          odrServer.command === configCommand &&
-          JSON.stringify(odrServer.args) === JSON.stringify(configArgs)
-        );
-      });
-
-      if (matchingServer?.identifier) {
-        return matchingServer.identifier;
-      }
-    } catch (error) {}
-  }
+    if (matchingServer?.identifier) {
+      return matchingServer.identifier;
+    }
+  } catch (error) {}
 
   return originalServerName;
 }
@@ -87,6 +81,7 @@ export async function updateActionWithMCP(args?: any[]): Promise<Result<any, FxE
   let server = args && args.length > 0 ? args[0].serverConfig?.url : undefined;
   let command = args && args.length > 0 ? args[0].serverConfig?.command : undefined;
   let isLocalMCP = args && args.length > 0 && args[0].serverConfig?.type === "stdio";
+  let serverConfig = args && args.length > 0 ? args[0].serverConfig : undefined;
 
   // Sanitize mcpName if it's provided as an argument
   if (mcpName) {
@@ -94,7 +89,7 @@ export async function updateActionWithMCP(args?: any[]): Promise<Result<any, FxE
   }
 
   let localServerIdentifier = isLocalMCP
-    ? await extractLocalServerIdentifier(args?.[0].serverConfig, args?.[0].serverName)
+    ? await extractLocalServerIdentifier(serverConfig, args?.[0].serverName)
     : undefined;
 
   if (!mcpName && !server && !isLocalMCP) {
@@ -151,7 +146,7 @@ export async function updateActionWithMCP(args?: any[]): Promise<Result<any, FxE
     }
     if (mcpNames.length === 1) {
       mcpName = sanitizeMCPName(mcpNames[0]);
-      const serverConfig = mcpContent.servers[mcpNames[0]];
+      serverConfig = mcpContent.servers[mcpNames[0]];
       server = serverConfig.url;
       command = serverConfig.command;
       isLocalMCP = serverConfig.type === "stdio";
@@ -187,7 +182,7 @@ export async function updateActionWithMCP(args?: any[]): Promise<Result<any, FxE
       }
       const originalMcpName = result.value.result as string;
       mcpName = sanitizeMCPName(originalMcpName);
-      const serverConfig = mcpContent.servers[originalMcpName];
+      serverConfig = mcpContent.servers[originalMcpName];
       server = serverConfig.url;
       command = serverConfig.command;
       isLocalMCP = serverConfig.type === "stdio";
@@ -224,21 +219,39 @@ export async function updateActionWithMCP(args?: any[]): Promise<Result<any, FxE
     inputs[QuestionNames.MCPLocalServerIdentifier] = localServerIdentifier;
   }
 
-  const allMcpTools = vscode.lm.tools;
-  const tools = allMcpTools
-    .filter((tool: vscode.LanguageModelToolInformation) =>
-      tool.name.toLowerCase().includes(`mcp_${(mcpName as string).toLowerCase()}`)
-    )
-    .map((tool: vscode.LanguageModelToolInformation) => {
-      const index = tool.name.indexOf(mcpName);
-      const newName = tool.name.substring(index + (mcpName as string).length + 1);
-      return {
-        name: newName,
-        description: tool.description,
-        inputSchema: tool.inputSchema,
-        tags: tool.tags,
-      };
-    });
+  let tools: Array<{
+    name: string;
+    description: string;
+    inputSchema: any;
+    tags?: readonly string[];
+  }>;
+  if (ODRProvider.isODRServer(serverConfig)) {
+    const odrTools = await ODRProvider.getToolsForODRServer(
+      serverConfig.command,
+      serverConfig.args || []
+    );
+    tools = odrTools.map((tool: ODRTool) => ({
+      name: tool.name,
+      description: tool.description,
+      inputSchema: tool.inputSchema,
+    }));
+  } else {
+    const allMcpTools = vscode.lm.tools;
+    tools = allMcpTools
+      .filter((tool: vscode.LanguageModelToolInformation) =>
+        tool.name.toLowerCase().includes(`mcp_${(mcpName as string).toLowerCase()}`)
+      )
+      .map((tool: vscode.LanguageModelToolInformation) => {
+        const index = tool.name.indexOf(mcpName);
+        const newName = tool.name.substring(index + (mcpName as string).length + 1);
+        return {
+          name: newName,
+          description: tool.description,
+          inputSchema: tool.inputSchema,
+          tags: tool.tags,
+        };
+      });
+  }
 
   if (tools.length === 0) {
     void vscode.window.showErrorMessage(localize("teamstoolkit.MCP.ToolsNotFound"));

--- a/packages/vscode-extension/src/handlers/updateActionWithMCP.ts
+++ b/packages/vscode-extension/src/handlers/updateActionWithMCP.ts
@@ -14,7 +14,7 @@ import { ExtTelemetry } from "../telemetry/extTelemetry";
 import { TelemetryEvent } from "../telemetry/extTelemetryEvents";
 import path from "path";
 import * as fs from "fs-extra";
-import { QuestionNames } from "@microsoft/teamsfx-core";
+import { QuestionNames, ODRProvider } from "@microsoft/teamsfx-core";
 import * as vscode from "vscode";
 import axios from "axios";
 import { runCommand } from "./sharedOpts";
@@ -30,11 +30,54 @@ function sanitizeMCPName(name: string): string {
   return name
     .replace(/[^a-zA-Z0-9-]+/g, "_")
     .replace(/^_+|_+$/g, "")
-    .substring(0, 13);
+    .substring(0, 13)
+    .toLowerCase();
 }
 
-function extractLocalServerIdentifier(serverConfig: any): string | undefined {
-  return serverConfig?.type === "stdio" ? serverConfig.args?.[2] : undefined;
+/**
+ * Extract local server identifier from serverConfig.
+ * For ODR-based servers, matches against odr list output to get proper identifier.
+ * For non-ODR servers, returns original serverName as fallback.
+ */
+async function extractLocalServerIdentifier(
+  serverConfig: any,
+  originalServerName: string
+): Promise<string> {
+  if (serverConfig?.type !== "stdio") {
+    return originalServerName;
+  }
+
+  const configCommand = serverConfig.command || serverConfig.args?.[0] || "";
+  const isODRCommand =
+    configCommand.toLowerCase() === "odr" || configCommand.toLowerCase().endsWith("odr.exe");
+
+  if (isODRCommand) {
+    try {
+      const odrServers = await ODRProvider.listServers();
+
+      // Match by command and args to find the right ODR server
+      const matchingServer = odrServers.find((odrServer) => {
+        if (!serverConfig.command && !serverConfig.args) {
+          return false;
+        }
+
+        const configArgs = serverConfig.command
+          ? serverConfig.args || []
+          : serverConfig.args?.slice(1) || [];
+
+        return (
+          odrServer.command === configCommand &&
+          JSON.stringify(odrServer.args) === JSON.stringify(configArgs)
+        );
+      });
+
+      if (matchingServer?.identifier) {
+        return matchingServer.identifier;
+      }
+    } catch (error) {}
+  }
+
+  return originalServerName;
 }
 
 export async function updateActionWithMCP(args?: any[]): Promise<Result<any, FxError>> {
@@ -46,14 +89,16 @@ export async function updateActionWithMCP(args?: any[]): Promise<Result<any, FxE
   let mcpName = args && args.length > 0 ? args[0].serverName : undefined;
   let server = args && args.length > 0 ? args[0].serverConfig?.url : undefined;
   let isLocalMCP = args && args.length > 0 && args[0].serverConfig?.type === "stdio";
-  // For stdio type (local MCP), extract identifier from args array (e.g., args[2] contains the identifier)
-  let localServerIdentifier =
-    args && args.length > 0 ? extractLocalServerIdentifier(args[0].serverConfig) : undefined;
 
   // Sanitize mcpName if it's provided as an argument
   if (mcpName) {
     mcpName = sanitizeMCPName(mcpName);
   }
+
+  let localServerIdentifier =
+    args && args.length > 0 && isLocalMCP
+      ? await extractLocalServerIdentifier(args[0].serverConfig, args[0].serverName)
+      : undefined;
 
   if (!mcpName && !server && !isLocalMCP) {
     const projectPath = inputs.projectPath;
@@ -112,18 +157,28 @@ export async function updateActionWithMCP(args?: any[]): Promise<Result<any, FxE
       const serverConfig = mcpContent.servers[mcpNames[0]];
       server = serverConfig.url;
       isLocalMCP = serverConfig.type === "stdio";
-      localServerIdentifier = extractLocalServerIdentifier(serverConfig);
+      localServerIdentifier = await extractLocalServerIdentifier(serverConfig, mcpNames[0]);
     } else {
       const mcpNameSelection: SingleSelectConfig = {
         name: "mcpName",
         title: "Select MCP Server",
         options: mcpNames.map((name) => {
           const serverConfig = mcpContent.servers[name];
-          const identifier = extractLocalServerIdentifier(serverConfig);
-          const detail =
-            serverConfig.type === "stdio"
-              ? `${identifier as string}`
-              : (serverConfig.url as string);
+          let detail: string;
+          if (serverConfig.type === "stdio") {
+            if (serverConfig.command) {
+              const args = serverConfig.args ? (serverConfig.args as string[]).join(" ") : "";
+              detail = args
+                ? `${serverConfig.command as string} ${args}`
+                : (serverConfig.command as string);
+            } else if (serverConfig.args && Array.isArray(serverConfig.args)) {
+              detail = (serverConfig.args as string[]).join(" ");
+            } else {
+              detail = "stdio";
+            }
+          } else {
+            detail = (serverConfig.url as string) || "";
+          }
           return {
             id: name,
             label: name,
@@ -140,11 +195,11 @@ export async function updateActionWithMCP(args?: any[]): Promise<Result<any, FxE
         return err(result.error);
       }
       const originalMcpName = result.value.result as string;
-      mcpName = originalMcpName.replace(/[^a-zA-Z0-9]/g, "").substring(0, 10);
+      mcpName = sanitizeMCPName(originalMcpName);
       const serverConfig = mcpContent.servers[originalMcpName];
       server = serverConfig.url;
       isLocalMCP = serverConfig.type === "stdio";
-      localServerIdentifier = extractLocalServerIdentifier(serverConfig);
+      localServerIdentifier = await extractLocalServerIdentifier(serverConfig, originalMcpName);
     }
   }
 
@@ -162,7 +217,7 @@ export async function updateActionWithMCP(args?: any[]): Promise<Result<any, FxE
 
   inputs[QuestionNames.MCPForDAServerUrl] = server;
   inputs[QuestionNames.MCPForDAServerName] = mcpName;
-  if (isLocalMCP && localServerIdentifier) {
+  if (isLocalMCP) {
     inputs[QuestionNames.MCPLocalServerIdentifier] = localServerIdentifier;
   }
 

--- a/packages/vscode-extension/src/handlers/updateActionWithMCP.ts
+++ b/packages/vscode-extension/src/handlers/updateActionWithMCP.ts
@@ -24,14 +24,17 @@ import { getDefaultString, localize } from "../utils/localizeUtils";
 import { ExtensionErrors } from "../error/error";
 import { getTriggerFromProperty } from "../utils/telemetryUtils";
 
+/**
+ * Sanitize MCP server name to match VS Code's tool prefix generation logic.
+ * Based on VS Code's McpPrefixGenerator class.
+ * See: https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/mcp/common/mcpService.ts#L231
+ */
 function sanitizeMCPName(name: string): string {
-  // Replace special characters except "-" with "_", but if two special characters are adjacent,
-  // only replace with one "_". Finally, substring to the first 13 characters.
+  // VS Code's logic: lowercase, replace non-alphanumeric (except _.-) with _, truncate to 13 chars
   return name
-    .replace(/[^a-zA-Z0-9-]+/g, "_")
-    .replace(/^_+|_+$/g, "")
-    .substring(0, 13)
-    .toLowerCase();
+    .toLowerCase()
+    .replace(/[^a-z0-9_.-]+/g, "_")
+    .slice(0, 13);
 }
 
 /**
@@ -43,11 +46,11 @@ async function extractLocalServerIdentifier(
   serverConfig: any,
   originalServerName: string
 ): Promise<string> {
-  if (serverConfig?.type !== "stdio") {
+  if (serverConfig?.type !== "stdio" || !serverConfig.command) {
     return originalServerName;
   }
 
-  const configCommand = serverConfig.command || serverConfig.args?.[0] || "";
+  const configCommand = serverConfig.command;
   const isODRCommand =
     configCommand.toLowerCase() === "odr" || configCommand.toLowerCase().endsWith("odr.exe");
 
@@ -57,9 +60,7 @@ async function extractLocalServerIdentifier(
 
       // Match by command and args to find the right ODR server
       const matchingServer = odrServers.find((odrServer) => {
-        const configArgs = serverConfig.command
-          ? serverConfig.args || []
-          : serverConfig.args?.slice(1) || [];
+        const configArgs = serverConfig.args || [];
 
         return (
           odrServer.command === configCommand &&
@@ -84,6 +85,7 @@ export async function updateActionWithMCP(args?: any[]): Promise<Result<any, FxE
   const inputs = getSystemInputs();
   let mcpName = args && args.length > 0 ? args[0].serverName : undefined;
   let server = args && args.length > 0 ? args[0].serverConfig?.url : undefined;
+  let command = args && args.length > 0 ? args[0].serverConfig?.command : undefined;
   let isLocalMCP = args && args.length > 0 && args[0].serverConfig?.type === "stdio";
 
   // Sanitize mcpName if it's provided as an argument
@@ -91,10 +93,9 @@ export async function updateActionWithMCP(args?: any[]): Promise<Result<any, FxE
     mcpName = sanitizeMCPName(mcpName);
   }
 
-  let localServerIdentifier =
-    args && args.length > 0 && isLocalMCP
-      ? await extractLocalServerIdentifier(args[0].serverConfig, args[0].serverName)
-      : undefined;
+  let localServerIdentifier = isLocalMCP
+    ? await extractLocalServerIdentifier(args?.[0].serverConfig, args?.[0].serverName)
+    : undefined;
 
   if (!mcpName && !server && !isLocalMCP) {
     const projectPath = inputs.projectPath;
@@ -152,6 +153,7 @@ export async function updateActionWithMCP(args?: any[]): Promise<Result<any, FxE
       mcpName = sanitizeMCPName(mcpNames[0]);
       const serverConfig = mcpContent.servers[mcpNames[0]];
       server = serverConfig.url;
+      command = serverConfig.command;
       isLocalMCP = serverConfig.type === "stdio";
       localServerIdentifier = await extractLocalServerIdentifier(serverConfig, mcpNames[0]);
     } else {
@@ -162,14 +164,9 @@ export async function updateActionWithMCP(args?: any[]): Promise<Result<any, FxE
           const serverConfig = mcpContent.servers[name];
           let detail: string;
           if (serverConfig.type === "stdio") {
-            if (serverConfig.command) {
-              const args = serverConfig.args ? (serverConfig.args as string[]).join(" ") : "";
-              detail = args
-                ? `${serverConfig.command as string} ${args}`
-                : (serverConfig.command as string);
-            } else {
-              detail = "stdio";
-            }
+            const command = (serverConfig.command as string) || "";
+            const args = serverConfig.args ? (serverConfig.args as string[]).join(" ") : "";
+            detail = args ? `${command} ${args}` : command;
           } else {
             detail = (serverConfig.url as string) || "";
           }
@@ -192,18 +189,30 @@ export async function updateActionWithMCP(args?: any[]): Promise<Result<any, FxE
       mcpName = sanitizeMCPName(originalMcpName);
       const serverConfig = mcpContent.servers[originalMcpName];
       server = serverConfig.url;
+      command = serverConfig.command;
       isLocalMCP = serverConfig.type === "stdio";
       localServerIdentifier = await extractLocalServerIdentifier(serverConfig, originalMcpName);
     }
   }
 
-  if (!mcpName || (!isLocalMCP && !server) || (isLocalMCP && !localServerIdentifier)) {
+  if (!mcpName || (!isLocalMCP && !server)) {
     void vscode.window.showErrorMessage(localize("teamstoolkit.MCP.NameOrServerUrlMissing"));
     const error = new UserError(
       "da-mcp",
       ExtensionErrors.MCPNameOrServerUrlMissing,
       getDefaultString("teamstoolkit.MCP.NameOrServerUrlMissing"),
       localize("teamstoolkit.MCP.NameOrServerUrlMissing")
+    );
+    ExtTelemetry.sendTelemetryErrorEvent(TelemetryEvent.UpdateActionWithMCP, error);
+    return err(error);
+  }
+  if (isLocalMCP && !command) {
+    void vscode.window.showErrorMessage(localize("teamstoolkit.MCP.LocalMcpCommandMissing"));
+    const error = new UserError(
+      "da-mcp",
+      ExtensionErrors.MCPLocalMcpCommandMissing,
+      getDefaultString("teamstoolkit.MCP.LocalMcpCommandMissing"),
+      localize("teamstoolkit.MCP.LocalMcpCommandMissing")
     );
     ExtTelemetry.sendTelemetryErrorEvent(TelemetryEvent.UpdateActionWithMCP, error);
     return err(error);
@@ -218,7 +227,7 @@ export async function updateActionWithMCP(args?: any[]): Promise<Result<any, FxE
   const allMcpTools = vscode.lm.tools;
   const tools = allMcpTools
     .filter((tool: vscode.LanguageModelToolInformation) =>
-      tool.name.includes(`mcp_${mcpName as string}`)
+      tool.name.toLowerCase().includes(`mcp_${(mcpName as string).toLowerCase()}`)
     )
     .map((tool: vscode.LanguageModelToolInformation) => {
       const index = tool.name.indexOf(mcpName);

--- a/packages/vscode-extension/test/handlers/updateActionWithMCP.test.ts
+++ b/packages/vscode-extension/test/handlers/updateActionWithMCP.test.ts
@@ -15,7 +15,7 @@ import * as systemEnvUtils from "../../src/utils/systemEnvUtils";
 import * as sharedOpts from "../../src/handlers/sharedOpts";
 import { ExtTelemetry } from "../../src/telemetry/extTelemetry";
 import * as vscUI from "../../src/qm/vsc_ui";
-import { QuestionNames } from "@microsoft/teamsfx-core";
+import { QuestionNames, ODRProvider } from "@microsoft/teamsfx-core";
 import { MockCore } from "../mocks/mockCore";
 import * as globalVariables from "../../src/globalVariables";
 
@@ -79,13 +79,13 @@ describe("updateActionWithMCP", () => {
       const args = [{ serverName: "testServer", serverConfig: { url: "http://test.com" } }];
       const mockTools = [
         {
-          name: "mcp_testServer_tool1",
+          name: "mcp_testserver_tool1",
           description: "Test tool 1",
           inputSchema: {},
           tags: [],
         },
         {
-          name: "mcp_testServer_tool2",
+          name: "mcp_testserver_tool2",
           description: "Test tool 2",
           inputSchema: {},
           tags: [],
@@ -197,12 +197,13 @@ describe("updateActionWithMCP", () => {
       sinon.assert.calledOnce(runCommandStub);
     });
 
-    it("should process single local MCP server automatically", async () => {
+    it("should process single local MCP server automatically (non-ODR)", async () => {
       const mcpContent = {
         servers: {
           "local-server": {
             type: "stdio",
-            args: ["node", "server.js", "local-identifier"],
+            command: "node",
+            args: ["server.js"],
           },
         },
       };
@@ -222,6 +223,57 @@ describe("updateActionWithMCP", () => {
         .withArgs(expectedPath, "utf-8")
         .returns(JSON.stringify(mcpContent));
       sandbox.stub(parser, "parse").returns(mcpContent);
+      sandbox.stub(vscode.lm, "tools").value(mockTools);
+      const runCommandStub = sandbox.stub(sharedOpts, "runCommand").resolves(ok(undefined));
+
+      const result = await updateActionWithMCP();
+
+      chai.assert.isTrue(result.isOk());
+      sinon.assert.calledOnce(runCommandStub);
+      const calledInputs = runCommandStub.getCall(0).args[1] as Inputs;
+      chai.assert.equal(calledInputs[QuestionNames.MCPLocalServerIdentifier], "local-server");
+    });
+
+    it("should process single local MCP server automatically (ODR)", async () => {
+      const mcpContent = {
+        servers: {
+          "odr-server": {
+            type: "stdio",
+            command: "odr",
+            args: ["run", "my-mcp-server"],
+          },
+        },
+      };
+      const mockTools = [
+        {
+          name: "mcp_odr-server_tool1",
+          description: "Test tool",
+          inputSchema: {},
+          tags: [],
+        },
+      ];
+      const mockODRServers = [
+        {
+          name: "my-mcp-server",
+          display_name: "My MCP Server",
+          description: "Test MCP Server",
+          version: "1.0.0",
+          identifier: "my-mcp-server-id",
+          tools: [],
+          packageFamily: "test.package",
+          command: "odr",
+          args: ["run", "my-mcp-server"],
+        },
+      ];
+
+      const expectedPath = path.join(mockProjectPath, ".vscode", "mcp.json");
+      sandbox.stub(fs, "pathExistsSync").withArgs(expectedPath).returns(true);
+      sandbox
+        .stub(fs, "readFileSync")
+        .withArgs(expectedPath, "utf-8")
+        .returns(JSON.stringify(mcpContent));
+      sandbox.stub(parser, "parse").returns(mcpContent);
+      sandbox.stub(ODRProvider, "listServers").resolves(mockODRServers);
       Object.defineProperty(vscode.lm, "tools", { value: mockTools, configurable: true });
       const runCommandStub = sandbox.stub(sharedOpts, "runCommand").resolves(ok(undefined));
 
@@ -230,7 +282,7 @@ describe("updateActionWithMCP", () => {
       chai.assert.isTrue(result.isOk());
       sinon.assert.calledOnce(runCommandStub);
       const calledInputs = runCommandStub.getCall(0).args[1] as Inputs;
-      chai.assert.equal(calledInputs[QuestionNames.MCPLocalServerIdentifier], "local-identifier");
+      chai.assert.equal(calledInputs[QuestionNames.MCPLocalServerIdentifier], "my-mcp-server-id");
     });
 
     it("should show selection UI for multiple MCP servers", async () => {
@@ -275,13 +327,14 @@ describe("updateActionWithMCP", () => {
           "remote-server": { url: "http://remote.com" },
           "local-server": {
             type: "stdio",
-            args: ["node", "server.js", "local-id"],
+            command: "node",
+            args: ["server.js"],
           },
         },
       };
       const mockTools = [
         {
-          name: "mcp_localserver_tool1",
+          name: "mcp_local-server_tool1",
           description: "Test tool",
           inputSchema: {},
           tags: [],
@@ -295,6 +348,7 @@ describe("updateActionWithMCP", () => {
         .withArgs(expectedPath, "utf-8")
         .returns(JSON.stringify(mcpContent));
       sandbox.stub(parser, "parse").returns(mcpContent);
+      sandbox.stub(ODRProvider, "listServers").resolves([]);
       Object.defineProperty(vscode.lm, "tools", { value: mockTools, configurable: true });
       sandbox.stub(vscUI, "VS_CODE_UI").value({
         selectOption: sandbox.stub().resolves(ok({ type: "success", result: "local-server" })),
@@ -306,7 +360,7 @@ describe("updateActionWithMCP", () => {
       chai.assert.isTrue(result.isOk());
       sinon.assert.calledOnce(runCommandStub);
       const calledInputs = runCommandStub.getCall(0).args[1] as Inputs;
-      chai.assert.equal(calledInputs[QuestionNames.MCPLocalServerIdentifier], "local-id");
+      chai.assert.equal(calledInputs[QuestionNames.MCPLocalServerIdentifier], "local-server");
     });
 
     it("should return error when user cancels server selection", async () => {
@@ -341,7 +395,8 @@ describe("updateActionWithMCP", () => {
           "remote-server": { url: "http://remote.com" },
           "local-server": {
             type: "stdio",
-            args: ["node", "server.js", "my-local-identifier"],
+            command: "node",
+            args: ["server.js", "arg1"],
           },
         },
       };
@@ -375,11 +430,9 @@ describe("updateActionWithMCP", () => {
 
       await updateActionWithMCP();
 
-      // Verify that local server has correct detail with identifier
       const localServerOption = capturedOptions.find((opt: any) => opt.id === "local-server");
-      chai.assert.equal(localServerOption.detail, "my-local-identifier");
+      chai.assert.equal(localServerOption.detail, "node server.js arg1");
 
-      // Verify that remote server has correct detail with URL
       const remoteServerOption = capturedOptions.find((opt: any) => opt.id === "remote-server");
       chai.assert.equal(remoteServerOption.detail, "http://remote.com");
     });
@@ -400,19 +453,19 @@ describe("updateActionWithMCP", () => {
       const args = [{ serverName: "testServer", serverConfig: { url: "http://test.com" } }];
       const mockTools = [
         {
-          name: "mcp_testServer_getTodos",
+          name: "mcp_testserver_getTodos",
           description: "Get todos",
           inputSchema: { type: "object" },
           tags: ["todo"],
         },
         {
-          name: "mcp_testServer_createTodo",
+          name: "mcp_testserver_createTodo",
           description: "Create todo",
           inputSchema: { type: "object" },
           tags: ["todo"],
         },
         {
-          name: "mcp_otherServer_tool", // Should be filtered out
+          name: "mcp_otherserver_tool", // Should be filtered out
           description: "Other tool",
           inputSchema: {},
           tags: [],
@@ -441,7 +494,7 @@ describe("updateActionWithMCP", () => {
     it("should handle no authentication (200 response)", async () => {
       const args = [{ serverName: "testServer", serverConfig: { url: "http://test.com" } }];
       const mockTools = [
-        { name: "mcp_testServer_tool1", description: "Test", inputSchema: {}, tags: [] },
+        { name: "mcp_testserver_tool1", description: "Test", inputSchema: {}, tags: [] },
       ];
 
       sandbox.stub(vscode.lm, "tools").value(mockTools);
@@ -457,7 +510,7 @@ describe("updateActionWithMCP", () => {
     it("should handle OAuth authentication (401 response)", async () => {
       const args = [{ serverName: "testServer", serverConfig: { url: "http://test.com" } }];
       const mockTools = [
-        { name: "mcp_testServer_tool1", description: "Test", inputSchema: {}, tags: [] },
+        { name: "mcp_testserver_tool1", description: "Test", inputSchema: {}, tags: [] },
       ];
       const axiosError = {
         status: 401,
@@ -490,7 +543,7 @@ describe("updateActionWithMCP", () => {
     it("should handle OAuth with well-known URL fallback", async () => {
       const args = [{ serverName: "testServer", serverConfig: { url: "https://api.test.com/v1" } }];
       const mockTools = [
-        { name: "mcp_testServer_tool1", description: "Test", inputSchema: {}, tags: [] },
+        { name: "mcp_testserver_tool1", description: "Test", inputSchema: {}, tags: [] },
       ];
       const axiosError = {
         status: 401,
@@ -520,7 +573,7 @@ describe("updateActionWithMCP", () => {
     it("should handle network errors gracefully", async () => {
       const args = [{ serverName: "testServer", serverConfig: { url: "http://test.com" } }];
       const mockTools = [
-        { name: "mcp_testServer_tool1", description: "Test", inputSchema: {}, tags: [] },
+        { name: "mcp_testserver_tool1", description: "Test", inputSchema: {}, tags: [] },
       ];
       const networkError = new Error("Network error");
 
@@ -539,7 +592,7 @@ describe("updateActionWithMCP", () => {
     it("should set correct input values", async () => {
       const args = [{ serverName: "testServer", serverConfig: { url: "http://test.com" } }];
       const mockTools = [
-        { name: "mcp_testServer_tool1", description: "Test", inputSchema: {}, tags: [] },
+        { name: "mcp_testserver_tool1", description: "Test", inputSchema: {}, tags: [] },
       ];
 
       sandbox.stub(vscode.lm, "tools").value(mockTools);
@@ -550,7 +603,7 @@ describe("updateActionWithMCP", () => {
 
       const calledInputs = runCommandStub.getCall(0).args[1] as Inputs;
       chai.assert.equal(calledInputs[QuestionNames.MCPForDAServerUrl], "http://test.com");
-      chai.assert.equal(calledInputs[QuestionNames.MCPForDAServerName], "testServer");
+      chai.assert.equal(calledInputs[QuestionNames.MCPForDAServerName], "testserver");
       chai.assert.isArray(calledInputs[QuestionNames.MCPForDAAvailableTools]);
       chai.assert.equal(calledInputs[QuestionNames.MCPForDAAuth], "NoneAuth");
     });
@@ -558,7 +611,7 @@ describe("updateActionWithMCP", () => {
     it("should propagate runCommand errors", async () => {
       const args = [{ serverName: "testServer", serverConfig: { url: "http://test.com" } }];
       const mockTools = [
-        { name: "mcp_testServer_tool1", description: "Test", inputSchema: {}, tags: [] },
+        { name: "mcp_testserver_tool1", description: "Test", inputSchema: {}, tags: [] },
       ];
       const runCommandError = new UserError("test", "RunCommandError", "Run command failed");
 
@@ -600,7 +653,7 @@ describe("updateActionWithMCP", () => {
         },
       ];
       const mockTools = [
-        { name: "mcp_testServer_tool1", description: "Test", inputSchema: {}, tags: [] },
+        { name: "mcp_testserver_tool1", description: "Test", inputSchema: {}, tags: [] },
       ];
 
       sandbox.stub(vscode.lm, "tools").value(mockTools);
@@ -614,28 +667,67 @@ describe("updateActionWithMCP", () => {
       chai.assert.isUndefined(calledInputs[QuestionNames.MCPLocalServerIdentifier]);
     });
 
-    it("should handle local MCP with stdio type", async () => {
+    it("should handle local MCP with stdio type (non-ODR)", async () => {
       const args = [
         {
           serverName: "localServer",
-          serverConfig: { type: "stdio", args: ["node", "server.js", "local-identifier"] },
+          serverConfig: { type: "stdio", command: "node", args: ["server.js"] },
         },
       ];
       const mockTools = [
-        { name: "mcp_localServer_tool1", description: "Test", inputSchema: {}, tags: [] },
+        { name: "mcp_localserver_tool1", description: "Test", inputSchema: {}, tags: [] },
       ];
 
       sandbox.stub(vscode.lm, "tools").value(mockTools);
+      sandbox.stub(ODRProvider, "listServers").resolves([]);
       const runCommandStub = sandbox.stub(sharedOpts, "runCommand").resolves(ok(undefined));
 
       const result = await updateActionWithMCP(args);
 
       chai.assert.isTrue(result.isOk());
       const calledInputs = runCommandStub.getCall(0).args[1] as Inputs;
-      chai.assert.equal(calledInputs[QuestionNames.MCPLocalServerIdentifier], "local-identifier");
+      chai.assert.equal(calledInputs[QuestionNames.MCPLocalServerIdentifier], "localServer");
     });
 
-    it("should error when local MCP missing identifier", async () => {
+    it("should handle local MCP with stdio type (ODR)", async () => {
+      const args = [
+        {
+          serverName: "odrServer",
+          serverConfig: { type: "stdio", command: "odr", args: ["run", "my-server"] },
+        },
+      ];
+      const mockTools = [
+        { name: "mcp_odrserver_tool1", description: "Test", inputSchema: {}, tags: [] },
+      ];
+      const mockODRServers = [
+        {
+          name: "my-server",
+          display_name: "My Server",
+          description: "Test Server",
+          version: "1.0.0",
+          identifier: "my-server-identifier",
+          tools: [],
+          packageFamily: "test.package",
+          command: "odr",
+          args: ["run", "my-server"],
+        },
+      ];
+
+      sandbox.stub(vscode.lm, "tools").value(mockTools);
+      sandbox.stub(ODRProvider, "listServers").resolves(mockODRServers);
+      const runCommandStub = sandbox.stub(sharedOpts, "runCommand").resolves(ok(undefined));
+
+      const result = await updateActionWithMCP(args);
+
+      chai.assert.isTrue(result.isOk());
+      const calledInputs = runCommandStub.getCall(0).args[1] as Inputs;
+      chai.assert.equal(
+        calledInputs[QuestionNames.MCPLocalServerIdentifier],
+        "my-server-identifier"
+      );
+    });
+
+    it("should handle local MCP with only stdio type using serverName as identifier", async () => {
       const args = [
         {
           serverName: "localServer",
@@ -643,46 +735,57 @@ describe("updateActionWithMCP", () => {
         },
       ];
       const mockTools = [
-        { name: "mcp_localServer_tool1", description: "Test", inputSchema: {}, tags: [] },
+        { name: "mcp_localserver_tool1", description: "Test", inputSchema: {}, tags: [] },
       ];
 
       sandbox.stub(vscode.lm, "tools").value(mockTools);
+      sandbox.stub(ODRProvider, "listServers").resolves([]);
+      const runCommandStub = sandbox.stub(sharedOpts, "runCommand").resolves(ok(undefined));
 
       const result = await updateActionWithMCP(args);
 
-      chai.assert.isTrue(result.isErr());
+      chai.assert.isTrue(result.isOk());
+      const calledInputs = runCommandStub.getCall(0).args[1] as Inputs;
+      // Should use original server name as identifier for non-ODR local server
+      chai.assert.equal(calledInputs[QuestionNames.MCPLocalServerIdentifier], "localServer");
     });
 
-    it("should error when local MCP missing identifier from args array", async () => {
+    it("should handle ODR server when ODRProvider fails gracefully", async () => {
       const args = [
         {
-          serverName: "localServer",
-          serverConfig: { type: "stdio", args: ["node", "server.js"] },
+          serverName: "odrServer",
+          serverConfig: { type: "stdio", command: "odr", args: ["run", "my-server"] },
         },
       ];
       const mockTools = [
-        { name: "mcp_localServer_tool1", description: "Test", inputSchema: {}, tags: [] },
+        { name: "mcp_odrserver_tool1", description: "Test", inputSchema: {}, tags: [] },
       ];
 
       sandbox.stub(vscode.lm, "tools").value(mockTools);
+      sandbox.stub(ODRProvider, "listServers").rejects(new Error("ODR not available"));
+      const runCommandStub = sandbox.stub(sharedOpts, "runCommand").resolves(ok(undefined));
 
       const result = await updateActionWithMCP(args);
 
-      chai.assert.isTrue(result.isErr());
+      chai.assert.isTrue(result.isOk());
+      const calledInputs = runCommandStub.getCall(0).args[1] as Inputs;
+      // Should fallback to original server name when ODRProvider fails
+      chai.assert.equal(calledInputs[QuestionNames.MCPLocalServerIdentifier], "odrServer");
     });
 
     it("should set mcp-type to local for stdio servers", async () => {
       const args = [
         {
           serverName: "localServer",
-          serverConfig: { type: "stdio", args: ["node", "server.js", "local-id"] },
+          serverConfig: { type: "stdio", command: "node", args: ["server.js"] },
         },
       ];
       const mockTools = [
-        { name: "mcp_localServer_tool1", description: "Test", inputSchema: {}, tags: [] },
+        { name: "mcp_localserver_tool1", description: "Test", inputSchema: {}, tags: [] },
       ];
 
       sandbox.stub(vscode.lm, "tools").value(mockTools);
+      sandbox.stub(ODRProvider, "listServers").resolves([]);
       sandbox.stub(sharedOpts, "runCommand").resolves(ok(undefined));
 
       await updateActionWithMCP(args);
@@ -694,7 +797,7 @@ describe("updateActionWithMCP", () => {
     it("should set mcp-type to remote for non-stdio servers", async () => {
       const args = [{ serverName: "remoteServer", serverConfig: { url: "http://remote.com" } }];
       const mockTools = [
-        { name: "mcp_remoteServer_tool1", description: "Test", inputSchema: {}, tags: [] },
+        { name: "mcp_remoteserver_tool1", description: "Test", inputSchema: {}, tags: [] },
       ];
 
       sandbox.stub(vscode.lm, "tools").value(mockTools);
@@ -711,15 +814,16 @@ describe("updateActionWithMCP", () => {
       const args = [
         {
           serverName: "localServer",
-          serverConfig: { type: "stdio", args: ["node", "server.js", "local-id"] },
+          serverConfig: { type: "stdio", command: "node", args: ["server.js"] },
         },
       ];
       const mockTools = [
-        { name: "mcp_localServer_tool1", description: "Test", inputSchema: {}, tags: [] },
+        { name: "mcp_localserver_tool1", description: "Test", inputSchema: {}, tags: [] },
       ];
       const runCommandError = new UserError("test", "RunCommandError", "Run command failed");
 
       sandbox.stub(vscode.lm, "tools").value(mockTools);
+      sandbox.stub(ODRProvider, "listServers").resolves([]);
       sandbox.stub(sharedOpts, "runCommand").resolves(err(runCommandError));
 
       await updateActionWithMCP(args);
@@ -731,7 +835,7 @@ describe("updateActionWithMCP", () => {
     it("should handle 401 error with no response headers", async () => {
       const args = [{ serverName: "testServer", serverConfig: { url: "http://test.com" } }];
       const mockTools = [
-        { name: "mcp_testServer_tool1", description: "Test", inputSchema: {}, tags: [] },
+        { name: "mcp_testserver_tool1", description: "Test", inputSchema: {}, tags: [] },
       ];
       const axiosError = {
         status: 401,
@@ -755,7 +859,7 @@ describe("updateActionWithMCP", () => {
     it("should parse www-authenticate header with match", async () => {
       const args = [{ serverName: "testServer", serverConfig: { url: "http://test.com" } }];
       const mockTools = [
-        { name: "mcp_testServer_tool1", description: "Test", inputSchema: {}, tags: [] },
+        { name: "mcp_testserver_tool1", description: "Test", inputSchema: {}, tags: [] },
       ];
       const axiosError = {
         status: 401,
@@ -783,14 +887,15 @@ describe("updateActionWithMCP", () => {
       const args = [
         {
           serverName: "localServer",
-          serverConfig: { type: "stdio", args: ["node", "server.js", "local-id"] },
+          serverConfig: { type: "stdio", command: "node", args: ["server.js"] },
         },
       ];
       const mockTools = [
-        { name: "mcp_localServer_tool1", description: "Test", inputSchema: {}, tags: [] },
+        { name: "mcp_localserver_tool1", description: "Test", inputSchema: {}, tags: [] },
       ];
 
       sandbox.stub(vscode.lm, "tools").value(mockTools);
+      sandbox.stub(ODRProvider, "listServers").resolves([]);
       const axiosStub = sandbox.stub(axios, "get");
       const runCommandStub = sandbox.stub(sharedOpts, "runCommand").resolves(ok(undefined));
 

--- a/packages/vscode-extension/test/handlers/updateActionWithMCP.test.ts
+++ b/packages/vscode-extension/test/handlers/updateActionWithMCP.test.ts
@@ -670,34 +670,11 @@ describe("updateActionWithMCP", () => {
   });
 
   describe("edge cases", () => {
-    it("should handle args with serverConfig but no url (local MCP missing identifier)", async () => {
-      const args = [
-        {
-          serverName: "localServer",
-          serverConfig: { type: "stdio" }, // No command or args, identifier extraction should fail
-        },
-      ];
-      const mockTools = [
-        { name: "mcp_localserver_tool1", description: "Test", inputSchema: {}, tags: [] },
-      ];
-
-      sandbox.stub(vscode.lm, "tools").value(mockTools);
-      sandbox.stub(ODRProvider, "listServers").resolves([]);
-      const runCommandStub = sandbox.stub(sharedOpts, "runCommand").resolves(ok(undefined));
-
-      const result = await updateActionWithMCP(args);
-
-      chai.assert.isTrue(result.isOk());
-      const calledInputs = runCommandStub.getCall(0).args[1] as Inputs;
-      chai.assert.equal(calledInputs[QuestionNames.MCPLocalServerIdentifier], "localServer");
-    });
-
-    it("should handle server config with args but no command for detail construction", async () => {
+    it("should handle server config with no command", async () => {
       const mcpContent = {
         servers: {
           "local-server": {
             type: "stdio",
-            args: ["python", "server.py"],
           },
         },
       };
@@ -719,12 +696,10 @@ describe("updateActionWithMCP", () => {
       sandbox.stub(parser, "parse").returns(mcpContent);
       sandbox.stub(ODRProvider, "listServers").resolves([]);
       Object.defineProperty(vscode.lm, "tools", { value: mockTools, configurable: true });
-      const runCommandStub = sandbox.stub(sharedOpts, "runCommand").resolves(ok(undefined));
 
       const result = await updateActionWithMCP();
 
-      chai.assert.isTrue(result.isOk());
-      sinon.assert.calledOnce(runCommandStub);
+      chai.assert.isTrue(result.isErr());
     });
 
     it("should handle server config with empty args for detail fallback", async () => {
@@ -770,49 +745,6 @@ describe("updateActionWithMCP", () => {
 
       const localServerOption = capturedOptions.find((opt: any) => opt.id === "local-server");
       chai.assert.equal(localServerOption.detail, "python");
-    });
-
-    it("should handle server config with no command and no args (stdio fallback)", async () => {
-      const mcpContent = {
-        servers: {
-          "remote-server": { url: "http://remote.com" },
-          "local-server": {
-            type: "stdio",
-          },
-        },
-      };
-      const mockTools = [
-        {
-          name: "mcp_remote-server_tool1",
-          description: "Test tool",
-          inputSchema: {},
-          tags: [],
-        },
-      ];
-
-      const expectedPath = path.join(mockProjectPath, ".vscode", "mcp.json");
-      sandbox.stub(fs, "pathExistsSync").withArgs(expectedPath).returns(true);
-      sandbox
-        .stub(fs, "readFileSync")
-        .withArgs(expectedPath, "utf-8")
-        .returns(JSON.stringify(mcpContent));
-      sandbox.stub(parser, "parse").returns(mcpContent);
-      Object.defineProperty(vscode.lm, "tools", { value: mockTools, configurable: true });
-      sandbox.stub(axios, "get").resolves({ status: 200 });
-
-      let capturedOptions: any;
-      sandbox.stub(vscUI, "VS_CODE_UI").value({
-        selectOption: sandbox.stub().callsFake((config: any) => {
-          capturedOptions = config.options;
-          return Promise.resolve(ok({ type: "success", result: "remote-server" }));
-        }),
-      });
-      sandbox.stub(sharedOpts, "runCommand").resolves(ok(undefined));
-
-      await updateActionWithMCP();
-
-      const localServerOption = capturedOptions.find((opt: any) => opt.id === "local-server");
-      chai.assert.equal(localServerOption.detail, "stdio");
     });
 
     it("should handle remote server config with empty url", async () => {
@@ -956,29 +888,6 @@ describe("updateActionWithMCP", () => {
         calledInputs[QuestionNames.MCPLocalServerIdentifier],
         "my-server-identifier"
       );
-    });
-
-    it("should handle local MCP with only stdio type using serverName as identifier", async () => {
-      const args = [
-        {
-          serverName: "localServer",
-          serverConfig: { type: "stdio" },
-        },
-      ];
-      const mockTools = [
-        { name: "mcp_localserver_tool1", description: "Test", inputSchema: {}, tags: [] },
-      ];
-
-      sandbox.stub(vscode.lm, "tools").value(mockTools);
-      sandbox.stub(ODRProvider, "listServers").resolves([]);
-      const runCommandStub = sandbox.stub(sharedOpts, "runCommand").resolves(ok(undefined));
-
-      const result = await updateActionWithMCP(args);
-
-      chai.assert.isTrue(result.isOk());
-      const calledInputs = runCommandStub.getCall(0).args[1] as Inputs;
-      // Should use original server name as identifier for non-ODR local server
-      chai.assert.equal(calledInputs[QuestionNames.MCPLocalServerIdentifier], "localServer");
     });
 
     it("should handle ODR server when ODRProvider fails gracefully", async () => {
@@ -1136,97 +1045,6 @@ describe("updateActionWithMCP", () => {
       chai.assert.isFalse(axiosStub.called);
       const calledInputs = runCommandStub.getCall(0).args[1] as Inputs;
       chai.assert.equal(calledInputs[QuestionNames.MCPForDAAuth], "NoneAuth");
-    });
-
-    it("should handle server config without type field in selection UI", async () => {
-      const mcpContent = {
-        servers: {
-          "remote-server": { url: "http://remote.com" },
-          "remote-server2": { url: "" },
-        },
-      };
-      const mockTools = [
-        {
-          name: "mcp_remote-server_tool1",
-          description: "Test tool",
-          inputSchema: {},
-          tags: [],
-        },
-      ];
-
-      const expectedPath = path.join(mockProjectPath, ".vscode", "mcp.json");
-      sandbox.stub(fs, "pathExistsSync").withArgs(expectedPath).returns(true);
-      sandbox
-        .stub(fs, "readFileSync")
-        .withArgs(expectedPath, "utf-8")
-        .returns(JSON.stringify(mcpContent));
-      sandbox.stub(parser, "parse").returns(mcpContent);
-      Object.defineProperty(vscode.lm, "tools", { value: mockTools, configurable: true });
-      sandbox.stub(axios, "get").resolves({ status: 200 });
-
-      let capturedOptions: any;
-      sandbox.stub(vscUI, "VS_CODE_UI").value({
-        selectOption: sandbox.stub().callsFake((config: any) => {
-          capturedOptions = config.options;
-          return Promise.resolve(ok({ type: "success", result: "remote-server" }));
-        }),
-      });
-      sandbox.stub(sharedOpts, "runCommand").resolves(ok(undefined));
-
-      await updateActionWithMCP();
-
-      const remoteServer2Option = capturedOptions.find((opt: any) => opt.id === "remote-server2");
-      chai.assert.equal(remoteServer2Option.detail, "");
-    });
-
-    it("should handle ODR server config in mcp.json with only args array", async () => {
-      const mcpContent = {
-        servers: {
-          "odr-server": {
-            type: "stdio",
-            args: ["odr.exe"],
-          },
-        },
-      };
-      const mockTools = [
-        {
-          name: "mcp_odr-server_tool1",
-          description: "Test tool",
-          inputSchema: {},
-          tags: [],
-        },
-      ];
-      const mockODRServers = [
-        {
-          name: "my-server",
-          display_name: "My Server",
-          description: "Test Server",
-          version: "1.0.0",
-          identifier: "my-server-id",
-          tools: [],
-          packageFamily: "test.package",
-          command: "odr",
-          args: ["run", "server"],
-        },
-      ];
-
-      const expectedPath = path.join(mockProjectPath, ".vscode", "mcp.json");
-      sandbox.stub(fs, "pathExistsSync").withArgs(expectedPath).returns(true);
-      sandbox
-        .stub(fs, "readFileSync")
-        .withArgs(expectedPath, "utf-8")
-        .returns(JSON.stringify(mcpContent));
-      sandbox.stub(parser, "parse").returns(mcpContent);
-      sandbox.stub(ODRProvider, "listServers").resolves(mockODRServers);
-      Object.defineProperty(vscode.lm, "tools", { value: mockTools, configurable: true });
-      const runCommandStub = sandbox.stub(sharedOpts, "runCommand").resolves(ok(undefined));
-
-      const result = await updateActionWithMCP();
-
-      chai.assert.isTrue(result.isOk());
-      // Should fallback to original name since args is just ["odr.exe"] which won't match any ODR server
-      const calledInputs = runCommandStub.getCall(0).args[1] as Inputs;
-      chai.assert.equal(calledInputs[QuestionNames.MCPLocalServerIdentifier], "odr-server");
     });
   });
 });

--- a/packages/vscode-extension/test/handlers/updateActionWithMCP.test.ts
+++ b/packages/vscode-extension/test/handlers/updateActionWithMCP.test.ts
@@ -197,6 +197,49 @@ describe("updateActionWithMCP", () => {
       sinon.assert.calledOnce(runCommandStub);
     });
 
+    it("should handle ODR server with command but no args", async () => {
+      const args = [
+        {
+          serverName: "odrServerNoArgs",
+          serverConfig: { type: "stdio", command: "odr" },
+        },
+      ];
+      const mockTools = [
+        {
+          name: "mcp_odrservernoargs_tool1",
+          description: "Test tool",
+          inputSchema: {},
+          tags: [],
+        },
+      ];
+      const mockODRServers = [
+        {
+          name: "my-server-noargs",
+          display_name: "My Server NoArgs",
+          description: "Test Server NoArgs",
+          version: "1.0.0",
+          identifier: "my-server-identifier-noargs",
+          tools: [],
+          packageFamily: "test.package",
+          command: "odr",
+          args: [],
+        },
+      ];
+
+      sandbox.stub(vscode.lm, "tools").value(mockTools);
+      sandbox.stub(ODRProvider, "listServers").resolves(mockODRServers);
+      const runCommandStub = sandbox.stub(sharedOpts, "runCommand").resolves(ok(undefined));
+
+      const result = await updateActionWithMCP(args);
+
+      chai.assert.isTrue(result.isOk());
+      const calledInputs = runCommandStub.getCall(0).args[1] as Inputs;
+      chai.assert.equal(
+        calledInputs[QuestionNames.MCPLocalServerIdentifier],
+        "my-server-identifier-noargs"
+      );
+    });
+
     it("should process single local MCP server automatically (non-ODR)", async () => {
       const mcpContent = {
         servers: {
@@ -1093,6 +1136,97 @@ describe("updateActionWithMCP", () => {
       chai.assert.isFalse(axiosStub.called);
       const calledInputs = runCommandStub.getCall(0).args[1] as Inputs;
       chai.assert.equal(calledInputs[QuestionNames.MCPForDAAuth], "NoneAuth");
+    });
+
+    it("should handle server config without type field in selection UI", async () => {
+      const mcpContent = {
+        servers: {
+          "remote-server": { url: "http://remote.com" },
+          "remote-server2": { url: "" },
+        },
+      };
+      const mockTools = [
+        {
+          name: "mcp_remote-server_tool1",
+          description: "Test tool",
+          inputSchema: {},
+          tags: [],
+        },
+      ];
+
+      const expectedPath = path.join(mockProjectPath, ".vscode", "mcp.json");
+      sandbox.stub(fs, "pathExistsSync").withArgs(expectedPath).returns(true);
+      sandbox
+        .stub(fs, "readFileSync")
+        .withArgs(expectedPath, "utf-8")
+        .returns(JSON.stringify(mcpContent));
+      sandbox.stub(parser, "parse").returns(mcpContent);
+      Object.defineProperty(vscode.lm, "tools", { value: mockTools, configurable: true });
+      sandbox.stub(axios, "get").resolves({ status: 200 });
+
+      let capturedOptions: any;
+      sandbox.stub(vscUI, "VS_CODE_UI").value({
+        selectOption: sandbox.stub().callsFake((config: any) => {
+          capturedOptions = config.options;
+          return Promise.resolve(ok({ type: "success", result: "remote-server" }));
+        }),
+      });
+      sandbox.stub(sharedOpts, "runCommand").resolves(ok(undefined));
+
+      await updateActionWithMCP();
+
+      const remoteServer2Option = capturedOptions.find((opt: any) => opt.id === "remote-server2");
+      chai.assert.equal(remoteServer2Option.detail, "");
+    });
+
+    it("should handle ODR server config in mcp.json with only args array", async () => {
+      const mcpContent = {
+        servers: {
+          "odr-server": {
+            type: "stdio",
+            args: ["odr.exe"],
+          },
+        },
+      };
+      const mockTools = [
+        {
+          name: "mcp_odr-server_tool1",
+          description: "Test tool",
+          inputSchema: {},
+          tags: [],
+        },
+      ];
+      const mockODRServers = [
+        {
+          name: "my-server",
+          display_name: "My Server",
+          description: "Test Server",
+          version: "1.0.0",
+          identifier: "my-server-id",
+          tools: [],
+          packageFamily: "test.package",
+          command: "odr",
+          args: ["run", "server"],
+        },
+      ];
+
+      const expectedPath = path.join(mockProjectPath, ".vscode", "mcp.json");
+      sandbox.stub(fs, "pathExistsSync").withArgs(expectedPath).returns(true);
+      sandbox
+        .stub(fs, "readFileSync")
+        .withArgs(expectedPath, "utf-8")
+        .returns(JSON.stringify(mcpContent));
+      sandbox.stub(parser, "parse").returns(mcpContent);
+      sandbox.stub(ODRProvider, "listServers").resolves(mockODRServers);
+      Object.defineProperty(vscode.lm, "tools", { value: mockTools, configurable: true });
+      const runCommandStub = sandbox.stub(sharedOpts, "runCommand").resolves(ok(undefined));
+
+      const result = await updateActionWithMCP();
+
+      chai.assert.isTrue(result.isOk());
+      // Should fallback to original name since args is just ["odr.exe"] which won't match any ODR server
+      const calledInputs = runCommandStub.getCall(0).args[1] as Inputs;
+      chai.assert.equal(calledInputs[QuestionNames.MCPLocalServerIdentifier], "odr-server");
     });
   });
 });

--- a/packages/vscode-extension/test/handlers/updateActionWithMCP.test.ts
+++ b/packages/vscode-extension/test/handlers/updateActionWithMCP.test.ts
@@ -204,12 +204,11 @@ describe("updateActionWithMCP", () => {
           serverConfig: { type: "stdio", command: "odr" },
         },
       ];
-      const mockTools = [
+      const mockODRTools = [
         {
-          name: "mcp_odrservernoargs_tool1",
+          name: "tool1",
           description: "Test tool",
           inputSchema: {},
-          tags: [],
         },
       ];
       const mockODRServers = [
@@ -219,15 +218,16 @@ describe("updateActionWithMCP", () => {
           description: "Test Server NoArgs",
           version: "1.0.0",
           identifier: "my-server-identifier-noargs",
-          tools: [],
+          tools: mockODRTools,
           packageFamily: "test.package",
           command: "odr",
           args: [],
         },
       ];
 
-      sandbox.stub(vscode.lm, "tools").value(mockTools);
       sandbox.stub(ODRProvider, "listServers").resolves(mockODRServers);
+      sandbox.stub(ODRProvider, "getToolsForODRServer").resolves(mockODRTools);
+      sandbox.stub(ODRProvider, "isODRServer").returns(true);
       const runCommandStub = sandbox.stub(sharedOpts, "runCommand").resolves(ok(undefined));
 
       const result = await updateActionWithMCP(args);
@@ -238,6 +238,8 @@ describe("updateActionWithMCP", () => {
         calledInputs[QuestionNames.MCPLocalServerIdentifier],
         "my-server-identifier-noargs"
       );
+      chai.assert.equal(calledInputs[QuestionNames.MCPForDAAvailableTools].length, 1);
+      chai.assert.equal(calledInputs[QuestionNames.MCPForDAAvailableTools][0].name, "tool1");
     });
 
     it("should process single local MCP server automatically (non-ODR)", async () => {
@@ -287,12 +289,11 @@ describe("updateActionWithMCP", () => {
           },
         },
       };
-      const mockTools = [
+      const mockODRTools = [
         {
-          name: "mcp_odr-server_tool1",
+          name: "tool1",
           description: "Test tool",
           inputSchema: {},
-          tags: [],
         },
       ];
       const mockODRServers = [
@@ -302,7 +303,7 @@ describe("updateActionWithMCP", () => {
           description: "Test MCP Server",
           version: "1.0.0",
           identifier: "my-mcp-server-id",
-          tools: [],
+          tools: mockODRTools,
           packageFamily: "test.package",
           command: "odr",
           args: ["run", "my-mcp-server"],
@@ -317,7 +318,8 @@ describe("updateActionWithMCP", () => {
         .returns(JSON.stringify(mcpContent));
       sandbox.stub(parser, "parse").returns(mcpContent);
       sandbox.stub(ODRProvider, "listServers").resolves(mockODRServers);
-      Object.defineProperty(vscode.lm, "tools", { value: mockTools, configurable: true });
+      sandbox.stub(ODRProvider, "getToolsForODRServer").resolves(mockODRTools);
+      sandbox.stub(ODRProvider, "isODRServer").returns(true);
       const runCommandStub = sandbox.stub(sharedOpts, "runCommand").resolves(ok(undefined));
 
       const result = await updateActionWithMCP();
@@ -326,6 +328,8 @@ describe("updateActionWithMCP", () => {
       sinon.assert.calledOnce(runCommandStub);
       const calledInputs = runCommandStub.getCall(0).args[1] as Inputs;
       chai.assert.equal(calledInputs[QuestionNames.MCPLocalServerIdentifier], "my-mcp-server-id");
+      chai.assert.equal(calledInputs[QuestionNames.MCPForDAAvailableTools].length, 1);
+      chai.assert.equal(calledInputs[QuestionNames.MCPForDAAvailableTools][0].name, "tool1");
     });
 
     it("should show selection UI for multiple MCP servers", async () => {
@@ -859,9 +863,7 @@ describe("updateActionWithMCP", () => {
           serverConfig: { type: "stdio", command: "odr", args: ["run", "my-server"] },
         },
       ];
-      const mockTools = [
-        { name: "mcp_odrserver_tool1", description: "Test", inputSchema: {}, tags: [] },
-      ];
+      const mockODRTools = [{ name: "tool1", description: "Test", inputSchema: {} }];
       const mockODRServers = [
         {
           name: "my-server",
@@ -869,15 +871,16 @@ describe("updateActionWithMCP", () => {
           description: "Test Server",
           version: "1.0.0",
           identifier: "my-server-identifier",
-          tools: [],
+          tools: mockODRTools,
           packageFamily: "test.package",
           command: "odr",
           args: ["run", "my-server"],
         },
       ];
 
-      sandbox.stub(vscode.lm, "tools").value(mockTools);
       sandbox.stub(ODRProvider, "listServers").resolves(mockODRServers);
+      sandbox.stub(ODRProvider, "getToolsForODRServer").resolves(mockODRTools);
+      sandbox.stub(ODRProvider, "isODRServer").returns(true);
       const runCommandStub = sandbox.stub(sharedOpts, "runCommand").resolves(ok(undefined));
 
       const result = await updateActionWithMCP(args);
@@ -888,29 +891,8 @@ describe("updateActionWithMCP", () => {
         calledInputs[QuestionNames.MCPLocalServerIdentifier],
         "my-server-identifier"
       );
-    });
-
-    it("should handle ODR server when ODRProvider fails gracefully", async () => {
-      const args = [
-        {
-          serverName: "odrServer",
-          serverConfig: { type: "stdio", command: "odr", args: ["run", "my-server"] },
-        },
-      ];
-      const mockTools = [
-        { name: "mcp_odrserver_tool1", description: "Test", inputSchema: {}, tags: [] },
-      ];
-
-      sandbox.stub(vscode.lm, "tools").value(mockTools);
-      sandbox.stub(ODRProvider, "listServers").rejects(new Error("ODR not available"));
-      const runCommandStub = sandbox.stub(sharedOpts, "runCommand").resolves(ok(undefined));
-
-      const result = await updateActionWithMCP(args);
-
-      chai.assert.isTrue(result.isOk());
-      const calledInputs = runCommandStub.getCall(0).args[1] as Inputs;
-      // Should fallback to original server name when ODRProvider fails
-      chai.assert.equal(calledInputs[QuestionNames.MCPLocalServerIdentifier], "odrServer");
+      chai.assert.equal(calledInputs[QuestionNames.MCPForDAAvailableTools].length, 1);
+      chai.assert.equal(calledInputs[QuestionNames.MCPForDAAvailableTools][0].name, "tool1");
     });
 
     it("should set mcp-type to local for stdio servers", async () => {
@@ -1067,28 +1049,6 @@ describe("updateActionWithMCP", () => {
       chai.assert.isTrue(result.isOk());
       const calledInputs = runCommandStub.getCall(0).args[1] as Inputs;
       chai.assert.isUndefined(calledInputs[QuestionNames.MCPLocalServerIdentifier]);
-    });
-
-    it("should handle ODRProvider.listServers throwing an error", async () => {
-      const args = [
-        {
-          serverName: "testServer",
-          serverConfig: { type: "stdio", command: "odr.exe", args: ["run", "test-server"] },
-        },
-      ];
-      const mockTools = [
-        { name: "mcp_testserver_tool1", description: "Test tool", inputSchema: {}, tags: [] },
-      ];
-
-      sandbox.stub(vscode.lm, "tools").value(mockTools);
-      sandbox.stub(ODRProvider, "listServers").throws(new Error("ODR error"));
-      const runCommandStub = sandbox.stub(sharedOpts, "runCommand").resolves(ok(undefined));
-
-      const result = await updateActionWithMCP(args);
-
-      chai.assert.isTrue(result.isOk());
-      const calledInputs = runCommandStub.getCall(0).args[1] as Inputs;
-      chai.assert.equal(calledInputs[QuestionNames.MCPLocalServerIdentifier], "testServer");
     });
 
     it("should construct detail with command only when args is undefined", async () => {

--- a/packages/vscode-extension/test/handlers/updateActionWithMCP.test.ts
+++ b/packages/vscode-extension/test/handlers/updateActionWithMCP.test.ts
@@ -1046,5 +1046,88 @@ describe("updateActionWithMCP", () => {
       const calledInputs = runCommandStub.getCall(0).args[1] as Inputs;
       chai.assert.equal(calledInputs[QuestionNames.MCPForDAAuth], "NoneAuth");
     });
+
+    it("should return original server name when serverConfig type is not stdio", async () => {
+      const args = [
+        {
+          serverName: "remoteServer",
+          serverConfig: { type: "sse", url: "http://test.com" },
+        },
+      ];
+      const mockTools = [
+        { name: "mcp_remoteserver_tool1", description: "Test", inputSchema: {}, tags: [] },
+      ];
+
+      sandbox.stub(vscode.lm, "tools").value(mockTools);
+      sandbox.stub(axios, "get").resolves({ status: 200 });
+      const runCommandStub = sandbox.stub(sharedOpts, "runCommand").resolves(ok(undefined));
+
+      const result = await updateActionWithMCP(args);
+
+      chai.assert.isTrue(result.isOk());
+      const calledInputs = runCommandStub.getCall(0).args[1] as Inputs;
+      chai.assert.isUndefined(calledInputs[QuestionNames.MCPLocalServerIdentifier]);
+    });
+
+    it("should handle ODRProvider.listServers throwing an error", async () => {
+      const args = [
+        {
+          serverName: "testServer",
+          serverConfig: { type: "stdio", command: "odr.exe", args: ["run", "test-server"] },
+        },
+      ];
+      const mockTools = [
+        { name: "mcp_testserver_tool1", description: "Test tool", inputSchema: {}, tags: [] },
+      ];
+
+      sandbox.stub(vscode.lm, "tools").value(mockTools);
+      sandbox.stub(ODRProvider, "listServers").throws(new Error("ODR error"));
+      const runCommandStub = sandbox.stub(sharedOpts, "runCommand").resolves(ok(undefined));
+
+      const result = await updateActionWithMCP(args);
+
+      chai.assert.isTrue(result.isOk());
+      const calledInputs = runCommandStub.getCall(0).args[1] as Inputs;
+      chai.assert.equal(calledInputs[QuestionNames.MCPLocalServerIdentifier], "testServer");
+    });
+
+    it("should construct detail with command only when args is undefined", async () => {
+      const mcpContent = {
+        servers: {
+          "test-server": { url: "http://test.com" },
+          "test-server2": {
+            type: "stdio",
+            command: "node",
+          },
+        },
+      };
+      const mockTools = [
+        { name: "mcp_test-server_tool1", description: "Test tool", inputSchema: {}, tags: [] },
+      ];
+
+      const expectedPath = path.join(mockProjectPath, ".vscode", "mcp.json");
+      sandbox.stub(fs, "pathExistsSync").withArgs(expectedPath).returns(true);
+      sandbox
+        .stub(fs, "readFileSync")
+        .withArgs(expectedPath, "utf-8")
+        .returns(JSON.stringify(mcpContent));
+      sandbox.stub(parser, "parse").returns(mcpContent);
+      Object.defineProperty(vscode.lm, "tools", { value: mockTools, configurable: true });
+      sandbox.stub(axios, "get").resolves({ status: 200 });
+
+      let capturedOptions: any;
+      sandbox.stub(vscUI, "VS_CODE_UI").value({
+        selectOption: sandbox.stub().callsFake((config: any) => {
+          capturedOptions = config.options;
+          return Promise.resolve(ok({ type: "success", result: "test-server" }));
+        }),
+      });
+      sandbox.stub(sharedOpts, "runCommand").resolves(ok(undefined));
+
+      await updateActionWithMCP();
+
+      const server2Option = capturedOptions.find((opt: any) => opt.id === "test-server2");
+      chai.assert.equal(server2Option.detail, "node");
+    });
   });
 });

--- a/packages/vscode-extension/test/handlers/updateActionWithMCP.test.ts
+++ b/packages/vscode-extension/test/handlers/updateActionWithMCP.test.ts
@@ -288,13 +288,13 @@ describe("updateActionWithMCP", () => {
     it("should show selection UI for multiple MCP servers", async () => {
       const mcpContent = {
         servers: {
-          server1: { url: "http://server1.com" },
-          server2: { url: "http://server2.com" },
+          "remote-server": { url: "http://remote.com" },
+          "remote-server2": { url: "http://remote2.com" },
         },
       };
       const mockTools = [
         {
-          name: "mcp_server1_tool1",
+          name: "mcp_remote-server_tool1",
           description: "Test tool",
           inputSchema: {},
           tags: [],
@@ -311,7 +311,7 @@ describe("updateActionWithMCP", () => {
       Object.defineProperty(vscode.lm, "tools", { value: mockTools, configurable: true });
       sandbox.stub(axios, "get").resolves({ status: 200 });
       sandbox.stub(vscUI, "VS_CODE_UI").value({
-        selectOption: sandbox.stub().resolves(ok({ type: "success", result: "server1" })),
+        selectOption: sandbox.stub().resolves(ok({ type: "success", result: "remote-server" })),
       });
       const runCommandStub = sandbox.stub(sharedOpts, "runCommand").resolves(ok(undefined));
 
@@ -366,8 +366,8 @@ describe("updateActionWithMCP", () => {
     it("should return error when user cancels server selection", async () => {
       const mcpContent = {
         servers: {
-          server1: { url: "http://server1.com" },
-          server2: { url: "http://server2.com" },
+          "remote-server": { url: "http://remote.com" },
+          "remote-server2": { url: "http://remote2.com" },
         },
       };
 
@@ -627,6 +627,194 @@ describe("updateActionWithMCP", () => {
   });
 
   describe("edge cases", () => {
+    it("should handle args with serverConfig but no url (local MCP missing identifier)", async () => {
+      const args = [
+        {
+          serverName: "localServer",
+          serverConfig: { type: "stdio" }, // No command or args, identifier extraction should fail
+        },
+      ];
+      const mockTools = [
+        { name: "mcp_localserver_tool1", description: "Test", inputSchema: {}, tags: [] },
+      ];
+
+      sandbox.stub(vscode.lm, "tools").value(mockTools);
+      sandbox.stub(ODRProvider, "listServers").resolves([]);
+      const runCommandStub = sandbox.stub(sharedOpts, "runCommand").resolves(ok(undefined));
+
+      const result = await updateActionWithMCP(args);
+
+      chai.assert.isTrue(result.isOk());
+      const calledInputs = runCommandStub.getCall(0).args[1] as Inputs;
+      chai.assert.equal(calledInputs[QuestionNames.MCPLocalServerIdentifier], "localServer");
+    });
+
+    it("should handle server config with args but no command for detail construction", async () => {
+      const mcpContent = {
+        servers: {
+          "local-server": {
+            type: "stdio",
+            args: ["python", "server.py"],
+          },
+        },
+      };
+      const mockTools = [
+        {
+          name: "mcp_local-server_tool1",
+          description: "Test tool",
+          inputSchema: {},
+          tags: [],
+        },
+      ];
+
+      const expectedPath = path.join(mockProjectPath, ".vscode", "mcp.json");
+      sandbox.stub(fs, "pathExistsSync").withArgs(expectedPath).returns(true);
+      sandbox
+        .stub(fs, "readFileSync")
+        .withArgs(expectedPath, "utf-8")
+        .returns(JSON.stringify(mcpContent));
+      sandbox.stub(parser, "parse").returns(mcpContent);
+      sandbox.stub(ODRProvider, "listServers").resolves([]);
+      Object.defineProperty(vscode.lm, "tools", { value: mockTools, configurable: true });
+      const runCommandStub = sandbox.stub(sharedOpts, "runCommand").resolves(ok(undefined));
+
+      const result = await updateActionWithMCP();
+
+      chai.assert.isTrue(result.isOk());
+      sinon.assert.calledOnce(runCommandStub);
+    });
+
+    it("should handle server config with empty args for detail fallback", async () => {
+      const mcpContent = {
+        servers: {
+          "remote-server": { url: "http://remote.com" },
+          "local-server": {
+            type: "stdio",
+            command: "python",
+            args: [],
+          },
+        },
+      };
+      const mockTools = [
+        {
+          name: "mcp_remote-server_tool1",
+          description: "Test tool",
+          inputSchema: {},
+          tags: [],
+        },
+      ];
+
+      const expectedPath = path.join(mockProjectPath, ".vscode", "mcp.json");
+      sandbox.stub(fs, "pathExistsSync").withArgs(expectedPath).returns(true);
+      sandbox
+        .stub(fs, "readFileSync")
+        .withArgs(expectedPath, "utf-8")
+        .returns(JSON.stringify(mcpContent));
+      sandbox.stub(parser, "parse").returns(mcpContent);
+      Object.defineProperty(vscode.lm, "tools", { value: mockTools, configurable: true });
+      sandbox.stub(axios, "get").resolves({ status: 200 });
+
+      let capturedOptions: any;
+      sandbox.stub(vscUI, "VS_CODE_UI").value({
+        selectOption: sandbox.stub().callsFake((config: any) => {
+          capturedOptions = config.options;
+          return Promise.resolve(ok({ type: "success", result: "remote-server" }));
+        }),
+      });
+      sandbox.stub(sharedOpts, "runCommand").resolves(ok(undefined));
+
+      await updateActionWithMCP();
+
+      const localServerOption = capturedOptions.find((opt: any) => opt.id === "local-server");
+      chai.assert.equal(localServerOption.detail, "python");
+    });
+
+    it("should handle server config with no command and no args (stdio fallback)", async () => {
+      const mcpContent = {
+        servers: {
+          "remote-server": { url: "http://remote.com" },
+          "local-server": {
+            type: "stdio",
+          },
+        },
+      };
+      const mockTools = [
+        {
+          name: "mcp_remote-server_tool1",
+          description: "Test tool",
+          inputSchema: {},
+          tags: [],
+        },
+      ];
+
+      const expectedPath = path.join(mockProjectPath, ".vscode", "mcp.json");
+      sandbox.stub(fs, "pathExistsSync").withArgs(expectedPath).returns(true);
+      sandbox
+        .stub(fs, "readFileSync")
+        .withArgs(expectedPath, "utf-8")
+        .returns(JSON.stringify(mcpContent));
+      sandbox.stub(parser, "parse").returns(mcpContent);
+      Object.defineProperty(vscode.lm, "tools", { value: mockTools, configurable: true });
+      sandbox.stub(axios, "get").resolves({ status: 200 });
+
+      let capturedOptions: any;
+      sandbox.stub(vscUI, "VS_CODE_UI").value({
+        selectOption: sandbox.stub().callsFake((config: any) => {
+          capturedOptions = config.options;
+          return Promise.resolve(ok({ type: "success", result: "remote-server" }));
+        }),
+      });
+      sandbox.stub(sharedOpts, "runCommand").resolves(ok(undefined));
+
+      await updateActionWithMCP();
+
+      const localServerOption = capturedOptions.find((opt: any) => opt.id === "local-server");
+      chai.assert.equal(localServerOption.detail, "stdio");
+    });
+
+    it("should handle remote server config with empty url", async () => {
+      const mcpContent = {
+        servers: {
+          "remote-server": { url: "http://remote.com" },
+          "remote-server2": {
+            url: "",
+          },
+        },
+      };
+      const mockTools = [
+        {
+          name: "mcp_remote-server_tool1",
+          description: "Test tool",
+          inputSchema: {},
+          tags: [],
+        },
+      ];
+
+      const expectedPath = path.join(mockProjectPath, ".vscode", "mcp.json");
+      sandbox.stub(fs, "pathExistsSync").withArgs(expectedPath).returns(true);
+      sandbox
+        .stub(fs, "readFileSync")
+        .withArgs(expectedPath, "utf-8")
+        .returns(JSON.stringify(mcpContent));
+      sandbox.stub(parser, "parse").returns(mcpContent);
+      Object.defineProperty(vscode.lm, "tools", { value: mockTools, configurable: true });
+      sandbox.stub(axios, "get").resolves({ status: 200 });
+
+      let capturedOptions: any;
+      sandbox.stub(vscUI, "VS_CODE_UI").value({
+        selectOption: sandbox.stub().callsFake((config: any) => {
+          capturedOptions = config.options;
+          return Promise.resolve(ok({ type: "success", result: "remote-server" }));
+        }),
+      });
+      sandbox.stub(sharedOpts, "runCommand").resolves(ok(undefined));
+
+      await updateActionWithMCP();
+
+      const remoteServer2Option = capturedOptions.find((opt: any) => opt.id === "remote-server2");
+      chai.assert.equal(remoteServer2Option.detail, "");
+    });
+
     it("should handle undefined args", async () => {
       const expectedPath = path.join(mockProjectPath, ".vscode", "mcp.json");
       sandbox.stub(fs, "pathExistsSync").withArgs(expectedPath).returns(false);


### PR DESCRIPTION
Fixing bugs in local MCP:
- Read server name from manifest,
- For non-odr servers, use placeholder in local_endpoint.
- Convert server names to lower case to match vs code format https://github.com/microsoft/vscode/blob/a7a6e5c17bb5a9cbea962be9fdbd80ac09c8c488/src/vs/workbench/contrib/mcp/common/mcpService.ts#L231