### PR TITLE
fix: template retrieval logic

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -289,7 +289,13 @@ jobs:
           token: ${{ steps.generate-token.outputs.token }}
           prerelease: true
           tag: "templates@0.0.0-rc"
-          artifacts: ${{ github.workspace }}/templates/build/fallback/*.zip,${{ github.workspace }}/templates/build/metadata.zip
+          artifacts: |
+            ${{ github.workspace }}/templates/build/fallback/common.zip
+            ${{ github.workspace }}/templates/build/fallback/js.zip
+            ${{ github.workspace }}/templates/build/fallback/ts.zip
+            ${{ github.workspace }}/templates/build/fallback/python.zip
+            ${{ github.workspace }}/templates/build/fallback/csharp.zip
+            ${{ github.workspace }}/templates/build/metadata.zip
           allowUpdates: true
           removeArtifacts: true
 
@@ -297,7 +303,13 @@ jobs:
         if: ${{ contains(steps.version-change.outputs.CHANGED, 'templates@') && github.event_name == 'workflow_dispatch' && github.event.inputs.preid == 'stable' }}
         uses: ncipollo/release-action@v1.10.0
         with:
-          artifacts: ${{ github.workspace }}/templates/build/fallback/*.zip,${{ github.workspace }}/templates/build/metadata.zip
+          artifacts: |
+            ${{ github.workspace }}/templates/build/fallback/common.zip
+            ${{ github.workspace }}/templates/build/fallback/js.zip
+            ${{ github.workspace }}/templates/build/fallback/ts.zip
+            ${{ github.workspace }}/templates/build/fallback/python.zip
+            ${{ github.workspace }}/templates/build/fallback/csharp.zip
+            ${{ github.workspace }}/templates/build/metadata.zip
           name: "Release for ${{ steps.version-change.outputs.TEMPLATE_VERSION }}"
           token: ${{ steps.generate-token.outputs.token }}
           tag: ${{ steps.version-change.outputs.TEMPLATE_VERSION }}
@@ -330,7 +342,7 @@ jobs:
           prerelease: true
           clear_attachments: true
           files: |
-            ${{ github.workspace }}/templates/build/csharp.zip
+            ${{ github.workspace }}/templates/build/fallback/csharp.zip
       
       - name: Get VS Templates version
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.vsrelease == 'true' && github.event.inputs.vstemplate == 'true' }}
@@ -350,7 +362,7 @@ jobs:
           target_commit: ${{ github.sha }}
           clear_attachments: true
           files: |
-            ${{ github.workspace }}/templates/build/csharp.zip
+            ${{ github.workspace }}/templates/build/fallback/csharp.zip
 
       - name: enable prerelease only features
         if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && (github.event.inputs.preid == 'alpha' || github.event.inputs.preid == 'preview')) }}

--- a/packages/fx-core/src/common/localizeUtils.ts
+++ b/packages/fx-core/src/common/localizeUtils.ts
@@ -6,7 +6,7 @@ import fs from "fs-extra";
 import os from "os";
 import * as path from "path";
 import * as util from "util";
-import templateConfig from "../common/templates-config.json";
+import { useLocalTemplate } from "../component/generator/templateHelper";
 import { getResourceFolder } from "../folder";
 import { Locale } from "./globalVars";
 
@@ -47,7 +47,7 @@ function getLocaleJson(locale?: string): any {
 
   // Check if cached resource folder exists, otherwise fallback to bundled templates resource folder
   if (
-    !templateConfig.useLocalTemplate &&
+    !useLocalTemplate() &&
     cachedResourcePath &&
     fs.pathExistsSync(path.join(cachedResourcePath, "package.nls.json"))
   ) {

--- a/packages/fx-core/src/component/generator/templateHelper.ts
+++ b/packages/fx-core/src/component/generator/templateHelper.ts
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+const packageJson = require("../../../package.json");
+
+/**
+ * Determines whether to use local templates based on environment variables and package version.
+ * Returns true if:
+ * - TEMPLATE_VERSION env variable is set to "local", OR
+ * - Package version contains "alpha" (daily build version)
+ */
+export function useLocalTemplate(): boolean {
+  const templateVersionEnv = process.env["TEMPLATE_VERSION"];
+  if (templateVersionEnv === "local") {
+    return true;
+  }
+  const version: string = packageJson.version;
+  if (version.includes("alpha")) {
+    // daily build version
+    return true;
+  }
+
+  return false;
+}

--- a/packages/fx-core/src/component/generator/templates/metadata/index.ts
+++ b/packages/fx-core/src/component/generator/templates/metadata/index.ts
@@ -5,8 +5,8 @@ import { ConfigFolderName, Platform } from "@microsoft/teamsfx-api";
 import fs from "fs-extra";
 import os from "os";
 import path from "path";
-import templateConfig from "../../../../common/templates-config.json";
 import { getTemplatesFolder } from "../../../../folder";
