### PR TITLE
feat: improve declarative agent sharing experience

### DIFF
--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -252,7 +252,7 @@
   "error.m365.NotExtendedToM365Error": "Unable to extend the app to Microsoft 365. Use 'teamsApp/extendToM365' action to extend the app to Microsoft 365.",
   "error.m365.SharedScopeAdvancedDADisabled": "Deployment blocked: Advanced declarative agent can't be deployed due to tenant permission settings. Get more info: [Manage agents for Microsoft 365 Copilot in the Microsoft 365 admin center - Microsoft 365 admin | Microsoft Learn](%s)",
   "error.share.yamlConfigNotFound": "Unable to find the \"provision\" or \"deploy\" config in the m365agents.yml",
-  "error.share.yamlConfigNotSupported": "Your project is using an outdated YAML schema %s that doesn't support Declaratvie Agent share (requires v1.10+). To use \"atk share\", upgrade your m365agents.yml version and specify \"scope: shared\" in teamsApp/extendToM365 action or generate a new project with the latest schema.",
+  "error.share.yamlConfigNotSupported": "Share feature only supports m365agents.yml version v1.10 or above, follow [the guide](https://github.com/OfficeDev/microsoft-365-agents-toolkit/wiki/Share-Declarative-Agents-with-Others#About-YAML-schema) to upgrade and proceed.",
   "error.share.shareActionConfigNotFound": "Unable to find the \"%s\" action config in the m365agents.yml",
   "error.share.appPackageConfigNotFound": "Unable to find the appPackagePath config in the m365agents.yml",
   "error.share.manifestFileNotFound": "Unable to find the manifest file in the app package",

--- a/packages/fx-core/resource/package.nls.json
+++ b/packages/fx-core/resource/package.nls.json
@@ -252,6 +252,7 @@
   "error.m365.NotExtendedToM365Error": "Unable to extend the app to Microsoft 365. Use 'teamsApp/extendToM365' action to extend the app to Microsoft 365.",
   "error.m365.SharedScopeAdvancedDADisabled": "Deployment blocked: Advanced declarative agent can't be deployed due to tenant permission settings. Get more info: [Manage agents for Microsoft 365 Copilot in the Microsoft 365 admin center - Microsoft 365 admin | Microsoft Learn](%s)",
   "error.share.yamlConfigNotFound": "Unable to find the \"provision\" or \"deploy\" config in the m365agents.yml",
+  "error.share.yamlConfigNotSupported": "Your project is using an outdated YAML schema %s that doesn't support Declaratvie Agent share (requires v1.10+). To use \"atk share\", upgrade your m365agents.yml version and specify \"scope: shared\" in teamsApp/extendToM365 action or generate a new project with the latest schema.",
   "error.share.shareActionConfigNotFound": "Unable to find the \"%s\" action config in the m365agents.yml",
   "error.share.appPackageConfigNotFound": "Unable to find the appPackagePath config in the m365agents.yml",
   "error.share.manifestFileNotFound": "Unable to find the manifest file in the app package",

--- a/packages/fx-core/src/component/driver/share/utils.ts
+++ b/packages/fx-core/src/component/driver/share/utils.ts
@@ -5,6 +5,7 @@ import { err, FxError, ok, Result, TeamsAppManifest, UserError } from "@microsof
 import AdmZip from "adm-zip";
 import fs from "fs-extra";
 import path from "path";
+import semver from "semver";
 import { getLocalizedString } from "../../../common/localizeUtils";
 import { DriverDefinition } from "../../configManager/interface";
 import { resolve } from "../../configManager/lifecycle";
