### PR TITLE
fix: mock keytar for e2e test

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -224,11 +224,6 @@ jobs:
 
       - uses: pnpm/action-setup@v4
 
-      - name: Install libsecret
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libsecret-1-dev
-
       - name: Setup project
         run: |
           npm run setup:e2e

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -81,6 +81,11 @@ jobs:
         with:
           range: "e2e"
 
+      - name: Install libsecret to enable keytar
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libsecret-1-dev
+
       - name: List cases for schedule or pull request
         id: schedule-cases
         if: ${{  github.event_name == 'schedule' }}
@@ -223,6 +228,11 @@ jobs:
           python-version: '3.11'
 
       - uses: pnpm/action-setup@v4
+
+      - name: Install libsecret
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libsecret-1-dev
 
       - name: Setup project
         run: |

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -81,11 +81,6 @@ jobs:
         with:
           range: "e2e"
 
-      - name: Install libsecret to enable keytar
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libsecret-1-dev
-
       - name: List cases for schedule or pull request
         id: schedule-cases
         if: ${{  github.event_name == 'schedule' }}

--- a/packages/cli/src/activate.ts
+++ b/packages/cli/src/activate.ts
@@ -5,7 +5,7 @@ import { FxError, Result, Tools, err, ok } from "@microsoft/teamsfx-api";
 import { FxCore, UnhandledError } from "@microsoft/teamsfx-core";
 import AzureAccountManager from "./commonlib/azureLogin";
 import { logger } from "./commonlib/logger";
-import M365Login from "./commonlib/m365Login";
+import M365Login from "./commonlib/M365TokenProviderWrapper";
 import { cliSource } from "./constants";
 import CliTelemetry from "./telemetry/cliTelemetry";
 import CLIUserInteraction from "./userInteraction";

--- a/packages/cli/src/cmds/preview/previewEnv.ts
+++ b/packages/cli/src/cmds/preview/previewEnv.ts
@@ -22,7 +22,7 @@ import * as path from "path";
 import * as util from "util";
 import activate from "../../activate";
 import cliLogger from "../../commonlib/log";
-import M365TokenInstance from "../../commonlib/m365Login";
+import M365TokenInstance from "../../commonlib/M365TokenProviderWrapper";
 import { cliSource } from "../../constants";
 import cliTelemetry from "../../telemetry/cliTelemetry";
 import { TelemetryEvent, TelemetryProperty } from "../../telemetry/cliTelemetryEvents";

--- a/packages/cli/src/commands/models/accountLoginM365.ts
+++ b/packages/cli/src/commands/models/accountLoginM365.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 import { CLICommand, ok } from "@microsoft/teamsfx-api";
-import M365TokenProvider from "../../commonlib/m365Login";
+import M365TokenProvider from "../../commonlib/M365TokenProviderWrapper";
 import { commands } from "../../resource";
 import { TelemetryEvent } from "../../telemetry/cliTelemetryEvents";
 import { accountUtils } from "./accountShow";

--- a/packages/cli/src/commands/models/accountLogout.ts
+++ b/packages/cli/src/commands/models/accountLogout.ts
@@ -3,7 +3,7 @@
 import { CLICommand, ok } from "@microsoft/teamsfx-api";
 import AzureTokenProvider from "../../commonlib/azureLogin";
 import { logger } from "../../commonlib/logger";
-import M365TokenProvider from "../../commonlib/m365Login";
+import M365TokenProvider from "../../commonlib/M365TokenProviderWrapper";
 import { commands, strings } from "../../resource";
 import { TelemetryEvent } from "../../telemetry/cliTelemetryEvents";
 

--- a/packages/cli/src/commands/models/accountShow.ts
+++ b/packages/cli/src/commands/models/accountShow.ts
@@ -12,7 +12,7 @@ import AzureTokenProvider, { getAzureProvider } from "../../commonlib/azureLogin
 import AzureTokenCIProvider from "../../commonlib/azureLoginCI";
 import { checkIsOnline } from "../../commonlib/codeFlowLogin";
 import { logger } from "../../commonlib/logger";
-import M365TokenProvider from "../../commonlib/m365Login";
+import M365TokenProvider from "../../commonlib/M365TokenProviderWrapper";
 import { commands, strings } from "../../resource";
 import { TelemetryEvent } from "../../telemetry/cliTelemetryEvents";
 import { listAllTenants } from "@microsoft/teamsfx-core/build/common/tools";

--- a/packages/cli/src/commands/models/m365Sideloading.ts
+++ b/packages/cli/src/commands/models/m365Sideloading.ts
@@ -3,7 +3,7 @@
 import { CLICommand, err, ok } from "@microsoft/teamsfx-api";
 import { PackageService, MosServiceEndpoint, MosServiceScope } from "@microsoft/teamsfx-core";
 import { logger } from "../../commonlib/logger";
