### PR TITLE
fix: no schema of declarative agent in mcp server

### DIFF
--- a/templates/vsc/common/declarative-agent-with-action-from-mcp/appPackage/declarativeAgent.json.tpl
+++ b/templates/vsc/common/declarative-agent-with-action-from-mcp/appPackage/declarativeAgent.json.tpl
@@ -4,6 +4,7 @@
     "version": "v1.5",
     {{/EmbeddedKnowledgeEnabled}}
     {{#EmbeddedKnowledgeEnabled}}
+    "$schema": "https://developer.microsoft.com/json-schemas/copilot/declarative-agent/v1.6/schema.json",
     "version": "v1.6",
     {{/EmbeddedKnowledgeEnabled}}
     {{#SensitivityLabelEnabled}}


### PR DESCRIPTION
[Bug 36929455 Failed to validate app manifest schema for project of DA with mcp action](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/36929455)