@@ -22,6 +23,17 @@ export async function parseShareAppActionYamlConfig(
   const maybeProjectModel = await metadataUtil.parse(templatePath);
   if (maybeProjectModel.isErr()) {
     return err(maybeProjectModel.error);
+  }
+  const version = semver.coerce(maybeProjectModel.value.version);
+  if (version && semver.lt(version, "1.10.0")) {
+    // it's not supported before v1.10.
+    return err(
+      new UserError(
+        "FxCore",
+        "Share",
+        getLocalizedString("error.share.yamlConfigNotSupported", maybeProjectModel.value.version)
+      )
+    );
   }
   const projectModel = maybeProjectModel.value;
   if (

--- a/packages/fx-core/src/component/driver/share/utils.ts
+++ b/packages/fx-core/src/component/driver/share/utils.ts
@@ -28,11 +28,7 @@ export async function parseShareAppActionYamlConfig(
   if (version && semver.lt(version, "1.10.0")) {
     // it's not supported before v1.10.
     return err(
-      new UserError(
-        "FxCore",
-        "Share",
-        getLocalizedString("error.share.yamlConfigNotSupported", maybeProjectModel.value.version)
-      )
+      new UserError("FxCore", "Share", getLocalizedString("error.share.yamlConfigNotSupported"))
     );
   }
   const projectModel = maybeProjectModel.value;

--- a/packages/fx-core/src/component/middleware/envMW.ts
+++ b/packages/fx-core/src/component/middleware/envMW.ts
@@ -4,6 +4,8 @@ import { Middleware, NextFunction } from "@feathersjs/hooks";
 import { Inputs, err } from "@microsoft/teamsfx-api";
 import _ from "lodash";
 import { TOOLS } from "../../common/globalVars";
+import { IsDeclarativeAgentManifest } from "../../common/projectTypeChecker";
+import { manifestUtils } from "../../component/driver/teamsApp/utils/ManifestUtils";
 import { environmentNameManager } from "../../core/environmentName";
 import { CoreHookContext } from "../../core/types";
 import { NoProjectOpenedError } from "../../error";
@@ -57,6 +59,11 @@ const envLoaderMWImpl = async (
       process.env.TEAMSFX_ENV = "dev"; // set TEAMSFX_ENV = dev is to avoid unexpected error in other components that depends on this env variable
       await next();
       return;
+    }
+    const manifestRes = await manifestUtils.readAppManifest(projectPath);
+    if (manifestRes.isOk() && IsDeclarativeAgentManifest(manifestRes.value)) {
+      // Enable local env provision for DA
+      withLocalEnv = true;
     }
     const question = selectTargetEnvQuestion(QuestionNames.Env, !withLocalEnv, true);
     const res = await traverse({ data: question }, inputs, TOOLS.ui);

--- a/packages/fx-core/tests/component/driver/share/utils.test.ts
+++ b/packages/fx-core/tests/component/driver/share/utils.test.ts
@@ -441,7 +441,10 @@ describe("parseShareAppActionYamlConfig", () => {
       chai.assert.instanceOf(result.error, UserError);
       chai.assert.equal(result.error.name, "Share");
       // message should include the unsupported version string
-      chai.assert.include(result.error.message, "v1.9");
+      chai.assert.include(
+        result.error.message,
+        "Share feature only supports m365agents.yml version v1.10 or above"
+      );
     }
   });
 

--- a/packages/fx-core/tests/component/driver/share/utils.test.ts
+++ b/packages/fx-core/tests/component/driver/share/utils.test.ts
@@ -429,4 +429,34 @@ describe("parseShareAppActionYamlConfig", () => {
       chai.assert.equal(result.error.name, "Share to Users");
     }
   });
+
+  it("should error with yamlConfigNotSupported for version < 1.10.0", async () => {
+    sandbox.stub(pathUtils, "getYmlFilePath").returns("mockTemplatePath");
+    sandbox.stub(metadataUtil, "parse").resolves(ok({ version: "v1.9" } as any));
+
+    const result = await parseShareAppActionYamlConfig("mockProjectPath");
+
+    chai.assert.isTrue(result.isErr());
+    if (result.isErr()) {
+      chai.assert.instanceOf(result.error, UserError);
+      chai.assert.equal(result.error.name, "Share");
+      // message should include the unsupported version string
+      chai.assert.include(result.error.message, "v1.9");
+    }
+  });
+
+  it("should proceed when version >= 1.10.0", async () => {
+    sandbox.stub(pathUtils, "getYmlFilePath").returns("mockTemplatePath");
+    // minimal model with only version; subsequent checks will return yamlConfigNotFound
+    sandbox.stub(metadataUtil, "parse").resolves(ok({ version: "v1.10" } as any));
+
+    const result = await parseShareAppActionYamlConfig("mockProjectPath");
+
+    chai.assert.isTrue(result.isErr());
+    if (result.isErr()) {
+      // ensure not failing due to version gate by checking generic Share error
+      chai.assert.instanceOf(result.error, UserError);
+      chai.assert.equal(result.error.name, "Share");
+    }
+  });
 });

--- a/packages/fx-core/tests/component/envUtil.test.ts
+++ b/packages/fx-core/tests/component/envUtil.test.ts
@@ -15,8 +15,11 @@ import "mocha";
 import mockedEnv, { RestoreFn } from "mocked-env";
 import * as path from "path";
 import * as sinon from "sinon";