-import M365TokenProvider from "../../commonlib/m365Login";
+import M365TokenProvider from "../../commonlib/M365TokenProviderWrapper";
 import { ArgumentConflictError, MissingRequiredOptionError } from "../../error";
 import { commands } from "../../resource";
 import { TelemetryEvent } from "../../telemetry/cliTelemetryEvents";

--- a/packages/cli/src/commands/models/teamsapp/doctor.ts
+++ b/packages/cli/src/commands/models/teamsapp/doctor.ts
@@ -16,7 +16,7 @@ import * as util from "util";
 import { getFxCore } from "../../../activate";
 import { DoneText, TextType, WarningText, colorize } from "../../../colorize";
 import { logger } from "../../../commonlib/logger";
-import M365TokenInstance from "../../../commonlib/m365Login";
+import M365TokenInstance from "../../../commonlib/M365TokenProviderWrapper";
 import { cliSource } from "../../../constants";
 import { commands, strings } from "../../../resource";
 import { TelemetryEvent } from "../../../telemetry/cliTelemetryEvents";

--- a/packages/cli/src/commonlib/M365TokenProviderWrapper.ts
+++ b/packages/cli/src/commonlib/M365TokenProviderWrapper.ts
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+"use strict";
+
+import {
+  FxError,
+  LoginStatus,
+  M365TokenProvider,
+  Result,
+  TokenRequest,
+} from "@microsoft/teamsfx-api";
+import M365TokenProviderUserPassword from "./m365LoginUserPassword";
+import { M365Login } from "./m365Login";
+import ui from "../userInteraction";
+
+/**
+ * this class is a wrapper for M365TokenProvider that will use M365Login if interactive is true, otherwise use M365TokenProviderUserPassword
+ */
+class MM365TokenProviderWrapper implements M365TokenProvider {
+  getProvider(): M365TokenProvider {
+    // if interactive is false and system environment variables (M365_ACCOUNT_NAME, M365_ACCOUNT_PASSWORD) are set, then use M365TokenProviderUserPassword
+    const m365Login =
+      !ui.interactive && process.env.M365_ACCOUNT_NAME && process.env.M365_ACCOUNT_PASSWORD
+        ? M365TokenProviderUserPassword
+        : M365Login.getInstance();
+    return m365Login;
+  }
+  getAccessToken(tokenRequest: TokenRequest): Promise<Result<string, FxError>> {
+    return this.getProvider().getAccessToken(tokenRequest);
+  }
+  getJsonObject(
+    tokenRequest: TokenRequest,
+    tenantId?: string
+  ): Promise<Result<Record<string, unknown>, FxError>> {
+    return this.getProvider().getJsonObject(tokenRequest, tenantId);
+  }
+  getStatus(tokenRequest: TokenRequest): Promise<Result<LoginStatus, FxError>> {
+    return this.getProvider().getStatus(tokenRequest);
+  }
+  setStatusChangeMap(
+    name: string,
+    tokenRequest: TokenRequest,
+    statusChange: (
+      status: string,
+      token?: string,
+      accountInfo?: Record<string, unknown>
+    ) => Promise<void>,
+    immediateCall?: boolean
+  ): Promise<Result<boolean, FxError>> {
+    return this.getProvider().setStatusChangeMap(name, tokenRequest, statusChange, immediateCall);
+  }
+  removeStatusChangeMap(name: string): Promise<Result<boolean, FxError>> {
+    return this.getProvider().removeStatusChangeMap(name);
+  }
+  async signout(): Promise<boolean> {
+    return await (this.getProvider() as any).signout();
+  }
+  async switchTenant(tenantId: string): Promise<Result<string, FxError>> {
+    return await this.getProvider().switchTenant(tenantId);
+  }
+  async getTenant(): Promise<string | undefined> {
+    return await (this.getProvider() as any).getTenant();
+  }
+}
+
+export default new MM365TokenProviderWrapper();

--- a/packages/cli/src/commonlib/azureLogin.ts
+++ b/packages/cli/src/commonlib/azureLogin.ts
@@ -6,7 +6,6 @@
 import { SubscriptionClient } from "@azure/arm-subscriptions";
 import { AccessToken, GetTokenOptions, TokenCredential } from "@azure/core-auth";
 import { LogLevel, Configuration } from "@azure/msal-node";
-import { NativeBrokerPlugin } from "@azure/msal-node-extensions";
 import {
   AuthenticationWWWAuthenticateRequest,
   AzureAccountProvider,
@@ -89,9 +88,16 @@ function getConfig(tenantId?: string): Configuration {
   };
 
   if (featureFlagManager.getBooleanValue(FeatureFlags.BrokerAuth) && process.platform === "win32") {
-    config.broker = {
-      nativeBrokerPlugin: new NativeBrokerPlugin(),
-    };
+    try {
+      // Dynamically require to avoid loading @azure/msal-node-extensions on Linux
+      // where keytar (a dependency) requires libsecret to be installed
+      const { NativeBrokerPlugin } = require("@azure/msal-node-extensions");
+      config.broker = {
+        nativeBrokerPlugin: new NativeBrokerPlugin(),
+      };
+    } catch {
+      // NativeBrokerPlugin not available, ignore
+    }
   }
   return config;
 }

