### PR TITLE
fix: resolve Invalid id in Terminal add in still installed error

### DIFF
--- a/templates/vsc/common/declarative-agent-meta-os-new-project/package.json.tpl
+++ b/templates/vsc/common/declarative-agent-meta-os-new-project/package.json.tpl
@@ -30,7 +30,7 @@
     "start:desktop:powerpoint": "office-addin-debugging start appPackage/manifest.json desktop --app powerpoint",
     "start:desktop:outlook": "office-addin-debugging start appPackage/manifest.json desktop --app outlook",
     "start:web": "office-addin-debugging start appPackage/manifest.json web",
-    "stop": "office-addin-debugging stop appPackage/manifest.json",
+    "stop": "powershell -ExecutionPolicy Bypass -File ./scripts/uninstall-addin.ps1",
     "validate": "office-addin-manifest validate appPackage/manifest.json",
     "watch": "webpack --mode development --watch"
   },

--- a/templates/vsc/common/declarative-agent-meta-os-new-project/scripts/uninstall-addin.ps1
+++ b/templates/vsc/common/declarative-agent-meta-os-new-project/scripts/uninstall-addin.ps1
@@ -1,0 +1,26 @@
+$ErrorActionPreference = 'Continue'
+
+# Read manifest ID
+$manifest = Get-Content 'appPackage/manifest.json' -Raw | ConvertFrom-Json
+$manifestId = $manifest.id
+
+Write-Host "Uninstalling add-in with Manifest ID: $manifestId"
+Write-Host ""
+
+# Uninstall via atk
+npx -p @microsoft/m365agentstoolkit-cli atk uninstall --mode manifest-id --manifest-id $manifestId --interactive false --options m365-app
+
+Write-Host ""
+
+# Stop debugging
+office-addin-debugging stop appPackage/manifest.json 2>$null
+
+# Clear Office cache
+$wefPath = "$env:LOCALAPPDATA\Microsoft\Office\16.0\Wef"
+if (Test-Path $wefPath) {
+    Remove-Item -Recurse -Force $wefPath
+    Write-Host "Office cache cleared"
+}
+
+Write-Host ""
+Write-Host "Add-in uninstalled successfully!"


### PR DESCRIPTION
For the Bug : https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/36076480/

**Fix: Proper add‑in cleanup on debug stop**

`office-addin-debugging start `registers add-ins via `atk install`, but `office-addin-debugging stop` did not call `atk uninstall`, leaving add-ins registered after the debug session ends.

**Change:**
Added a custom uninstall script that extracts the Manifest ID and calls atk uninstall before running office-addin-debugging stop. Updated package.json to route stop through this script.

**Result:**
Clean add-in unregistration when office app is closed and debug is stopped.

<img width="1076" height="443" alt="image (1)" src="https://github.com/user-attachments/assets/ada5a210-38cd-4e5c-8611-6abf9ed3b99d" />
