### PR TITLE
Change variable declaration to `alias` in generate-env.js

### DIFF
--- a/templates/vsc/common/declarative-agent-typespec/scripts/generate-env.js
+++ b/templates/vsc/common/declarative-agent-typespec/scripts/generate-env.js
@@ -70,7 +70,7 @@
       // Escape backslashes and double quotes for safe TS string literal
       const escaped = value.replace(/\\/g, "\\\\").replace(/\"/g, '\\"');
 
-      tspLines.push(`  const ${ident} = "${escaped}";`);
+      tspLines.push(`  alias ${ident} = "${escaped}";`);
       tspLines.push("");
     }
 


### PR DESCRIPTION
When declared as a constant, the envvar can't be used in string concatenation (string interpolation). For example, say you have an authenticated endpoint. When envvars are constants, you can't use it when creating an `alias`.

If this PR is merged, this fixes the issue and allows envvars to be used in string interpolation scenarios. See #15017 for the issue that this fixes with examples

fixes #15017