--- a/packages/cli/src/commonlib/m365Login.ts
+++ b/packages/cli/src/commonlib/m365Login.ts
@@ -4,7 +4,6 @@
 "use strict";
 
 import { Configuration, LogLevel } from "@azure/msal-node";
-import { NativeBrokerPlugin } from "@azure/msal-node-extensions";
 import {
   BasicLogin,
   err,
@@ -32,32 +31,43 @@ const SERVER_PORT = 0;
 
 const cachePlugin = new CryptoCachePlugin(m365CacheName);
 
-const config: Configuration = {
-  auth: {
-    clientId: "7ea7c24c-b1f6-4a20-9d11-9ae12e9e7ac0",
-    authority: "https://login.microsoftonline.com/common",
-  },
-  broker: {
-    nativeBrokerPlugin:
-      featureFlagManager.getBooleanValue(FeatureFlags.BrokerAuth) && process.platform === "win32"
-        ? new NativeBrokerPlugin()
-        : undefined,
-  },
-  system: {
-    loggerOptions: {
-      loggerCallback(loglevel: any, message: any, containsPii: any) {
-        if (this.logLevel && this.logLevel <= LogLevel.Error) {
-          CLILogProvider.log(4 - loglevel, message);
-        }
-      },
-      piiLoggingEnabled: false,
-      logLevel: LogLevel.Error,
+function getConfig(): Configuration {
+  const config: Configuration = {
+    auth: {
+      clientId: "7ea7c24c-b1f6-4a20-9d11-9ae12e9e7ac0",
+      authority: "https://login.microsoftonline.com/common",
     },
-  },
-  cache: {
-    cachePlugin,
-  },
-};
+    system: {
+      loggerOptions: {
+        loggerCallback(loglevel: any, message: any, containsPii: any) {
+          if (this.logLevel && this.logLevel <= LogLevel.Error) {
+            CLILogProvider.log(4 - loglevel, message);
+          }
+        },
+        piiLoggingEnabled: false,
+        logLevel: LogLevel.Error,
+      },
+    },
+    cache: {
+      cachePlugin,
+    },
+  };
+
+  if (featureFlagManager.getBooleanValue(FeatureFlags.BrokerAuth) && process.platform === "win32") {
+    try {
+      // Dynamically require to avoid loading @azure/msal-node-extensions on Linux
+      // where keytar (a dependency) requires libsecret to be installed
+      const { NativeBrokerPlugin } = require("@azure/msal-node-extensions");
+      config.broker = {
+        nativeBrokerPlugin: new NativeBrokerPlugin(),
+      };
+    } catch {
+      // NativeBrokerPlugin not available, ignore
+    }
+  }
+
+  return config;
+}
 
 export class M365Login extends BasicLogin implements M365TokenProvider {
   private static instance: M365Login;
@@ -65,7 +75,7 @@ export class M365Login extends BasicLogin implements M365TokenProvider {
 
   private constructor() {
     super();
-    M365Login.codeFlowInstance = new CodeFlowLogin([], config, SERVER_PORT, m365CacheName);
+    M365Login.codeFlowInstance = new CodeFlowLogin([], getConfig(), SERVER_PORT, m365CacheName);
   }
 
   /**

--- a/packages/cli/src/commonlib/m365Login.ts
+++ b/packages/cli/src/commonlib/m365Login.ts
@@ -22,13 +22,11 @@ import {
   FeatureFlags,
   teamsDevPortalClient,
 } from "@microsoft/teamsfx-core";
-import ui from "../userInteraction";
 import { CryptoCachePlugin, loadTenantId } from "./cacheAccess";
 import { CodeFlowLogin, ConvertTokenToJson, ErrorMessage } from "./codeFlowLogin";
 import { m365CacheName } from "./common/constant";
 import { LoginStatus } from "./common/login";
 import CLILogProvider from "./log";
-import M365TokenProviderUserPassword from "./m365LoginUserPassword";
 
 const SERVER_PORT = 0;
 
@@ -176,55 +174,3 @@ export class M365Login extends BasicLogin implements M365TokenProvider {
     }
   }
 }
-
-/**
- * this class is a wrapper for M365TokenProvider that will use M365Login if interactive is true, otherwise use M365TokenProviderUserPassword
- */
-class MM365TokenProviderWrapper implements M365TokenProvider {
-  getProvider(): M365TokenProvider {
-    // if interactive is false and system environment variables (M365_ACCOUNT_NAME, M365_ACCOUNT_PASSWORD) are set, then use M365TokenProviderUserPassword
-    const m365Login =
-      !ui.interactive && process.env.M365_ACCOUNT_NAME && process.env.M365_ACCOUNT_PASSWORD
-        ? M365TokenProviderUserPassword
-        : M365Login.getInstance();
-    return m365Login;
-  }
-  getAccessToken(tokenRequest: TokenRequest): Promise<Result<string, FxError>> {
-    return this.getProvider().getAccessToken(tokenRequest);
-  }
-  getJsonObject(
-    tokenRequest: TokenRequest,
-    tenantId?: string
-  ): Promise<Result<Record<string, unknown>, FxError>> {
-    return this.getProvider().getJsonObject(tokenRequest, tenantId);
-  }
-  getStatus(tokenRequest: TokenRequest): Promise<Result<LoginStatus, FxError>> {
-    return this.getProvider().getStatus(tokenRequest);
-  }
-  setStatusChangeMap(
-    name: string,
-    tokenRequest: TokenRequest,
-    statusChange: (
-      status: string,
-      token?: string,
-      accountInfo?: Record<string, unknown>
-    ) => Promise<void>,
-    immediateCall?: boolean
-  ): Promise<Result<boolean, FxError>> {
-    return this.getProvider().setStatusChangeMap(name, tokenRequest, statusChange, immediateCall);
-  }
-  removeStatusChangeMap(name: string): Promise<Result<boolean, FxError>> {
-    return this.getProvider().removeStatusChangeMap(name);
-  }
-  async signout(): Promise<boolean> {
-    return await (this.getProvider() as any).signout();
-  }
-  async switchTenant(tenantId: string): Promise<Result<string, FxError>> {
-    return await this.getProvider().switchTenant(tenantId);
-  }
-  async getTenant(): Promise<string | undefined> {
-    return await (this.getProvider() as any).getTenant();
-  }
-}
-
-export default new MM365TokenProviderWrapper();

--- a/packages/cli/tests/unit/cmds/preview/previewEnv.tests.ts
+++ b/packages/cli/tests/unit/cmds/preview/previewEnv.tests.ts
@@ -25,7 +25,7 @@ import PreviewEnv from "../../../../src/cmds/preview/previewEnv";
 import { ServiceLogWriter } from "../../../../src/cmds/preview/serviceLogWriter";
 import { Task } from "../../../../src/cmds/preview/task";
 import cliLogger from "../../../../src/commonlib/log";
-import M365TokenInstance from "../../../../src/commonlib/m365Login";
+import M365TokenInstance from "../../../../src/commonlib/M365TokenProviderWrapper";
 import cliTelemetry from "../../../../src/telemetry/cliTelemetry";
 import CLIUIInstance from "../../../../src/userInteraction";
 import * as Utils from "../../../../src/utils";

--- a/packages/cli/tests/unit/commands.tests.ts
+++ b/packages/cli/tests/unit/commands.tests.ts
@@ -72,7 +72,7 @@ import AzureTokenProvider from "../../src/commonlib/azureLogin";
 import AzureTokenCIProvider from "../../src/commonlib/azureLoginCI";
 import { AzureSpCrypto } from "../../src/commonlib/cacheAccess";
 import { logger } from "../../src/commonlib/logger";
-import M365TokenProvider from "../../src/commonlib/m365Login";
+import M365TokenProvider from "../../src/commonlib/M365TokenProviderWrapper";
 import { MissingRequiredOptionError } from "../../src/error";
 import * as utils from "../../src/utils";
 

--- a/packages/cli/tests/unit/commonlib/M365TokenProviderWrapper.tests.ts
+++ b/packages/cli/tests/unit/commonlib/M365TokenProviderWrapper.tests.ts
@@ -1,0 +1,213 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import "mocha";
+import mockedEnv, { RestoreFn } from "mocked-env";
+import sinon from "sinon";
+import { expect } from "../utils";
+import { ok, err, FxError, UserError } from "@microsoft/teamsfx-api";
+import ui from "../../../src/userInteraction";
+import { M365Login } from "../../../src/commonlib/m365Login";
+import M365TokenProviderUserPassword from "../../../src/commonlib/m365LoginUserPassword";
+import M365TokenProviderWrapper from "../../../src/commonlib/M365TokenProviderWrapper";
+
+describe("M365TokenProviderWrapper Tests", function () {
+  const sandbox = sinon.createSandbox();
+  let mockedEnvRestore: RestoreFn = () => {};
+
+  afterEach(() => {
+    sandbox.restore();
+    mockedEnvRestore();
+  });
+
+  describe("getProvider", () => {
+    it("should return M365Login when interactive is true", async () => {
+      sandbox.stub(ui, "interactive").value(true);
+      const mockM365Login = {
+        getAccessToken: sandbox.stub().resolves(ok("token")),
+      };
+      sandbox.stub(M365Login, "getInstance").returns(mockM365Login as any);
+
+      const provider = M365TokenProviderWrapper.getProvider();
+
+      expect(provider).to.equal(mockM365Login);
+    });
+
+    it("should return M365Login when interactive is false but env vars not set", async () => {
+      sandbox.stub(ui, "interactive").value(false);
+      // Explicitly ensure env vars are not set
+      mockedEnvRestore = mockedEnv({
+        M365_ACCOUNT_NAME: undefined,
+        M365_ACCOUNT_PASSWORD: undefined,
+      });
+      const mockM365Login = {
+        getAccessToken: sandbox.stub().resolves(ok("token")),
+      };
+      sandbox.stub(M365Login, "getInstance").returns(mockM365Login as any);
+
+      const provider = M365TokenProviderWrapper.getProvider();
+
+      expect(provider).to.equal(mockM365Login);
+    });
+
+    it("should return M365TokenProviderUserPassword when interactive is false and env vars are set", async () => {
+      sandbox.stub(ui, "interactive").value(false);
+      mockedEnvRestore = mockedEnv({
+        M365_ACCOUNT_NAME: "test@test.com",
+        M365_ACCOUNT_PASSWORD: "password",
+      });
+
+      const provider = M365TokenProviderWrapper.getProvider();
+
+      expect(provider).to.equal(M365TokenProviderUserPassword);
+    });
+  });
+
+  describe("getAccessToken", () => {
+    it("should delegate to the provider's getAccessToken", async () => {
+      sandbox.stub(ui, "interactive").value(true);
+      const mockToken = "test-token";
+      const mockM365Login = {
+        getAccessToken: sandbox.stub().resolves(ok(mockToken)),
+      };
+      sandbox.stub(M365Login, "getInstance").returns(mockM365Login as any);
+
+      const result = await M365TokenProviderWrapper.getAccessToken({ scopes: ["scope1"] });
+
+      expect(result.isOk()).to.be.true;
+      expect(result._unsafeUnwrap()).to.equal(mockToken);
+      expect(mockM365Login.getAccessToken.calledOnce).to.be.true;
+    });
+  });
+
+  describe("getJsonObject", () => {
+    it("should delegate to the provider's getJsonObject", async () => {
+      sandbox.stub(ui, "interactive").value(true);
+      const mockJson = { name: "test" };
+      const mockM365Login = {
+        getJsonObject: sandbox.stub().resolves(ok(mockJson)),
+      };
+      sandbox.stub(M365Login, "getInstance").returns(mockM365Login as any);
+
+      const result = await M365TokenProviderWrapper.getJsonObject(
+        { scopes: ["scope1"] },
+        "tenantId"
+      );
+
+      expect(result.isOk()).to.be.true;
+      expect(result._unsafeUnwrap()).to.deep.equal(mockJson);
+      expect(mockM365Login.getJsonObject.calledOnce).to.be.true;
+    });
+  });
+
+  describe("getStatus", () => {
+    it("should delegate to the provider's getStatus", async () => {
+      sandbox.stub(ui, "interactive").value(true);
+      const mockStatus = { status: "signedIn", accountInfo: { upn: "test@test.com" } };
+      const mockM365Login = {
+        getStatus: sandbox.stub().resolves(ok(mockStatus)),
+      };
+      sandbox.stub(M365Login, "getInstance").returns(mockM365Login as any);
+
+      const result = await M365TokenProviderWrapper.getStatus({ scopes: ["scope1"] });
+
+      expect(result.isOk()).to.be.true;
+      expect(result._unsafeUnwrap()).to.deep.equal(mockStatus);
+      expect(mockM365Login.getStatus.calledOnce).to.be.true;
+    });
+  });
+
+  describe("setStatusChangeMap", () => {
+    it("should delegate to the provider's setStatusChangeMap", async () => {
+      sandbox.stub(ui, "interactive").value(true);
+      const mockM365Login = {
+        setStatusChangeMap: sandbox.stub().resolves(ok(true)),
+      };
+      sandbox.stub(M365Login, "getInstance").returns(mockM365Login as any);
+
+      const statusChange = async () => {};
+      const result = await M365TokenProviderWrapper.setStatusChangeMap(
+        "test",
+        { scopes: ["scope1"] },
+        statusChange,
+        true
+      );
+
+      expect(result.isOk()).to.be.true;
+      expect(mockM365Login.setStatusChangeMap.calledOnce).to.be.true;
+    });
+  });
+
+  describe("removeStatusChangeMap", () => {
+    it("should delegate to the provider's removeStatusChangeMap", async () => {
+      sandbox.stub(ui, "interactive").value(true);
+      const mockM365Login = {
+        removeStatusChangeMap: sandbox.stub().resolves(ok(true)),
+      };
+      sandbox.stub(M365Login, "getInstance").returns(mockM365Login as any);
+
+      const result = await M365TokenProviderWrapper.removeStatusChangeMap("test");
+
+      expect(result.isOk()).to.be.true;
+      expect(mockM365Login.removeStatusChangeMap.calledOnce).to.be.true;
+    });
+  });
+
+  describe("signout", () => {
+    it("should delegate to the provider's signout", async () => {
+      sandbox.stub(ui, "interactive").value(true);
+      const mockM365Login = {
+        signout: sandbox.stub().resolves(true),
+      };
+      sandbox.stub(M365Login, "getInstance").returns(mockM365Login as any);
+
+      const result = await M365TokenProviderWrapper.signout();
+
+      expect(result).to.be.true;
+      expect(mockM365Login.signout.calledOnce).to.be.true;
+    });
+  });
+
+  describe("switchTenant", () => {
+    it("should delegate to the provider's switchTenant", async () => {
+      sandbox.stub(ui, "interactive").value(true);
+      const mockM365Login = {
+        switchTenant: sandbox.stub().resolves(ok("newTenantId")),
+      };
+      sandbox.stub(M365Login, "getInstance").returns(mockM365Login as any);
+
+      const result = await M365TokenProviderWrapper.switchTenant("newTenantId");
+
+      expect(result.isOk()).to.be.true;
+      expect(mockM365Login.switchTenant.calledOnce).to.be.true;
+    });
+  });
+
+  describe("getTenant", () => {
+    it("should delegate to the provider's getTenant", async () => {
+      sandbox.stub(ui, "interactive").value(true);
+      const mockTenantId = "test-tenant-id";
+      const mockM365Login = {
+        getTenant: sandbox.stub().resolves(mockTenantId),
+      };
+      sandbox.stub(M365Login, "getInstance").returns(mockM365Login as any);
+
+      const result = await M365TokenProviderWrapper.getTenant();
+
+      expect(result).to.equal(mockTenantId);
+      expect(mockM365Login.getTenant.calledOnce).to.be.true;
+    });
+
+    it("should return undefined when provider's getTenant returns undefined", async () => {
+      sandbox.stub(ui, "interactive").value(true);
+      const mockM365Login = {
+        getTenant: sandbox.stub().resolves(undefined),
+      };
+      sandbox.stub(M365Login, "getInstance").returns(mockM365Login as any);
+
+      const result = await M365TokenProviderWrapper.getTenant();
+
+      expect(result).to.be.undefined;
+    });
+  });
+});

--- a/packages/tests/.mocharc.js
+++ b/packages/tests/.mocharc.js
@@ -2,5 +2,5 @@ module.exports = {
     timeout: 20 * 60 * 1000,
     exit: true,
     reporter: "mochawesome",
-    require: ["ts-node/register", "./src/e2e/setup.ts"]
+    require: ["ts-node/register"]
 };

--- a/packages/tests/.mocharc.js
+++ b/packages/tests/.mocharc.js
@@ -2,5 +2,5 @@ module.exports = {
     timeout: 20 * 60 * 1000,
     exit: true,
     reporter: "mochawesome",
-    require: ["ts-node/register"]
+    require: "ts-node/register"
 };

--- a/packages/tests/.mocharc.js
+++ b/packages/tests/.mocharc.js
@@ -2,5 +2,5 @@ module.exports = {
     timeout: 20 * 60 * 1000,
     exit: true,
     reporter: "mochawesome",
-    require: "ts-node/register"
+    require: ["ts-node/register", "./src/e2e/setup.ts"]
 };

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "rimraf out && tsc -p ./",
     "test:e2e": "npm run test:e2e:clean && npm run test:e2e:parallel",
-    "test:e2e:clean": "NODE_OPTIONS=\"--unhandled-rejections=strict\" ts-node src/e2e/clean.ts",
+    "test:e2e:clean": "ts-node --require ./src/e2e/setup.ts src/e2e/clean.ts",
     "test:e2e:parallel": "mocha --parallel --exit --reporter @mochajs/json-file-reporter \"src/e2e/**/*.tests.ts\"",
     "test:e2e:smoke": "mocha --exit --reporter @mochajs/json-file-reporter \"src/e2e/smoke/*.tests.ts\"",
     "test:e2e:others": "mocha --exit --reporter @mochajs/json-file-reporter \"src/e2e/{,!(smoke)}/*.tests.ts\"",

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -8,10 +8,10 @@
   "scripts": {
     "build": "rimraf out && tsc -p ./",
     "test:e2e": "npm run test:e2e:clean && npm run test:e2e:parallel",
-    "test:e2e:clean": "ts-node --require ./src/e2e/setup.ts src/e2e/clean.ts",
-    "test:e2e:parallel": "mocha --parallel --exit --reporter @mochajs/json-file-reporter \"src/e2e/**/*.tests.ts\"",
-    "test:e2e:smoke": "mocha --exit --reporter @mochajs/json-file-reporter \"src/e2e/smoke/*.tests.ts\"",
-    "test:e2e:others": "mocha --exit --reporter @mochajs/json-file-reporter \"src/e2e/{,!(smoke)}/*.tests.ts\"",
+    "test:e2e:clean": "NODE_OPTIONS=\"--unhandled-rejections=strict\" ts-node --require ./src/e2e/setup.ts src/e2e/clean.ts",
+    "test:e2e:parallel": "mocha --require ./src/e2e/setup.ts --parallel --exit --reporter @mochajs/json-file-reporter \"src/e2e/**/*.tests.ts\"",
+    "test:e2e:smoke": "mocha --require ./src/e2e/setup.ts --exit --reporter @mochajs/json-file-reporter \"src/e2e/smoke/*.tests.ts\"",
+    "test:e2e:others": "mocha --require ./src/e2e/setup.ts --exit --reporter @mochajs/json-file-reporter \"src/e2e/{,!(smoke)}/*.tests.ts\"",
     "precommit": "lint-staged"
   },
   "devDependencies": {

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -9,9 +9,9 @@
     "build": "rimraf out && tsc -p ./",
     "test:e2e": "npm run test:e2e:clean && npm run test:e2e:parallel",
     "test:e2e:clean": "NODE_OPTIONS=\"--unhandled-rejections=strict\" ts-node --require ./src/e2e/setup.ts src/e2e/clean.ts",
-    "test:e2e:parallel": "mocha --require ./src/e2e/setup.ts --parallel --exit --reporter @mochajs/json-file-reporter \"src/e2e/**/*.tests.ts\"",
-    "test:e2e:smoke": "mocha --require ./src/e2e/setup.ts --exit --reporter @mochajs/json-file-reporter \"src/e2e/smoke/*.tests.ts\"",
-    "test:e2e:others": "mocha --require ./src/e2e/setup.ts --exit --reporter @mochajs/json-file-reporter \"src/e2e/{,!(smoke)}/*.tests.ts\"",
+    "test:e2e:parallel": "mocha --parallel --exit --reporter @mochajs/json-file-reporter \"src/e2e/**/*.tests.ts\"",
+    "test:e2e:smoke": "mocha --exit --reporter @mochajs/json-file-reporter \"src/e2e/smoke/*.tests.ts\"",
+    "test:e2e:others": "mocha --exit --reporter @mochajs/json-file-reporter \"src/e2e/{,!(smoke)}/*.tests.ts\"",
     "precommit": "lint-staged"
   },
   "devDependencies": {

--- a/packages/tests/src/e2e/README.md
+++ b/packages/tests/src/e2e/README.md
@@ -150,7 +150,7 @@ import {
 import { AadValidator, BotValidator } from "../../commonlib";
 import { TemplateProject } from "../../commonlib/constants";
 import { CliHelper } from "../../commonlib/cliHelper";
-import m365Login from "@microsoft/m365agentstoolkit-cli/src/commonlib/m365Login";
+import { M365ProviderUserPassword } from "@microsoft/m365agentstoolkit-cli/src/commonlib/m365LoginUserPassword";
 import { environmentNameManager } from "@microsoft/teamsfx-core";
 
 describe("teamsfx new sample", function () {
@@ -192,7 +192,7 @@ describe("teamsfx new sample", function () {
       const context = await fs.readJSON(`${projectPath}/.fx/states/state.dev.json`);
 
       // Validate Aad App
-      const aad = AadValidator.init(context, false, m365Login);
+      const aad = AadValidator.init(context, false, M365ProviderUserPassword.getInstance());
       await AadValidator.validate(aad);
 
       // Validate Bot Deploy

--- a/packages/tests/src/e2e/caseFactory.ts
+++ b/packages/tests/src/e2e/caseFactory.ts
@@ -6,7 +6,7 @@
  */
 
 import { it } from "@microsoft/extra-shot-mocha";
-import m365Login from "@microsoft/m365agentstoolkit-cli/src/commonlib/m365Login";
+import { M365ProviderUserPassword } from "@microsoft/m365agentstoolkit-cli/src/commonlib/m365LoginUserPassword";
 import {
   environmentNameManager,
   ProgrammingLanguage,
@@ -200,7 +200,11 @@ export abstract class CaseFactory {
             }
             if (validate.includes("aad")) {
               // Validate Aad App
-              const aad = AadValidator.init(context, false, m365Login);
+              const aad = AadValidator.init(
+                context,
+                false,
+                M365ProviderUserPassword.getInstance()
+              );
               await AadValidator.validate(aad);
             }
             if (validate.includes("tab & bot")) {

--- a/packages/tests/src/e2e/commonUtils.ts
+++ b/packages/tests/src/e2e/commonUtils.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import MockAzureAccountProvider from "@microsoft/m365agentstoolkit-cli/src/commonlib/azureLoginUserPassword";
-import m365Login from "@microsoft/m365agentstoolkit-cli/src/commonlib/m365Login";
+import m365Login from "@microsoft/m365agentstoolkit-cli/src/commonlib/M365TokenProviderWrapper";
 import {
   AppPackageFolderName,
   ConfigFolderName,

--- a/packages/tests/src/e2e/commonUtils.ts
+++ b/packages/tests/src/e2e/commonUtils.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import MockAzureAccountProvider from "@microsoft/m365agentstoolkit-cli/src/commonlib/azureLoginUserPassword";
-import m365Login from "@microsoft/m365agentstoolkit-cli/src/commonlib/M365TokenProviderWrapper";
+import { M365ProviderUserPassword } from "@microsoft/m365agentstoolkit-cli/src/commonlib/m365LoginUserPassword";
 import {
   AppPackageFolderName,
   ConfigFolderName,
@@ -600,7 +600,11 @@ export async function validateTabAndBotProjectProvision(
 ) {
   const context = await readContextMultiEnvV3(projectPath, env);
   // Validate Aad App
-  const aad = AadValidator.init(context, false, m365Login);
+  const aad = AadValidator.init(
+    context,
+    false,
+    M365ProviderUserPassword.getInstance()
+  );
   await AadValidator.validate(aad);
 
   // Validate Tab Frontend

--- a/packages/tests/src/e2e/feature/multienv.tests.ts
+++ b/packages/tests/src/e2e/feature/multienv.tests.ts
@@ -6,7 +6,7 @@
  */
 
 import { it } from "@microsoft/extra-shot-mocha";
-import M365Login from "@microsoft/m365agentstoolkit-cli/src/commonlib/m365Login";
+import { M365ProviderUserPassword } from "@microsoft/m365agentstoolkit-cli/src/commonlib/m365LoginUserPassword";
 import { AppPackageFolderName, BuildFolderName } from "@microsoft/teamsfx-api";
 import * as chai from "chai";
 import { expect } from "chai";
@@ -155,7 +155,7 @@ describe("Multi Env Happy Path for Azure", function () {
           const context = await readContextMultiEnvV3(projectPath, env);
           teamsAppId = context[EnvConstants.TEAMS_APP_ID];
           chai.assert.isNotNull(teamsAppId);
-          AppStudioValidator.provider = M365Login;
+          AppStudioValidator.provider = M365ProviderUserPassword.getInstance();
           await AppStudioValidator.validatePublish(teamsAppId!);
         }
       } catch (e: any) {

--- a/packages/tests/src/e2e/samples/sampleCaseFactory.ts
+++ b/packages/tests/src/e2e/samples/sampleCaseFactory.ts
@@ -27,7 +27,7 @@ import {
   ContainerAppValidator,
   StaticSiteValidator,
 } from "../../commonlib";
-import m365Login from "@microsoft/m365agentstoolkit-cli/src/commonlib/m365Login";
+import { M365ProviderUserPassword } from "@microsoft/m365agentstoolkit-cli/src/commonlib/m365LoginUserPassword";
 
 export abstract class CaseFactory {
   public sampleName: TemplateProjectFolder;
@@ -166,7 +166,11 @@ export abstract class CaseFactory {
           }
           if (validate.includes("aad")) {
             // Validate Aad App
-            const aad = AadValidator.init(context, false, m365Login);
+            const aad = AadValidator.init(
+              context,
+              false,
+              M365ProviderUserPassword.getInstance()
+            );
             await AadValidator.validate(aad);
           }
           if (validate.includes("tab & bot")) {

--- a/packages/tests/src/e2e/setup.ts
+++ b/packages/tests/src/e2e/setup.ts
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/**
+ * Test setup file that runs before all tests.
+ * This file mocks native modules that are not needed for e2e tests
+ * and may cause issues on certain platforms (e.g., Linux CI).
+ */
+
+// Mock keytar to prevent native module loading issues on Linux
+// keytar is used by @azure/msal-node-extensions for secure credential storage,
+// but is not needed in e2e tests where we mock authentication
+const Module = require("module");
+const originalRequire = Module.prototype.require;
+
+Module.prototype.require = function (id: string, ...args: any[]) {
+  if (id === "keytar") {
+    return {
+      getPassword: async () => null,
+      setPassword: async () => {},
+      deletePassword: async () => true,
+      findPassword: async () => null,
+      findCredentials: async () => [],
+    };
+  }
+  return originalRequire.apply(this, [id, ...args]);
+};


### PR DESCRIPTION
1> Fixed libsecret not found issue during e2e cleanup by mocking keytar before cleanup
2> Fixed case execution error by separating M365TokenProvider with M365 interactive login for CLI. E2E will only load username password instance to avoid keytar loading issue
3> Fixed CLI command execution issue by dynamic loading `@azure/msal-node-extensions` package. On Linux, if libsecret is not installed, nativeBrokerPlugin will not be used 
ADO: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/36331776/?view=edit

Successful job run: https://github.com/OfficeDev/microsoft-365-agents-toolkit/actions/runs/20803530855/