### PR TITLE
fix: Skip scaffolding for MetaOS upgrade and handle missing env file in Extend to DA

### DIFF
--- a/packages/fx-core/src/component/generator/officeAddin/generator.ts
+++ b/packages/fx-core/src/component/generator/officeAddin/generator.ts
@@ -139,12 +139,13 @@ export class OfficeAddinGeneratorNew extends DefaultTemplateGenerator {
     const templateName = inputs[QuestionNames.TemplateName];
 
     // Handle the Declarative Agent MetaOS project
-    if (
-      [
-        TemplateNames.DeclarativeAgentMetaOSNewProject,
-        TemplateNames.DeclarativeAgentMetaOSUpgradeProject,
-      ].includes(templateName)
-    ) {
+    // Handle upgrade - NO scaffolding needed
+    if (templateName === TemplateNames.DeclarativeAgentMetaOSUpgradeProject) {
+      return Promise.resolve(ok([]));
+    }
+
+    // Handle new project - needs scaffolding
+    if (templateName === TemplateNames.DeclarativeAgentMetaOSNewProject) {
       return Promise.resolve(
         ok([
           {

--- a/packages/fx-core/src/component/generator/officeAddin/metaOSHelper.ts
+++ b/packages/fx-core/src/component/generator/officeAddin/metaOSHelper.ts
@@ -107,15 +107,22 @@ export class MetaOSHelper {
       manifestPath
     )) as TeamsManifestVDevPreview.TeamsManifestVDevPreview;
 
-    // use dotenvUtil rather than envUtil to avoid touch to the process.env
-    const envVars = dotenvUtil.deserialize(await fse.readFile(envFilePath, { encoding: "utf8" }));
-
     const newUUID = getUuid();
     manifest.id = newUUID;
-    envVars.obj.TEAMS_APP_ID = newUUID;
+
+    // Check if env file exists before trying to read it
+    if (await fse.pathExists(envFilePath)) {
+      const envVars = dotenvUtil.deserialize(await fse.readFile(envFilePath, { encoding: "utf8" }));
+      envVars.obj.TEAMS_APP_ID = newUUID;
+      await fse.writeFile(envFilePath, dotenvUtil.serialize(envVars), { encoding: "utf8" });
+    } else {
+      // If env file doesn't exist, create it with the new UUID
+      await fse.ensureDir(path.join(projectFolder, ENV_FOLDER));
+      const envContent = `TEAMS_APP_ID=${newUUID}\n`;
+      await fse.writeFile(envFilePath, envContent, { encoding: "utf8" });
+    }
 
     await AppManifestUtils.writeTeamsManifest(manifestPath, manifest);
-    await fse.writeFile(envFilePath, dotenvUtil.serialize(envVars), { encoding: "utf8" });
   }
 
   static async extendToDA(projectFolder: string, appName: string): Promise<void> {

--- a/packages/fx-core/tests/common/featureFlags.test.ts
+++ b/packages/fx-core/tests/common/featureFlags.test.ts
@@ -42,6 +42,6 @@ describe("FeatureFlagManager", () => {
   it("listEnabled", async () => {
     mockedEnvRestore = mockedEnv({ TEAMSFX_CLI_DOTNET: "true", SME_OAUTH: "true" });
     const list = featureFlagManager.listEnabled();
-    chai.assert.deepEqual(list, ["TEAMSFX_CLI_DOTNET", "SME_OAUTH"]);
+    chai.assert.deepEqual(list, ["TEAMSFX_CLI_DOTNET", "SME_OAUTH", "TEAMSFX_DA_METAOS"]);
   });
 });

--- a/packages/fx-core/tests/common/featureFlags.test.ts
+++ b/packages/fx-core/tests/common/featureFlags.test.ts
@@ -42,6 +42,6 @@ describe("FeatureFlagManager", () => {
   it("listEnabled", async () => {
     mockedEnvRestore = mockedEnv({ TEAMSFX_CLI_DOTNET: "true", SME_OAUTH: "true" });
     const list = featureFlagManager.listEnabled();
-    chai.assert.deepEqual(list, ["TEAMSFX_CLI_DOTNET", "SME_OAUTH", "TEAMSFX_DA_METAOS"]);
+    chai.assert.deepEqual(list, ["TEAMSFX_CLI_DOTNET", "SME_OAUTH"]);
   });
 });

--- a/packages/fx-core/tests/component/generator/officeAddinGenerator.test.ts
+++ b/packages/fx-core/tests/component/generator/officeAddinGenerator.test.ts
@@ -512,6 +512,20 @@ describe("OfficeAddinGeneratorNew", () => {
       chai.assert.isTrue(res.isOk());
     });
 
+    it("getTemplateInfos: DeclarativeAgentMetaOSNewProject should return empty array", async () => {
+      const inputs: Inputs = {
+        platform: Platform.VSCode,
+        projectPath: "./",
+      };
+      inputs[QuestionNames.TemplateName] = TemplateNames.DeclarativeAgentMetaOSUpgradeProject;
+      const result = await generator.getTemplateInfos(context, inputs, "destinationPath");
+      chai.assert.isTrue(result.isOk());
+      if (result.isOk()) {
+        // Should return empty array because upgrade doesn't need scaffolding
+        chai.assert.equal(result.value.length, 0);
+      }
+    });
+
     it(`should return office-addin-config template outlookAddin`, async () => {
       sandbox.stub(OfficeAddinGenerator, "doScaffolding").resolves(ok(undefined));
       const inputs: Inputs = {
@@ -893,5 +907,24 @@ describe("MetaOSHelper", () => {
     } catch (e) {
       chai.assert.isNotNull(e);
     }
+  });
+
+  it("unifyProjectID: env file doesn't exist", async () => {
+    const readManifestStub = sandbox.stub(AppManifestUtils, "readTeamsManifest").resolves({
+      id: "test",
+    } as any);
+    const writeManifestStub = sandbox.stub(AppManifestUtils, "writeTeamsManifest").resolves();
+    const writeFileStub = sandbox.stub(fse, "writeFile").resolves();
+    const pathExistsStub = sandbox.stub(fse, "pathExists").resolves(false); // File doesn't exist
+    const ensureDirStub = sandbox.stub(fse, "ensureDir").resolves();
+    await MetaOSHelper.unifyProjectID("projectFolder");
+    chai.assert.isTrue(readManifestStub.calledOnce);
+    chai.assert.isTrue(writeManifestStub.calledOnce);
+    chai.assert.isTrue(pathExistsStub.calledOnce);
+    chai.assert.isTrue(ensureDirStub.calledOnce);
+    chai.assert.isTrue(writeFileStub.calledOnce);
+    // Verify that the env file content contains TEAMS_APP_ID
+    const writeFileCall = writeFileStub.getCall(0);
+    chai.assert.include(writeFileCall.args[1], "TEAMS_APP_ID=");
   });
 });

--- a/packages/fx-core/tests/component/generator/officeAddinGenerator.test.ts
+++ b/packages/fx-core/tests/component/generator/officeAddinGenerator.test.ts
@@ -718,6 +718,7 @@ describe("MetaOSHelper", () => {
     const writeManifestStub = sandbox.stub(AppManifestUtils, "writeTeamsManifest").resolves();
     const readFileStub = sandbox.stub(fse, "readFile").resolves(Buffer.from(`{"id": "test"}`));
     const writeFileStub = sandbox.stub(fse, "writeFile").resolves();
+    const pathExistsStub = sandbox.stub(fse, "pathExists").resolves(true);
     const deserializeStub = sandbox.stub(dotenvUtil, "deserialize").returns({ obj: {} } as any);
     const serializeStub = sandbox.stub(dotenvUtil, "serialize").returns("test");
 
@@ -727,6 +728,7 @@ describe("MetaOSHelper", () => {
     chai.assert.isTrue(writeManifestStub.calledOnce);
     chai.assert.isTrue(readFileStub.calledOnce);
     chai.assert.isTrue(writeFileStub.calledOnce);
+    chai.assert.isTrue(pathExistsStub.calledOnce);
     chai.assert.isTrue(deserializeStub.calledOnce);
     chai.assert.isTrue(serializeStub.calledOnce);
   });


### PR DESCRIPTION
## Summary
Fixes the "Extend to Declarative Agent" feature that was failing with `TemplateNotFoundError` when upgrading existing Office add-in projects to Declarative Agents.

## Root Cause
1. **Primary Issue**: The `getTemplateInfos()` method was triggering template scaffolding for both new and upgrade scenarios. Upgrade scenarios should not scaffold templates since the project structure already exists and only needs modification.
2. **Secondary Issue**: The `unifyProjectID()` function assumed the `env/.env.dev` file exists, but the file copy operation excludes the `env` folder (via `NOT_COPY_FOLDERS` filter), causing an ENOENT error.

## Validation
Verified that extend to DA is working fine and DA project is also working fine.

Attaching video for the reference:
https://github.com/user-attachments/assets/1ab04fec-4125-45ba-a233-20de1870e553


