### PR TITLE
fix: get subscriptions silently when failed to login

### DIFF
--- a/packages/cli/src/commonlib/azureLogin.ts
+++ b/packages/cli/src/commonlib/azureLogin.ts
@@ -109,14 +109,20 @@ const memoryDictionary: { [tenantId: string]: MemoryCache } = {};
 class TeamsFxTokenCredential implements ITeamsFxTokenCredential {
   private codeFlowInstance: CodeFlowLogin;
   private tenantId: string;
+  private silent: boolean;
 
-  constructor(codeFlowInstance: CodeFlowLogin) {
+  constructor(codeFlowInstance: CodeFlowLogin, silent = false) {
     this.codeFlowInstance = codeFlowInstance;
     this.tenantId = "";
+    this.silent = silent;
   }
 
   public setTenantId(tenantId: string) {
     this.tenantId = tenantId;
+  }
+
+  public setSilent(silent: boolean) {
+    this.silent = silent;
   }
 
   async getToken(
@@ -125,7 +131,7 @@ class TeamsFxTokenCredential implements ITeamsFxTokenCredential {
   ): Promise<AccessToken | null> {
     const tokenRes: Result<string, FxError> = await this.codeFlowInstance.getTokenByScopes(
       scopes,
-      true,
+      !this.silent, // When silent is true, don't refresh (trigger login) on failure
       this.tenantId
     );
 
@@ -353,7 +359,8 @@ export class AzureAccountManager extends login implements AzureAccountProvider {
       if (!AzureAccountManager.tenantId) {
         const tenantClient = new SubscriptionClient(AzureAccountManager.teamsFxTokenCredential);
         const tenantTokenCredential: TeamsFxTokenCredential = new TeamsFxTokenCredential(
-          AzureAccountManager.codeFlowInstance
+          AzureAccountManager.codeFlowInstance,
+          true // silent mode - don't trigger login on failure
         );
         const cachedTenantId = await loadTenantId(accountName);
         for await (const page of tenantClient.tenants.list().byPage()) {

--- a/packages/cli/src/commonlib/codeFlowLogin.ts
+++ b/packages/cli/src/commonlib/codeFlowLogin.ts
@@ -441,18 +441,21 @@ export class CodeFlowLogin {
           return err(LoginCodeFlowError(new Error("No token response")));
         }
       } catch (error: any) {
-        CliCodeLogInstance.necessaryLog(
-          LogLevel.Debug,
-          "[Login] Failed to retrieve token silently. If you encounter this problem multiple times, you can delete `" +
-            path.join(os.homedir(), ".fx", "account") +
-            "` and try again. " +
-            error.message
-        );
+        if (refresh) {
+          CliCodeLogInstance.necessaryLog(
+            LogLevel.Debug,
+            "[Login] Failed to retrieve token silently. If you encounter this problem multiple times, you can delete `" +
+              path.join(os.homedir(), ".fx", "account") +
+              "` and try again. " +
+              error.message
+          );
+        }
+
         if (!(await checkIsOnline())) {
           return err(CheckOnlineError());
         }
-        await this.logout();
         if (refresh) {
+          await this.logout();
           const accessToken = await this.login(myScopes, tenantId);
           return ok(accessToken);
         }


### PR DESCRIPTION
ADO: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/36565044/?view=edit
Before:
<img width="1472" height="518" alt="image" src="https://github.com/user-attachments/assets/ef0e6b1b-e0d3-4c8f-ad92-5e214b1d44a9" />

After:
<img width="1606" height="551" alt="image" src="https://github.com/user-attachments/assets/f3405928-0c39-4ac1-bf9c-929cec89e8ec" />