-import { MetadataV3, MetadataV3Abandoned, MetadataV4 } from "../../src/common/versionMetadata";
-import { ProjectModel } from "../../src/component/configManager/interface";
+import { globalVars, setTools, TOOLS } from "../../src/common/globalVars";
+import * as projectTypeChecker from "../../src/common/projectTypeChecker";
+import { MetadataV3, MetadataV4 } from "../../src/common/versionMetadata";
+import { parseSetOutputCommand } from "../../src/component/driver/script/scriptDriver";
+import { manifestUtils } from "../../src/component/driver/teamsApp/utils/ManifestUtils";
 import { EnvLoaderMW, EnvWriterMW } from "../../src/component/middleware/envMW";
 import { DotenvOutput, dotenvUtil, envUtil } from "../../src/component/utils/envUtil";
 import { pathUtils } from "../../src/component/utils/pathUtils";
@@ -24,7 +27,6 @@ import { settingsUtil } from "../../src/component/utils/settingsUtil";
 import { LocalCrypto } from "../../src/core/crypto";
 import { environmentManager } from "../../src/core/environment";
 import { FxCore } from "../../src/core/FxCore";
-import { globalVars, setTools, TOOLS } from "../../src/common/globalVars";
 import { ContextInjectorMW } from "../../src/core/middleware/contextInjector";
 import { CoreHookContext } from "../../src/core/types";
 import {
@@ -35,8 +37,6 @@ import {
   UserCancelError,
 } from "../../src/error/common";
 import { MockTools } from "../core/utils";
-import { parseSetOutputCommand } from "../../src/component/driver/script/scriptDriver";
-import * as yaml from "yaml";
 
 describe("envUtils", () => {
   const tools = new MockTools();
@@ -479,6 +479,75 @@ describe("envUtils", () => {
   });
 
   describe("EnvLoaderMW", () => {
+    it("Enables local env when manifest is Declarative Agent", async () => {
+      sandbox
+        .stub(manifestUtils, "readAppManifest")
+        .resolves(ok({ copilotAgents: { declarativeAgents: [{}] } } as any));
+      sandbox.stub(projectTypeChecker, "IsDeclarativeAgentManifest").returns(true);
+      let capturedRemoteOnly: boolean | undefined;
+      sandbox
+        .stub(envUtil, "listEnv")
+        .callsFake(async (projectPath: string, remoteOnly?: boolean) => {
+          capturedRemoteOnly = remoteOnly;
+          return ok([]);
+        });
+      sandbox.stub(TOOLS.ui, "selectOption").callsFake(async (config: any) => {
+        if (typeof config.options === "function") {
+          await config.options();
+        }
+        return ok({ type: "success", result: "dev", options: ["dev"] } as any);
+      });
+      sandbox.stub(envUtil, "readEnv").resolves(ok({}));
+
+      class MyClass {
+        async myMethod(inputs: Inputs): Promise<Result<any, FxError>> {
+          return ok(undefined);
+        }
+      }
+      hooks(MyClass, { myMethod: [EnvLoaderMW(false)] });
+      const my = new MyClass();
+      const inputs = {
+        platform: Platform.VSCode,
+        projectPath: ".",
+      };
+      const res = await my.myMethod(inputs);
+      assert.isTrue(res.isOk());
+      assert.equal(capturedRemoteOnly, false, "should include local env when DA manifest detected");
+    });
+
+    it("Keeps local env disabled when manifest is not Declarative Agent", async () => {
+      sandbox.stub(manifestUtils, "readAppManifest").resolves(ok({} as any));
+      sandbox.stub(projectTypeChecker, "IsDeclarativeAgentManifest").returns(false);
+      let capturedRemoteOnly: boolean | undefined;
+      sandbox
+        .stub(envUtil, "listEnv")
+        .callsFake(async (projectPath: string, remoteOnly?: boolean) => {
+          capturedRemoteOnly = remoteOnly;
+          return ok([]);
+        });
+      sandbox.stub(TOOLS.ui, "selectOption").callsFake(async (config: any) => {
+        if (typeof config.options === "function") {
+          await config.options();
+        }
+        return ok({ type: "success", result: "dev", options: ["dev"] } as any);
+      });
+      sandbox.stub(envUtil, "readEnv").resolves(ok({}));
+
+      class MyClass {
+        async myMethod(inputs: Inputs): Promise<Result<any, FxError>> {
+          return ok(undefined);
+        }
+      }
+      hooks(MyClass, { myMethod: [EnvLoaderMW(false)] });
+      const my = new MyClass();
+      const inputs = {
+        platform: Platform.VSCode,
+        projectPath: ".",
+      };
+      const res = await my.myMethod(inputs);
+      assert.isTrue(res.isOk());
+      assert.equal(capturedRemoteOnly, true, "should exclude local env when non-DA manifest");
+    });
     it("EnvLoaderMW success", async () => {
       sandbox.stub(pathUtils, "getEnvFolderPath").resolves(ok("teamsfx"));
       const encRes = await cryptoProvider.encrypt(decrypted);

--- a/templates/vsc/common/declarative-agent-typespec/env/.env.dev.tpl
+++ b/templates/vsc/common/declarative-agent-typespec/env/.env.dev.tpl
@@ -4,7 +4,7 @@
 TEAMSFX_ENV=dev
 APP_NAME_SUFFIX=dev
 GITHUB_API_URL=https://api.github.com
-AGENT_SCOPE=shared
+AGENT_SCOPE=personal
 
 # Generated during provision, you can also add your own variables.
 TEAMS_APP_ID=

--- a/templates/vsc/common/declarative-agent-with-action-from-existing-api/env/.env.dev.tpl
+++ b/templates/vsc/common/declarative-agent-with-action-from-existing-api/env/.env.dev.tpl
@@ -3,7 +3,7 @@
 # Built-in environment variables
 TEAMSFX_ENV=dev
 APP_NAME_SUFFIX=dev
-AGENT_SCOPE=shared
+AGENT_SCOPE=personal
 
 # Generated during provision, you can also add your own variables.
 TEAMS_APP_ID=

--- a/templates/vsc/js/declarative-agent-with-action-from-scratch-bearer/env/.env.dev
+++ b/templates/vsc/js/declarative-agent-with-action-from-scratch-bearer/env/.env.dev
@@ -3,7 +3,7 @@
 # Built-in environment variables
 TEAMSFX_ENV=dev
 APP_NAME_SUFFIX=dev
-AGENT_SCOPE=shared
+AGENT_SCOPE=personal
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/vsc/js/declarative-agent-with-action-from-scratch-oauth/env/.env.dev
+++ b/templates/vsc/js/declarative-agent-with-action-from-scratch-oauth/env/.env.dev
@@ -3,7 +3,7 @@
 # Built-in environment variables
 TEAMSFX_ENV=dev
 APP_NAME_SUFFIX=dev
-AGENT_SCOPE=shared
+AGENT_SCOPE=personal
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/vsc/js/declarative-agent-with-action-from-scratch/env/.env.dev
+++ b/templates/vsc/js/declarative-agent-with-action-from-scratch/env/.env.dev
@@ -3,7 +3,7 @@
 # Built-in environment variables
 TEAMSFX_ENV=dev
 APP_NAME_SUFFIX=dev
-AGENT_SCOPE=shared
+AGENT_SCOPE=personal
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/vsc/ts/declarative-agent-with-action-from-scratch-bearer/env/.env.dev
+++ b/templates/vsc/ts/declarative-agent-with-action-from-scratch-bearer/env/.env.dev
@@ -3,7 +3,7 @@
 # Built-in environment variables
 TEAMSFX_ENV=dev
 APP_NAME_SUFFIX=dev
-AGENT_SCOPE=shared
+AGENT_SCOPE=personal
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/vsc/ts/declarative-agent-with-action-from-scratch-oauth/env/.env.dev
+++ b/templates/vsc/ts/declarative-agent-with-action-from-scratch-oauth/env/.env.dev
@@ -3,7 +3,7 @@
 # Built-in environment variables
 TEAMSFX_ENV=dev
 APP_NAME_SUFFIX=dev
-AGENT_SCOPE=shared
+AGENT_SCOPE=personal
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=

--- a/templates/vsc/ts/declarative-agent-with-action-from-scratch/env/.env.dev
+++ b/templates/vsc/ts/declarative-agent-with-action-from-scratch/env/.env.dev
@@ -3,7 +3,7 @@
 # Built-in environment variables
 TEAMSFX_ENV=dev
 APP_NAME_SUFFIX=dev
-AGENT_SCOPE=shared
+AGENT_SCOPE=personal
 
 # Updating AZURE_SUBSCRIPTION_ID or AZURE_RESOURCE_GROUP_NAME after provision may also require an update to RESOURCE_SUFFIX, because some services require a globally unique name across subscriptions/resource groups.
 AZURE_SUBSCRIPTION_ID=


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/33797232/

Improvements:
1. Enable choosing local environment when provision.
2. Make advanced declarative agent scope in dev environment 'personal' by default as sharing is not supported now.
3. Show error message and instruction when user is using YAML schema under v1.10 to share.
Preview:
<img width="801" height="239" alt="image" src="https://github.com/user-attachments/assets/9a0b483d-2edb-4b6e-8ee6-f83b87b05d33" />