+import { useLocalTemplate } from "../../templateHelper";
 import { Template } from "./interface";
 
 function getTemplateMetadataConfig(configName: string): Template[] {
@@ -20,7 +20,7 @@ function getTemplateMetadataConfig(configName: string): Template[] {
   );
 
   // Check if cached JSON exists, otherwise fallback to bundled templates folder
-  if (!templateConfig.useLocalTemplate && cachedJsonPath && fs.pathExistsSync(cachedJsonPath)) {
+  if (!useLocalTemplate() && cachedJsonPath && fs.pathExistsSync(cachedJsonPath)) {
     jsonPath = cachedJsonPath;
   } else {
     jsonPath = path.join(getTemplatesFolder(), "metadata", configName);

--- a/packages/fx-core/src/component/generator/utils.ts
+++ b/packages/fx-core/src/component/generator/utils.ts
@@ -55,6 +55,7 @@ async function getTemplateVSCUrl(
       templateConfig.tagPrefix
     );
   }
+
   const version: string = packageJson.version;
   if (version.includes("alpha")) {
     // daily build version

--- a/packages/fx-core/src/component/generator/utils.ts
+++ b/packages/fx-core/src/component/generator/utils.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { Context as FxContext, Platform, signedIn } from "@microsoft/teamsfx-api";
 import AdmZip from "adm-zip";
 import axios, { AxiosError, AxiosResponse } from "axios";
 import * as fs from "fs-extra";
@@ -8,11 +9,15 @@ import { cloneDeep } from "lodash";
 import Mustache, { Context, Writer } from "mustache";
 import path from "path";
 import semver from "semver";
+import { GraphClient } from "../../client/graphClient";
+import { ListSensitivityLabelScope } from "../../common/constants";
+import { getDefaultString } from "../../common/localizeUtils";
 import { sendRequestWithRetry, sendRequestWithTimeout } from "../../common/requestUtils";
 import { SampleConfig, SampleUrlInfo, sampleProvider } from "../../common/samples";
 import templateConfig from "../../common/templates-config.json";
 import { InputValidationError } from "../../error";
 import { ProgrammingLanguage } from "../../question/constants";
+import { copilotGptManifestUtils } from "../driver/teamsApp/utils/CopilotGptManifestUtils";
 import {
   defaultTimeoutInMs,
   defaultTryLimits,
@@ -22,39 +27,51 @@ import {
   sampleDefaultRetryLimits,
   templateFileExt,
 } from "./constant";
-import { Context as FxContext, signedIn, Platform } from "@microsoft/teamsfx-api";
-import { getDefaultString } from "../../common/localizeUtils";
-import { copilotGptManifestUtils } from "../driver/teamsApp/utils/CopilotGptManifestUtils";
-import { ListSensitivityLabelScope } from "../../common/constants";
-import { GraphClient } from "../../client/graphClient";
+
+const packageJson = require("../../../package.json");
 
 export async function getTemplateUrl(
-  name: string,
+  programmingLanguage: string,
   getLatestVersion: () => Promise<string>,
   platform?: Platform
 ): Promise<string | undefined> {
   return platform === Platform.VS
-    ? getTemplateVSUrl(name)
-    : await getTemplateVSCUrl(name, getLatestVersion);
+    ? getTemplateVSUrl(programmingLanguage)
+    : await getTemplateVSCUrl(programmingLanguage, getLatestVersion);
 }
 
+// Return undefined to use local templates.
 async function getTemplateVSCUrl(
-  name: string,
+  programmingLanguage: string,
   getLatestVersion: () => Promise<string>
 ): Promise<string | undefined> {
-  if (process.env.TEAMSFX_TEMPLATE_PRERELEASE) {
+  const templateVersionEnv = process.env["TEMPLATE_VERSION"];
+  if (templateVersionEnv === "local") {
+    return;
+  } else if (templateVersionEnv) {
     return getTemplateZipUrlByVersion(
-      name,
-      `0.0.0-${process.env.TEAMSFX_TEMPLATE_PRERELEASE}`,
+      programmingLanguage,
+      templateVersionEnv,
       templateConfig.tagPrefix
     );
   }
-  if (!templateConfig.useLocalTemplate) {
-    const latestVersion = await getLatestVersion();
-    if (semver.gt(latestVersion, templateConfig.localVersion)) {
-      // Upstream latest version is higher than the local version, return upstream templates url for downloading.
-      return getTemplateZipUrlByVersion(name, latestVersion, templateConfig.tagPrefix);
-    }
+  const version: string = packageJson.version;
+  if (version.includes("alpha")) {
+    // daily build version
+    return;
+  } else if (version.includes("beta")) {
+    // prerelease build version
+  } else if (version.includes("rc")) {
+    // rc version before stable / prerelease release
+    return getTemplateZipUrlByVersion(programmingLanguage, "0.0.0-rc", templateConfig.tagPrefix);
+  } else {
+    // stable version
+  }
+
+  const latestVersion = await getLatestVersion();
+  if (semver.gt(latestVersion, templateConfig.localVersion)) {
+    // Upstream latest version is higher than the local version, return upstream templates url for downloading.
+    return getTemplateZipUrlByVersion(programmingLanguage, latestVersion, templateConfig.tagPrefix);
   }
 }
 

--- a/packages/fx-core/src/core/FxCore.ts
+++ b/packages/fx-core/src/core/FxCore.ts
@@ -139,6 +139,7 @@ import {
   injectAuthAction,
   listOperations,
 } from "../component/generator/openApiSpec/helper";
+import { useLocalTemplate } from "../component/generator/templateHelper";
 import { TemplateNames } from "../component/generator/templates/templateNames";
 import { fetchZipFromUrl, getTemplateLatestVersion, unzip } from "../component/generator/utils";
 import { LaunchHelper } from "../component/m365/launchHelper";
@@ -195,6 +196,7 @@ import {
 } from "./collaborator";
 import { LocalCrypto } from "./crypto";
 import { environmentNameManager } from "./environmentName";
+import { FxCoreDeclarativeAgentPart } from "./FxCore.declarativeAgent";
 import { generateConfigFiles } from "./generateConfigFiles";
 import { ConcurrentLockerMW } from "./middleware/concurrentLocker";
 import { ContextInjectorMW } from "./middleware/contextInjector";
@@ -210,7 +212,6 @@ import {
 import { addSharedUsers, removeShareAccess, shareWithTenant } from "./share";
 import { CoreTelemetryEvent, CoreTelemetryProperty } from "./telemetry";
 import { CoreHookContext, PreProvisionResForVS, VersionCheckRes } from "./types";
-import { FxCoreDeclarativeAgentPart } from "./FxCore.declarativeAgent";
 
 export class FxCore extends FxCoreDeclarativeAgentPart {
   constructor(tools: Tools) {
@@ -2905,7 +2906,7 @@ export class FxCore extends FxCoreDeclarativeAgentPart {
     ErrorHandlerMW,
   ])
   async fetchOnlineTemplateMetadata(): Promise<Result<undefined, FxError>> {
-    if (templateConfig.useLocalTemplate) {
+    if (useLocalTemplate()) {
       return ok(undefined); // Skip if using local templates
     }
     // Downloads the latest online template metadata (metadata.zip) into user's home .fx folder.
@@ -2967,7 +2968,7 @@ export class FxCore extends FxCoreDeclarativeAgentPart {
   }
 
   /**
-   * dynamic template metadata download
+   * generate config files
    */
   @hooks([ErrorContextMW({ component: "FxCore", stage: "generateConfigFiles" }), ErrorHandlerMW])
   async generateConfigFiles(inputs: Inputs): Promise<Result<undefined, FxError>> {

--- a/packages/fx-core/src/question/scaffold/vsc/customEngineAgentNode.ts
+++ b/packages/fx-core/src/question/scaffold/vsc/customEngineAgentNode.ts
@@ -5,7 +5,7 @@ import { ConfigFolderName, IQTreeNode } from "@microsoft/teamsfx-api";
 import fs from "fs-extra";
 import os from "os";
 import path from "path";
-import templateConfig from "../../../common/templates-config.json";
+import { useLocalTemplate } from "../../../component/generator/templateHelper";
 import { getTemplatesFolder } from "../../../folder";
 import { constructNode } from "../constructNode";
 
@@ -20,7 +20,7 @@ export function getCustomEngineAgentNode(): IQTreeNode {
   );
 
   // Check if cached JSON exists, otherwise fallback to bundledtemplates folder
-  if (!templateConfig.useLocalTemplate && fs.pathExistsSync(cachedJsonPath)) {
+  if (!useLocalTemplate() && fs.pathExistsSync(cachedJsonPath)) {
     jsonPath = cachedJsonPath;
   } else {
     jsonPath = path.join(getTemplatesFolder(), "ui", "ceaNode.json");

--- a/packages/fx-core/src/question/scaffold/vsc/teamsProjectTypeNode.ts
+++ b/packages/fx-core/src/question/scaffold/vsc/teamsProjectTypeNode.ts
@@ -14,7 +14,7 @@ import * as fs from "fs-extra";
 import os from "os";
 import path from "path";
 import { getLocalizedString } from "../../../common/localizeUtils";
-import templateConfig from "../../../common/templates-config.json";
+import { useLocalTemplate } from "../../../component/generator/templateHelper";
 import { ODRProvider, ODRServer } from "../../../component/utils/odrProvider";
 import { getTemplatesFolder } from "../../../folder";
 import {
@@ -51,7 +51,7 @@ export function getTeamsProjectNode(): IQTreeNode {
   );
 
   // Check if cached JSON exists, otherwise fallback to bundled templates folder
-  if (!templateConfig.useLocalTemplate && fs.pathExistsSync(cachedJsonPath)) {
+  if (!useLocalTemplate() && fs.pathExistsSync(cachedJsonPath)) {
     jsonPath = cachedJsonPath;
   } else {
     jsonPath = path.join(getTemplatesFolder(), "ui", "teamsNode.json");

--- a/packages/fx-core/tests/component/generator/generator.test.ts
+++ b/packages/fx-core/tests/component/generator/generator.test.ts
@@ -37,6 +37,7 @@ import {
   TemplateActionSeq,
   fetchSampleInfoAction,
 } from "../../../src/component/generator/generatorAction";
+import * as templateHelper from "../../../src/component/generator/templateHelper";
 import * as templateMetadata from "../../../src/component/generator/templates/metadata";
 import { TemplateNames } from "../../../src/component/generator/templates/templateNames";
 import { getTemplateReplaceMap } from "../../../src/component/generator/templates/templateReplaceMap";
@@ -123,7 +124,7 @@ describe("Generator utils", () => {
       TEAMSFX_TEMPLATE_PRERELEASE: "rc",
     });
     const tagList = "1.0.0\n 2.0.0\n 2.1.0\n 3.0.0\n 0.0.0-rc";
-    sandbox.replace(templateConfig, "useLocalTemplate", false);
+    sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
     sandbox.stub(axios, "get").resolves({ data: tagList, status: 200 } as AxiosResponse);
     const url = await generatorUtils.getTemplateUrl(
       "templateName",
@@ -138,7 +139,7 @@ describe("Generator utils", () => {
     });
     const tagList = "1.0.0\n 2.0.0\n 2.1.0\n 3.0.0";
     const tag = "2.1.0";
-    sandbox.replace(templateConfig, "useLocalTemplate", false);
+    sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
     sandbox.stub(axios, "get").resolves({ data: tagList, status: 200 } as AxiosResponse);
     sandbox.stub(templateConfig, "version").value("^2.0.0");
     sandbox.replace(templateConfig, "tagPrefix", "templates@");
@@ -1045,7 +1046,7 @@ describe("render template", () => {
       };
       await buildFakeTemplateZip(templateName, mockFileName);
 
-      sandbox.replace(templateConfig, "useLocalTemplate", true);
+      sandbox.stub(templateHelper, "useLocalTemplate").returns(true);
       sandbox.stub(folderUtils, "getTemplatesFolder").returns(tmpDir);
       sandbox.stub(ScaffoldRemoteTemplateAction, "run").throws(new Error("test"));
 
@@ -1071,7 +1072,7 @@ describe("render template", () => {
       };
       await buildFakeTemplateZip(templateName, mockFileName);
 
-      sandbox.replace(templateConfig, "useLocalTemplate", true);
+      sandbox.stub(templateHelper, "useLocalTemplate").returns(true);
       sandbox.stub(folderUtils, "getTemplatesFolder").returns(tmpDir);
 
       const result = newGeneratorFlag
@@ -1096,7 +1097,7 @@ describe("render template", () => {
       };
       await buildFakeTemplateZip(templateName, mockFileName);
 
-      sandbox.replace(templateConfig, "useLocalTemplate", false);
+      sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
       sandbox.replace(templateConfig, "localVersion", "9.9.9");
       sandbox.replace(templateConfig, "version", "~3.0.0");
       const tagList = "1.0.0\n 2.0.0\n 2.1.0\n 3.0.0";
@@ -1128,7 +1129,7 @@ describe("render template", () => {
         telemetryProps: {},
       };
 
-      sandbox.replace(templateConfig, "useLocalTemplate", false);
+      sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
       sandbox.replace(templateConfig, "localVersion", "0.1.0");
       sandbox.stub(folderUtils, "getTemplatesFolder").returns(tmpDir);
       sandbox.stub(generatorUtils, "getTemplateLatestVersion").resolves("0.1.1");
@@ -1159,7 +1160,7 @@ describe("render template", () => {
       mockedEnvRestore = mockedEnv({
         TEAMSFX_TEMPLATE_PRERELEASE: "rc",
       });
-      sandbox.replace(templateConfig, "useLocalTemplate", false);
+      sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
       sandbox.replace(templateConfig, "localVersion", "0.1.0");
       sandbox.stub(folderUtils, "getTemplatesFolder").returns(tmpDir);
       sandbox.stub(generatorUtils, "getTemplateLatestVersion").resolves("0.1.1");

--- a/packages/fx-core/tests/component/generator/generator.test.ts
+++ b/packages/fx-core/tests/component/generator/generator.test.ts
@@ -121,7 +121,7 @@ describe("Generator utils", () => {
 
   it("return rc if set env rc", async () => {
     mockedEnvRestore = mockedEnv({
-      TEAMSFX_TEMPLATE_PRERELEASE: "rc",
+      TEMPLATE_VERSION: "0.0.0-rc",
     });
     const tagList = "1.0.0\n 2.0.0\n 2.1.0\n 3.0.0\n 0.0.0-rc";
     sandbox.stub(templateHelper, "useLocalTemplate").returns(false);

--- a/packages/fx-core/tests/component/generator/utils.test.ts
+++ b/packages/fx-core/tests/component/generator/utils.test.ts
@@ -9,6 +9,7 @@ import * as sinon from "sinon";
 import { GraphClient } from "../../../src/client/graphClient";
 import { createContext, setTools } from "../../../src/common/globalVars";
 import { copilotGptManifestUtils } from "../../../src/component/driver/teamsApp/utils/CopilotGptManifestUtils";
+import { useLocalTemplate } from "../../../src/component/generator/templateHelper";
 import {
   getTemplateUrl,
   getTemplateZipUrlByVersion,
@@ -119,6 +120,92 @@ describe("utils unit test cases", () => {
     restore();
   });
 
+  it("should return undefined for alpha version in package.json", async () => {
+    const mockPackageJson = {
+      version: "3.0.0-alpha.1",
+    };
+    const dUtils = proxyquire("../../../src/component/generator/utils", {
+      "../../../package.json": mockPackageJson,
+    });
+    const getLatestVersion = () => Promise.resolve("6.0.0");
+    const result = await dUtils.getTemplateUrl("ts", getLatestVersion, Platform.VSCode);
+    assert.isUndefined(result);
+  });
+
+  it("should return rc URL for rc version in package.json", async () => {
+    const mockPackageJson = {
+      version: "3.0.0-rc.1",
+    };
+    const dUtils = proxyquire("../../../src/component/generator/utils", {
+      "../../../package.json": mockPackageJson,
+    });
+    const getLatestVersion = () => Promise.resolve("6.0.0");
+    const result = await dUtils.getTemplateUrl("ts", getLatestVersion, Platform.VSCode);
+    const expectedUrl =
+      "https://github.com/OfficeDev/microsoft-365-agents-toolkit/releases/download/templates@0.0.0-rc/ts.zip";
+    assert.strictEqual(result, expectedUrl);
+  });
+
+  it("should use latest version for beta version in package.json when latest is higher", async () => {
+    const mockPackageJson = {
+      version: "3.0.0-beta.1",
+    };
+    const mockSettings = {
+      version: "~6.0",
+      localVersion: "5.0.0",
+      tagPrefix: "templates@",
+      vstagPrefix: "templates-vs@",
+      vsversion: "18.0.0",
+      tagListURL:
+        "https://github.com/OfficeDev/microsoft-365-agents-toolkit/releases/download/template-tag-list/template-tags.txt",
+      templateDownloadBaseURL:
+        "https://github.com/OfficeDev/microsoft-365-agents-toolkit/releases/download",
+      templateReleaseURL:
+        "https://github.com/OfficeDev/microsoft-365-agents-toolkit/releases/expanded_assets",
+      templateDownloadBasePath: "/OfficeDev/microsoft-365-agents-toolkit/releases/download",
+      templateExt: ".zip",
+      useLocalTemplate: false,
+    };
+    const dUtils = proxyquire("../../../src/component/generator/utils", {
+      "../../../package.json": mockPackageJson,
+      "../../common/templates-config.json": mockSettings,
+    });
+    const getLatestVersion = () => Promise.resolve("6.0.0");
+    const result = await dUtils.getTemplateUrl("ts", getLatestVersion, Platform.VSCode);
+    const expectedUrl =
+      "https://github.com/OfficeDev/microsoft-365-agents-toolkit/releases/download/templates@6.0.0/ts.zip";
+    assert.strictEqual(result, expectedUrl);
+  });
+
+  it("should return undefined for stable version when latest is not higher than local", async () => {
+    const mockPackageJson = {
+      version: "3.0.0",
+    };
+    const mockSettings = {
+      version: "~6.0",
+      localVersion: "6.0.0",
+      tagPrefix: "templates@",
+      vstagPrefix: "templates-vs@",
+      vsversion: "18.0.0",
+      tagListURL:
+        "https://github.com/OfficeDev/microsoft-365-agents-toolkit/releases/download/template-tag-list/template-tags.txt",
+      templateDownloadBaseURL:
+        "https://github.com/OfficeDev/microsoft-365-agents-toolkit/releases/download",
+      templateReleaseURL:
+        "https://github.com/OfficeDev/microsoft-365-agents-toolkit/releases/expanded_assets",
+      templateDownloadBasePath: "/OfficeDev/microsoft-365-agents-toolkit/releases/download",
+      templateExt: ".zip",
+      useLocalTemplate: false,
+    };
+    const dUtils = proxyquire("../../../src/component/generator/utils", {
+      "../../../package.json": mockPackageJson,
+      "../../common/templates-config.json": mockSettings,
+    });
+    const getLatestVersion = () => Promise.resolve("5.0.0");
+    const result = await dUtils.getTemplateUrl("ts", getLatestVersion, Platform.VSCode);
+    assert.isUndefined(result);
+  });
+
   it("setGeneralSensitivityLabel happy path", async () => {
     const gtools = new MockTools();
     setTools(gtools);
@@ -198,5 +285,91 @@ describe("utils unit test cases", () => {
 
     const sensitivityLabel = (DAManifest as any).sensitivity_label;
     assert.isUndefined(sensitivityLabel);
+  });
+});
+
+describe("templateHelper unit test cases", () => {
+  it("should return true when TEMPLATE_VERSION is set to local", () => {
+    const restore = mockedEnv({
+      TEMPLATE_VERSION: "local",
+    });
+    const result = useLocalTemplate();
+    assert.isTrue(result);
+    restore();
+  });
+
+  it("should return false when TEMPLATE_VERSION is not set to local", () => {
+    const restore = mockedEnv({
+      TEMPLATE_VERSION: "1.0.0",
+    });
+    const mockPackageJson = {
+      version: "3.0.0",
+    };
+    const templateHelper = proxyquire("../../../src/component/generator/templateHelper", {
+      "../../../package.json": mockPackageJson,
+    });
+    const result = templateHelper.useLocalTemplate();
+    assert.isFalse(result);
+    restore();
+  });
+
+  it("should return true when package version contains alpha", () => {
+    const restore = mockedEnv({
+      TEMPLATE_VERSION: "",
+    });
+    const mockPackageJson = {
+      version: "3.0.0-alpha.1",
+    };
+    const templateHelper = proxyquire("../../../src/component/generator/templateHelper", {
+      "../../../package.json": mockPackageJson,
+    });
+    const result = templateHelper.useLocalTemplate();
+    assert.isTrue(result);
+    restore();
+  });
+
+  it("should return false when package version is stable and TEMPLATE_VERSION is not local", () => {
+    const restore = mockedEnv({
+      TEMPLATE_VERSION: "",
+    });
+    const mockPackageJson = {
+      version: "3.0.0",
+    };
+    const templateHelper = proxyquire("../../../src/component/generator/templateHelper", {
+      "../../../package.json": mockPackageJson,
+    });
+    const result = templateHelper.useLocalTemplate();
+    assert.isFalse(result);
+    restore();
+  });
+
+  it("should return false when package version contains beta", () => {
+    const restore = mockedEnv({
+      TEMPLATE_VERSION: "",
+    });
+    const mockPackageJson = {
+      version: "3.0.0-beta.1",
+    };
+    const templateHelper = proxyquire("../../../src/component/generator/templateHelper", {
+      "../../../package.json": mockPackageJson,
+    });
+    const result = templateHelper.useLocalTemplate();
+    assert.isFalse(result);
+    restore();
+  });
+
+  it("should return false when package version contains rc", () => {
+    const restore = mockedEnv({
+      TEMPLATE_VERSION: "",
+    });
+    const mockPackageJson = {
+      version: "3.0.0-rc.1",
+    };
+    const templateHelper = proxyquire("../../../src/component/generator/templateHelper", {
+      "../../../package.json": mockPackageJson,
+    });
+    const result = templateHelper.useLocalTemplate();
+    assert.isFalse(result);
+    restore();
   });
 });

--- a/packages/fx-core/tests/component/generator/utils.test.ts
+++ b/packages/fx-core/tests/component/generator/utils.test.ts
@@ -1,19 +1,19 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+import { DeclarativeAgentManifest, Platform, err, ok, signedIn } from "@microsoft/teamsfx-api";
 import { assert } from "chai";
-import * as sinon from "sinon";
 import "mocha";
-import {
-  getTemplateZipUrlByVersion,
-  getTemplateUrl,
-  setGeneralSensitivityLabel,
-} from "../../../src/component/generator/utils";
-import { Platform, ok, signedIn, DeclarativeAgentManifest, err } from "@microsoft/teamsfx-api";
 import mockedEnv from "mocked-env";
 import proxyquire from "proxyquire";
+import * as sinon from "sinon";
+import { GraphClient } from "../../../src/client/graphClient";
 import { createContext, setTools } from "../../../src/common/globalVars";
 import { copilotGptManifestUtils } from "../../../src/component/driver/teamsApp/utils/CopilotGptManifestUtils";
-import { GraphClient } from "../../../src/client/graphClient";
+import {
+  getTemplateUrl,
+  getTemplateZipUrlByVersion,
+  setGeneralSensitivityLabel,
+} from "../../../src/component/generator/utils";
 import { MockTools } from "../../core/utils";
 
 describe("utils unit test cases", () => {
@@ -99,7 +99,7 @@ describe("utils unit test cases", () => {
 
   it("should return the correct URL for getTemplateVSCUrl", async () => {
     const restore = mockedEnv({
-      TEAMSFX_TEMPLATE_PRERELEASE: "rc",
+      TEMPLATE_VERSION: "0.0.0-rc",
     });
     const getLatestVersion = () => Promise.resolve("0.0.0-rc");
     const result = await getTemplateUrl("ts", getLatestVersion, Platform.VSCode);
@@ -111,7 +111,7 @@ describe("utils unit test cases", () => {
 
   it("should return undefined for use local template for getTemplateVSCUrl", async () => {
     const restore = mockedEnv({
-      TEAMSFX_TEMPLATE_PRERELEASE: "",
+      TEMPLATE_VERSION: "local",
     });
     const getLatestVersion = () => Promise.resolve("0.0.0-rc");
     const result = await getTemplateUrl("ts", getLatestVersion, Platform.VSCode);

--- a/packages/fx-core/tests/core/FxCore.test.ts
+++ b/packages/fx-core/tests/core/FxCore.test.ts
@@ -91,6 +91,7 @@ import "../../src/component/feature/sso";
 import * as declarativeAgentHelper from "../../src/component/generator/declarativeAgent/helper";
 import * as oneDriveSharePointHandler from "../../src/component/generator/declarativeAgent/oneDriveSharePointHandler";
 import * as openApiSpecHelper from "../../src/component/generator/openApiSpec/helper";
+import * as templateHelper from "../../src/component/generator/templateHelper";
 import { TemplateNames } from "../../src/component/generator/templates/templateNames";
 import * as generatorUtils from "../../src/component/generator/utils";
 import { LaunchHelper } from "../../src/component/m365/launchHelper";
@@ -9026,7 +9027,7 @@ describe("fetchOnlineTemplateMetadata", () => {
   });
 
   it("should skip download when using local template", async () => {
-    sandbox.stub(templateConfigModule, "useLocalTemplate").value(true);
+    sandbox.stub(templateHelper, "useLocalTemplate").returns(true);
 
     const result = await core.fetchOnlineTemplateMetadata();
 
@@ -9037,7 +9038,7 @@ describe("fetchOnlineTemplateMetadata", () => {
   });
 
   it("should download metadata for rc version when coreVersion contains 'rc'", async () => {
-    sandbox.stub(templateConfigModule, "useLocalTemplate").value(false);
+    sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
     sandbox.stub(templateConfigModule, "tagPrefix").value("templates@");
     sandbox
       .stub(templateConfigModule, "templateDownloadBaseURL")
@@ -9066,7 +9067,7 @@ describe("fetchOnlineTemplateMetadata", () => {
   });
 
   it("should download metadata for stable version", async () => {
-    sandbox.stub(templateConfigModule, "useLocalTemplate").value(false);
+    sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
     sandbox.stub(templateConfigModule, "tagPrefix").value("templates@");
     sandbox
       .stub(templateConfigModule, "templateDownloadBaseURL")
@@ -9097,7 +9098,7 @@ describe("fetchOnlineTemplateMetadata", () => {
   });
 
   it("should skip download when cached version matches latest version", async () => {
-    sandbox.stub(templateConfigModule, "useLocalTemplate").value(false);
+    sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
     sandbox.stub(packageJson, "version").value("1.0.0");
 
     sandbox.stub(generatorUtils, "getTemplateLatestVersion").resolves("2.0.0");
@@ -9117,7 +9118,7 @@ describe("fetchOnlineTemplateMetadata", () => {
   });
 
   it("should download when cached version file does not exist", async () => {
-    sandbox.stub(templateConfigModule, "useLocalTemplate").value(false);
+    sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
     sandbox.stub(templateConfigModule, "tagPrefix").value("templates@");
     sandbox
       .stub(templateConfigModule, "templateDownloadBaseURL")
@@ -9141,7 +9142,7 @@ describe("fetchOnlineTemplateMetadata", () => {
   });
 
   it("should download when cached version differs from latest version", async () => {
-    sandbox.stub(templateConfigModule, "useLocalTemplate").value(false);
+    sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
     sandbox.stub(templateConfigModule, "tagPrefix").value("templates@");
     sandbox
       .stub(templateConfigModule, "templateDownloadBaseURL")
@@ -9166,7 +9167,7 @@ describe("fetchOnlineTemplateMetadata", () => {
   });
 
   it("should re-download when cached version file is corrupted", async () => {
-    sandbox.stub(templateConfigModule, "useLocalTemplate").value(false);
+    sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
     sandbox.stub(templateConfigModule, "tagPrefix").value("templates@");
     sandbox
       .stub(templateConfigModule, "templateDownloadBaseURL")
@@ -9191,7 +9192,7 @@ describe("fetchOnlineTemplateMetadata", () => {
   });
 
   it("should handle alpha version correctly", async () => {
-    sandbox.stub(templateConfigModule, "useLocalTemplate").value(false);
+    sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
     sandbox.stub(templateConfigModule, "tagPrefix").value("templates@");
     sandbox
       .stub(templateConfigModule, "templateDownloadBaseURL")
@@ -9217,7 +9218,7 @@ describe("fetchOnlineTemplateMetadata", () => {
   });
 
   it("should handle beta version correctly", async () => {
-    sandbox.stub(templateConfigModule, "useLocalTemplate").value(false);
+    sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
     sandbox.stub(templateConfigModule, "tagPrefix").value("templates@");
     sandbox
       .stub(templateConfigModule, "templateDownloadBaseURL")
@@ -9243,7 +9244,7 @@ describe("fetchOnlineTemplateMetadata", () => {
   });
 
   it("should return error when fetchZipFromUrl fails", async () => {
-    sandbox.stub(templateConfigModule, "useLocalTemplate").value(false);
+    sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
     sandbox.stub(templateConfigModule, "tagPrefix").value("templates@");
     sandbox
       .stub(templateConfigModule, "templateDownloadBaseURL")
@@ -9269,7 +9270,7 @@ describe("fetchOnlineTemplateMetadata", () => {
   });
 
   it("should return error when unzip fails", async () => {
-    sandbox.stub(templateConfigModule, "useLocalTemplate").value(false);
+    sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
     sandbox.stub(templateConfigModule, "tagPrefix").value("templates@");
     sandbox
       .stub(templateConfigModule, "templateDownloadBaseURL")
@@ -9295,7 +9296,7 @@ describe("fetchOnlineTemplateMetadata", () => {
   });
 
   it("should return error when fs.writeFile fails", async () => {
-    sandbox.stub(templateConfigModule, "useLocalTemplate").value(false);
+    sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
     sandbox.stub(templateConfigModule, "tagPrefix").value("templates@");
     sandbox
       .stub(templateConfigModule, "templateDownloadBaseURL")
@@ -9322,7 +9323,7 @@ describe("fetchOnlineTemplateMetadata", () => {
   });
 
   it("should use correct metadata directory path", async () => {
-    sandbox.stub(templateConfigModule, "useLocalTemplate").value(false);
+    sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
     sandbox.stub(templateConfigModule, "tagPrefix").value("templates@");
     sandbox
       .stub(templateConfigModule, "templateDownloadBaseURL")

--- a/packages/fx-core/tests/question/scaffold.test.ts
+++ b/packages/fx-core/tests/question/scaffold.test.ts
@@ -11,6 +11,7 @@ import {
 } from "@microsoft/teamsfx-api";
 import { assert } from "chai";
 import "mocha";
+import proxyquire from "proxyquire";
 import sinon from "sinon";
 import { featureFlagManager, FeatureFlags } from "../../src/common/featureFlags";
 import { getLocalizedString } from "../../src/common/localizeUtils";
@@ -345,6 +346,206 @@ describe("customEngineAgentProjectTypeNode", () => {
 
     const basicCustomeEngineAgent = node.children?.[0];
     assert.isDefined(basicCustomeEngineAgent);
+  });
+
+  it("should use cached JSON path when not using local template and cached file exists", () => {
+    const mockFs = {
+      pathExistsSync: sandbox.stub().returns(true),
+      readFileSync: sandbox.stub().returns('{"data": "test"}'),
+    };
+    const mockTemplateHelper = {
+      useLocalTemplate: sandbox.stub().returns(false),
+    };
+    const mockFolder = {
+      getTemplatesFolder: sandbox.stub().returns("/templates"),
+    };
+    const mockConstructNode = sandbox.stub().returns({ test: "node" });
+
+    const customEngineAgentModule = proxyquire(
+      "../../src/question/scaffold/vsc/customEngineAgentNode",
+      {
+        "fs-extra": mockFs,
+        "../../../component/generator/templateHelper": mockTemplateHelper,
+        "../../../folder": mockFolder,
+        "../constructNode": { constructNode: mockConstructNode },
+      }
+    );
+
+    const node = customEngineAgentModule.getCustomEngineAgentNode();
+
+    assert.isTrue(mockTemplateHelper.useLocalTemplate.calledOnce);
+    assert.isTrue(mockFs.pathExistsSync.calledOnce);
+    assert.isTrue(mockFs.readFileSync.calledOnce);
+    assert.isFalse(mockFolder.getTemplatesFolder.called);
+    assert.isDefined(node);
+  });
+
+  it("should use templates folder when using local template", () => {
+    const mockFs = {
+      pathExistsSync: sandbox.stub().returns(true),
+      readFileSync: sandbox.stub().returns('{"data": "test"}'),
+    };
+    const mockTemplateHelper = {
+      useLocalTemplate: sandbox.stub().returns(true),
+    };
+    const mockFolder = {
+      getTemplatesFolder: sandbox.stub().returns("/templates"),
+    };
+    const mockConstructNode = sandbox.stub().returns({ test: "node" });
+
+    const customEngineAgentModule = proxyquire(
+      "../../src/question/scaffold/vsc/customEngineAgentNode",
+      {
+        "fs-extra": mockFs,
+        "../../../component/generator/templateHelper": mockTemplateHelper,
+        "../../../folder": mockFolder,
+        "../constructNode": { constructNode: mockConstructNode },
+      }
+    );
+
+    const node = customEngineAgentModule.getCustomEngineAgentNode();
+
+    assert.isTrue(mockTemplateHelper.useLocalTemplate.calledOnce);
+    assert.isFalse(mockFs.pathExistsSync.called);
+    assert.isTrue(mockFolder.getTemplatesFolder.calledOnce);
+    assert.isTrue(mockFs.readFileSync.calledOnce);
+    assert.isDefined(node);
+  });
+
+  it("should use templates folder when cached file does not exist", () => {
+    const mockFs = {
+      pathExistsSync: sandbox.stub().returns(false),
+      readFileSync: sandbox.stub().returns('{"data": "test"}'),
+    };
+    const mockTemplateHelper = {
+      useLocalTemplate: sandbox.stub().returns(false),
+    };
+    const mockFolder = {
+      getTemplatesFolder: sandbox.stub().returns("/templates"),
+    };
+    const mockConstructNode = sandbox.stub().returns({ test: "node" });
+
+    const customEngineAgentModule = proxyquire(
+      "../../src/question/scaffold/vsc/customEngineAgentNode",
+      {
+        "fs-extra": mockFs,
+        "../../../component/generator/templateHelper": mockTemplateHelper,
+        "../../../folder": mockFolder,
+        "../constructNode": { constructNode: mockConstructNode },
+      }
+    );
+
+    const node = customEngineAgentModule.getCustomEngineAgentNode();
+
+    assert.isTrue(mockTemplateHelper.useLocalTemplate.calledOnce);
+    assert.isTrue(mockFs.pathExistsSync.calledOnce);
+    assert.isTrue(mockFolder.getTemplatesFolder.calledOnce);
+    assert.isTrue(mockFs.readFileSync.calledOnce);
+    assert.isDefined(node);
+  });
+});
+
+describe("teamsProjectTypeNode", () => {
+  const sandbox = sinon.createSandbox();
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("should use cached JSON path when not using local template and cached file exists", () => {
+    const mockFs = {
+      pathExistsSync: sandbox.stub().returns(true),
+      readFileSync: sandbox.stub().returns('{"data": "test"}'),
+    };
+    const mockTemplateHelper = {
+      useLocalTemplate: sandbox.stub().returns(false),
+    };
+    const mockFolder = {
+      getTemplatesFolder: sandbox.stub().returns("/templates"),
+    };
+    const mockConstructNode = sandbox.stub().returns({ test: "node" });
+
+    const teamsProjectTypeModule = proxyquire(
+      "../../src/question/scaffold/vsc/teamsProjectTypeNode",
+      {
+        "fs-extra": mockFs,
+        "../../../component/generator/templateHelper": mockTemplateHelper,
+        "../../../folder": mockFolder,
+        "../constructNode": { constructNode: mockConstructNode },
+      }
+    );
+
+    const node = teamsProjectTypeModule.getTeamsProjectNode();
+
+    assert.isTrue(mockTemplateHelper.useLocalTemplate.calledOnce);
+    assert.isTrue(mockFs.pathExistsSync.calledOnce);
+    assert.isFalse(mockFolder.getTemplatesFolder.called);
+    assert.isTrue(mockFs.readFileSync.calledOnce);
+    assert.isDefined(node);
+  });
+
+  it("should use templates folder when using local template", () => {
+    const mockFs = {
+      pathExistsSync: sandbox.stub().returns(true),
+      readFileSync: sandbox.stub().returns('{"data": "test"}'),
+    };
+    const mockTemplateHelper = {
+      useLocalTemplate: sandbox.stub().returns(true),
+    };
+    const mockFolder = {
+      getTemplatesFolder: sandbox.stub().returns("/templates"),
+    };
+    const mockConstructNode = sandbox.stub().returns({ test: "node" });
+
+    const teamsProjectTypeModule = proxyquire(
+      "../../src/question/scaffold/vsc/teamsProjectTypeNode",
+      {
+        "fs-extra": mockFs,
+        "../../../component/generator/templateHelper": mockTemplateHelper,
+        "../../../folder": mockFolder,
+        "../constructNode": { constructNode: mockConstructNode },
+      }
+    );
+
+    const node = teamsProjectTypeModule.getTeamsProjectNode();
+
+    assert.isTrue(mockTemplateHelper.useLocalTemplate.calledOnce);
+    assert.isFalse(mockFs.pathExistsSync.called);
+    assert.isTrue(mockFolder.getTemplatesFolder.calledOnce);
+    assert.isTrue(mockFs.readFileSync.calledOnce);
+    assert.isDefined(node);
+  });
+
+  it("should use templates folder when cached file does not exist", () => {
+    const mockFs = {
+      pathExistsSync: sandbox.stub().returns(false),
+      readFileSync: sandbox.stub().returns('{"data": "test"}'),
+    };
+    const mockTemplateHelper = {
+      useLocalTemplate: sandbox.stub().returns(false),
+    };
+    const mockFolder = {
+      getTemplatesFolder: sandbox.stub().returns("/templates"),
+    };
+    const mockConstructNode = sandbox.stub().returns({ test: "node" });
+
+    const teamsProjectTypeModule = proxyquire(
+      "../../src/question/scaffold/vsc/teamsProjectTypeNode",
+      {
+        "fs-extra": mockFs,
+        "../../../component/generator/templateHelper": mockTemplateHelper,
+        "../../../folder": mockFolder,
+        "../constructNode": { constructNode: mockConstructNode },
+      }
+    );
+
+    const node = teamsProjectTypeModule.getTeamsProjectNode();
+
+    assert.isTrue(mockTemplateHelper.useLocalTemplate.calledOnce);
+    assert.isTrue(mockFs.pathExistsSync.calledOnce);
+    assert.isTrue(mockFolder.getTemplatesFolder.calledOnce);
+    assert.isTrue(mockFs.readFileSync.calledOnce);
+    assert.isDefined(node);
   });
 });
 

--- a/packages/vscode-extension/.vscode/launch.json
+++ b/packages/vscode-extension/.vscode/launch.json
@@ -13,6 +13,7 @@
       "env": {
         "NODE_ENV": "development",
         "TEAMSFX_SAMPLE_CONFIG_BRANCH": "dev",
+        "TEMPLATE_VERSION": "local",
         "TEAMSFX_MCP_FOR_DA": "true"
       },
       "preLaunchTask": "watch"


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/36176572

This pull request refactors how the system determines whether to use local or remote templates, centralizing the logic and updating all relevant code paths to use a new utility function. Additionally, it updates the release workflow to handle new artifact paths for template files. The changes improve maintainability, consistency, and flexibility in managing template sources.

**Template Source Selection Refactor:**

* Introduced a new `useLocalTemplate` function in `templateHelper.ts` that encapsulates the logic for determining whether to use local templates based on environment variables and package version. All references to the previous `useLocalTemplate` property in `templates-config.json` have been replaced with calls to this function across the codebase. [[1]](diffhunk://#diff-0414a5cfbabc60f2669a4e0ab91777e77a42378fa6efb2605f0f99f19440907cR1-R24) [[2]](diffhunk://#diff-1b4c123e38992fa5569e6398502483ee6fafb698e66b52ced295736334c7aa96L9-R9) [[3]](diffhunk://#diff-1b4c123e38992fa5569e6398502483ee6fafb698e66b52ced295736334c7aa96L50-R50) [[4]](diffhunk://#diff-b0b8e9b574de5589472cbb51890f06f1847c8fcc514d302cebd2ac2e92cb5e3fL8-R9) [[5]](diffhunk://#diff-b0b8e9b574de5589472cbb51890f06f1847c8fcc514d302cebd2ac2e92cb5e3fL23-R23) [[6]](diffhunk://#diff-10159345d62a8197aef7d191bf8684f26090bd4954b855df89eca115bc59a76eR142) [[7]](diffhunk://#diff-10159345d62a8197aef7d191bf8684f26090bd4954b855df89eca115bc59a76eL2908-R2909) [[8]](diffhunk://#diff-3d72406439baa14b96ab6ddd52deee939c1f1c5e3f54970ea4564d625266a71cL8-R8) [[9]](diffhunk://#diff-3d72406439baa14b96ab6ddd52deee939c1f1c5e3f54970ea4564d625266a71cL23-R23) [[10]](diffhunk://#diff-5b03f68e26bb232f9797f20007a6e238fda2e37ef6cc6cc1c3efa3eb8fc240f2L17-R17) [[11]](diffhunk://#diff-5b03f68e26bb232f9797f20007a6e238fda2e37ef6cc6cc1c3efa3eb8fc240f2L54-R54)

* Updated unit tests to stub the new `useLocalTemplate` function instead of replacing the old config property, ensuring tests reflect the new logic. [[1]](diffhunk://#diff-9e2819223301a1151fd621af275580eb0c98e82e508f48f575c088b6b843a0faR40) [[2]](diffhunk://#diff-9e2819223301a1151fd621af275580eb0c98e82e508f48f575c088b6b843a0faL126-R127) [[3]](diffhunk://#diff-9e2819223301a1151fd621af275580eb0c98e82e508f48f575c088b6b843a0faL141-R142) [[4]](diffhunk://#diff-9e2819223301a1151fd621af275580eb0c98e82e508f48f575c088b6b843a0faL1048-R1049) [[5]](diffhunk://#diff-9e2819223301a1151fd621af275580eb0c98e82e508f48f575c088b6b843a0faL1074-R1075) [[6]](diffhunk://#diff-9e2819223301a1151fd621af275580eb0c98e82e508f48f575c088b6b843a0faL1099-R1100) [[7]](diffhunk://#diff-9e2819223301a1151fd621af275580eb0c98e82e508f48f575c088b6b843a0faL1131-R1132)

**Template Download Logic Improvements:**

* Refactored the template download logic in `utils.ts` to use the new `useLocalTemplate` function and to check the `TEMPLATE_VERSION` environment variable and package version for determining the template source. This adds support for local, alpha, beta, rc, and stable versions in a more maintainable way. [[1]](diffhunk://#diff-e3ce6386dea44c9cb21540071197f433eb1d33ac6ad03cee4f23bfd14529be04R4-R20) [[2]](diffhunk://#diff-e3ce6386dea44c9cb21540071197f433eb1d33ac6ad03cee4f23bfd14529be04L25-R74)

**Release Workflow Updates:**

* Modified the GitHub Actions workflow (`cd.yml`) to reference new artifact paths for template zip files, splitting them by language and moving them into a `fallback` directory. This affects both prerelease and stable release steps. [[1]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L292-R312) [[2]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L333-R345) [[3]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L353-R365)

**Minor Codebase Cleanups:**

* Updated some import and class declaration orders for clarity and consistency. [[1]](diffhunk://#diff-10159345d62a8197aef7d191bf8684f26090bd4954b855df89eca115bc59a76eR199) [[2]](diffhunk://#diff-10159345d62a8197aef7d191bf8684f26090bd4954b855df89eca115bc59a76eL213) [[3]](diffhunk://#diff-10159345d62a8197aef7d191bf8684f26090bd4954b855df89eca115bc59a76eL2970-R2971)