### PR TITLE
fix(cli): add real-time output to terminal while capturing in runCommand

### DIFF
--- a/packages/cli/src/userInteraction.ts
+++ b/packages/cli/src/userInteraction.ts
@@ -649,10 +649,14 @@ class CLIUserInteraction implements UserInteraction {
         env: args.env,
       });
       childProcess.stdout?.on("data", (data) => {
-        output += data.toString();
+        const str = data.toString();
+        process.stdout.write(str); // Real-time output to terminal
+        output += str;
       });
       childProcess.stderr?.on("data", (data) => {
-        output += data.toString();
+        const str = data.toString();
+        process.stderr.write(str); // Real-time output to terminal
+        output += str;
       });
       childProcess.on("close", (code: number) => {
         if (code === 0) {

--- a/packages/cli/tests/unit/ui2.tests.ts
+++ b/packages/cli/tests/unit/ui2.tests.ts
@@ -367,6 +367,8 @@ describe("runCommand", () => {
     };
     sandbox.stub(process, "platform").value("win32");
     sandbox.stub(logger, "info").returns();
+    sandbox.stub(process.stdout, "write").returns(true);
+    sandbox.stub(process.stderr, "write").returns(true);
     sandbox.stub(child_process, "spawn").returns(mockChildProcess as any);
     const res = await UI.runCommand({ cmd: 'echo "test"' });
     assert.isTrue(res.isOk());
@@ -395,6 +397,8 @@ describe("runCommand", () => {
     };
     sandbox.stub(process, "platform").value("linux");
     sandbox.stub(logger, "info").returns();
+    sandbox.stub(process.stdout, "write").returns(true);
+    sandbox.stub(process.stderr, "write").returns(true);
     sandbox.stub(child_process, "spawn").returns(mockChildProcess as any);
     const res = await UI.runCommand({ cmd: 'echo "test"' });
     assert.isTrue(res.isOk());
@@ -428,6 +432,8 @@ describe("runCommand", () => {
     };
     sandbox.stub(process, "platform").value("linux");
     sandbox.stub(logger, "info").returns();
+    sandbox.stub(process.stdout, "write").returns(true);
+    sandbox.stub(process.stderr, "write").returns(true);
     sandbox.stub(child_process, "spawn").returns(mockChildProcess as any);
     const res = await UI.runCommand({ cmd: 'echo "test"' });
     assert.isTrue(res.isOk());
@@ -448,6 +454,8 @@ describe("runCommand", () => {
     };
     sandbox.stub(process, "platform").value("linux");
     sandbox.stub(logger, "info").returns();
+    sandbox.stub(process.stdout, "write").returns(true);
+    sandbox.stub(process.stderr, "write").returns(true);
     const spawnStub = sandbox.stub(child_process, "spawn").returns(mockChildProcess as any);
     const res = await UI.runCommand({ cmd: "pwd", workingDirectory: workingDir });
     assert.isTrue(res.isOk());
@@ -468,6 +476,8 @@ describe("runCommand", () => {
     };
     sandbox.stub(process, "platform").value("linux");
     sandbox.stub(logger, "info").returns();
+    sandbox.stub(process.stdout, "write").returns(true);
+    sandbox.stub(process.stderr, "write").returns(true);
     const spawnStub = sandbox.stub(child_process, "spawn").returns(mockChildProcess as any);
     const res = await UI.runCommand({ cmd: "sleep 1", timeout: timeout });
     assert.isTrue(res.isOk());
@@ -488,6 +498,8 @@ describe("runCommand", () => {
     };
     sandbox.stub(process, "platform").value("win32");
     sandbox.stub(logger, "info").returns();
+    sandbox.stub(process.stdout, "write").returns(true);
+    sandbox.stub(process.stderr, "write").returns(true);
     const spawnStub = sandbox.stub(child_process, "spawn").returns(mockChildProcess as any);
     const res = await UI.runCommand({ cmd: "echo %TEST_VAR%", env: envVars });
     assert.isTrue(res.isOk());
@@ -515,6 +527,8 @@ describe("runCommand", () => {
     sandbox.stub(process, "platform").value("linux");
     sandbox.stub(logger, "info").returns();
     sandbox.stub(logger, "error").returns();
+    sandbox.stub(process.stdout, "write").returns(true);
+    sandbox.stub(process.stderr, "write").returns(true);
     sandbox.stub(child_process, "spawn").returns(mockChildProcess as any);
     const res = await UI.runCommand({ cmd: "invalid-command" });
     assert.isTrue(res.isErr());


### PR DESCRIPTION
## Summary

This PR fixes the issue where interactive commands (like `@azure/static-web-apps-cli`) would wait for user input without displaying prompts to the terminal.

## Root Cause

In commit [6bfb69e](https://github.com/OfficeDev/microsoft-365-agents-toolkit/commit/6bfb69e98950fe0ece137697f56fed0e133b7ea5), the `stdio` configuration was changed from `"inherit"` to `["inherit", "pipe", "pipe"]` to capture output for parsing `::set-output` commands. This caused stdout/stderr to be piped instead of displayed to the user, making interactive prompts invisible while still waiting for input.

## Solution

Added real-time output by writing captured data to `process.stdout/stderr` while still maintaining the ability to capture and parse output.

### Changes

- **Modified** `runCommand()` in [userInteraction.ts](packages/cli/src/userInteraction.ts) to write stdout/stderr to terminal in real-time
- **Updated** all related unit tests in [ui2.tests.ts](packages/cli/tests/unit/ui2.tests.ts) to stub `process.stdout.write` and `process.stderr.write`

### Before (Alpha version with issue)
```typescript
childProcess.stdout?.on("data", (data) => {
  output += data.toString();  // Only captures, doesn't display
});
```

### After (This PR)
```typescript
childProcess.stdout?.on("data", (data) => {
  const str = data.toString();
  process.stdout.write(str);  // Real-time output to terminal
  output += str;              // Still capture for parsing
});
```

## Testing

- ✅ All 9 `runCommand` unit tests pass
- ✅ Manual testing shows interactive prompts are now visible
- ✅ Output capture still works for `::set-output` parsing

## Impact

| Aspect | Before | After |
|--------|--------|-------|
| **User Experience** | ❌ Cannot see interactive prompts | ✅ Can see interactive prompts |
| **Output Capture** | ✅ Captures output | ✅ Captures output |
| **::set-output Parsing** | ✅ Supported | ✅ Supported |
| **stdin Interaction** | ✅ Supported | ✅ Supported |
