### PR TITLE
fix: set auth type to None

### DIFF
--- a/templates/vsc/common/declarative-agent-meta-os-new-project/appPackage/alchemy-plugin.json.tpl
+++ b/templates/vsc/common/declarative-agent-meta-os-new-project/appPackage/alchemy-plugin.json.tpl
@@ -89,6 +89,9 @@
   "runtimes": [
     {
       "type": "LocalPlugin",
+      "auth": {
+        "type": "None"
+      },
       "spec": {
         "local_endpoint": "Microsoft.Office.Addin"
       },


### PR DESCRIPTION
For the bug : https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/33035312

1. Set auth type to None for LocalPlugin runtime in alchemy-plugin template.
For LocalPlugin runtimes using Microsoft.Office.Addin, authentication is 
handled by the Office host application itself, so the auth type should be 
"None" as the add-in runs within the trusted Office environment.

2. The namespace property is already present in alchemy-plugin.json.tpl

After these changes, success is observed in Manifest File Validation.

<img width="1080" height="200" alt="image" src="https://github.com/user-attachments/assets/15274332-1342-4bfb-ab52-9c1d8e175cea" />
