### PR TITLE
fix(vscode-ui): add real-time output to terminal while capturing in r…

### DIFF
--- a/packages/vscode-ui/src/ui.ts
+++ b/packages/vscode-ui/src/ui.ts
@@ -1136,12 +1136,14 @@ export class VSCodeUI implements UserInteraction {
 
     if (isWindows) {
       // PowerShell script for Windows
+      // Use Tee-Object to display output in terminal while also capturing to file
       scriptContent = `$ErrorActionPreference = 'Continue'\n${cmd}\n`;
-      wrappedCmd = `powershell -NoProfile -ExecutionPolicy Bypass -File "${scriptFile}" > "${tempFile}" 2>&1`;
+      wrappedCmd = `powershell -NoProfile -ExecutionPolicy Bypass -File "${scriptFile}" 2>&1 | Tee-Object -FilePath "${tempFile}"`;
     } else {
       // Bash script for Unix-like systems
+      // Use tee to display output in terminal while also capturing to file
       scriptContent = `#!/bin/bash\nset +e\n${cmd}\n`;
-      wrappedCmd = `bash "${scriptFile}" > "${tempFile}" 2>&1`;
+      wrappedCmd = `bash "${scriptFile}" 2>&1 | tee "${tempFile}"`;
     }
 
     fs.writeFileSync(scriptFile, scriptContent, "utf-8");

--- a/packages/vscode-ui/tests/ui.test.ts
+++ b/packages/vscode-ui/tests/ui.test.ts
@@ -816,10 +816,11 @@ describe("UI Unit Tests", async () => {
       fsUnlinkSyncStub = sinon.stub(fs, "unlinkSync");
       tasksExecuteTaskStub = sinon.stub(tasks, "executeTask").callsFake((task: any) => {
         // Capture the temp file path from the shell execution command
-        // The commandLine looks like: cmd > "path/to/file" 2>&1
+        // The commandLine uses tee/Tee-Object: cmd 2>&1 | tee "path/to/file" or cmd 2>&1 | Tee-Object -FilePath "path/to/file"
         const execution = task.execution;
         if (execution && execution.commandLine) {
-          const match = execution.commandLine.match(/>\s*"([^"]+)"/);
+          // Match both tee "path" and Tee-Object -FilePath "path" patterns
+          const match = execution.commandLine.match(/(?:tee|Tee-Object -FilePath)\s+"([^"]+)"/);
           if (match) {
             const tempFilePath = match[1];
             tempFiles.push(tempFilePath);


### PR DESCRIPTION
Use tee/Tee-Object to display command output in terminal while also capturing to file for parsing. This fixes the issue where prompts from tools like @azure/static-web-apps-cli were not showing in the terminal.