### PR TITLE
feat: government cloud support in ATK

### DIFF
--- a/packages/cli/src/cmds/preview/previewEnv.ts
+++ b/packages/cli/src/cmds/preview/previewEnv.ts
@@ -234,15 +234,15 @@ export default class PreviewEnv {
     let loginHint: string | undefined = undefined;
     let tenantId: string | undefined = undefined;
     try {
-      let loginStatusRes = await M365TokenInstance.getStatus({ scopes: AppStudioScopes });
+      let loginStatusRes = await M365TokenInstance.getStatus({ scopes: AppStudioScopes() });
       let token = loginStatusRes.isOk() ? loginStatusRes.value.token : undefined;
       if (loginStatusRes.isOk() && loginStatusRes.value.status === signedOut) {
         const tokenRes = await M365TokenInstance.getAccessToken({
-          scopes: AppStudioScopes,
+          scopes: AppStudioScopes(),
           showDialog: true,
         });
         token = tokenRes.isOk() ? tokenRes.value : undefined;
-        loginStatusRes = await M365TokenInstance.getStatus({ scopes: AppStudioScopes });
+        loginStatusRes = await M365TokenInstance.getStatus({ scopes: AppStudioScopes() });
       }
       if (token === undefined) {
         result = false;
@@ -408,7 +408,7 @@ export default class PreviewEnv {
     browser: constants.Browser,
     browserArgs: string[]
   ): Promise<Result<null, FxError>> {
-    const loginStatusRes = await M365TokenInstance.getStatus({ scopes: AppStudioScopes });
+    const loginStatusRes = await M365TokenInstance.getStatus({ scopes: AppStudioScopes() });
     let username = "";
     if (
       loginStatusRes.isOk() &&

--- a/packages/cli/src/commands/models/accountShow.ts
+++ b/packages/cli/src/commands/models/accountShow.ts
@@ -48,7 +48,7 @@ class AccountUtils {
 
       const cachedTenantId = await M365TokenProvider.getTenant();
       if (cachedTenantId) {
-        const listTenantToken = await M365TokenProvider.getAccessToken({ scopes: AzureScopes });
+        const listTenantToken = await M365TokenProvider.getAccessToken({ scopes: AzureScopes() });
         if (listTenantToken.isOk()) {
           const tenants = await listAllTenants(listTenantToken.value);
           const curTenant = tenants.find((tenant) => tenant.tenantId === cachedTenantId);
@@ -99,7 +99,7 @@ class AccountUtils {
         const identityCredential = await azureProvider.getIdentityCredentialAsync(false);
         const listTenantToken = identityCredential
           ? await identityCredential.getToken(
-              AzureSpCrypto.checkAzureSPFile() ? env.managementEndpointDefaultScope : AzureScopes
+              AzureSpCrypto.checkAzureSPFile() ? env.managementEndpointDefaultScope : AzureScopes()
             )
           : undefined;
         if (listTenantToken && listTenantToken.token) {

--- a/packages/cli/src/commands/models/accountShow.ts
+++ b/packages/cli/src/commands/models/accountShow.ts
@@ -32,7 +32,7 @@ class AccountUtils {
   async outputM365Info(commandType: "login" | "show", tid?: string): Promise<boolean> {
     const appStudioTokenJsonRes = await M365TokenProvider.getJsonObject(
       {
-        scopes: AppStudioScopes,
+        scopes: AppStudioScopes(),
       },
       tid
     );
@@ -143,7 +143,7 @@ export const accountShowCommand: CLICommand = {
     event: TelemetryEvent.AccountShow,
   },
   handler: async (ctx) => {
-    const m365StatusRes = await M365TokenProvider.getStatus({ scopes: AppStudioScopes });
+    const m365StatusRes = await M365TokenProvider.getStatus({ scopes: AppStudioScopes() });
     if (m365StatusRes.isErr()) {
       return err(m365StatusRes.error);
     }

--- a/packages/cli/src/commands/models/m365LaunchInfo.ts
+++ b/packages/cli/src/commands/models/m365LaunchInfo.ts
@@ -6,7 +6,11 @@ import { logger } from "../../commonlib/logger";
 import { MissingRequiredOptionError } from "../../error";
 import { commands } from "../../resource";
 import { TelemetryEvent } from "../../telemetry/cliTelemetryEvents";
-import { m365utils, sideloadingServiceEndpoint } from "./m365Sideloading";
+import { m365utils } from "./m365Sideloading";
+import {
+  getResourceServiceEndpoint,
+  ResourceServiceType,
+} from "@microsoft/teamsfx-core/build/common/constants";
 
 export const m365LaunchInfoCommand: CLICommand = {
   name: "launchinfo",
@@ -38,7 +42,10 @@ export const m365LaunchInfoCommand: CLICommand = {
   },
   defaultInteractiveOption: false,
   handler: async (ctx) => {
-    const packageService = new PackageService(sideloadingServiceEndpoint, logger);
+    const packageService = new PackageService(
+      getResourceServiceEndpoint(ResourceServiceType.MOS3),
+      logger
+    );
     let titleId = ctx.optionValues["title-id"] as string;
     const manifestId = ctx.optionValues["manifest-id"] as string;
     if (titleId === undefined && manifestId === undefined) {

--- a/packages/cli/src/commands/models/m365Sideloading.ts
+++ b/packages/cli/src/commands/models/m365Sideloading.ts
@@ -1,21 +1,23 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 import { CLICommand, err, ok } from "@microsoft/teamsfx-api";
-import { PackageService, MosServiceEndpoint, MosServiceScope } from "@microsoft/teamsfx-core";
+import { PackageService, MosServiceScope } from "@microsoft/teamsfx-core";
 import { logger } from "../../commonlib/logger";
 import M365TokenProvider from "../../commonlib/M365TokenProviderWrapper";
 import { ArgumentConflictError, MissingRequiredOptionError } from "../../error";
 import { commands } from "../../resource";
 import { TelemetryEvent } from "../../telemetry/cliTelemetryEvents";
 import { AppScope } from "@microsoft/teamsfx-core/build/component/m365/packageService";
+import {
+  getResourceServiceEndpoint,
+  ResourceServiceType,
+} from "@microsoft/teamsfx-core/build/common/constants";
 
-export const sideloadingServiceEndpoint =
-  process.env.SIDELOADING_SERVICE_ENDPOINT ?? MosServiceEndpoint;
 export const sideloadingServiceScope = process.env.SIDELOADING_SERVICE_SCOPE ?? MosServiceScope;
 
 class M365Utils {
   async getTokenAndUpn(): Promise<[string, string]> {
-    const tokenRes = await M365TokenProvider.getAccessToken({ scopes: [sideloadingServiceScope] });
+    const tokenRes = await M365TokenProvider.getAccessToken({ scopes: MosServiceScope() });
     if (tokenRes.isErr()) {
       logger.error(
         `Cannot get token. Use '${process.env.TEAMSFX_CLI_BIN_NAME} account login m365' to log in the correct account.`
@@ -104,7 +106,10 @@ export const m365SideloadingCommand: CLICommand = {
       return err(new ArgumentConflictError(ctx.command.fullName, `--file-path`, `--xml-path`));
     }
 
-    const packageService = new PackageService(sideloadingServiceEndpoint, logger);
+    const packageService = new PackageService(
+      getResourceServiceEndpoint(ResourceServiceType.MOS3),
+      logger
+    );
     const manifestPath = zipAppPackagePath ?? xmlPath;
     const tokenAndUpn = await m365utils.getTokenAndUpn();
     if (ctx.optionValues["file-path"] !== undefined) {

--- a/packages/cli/src/commands/models/m365Unacquire.ts
+++ b/packages/cli/src/commands/models/m365Unacquire.ts
@@ -2,11 +2,8 @@
 // Licensed under the MIT license.
 import { CLICommand, err, ok } from "@microsoft/teamsfx-api";
 import { UninstallInputs, QuestionNames } from "@microsoft/teamsfx-core";
-import { logger } from "../../commonlib/logger";
-import { MissingRequiredOptionError } from "../../error";
 import { commands } from "../../resource";
 import { TelemetryEvent } from "../../telemetry/cliTelemetryEvents";
-import { m365utils, sideloadingServiceEndpoint } from "./m365Sideloading";
 import { getFxCore } from "../../activate";
 
 export const m365UnacquireCommand: CLICommand = {

--- a/packages/cli/src/commands/models/teamsapp/doctor.ts
+++ b/packages/cli/src/commands/models/teamsapp/doctor.ts
@@ -108,15 +108,15 @@ export class DoctorChecker {
     let error = undefined;
     let loginHint: string | undefined = undefined;
     try {
-      let loginStatusRes = await M365TokenInstance.getStatus({ scopes: AppStudioScopes });
+      let loginStatusRes = await M365TokenInstance.getStatus({ scopes: AppStudioScopes() });
       let token = loginStatusRes.isOk() ? loginStatusRes.value.token : undefined;
       if (loginStatusRes.isOk() && loginStatusRes.value.status === signedOut) {
         const tokenRes = await M365TokenInstance.getAccessToken({
-          scopes: AppStudioScopes,
+          scopes: AppStudioScopes(),
           showDialog: true,
         });
         token = tokenRes.isOk() ? tokenRes.value : undefined;
-        loginStatusRes = await M365TokenInstance.getStatus({ scopes: AppStudioScopes });
+        loginStatusRes = await M365TokenInstance.getStatus({ scopes: AppStudioScopes() });
       }
       if (token === undefined) {
         result = false;

--- a/packages/cli/src/commonlib/azureLogin.ts
+++ b/packages/cli/src/commonlib/azureLogin.ts
@@ -218,7 +218,7 @@ export class AzureAccountManager extends login implements AzureAccountProvider {
       AzureAccountManager.codeFlowInstance.account;
     if (AzureAccountManager.statusChange !== undefined && checkCodeFlow) {
       const credential = await this.getIdentityCredentialAsync();
-      const accessToken = await credential?.getToken(AzureScopes);
+      const accessToken = await credential?.getToken(AzureScopes());
       const accountJson = await this.getJsonObject();
       await AzureAccountManager.statusChange("SignedIn", accessToken?.token, accountJson);
     }
@@ -226,7 +226,7 @@ export class AzureAccountManager extends login implements AzureAccountProvider {
   }
 
   private async login(showDialog: boolean, tenantId?: string): Promise<void> {
-    const accessToken = await AzureAccountManager.codeFlowInstance.getTokenByScopes(AzureScopes);
+    const accessToken = await AzureAccountManager.codeFlowInstance.getTokenByScopes(AzureScopes());
     const tokenJson = await this.getJsonObject(false, tenantId);
     if (accessToken.isOk() && accessToken.value) {
       this.setMemoryCache(accessToken.value, tokenJson);
@@ -274,7 +274,7 @@ export class AzureAccountManager extends login implements AzureAccountProvider {
     claimsChallenge?: string
   ): Promise<Record<string, unknown> | undefined> {
     const token = await AzureAccountManager.codeFlowInstance.getTokenByScopes(
-      claimsChallenge ? { scopes: AzureScopes, wwwAuthenticate: claimsChallenge } : AzureScopes,
+      claimsChallenge ? { scopes: AzureScopes(), wwwAuthenticate: claimsChallenge } : AzureScopes(),
       true,
       tenantId
     );
@@ -320,7 +320,7 @@ export class AzureAccountManager extends login implements AzureAccountProvider {
         }
       }
       const credential = await this.getIdentityCredentialAsync();
-      const token = await credential?.getToken(AzureScopes);
+      const token = await credential?.getToken(AzureScopes());
       const accountJson = await this.getJsonObject();
       return Promise.resolve({
         status: signedIn,

--- a/packages/cli/src/commonlib/azureLoginUserPassword.ts
+++ b/packages/cli/src/commonlib/azureLoginUserPassword.ts
@@ -100,7 +100,7 @@ export class AzureAccountProviderUserPassword implements AzureAccountProvider {
   }
   async getJsonObject(showDialog?: boolean): Promise<Record<string, unknown> | undefined> {
     const identity = await this.getIdentityCredentialAsync();
-    const token = await identity?.getToken(AzureScopes);
+    const token = await identity?.getToken(AzureScopes());
     if (token?.token) {
       return ConvertTokenToJson(token?.token);
     } else {

--- a/packages/cli/src/commonlib/m365Login.ts
+++ b/packages/cli/src/commonlib/m365Login.ts
@@ -101,7 +101,7 @@ export class M365Login extends BasicLogin implements M365TokenProvider {
     if (!M365Login.codeFlowInstance.account) {
       await M365Login.codeFlowInstance.reloadCache();
       if (M365Login.codeFlowInstance.account) {
-        const regionTokenRes = await M365Login.codeFlowInstance.getTokenByScopes(AuthSvcScopes);
+        const regionTokenRes = await M365Login.codeFlowInstance.getTokenByScopes(AuthSvcScopes());
         if (regionTokenRes.isOk()) {
           await teamsDevPortalClient.setRegionEndpointByToken(regionTokenRes.value);
         }
@@ -115,7 +115,7 @@ export class M365Login extends BasicLogin implements M365TokenProvider {
       tenantId
     );
     if (needLogin == true && M365Login.codeFlowInstance.account) {
-      const regionTokenRes = await M365Login.codeFlowInstance.getTokenByScopes(AuthSvcScopes);
+      const regionTokenRes = await M365Login.codeFlowInstance.getTokenByScopes(AuthSvcScopes());
       if (regionTokenRes.isOk()) {
         await teamsDevPortalClient.setRegionEndpointByToken(regionTokenRes.value);
       }

--- a/packages/cli/src/commonlib/m365LoginUserPassword.ts
+++ b/packages/cli/src/commonlib/m365LoginUserPassword.ts
@@ -74,9 +74,9 @@ export class M365ProviderUserPassword extends BasicLogin implements M365TokenPro
       const m365Token = M365ProviderUserPassword.accessToken;
 
       // Set region for App Studio API
-      if (tokenRequest.scopes === AppStudioScopes) {
+      if (tokenRequest.scopes === AppStudioScopes()) {
         const authSvcRequest = {
-          scopes: AuthSvcScopes,
+          scopes: AuthSvcScopes(),
           username: user!,
           password: password!,
         };

--- a/packages/fx-core/src/client/aadAppClient.ts
+++ b/packages/fx-core/src/client/aadAppClient.ts
@@ -5,7 +5,7 @@ import { hooks } from "@feathersjs/hooks/lib";
 import { LogProvider, M365TokenProvider } from "@microsoft/teamsfx-api";
 import axios, { AxiosError, AxiosInstance, AxiosRequestHeaders } from "axios";
 import axiosRetry, { IAxiosRetryConfig } from "axios-retry";
-import { GraphScopes } from "../common/constants";
+import { getResourceServiceEndpoint, GraphScopes, ResourceServiceType } from "../common/constants";
 import { getLocalizedString } from "../common/localizeUtils";
 import { AadOwner } from "../common/permissionInterface";
 import { ErrorContextMW } from "../common/globalVars";
@@ -37,7 +37,9 @@ export class AadAppClient {
   private readonly tokenProvider: M365TokenProvider;
   private readonly logProvider: LogProvider | undefined;
   private readonly axios: AxiosInstance;
-  private readonly baseUrl: string = "https://graph.microsoft.com/v1.0";
+  private readonly baseUrl: string = `${getResourceServiceEndpoint(
+    ResourceServiceType.Graph
+  )}/v1.0`;
 
   constructor(m365TokenProvider: M365TokenProvider, logProvider?: LogProvider) {
     this.tokenProvider = m365TokenProvider;

--- a/packages/fx-core/src/client/graphClient.ts
+++ b/packages/fx-core/src/client/graphClient.ts
@@ -330,7 +330,9 @@ export class GraphClient {
     const requester = this.createRequesterWithToken(tokenResponse.value);
 
     const teamData = {
-      "template@odata.bind": "https://graph.microsoft.com/beta/teamsTemplates('standard')",
+      "template@odata.bind": `${getResourceServiceEndpoint(
+        ResourceServiceType.Graph
+      )}/beta/teamsTemplates('standard')`,
       displayName: teamName,
       description: description,
       firstChannelName: defaultChannelName,

--- a/packages/fx-core/src/client/graphClient.ts
+++ b/packages/fx-core/src/client/graphClient.ts
@@ -15,6 +15,7 @@ import {
 } from "@microsoft/teamsfx-api";
 import { AxiosInstance } from "axios";
 import {
+  getResourceServiceEndpoint,
   GraphScopes,
   GraphTeamsAppSettingsReadScopes,
   GraphTeamsChannelCreateScopes,
@@ -24,6 +25,7 @@ import {
   GraphTeamsTeamReadScopes,
   GroupSearchScopes,
   ListSensitivityLabelScope,
+  ResourceServiceType,
 } from "../common/constants";
 import { globalStateGet, globalStateUpdate } from "../common/globalState";
 import { ErrorContextMW } from "../common/globalVars";
@@ -67,7 +69,7 @@ export class RetryHandler {
 
 export class GraphClient {
   private readonly baseUrl: string =
-    process.env.GRAPH_ENDPOINT ?? "https://graph.microsoft.com/beta";
+    process.env.GRAPH_ENDPOINT ?? `${getResourceServiceEndpoint(ResourceServiceType.Graph)}/beta`;
   private readonly tokenProvider: M365TokenProvider;
   private readonly logProvider: LogProvider | undefined;
 

--- a/packages/fx-core/src/client/teamsDevPortalClient.ts
+++ b/packages/fx-core/src/client/teamsDevPortalClient.ts
@@ -4,7 +4,7 @@
 import { hooks } from "@feathersjs/hooks";
 import { SystemError } from "@microsoft/teamsfx-api";
 import axios, { AxiosInstance, AxiosResponse } from "axios";
-import { HelpLinks } from "../common/constants";
+import { getResourceServiceEndpoint, HelpLinks, ResourceServiceType } from "../common/constants";
 import { ErrorContextMW, TOOLS } from "../common/globalVars";
 import { getDefaultString, getLocalizedString } from "../common/localizeUtils";
 import {
@@ -87,20 +87,14 @@ export class RetryHandler {
 export class TeamsDevPortalClient {
   regionEndpoint?: string;
 
-  getGlobalEndpoint(): string {
-    if (process.env.APP_STUDIO_ENV && process.env.APP_STUDIO_ENV === "int") {
-      return "https://dev-int.teams.microsoft.com";
-    } else {
-      return "https://dev.teams.microsoft.com";
-    }
-  }
-
   setRegionEndpoint(regionEndpoint: string): void {
     this.regionEndpoint = regionEndpoint;
   }
 
   async setRegionEndpointByToken(authSvcToken: string): Promise<void> {
-    if (this.getGlobalEndpoint() === "https://dev-int.teams.microsoft.com") {
+    if (
+      getResourceServiceEndpoint(ResourceServiceType.TDP) === "https://dev-int.teams.microsoft.com"
+    ) {
       // Do not set region for INT env
       return;
     }
@@ -114,7 +108,7 @@ export class TeamsDevPortalClient {
   }
 
   getEndpoint(): string {
-    return this.regionEndpoint || this.getGlobalEndpoint();
+    return this.regionEndpoint || getResourceServiceEndpoint(ResourceServiceType.TDP);
   }
 
   /**

--- a/packages/fx-core/src/client/teamsDevPortalClient.ts
+++ b/packages/fx-core/src/client/teamsDevPortalClient.ts
@@ -99,7 +99,7 @@ export class TeamsDevPortalClient {
       return;
     }
     const requester = WrappedAxiosClient.create({
-      baseURL: "https://teams.microsoft.com/api/authsvc",
+      baseURL: getResourceServiceEndpoint(ResourceServiceType.AuthSvc),
     });
     requester.defaults.headers.common["Authorization"] = `Bearer ${authSvcToken}`;
     requester.defaults.headers.common["Client-Source"] = "teamstoolkit";

--- a/packages/fx-core/src/common/accountUtils.ts
+++ b/packages/fx-core/src/common/accountUtils.ts
@@ -3,7 +3,8 @@
 
 import { featureFlagManager, FeatureFlags } from "./featureFlags";
 
-enum SovereignCloudEnvironment {
+export enum SovereignCloudEnvironment {
+  Public = "Public",
   GCCM = "GCC M",
   GCCH = "GCC High",
   DOD = "DOD",
@@ -28,4 +29,19 @@ export function getDefaultAuthorityUrl(): string {
 
 export function getTenantedAuthorityUrl(tenantId: string): string {
   return `${getEntraEndpoint()}/${tenantId}`;
+}
+
+export function getSovereignCloudEnvironment(): SovereignCloudEnvironment {
+  const sovereignCloudEnvironment = featureFlagManager.getStringValue(
+    FeatureFlags.SovereignCloudEnvironment
+  );
+  if (
+    sovereignCloudEnvironment &&
+    Object.values(SovereignCloudEnvironment).includes(
+      sovereignCloudEnvironment as SovereignCloudEnvironment
+    )
+  ) {
+    return sovereignCloudEnvironment as SovereignCloudEnvironment;
+  }
+  return SovereignCloudEnvironment.Public;
 }

--- a/packages/fx-core/src/common/accountUtils.ts
+++ b/packages/fx-core/src/common/accountUtils.ts
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { featureFlagManager, FeatureFlags } from "./featureFlags";
+
+enum SovereignCloudEnvironment {
+  GCCM = "GCC M",
+  GCCH = "GCC High",
+  DOD = "DOD",
+}
+
+export function getEntraEndpoint(): string {
+  const sovereignCloudEnvironment = featureFlagManager.getStringValue(
+    FeatureFlags.SovereignCloudEnvironment
+  );
+  if (
+    sovereignCloudEnvironment === SovereignCloudEnvironment.GCCH ||
+    sovereignCloudEnvironment === SovereignCloudEnvironment.DOD
+  ) {
+    return "https://login.microsoftonline.us";
+  }
+  return "https://login.microsoftonline.com";
+}
+
+export function getDefaultAuthorityUrl(): string {
+  return `${getEntraEndpoint()}/common`;
+}
+
+export function getTenantedAuthorityUrl(tenantId: string): string {
+  return `${getEntraEndpoint()}/${tenantId}`;
+}

--- a/packages/fx-core/src/common/constants.ts
+++ b/packages/fx-core/src/common/constants.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+import { getSovereignCloudEnvironment, SovereignCloudEnvironment } from "./accountUtils";
 import { getLocalizedString } from "./localizeUtils";
 
 export class ConstantString {
@@ -63,23 +64,81 @@ export function getResourceGroupInPortal(
     return undefined;
   }
 }
-export function getAppStudioEndpoint(): string {
-  if (process.env.APP_STUDIO_ENV && process.env.APP_STUDIO_ENV === "int") {
-    return "https://dev-int.teams.microsoft.com";
-  } else {
-    return "https://dev.teams.microsoft.com";
-  }
+
+export enum ResourceServiceType {
+  AuthSvc = "AuthSvc",
+  TDP = "TDP",
+  MOS3 = "MOS3",
+  Graph = "Graph",
+  Azure = "Azure",
 }
 
-export const AuthSvcScopes = ["https://api.spaces.skype.com/Region.ReadWrite"];
+export const serviceEndpoints: Record<
+  SovereignCloudEnvironment,
+  Record<ResourceServiceType, string>
+> = {
+  [SovereignCloudEnvironment.Public]: {
+    [ResourceServiceType.AuthSvc]: "https://api.spaces.skype.com",
+    [ResourceServiceType.TDP]: "https://dev.teams.microsoft.com",
+    [ResourceServiceType.MOS3]: "https://titles.prod.mos.microsoft.com",
+    [ResourceServiceType.Graph]: "https://graph.microsoft.com",
+    [ResourceServiceType.Azure]: "https://management.core.windows.net",
+  },
+  [SovereignCloudEnvironment.GCCM]: {
+    [ResourceServiceType.AuthSvc]: "https://api.spaces.skype.com",
+    [ResourceServiceType.TDP]: "https://dev.teams.microsoft.com",
+    [ResourceServiceType.MOS3]: "https://titles.gccm.mos.microsoft.com",
+    [ResourceServiceType.Graph]: "https://graph.microsoft.com",
+    [ResourceServiceType.Azure]: "https://management.core.windows.net",
+  },
+  [SovereignCloudEnvironment.GCCH]: {
+    [ResourceServiceType.AuthSvc]: "https://api.spaces.skype.com",
+    [ResourceServiceType.TDP]: "https://dev.gov.teams.microsoft.us",
+    [ResourceServiceType.MOS3]: "https://titles.gcch.mos.svc.usgovcloud.microsoft",
+    [ResourceServiceType.Graph]: "https://graph.microsoft.us",
+    [ResourceServiceType.Azure]: "https://management.usgovcloudapi.net",
+  },
+  [SovereignCloudEnvironment.DOD]: {
+    [ResourceServiceType.AuthSvc]: "https://api.spaces.skype.com",
+    [ResourceServiceType.TDP]: "https://dev.dod.teams.microsoft.us",
+    [ResourceServiceType.MOS3]: "https://titles.dod.mos.svc.usgovcloud.microsoft",
+    [ResourceServiceType.Graph]: "https://dod-graph.microsoft.us",
+    [ResourceServiceType.Azure]: "https://management.usgovcloudapi.net",
+  },
+};
+
+export function getResourceServiceEndpoint(resourceServiceType: ResourceServiceType): string {
+  if (
+    resourceServiceType === ResourceServiceType.TDP &&
+    process.env.APP_STUDIO_ENV &&
+    process.env.APP_STUDIO_ENV === "int"
+  ) {
+    return "https://dev-int.teams.microsoft.com";
+  }
+  const sovereignCloudEnvironment = getSovereignCloudEnvironment();
+  return serviceEndpoints[sovereignCloudEnvironment][resourceServiceType];
+}
+
+// AuthSvc
+export const AuthSvcScopes = () => {
+  return [`${getResourceServiceEndpoint(ResourceServiceType.AuthSvc)}/Region.ReadWrite`];
+};
+
+// TDP
+export const AppStudioScopes = () => {
+  return [`${getResourceServiceEndpoint(ResourceServiceType.TDP)}/AppDefinitions.ReadWrite`];
+};
+
+// MOS3
+export const MosServiceScope = () => {
+  return [`${getResourceServiceEndpoint(ResourceServiceType.MOS3)}/.default`];
+};
+
+// Graph
 export const GraphScopes = ["Application.ReadWrite.All", "TeamsAppInstallation.ReadForUser"];
 export const GroupSearchScopes = ["GroupMember.Read.All"];
 export const GCScopes = ["ExternalConnection.Read.All"];
 export const GraphReadUserScopes = ["https://graph.microsoft.com/User.ReadBasic.All"];
-export const SPFxScopes = (tenant: string) => [`${tenant}/Sites.FullControl.All`];
-export const AzureScopes = ["https://management.core.windows.net/user_impersonation"];
-export const AppStudioScopes = [`${getAppStudioEndpoint()}/AppDefinitions.ReadWrite`];
-export const SpecParserSource = "SpecParser";
 export const GraphTeamsAppSettingsReadScopes = ["TeamworkAppSettings.Read.All"];
 export const GraphTeamsTeamCreateScopes = ["Team.Create"];
 export const GraphTeamsChannelCreateScopes = ["Channel.Create"];
@@ -87,3 +146,11 @@ export const GraphTeamsTeamReadScopes = ["Team.ReadBasic.All"];
 export const GraphTeamsChannelReadScopes = ["Channel.ReadBasic.All"];
 export const GraphTeamsInstallAppScopes = ["TeamsAppInstallation.ReadWriteAndConsentForTeam"];
 export const ListSensitivityLabelScope = "InformationProtectionPolicy.Read";
+
+// SPFx
+export const SPFxScopes = (tenant: string) => [`${tenant}/Sites.FullControl.All`];
+
+// Azure
+export const AzureScopes = ["https://management.core.windows.net/user_impersonation"];
+
+export const SpecParserSource = "SpecParser";

--- a/packages/fx-core/src/common/constants.ts
+++ b/packages/fx-core/src/common/constants.ts
@@ -67,6 +67,7 @@ export function getResourceGroupInPortal(
 
 export enum ResourceServiceType {
   AuthSvc = "AuthSvc",
+  AuthSvcAud = "AuthSvcAud",
   TDP = "TDP",
   MOS3 = "MOS3",
   Graph = "Graph",
@@ -78,29 +79,33 @@ export const serviceEndpoints: Record<
   Record<ResourceServiceType, string>
 > = {
   [SovereignCloudEnvironment.Public]: {
-    [ResourceServiceType.AuthSvc]: "https://api.spaces.skype.com",
+    [ResourceServiceType.AuthSvc]: "https://teams.microsoft.com/api/authsvc",
+    [ResourceServiceType.AuthSvcAud]: "https://api.spaces.skype.com",
     [ResourceServiceType.TDP]: "https://dev.teams.microsoft.com",
     [ResourceServiceType.MOS3]: "https://titles.prod.mos.microsoft.com",
     [ResourceServiceType.Graph]: "https://graph.microsoft.com",
     [ResourceServiceType.Azure]: "https://management.azure.com",
   },
   [SovereignCloudEnvironment.GCCM]: {
-    [ResourceServiceType.AuthSvc]: "https://api.spaces.skype.com",
+    [ResourceServiceType.AuthSvc]: "https://teams.microsoft.com/api/authsvc",
+    [ResourceServiceType.AuthSvcAud]: "https://api.spaces.skype.com",
     [ResourceServiceType.TDP]: "https://dev.teams.microsoft.com",
     [ResourceServiceType.MOS3]: "https://titles.gccm.mos.microsoft.com",
     [ResourceServiceType.Graph]: "https://graph.microsoft.com",
     [ResourceServiceType.Azure]: "https://management.azure.com",
   },
   [SovereignCloudEnvironment.GCCH]: {
-    [ResourceServiceType.AuthSvc]: "https://api.spaces.skype.com",
-    [ResourceServiceType.TDP]: "https://dev.gov.teams.microsoft.us",
+    [ResourceServiceType.AuthSvc]: "https://gov.teams.microsoft.us/api/authsvc",
+    [ResourceServiceType.AuthSvcAud]: "https://api.spaces.skype.com",
+    [ResourceServiceType.TDP]: "https://gov.dev.teams.microsoft.us",
     [ResourceServiceType.MOS3]: "https://titles.gcch.mos.svc.usgovcloud.microsoft",
     [ResourceServiceType.Graph]: "https://graph.microsoft.us",
     [ResourceServiceType.Azure]: "https://management.usgovcloudapi.net",
   },
   [SovereignCloudEnvironment.DOD]: {
-    [ResourceServiceType.AuthSvc]: "https://api.spaces.skype.com",
-    [ResourceServiceType.TDP]: "https://dev.dod.teams.microsoft.us",
+    [ResourceServiceType.AuthSvc]: "https://dod.teams.microsoft.us/api/authsvc",
+    [ResourceServiceType.AuthSvcAud]: "https://api.spaces.skype.com",
+    [ResourceServiceType.TDP]: "https://dod.dev.teams.microsoft.us",
     [ResourceServiceType.MOS3]: "https://titles.dod.mos.svc.usgovcloud.microsoft",
     [ResourceServiceType.Graph]: "https://dod-graph.microsoft.us",
     [ResourceServiceType.Azure]: "https://management.usgovcloudapi.net",
@@ -121,7 +126,7 @@ export function getResourceServiceEndpoint(resourceServiceType: ResourceServiceT
 
 // AuthSvc
 export const AuthSvcScopes = () => {
-  return [`${getResourceServiceEndpoint(ResourceServiceType.AuthSvc)}/Region.ReadWrite`];
+  return [`${getResourceServiceEndpoint(ResourceServiceType.AuthSvcAud)}/Region.ReadWrite`];
 };
 
 // TDP

--- a/packages/fx-core/src/common/constants.ts
+++ b/packages/fx-core/src/common/constants.ts
@@ -82,14 +82,14 @@ export const serviceEndpoints: Record<
     [ResourceServiceType.TDP]: "https://dev.teams.microsoft.com",
     [ResourceServiceType.MOS3]: "https://titles.prod.mos.microsoft.com",
     [ResourceServiceType.Graph]: "https://graph.microsoft.com",
-    [ResourceServiceType.Azure]: "https://management.core.windows.net",
+    [ResourceServiceType.Azure]: "https://management.azure.com",
   },
   [SovereignCloudEnvironment.GCCM]: {
     [ResourceServiceType.AuthSvc]: "https://api.spaces.skype.com",
     [ResourceServiceType.TDP]: "https://dev.teams.microsoft.com",
     [ResourceServiceType.MOS3]: "https://titles.gccm.mos.microsoft.com",
     [ResourceServiceType.Graph]: "https://graph.microsoft.com",
-    [ResourceServiceType.Azure]: "https://management.core.windows.net",
+    [ResourceServiceType.Azure]: "https://management.azure.com",
   },
   [SovereignCloudEnvironment.GCCH]: {
     [ResourceServiceType.AuthSvc]: "https://api.spaces.skype.com",
@@ -138,7 +138,7 @@ export const MosServiceScope = () => {
 export const GraphScopes = ["Application.ReadWrite.All", "TeamsAppInstallation.ReadForUser"];
 export const GroupSearchScopes = ["GroupMember.Read.All"];
 export const GCScopes = ["ExternalConnection.Read.All"];
-export const GraphReadUserScopes = ["https://graph.microsoft.com/User.ReadBasic.All"];
+export const GraphReadUserScopes = ["User.ReadBasic.All"];
 export const GraphTeamsAppSettingsReadScopes = ["TeamworkAppSettings.Read.All"];
 export const GraphTeamsTeamCreateScopes = ["Team.Create"];
 export const GraphTeamsChannelCreateScopes = ["Channel.Create"];

--- a/packages/fx-core/src/common/constants.ts
+++ b/packages/fx-core/src/common/constants.ts
@@ -156,6 +156,8 @@ export const ListSensitivityLabelScope = "InformationProtectionPolicy.Read";
 export const SPFxScopes = (tenant: string) => [`${tenant}/Sites.FullControl.All`];
 
 // Azure
-export const AzureScopes = ["https://management.core.windows.net/user_impersonation"];
+export const AzureScopes = () => {
+  return [`${getResourceServiceEndpoint(ResourceServiceType.Azure)}/.default`];
+};
 
 export const SpecParserSource = "SpecParser";

--- a/packages/fx-core/src/common/featureFlags.ts
+++ b/packages/fx-core/src/common/featureFlags.ts
@@ -31,6 +31,9 @@ export class FeatureFlagName {
   static readonly BrokerAuth = "TEAMSFX_BROKER_AUTH";
   // Add config files to existing project to make it toolkit compatible
   static readonly GenerateConfigFiles = "TEAMSFX_GENERATE_CONFIG_FILES";
+
+  // Permanent feature flag for sovereign cloud environment setting
+  static readonly SovereignCloudEnvironment = "TEAMSFX_SOVEREIGN_CLOUD_ENVIRONMENT";
 }
 
 export interface FeatureFlag {
@@ -107,6 +110,10 @@ export class FeatureFlags {
   static readonly GenerateConfigFiles = {
     name: FeatureFlagName.GenerateConfigFiles,
     defaultValue: "false",
+  };
+  static readonly SovereignCloudEnvironment = {
+    name: FeatureFlagName.SovereignCloudEnvironment,
+    defaultValue: "",
   };
 }
 

--- a/packages/fx-core/src/common/tools.ts
+++ b/packages/fx-core/src/common/tools.ts
@@ -9,7 +9,12 @@ import { FxError, M365TokenProvider, Result, SystemError, err, ok } from "@micro
 import axios from "axios";
 import { teamsDevPortalClient } from "../client/teamsDevPortalClient";
 import { GraphClient } from "../client/graphClient";
-import { GraphReadUserScopes, SPFxScopes } from "./constants";
+import {
+  getResourceServiceEndpoint,
+  GraphReadUserScopes,
+  ResourceServiceType,
+  SPFxScopes,
+} from "./constants";
 import fs from "fs-extra";
 import path from "path";
 import { MetadataV3, MetadataV4 } from "./versionMetadata";
@@ -37,7 +42,9 @@ export async function isSandboxedEnabled(tokenProvider: M365TokenProvider): Prom
 }
 
 export async function listAllTenants(token: string): Promise<Record<string, any>[]> {
-  const RM_ENDPOINT = "https://management.azure.com/tenants?api-version=2022-06-01";
+  const RM_ENDPOINT = `${getResourceServiceEndpoint(
+    ResourceServiceType.Azure
+  )}/tenants?api-version=2022-06-01`;
   if (token.length > 0) {
     try {
       const response = await axios.get(RM_ENDPOINT, {

--- a/packages/fx-core/src/component/coordinator/index.ts
+++ b/packages/fx-core/src/component/coordinator/index.ts
@@ -899,7 +899,7 @@ class Coordinator {
     }
     let loginHint = "";
     const accountRes = await ctx.tokenProvider.m365TokenProvider.getJsonObject({
-      scopes: AppStudioScopes,
+      scopes: AppStudioScopes(),
     });
     if (accountRes.isOk()) {
       loginHint = accountRes.value.unique_name as string;

--- a/packages/fx-core/src/component/driver/aad/create.ts
+++ b/packages/fx-core/src/component/driver/aad/create.ts
@@ -44,6 +44,7 @@ import {
   telemetryKeys,
 } from "./utility/constants";
 import { TeamsDevPortalClient } from "../../../client/teamsDevPortalClient";
+import { getEntraEndpoint, getTenantedAuthorityUrl } from "../../../common/accountUtils";
 
 const actionName = "aadApp/create"; // DO NOT MODIFY the name
 const helpLink = "https://aka.ms/teamsfx-actions/aadapp-create";
@@ -391,7 +392,7 @@ export class CreateAadAppDriver implements StepDriver {
 
     const tenantId = tokenObjectResponse.value.tid as string; // The tid claim is AAD tenant id
     state.tenantId = tenantId;
-    state.authorityHost = constants.oauthAuthorityPrefix;
-    state.authority = `${constants.oauthAuthorityPrefix}/${tenantId}`;
+    state.authorityHost = getEntraEndpoint();
+    state.authority = getTenantedAuthorityUrl(tenantId);
   }
 }

--- a/packages/fx-core/src/component/driver/aad/create.ts
+++ b/packages/fx-core/src/component/driver/aad/create.ts
@@ -119,7 +119,7 @@ export class CreateAadAppDriver implements StepDriver {
         let aadApp;
         if (args.generateServicePrincipal) {
           const tokenRes = await context.m365TokenProvider.getAccessToken({
-            scopes: AppStudioScopes,
+            scopes: AppStudioScopes(),
           });
           if (tokenRes.isErr()) {
             throw tokenRes.error;

--- a/packages/fx-core/src/component/driver/aad/utility/constants.ts
+++ b/packages/fx-core/src/component/driver/aad/utility/constants.ts
@@ -50,7 +50,6 @@ export const aadErrorCode = {
 
 export const constants = {
   aadAppPasswordDisplayName: "default",
-  oauthAuthorityPrefix: "https://login.microsoftonline.com",
   defaultHelpLink: "https://aka.ms/teamsfx-actions/aadapp-create",
   sniHelpLink: "https://aka.ms/teams-toolkit-sni-guide",
   insufficientPermissionErrorMessage: "Insufficient privileges to complete the operation.",

--- a/packages/fx-core/src/component/driver/apiKey/create.ts
+++ b/packages/fx-core/src/component/driver/apiKey/create.ts
@@ -66,7 +66,7 @@ export class CreateApiKeyDriver implements StepDriver {
 
       const state = loadStateFromEnv(outputEnvVarNames) as CreateApiKeyOutputs;
       const appStudioTokenRes = await context.m365TokenProvider.getAccessToken({
-        scopes: AppStudioScopes,
+        scopes: AppStudioScopes(),
       });
       if (appStudioTokenRes.isErr()) {
         throw appStudioTokenRes.error;

--- a/packages/fx-core/src/component/driver/apiKey/update.ts
+++ b/packages/fx-core/src/component/driver/apiKey/update.ts
@@ -56,7 +56,7 @@ export class UpdateApiKeyDriver implements StepDriver {
       }
 
       const appStudioTokenRes = await context.m365TokenProvider.getAccessToken({
-        scopes: AppStudioScopes,
+        scopes: AppStudioScopes(),
       });
       if (appStudioTokenRes.isErr()) {
         throw appStudioTokenRes.error;

--- a/packages/fx-core/src/component/driver/deploy/azure/impl/AzureZipDeployImpl.ts
+++ b/packages/fx-core/src/component/driver/deploy/azure/impl/AzureZipDeployImpl.ts
@@ -26,6 +26,7 @@ import { DeployZipPackageError } from "../../../../../error/deploy";
 import { ErrorContextMW } from "../../../../../common/globalVars";
 import { hooks } from "@feathersjs/hooks";
 import { ReadStream } from "fs-extra";
+import { getResourceServiceEndpoint, ResourceServiceType } from "../../../../../common/constants";
 
 export class AzureZipDeployImpl extends AzureDeployImpl {
   pattern =
@@ -247,7 +248,11 @@ export class AzureZipDeployImpl extends AzureDeployImpl {
     config: AzureUploadConfig
   ): Promise<string> {
     const response = await fetch(
-      `https://management.azure.com/subscriptions/${azureResource.subscriptionId}/resourceGroups/${azureResource.resourceGroupName}/providers/Microsoft.Web/sites/${azureResource.instanceId}?api-version=2024-04-01`,
+      `${getResourceServiceEndpoint(ResourceServiceType.Azure)}/subscriptions/${
+        azureResource.subscriptionId
+      }/resourceGroups/${azureResource.resourceGroupName}/providers/Microsoft.Web/sites/${
+        azureResource.instanceId
+      }?api-version=2024-04-01`,
       {
         headers: config.headers,
       }

--- a/packages/fx-core/src/component/driver/deploy/azure/impl/azureDeployImpl.ts
+++ b/packages/fx-core/src/component/driver/deploy/azure/impl/azureDeployImpl.ts
@@ -35,6 +35,7 @@ import {
 } from "../../../interface/buildAndDeployArgs";
 import { AzureResourceInfo } from "../../../interface/commonArgs";
 import { BaseDeployImpl } from "./baseDeployImpl";
+import { getResourceServiceEndpoint, ResourceServiceType } from "../../../../../common/constants";
 
 export abstract class AzureDeployImpl extends BaseDeployImpl {
   protected managementClient: appService.WebSiteManagementClient | undefined;
@@ -213,7 +214,7 @@ export abstract class AzureDeployImpl extends BaseDeployImpl {
       azureResource.subscriptionId
     );
     try {
-      const defaultScope = "https://management.azure.com/.default";
+      const defaultScope = `${getResourceServiceEndpoint(ResourceServiceType.Azure)}/.default`;
       const token = await azureCredential.getToken(defaultScope);
       if (token) {
         this.logger.info(

--- a/packages/fx-core/src/component/driver/m365/acquire.ts
+++ b/packages/fx-core/src/component/driver/m365/acquire.ts
@@ -10,7 +10,11 @@ import { FxError, Result, SystemError, UserError } from "@microsoft/teamsfx-api"
 import { getLocalizedString } from "../../../common/localizeUtils";
 import { FileNotFoundError, InvalidActionInputError, assembleError } from "../../../error/common";
 import { AppScope, PackageService } from "../../m365/packageService";
-import { MosServiceEndpoint, MosServiceScope } from "../../m365/serviceConstant";
+import {
+  getResourceServiceEndpoint,
+  MosServiceScope,
+  ResourceServiceType,
+} from "../../../common/constants";
 import { getAbsolutePath, wrapRun } from "../../utils/common";
 import { logMessageKeys } from "../aad/utility/constants";
 import { DriverContext } from "../interface/commonArgs";
@@ -82,13 +86,11 @@ export class M365TitleAcquireDriver implements StepDriver {
       }
 
       // get sideloading service settings
-      const sideloadingServiceEndpoint =
-        process.env.SIDELOADING_SERVICE_ENDPOINT ?? MosServiceEndpoint;
-      const sideloadingServiceScope = process.env.SIDELOADING_SERVICE_SCOPE ?? MosServiceScope;
+      const sideloadingServiceEndpoint = getResourceServiceEndpoint(ResourceServiceType.MOS3);
 
       const packageService = new PackageService(sideloadingServiceEndpoint, context.logProvider);
       const sideloadingTokenRes = await context.m365TokenProvider.getAccessToken({
-        scopes: [sideloadingServiceScope],
+        scopes: MosServiceScope(),
       });
       if (sideloadingTokenRes.isErr()) {
         throw sideloadingTokenRes.error;

--- a/packages/fx-core/src/component/driver/oauth/create.ts
+++ b/packages/fx-core/src/component/driver/oauth/create.ts
@@ -55,7 +55,7 @@ export class CreateOauthDriver implements StepDriver {
 
       const state = loadStateFromEnv(outputEnvVarNames) as CreateOauthOutputs;
       const appStudioTokenRes = await context.m365TokenProvider.getAccessToken({
-        scopes: AppStudioScopes,
+        scopes: AppStudioScopes(),
       });
       if (appStudioTokenRes.isErr()) {
         throw appStudioTokenRes.error;

--- a/packages/fx-core/src/component/driver/oauth/update.ts
+++ b/packages/fx-core/src/component/driver/oauth/update.ts
@@ -52,7 +52,7 @@ export class UpdateOauthDriver implements StepDriver {
       const authInfo = await getAuthInfo(args, context, actionName);
 
       const appStudioTokenRes = await context.m365TokenProvider.getAccessToken({
-        scopes: AppStudioScopes,
+        scopes: AppStudioScopes(),
       });
       if (appStudioTokenRes.isErr()) {
         throw appStudioTokenRes.error;

--- a/packages/fx-core/src/component/driver/teamsApp/appStudio.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/appStudio.ts
@@ -53,7 +53,7 @@ export async function checkIfAppInDifferentAcountSameTenant(
   logger: LogProvider
 ): Promise<Result<boolean, FxError>> {
   const appStudioTokenRes = await tokenProvider.getAccessToken({
-    scopes: AppStudioScopes,
+    scopes: AppStudioScopes(),
   });
   if (appStudioTokenRes.isErr()) {
     return err(appStudioTokenRes.error);
@@ -146,7 +146,7 @@ export async function updateManifestV3(
   }
 
   const appStudioTokenRes = await ctx.tokenProvider!.m365TokenProvider.getAccessToken({
-    scopes: AppStudioScopes,
+    scopes: AppStudioScopes(),
   });
   if (appStudioTokenRes.isErr()) {
     return err(appStudioTokenRes.error);
@@ -180,7 +180,7 @@ export async function updateManifestV3(
 
     let loginHint = "";
     const accountRes = await ctx.tokenProvider!.m365TokenProvider.getJsonObject({
-      scopes: AppStudioScopes,
+      scopes: AppStudioScopes(),
     });
     if (accountRes.isOk()) {
       loginHint = accountRes.value.unique_name as string;
@@ -306,7 +306,7 @@ export async function getAppPackage(
   logProvider?: LogProvider
 ): Promise<Result<AppPackage, FxError>> {
   const appStudioTokenRes = await m365TokenProvider.getAccessToken({
-    scopes: AppStudioScopes,
+    scopes: AppStudioScopes(),
   });
   if (appStudioTokenRes.isErr()) {
     return err(appStudioTokenRes.error);

--- a/packages/fx-core/src/component/driver/teamsApp/configure.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/configure.ts
@@ -60,7 +60,7 @@ export class ConfigureTeamsAppDriver implements StepDriver {
     }
 
     const appStudioTokenRes = await context.m365TokenProvider.getAccessToken({
-      scopes: AppStudioScopes,
+      scopes: AppStudioScopes(),
     });
     if (appStudioTokenRes.isErr()) {
       return err(appStudioTokenRes.error);

--- a/packages/fx-core/src/component/driver/teamsApp/create.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/create.ts
@@ -87,7 +87,7 @@ export class CreateTeamsAppDriver implements StepDriver {
 
     let create = true;
     const appStudioTokenRes = await context.m365TokenProvider.getAccessToken({
-      scopes: AppStudioScopes,
+      scopes: AppStudioScopes(),
     });
     if (appStudioTokenRes.isErr()) {
       return err(appStudioTokenRes.error);

--- a/packages/fx-core/src/component/driver/teamsApp/publishAppPackage.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/publishAppPackage.ts
@@ -128,7 +128,7 @@ export class PublishAppPackageDriver implements StepDriver {
 
     // manifest.id === externalID
     const appStudioTokenRes = await context.m365TokenProvider.getAccessToken({
-      scopes: AppStudioScopes,
+      scopes: AppStudioScopes(),
     });
     if (appStudioTokenRes.isErr()) {
       return err(appStudioTokenRes.error);

--- a/packages/fx-core/src/component/driver/teamsApp/teamsappMgr.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/teamsappMgr.ts
@@ -272,7 +272,7 @@ class TeamsAppMgr {
     // 4. show result
     let loginHint = "";
     const accountRes = await driverContext.m365TokenProvider.getJsonObject({
-      scopes: AppStudioScopes,
+      scopes: AppStudioScopes(),
     });
     if (accountRes.isOk()) {
       loginHint = accountRes.value.unique_name as string;

--- a/packages/fx-core/src/component/driver/teamsApp/validateAppPackage.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/validateAppPackage.ts
@@ -92,7 +92,7 @@ export class ValidateAppPackageDriver implements StepDriver {
     }
 
     const appStudioTokenRes = await context.m365TokenProvider.getAccessToken({
-      scopes: AppStudioScopes,
+      scopes: AppStudioScopes(),
     });
     if (appStudioTokenRes.isErr()) {
       return err(appStudioTokenRes.error);

--- a/packages/fx-core/src/component/driver/teamsApp/validateTestCases.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/validateTestCases.ts
@@ -18,7 +18,11 @@ import { EOL } from "os";
 import * as path from "path";
 import { Service } from "typedi";
 import { teamsDevPortalClient } from "../../../client/teamsDevPortalClient";
-import { AppStudioScopes, getAppStudioEndpoint } from "../../../common/constants";
+import {
+  AppStudioScopes,
+  getResourceServiceEndpoint,
+  ResourceServiceType,
+} from "../../../common/constants";
 import { getLocalizedString } from "../../../common/localizeUtils";
 import { waitSeconds } from "../../../common/utils";
 import { FileNotFoundError, InvalidActionInputError } from "../../../error/common";
@@ -90,7 +94,7 @@ export class ValidateWithTestCasesDriver implements StepDriver {
       merge(context.telemetryProperties, manifestTelemetries);
 
       const appStudioTokenRes = await context.m365TokenProvider.getAccessToken({
-        scopes: AppStudioScopes,
+        scopes: AppStudioScopes(),
       });
       if (appStudioTokenRes.isErr()) {
         return err(appStudioTokenRes.error);
@@ -114,9 +118,9 @@ export class ValidateWithTestCasesDriver implements StepDriver {
                   color: Colors.BRIGHT_YELLOW,
                 },
                 {
-                  content: `${getAppStudioEndpoint()}/apps/${manifest.id}/app-validation/${
-                    validation.id
-                  }`,
+                  content: `${getResourceServiceEndpoint(ResourceServiceType.TDP)}/apps/${
+                    manifest.id
+                  }/app-validation/${validation.id}`,
                   color: Colors.BRIGHT_CYAN,
                 },
               ];
@@ -124,7 +128,9 @@ export class ValidateWithTestCasesDriver implements StepDriver {
             } else {
               const message = getLocalizedString(
                 "driver.teamsApp.progressBar.validateWithTestCases.conflict",
-                `${getAppStudioEndpoint()}/apps/${manifest.id}/app-validation/${validation.id}`
+                `${getResourceServiceEndpoint(ResourceServiceType.TDP)}/apps/${
+                  manifest.id
+                }/app-validation/${validation.id}`
               );
               context.logProvider.warning(message);
             }
@@ -142,9 +148,9 @@ export class ValidateWithTestCasesDriver implements StepDriver {
             color: Colors.BRIGHT_WHITE,
           },
           {
-            content: `${getAppStudioEndpoint()}/apps/${manifest.id}/app-validation/${
-              response.appValidationId
-            }`,
+            content: `${getResourceServiceEndpoint(ResourceServiceType.TDP)}/apps/${
+              manifest.id
+            }/app-validation/${response.appValidationId}`,
             color: Colors.BRIGHT_CYAN,
           },
         ];
@@ -153,7 +159,9 @@ export class ValidateWithTestCasesDriver implements StepDriver {
         const message = getLocalizedString(
           "driver.teamsApp.progressBar.validateWithTestCases.step",
           response.status,
-          `${getAppStudioEndpoint()}/apps/${manifest.id}/app-validation`
+          `${getResourceServiceEndpoint(ResourceServiceType.TDP)}/apps/${
+            manifest.id
+          }/app-validation`
         );
         context.logProvider.info(message);
 
@@ -181,7 +189,9 @@ export class ValidateWithTestCasesDriver implements StepDriver {
     response: AsyncAppValidationResponse,
     teamsAppId: string
   ): Promise<void> {
-    const validationRequestListUrl = `${getAppStudioEndpoint()}/apps/${teamsAppId}/app-validation`;
+    const validationRequestListUrl = `${getResourceServiceEndpoint(
+      ResourceServiceType.TDP
+    )}/apps/${teamsAppId}/app-validation`;
 
     try {
       if (args.showProgressBar && context.ui) {
@@ -233,9 +243,9 @@ export class ValidateWithTestCasesDriver implements StepDriver {
     resultResp: AsyncAppValidationResultsResponse,
     teamsAppId: string
   ): void {
-    const validationStatusUrl = `${getAppStudioEndpoint()}/apps/${teamsAppId}/app-validation/${
-      resultResp.appValidationId
-    }`;
+    const validationStatusUrl = `${getResourceServiceEndpoint(
+      ResourceServiceType.TDP
+    )}/apps/${teamsAppId}/app-validation/${resultResp.appValidationId}`;
     const failed = resultResp.validationResults?.failures?.length ?? 0;
     const warns = resultResp.validationResults?.warnings?.length ?? 0;
     const skipped = resultResp.validationResults?.skipped?.length ?? 0;

--- a/packages/fx-core/src/component/feature/collaboration.ts
+++ b/packages/fx-core/src/component/feature/collaboration.ts
@@ -24,7 +24,7 @@ import {
   TeamsAppAdmin,
 } from "../../common/permissionInterface";
 import { AgentPermission, PackageService } from "../../component/m365/packageService";
-import { MosServiceScope } from "../../component/m365/serviceConstant";
+import { MosServiceScope } from "../../common/constants";
 import { HttpClientError, HttpServerError, assembleError } from "../../error/common";
 import { AppIdNotExist } from "../../error/teamsApp";
 import { AadAppClient } from "../../client/aadAppClient";
@@ -153,7 +153,7 @@ export class TeamsCollaboration {
   ): Promise<Result<ResourcePermission[], FxError>> {
     try {
       const appStudioTokenRes = await this.tokenProvider.getAccessToken({
-        scopes: AppStudioScopes,
+        scopes: AppStudioScopes(),
       });
       const appStudioToken = appStudioTokenRes.isOk() ? appStudioTokenRes.value : undefined;
 
@@ -181,7 +181,7 @@ export class TeamsCollaboration {
   ): Promise<Result<TeamsAppAdmin[], FxError>> {
     try {
       const appStudioTokenRes = await this.tokenProvider.getAccessToken({
-        scopes: AppStudioScopes,
+        scopes: AppStudioScopes(),
       });
       const appStudioToken = appStudioTokenRes.isOk() ? appStudioTokenRes.value : undefined;
 
@@ -222,7 +222,7 @@ export class TeamsCollaboration {
   ): Promise<Result<ResourcePermission[], FxError>> {
     try {
       const appStudioTokenRes = await this.tokenProvider.getAccessToken({
-        scopes: AppStudioScopes,
+        scopes: AppStudioScopes(),
       });
       const appStudioToken = appStudioTokenRes.isOk() ? appStudioTokenRes.value : undefined;
 
@@ -286,7 +286,7 @@ export class AgentCollaboration {
     userInfo: AppUser
   ): Promise<Result<ResourcePermission[], FxError>> {
     const mosTokenRes = await this.tokenProvider.getAccessToken({
-      scopes: [MosServiceScope],
+      scopes: MosServiceScope(),
     });
     if (mosTokenRes.isErr()) {
       return err(mosTokenRes.error);
@@ -317,7 +317,7 @@ export class AgentCollaboration {
     titleId: string
   ): Promise<Result<AgentOwner[], FxError>> {
     const mosTokenRes = await this.tokenProvider.getAccessToken({
-      scopes: [MosServiceScope],
+      scopes: MosServiceScope(),
     });
     if (mosTokenRes.isErr()) {
       return err(mosTokenRes.error);

--- a/packages/fx-core/src/component/generator/declarativeAgent/helper.ts
+++ b/packages/fx-core/src/component/generator/declarativeAgent/helper.ts
@@ -26,7 +26,11 @@ import { getEnvironmentVariables } from "../../utils/common";
 import { sendTelemetryErrorEvent } from "../../../common/telemetry";
 import { assembleError } from "../../../error";
 import axios, { isAxiosError } from "axios";
-import { GCScopes } from "../../../common/constants";
+import {
+  GCScopes,
+  getResourceServiceEndpoint,
+  ResourceServiceType,
+} from "../../../common/constants";
 import {
   createGraphClientWithToken,
   encodeSharePointUrl,
@@ -324,7 +328,7 @@ export async function getGraphConnectors(): Promise<GCItem[]> {
   const graphToken = graphTokenRes.value;
 
   const instance = axios.create({
-    baseURL: "https://graph.microsoft.com/v1.0",
+    baseURL: `${getResourceServiceEndpoint(ResourceServiceType.Graph)}/v1.0`,
     headers: { Authorization: `Bearer ${graphToken}` },
   });
 

--- a/packages/fx-core/src/component/generator/declarativeAgent/oneDriveSharePointHandler.ts
+++ b/packages/fx-core/src/component/generator/declarativeAgent/oneDriveSharePointHandler.ts
@@ -2,7 +2,11 @@
 // Licensed under the MIT license.
 
 import { Context, FxError, Result, SystemError, UserError, err, ok } from "@microsoft/teamsfx-api";
-import { GraphScopes } from "../../../common/constants";
+import {
+  getResourceServiceEndpoint,
+  GraphScopes,
+  ResourceServiceType,
+} from "../../../common/constants";
 import axios, { AxiosInstance } from "axios";
 import { OneDriveSharePointItemType } from "../constant";
 
@@ -39,7 +43,7 @@ export async function createGraphClientWithToken(
     );
   }
   const client = axios.create({
-    baseURL: "https://graph.microsoft.com/v1.0",
+    baseURL: `${getResourceServiceEndpoint(ResourceServiceType.Graph)}/v1.0`,
     headers: { Authorization: `Bearer ${graphTokenRes.value}` },
   });
   return ok(client);

--- a/packages/fx-core/src/component/m365/launchHelper.ts
+++ b/packages/fx-core/src/component/m365/launchHelper.ts
@@ -12,14 +12,18 @@ import {
 } from "@microsoft/teamsfx-api";
 
 import { hooks } from "@feathersjs/hooks";
-import { AppStudioScopes } from "../../common/constants";
+import {
+  AppStudioScopes,
+  getResourceServiceEndpoint,
+  ResourceServiceType,
+} from "../../common/constants";
 import { ErrorContextMW } from "../../common/globalVars";
 import { CoreSource } from "../../error";
 import { assembleError } from "../../error/common";
 import { HubTypes } from "../../question/constants";
 import { NotExtendedToM365Error } from "./errors";
 import { PackageService } from "./packageService";
-import { MosServiceEndpoint, MosServiceScope } from "./serviceConstant";
+import { MosServiceScope } from "../../common/constants";
 import { officeBaseUrl, outlookBaseUrl, outlookCopilotAppId } from "./constants";
 import { featureFlagManager, FeatureFlags } from "../../common/featureFlags";
 
@@ -105,13 +109,11 @@ export class LaunchHelper {
   }
 
   public async getM365AppId(teamsAppId: string): Promise<Result<string, FxError>> {
-    const sideloadingServiceEndpoint =
-      process.env.SIDELOADING_SERVICE_ENDPOINT ?? MosServiceEndpoint;
-    const sideloadingServiceScope = process.env.SIDELOADING_SERVICE_SCOPE ?? MosServiceScope;
+    const sideloadingServiceEndpoint = getResourceServiceEndpoint(ResourceServiceType.MOS3);
     const packageService = new PackageService(sideloadingServiceEndpoint, this.logger);
 
     const sideloadingTokenRes = await this.m365TokenProvider.getAccessToken({
-      scopes: [sideloadingServiceScope],
+      scopes: MosServiceScope(),
     });
     if (sideloadingTokenRes.isErr()) {
       return err(sideloadingTokenRes.error);
@@ -131,7 +133,7 @@ export class LaunchHelper {
 
   private async getTidFromToken(): Promise<string | undefined> {
     try {
-      const statusRes = await this.m365TokenProvider.getStatus({ scopes: AppStudioScopes });
+      const statusRes = await this.m365TokenProvider.getStatus({ scopes: AppStudioScopes() });
       const tokenObject = statusRes.isOk() ? statusRes.value.accountInfo : undefined;
       return tokenObject?.tid as string;
     } catch {
@@ -141,7 +143,7 @@ export class LaunchHelper {
 
   private async getUpnFromToken(): Promise<string | undefined> {
     try {
-      const statusRes = await this.m365TokenProvider.getStatus({ scopes: AppStudioScopes });
+      const statusRes = await this.m365TokenProvider.getStatus({ scopes: AppStudioScopes() });
       const tokenObject = statusRes.isOk() ? statusRes.value.accountInfo : undefined;
       return tokenObject?.upn as string;
     } catch {

--- a/packages/fx-core/src/component/m365/packageService.ts
+++ b/packages/fx-core/src/component/m365/packageService.ts
@@ -34,7 +34,7 @@ import { AppUser } from "../driver/teamsApp/interfaces/appdefinitions/appUser";
 import { advancedDASettingUrl, M365HelpLink } from "./constants";
 import { NotExtendedToM365Error } from "./errors";
 import { M365AppDefinition, M365AppEntity } from "./interface";
-import { MosServiceEndpoint } from "./serviceConstant";
+import { getResourceServiceEndpoint, ResourceServiceType } from "../../common/constants";
 
 const M365ErrorSource = "M365";
 const M365ErrorComponent = "PackageService";
@@ -62,7 +62,7 @@ export class PackageService {
   public static GetSharedInstance(): PackageService {
     if (!PackageService.sharedInstance) {
       PackageService.sharedInstance = new PackageService(
-        process.env.SIDELOADING_SERVICE_ENDPOINT ?? MosServiceEndpoint,
+        getResourceServiceEndpoint(ResourceServiceType.MOS3),
         TOOLS.logProvider
       );
     }

--- a/packages/fx-core/src/component/m365/serviceConstant.ts
+++ b/packages/fx-core/src/component/m365/serviceConstant.ts
@@ -1,9 +1,5 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-
-export const MosServiceEndpoint = "https://titles.prod.mos.microsoft.com";
-export const MosServiceScope = "https://titles.prod.mos.microsoft.com/.default";
-
 export interface MOS3Api {
   key: string;
   method: "GET" | "POST" | "PUT" | "DELETE";

--- a/packages/fx-core/src/component/provisionUtils.ts
+++ b/packages/fx-core/src/component/provisionUtils.ts
@@ -128,12 +128,12 @@ class ProvisionUtils {
     // Just to trigger M365 login before the concurrent execution of localDebug.
     // Because concurrent execution of localDebug may getAccessToken() concurrently, which
     // causes 2 M365 logins before the token caching in common lib takes effect.
-    const appStudioTokenRes = await m365TokenProvider.getAccessToken({ scopes: AppStudioScopes });
+    const appStudioTokenRes = await m365TokenProvider.getAccessToken({ scopes: AppStudioScopes() });
     if (appStudioTokenRes.isErr()) {
       return err(appStudioTokenRes.error);
     }
     const appStudioTokenJsonRes = await m365TokenProvider.getJsonObject({
-      scopes: AppStudioScopes,
+      scopes: AppStudioScopes(),
     });
     const appStudioTokenJson = appStudioTokenJsonRes.isOk()
       ? appStudioTokenJsonRes.value

--- a/packages/fx-core/src/component/resource/botService/botRegistration/botFrameworkRegistration.ts
+++ b/packages/fx-core/src/component/resource/botService/botRegistration/botFrameworkRegistration.ts
@@ -21,7 +21,7 @@ export async function createOrUpdateBotRegistration(
   //      3.1 Merge bot registration (remote + passed-in, respect passed-in).
   //      3.2 Update bot registration.
   const appStudioTokenRes = await m365TokenProvider.getAccessToken({
-    scopes: AppStudioScopes,
+    scopes: AppStudioScopes(),
   });
   if (appStudioTokenRes.isErr()) {
     return err(appStudioTokenRes.error);

--- a/packages/fx-core/src/component/utils/azureClient.ts
+++ b/packages/fx-core/src/component/utils/azureClient.ts
@@ -6,7 +6,6 @@ import { ResourceManagementClient } from "@azure/arm-resources";
 import { InvalidAzureCredentialError } from "../../error";
 import { Pipeline, PipelinePolicy } from "@azure/core-rest-pipeline";
 import { BearerChallengePolicy } from "./pipelinePolicy";
-import { AzureScopes } from "../../common/constants";
 
 class AzureClientHelper {
   async createRmClient(azureAccountProvider: AzureAccountProvider, subscriptionId: string) {

--- a/packages/fx-core/src/component/utils/pipelinePolicy.ts
+++ b/packages/fx-core/src/component/utils/pipelinePolicy.ts
@@ -32,7 +32,7 @@ export class BearerChallengePolicy implements PipelinePolicy {
 
         const token = await this.getTokenForChallenge({
           wwwAuthenticate: header,
-          scopes: AzureScopes,
+          scopes: AzureScopes(),
         });
         if (token) {
           request.headers.set("Authorization", `Bearer ${token}`);

--- a/packages/fx-core/src/core/FxCore.ts
+++ b/packages/fx-core/src/core/FxCore.ts
@@ -52,7 +52,12 @@ import { Container } from "typedi";
 import { pathToFileURL } from "url";
 import { teamsDevPortalClient } from "../client/teamsDevPortalClient";
 import { ApiKeyParameters, AuthParameters, OAuthParameters } from "../common/authInterface";
-import { AppStudioScopes, VSCodeExtensionCommand } from "../common/constants";
+import {
+  AppStudioScopes,
+  getResourceServiceEndpoint,
+  ResourceServiceType,
+  VSCodeExtensionCommand,
+} from "../common/constants";
 import { listAPIInfo, parseAndUpdatePluginManifestForKiota } from "../common/daSpecParser";
 import {
   ErrorContextMW,
@@ -143,7 +148,7 @@ import { TemplateNames } from "../component/generator/templates/templateNames";
 import { fetchZipFromUrl, getTemplateLatestVersion, unzip } from "../component/generator/utils";
 import { LaunchHelper } from "../component/m365/launchHelper";
 import { PackageService } from "../component/m365/packageService";
-import { MosServiceEndpoint, MosServiceScope } from "../component/m365/serviceConstant";
+import { MosServiceScope } from "../common/constants";
 import { EnvLoaderMW, EnvWriterMW } from "../component/middleware/envMW";
 import { QuestionMW } from "../component/middleware/questionMW";
 import {
@@ -560,11 +565,9 @@ export class FxCore extends FxCoreDeclarativeAgentPart {
     if (titleId === undefined && manifestId === undefined) {
       return err(new MissingRequiredInputError("title id or manifest id", "FxCore"));
     }
-    const sideloadingServiceEndpoint =
-      process.env.SIDELOADING_SERVICE_ENDPOINT ?? MosServiceEndpoint;
-    const sideloadingServiceScope = process.env.SIDELOADING_SERVICE_SCOPE ?? MosServiceScope;
+    const sideloadingServiceEndpoint = getResourceServiceEndpoint(ResourceServiceType.MOS3);
     const sideloadingTokenRes = await TOOLS.tokenProvider.m365TokenProvider.getAccessToken({
-      scopes: [sideloadingServiceScope],
+      scopes: MosServiceScope(),
     });
     if (sideloadingTokenRes.isErr()) {
       return err(sideloadingTokenRes.error);
@@ -619,7 +622,7 @@ export class FxCore extends FxCoreDeclarativeAgentPart {
   ])
   async uninstallAppRegistration(manifestId: string): Promise<Result<undefined, FxError>> {
     const appStudioTokenRes = await TOOLS.tokenProvider.m365TokenProvider.getAccessToken({
-      scopes: AppStudioScopes,
+      scopes: AppStudioScopes(),
     });
     if (appStudioTokenRes.isErr()) {
       return err(appStudioTokenRes.error);
@@ -663,7 +666,7 @@ export class FxCore extends FxCoreDeclarativeAgentPart {
       return err(new MissingRequiredInputError("bot id or manifest id", "FxCore"));
     }
     const appStudioTokenRes = await TOOLS.tokenProvider.m365TokenProvider.getAccessToken({
-      scopes: AppStudioScopes,
+      scopes: AppStudioScopes(),
     });
     if (appStudioTokenRes.isErr()) {
       return err(appStudioTokenRes.error);
@@ -875,14 +878,14 @@ export class FxCore extends FxCoreDeclarativeAgentPart {
 
     const tokenProvider = TOOLS.tokenProvider.m365TokenProvider;
     const appStudioTokenRes = await tokenProvider.getAccessToken({
-      scopes: AppStudioScopes,
+      scopes: AppStudioScopes(),
     });
     if (appStudioTokenRes.isErr()) {
       return err(appStudioTokenRes.error);
     }
     const appStudioToken = appStudioTokenRes.value;
     const mosTokenRes = await tokenProvider.getAccessToken({
-      scopes: [MosServiceScope],
+      scopes: MosServiceScope(),
     });
     if (mosTokenRes.isErr()) {
       return err(mosTokenRes.error);
@@ -964,7 +967,7 @@ export class FxCore extends FxCoreDeclarativeAgentPart {
     const sharedTitleId = parseRes.value.titleId;
     const tokenProvider = TOOLS.tokenProvider.m365TokenProvider;
     const mosTokenRes = await tokenProvider.getAccessToken({
-      scopes: [MosServiceScope],
+      scopes: MosServiceScope(),
     });
     if (mosTokenRes.isErr()) {
       return err(mosTokenRes.error);

--- a/packages/fx-core/src/core/collaborator.ts
+++ b/packages/fx-core/src/core/collaborator.ts
@@ -19,7 +19,12 @@ import axios from "axios";
 import * as dotenv from "dotenv";
 import fs from "fs-extra";
 import { validate as uuidValidate } from "uuid";
-import { GraphScopes, VSCodeExtensionCommand } from "../common/constants";
+import {
+  getResourceServiceEndpoint,
+  GraphScopes,
+  ResourceServiceType,
+  VSCodeExtensionCommand,
+} from "../common/constants";
 import { getDefaultString, getLocalizedString } from "../common/localizeUtils";
 import {
   AadOwner,
@@ -101,7 +106,7 @@ export class CollaborationUtil {
       const graphTokenRes = await m365TokenProvider?.getAccessToken({ scopes: GraphScopes });
       const graphToken = graphTokenRes?.isOk() ? graphTokenRes.value : undefined;
       const instance = axios.create({
-        baseURL: "https://graph.microsoft.com/v1.0",
+        baseURL: `${getResourceServiceEndpoint(ResourceServiceType.Graph)}/v1.0`,
       });
       instance.defaults.headers.common["Authorization"] = `Bearer ${graphToken as string}`;
       const res = await instance.get(

--- a/packages/fx-core/src/index.ts
+++ b/packages/fx-core/src/index.ts
@@ -24,6 +24,7 @@ export {
   GraphScopes,
   ListSensitivityLabelScope,
   SPFxScopes,
+  MosServiceScope,
 } from "./common/constants";
 export { Correlator } from "./common/correlator";
 export {
@@ -103,7 +104,6 @@ export { LocalTelemetryReporter, TelemetryContext } from "./component/local/loca
 export { loadTeamsFxDevScript } from "./component/local/packageJsonHelper";
 export { Hub } from "./component/m365/constants";
 export { PackageService } from "./component/m365/packageService";
-export { MosServiceEndpoint, MosServiceScope } from "./component/m365/serviceConstant";
 export * from "./component/middleware/actionExecutionMW";
 export { outputScaffoldingWarningMessage } from "./component/utils/common";
 export { DotenvOutput, envUtil } from "./component/utils/envUtil";

--- a/packages/fx-core/src/index.ts
+++ b/packages/fx-core/src/index.ts
@@ -32,6 +32,11 @@ export {
   FeatureFlags,
   isFeatureFlagEnabled,
 } from "./common/featureFlags";
+export {
+  getEntraEndpoint,
+  getDefaultAuthorityUrl,
+  getTenantedAuthorityUrl,
+} from "./common/accountUtils";
 export { globalStateGet, globalStateUpdate } from "./common/globalState";
 export { AadSet } from "./common/globalVars";
 export { getDefaultString, getLocalizedString } from "./common/localizeUtils";

--- a/packages/fx-core/src/question/other.ts
+++ b/packages/fx-core/src/question/other.ts
@@ -456,7 +456,7 @@ export function selectTargetEnvQuestion(
 async function getDefaultUserEmail() {
   if (!TOOLS?.tokenProvider.m365TokenProvider) return undefined;
   const jsonObjectRes = await TOOLS.tokenProvider.m365TokenProvider.getJsonObject({
-    scopes: AppStudioScopes,
+    scopes: AppStudioScopes(),
   });
   if (jsonObjectRes.isErr()) {
     throw jsonObjectRes.error;

--- a/packages/fx-core/src/question/share.ts
+++ b/packages/fx-core/src/question/share.ts
@@ -146,7 +146,7 @@ export function selectUsersToRemoveSharedAccess(): MultiSelectQuestion {
         throw new Error("Project path is not defined");
       }
       const tokenRes = await TOOLS.tokenProvider.m365TokenProvider.getAccessToken({
-        scopes: AppStudioScopes,
+        scopes: AppStudioScopes(),
       });
       if (tokenRes.isErr()) {
         throw tokenRes.error;

--- a/packages/fx-core/tests/common/wrappedAxiosClient.test.ts
+++ b/packages/fx-core/tests/common/wrappedAxiosClient.test.ts
@@ -6,7 +6,7 @@ import * as chai from "chai";
 import "mocha";
 import * as sinon from "sinon";
 import { v4 as uuid } from "uuid";
-import { getAppStudioEndpoint } from "../../src/common/constants";
+import { getResourceServiceEndpoint, ResourceServiceType } from "../../src/common/constants";
 import { setTools } from "../../src/common/globalVars";
 import { WrappedAxiosClient } from "../../src/common/wrappedAxiosClient";
 import { APP_STUDIO_API_NAMES } from "../../src/component/driver/teamsApp/constants";
@@ -43,7 +43,7 @@ describe("Wrapped Axios Client Test", () => {
 
     const mockedRequest = {
       method: "POST",
-      baseURL: getAppStudioEndpoint(),
+      baseURL: getResourceServiceEndpoint(ResourceServiceType.TDP),
       url: "/amer/api/appdefinitions/v2/import",
       params: {
         overwriteIfAppAlreadyExists: true,
@@ -56,7 +56,7 @@ describe("Wrapped Axios Client Test", () => {
     const mockedResponse = {
       request: {
         method: "GET",
-        host: getAppStudioEndpoint(),
+        host: getResourceServiceEndpoint(ResourceServiceType.TDP),
         path: "/api/appdefinitions/manifest",
       },
       config: {
@@ -70,7 +70,7 @@ describe("Wrapped Axios Client Test", () => {
     const mockedError = {
       request: {
         method: "GET",
-        host: getAppStudioEndpoint(),
+        host: getResourceServiceEndpoint(ResourceServiceType.TDP),
         path: "/api/appdefinitions/fakeId",
       },
       config: {
@@ -91,7 +91,7 @@ describe("Wrapped Axios Client Test", () => {
 
     const mockedRequest = {
       method: "POST",
-      baseURL: getAppStudioEndpoint(),
+      baseURL: getResourceServiceEndpoint(ResourceServiceType.TDP),
       url: "/amer/api/appdefinitions/v2/import",
       params: {
         overwriteIfAppAlreadyExists: true,
@@ -104,7 +104,7 @@ describe("Wrapped Axios Client Test", () => {
     const mockedResponse = {
       request: {
         method: "GET",
-        host: getAppStudioEndpoint(),
+        host: getResourceServiceEndpoint(ResourceServiceType.TDP),
         path: "/api/appdefinitions/manifest",
       },
       config: {
@@ -118,7 +118,7 @@ describe("Wrapped Axios Client Test", () => {
     const mockedError = {
       request: {
         method: "GET",
-        host: getAppStudioEndpoint(),
+        host: getResourceServiceEndpoint(ResourceServiceType.TDP),
         path: "/api/appdefinitions/fakeId",
       },
       config: {},
@@ -135,7 +135,7 @@ describe("Wrapped Axios Client Test", () => {
   it("TDP API start telemetry", async () => {
     const mockedRequest = {
       method: "POST",
-      baseURL: getAppStudioEndpoint(),
+      baseURL: getResourceServiceEndpoint(ResourceServiceType.TDP),
       url: "/amer/api/appdefinitions/v2/import",
       params: {
         overwriteIfAppAlreadyExists: true,
@@ -168,7 +168,7 @@ describe("Wrapped Axios Client Test", () => {
     const mockedResponse = {
       request: {
         method: "GET",
-        host: getAppStudioEndpoint(),
+        host: getResourceServiceEndpoint(ResourceServiceType.TDP),
         path: "/api/appdefinitions/manifest",
       },
       config: {
@@ -206,7 +206,7 @@ describe("Wrapped Axios Client Test", () => {
     const mockedError = {
       request: {
         method: "GET",
-        host: getAppStudioEndpoint(),
+        host: getResourceServiceEndpoint(ResourceServiceType.TDP),
         path: "/api/appdefinitions/fakeId",
       },
       config: {},
@@ -288,7 +288,7 @@ describe("Wrapped Axios Client Test", () => {
   it("Create bot API start telemetry", async () => {
     const mockedRequest = {
       method: "POST",
-      baseURL: getAppStudioEndpoint(),
+      baseURL: getResourceServiceEndpoint(ResourceServiceType.TDP),
       url: "/api/botframework",
       params: {},
       status: 200,
@@ -305,7 +305,7 @@ describe("Wrapped Axios Client Test", () => {
   it("Update bot API start telemetry", async () => {
     const mockedRequest = {
       method: "POST",
-      baseURL: getAppStudioEndpoint(),
+      baseURL: getResourceServiceEndpoint(ResourceServiceType.TDP),
       url: `/api/botframework/${uuid()}`,
       params: {},
       status: 200,
@@ -321,158 +321,174 @@ describe("Wrapped Axios Client Test", () => {
     const fakeId = uuid();
 
     let apiName = WrappedAxiosClient.convertUrlToApiName(
-      getAppStudioEndpoint() + "/api/appdefinitions/partnerCenterAppPackageValidation",
+      getResourceServiceEndpoint(ResourceServiceType.TDP) +
+        "/api/appdefinitions/partnerCenterAppPackageValidation",
       "POST"
     );
     chai.assert.equal(apiName, APP_STUDIO_API_NAMES.VALIDATE_APP_PACKAGE);
 
     apiName = WrappedAxiosClient.convertUrlToApiName(
-      getAppStudioEndpoint() + `/api/appdefinitions/${fakeId}/manifest`,
+      getResourceServiceEndpoint(ResourceServiceType.TDP) +
+        `/api/appdefinitions/${fakeId}/manifest`,
       "GET"
     );
     chai.assert.equal(apiName, APP_STUDIO_API_NAMES.GET_APP_PACKAGE);
 
     apiName = WrappedAxiosClient.convertUrlToApiName(
-      getAppStudioEndpoint() + `/api/appdefinitions/${fakeId}/owner`,
+      getResourceServiceEndpoint(ResourceServiceType.TDP) + `/api/appdefinitions/${fakeId}/owner`,
       "POST"
     );
     chai.assert.equal(apiName, APP_STUDIO_API_NAMES.UPDATE_OWNER);
 
     apiName = WrappedAxiosClient.convertUrlToApiName(
-      getAppStudioEndpoint() + `/api/appdefinitions/${fakeId}`,
+      getResourceServiceEndpoint(ResourceServiceType.TDP) + `/api/appdefinitions/${fakeId}`,
       "GET"
     );
     chai.assert.equal(apiName, APP_STUDIO_API_NAMES.GET_APP);
 
     apiName = WrappedAxiosClient.convertUrlToApiName(
-      getAppStudioEndpoint() + `/api/appdefinitions/${fakeId}`,
+      getResourceServiceEndpoint(ResourceServiceType.TDP) + `/api/appdefinitions/${fakeId}`,
       "DELETE"
     );
     chai.assert.equal(apiName, APP_STUDIO_API_NAMES.DELETE_APP);
 
     apiName = WrappedAxiosClient.convertUrlToApiName(
-      getAppStudioEndpoint() + `/api/publishing/${fakeId}`,
+      getResourceServiceEndpoint(ResourceServiceType.TDP) + `/api/publishing/${fakeId}`,
       "GET"
     );
     chai.assert.equal(apiName, APP_STUDIO_API_NAMES.GET_PUBLISHED_APP);
 
     apiName = WrappedAxiosClient.convertUrlToApiName(
-      getAppStudioEndpoint() + `/api/publishing`,
+      getResourceServiceEndpoint(ResourceServiceType.TDP) + `/api/publishing`,
       "POST"
     );
     chai.assert.equal(apiName, APP_STUDIO_API_NAMES.PUBLISH_APP);
 
     apiName = WrappedAxiosClient.convertUrlToApiName(
-      getAppStudioEndpoint() + `/api/publishing/${fakeId}/appdefinitions`,
+      getResourceServiceEndpoint(ResourceServiceType.TDP) +
+        `/api/publishing/${fakeId}/appdefinitions`,
       "POST"
     );
     chai.assert.equal(apiName, APP_STUDIO_API_NAMES.UPDATE_PUBLISHED_APP);
 
     apiName = WrappedAxiosClient.convertUrlToApiName(
-      getAppStudioEndpoint() + `/api/usersettings/mtUserAppPolicy`,
+      getResourceServiceEndpoint(ResourceServiceType.TDP) + `/api/usersettings/mtUserAppPolicy`,
       "GET"
     );
     chai.assert.equal(apiName, APP_STUDIO_API_NAMES.CHECK_SIDELOADING_STATUS);
 
     apiName = WrappedAxiosClient.convertUrlToApiName(
-      getAppStudioEndpoint() + `/api/v1.0/apiSecretRegistrations/${fakeId}`,
+      getResourceServiceEndpoint(ResourceServiceType.TDP) +
+        `/api/v1.0/apiSecretRegistrations/${fakeId}`,
       "GET"
     );
     chai.assert.equal(apiName, APP_STUDIO_API_NAMES.GET_API_KEY);
 
     apiName = WrappedAxiosClient.convertUrlToApiName(
-      getAppStudioEndpoint() + `/api/v1.0/apiSecretRegistrations/${fakeId}`,
+      getResourceServiceEndpoint(ResourceServiceType.TDP) +
+        `/api/v1.0/apiSecretRegistrations/${fakeId}`,
       "PATCH"
     );
     chai.assert.equal(apiName, APP_STUDIO_API_NAMES.UPDATE_API_KEY);
 
     apiName = WrappedAxiosClient.convertUrlToApiName(
-      getAppStudioEndpoint() + `/api/v1.0/apiSecretRegistrations`,
+      getResourceServiceEndpoint(ResourceServiceType.TDP) + `/api/v1.0/apiSecretRegistrations`,
       "POST"
     );
     chai.assert.equal(apiName, APP_STUDIO_API_NAMES.CREATE_API_KEY);
 
     apiName = WrappedAxiosClient.convertUrlToApiName(
-      getAppStudioEndpoint() + `/api/botframework/${fakeId}`,
+      getResourceServiceEndpoint(ResourceServiceType.TDP) + `/api/botframework/${fakeId}`,
       "GET"
     );
     chai.assert.equal(apiName, APP_STUDIO_API_NAMES.GET_BOT);
 
     apiName = WrappedAxiosClient.convertUrlToApiName(
-      getAppStudioEndpoint() + `/api/botframework/${fakeId}`,
+      getResourceServiceEndpoint(ResourceServiceType.TDP) + `/api/botframework/${fakeId}`,
       "POST"
     );
     chai.assert.equal(apiName, APP_STUDIO_API_NAMES.UPDATE_BOT);
 
     apiName = WrappedAxiosClient.convertUrlToApiName(
-      getAppStudioEndpoint() + `/api/botframework/${fakeId}`,
+      getResourceServiceEndpoint(ResourceServiceType.TDP) + `/api/botframework/${fakeId}`,
       "DELETE"
     );
     chai.assert.equal(apiName, APP_STUDIO_API_NAMES.DELETE_BOT);
 
     apiName = WrappedAxiosClient.convertUrlToApiName(
-      getAppStudioEndpoint() + `/api/botframework`,
+      getResourceServiceEndpoint(ResourceServiceType.TDP) + `/api/botframework`,
       "GET"
     );
     chai.assert.equal(apiName, APP_STUDIO_API_NAMES.LIST_BOT);
 
     apiName = WrappedAxiosClient.convertUrlToApiName(
-      getAppStudioEndpoint() + `/api/aadapp/v2`,
+      getResourceServiceEndpoint(ResourceServiceType.TDP) + `/api/aadapp/v2`,
       "POST"
     );
     chai.assert.equal(apiName, APP_STUDIO_API_NAMES.CREATE_AAD_APP);
 
     apiName = WrappedAxiosClient.convertUrlToApiName(
-      getAppStudioEndpoint() + `/api/botframework`,
+      getResourceServiceEndpoint(ResourceServiceType.TDP) + `/api/botframework`,
       "POST"
     );
     chai.assert.equal(apiName, APP_STUDIO_API_NAMES.CREATE_BOT);
 
     apiName = WrappedAxiosClient.convertUrlToApiName(
-      getAppStudioEndpoint() + `/api/v1.0/appvalidations/appdefinition/validate`,
+      getResourceServiceEndpoint(ResourceServiceType.TDP) +
+        `/api/v1.0/appvalidations/appdefinition/validate`,
       "POST"
     );
     chai.assert.equal(apiName, APP_STUDIO_API_NAMES.SUBMIT_APP_VALIDATION);
 
     apiName = WrappedAxiosClient.convertUrlToApiName(
-      getAppStudioEndpoint() +
+      getResourceServiceEndpoint(ResourceServiceType.TDP) +
         `/api/v1.0/appvalidations/appdefinitions/efe81961-44bc-49ae-99f8-1476caef994c`,
       "GET"
     );
     chai.assert.equal(apiName, APP_STUDIO_API_NAMES.GET_APP_VALIDATION_REQUESTS);
 
     apiName = WrappedAxiosClient.convertUrlToApiName(
-      getAppStudioEndpoint() + `/api/v1.0/appvalidations/2512d616-8aac-461f-8af0-23e9b09ec650`,
+      getResourceServiceEndpoint(ResourceServiceType.TDP) +
+        `/api/v1.0/appvalidations/2512d616-8aac-461f-8af0-23e9b09ec650`,
       "GET"
     );
     chai.assert.equal(apiName, APP_STUDIO_API_NAMES.GET_APP_VALIDATION_RESULT);
 
     apiName = WrappedAxiosClient.convertUrlToApiName(
-      getAppStudioEndpoint() + `/api/v1.0/oAuthConfigurations`,
+      getResourceServiceEndpoint(ResourceServiceType.TDP) + `/api/v1.0/oAuthConfigurations`,
       "POST"
     );
     chai.assert.equal(apiName, APP_STUDIO_API_NAMES.CREATE_OAUTH);
 
     apiName = WrappedAxiosClient.convertUrlToApiName(
-      getAppStudioEndpoint() + `/api/v1.0/oAuthConfigurations/${fakeId}`,
+      getResourceServiceEndpoint(ResourceServiceType.TDP) +
+        `/api/v1.0/oAuthConfigurations/${fakeId}`,
       "GET"
     );
     chai.assert.equal(apiName, APP_STUDIO_API_NAMES.GET_OAUTH);
 
     apiName = WrappedAxiosClient.convertUrlToApiName(
-      getAppStudioEndpoint() + `/api/v1.0/oAuthConfigurations/${fakeId}`,
+      getResourceServiceEndpoint(ResourceServiceType.TDP) +
+        `/api/v1.0/oAuthConfigurations/${fakeId}`,
       "PATCH"
     );
     chai.assert.equal(apiName, APP_STUDIO_API_NAMES.UPDATE_OAUTH);
 
     apiName = WrappedAxiosClient.convertUrlToApiName(
-      getAppStudioEndpoint() + `/api/v1.0/oAuthConfigurations/${fakeId}`,
+      getResourceServiceEndpoint(ResourceServiceType.TDP) +
+        `/api/v1.0/oAuthConfigurations/${fakeId}`,
       ""
     );
     chai.assert.notEqual(apiName, APP_STUDIO_API_NAMES.UPDATE_OAUTH);
 
-    apiName = WrappedAxiosClient.convertUrlToApiName(getAppStudioEndpoint() + `unknown`, "GET");
-    chai.assert.equal(apiName, (getAppStudioEndpoint() + `unknown`).replace(/\//g, `-`));
+    apiName = WrappedAxiosClient.convertUrlToApiName(
+      getResourceServiceEndpoint(ResourceServiceType.TDP) + `unknown`,
+      "GET"
+    );
+    chai.assert.equal(
+      apiName,
+      (getResourceServiceEndpoint(ResourceServiceType.TDP) + `unknown`).replace(/\//g, `-`)
+    );
 
     apiName = WrappedAxiosClient.convertUrlToApiName(
       "https://authsvc.teams.microsoft.com/v1.0/users/region",

--- a/packages/tests/src/commonlib/appStudioValidator.ts
+++ b/packages/tests/src/commonlib/appStudioValidator.ts
@@ -31,7 +31,7 @@ export class AppStudioValidator {
 
   public static async validatePublish(appId: string): Promise<void> {
     const appStudioTokenRes = await this.provider.getAccessToken({
-      scopes: AppStudioScopes,
+      scopes: AppStudioScopes(),
     });
     const appStudioToken = appStudioTokenRes.isOk()
       ? appStudioTokenRes.value
@@ -56,7 +56,7 @@ export class AppStudioValidator {
 
   public static async deleteApp(teamsAppId: string): Promise<void> {
     const appStudioTokenRes = await this.provider.getAccessToken({
-      scopes: AppStudioScopes,
+      scopes: AppStudioScopes(),
     });
     const appStudioToken = appStudioTokenRes.isOk()
       ? appStudioTokenRes.value
@@ -89,7 +89,7 @@ export class AppStudioValidator {
       return;
     }
     const appStudioTokenRes = await this.provider.getAccessToken({
-      scopes: AppStudioScopes,
+      scopes: AppStudioScopes(),
     });
     const appStudioToken = appStudioTokenRes.isOk()
       ? appStudioTokenRes.value
@@ -144,7 +144,7 @@ export class AppStudioValidator {
     teamsAppId: string
   ): Promise<boolean> {
     const appStudioTokenRes = await this.provider.getAccessToken({
-      scopes: AppStudioScopes,
+      scopes: AppStudioScopes(),
     });
     const appStudioToken = appStudioTokenRes.isOk()
       ? appStudioTokenRes.value
@@ -165,7 +165,7 @@ export class AppStudioValidator {
 
   public static async getApp(teamsAppId: string): Promise<JSON> {
     const appStudioTokenRes = await this.provider.getAccessToken({
-      scopes: AppStudioScopes,
+      scopes: AppStudioScopes(),
     });
     const appStudioToken = appStudioTokenRes.isOk()
       ? appStudioTokenRes.value

--- a/packages/tests/src/commonlib/botValidator.ts
+++ b/packages/tests/src/commonlib/botValidator.ts
@@ -128,7 +128,7 @@ export class BotValidator {
 
     const tokenProvider = MockAzureAccountProvider;
     const tokenCredential = await tokenProvider.getIdentityCredentialAsync();
-    const token = (await tokenCredential?.getToken(AzureScopes))?.token;
+    const token = (await tokenCredential?.getToken(AzureScopes()))?.token;
 
     console.log("Validating env variables");
     const response = await getWebappSettings(
@@ -182,7 +182,7 @@ export class BotValidator {
 
     const tokenProvider = MockAzureAccountProvider;
     const tokenCredential = await tokenProvider.getIdentityCredentialAsync();
-    const token = (await tokenCredential?.getToken(AzureScopes))?.token;
+    const token = (await tokenCredential?.getToken(AzureScopes()))?.token;
 
     const activeResourcePlugins = await getActivePluginsFromProjectSetting(
       this.projectPath

--- a/packages/tests/src/commonlib/containeraAppValidator.ts
+++ b/packages/tests/src/commonlib/containeraAppValidator.ts
@@ -52,7 +52,7 @@ export class ContainerAppValidator {
 
     const tokenProvider = MockAzureAccountProvider;
     const tokenCredential = await tokenProvider.getIdentityCredentialAsync();
-    const token = (await tokenCredential?.getToken(AzureScopes))?.token;
+    const token = (await tokenCredential?.getToken(AzureScopes()))?.token;
 
     for (const containerAppName of this.containerAppNames) {
       const response = await getContainerAppProperties(

--- a/packages/tests/src/commonlib/frontendValidator.ts
+++ b/packages/tests/src/commonlib/frontendValidator.ts
@@ -136,7 +136,7 @@ export class FrontendValidator {
 
     const tokenProvider = MockAzureAccountProvider;
     const tokenCredential = await tokenProvider.getIdentityCredentialAsync();
-    const token = (await tokenCredential?.getToken(AzureScopes))?.token;
+    const token = (await tokenCredential?.getToken(AzureScopes()))?.token;
     chai.assert.exists(token);
 
     console.log("Validating Storage Container.");
@@ -158,7 +158,7 @@ export class FrontendValidator {
 
     const tokenProvider = MockAzureAccountProvider;
     const tokenCredential = await tokenProvider.getIdentityCredentialAsync();
-    const token = (await tokenCredential?.getToken(AzureScopes))?.token;
+    const token = (await tokenCredential?.getToken(AzureScopes()))?.token;
     chai.assert.exists(token);
 
     const sasToken = await this.getSasToken(

--- a/packages/tests/src/commonlib/functionValidator.ts
+++ b/packages/tests/src/commonlib/functionValidator.ts
@@ -117,7 +117,7 @@ export class FunctionValidator {
 
     const tokenProvider = MockAzureAccountProvider;
     const tokenCredential = await tokenProvider.getIdentityCredentialAsync();
-    const token = (await tokenCredential?.getToken(AzureScopes))?.token;
+    const token = (await tokenCredential?.getToken(AzureScopes()))?.token;
 
     // Validating app settings
     console.log("validating app settings.");
@@ -143,7 +143,7 @@ export class FunctionValidator {
     // Disable validate deployment since we have too many requests and the test is not stable.
     const tokenCredential =
       await MockAzureAccountProvider.getIdentityCredentialAsync();
-    const token = (await tokenCredential?.getToken(AzureScopes))?.token;
+    const token = (await tokenCredential?.getToken(AzureScopes()))?.token;
 
     const deployments = await this.getDeployments(
       this.subscriptionId,

--- a/packages/tests/src/commonlib/keyVaultValidator.ts
+++ b/packages/tests/src/commonlib/keyVaultValidator.ts
@@ -84,7 +84,7 @@ export class KeyVaultValidator {
 
     const tokenProvider = MockAzureAccountProvider;
     const tokenCredential = await tokenProvider.getIdentityCredentialAsync();
-    const token = (await tokenCredential?.getToken(AzureScopes))?.token;
+    const token = (await tokenCredential?.getToken(AzureScopes()))?.token;
 
     console.log("Validating key vault instance.");
     const keyVaultResponse = await this.getKeyVault(

--- a/packages/tests/src/commonlib/simpleAuthValidator.ts
+++ b/packages/tests/src/commonlib/simpleAuthValidator.ts
@@ -70,7 +70,7 @@ export class SimpleAuthValidator {
 
     const tokenProvider = MockAzureAccountProvider;
     const tokenCredential = await tokenProvider.getIdentityCredentialAsync();
-    const token = (await tokenCredential?.getToken(AzureScopes))?.token;
+    const token = (await tokenCredential?.getToken(AzureScopes()))?.token;
 
     console.log("Validating app settings.");
     const activeResourcePlugins = await getActivePluginsFromProjectSetting(

--- a/packages/tests/src/commonlib/teamsAppHelper.ts
+++ b/packages/tests/src/commonlib/teamsAppHelper.ts
@@ -32,7 +32,7 @@ export class TeamsAppHelper {
   ): Promise<TeamsAppHelper> {
     if (!TeamsAppHelper.instance) {
       const res = await provider.getAccessToken({
-        scopes: AppStudioScopes,
+        scopes: AppStudioScopes(),
       });
       if (res.isErr()) {
         throw res.error;

--- a/packages/tests/src/e2e/commonUtils.ts
+++ b/packages/tests/src/e2e/commonUtils.ts
@@ -698,7 +698,7 @@ export async function validateServicePlan(
 
   const tokenProvider = MockAzureAccountProvider;
   const tokenCredential = await tokenProvider.getIdentityCredentialAsync();
-  const token = (await tokenCredential?.getToken(AzureScopes))?.token;
+  const token = (await tokenCredential?.getToken(AzureScopes()))?.token;
 
   const serivcePlanResponse = await getWebappServicePlan(
     subscription,

--- a/packages/tests/src/e2e/commonUtils.ts.back
+++ b/packages/tests/src/e2e/commonUtils.ts.back
@@ -797,7 +797,7 @@ export async function validateServicePlan(
 
   const tokenProvider = MockAzureAccountProvider;
   const tokenCredential = await tokenProvider.getIdentityCredentialAsync();
-  const token = (await tokenCredential?.getToken(AzureScopes))?.token;
+  const token = (await tokenCredential?.getToken(AzureScopes()))?.token;
 
   const serivcePlanResponse = await getWebappServicePlan(
     subscription,

--- a/packages/tests/src/e2e/debug/utility.ts
+++ b/packages/tests/src/e2e/debug/utility.ts
@@ -7,7 +7,7 @@ import axios, { AxiosInstance } from "axios";
 
 async function createRequester(): Promise<AxiosInstance> {
   const appStudioTokenRes = await m365Provider.getAccessToken({
-    scopes: AppStudioScopes,
+    scopes: AppStudioScopes(),
   });
   const appStudioToken = appStudioTokenRes.isOk()
     ? appStudioTokenRes.value

--- a/packages/tests/src/e2e/teamsAgent/teamsCollaboratorAgent.tests.ts
+++ b/packages/tests/src/e2e/teamsAgent/teamsCollaboratorAgent.tests.ts
@@ -171,7 +171,7 @@ describe("Teams Collaborator Agent", function () {
 
       const tokenProvider = MockAzureAccountProvider;
       const tokenCredential = await tokenProvider.getIdentityCredentialAsync();
-      const token = (await tokenCredential?.getToken(AzureScopes))?.token;
+      const token = (await tokenCredential?.getToken(AzureScopes()))?.token;
       assert.exists(token);
 
       const response = await getWebappSettings(

--- a/packages/tests/src/e2e/teamsApp/basicBot.tests.ts
+++ b/packages/tests/src/e2e/teamsApp/basicBot.tests.ts
@@ -159,7 +159,7 @@ describe("Basic Bot", function () {
 
       const tokenProvider = MockAzureAccountProvider;
       const tokenCredential = await tokenProvider.getIdentityCredentialAsync();
-      const token = (await tokenCredential?.getToken(AzureScopes))?.token;
+      const token = (await tokenCredential?.getToken(AzureScopes()))?.token;
       assert.exists(token);
 
       const response = await getWebappSettings(

--- a/packages/tests/src/e2e/teamsApp/basicMessageExtension.tests.ts
+++ b/packages/tests/src/e2e/teamsApp/basicMessageExtension.tests.ts
@@ -159,7 +159,7 @@ describe("Basic Message Extension", function () {
 
       const tokenProvider = MockAzureAccountProvider;
       const tokenCredential = await tokenProvider.getIdentityCredentialAsync();
-      const token = (await tokenCredential?.getToken(AzureScopes))?.token;
+      const token = (await tokenCredential?.getToken(AzureScopes()))?.token;
       assert.exists(token);
 
       const response = await getWebappSettings(

--- a/packages/tests/src/e2e/teamsApp/basicTab.tests.ts
+++ b/packages/tests/src/e2e/teamsApp/basicTab.tests.ts
@@ -151,7 +151,7 @@ describe("Basic Tab", function () {
 
       const tokenProvider = MockAzureAccountProvider;
       const tokenCredential = await tokenProvider.getIdentityCredentialAsync();
-      const token = (await tokenCredential?.getToken(AzureScopes))?.token;
+      const token = (await tokenCredential?.getToken(AzureScopes()))?.token;
       assert.exists(token);
 
       const response = await getWebappSettings(

--- a/packages/tests/src/e2e/vs/BasicTabHappyPath.dotnet.tests.ts
+++ b/packages/tests/src/e2e/vs/BasicTabHappyPath.dotnet.tests.ts
@@ -79,7 +79,7 @@ describe("Blazor App", function () {
 
       const tokenProvider = MockAzureAccountProvider;
       const tokenCredential = await tokenProvider.getIdentityCredentialAsync();
-      const token = (await tokenCredential?.getToken(AzureScopes))?.token;
+      const token = (await tokenCredential?.getToken(AzureScopes()))?.token;
       chai.assert.exists(token);
 
       const context = await readContextMultiEnvV3(projectPath, envName);

--- a/packages/tests/src/e2e/vs/TeamsCollaboratorAgent.dotnet.tests.ts
+++ b/packages/tests/src/e2e/vs/TeamsCollaboratorAgent.dotnet.tests.ts
@@ -161,7 +161,7 @@ describe("Teams Collaborator Agent for csharp version", function () {
 
       const tokenProvider = MockAzureAccountProvider;
       const tokenCredential = await tokenProvider.getIdentityCredentialAsync();
-      const token = (await tokenCredential?.getToken(AzureScopes))?.token;
+      const token = (await tokenCredential?.getToken(AzureScopes()))?.token;
       assert.exists(token);
 
       const response = await getWebappSettings(

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -1862,6 +1862,16 @@
     "configuration": {
       "title": "Microsoft 365 Agents Toolkit",
       "properties": {
+        "M365AgentsToolkit.sovereignCloudEnvironment": {
+          "type": "string",
+          "enum": [
+            "GCC M",
+            "GCC High",
+            "DOD"
+          ],
+          "default": "",
+          "markdownDescription": "Set the sovereign cloud environment for Microsoft 365 Agents Toolkit. This along with setting `#microsoft-sovereign-cloud.environment#` to `USGovernment` is required to use this feature. The default value is ``. The available values are `GCC M`, `GCC High`, and `DOD`."
+        },
         "M365AgentsToolkit.logLevel": {
           "type": "string",
           "enum": [

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -1865,12 +1865,10 @@
         "M365AgentsToolkit.sovereignCloudEnvironment": {
           "type": "string",
           "enum": [
-            "GCC M",
-            "GCC High",
-            "DOD"
+            "GCC M"
           ],
           "default": "",
-          "markdownDescription": "Set the sovereign cloud environment for Microsoft 365 Agents Toolkit. This along with setting `#microsoft-sovereign-cloud.environment#` to `USGovernment` is required to use this feature. The default value is ``. The available values are `GCC M`, `GCC High`, and `DOD`."
+          "markdownDescription": "Set the sovereign cloud environment for Microsoft 365 Agents Toolkit. This along with setting `#microsoft-sovereign-cloud.environment#` to `USGovernment` is required to use this feature."
         },
         "M365AgentsToolkit.logLevel": {
           "type": "string",

--- a/packages/vscode-extension/src/chat/commands/nextstep/helper.ts
+++ b/packages/vscode-extension/src/chat/commands/nextstep/helper.ts
@@ -10,7 +10,7 @@ export async function checkCredential(): Promise<{
   m365LoggedIn: boolean;
   azureLoggedIn: boolean;
 }> {
-  const m365Status = await M365Login.getInstance().getStatus({ scopes: core.AppStudioScopes });
+  const m365Status = await M365Login.getInstance().getStatus({ scopes: core.AppStudioScopes() });
   const azureStatus = await AzureAccountManager.getInstance().getStatus();
   return {
     m365LoggedIn: m365Status.isOk() && m365Status.value.status === signedIn,

--- a/packages/vscode-extension/src/commonlib/azureLogin.ts
+++ b/packages/vscode-extension/src/commonlib/azureLogin.ts
@@ -95,7 +95,7 @@ export class AzureAccountManager extends login implements AzureAccountProvider {
     if (!tenantId) {
       tenantId = await loadTenantId(azureCacheName);
     }
-    const session = await getSessionFromVSCode(AzureScopes, tenantId, {
+    const session = await getSessionFromVSCode(AzureScopes(), tenantId, {
       createIfNone: false,
       silent: true,
     });
@@ -122,7 +122,7 @@ export class AzureAccountManager extends login implements AzureAccountProvider {
     try {
       AzureAccountManager.currentStatus = loggingIn;
       void this.notifyStatus();
-      const session = await getSessionFromVSCode(AzureScopes, tenantId, { createIfNone: true });
+      const session = await getSessionFromVSCode(AzureScopes(), tenantId, { createIfNone: true });
       if (session === undefined) {
         throw new UserError(
           getDefaultString("teamstoolkit.codeFlowLogin.loginComponent"),
@@ -197,7 +197,7 @@ export class AzureAccountManager extends login implements AzureAccountProvider {
         }
         return subs[0].credential;
       } else {
-        const session = await getSessionFromVSCode(AzureScopes, undefined, {
+        const session = await getSessionFromVSCode(AzureScopes(), undefined, {
           createIfNone: false,
           silent: true,
         });
@@ -221,7 +221,7 @@ export class AzureAccountManager extends login implements AzureAccountProvider {
     authenticationSessionRequest?: vscode.AuthenticationWwwAuthenticateRequest
   ): Promise<Result<TokenCredential, FxError>> {
     const session = await getSessionFromVSCode(
-      authenticationSessionRequest ?? AzureScopes,
+      authenticationSessionRequest ?? AzureScopes(),
       tenantId,
       authenticationSessionRequest
         ? { createIfNone: true, silent: false }
@@ -284,7 +284,7 @@ export class AzureAccountManager extends login implements AzureAccountProvider {
 
   async getJsonObject(showDialog = true): Promise<Record<string, unknown> | undefined> {
     const credential = await this.getIdentityCredentialAsync(showDialog);
-    const token = await credential?.getToken("https://management.core.windows.net/.default");
+    const token = await credential?.getToken(AzureScopes());
     if (token) {
       const array = token.token.split(".");
       const buff = Buffer.from(array[1], "base64");
@@ -436,7 +436,7 @@ export class AzureAccountManager extends login implements AzureAccountProvider {
       }
       if (AzureAccountManager.currentStatus === loggedIn || (await this.isUserLogin())) {
         const credential = await this.doGetIdentityCredentialAsync();
-        const token = await credential?.getToken(AzureScopes);
+        const token = await credential?.getToken(AzureScopes());
         const accountJson = await this.getJsonObject();
         return Promise.resolve({
           status: signedIn,

--- a/packages/vscode-extension/src/commonlib/azureLogin.ts
+++ b/packages/vscode-extension/src/commonlib/azureLogin.ts
@@ -2,8 +2,6 @@
 // Licensed under the MIT license.
 /* eslint-disable @typescript-eslint/no-empty-function */
 
-/* eslint-disable @typescript-eslint/no-empty-function */
-
 "use strict";
 
 import type { TokenCredential } from "@azure/core-auth";
@@ -36,13 +34,7 @@ import {
   TelemetryErrorType,
 } from "../telemetry/extTelemetryEvents";
 import { VS_CODE_UI } from "../qm/vsc_ui";
-import {
-  AzureScopes,
-  featureFlagManager,
-  FeatureFlags,
-  globalStateGet,
-  globalStateUpdate,
-} from "@microsoft/teamsfx-core";
+import { AzureScopes, globalStateGet, globalStateUpdate } from "@microsoft/teamsfx-core";
 import { getDefaultString, localize } from "../utils/localizeUtils";
 import {
   Microsoft,

--- a/packages/vscode-extension/src/commonlib/codeFlowLogin.ts
+++ b/packages/vscode-extension/src/commonlib/codeFlowLogin.ts
@@ -51,10 +51,14 @@ import { ExtensionErrors } from "../error/error";
 import { randomBytes } from "crypto";
 import { getExchangeCode } from "./exchangeCode";
 import * as os from "os";
-import { ErrorCategory, featureFlagManager, FeatureFlags } from "@microsoft/teamsfx-core";
+import {
+  ErrorCategory,
+  featureFlagManager,
+  FeatureFlags,
+  getEntraEndpoint,
+  getTenantedAuthorityUrl,
+} from "@microsoft/teamsfx-core";
 import { getAccountByHomeId } from "./common/tokenCacheUtils";
-
-const BASE_AUTHORITY = "https://login.microsoftonline.com/";
 
 interface Deferred<T> {
   resolve: (result: T | Promise<T>) => void;
@@ -139,7 +143,7 @@ export class CodeFlowLogin {
     const app = express();
     const server = app.listen(serverPort);
     serverPort = (server.address() as AddressInfo).port;
-    const authority = tenantId ? BASE_AUTHORITY + tenantId : undefined;
+    const authority = tenantId ? getTenantedAuthorityUrl(tenantId) : undefined;
 
     const authCodeUrlParameters: AuthorizationUrlRequest = {
       scopes: scopes,
@@ -279,7 +283,7 @@ export class CodeFlowLogin {
     });
 
     this.status = loggingIn;
-    const authority = tenantId ? BASE_AUTHORITY + tenantId : undefined;
+    const authority = tenantId ? getTenantedAuthorityUrl(tenantId) : undefined;
 
     const loopbackTemplatePath = path.join(__dirname, "codeFlowResult", "index.html");
     let loopbackTemplate = undefined;
@@ -365,7 +369,7 @@ export class CodeFlowLogin {
     const codeChallenge = CodeFlowLogin.toBase64UrlEncoding(
       await CodeFlowLogin.sha256(codeVerifier)
     );
-    const authority = tenantId ? BASE_AUTHORITY + tenantId : undefined;
+    const authority = tenantId ? getTenantedAuthorityUrl(tenantId) : undefined;
     const authCodeUrlParameters: AuthorizationUrlRequest = {
       scopes: scopes,
       codeChallenge: codeChallenge,
@@ -465,7 +469,7 @@ export class CodeFlowLogin {
       let tokenRequest: SilentFlowRequest = {
         account: this.account,
         scopes: scopes,
-        authority: tenantId ? BASE_AUTHORITY + tenantId : this.config.auth.authority,
+        authority: tenantId ? getTenantedAuthorityUrl(tenantId) : this.config.auth.authority,
       };
       tokenRequest = this.isBrokerAvailable
         ? // HACK: Broker doesn't support forceRefresh so we need to pass in claims which will force a refresh
@@ -633,7 +637,7 @@ export function ConvertTokenToJson(token: string): object {
 
 export async function checkIsOnline(): Promise<boolean> {
   const options = {
-    hostname: "login.microsoftonline.com",
+    hostname: getEntraEndpoint(),
     path: "/",
     method: "head",
   };

--- a/packages/vscode-extension/src/commonlib/codeFlowLogin.ts
+++ b/packages/vscode-extension/src/commonlib/codeFlowLogin.ts
@@ -637,7 +637,7 @@ export function ConvertTokenToJson(token: string): object {
 
 export async function checkIsOnline(): Promise<boolean> {
   const options = {
-    hostname: getEntraEndpoint(),
+    hostname: "login.microsoftonline.com",
     path: "/",
     method: "head",
   };

--- a/packages/vscode-extension/src/commonlib/codeFlowLogin.ts
+++ b/packages/vscode-extension/src/commonlib/codeFlowLogin.ts
@@ -55,7 +55,6 @@ import {
   ErrorCategory,
   featureFlagManager,
   FeatureFlags,
-  getEntraEndpoint,
   getTenantedAuthorityUrl,
 } from "@microsoft/teamsfx-core";
 import { getAccountByHomeId } from "./common/tokenCacheUtils";

--- a/packages/vscode-extension/src/commonlib/m365Login.ts
+++ b/packages/vscode-extension/src/commonlib/m365Login.ts
@@ -37,7 +37,12 @@ import {
   TelemetrySuccess,
 } from "../telemetry/extTelemetryEvents";
 import { getDefaultString, localize } from "../utils/localizeUtils";
-import { AppStudioScopes, featureFlagManager, FeatureFlags } from "@microsoft/teamsfx-core";
+import {
+  AppStudioScopes,
+  featureFlagManager,
+  FeatureFlags,
+  getDefaultAuthorityUrl,
+} from "@microsoft/teamsfx-core";
 
 const SERVER_PORT = 0;
 const cachePlugin = new CryptoCachePlugin(m365CacheName);
@@ -45,7 +50,8 @@ const cachePlugin = new CryptoCachePlugin(m365CacheName);
 const config = {
   auth: {
     clientId: "7ea7c24c-b1f6-4a20-9d11-9ae12e9e7ac0",
-    authority: "https://login.microsoftonline.com/common",
+    authority: getDefaultAuthorityUrl(),
+    redirectUri: "http://localhost",
   },
   broker: {
     nativeBrokerPlugin:

--- a/packages/vscode-extension/src/commonlib/m365Login.ts
+++ b/packages/vscode-extension/src/commonlib/m365Login.ts
@@ -216,21 +216,21 @@ export class M365Login extends BasicLogin implements M365TokenProvider {
       throw UserCancelError(getDefaultString("teamstoolkit.commands.signOut.title"));
     }
     await M365Login.codeFlowInstance.logout();
-    await this.notifyStatus({ scopes: AppStudioScopes });
+    await this.notifyStatus({ scopes: AppStudioScopes() });
     return true;
   }
 
   async switchTenant(tenantId: string): Promise<Result<string, FxError>> {
     try {
       const res = await M365Login.codeFlowInstance.getTokenByScopes(
-        AppStudioScopes,
+        AppStudioScopes(),
         true,
         undefined,
         tenantId
       );
       if (res.isOk()) {
         await M365Login.codeFlowInstance.switchTenant(tenantId);
-        await this.notifyStatus({ scopes: AppStudioScopes });
+        await this.notifyStatus({ scopes: AppStudioScopes() });
       }
       return res;
     } catch (e) {
@@ -305,7 +305,7 @@ export class M365Login extends BasicLogin implements M365TokenProvider {
         // if token is empty, try to get token by app studio scope, normally this should only affect UX
         if (Object.keys(tokenJson).length === 0) {
           const appStudioRes = await M365Login.codeFlowInstance.getTokenByScopes(
-            AppStudioScopes,
+            AppStudioScopes(),
             false
           );
           if (appStudioRes.isOk()) {

--- a/packages/vscode-extension/src/commonlib/vscodeAzureSubscriptionProvider.ts
+++ b/packages/vscode-extension/src/commonlib/vscodeAzureSubscriptionProvider.ts
@@ -5,7 +5,7 @@ import { SubscriptionClient, TenantIdDescription } from "@azure/arm-resources-su
 import { TokenCredential } from "@azure/core-auth";
 import * as vscode from "vscode";
 import * as azureEnv from "@azure/ms-rest-azure-env";
-import { AzureScopes, featureFlagManager, FeatureFlags } from "@microsoft/teamsfx-core";
+import { AzureScopes } from "@microsoft/teamsfx-core";
 import { LoginFailureError } from "./codeFlowLogin";
 import { Environment } from "@azure/ms-rest-azure-env";
 
@@ -58,7 +58,7 @@ export class VSCodeAzureSubscriptionProvider {
    * @returns A list of tenants.
    */
   public async getTenants(): Promise<TenantIdDescription[]> {
-    const { client } = await this.getSubscriptionClient(undefined, AzureScopes);
+    const { client } = await this.getSubscriptionClient(undefined, AzureScopes());
 
     const results: TenantIdDescription[] = [];
 
@@ -105,7 +105,7 @@ export class VSCodeAzureSubscriptionProvider {
   private async getSubscriptionsForTenant(tenantId: string): Promise<AzureSubscription[]> {
     const { client, credential, authentication } = await this.getSubscriptionClient(
       tenantId,
-      AzureScopes
+      AzureScopes()
     );
     const environment = getConfiguredAzureEnv();
 

--- a/packages/vscode-extension/src/config.ts
+++ b/packages/vscode-extension/src/config.ts
@@ -45,6 +45,10 @@ export class ConfigManager {
       ConfigurationKey.EnableCFShortcutMetaOS,
       false
     ).toString();
+    process.env[FeatureFlags.SovereignCloudEnvironment.name] = this.getConfiguration(
+      ConfigurationKey.SovereignCloudEnvironment,
+      ""
+    ).toString();
   }
   loadLogLevel() {
     const logLevel = this.getConfiguration(ConfigurationKey.LogLevel, "Info") as string;

--- a/packages/vscode-extension/src/constants.ts
+++ b/packages/vscode-extension/src/constants.ts
@@ -8,6 +8,7 @@ export enum ConfigurationKey {
   EnableCEA = "enableLaunchAgentForTeamsInCopilot",
   EnableDAMetaOS = "enableDeclarativeAgentInOfficeAddIn",
   EnableCFShortcutMetaOS = "enableCustomFunctionShortcutInOfficeAddIn",
+  SovereignCloudEnvironment = "sovereignCloudEnvironment",
 }
 
 export const AzurePortalUrl = "https://portal.azure.com";

--- a/packages/vscode-extension/src/debug/deleteAadHelper.ts
+++ b/packages/vscode-extension/src/debug/deleteAadHelper.ts
@@ -15,6 +15,10 @@ import { localize } from "../utils/localizeUtils";
 import { ExtTelemetry } from "../telemetry/extTelemetry";
 import { TelemetryEvent } from "../telemetry/extTelemetryEvents";
 import { FxError } from "@microsoft/teamsfx-api";
+import {
+  getResourceServiceEndpoint,
+  ResourceServiceType,
+} from "@microsoft/teamsfx-core/build/common/constants";
 
 const defaultNotificationLocalFile = ".notification.localstore.json";
 export async function deleteAad(): Promise<boolean> {
@@ -49,7 +53,7 @@ export async function deleteAad(): Promise<boolean> {
       ExtTelemetry.sendTelemetryEvent(TelemetryEvent.StartDeleteAadAfterDebug);
 
       const aadClient = axios.create({
-        baseURL: "https://graph.microsoft.com/v1.0",
+        baseURL: `${getResourceServiceEndpoint(ResourceServiceType.Graph)}/v1.0`,
       });
       aadClient.interceptors.request.use((config) => {
         config.headers["Authorization"] = `Bearer ${tokenRes.value}`;

--- a/packages/vscode-extension/src/debug/depsChecker/common.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/common.ts
@@ -27,6 +27,7 @@ import {
   FindProcessError,
   HttpClientError,
   LocalEnvManager,
+  MosServiceScope,
   PackageService,
   PortsConflictError,
   SideloadingDisabledError,
@@ -68,7 +69,6 @@ import {
   DepsDisplayName,
   ProgressMessage,
   ResultStatus,
-  copilotCheckServiceScope,
 } from "./prerequisitesCheckerConstants";
 import { vscodeLogger } from "./vscodeLogger";
 import { vscodeTelemetry } from "./vscodeTelemetry";
@@ -356,7 +356,7 @@ function ensureM365Account(
       ctx: TelemetryContext
     ): Promise<Result<{ token: string; tenantId?: string; loginHint?: string }, FxError>> => {
       const m365Login: M365TokenProvider = M365TokenInstance;
-      let loginStatusRes = await m365Login.getStatus({ scopes: AppStudioScopes });
+      let loginStatusRes = await m365Login.getStatus({ scopes: AppStudioScopes() });
       if (loginStatusRes.isErr()) {
         ctx.properties[TelemetryProperty.DebugM365AccountStatus] = "error";
         return err(loginStatusRes.error);
@@ -368,13 +368,13 @@ function ensureM365Account(
       let tid = loginStatusRes.value.accountInfo?.tid;
       if (loginStatusRes.value.status === signedOut && showLoginPage) {
         const tokenRes = await tools.tokenProvider.m365TokenProvider.getAccessToken({
-          scopes: AppStudioScopes,
+          scopes: AppStudioScopes(),
           showDialog: true,
         });
         if (tokenRes.isErr()) {
           return err(tokenRes.error);
         }
-        loginStatusRes = await m365Login.getStatus({ scopes: AppStudioScopes });
+        loginStatusRes = await m365Login.getStatus({ scopes: AppStudioScopes() });
         if (loginStatusRes.isErr()) {
           return err(loginStatusRes.error);
         }
@@ -413,7 +413,7 @@ async function ensureCopilotAccess(
     async (ctx: TelemetryContext) => {
       const m365Login: M365TokenProvider = M365TokenInstance;
       const copilotTokenRes = await m365Login.getAccessToken({
-        scopes: [copilotCheckServiceScope],
+        scopes: MosServiceScope(),
         showDialog: false,
       });
       let hasCopilotAccess: boolean | undefined = undefined;

--- a/packages/vscode-extension/src/debug/depsChecker/prerequisitesCheckerConstants.ts
+++ b/packages/vscode-extension/src/debug/depsChecker/prerequisitesCheckerConstants.ts
@@ -29,5 +29,3 @@ export const ProgressMessage = Object.freeze({
   [DepsType.LtsNode]: `Checking ${DepsDisplayName[DepsType.LtsNode]}`,
   [DepsType.ProjectNode]: `Checking ${DepsDisplayName[DepsType.ProjectNode]}`,
 });
-
-export const copilotCheckServiceScope = process.env.SIDELOADING_SERVICE_SCOPE ?? MosServiceScope;

--- a/packages/vscode-extension/src/debug/taskTerminal/launchDesktopClientTerminal.ts
+++ b/packages/vscode-extension/src/debug/taskTerminal/launchDesktopClientTerminal.ts
@@ -62,12 +62,12 @@ export class LaunchDesktopClientTerminal extends BaseTaskTerminal {
     }
     const config = dotenvUtil.deserialize(fs.readFileSync(configPath, "utf-8"));
     const loginInfo = await tools.tokenProvider.m365TokenProvider.getStatus({
-      scopes: AppStudioScopes,
+      scopes: AppStudioScopes(),
     });
     const readMore = `${localize("teamstoolkit.common.readMore")}`;
     if (loginInfo.isOk() && loginInfo.value.status === "SignedIn") {
       const accountInfo = await tools.tokenProvider.m365TokenProvider.getJsonObject({
-        scopes: AppStudioScopes,
+        scopes: AppStudioScopes(),
       });
       let username = "";
       if (accountInfo.isOk() && accountInfo.value["unique_name"]) {

--- a/packages/vscode-extension/src/debug/teamsfxDebugProvider.ts
+++ b/packages/vscode-extension/src/debug/teamsfxDebugProvider.ts
@@ -230,7 +230,7 @@ async function generateAccountHint(includeTenantId = true): Promise<string> {
     loginHint = accountInfo.username;
   } else {
     try {
-      const tokenObjectRes = await M365TokenInstance.getStatus({ scopes: AppStudioScopes });
+      const tokenObjectRes = await M365TokenInstance.getStatus({ scopes: AppStudioScopes() });
       const tokenObject = tokenObjectRes.isOk() ? tokenObjectRes.value.accountInfo : undefined;
       if (tokenObject) {
         // user signed in

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -334,10 +334,10 @@ function activateTeamsFxRegistration(context: vscode.ExtensionContext) {
   // Set region for M365 account every
   void M365TokenInstance.setStatusChangeMap(
     "set-region",
-    { scopes: AuthSvcScopes },
+    { scopes: AuthSvcScopes() },
     async (status, token, accountInfo) => {
       if (status === "SignedIn") {
-        const tokenRes = await M365TokenInstance.getAccessToken({ scopes: AuthSvcScopes });
+        const tokenRes = await M365TokenInstance.getAccessToken({ scopes: AuthSvcScopes() });
         if (tokenRes.isOk()) {
           await teamsDevPortalClient.setRegionEndpointByToken(tokenRes.value);
         }

--- a/packages/vscode-extension/src/handlers/accounts/accountHandlers.ts
+++ b/packages/vscode-extension/src/handlers/accounts/accountHandlers.ts
@@ -104,7 +104,7 @@ export async function cmpAccountsHandler(args: any[]) {
   const quickPick = window.createQuickPick();
   const quickItemOptionArray: VscQuickPickItem[] = [];
 
-  const m365AccountRes = await M365TokenInstance.getStatus({ scopes: AppStudioScopes });
+  const m365AccountRes = await M365TokenInstance.getStatus({ scopes: AppStudioScopes() });
   const m365Account = m365AccountRes.isOk() ? m365AccountRes.value : undefined;
   if (m365Account && m365Account.status === "SignedIn") {
     const accountInfo = m365Account.accountInfo;

--- a/packages/vscode-extension/src/handlers/accounts/checkCopilotAccess.ts
+++ b/packages/vscode-extension/src/handlers/accounts/checkCopilotAccess.ts
@@ -17,7 +17,7 @@ import { signInM365 } from "../../utils/accountUtils";
 
 export async function checkCopilotAccessHandler(): Promise<Result<null, FxError>> {
   // check m365 login status, if not logged in, pop up a message
-  const status = await M365TokenInstance.getStatus({ scopes: AppStudioScopes });
+  const status = await M365TokenInstance.getStatus({ scopes: AppStudioScopes() });
   if (!(status.isOk() && status.value.status === signedIn)) {
     const message = localize("teamstoolkit.m365.needSignIn.message");
     const signin = localize("teamstoolkit.common.signin");
@@ -38,9 +38,8 @@ export async function checkCopilotAccessHandler(): Promise<Result<null, FxError>
   }
 
   // if logged in, check copilot access with a different scopes
-  const copilotCheckServiceScope = process.env.SIDELOADING_SERVICE_SCOPE ?? MosServiceScope;
   const copilotTokenRes = await M365TokenInstance.getAccessToken({
-    scopes: [copilotCheckServiceScope],
+    scopes: MosServiceScope(),
   });
   if (copilotTokenRes.isOk()) {
     const hasCopilotAccess = await PackageService.GetSharedInstance().getCopilotStatus(

--- a/packages/vscode-extension/src/handlers/accounts/refreshAccessHandlers.ts
+++ b/packages/vscode-extension/src/handlers/accounts/refreshAccessHandlers.ts
@@ -7,7 +7,7 @@ import accountTreeViewProviderInstance from "../../treeview/account/accountTreeV
 import M365TokenInstance from "../../commonlib/m365Login";
 
 export async function refreshSideloadingCallback(args?: any[]): Promise<Result<null, FxError>> {
-  const status = await M365TokenInstance.getStatus({ scopes: AppStudioScopes });
+  const status = await M365TokenInstance.getStatus({ scopes: AppStudioScopes() });
   if (status.isOk() && status.value.token !== undefined) {
     accountTreeViewProviderInstance.m365AccountNode.updateChecks(status.value.token, true, false);
   }
@@ -16,7 +16,7 @@ export async function refreshSideloadingCallback(args?: any[]): Promise<Result<n
 }
 
 export async function refreshCopilotCallback(args?: any[]): Promise<Result<null, FxError>> {
-  const status = await M365TokenInstance.getStatus({ scopes: AppStudioScopes });
+  const status = await M365TokenInstance.getStatus({ scopes: AppStudioScopes() });
   if (status.isOk() && status.value.token !== undefined) {
     accountTreeViewProviderInstance.m365AccountNode.updateChecks(status.value.token, false, true);
   }

--- a/packages/vscode-extension/src/handlers/accounts/signinAccountHandlers.ts
+++ b/packages/vscode-extension/src/handlers/accounts/signinAccountHandlers.ts
@@ -29,7 +29,7 @@ export async function signinM365Callback(...args: unknown[]): Promise<Result<nul
   });
 
   const tokenRes = await tools.tokenProvider.m365TokenProvider.getJsonObject({
-    scopes: AppStudioScopes,
+    scopes: AppStudioScopes(),
     showDialog: true,
   });
   const token = tokenRes.isOk() ? tokenRes.value : undefined;

--- a/packages/vscode-extension/src/handlers/accounts/switchTenantHandler.ts
+++ b/packages/vscode-extension/src/handlers/accounts/switchTenantHandler.ts
@@ -22,7 +22,7 @@ export async function onSwitchM365Tenant(...args: unknown[]): Promise<void> {
 
   let error: FxError | undefined = undefined;
   const tokenRes = await M365TokenInstance.getAccessToken({
-    scopes: AzureScopes,
+    scopes: AzureScopes(),
   });
   if (tokenRes.isOk()) {
     const config: SingleSelectConfig = {
@@ -86,7 +86,7 @@ export async function onSwitchAzureTenant(...args: unknown[]): Promise<void> {
     title: localize("teamstoolkit.handlers.switchtenant.quickpick.title"),
     options: async () => {
       const tokenCredential = await azureAccountManager.getIdentityCredentialAsync(false);
-      const token = tokenCredential ? await tokenCredential.getToken(AzureScopes) : undefined;
+      const token = tokenCredential ? await tokenCredential.getToken(AzureScopes()) : undefined;
       if (token && token.token) {
         const tenants = await listAllTenants(token.token);
         return tenants.map((tenant: any) => {

--- a/packages/vscode-extension/src/handlers/activate.ts
+++ b/packages/vscode-extension/src/handlers/activate.ts
@@ -84,7 +84,7 @@ export function activate(): Result<Void, FxError> {
 
     void M365TokenInstance.setStatusChangeMap(
       "successfully-sign-in-m365",
-      { scopes: AppStudioScopes },
+      { scopes: AppStudioScopes() },
       m365NotificationCallback,
       false
     );

--- a/packages/vscode-extension/src/handlers/lifecycleHandlers.ts
+++ b/packages/vscode-extension/src/handlers/lifecycleHandlers.ts
@@ -199,7 +199,7 @@ export async function scaffoldFromDeveloperPortalHandler(
   let token = undefined;
   try {
     const tokenRes = await M365TokenInstance.signInWhenInitiatedFromTdp(
-      { scopes: AppStudioScopes },
+      { scopes: AppStudioScopes() },
       loginHint
     );
     if (tokenRes.isErr()) {
@@ -221,7 +221,7 @@ export async function scaffoldFromDeveloperPortalHandler(
     token = tokenRes.value;
 
     // set region
-    const AuthSvcTokenRes = await M365TokenInstance.getAccessToken({ scopes: AuthSvcScopes });
+    const AuthSvcTokenRes = await M365TokenInstance.getAccessToken({ scopes: AuthSvcScopes() });
     if (AuthSvcTokenRes.isOk()) {
       await teamsDevPortalClient.setRegionEndpointByToken(AuthSvcTokenRes.value);
     }

--- a/packages/vscode-extension/src/handlers/openLinkHandlers.ts
+++ b/packages/vscode-extension/src/handlers/openLinkHandlers.ts
@@ -121,7 +121,7 @@ export async function openAzureAccountHandler() {
 
 export async function openAppManagement(...args: unknown[]): Promise<Result<boolean, FxError>> {
   ExtTelemetry.sendTelemetryEvent(TelemetryEvent.ManageTeamsApp, getTriggerFromProperty(args));
-  const accountRes = await M365TokenInstance.getStatus({ scopes: AppStudioScopes });
+  const accountRes = await M365TokenInstance.getStatus({ scopes: AppStudioScopes() });
 
   if (accountRes.isOk() && accountRes.value.status === signedIn) {
     const loginHint = accountRes.value.accountInfo?.upn as string;

--- a/packages/vscode-extension/src/treeview/account/accountTreeViewProvider.ts
+++ b/packages/vscode-extension/src/treeview/account/accountTreeViewProvider.ts
@@ -33,7 +33,7 @@ class AccountTreeViewProvider implements vscode.TreeDataProvider<DynamicNode> {
   public subscribeToStatusChanges(tokenProvider: TokenProvider) {
     void tokenProvider.m365TokenProvider?.setStatusChangeMap(
       "tree-view",
-      { scopes: AppStudioScopes },
+      { scopes: AppStudioScopes() },
       (status, token, accountInfo) =>
         m365AccountStatusChangeHandler("appStudio", status, token, accountInfo)
     );

--- a/packages/vscode-extension/src/treeview/account/copilotNode.ts
+++ b/packages/vscode-extension/src/treeview/account/copilotNode.ts
@@ -14,8 +14,6 @@ enum ContextValues {
   ShowInfo = "checkCopilot-info",
 }
 
-const copilotCheckServiceScope = process.env.SIDELOADING_SERVICE_SCOPE ?? MosServiceScope;
-
 export class CopilotNode extends DynamicNode {
   constructor(
     private eventEmitter: vscode.EventEmitter<DynamicNode | undefined | void>,
@@ -28,7 +26,7 @@ export class CopilotNode extends DynamicNode {
   private async checkCopilot(): Promise<boolean | undefined> {
     try {
       const m365TokenStatus = await M365TokenInstance.getAccessToken({
-        scopes: [copilotCheckServiceScope],
+        scopes: MosServiceScope(),
         showDialog: false,
       });
       if (m365TokenStatus.isOk()) {

--- a/packages/vscode-extension/src/treeview/account/m365Node.ts
+++ b/packages/vscode-extension/src/treeview/account/m365Node.ts
@@ -37,7 +37,7 @@ export class M365AccountNode extends DynamicNode {
 
     this.label = displayName;
     const tokenRes = await tools.tokenProvider.m365TokenProvider.getAccessToken({
-      scopes: AzureScopes,
+      scopes: AzureScopes(),
     });
     if (tokenRes.isOk() && tokenRes.value) {
       const tenants = await listAllTenants(tokenRes.value);

--- a/packages/vscode-extension/src/treeview/environmentTreeItem.ts
+++ b/packages/vscode-extension/src/treeview/environmentTreeItem.ts
@@ -92,7 +92,7 @@ export class EnvironmentNode extends DynamicNode {
     const warnings: string[] = [];
 
     // Check M365 account status
-    const loginStatusRes = await M365Login.getInstance().getStatus({ scopes: AppStudioScopes });
+    const loginStatusRes = await M365Login.getInstance().getStatus({ scopes: AppStudioScopes() });
     const loginStatus = loginStatusRes.isOk() ? loginStatusRes.value : undefined;
     if (loginStatus && loginStatus.status == signedIn) {
       // Signed account doesn't match

--- a/packages/vscode-extension/test/handlers/accounts/checkCopilotAccess.test.ts
+++ b/packages/vscode-extension/test/handlers/accounts/checkCopilotAccess.test.ts
@@ -22,7 +22,7 @@ describe("check copilot access", () => {
     const copilotCheckServiceScope = process.env.SIDELOADING_SERVICE_SCOPE ?? MosServiceScope;
     const m365GetStatusStub = sandbox
       .stub(M365TokenInstance, "getStatus")
-      .withArgs({ scopes: AppStudioScopes })
+      .withArgs({ scopes: AppStudioScopes() })
       .resolves(err({ error: "unknown" } as any));
     const m365GetAccessTokenStub = sandbox
       .stub(M365TokenInstance, "getAccessToken")
@@ -51,7 +51,7 @@ describe("check copilot access", () => {
     const copilotCheckServiceScope = process.env.SIDELOADING_SERVICE_SCOPE ?? MosServiceScope;
     const m365GetStatusStub = sandbox
       .stub(M365TokenInstance, "getStatus")
-      .withArgs({ scopes: AppStudioScopes })
+      .withArgs({ scopes: AppStudioScopes() })
       .resolves(err({ error: "unknown" } as any));
     const m365GetAccessTokenStub = sandbox
       .stub(M365TokenInstance, "getAccessToken")
@@ -84,7 +84,7 @@ describe("check copilot access", () => {
     const copilotCheckServiceScope = process.env.SIDELOADING_SERVICE_SCOPE ?? MosServiceScope;
     const m365GetStatusStub = sandbox
       .stub(M365TokenInstance, "getStatus")
-      .withArgs({ scopes: AppStudioScopes })
+      .withArgs({ scopes: AppStudioScopes() })
       .resolves(err({ error: "unknown" } as any));
     sandbox
       .stub(M365TokenInstance, "getAccessToken")
@@ -111,7 +111,7 @@ describe("check copilot access", () => {
     const copilotCheckServiceScope = process.env.SIDELOADING_SERVICE_SCOPE ?? MosServiceScope;
     const m365GetStatusStub = sandbox
       .stub(M365TokenInstance, "getStatus")
-      .withArgs({ scopes: AppStudioScopes })
+      .withArgs({ scopes: AppStudioScopes() })
       .resolves(ok({ status: "SignedIn", accountInfo: { upn: "test.email.com" } }));
     const m365GetAccessTokenStub = sandbox
       .stub(M365TokenInstance, "getAccessToken")
@@ -144,7 +144,7 @@ describe("check copilot access", () => {
     const copilotCheckServiceScope = process.env.SIDELOADING_SERVICE_SCOPE ?? MosServiceScope;
     const m365GetStatusStub = sandbox
       .stub(M365TokenInstance, "getStatus")
-      .withArgs({ scopes: AppStudioScopes })
+      .withArgs({ scopes: AppStudioScopes() })
       .resolves(ok({ status: "SignedIn", accountInfo: { upn: "test.email.com" } }));
     const m365GetAccessTokenStub = sandbox
       .stub(M365TokenInstance, "getAccessToken")
@@ -177,7 +177,7 @@ describe("check copilot access", () => {
     const copilotCheckServiceScope = process.env.SIDELOADING_SERVICE_SCOPE ?? MosServiceScope;
     const m365GetStatusStub = sandbox
       .stub(M365TokenInstance, "getStatus")
-      .withArgs({ scopes: AppStudioScopes })
+      .withArgs({ scopes: AppStudioScopes() })
       .resolves(ok({ status: "SignedIn", accountInfo: { upn: "test.email.com" } }));
     const m365GetAccessTokenStub = sandbox
       .stub(M365TokenInstance, "getAccessToken")

--- a/packages/vscode-extension/test/handlers/accounts/checkCopilotAccess.test.ts
+++ b/packages/vscode-extension/test/handlers/accounts/checkCopilotAccess.test.ts
@@ -5,7 +5,6 @@ import * as vscode from "vscode";
 import VsCodeLogInstance from "../../../src/commonlib/log";
 import M365TokenInstance from "../../../src/commonlib/m365Login";
 import { checkCopilotAccessHandler } from "../../../src/handlers/accounts/checkCopilotAccess";
-import { MockLogProvider } from "../../mocks/mockTools";
 
 describe("check copilot access", () => {
   const sandbox = sinon.createSandbox();
@@ -47,7 +46,6 @@ describe("check copilot access", () => {
   });
 
   it("check copilot access in walkthrough: not signed in && no access", async () => {
-    const copilotCheckServiceScope = process.env.SIDELOADING_SERVICE_SCOPE ?? MosServiceScope;
     const m365GetStatusStub = sandbox
       .stub(M365TokenInstance, "getStatus")
       .withArgs({ scopes: AppStudioScopes() })
@@ -80,7 +78,6 @@ describe("check copilot access", () => {
   });
 
   it("check copilot access in walkthrough: not signed in && throw error", async () => {
-    const copilotCheckServiceScope = process.env.SIDELOADING_SERVICE_SCOPE ?? MosServiceScope;
     const m365GetStatusStub = sandbox
       .stub(M365TokenInstance, "getStatus")
       .withArgs({ scopes: AppStudioScopes() })
@@ -107,7 +104,6 @@ describe("check copilot access", () => {
   });
 
   it("check copilot access in walkthrough: signed in && no access", async () => {
-    const copilotCheckServiceScope = process.env.SIDELOADING_SERVICE_SCOPE ?? MosServiceScope;
     const m365GetStatusStub = sandbox
       .stub(M365TokenInstance, "getStatus")
       .withArgs({ scopes: AppStudioScopes() })
@@ -140,7 +136,6 @@ describe("check copilot access", () => {
   });
 
   it("check copilot access in walkthrough: signed in && with access", async () => {
-    const copilotCheckServiceScope = process.env.SIDELOADING_SERVICE_SCOPE ?? MosServiceScope;
     const m365GetStatusStub = sandbox
       .stub(M365TokenInstance, "getStatus")
       .withArgs({ scopes: AppStudioScopes() })
@@ -173,7 +168,6 @@ describe("check copilot access", () => {
   });
 
   it("check copilot access in walkthrough: signed in && throw error", async () => {
-    const copilotCheckServiceScope = process.env.SIDELOADING_SERVICE_SCOPE ?? MosServiceScope;
     const m365GetStatusStub = sandbox
       .stub(M365TokenInstance, "getStatus")
       .withArgs({ scopes: AppStudioScopes() })

--- a/packages/vscode-extension/test/handlers/accounts/checkCopilotAccess.test.ts
+++ b/packages/vscode-extension/test/handlers/accounts/checkCopilotAccess.test.ts
@@ -19,14 +19,13 @@ describe("check copilot access", () => {
   });
 
   it("check copilot access in walkthrough: not signed in && with access", async () => {
-    const copilotCheckServiceScope = process.env.SIDELOADING_SERVICE_SCOPE ?? MosServiceScope;
     const m365GetStatusStub = sandbox
       .stub(M365TokenInstance, "getStatus")
       .withArgs({ scopes: AppStudioScopes() })
       .resolves(err({ error: "unknown" } as any));
     const m365GetAccessTokenStub = sandbox
       .stub(M365TokenInstance, "getAccessToken")
-      .withArgs({ scopes: [copilotCheckServiceScope] })
+      .withArgs({ scopes: MosServiceScope() })
       .resolves(ok("stubedString"));
     const getCopilotStatusStub = sandbox
       .stub(PackageService.prototype, "getCopilotStatus")
@@ -55,7 +54,7 @@ describe("check copilot access", () => {
       .resolves(err({ error: "unknown" } as any));
     const m365GetAccessTokenStub = sandbox
       .stub(M365TokenInstance, "getAccessToken")
-      .withArgs({ scopes: [copilotCheckServiceScope] })
+      .withArgs({ scopes: MosServiceScope() })
       .resolves(ok("stubedString"));
 
     const getCopilotStatusStub = sandbox
@@ -88,7 +87,7 @@ describe("check copilot access", () => {
       .resolves(err({ error: "unknown" } as any));
     sandbox
       .stub(M365TokenInstance, "getAccessToken")
-      .withArgs({ scopes: [copilotCheckServiceScope] })
+      .withArgs({ scopes: MosServiceScope() })
       .resolves(ok("stubedString"));
 
     sandbox.stub(PackageService.prototype, "getCopilotStatus").resolves(true);
@@ -115,7 +114,7 @@ describe("check copilot access", () => {
       .resolves(ok({ status: "SignedIn", accountInfo: { upn: "test.email.com" } }));
     const m365GetAccessTokenStub = sandbox
       .stub(M365TokenInstance, "getAccessToken")
-      .withArgs({ scopes: [copilotCheckServiceScope] })
+      .withArgs({ scopes: MosServiceScope() })
       .resolves(ok("stubedString"));
 
     const getCopilotStatusStub = sandbox
@@ -148,7 +147,7 @@ describe("check copilot access", () => {
       .resolves(ok({ status: "SignedIn", accountInfo: { upn: "test.email.com" } }));
     const m365GetAccessTokenStub = sandbox
       .stub(M365TokenInstance, "getAccessToken")
-      .withArgs({ scopes: [copilotCheckServiceScope] })
+      .withArgs({ scopes: MosServiceScope() })
       .resolves(ok("stubedString"));
 
     const getCopilotStatusStub = sandbox
@@ -181,7 +180,7 @@ describe("check copilot access", () => {
       .resolves(ok({ status: "SignedIn", accountInfo: { upn: "test.email.com" } }));
     const m365GetAccessTokenStub = sandbox
       .stub(M365TokenInstance, "getAccessToken")
-      .withArgs({ scopes: [copilotCheckServiceScope] })
+      .withArgs({ scopes: MosServiceScope() })
       .resolves(err({ error: "error" } as any));
 
     const result = await checkCopilotAccessHandler();


### PR DESCRIPTION
Add user setting in VSC to allow user to select government cloud type(GCC M, GCC H and DoD). As VSC ATK Azure login in using VSC API, so the setting must match the one in VSC.
ADO: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/36370668
<img width="1082" height="611" alt="image" src="https://github.com/user-attachments/assets/66c534ec-2b11-4355-917d-a155b9fdaaf6" />

