### PR TITLE
fix(cli): use alias name for template id

### DIFF
--- a/packages/cli/.vscode/launch.json
+++ b/packages/cli/.vscode/launch.json
@@ -10,7 +10,34 @@
       "name": "Launch new command (non-interactive)",
       "skipFiles": ["<node_internals>/**"],
       "program": "${workspaceFolder}/cli.js",
-      "args": ["new", "-i", "false"],
+      "args": ["new", "-c", "declarative-agent", "-n", "da","-i", "false"],
+      "env": {
+        "TEAMSFX_GENERATE_CONFIG_FILES": "true",
+        "TEMPLATE_VERSION": "local"
+      },
+      "outFiles": [
+        "${workspaceFolder}/lib/**/*.js",
+        "${workspaceFolder}/../fx-core/build/**/*.js",
+        "${workspaceFolder}/../api/build/**/*.js"
+      ],
+      "resolveSourceMapLocations": [
+        "${workspaceFolder}/lib/**/*.js",
+        "${workspaceFolder}/../fx-core/build/**/*.js",
+        "${workspaceFolder}/../api/build/**/*.js"
+      ],
+      "console": "integratedTerminal"
+    },
+    {
+      "type": "pwa-node",
+      "request": "launch",
+      "name": "Launch init command (non-interactive)",
+      "skipFiles": ["<node_internals>/**"],
+      "program": "${workspaceFolder}/cli.js",
+      "args": ["init"],
+      "env": {
+        "TEAMSFX_GENERATE_CONFIG_FILES": "true",
+        "TEMPLATE_VERSION": "local"
+      },
       "outFiles": [
         "${workspaceFolder}/lib/**/*.js",
         "${workspaceFolder}/../fx-core/build/**/*.js",

--- a/packages/cli/src/commands/models/create.ts
+++ b/packages/cli/src/commands/models/create.ts
@@ -31,7 +31,7 @@ function adjustOptions(options: CLICommandOption[]) {
   for (const option of options) {
     if (option.type === "string" && option.name === CliQuestionName.Capability) {
       // use dynamic options for capability question
-      option.choices = listAllTemplates().map((o) => o.name);
+      option.choices = listAllTemplates().map((o) => o.alias || o.name);
       break;
     }
   }
@@ -72,11 +72,12 @@ export function getCreateCommand(): CLICommand {
           // for non-interactive mode, we need to preset project-type from capability to make sure the question model works
           const capability = inputs.capabilities as string;
           inputs["template-name"] = capability;
-          if (inputs["programming-language"] === undefined) {
-            // preset programming language if not specified
-            const templates = listAllTemplates();
-            const matched = templates.find((t) => t.name === capability);
-            if (matched) {
+          const templates = listAllTemplates();
+          const matched = templates.find((t) => t.name === capability || t.alias === capability);
+          if (matched) {
+            inputs["template-name"] = matched.name;
+            if (inputs["programming-language"] === undefined) {
+              // preset programming language if not specified
               inputs["programming-language"] = matched.language as any;
             }
           }

--- a/packages/cli/src/commands/models/create.ts
+++ b/packages/cli/src/commands/models/create.ts
@@ -46,7 +46,7 @@ export function getCreateCommand(): CLICommand {
     options: [...adjustOptions(CreateProjectOptions)],
     examples: [
       {
-        command: `${process.env.TEAMSFX_CLI_BIN_NAME} new -c copilot-gpt-basic -n myagent -i false`,
+        command: `${process.env.TEAMSFX_CLI_BIN_NAME} new -c declarative-agent -n myagent -i false`,
         description: "Create a new declarative agent",
       },
       {

--- a/packages/cli/src/commands/models/create.ts
+++ b/packages/cli/src/commands/models/create.ts
@@ -31,7 +31,7 @@ function adjustOptions(options: CLICommandOption[]) {
   for (const option of options) {
     if (option.type === "string" && option.name === CliQuestionName.Capability) {
       // use dynamic options for capability question
-      option.choices = listAllTemplates().map((o) => o.alias || o.name);
+      option.choices = listAllTemplates().flatMap((o) => (o.alias ? [o.alias, o.name] : [o.name]));
       break;
     }
   }

--- a/packages/cli/src/commands/models/listTemplates.ts
+++ b/packages/cli/src/commands/models/listTemplates.ts
@@ -1,11 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 import { CLICommand, ok, Platform } from "@microsoft/teamsfx-api";
-import {
-  featureFlagManager,
-  FeatureFlags,
-  getAllTemplatesOnPlatform,
-} from "@microsoft/teamsfx-core";
+import * as teamsfxCore from "@microsoft/teamsfx-core";
 import { Template } from "@microsoft/teamsfx-core/build/component/generator/templates/metadata/interface";
 import chalk from "chalk";
 import Table from "cli-table3";
@@ -23,11 +19,15 @@ interface TemplateGroup {
 }
 
 export function listAllTemplates(): TemplateGroup[] {
-  let templates = getAllTemplatesOnPlatform(Platform.VSCode);
-  if (featureFlagManager.getBooleanValue(FeatureFlags.CLIDotNet)) {
-    templates = getAllTemplatesOnPlatform(Platform.VS);
+  let templates = teamsfxCore.getAllTemplatesOnPlatform(Platform.VSCode);
+  if (teamsfxCore.featureFlagManager.getBooleanValue(teamsfxCore.FeatureFlags.CLIDotNet)) {
+    templates = teamsfxCore.getAllTemplatesOnPlatform(Platform.VS);
   }
 
+  return groupTemplatesByName(templates as Template[]);
+}
+
+export function groupTemplatesByName(templates: Template[]): TemplateGroup[] {
   // Group by template name, ignoring programming language
   const groupedTemplates = new Map<string, TemplateGroup>();
 

--- a/packages/cli/src/commands/models/listTemplates.ts
+++ b/packages/cli/src/commands/models/listTemplates.ts
@@ -6,6 +6,7 @@ import {
   FeatureFlags,
   getAllTemplatesOnPlatform,
 } from "@microsoft/teamsfx-core";
+import { Template } from "@microsoft/teamsfx-core/build/component/generator/templates/metadata/interface";
 import chalk from "chalk";
 import Table from "cli-table3";
 import { logger } from "../../commonlib/logger";
@@ -15,6 +16,7 @@ import { ListFormatOption } from "../common";
 
 interface TemplateGroup {
   name: string;
+  alias?: string;
   displayName: string;
   description: string;
   language: string;
@@ -31,10 +33,11 @@ export function listAllTemplates(): TemplateGroup[] {
 
   templates.forEach((template) => {
     if (!groupedTemplates.has(template.name)) {
-      const templateWithDisplay = template as typeof template & { displayName?: string };
+      const templateWithDisplay = template as Template;
       groupedTemplates.set(template.name, {
         name: template.name,
-        displayName: templateWithDisplay.displayName || template.name,
+        alias: template.alias,
+        displayName: templateWithDisplay.displayName || template.alias || template.name,
         description: template.description,
         language: template.language,
       });
@@ -71,8 +74,9 @@ function jsonToTable(templates: TemplateGroup[]): string {
   let maxNameLength = 0;
   let maxDescriptionLength = 0;
   templates.forEach((template) => {
-    if (template.name.length > maxIdLength) {
-      maxIdLength = template.name.length;
+    const id = template.alias || template.name;
+    if (id.length > maxIdLength) {
+      maxIdLength = id.length;
     }
     if (template.displayName.length > maxNameLength) {
       maxNameLength = template.displayName.length;
@@ -105,7 +109,8 @@ function jsonToTable(templates: TemplateGroup[]): string {
   });
 
   templates.forEach((template) => {
-    table.push([template.name, template.displayName, template.description]);
+    const id = template.alias || template.name;
+    table.push([id, template.displayName, template.description]);
   });
 
   return table.toString();

--- a/packages/cli/tests/unit/commands.tests.ts
+++ b/packages/cli/tests/unit/commands.tests.ts
@@ -1,5 +1,6 @@
 import { CLIContext, SystemError, err, ok, signedIn, signedOut } from "@microsoft/teamsfx-api";
 import {
+  CliQuestionName,
   CollaborationConstants,
   CollaborationStateResult,
   FuncToolChecker,
@@ -58,6 +59,7 @@ import { addCapabilityCommand } from "../../src/commands/models/addCapability";
 import { addPluginCommand } from "../../src/commands/models/addPlugin";
 import { entraAppUpdateCommand } from "../../src/commands/models/entraAppUpdate";
 import { envResetCommand } from "../../src/commands/models/envReset";
+import * as listTemplatesModule from "../../src/commands/models/listTemplates";
 import { regeneratePluginCommand } from "../../src/commands/models/regeneratePlugin";
 import { setCommand } from "../../src/commands/models/set";
 import { setSensitivityLabelCommand } from "../../src/commands/models/setSensitivityLabel";
@@ -141,6 +143,90 @@ describe("CLI commands", () => {
       };
       const res = await getCreateCommand().handler!(ctx);
       assert.isTrue(res.isErr());
+    });
+
+    it("uses template alias and preset language in non-interactive mode", async () => {
+      sandbox.stub(activate, "getFxCore").returns(new FxCore({} as any));
+      const createProjectStub = sandbox
+        .stub(FxCore.prototype, "createProject")
+        .resolves(ok({ projectPath: "..." }));
+      sandbox.stub(featureFlagManager, "getBooleanValue").returns(false);
+      sandbox.stub(listTemplatesModule, "listAllTemplates").returns([
+        {
+          name: "api-plugin",
+          alias: "api-plugin-from-scratch",
+          displayName: "API Plugin",
+          description: "desc",
+          language: "typescript",
+        },
+      ] as any);
+
+      const ctx: CLIContext = {
+        command: { ...getCreateCommand(), fullName: "new" },
+        optionValues: {
+          capabilities: "api-plugin-from-scratch",
+          nonInteractive: true,
+        },
+        globalOptionValues: {},
+        argumentValues: [],
+        telemetryProperties: {},
+      };
+
+      const res = await getCreateCommand().handler!(ctx);
+
+      assert.isTrue(res.isOk());
+      assert.isTrue(createProjectStub.calledOnce);
+      const inputs = createProjectStub.firstCall.args[0] as any;
+      assert.equal(inputs["template-name"], "api-plugin");
+      assert.equal(inputs["programming-language"], "typescript");
+    });
+
+    it("keeps capability as template-name when template is not found", async () => {
+      sandbox.stub(activate, "getFxCore").returns(new FxCore({} as any));
+      const createProjectStub = sandbox
+        .stub(FxCore.prototype, "createProject")
+        .resolves(ok({ projectPath: "..." }));
+      sandbox.stub(featureFlagManager, "getBooleanValue").returns(false);
+      sandbox.stub(listTemplatesModule, "listAllTemplates").returns([] as any);
+
+      const ctx: CLIContext = {
+        command: { ...getCreateCommand(), fullName: "new" },
+        optionValues: {
+          capabilities: "unknown-template",
+          nonInteractive: true,
+          "programming-language": "javascript",
+        },
+        globalOptionValues: {},
+        argumentValues: [],
+        telemetryProperties: {},
+      };
+
+      const res = await getCreateCommand().handler!(ctx);
+
+      assert.isTrue(res.isOk());
+      const inputs = createProjectStub.firstCall.args[0] as any;
+      assert.equal(inputs["template-name"], "unknown-template");
+      assert.equal(inputs["programming-language"], "javascript");
+    });
+
+    it("includes alias and name in capability choices", async () => {
+      sandbox.stub(listTemplatesModule, "listAllTemplates").returns([
+        {
+          name: "api-plugin",
+          alias: "api-plugin-from-scratch",
+          displayName: "API Plugin",
+          description: "desc",
+          language: "typescript",
+        },
+      ] as any);
+
+      const command = getCreateCommand();
+      const capabilityOption = command.options?.find((o) => o.name === CliQuestionName.Capability);
+
+      assert.deepEqual((capabilityOption as any)?.choices, [
+        "api-plugin-from-scratch",
+        "api-plugin",
+      ]);
     });
   });
 
@@ -1589,6 +1675,32 @@ describe("CLI read-only commands", () => {
       };
       const res = await listTemplatesCommand.handler!(ctx);
       assert.isTrue(res.isOk());
+    });
+
+    it("groupTemplatesByName groups by name and falls back display name", async () => {
+      const templates = listTemplatesModule.groupTemplatesByName([
+        {
+          name: "dup-template",
+          alias: "dup-alias",
+          description: "desc 1",
+          language: "typescript",
+        },
+        {
+          name: "dup-template",
+          alias: "dup-alias-2",
+          description: "desc 2",
+          language: "javascript",
+        },
+        {
+          name: "no-alias-template",
+          description: "desc 3",
+          language: "typescript",
+        },
+      ] as any);
+
+      assert.equal(templates.length, 2);
+      assert.equal(templates[0].displayName, "dup-alias");
+      assert.equal(templates[1].displayName, "no-alias-template");
     });
   });
   describe("listSamplesCommand", async () => {

--- a/packages/cli/tests/unit/engine.tests.ts
+++ b/packages/cli/tests/unit/engine.tests.ts
@@ -3,13 +3,12 @@ import {
   CLICommandOption,
   CLIContext,
   CLIFoundCommand,
-  LogLevel,
-  SystemError,
   err,
+  LogLevel,
   ok,
+  SystemError,
 } from "@microsoft/teamsfx-api";
 import {
-  featureFlagManager,
   FxCore,
   InputValidationError,
   MissingEnvironmentVariablesError,
@@ -18,6 +17,7 @@ import {
 } from "@microsoft/teamsfx-core";
 import { assert } from "chai";
 import "mocha";
+import mockedEnv from "mocked-env";
 import * as sinon from "sinon";
 import * as activate from "../../src/activate";
 import { getFxCore, resetFxCore } from "../../src/activate";
@@ -42,9 +42,6 @@ import {
 import * as main from "../../src/index";
 import CliTelemetry from "../../src/telemetry/cliTelemetry";
 import { getVersion } from "../../src/utils";
-import mockedEnv, { RestoreFn } from "mocked-env";
-import { shareCommand } from "../../src/commands/models/share";
-import { setSensitivityLabelCommand } from "../../src/commands/models/setSensitivityLabel";
 
 describe("CLI Engine", () => {
   const sandbox = sinon.createSandbox();
@@ -417,7 +414,7 @@ describe("CLI Engine", () => {
     it("should validation failed for capability", async () => {
       sandbox
         .stub(process, "argv")
-        .value(["node", "cli", "new", "-c", "tab", "-n", "myapp", "-i", "false"]);
+        .value(["node", "cli", "new", "-c", "da", "-n", "myapp", "-i", "false"]);
       let error: any = {};
       sandbox.stub(engine, "processResult").callsFake(async (context, fxError) => {
         error = fxError;

--- a/packages/fx-core/src/component/generator/templates/metadata/interface.ts
+++ b/packages/fx-core/src/component/generator/templates/metadata/interface.ts
@@ -4,6 +4,8 @@
 export interface Template {
   id: string;
   name: string;
+  alias?: string;
+  displayName?: string;
   language: "typescript" | "javascript" | "csharp" | "python" | "none" | "common";
   description: string;
   link?: string;

--- a/packages/fx-core/src/component/m365/constants.ts
+++ b/packages/fx-core/src/component/m365/constants.ts
@@ -10,5 +10,5 @@ export enum Hub {
 export const outlookCopilotAppId = "d870f6cd-4aa5-4d42-9626-ab690c041429";
 export const outlookBaseUrl = "https://outlook.office.com";
 export const officeBaseUrl = "https://www.office.com";
-export const advancedDASettingUrl = "https://aka.ms/atk-actions/teamsapp-extendToM365";
+export const advancedDASettingUrl = "https://aka.ms/atk-da-share";
 export const M365HelpLink = "https://aka.ms/teamsfx-actions/teamsapp-extendToM365";

--- a/packages/fx-core/templates/metadata/allTemplates.json
+++ b/packages/fx-core/templates/metadata/allTemplates.json
@@ -463,8 +463,8 @@
     "description": "Receive user input, process it, and send customized results"
   },
   {
-    "id": "foundry-agent-ts",
-    "name": "foundry-agent",
+    "id": "foundry-agent-to-m365-ts",
+    "name": "foundry-agent-to-m365",
     "language": "typescript",
     "displayName": "Foundry Agent",
     "description": "An Microsoft 365 Agent that connects to Microsoft AI Foundry Agent."

--- a/packages/fx-core/templates/metadata/allTemplates.json
+++ b/packages/fx-core/templates/metadata/allTemplates.json
@@ -2,6 +2,7 @@
   {
     "id": "declarative-agent-basic",
     "name": "copilot-gpt-basic",
+    "alias": "declarative-agent",
     "language": "common",
     "displayName": "Declarative Agent",
     "description": "Basic Declarative Agent without action"
@@ -9,6 +10,7 @@
   {
     "id": "declarative-agent-basic-csharp",
     "name": "copilot-gpt-basic",
+    "alias": "declarative-agent",
     "language": "csharp",
     "displayName": "Declarative Agent",
     "description": "Basic Declarative Agent without action"
@@ -16,6 +18,7 @@
   {
     "id": "declarative-agent-with-action-from-scratch-ts",
     "name": "api-plugin-from-scratch",
+    "alias": "declarative-agent-action",
     "language": "typescript",
     "displayName": "Declarative Agent with Action from Scratch",
     "description": "Declarative Agent with a new action built from scratch"
@@ -23,6 +26,7 @@
   {
     "id": "declarative-agent-with-action-from-scratch-js",
     "name": "api-plugin-from-scratch",
+    "alias": "declarative-agent-action",
     "language": "javascript",
     "displayName": "Declarative Agent with Action from Scratch",
     "description": "Declarative Agent with a new action built from scratch"
@@ -30,6 +34,7 @@
   {
     "id": "declarative-agent-with-action-from-scratch-csharp",
     "name": "api-plugin-from-scratch",
+    "alias": "declarative-agent-action",
     "language": "csharp",
     "displayName": "Declarative Agent with Action from Scratch",
     "description": "Declarative Agent with a new action built from scratch"
@@ -37,6 +42,7 @@
   {
     "id": "declarative-agent-with-action-from-scratch-bearer-ts",
     "name": "api-plugin-from-scratch-bearer",
+    "alias": "declarative-agent-action-bearer",
     "language": "typescript",
     "displayName": "Declarative Agent with Action from Scratch (Bearer Token)",
     "description": "Declarative Agent with a new action built from scratch using Bearer Token authentication"
@@ -44,6 +50,7 @@
   {
     "id": "declarative-agent-with-action-from-scratch-bearer-js",
     "name": "api-plugin-from-scratch-bearer",
+    "alias": "declarative-agent-action-bearer",
     "language": "javascript",
     "displayName": "Declarative Agent with Action from Scratch (Bearer Token)",
     "description": "Declarative Agent with a new action built from scratch using Bearer Token authentication"
@@ -51,6 +58,7 @@
   {
     "id": "declarative-agent-with-action-from-scratch-bearer-csharp",
     "name": "api-plugin-from-scratch-bearer",
+    "alias": "declarative-agent-action-bearer",
     "language": "csharp",
     "displayName": "Declarative Agent with Action from Scratch (Bearer Token)",
     "description": "Declarative Agent with a new action built from scratch using Bearer Token authentication"
@@ -58,6 +66,7 @@
   {
     "id": "declarative-agent-with-action-from-scratch-oauth-ts",
     "name": "api-plugin-from-scratch-oauth",
+    "alias": "declarative-agent-action-oauth",
     "language": "typescript",
     "displayName": "Declarative Agent with Action from Scratch (OAuth)",
     "description": "Declarative Agent with a new action built from scratch using OAuth authentication"
@@ -65,6 +74,7 @@
   {
     "id": "declarative-agent-with-action-from-scratch-oauth-js",
     "name": "api-plugin-from-scratch-oauth",
+    "alias": "declarative-agent-action-oauth",
     "language": "javascript",
     "displayName": "Declarative Agent with Action from Scratch (OAuth)",
     "description": "Declarative Agent with a new action built from scratch using OAuth authentication"
@@ -72,6 +82,7 @@
   {
     "id": "declarative-agent-with-action-from-scratch-oauth-csharp",
     "name": "api-plugin-from-scratch-oauth",
+    "alias": "declarative-agent-action-oauth",
     "language": "csharp",
     "displayName": "Declarative Agent with Action from Scratch (OAuth)",
     "description": "Declarative Agent with a new action built from scratch using OAuth authentication"
@@ -79,6 +90,7 @@
   {
     "id": "declarative-agent-with-action-from-existing-api",
     "name": "api-plugin-from-existing-api",
+    "alias": "declarative-agent-action-from-existing-api",
     "language": "none",
     "displayName": "Declarative Agent with Action from Existing API",
     "description": "Declarative Agent with action from an existing API specification"
@@ -86,6 +98,7 @@
   {
     "id": "declarative-agent-with-action-from-existing-api-csharp",
     "name": "api-plugin-from-existing-api",
+    "alias": "declarative-agent-action-from-existing-api",
     "language": "csharp",
     "displayName": "Declarative Agent with Action from Existing API",
     "description": "Declarative Agent with action from an existing API specification"
@@ -177,6 +190,7 @@
   {
     "id": "graph-connector-ts",
     "name": "graph-connector",
+    "alias": "copilot-connector",
     "language": "typescript",
     "displayName": "Copilot Connector",
     "description": "Embed your organization data to make it searchable in Microsoft 365 Copilot"
@@ -184,6 +198,7 @@
   {
     "id": "custom-copilot-basic-ts",
     "name": "custom-copilot-basic",
+    "alias": "teams-agent",
     "language": "typescript",
     "displayName": "General Teams Agent",
     "description": "Agent that chats with users in Teams built with Teams AI Library and connects to LLMs"
@@ -191,6 +206,7 @@
   {
     "id": "custom-copilot-basic-js",
     "name": "custom-copilot-basic",
+    "alias": "teams-agent",
     "language": "javascript",
     "displayName": "General Teams Agent",
     "description": "Agent that chats with users in Teams built with Teams AI Library and connects to LLMs"
@@ -198,6 +214,7 @@
   {
     "id": "custom-copilot-basic-csharp",
     "name": "custom-copilot-basic",
+    "alias": "teams-agent",
     "language": "csharp",
     "displayName": "General Teams Agent",
     "description": "Agent that chats with users in Teams built with Teams AI Library and connects to LLMs"
@@ -205,6 +222,7 @@
   {
     "id": "custom-copilot-basic-python",
     "name": "custom-copilot-basic",
+    "alias": "teams-agent",
     "language": "python",
     "displayName": "General Teams Agent",
     "description": "Agent that chats with users in Teams built with Teams AI Library and connects to LLMs"
@@ -212,6 +230,7 @@
   {
     "id": "custom-copilot-rag-customize-ts",
     "name": "custom-copilot-rag-customize",
+    "alias": "teams-agent-rag-customize",
     "language": "typescript",
     "displayName": "Teams Agent with Data from Customized Source",
     "description": "Agent that uses your content and knowledge to accurately answer domain-specific questions"
@@ -219,6 +238,7 @@
   {
     "id": "custom-copilot-rag-customize-js",
     "name": "custom-copilot-rag-customize",
+    "alias": "teams-agent-rag-customize",
     "language": "javascript",
     "displayName": "Teams Agent with Data from Customized Source",
     "description": "Agent that uses your content and knowledge to accurately answer domain-specific questions"
@@ -226,6 +246,7 @@
   {
     "id": "custom-copilot-rag-customize-csharp",
     "name": "custom-copilot-rag-customize",
+    "alias": "teams-agent-rag-customize",
     "language": "csharp",
     "displayName": "Teams Agent with Data from Customized Source",
     "description": "Agent that uses your content and knowledge to accurately answer domain-specific questions"
@@ -233,6 +254,7 @@
   {
     "id": "custom-copilot-rag-customize-python",
     "name": "custom-copilot-rag-customize",
+    "alias": "teams-agent-rag-customize",
     "language": "python",
     "displayName": "Teams Agent with Data from Customized Source",
     "description": "Agent that uses your content and knowledge to accurately answer domain-specific questions"
@@ -240,6 +262,7 @@
   {
     "id": "custom-copilot-rag-azure-ai-search-ts",
     "name": "custom-copilot-rag-azure-ai-search",
+    "alias": "teams-agent-rag-azure-ai-search",
     "language": "typescript",
     "displayName": "Teams Agent with Data from Azure AI Search",
     "description": "Agent that uses your content and knowledge to accurately answer domain-specific questions"
@@ -247,6 +270,7 @@
   {
     "id": "custom-copilot-rag-azure-ai-search-js",
     "name": "custom-copilot-rag-azure-ai-search",
+    "alias": "teams-agent-rag-azure-ai-search",
     "language": "javascript",
     "displayName": "Teams Agent with Data from Azure AI Search",
     "description": "Agent that uses your content and knowledge to accurately answer domain-specific questions"
@@ -254,6 +278,7 @@
   {
     "id": "custom-copilot-rag-azure-ai-search-csharp",
     "name": "custom-copilot-rag-azure-ai-search",
+    "alias": "teams-agent-rag-azure-ai-search",
     "language": "csharp",
     "displayName": "Teams Agent with Data from Azure AI Search",
     "description": "Agent that uses your content and knowledge to accurately answer domain-specific questions"
@@ -261,6 +286,7 @@
   {
     "id": "custom-copilot-rag-azure-ai-search-python",
     "name": "custom-copilot-rag-azure-ai-search",
+    "alias": "teams-agent-rag-azure-ai-search",
     "language": "python",
     "displayName": "Teams Agent with Data from Azure AI Search",
     "description": "Agent that uses your content and knowledge to accurately answer domain-specific questions"
@@ -268,6 +294,7 @@
   {
     "id": "custom-copilot-rag-custom-api-ts",
     "name": "custom-copilot-rag-custom-api",
+    "alias": "teams-agent-rag-custom-api",
     "language": "typescript",
     "displayName": "Teams Agent with Data from Custom API using OpenAPI Spec",
     "description": "Agent that uses your content and knowledge to accurately answer domain-specific questions"
@@ -275,6 +302,7 @@
   {
     "id": "custom-copilot-rag-custom-api-js",
     "name": "custom-copilot-rag-custom-api",
+    "alias": "teams-agent-rag-custom-api",
     "language": "javascript",
     "displayName": "Teams Agent with Data from Custom API using OpenAPI Spec",
     "description": "Agent that uses your content and knowledge to accurately answer domain-specific questions"
@@ -282,6 +310,7 @@
   {
     "id": "teams-agent-with-data-custom-api-v2-csharp",
     "name": "custom-copilot-rag-custom-api",
+    "alias": "teams-agent-rag-custom-api",
     "language": "csharp",
     "displayName": "Teams Agent with Data from Custom API using OpenAPI Spec",
     "description": "Agent that uses your content and knowledge to accurately answer domain-specific questions"
@@ -289,6 +318,7 @@
   {
     "id": "teams-agent-with-data-custom-api-v2-python",
     "name": "custom-copilot-rag-custom-api",
+    "alias": "teams-agent-rag-custom-api",
     "language": "python",
     "displayName": "Teams Agent with Data from Custom API using OpenAPI Spec",
     "description": "Agent that uses your content and knowledge to accurately answer domain-specific questions"
@@ -310,6 +340,7 @@
   {
     "id": "basic-tab-ts",
     "name": "non-sso-tab",
+    "alias": "tab",
     "language": "typescript",
     "displayName": "Tab",
     "description": "A simple implementation of a web app that's ready to customize"
@@ -317,6 +348,7 @@
   {
     "id": "default-bot-ts",
     "name": "default-bot",
+    "alias": "bot",
     "language": "typescript",
     "displayName": "Simple Bot",
     "description": "A simple implementation of an echo bot that's ready for customization"
@@ -324,6 +356,7 @@
   {
     "id": "default-bot-js",
     "name": "default-bot",
+    "alias": "bot",
     "language": "javascript",
     "displayName": "Simple Bot",
     "description": "A simple implementation of an echo bot that's ready for customization"
@@ -331,6 +364,7 @@
   {
     "id": "default-bot-python",
     "name": "default-bot",
+    "alias": "bot",
     "language": "python",
     "displayName": "Simple Bot",
     "description": "A simple implementation of an echo bot that's ready for customization"
@@ -338,6 +372,7 @@
   {
     "id": "message-extension-v2-ts",
     "name": "default-message-extension",
+    "alias": "message-extension",
     "language": "typescript",
     "displayName": "Message Extension",
     "description": "Receive user input, process it, and send customized results"
@@ -345,6 +380,7 @@
   {
     "id": "message-extension-v2-python",
     "name": "default-message-extension",
+    "alias": "message-extension",
     "language": "python",
     "displayName": "Message Extension",
     "description": "Receive user input, process it, and send customized results"

--- a/packages/fx-core/templates/metadata/defaultGeneratorTemplates.json
+++ b/packages/fx-core/templates/metadata/defaultGeneratorTemplates.json
@@ -51,6 +51,7 @@
   {
     "id": "custom-copilot-basic-ts",
     "name": "custom-copilot-basic",
+    "alias": "teams-agent",
     "language": "typescript",
     "displayName": "General Teams Agent",
     "description": "Agent that chats with users in Teams built with Teams AI Library and connects to LLMs"
@@ -58,6 +59,7 @@
   {
     "id": "custom-copilot-basic-js",
     "name": "custom-copilot-basic",
+    "alias": "teams-agent",
     "language": "javascript",
     "displayName": "General Teams Agent",
     "description": "Agent that chats with users in Teams built with Teams AI Library and connects to LLMs"
@@ -65,6 +67,7 @@
   {
     "id": "custom-copilot-basic-csharp",
     "name": "custom-copilot-basic",
+    "alias": "teams-agent",
     "language": "csharp",
     "displayName": "General Teams Agent",
     "description": "Agent that chats with users in Teams built with Teams AI Library and connects to LLMs"
@@ -72,6 +75,7 @@
   {
     "id": "custom-copilot-basic-python",
     "name": "custom-copilot-basic",
+    "alias": "teams-agent",
     "language": "python",
     "displayName": "General Teams Agent",
     "description": "Agent that chats with users in Teams built with Teams AI Library and connects to LLMs"
@@ -79,6 +83,7 @@
   {
     "id": "custom-copilot-rag-customize-ts",
     "name": "custom-copilot-rag-customize",
+    "alias": "teams-agent-rag-customize",
     "language": "typescript",
     "displayName": "Teams Agent with Data from Customized Source",
     "description": "Agent that uses your content and knowledge to accurately answer domain-specific questions"
@@ -86,6 +91,7 @@
   {
     "id": "custom-copilot-rag-customize-js",
     "name": "custom-copilot-rag-customize",
+    "alias": "teams-agent-rag-customize",
     "language": "javascript",
     "displayName": "Teams Agent with Data from Customized Source",
     "description": "Agent that uses your content and knowledge to accurately answer domain-specific questions"
@@ -93,6 +99,7 @@
   {
     "id": "custom-copilot-rag-customize-csharp",
     "name": "custom-copilot-rag-customize",
+    "alias": "teams-agent-rag-customize",
     "language": "csharp",
     "displayName": "Teams Agent with Data from Customized Source",
     "description": "Agent that uses your content and knowledge to accurately answer domain-specific questions"
@@ -100,6 +107,7 @@
   {
     "id": "custom-copilot-rag-customize-python",
     "name": "custom-copilot-rag-customize",
+    "alias": "teams-agent-rag-customize",
     "language": "python",
     "displayName": "Teams Agent with Data from Customized Source",
     "description": "Agent that uses your content and knowledge to accurately answer domain-specific questions"
@@ -107,6 +115,7 @@
   {
     "id": "custom-copilot-rag-azure-ai-search-ts",
     "name": "custom-copilot-rag-azure-ai-search",
+    "alias": "teams-agent-rag-azure-ai-search",
     "language": "typescript",
     "displayName": "Teams Agent with Data from Azure AI Search",
     "description": "Agent that uses your content and knowledge to accurately answer domain-specific questions"
@@ -114,6 +123,7 @@
   {
     "id": "custom-copilot-rag-azure-ai-search-js",
     "name": "custom-copilot-rag-azure-ai-search",
+    "alias": "teams-agent-rag-azure-ai-search",
     "language": "javascript",
     "displayName": "Teams Agent with Data from Azure AI Search",
     "description": "Agent that uses your content and knowledge to accurately answer domain-specific questions"
@@ -121,6 +131,7 @@
   {
     "id": "custom-copilot-rag-azure-ai-search-csharp",
     "name": "custom-copilot-rag-azure-ai-search",
+    "alias": "teams-agent-rag-azure-ai-search",
     "language": "csharp",
     "displayName": "Teams Agent with Data from Azure AI Search",
     "description": "Agent that uses your content and knowledge to accurately answer domain-specific questions"
@@ -128,6 +139,7 @@
   {
     "id": "custom-copilot-rag-azure-ai-search-python",
     "name": "custom-copilot-rag-azure-ai-search",
+    "alias": "teams-agent-rag-azure-ai-search",
     "language": "python",
     "displayName": "Teams Agent with Data from Azure AI Search",
     "description": "Agent that uses your content and knowledge to accurately answer domain-specific questions"
@@ -149,6 +161,7 @@
   {
     "id": "basic-tab-ts",
     "name": "non-sso-tab",
+    "alias": "tab",
     "language": "typescript",
     "displayName": "Tab",
     "description": "A simple implementation of a web app that's ready to customize"
@@ -156,6 +169,7 @@
   {
     "id": "default-bot-ts",
     "name": "default-bot",
+    "alias": "bot",
     "language": "typescript",
     "displayName": "Simple Bot",
     "description": "A simple implementation of an echo bot that's ready for customization"
@@ -163,6 +177,7 @@
   {
     "id": "default-bot-js",
     "name": "default-bot",
+    "alias": "bot",
     "language": "javascript",
     "displayName": "Simple Bot",
     "description": "A simple implementation of an echo bot that's ready for customization"
@@ -170,6 +185,7 @@
   {
     "id": "default-bot-python",
     "name": "default-bot",
+    "alias": "bot",
     "language": "python",
     "displayName": "Simple Bot",
     "description": "A simple implementation of an echo bot that's ready for customization"
@@ -177,6 +193,7 @@
   {
     "id": "message-extension-v2-ts",
     "name": "default-message-extension",
+    "alias": "message-extension",
     "language": "typescript",
     "displayName": "Message Extension",
     "description": "Receive user input, process it, and send customized results"
@@ -184,6 +201,7 @@
   {
     "id": "message-extension-v2-python",
     "name": "default-message-extension",
+    "alias": "message-extension",
     "language": "python",
     "displayName": "Message Extension",
     "description": "Receive user input, process it, and send customized results"
@@ -226,6 +244,7 @@
   {
     "id": "graph-connector-ts",
     "name": "graph-connector",
+    "alias": "copilot-connector",
     "language": "typescript",
     "displayName": "Copilot Connector",
     "description": "Embed your organization data to make it searchable in Microsoft 365 Copilot"

--- a/packages/fx-core/templates/metadata/defaultGeneratorTemplates.json
+++ b/packages/fx-core/templates/metadata/defaultGeneratorTemplates.json
@@ -250,8 +250,8 @@
     "description": "Embed your organization data to make it searchable in Microsoft 365 Copilot"
   },
   {
-    "id": "foundry-agent-ts",
-    "name": "foundry-agent",
+    "id": "foundry-agent-to-m365-ts",
+    "name": "foundry-agent-to-m365",
     "language": "typescript",
     "displayName": "Foundry Agent",
     "description": "An Microsoft 365 Agent that connects to Microsoft AI Foundry Agent."

--- a/templates/src/metadata/declarativeAgent.ts
+++ b/templates/src/metadata/declarativeAgent.ts
@@ -1,13 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { TemplateNames } from "../templateNames";
+import { TemplateAlias, TemplateNames } from "../templateNames";
 import { Template } from "./interface";
 
 export const declarativeAgentTemplates: Template[] = [
   {
     id: "declarative-agent-basic",
     name: TemplateNames.DeclarativeAgentBasic,
+    alias: TemplateAlias.DeclarativeAgentBasic,
     language: "common",
     displayName: "Declarative Agent",
     description: "Basic Declarative Agent without action",
@@ -15,6 +16,7 @@ export const declarativeAgentTemplates: Template[] = [
   {
     id: "declarative-agent-basic-csharp",
     name: TemplateNames.DeclarativeAgentBasic,
+    alias: TemplateAlias.DeclarativeAgentBasic,
     language: "csharp",
     displayName: "Declarative Agent",
     description: "Basic Declarative Agent without action",
@@ -22,6 +24,7 @@ export const declarativeAgentTemplates: Template[] = [
   {
     id: "declarative-agent-with-action-from-scratch-ts",
     name: TemplateNames.DeclarativeAgentWithActionFromScratch,
+    alias: TemplateAlias.DeclarativeAgentWithActionFromScratch,
     language: "typescript",
     displayName: "Declarative Agent with Action from Scratch",
     description: "Declarative Agent with a new action built from scratch",
@@ -29,6 +32,7 @@ export const declarativeAgentTemplates: Template[] = [
   {
     id: "declarative-agent-with-action-from-scratch-js",
     name: TemplateNames.DeclarativeAgentWithActionFromScratch,
+    alias: TemplateAlias.DeclarativeAgentWithActionFromScratch,
     language: "javascript",
     displayName: "Declarative Agent with Action from Scratch",
     description: "Declarative Agent with a new action built from scratch",
@@ -36,6 +40,7 @@ export const declarativeAgentTemplates: Template[] = [
   {
     id: "declarative-agent-with-action-from-scratch-csharp",
     name: TemplateNames.DeclarativeAgentWithActionFromScratch,
+    alias: TemplateAlias.DeclarativeAgentWithActionFromScratch,
     language: "csharp",
     displayName: "Declarative Agent with Action from Scratch",
     description: "Declarative Agent with a new action built from scratch",
@@ -43,6 +48,7 @@ export const declarativeAgentTemplates: Template[] = [
   {
     id: "declarative-agent-with-action-from-scratch-bearer-ts",
     name: TemplateNames.DeclarativeAgentWithActionFromScratchBearer,
+    alias: TemplateAlias.DeclarativeAgentWithActionFromScratchBearer,
     language: "typescript",
     displayName: "Declarative Agent with Action from Scratch (Bearer Token)",
     description:
@@ -51,6 +57,7 @@ export const declarativeAgentTemplates: Template[] = [
   {
     id: "declarative-agent-with-action-from-scratch-bearer-js",
     name: TemplateNames.DeclarativeAgentWithActionFromScratchBearer,
+    alias: TemplateAlias.DeclarativeAgentWithActionFromScratchBearer,
     language: "javascript",
     displayName: "Declarative Agent with Action from Scratch (Bearer Token)",
     description:
@@ -59,6 +66,7 @@ export const declarativeAgentTemplates: Template[] = [
   {
     id: "declarative-agent-with-action-from-scratch-bearer-csharp",
     name: TemplateNames.DeclarativeAgentWithActionFromScratchBearer,
+    alias: TemplateAlias.DeclarativeAgentWithActionFromScratchBearer,
     language: "csharp",
     displayName: "Declarative Agent with Action from Scratch (Bearer Token)",
     description:
@@ -67,6 +75,7 @@ export const declarativeAgentTemplates: Template[] = [
   {
     id: "declarative-agent-with-action-from-scratch-oauth-ts",
     name: TemplateNames.DeclarativeAgentWithActionFromScratchOAuth,
+    alias: TemplateAlias.DeclarativeAgentWithActionFromScratchOAuth,
     language: "typescript",
     displayName: "Declarative Agent with Action from Scratch (OAuth)",
     description:
@@ -75,6 +84,7 @@ export const declarativeAgentTemplates: Template[] = [
   {
     id: "declarative-agent-with-action-from-scratch-oauth-js",
     name: TemplateNames.DeclarativeAgentWithActionFromScratchOAuth,
+    alias: TemplateAlias.DeclarativeAgentWithActionFromScratchOAuth,
     language: "javascript",
     displayName: "Declarative Agent with Action from Scratch (OAuth)",
     description:
@@ -83,6 +93,7 @@ export const declarativeAgentTemplates: Template[] = [
   {
     id: "declarative-agent-with-action-from-scratch-oauth-csharp",
     name: TemplateNames.DeclarativeAgentWithActionFromScratchOAuth,
+    alias: TemplateAlias.DeclarativeAgentWithActionFromScratchOAuth,
     language: "csharp",
     displayName: "Declarative Agent with Action from Scratch (OAuth)",
     description:
@@ -105,6 +116,7 @@ export const declarativeAgentTemplates: Template[] = [
   {
     id: "declarative-agent-with-action-from-existing-api",
     name: TemplateNames.DeclarativeAgentWithActionFromExistingApiSpec,
+    alias: TemplateAlias.DeclarativeAgentWithActionFromExistingApiSpec,
     language: "none",
     displayName: "Declarative Agent with Action from Existing API",
     description: "Declarative Agent with action from an existing API specification",
@@ -112,6 +124,7 @@ export const declarativeAgentTemplates: Template[] = [
   {
     id: "declarative-agent-with-action-from-existing-api-csharp",
     name: TemplateNames.DeclarativeAgentWithActionFromExistingApiSpec,
+    alias: TemplateAlias.DeclarativeAgentWithActionFromExistingApiSpec,
     language: "csharp",
     displayName: "Declarative Agent with Action from Existing API",
     description: "Declarative Agent with action from an existing API specification",

--- a/templates/src/metadata/graphConnector.ts
+++ b/templates/src/metadata/graphConnector.ts
@@ -1,13 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { TemplateNames } from "../templateNames";
+import { TemplateAlias, TemplateNames } from "../templateNames";
 import { Template } from "./interface";
 
 export const graphConnectorTemplates: Template[] = [
   {
     id: "graph-connector-ts",
     name: TemplateNames.GraphConnector,
+    alias: TemplateAlias.GraphConnector,
     language: "typescript",
     displayName: "Copilot Connector",
     description: "Embed your organization data to make it searchable in Microsoft 365 Copilot",

--- a/templates/src/metadata/interface.ts
+++ b/templates/src/metadata/interface.ts
@@ -4,6 +4,7 @@
 export interface Template {
   id: string; // internal unique identifier for scaffolding a template folder
   name: string; // unique in UI entry except language and also used in telemetry
+  alias?: string; // user friendly name, could be different from name field, used by cli to scaffold template
   language: "typescript" | "javascript" | "csharp" | "python" | "none" | "common";
   displayName?: string; // used by CLI to show a friendly name
   description: string;

--- a/templates/src/metadata/special.ts
+++ b/templates/src/metadata/special.ts
@@ -37,7 +37,7 @@ export const specialTemplates: Template[] = [
 ];
 
 export const foundryAgentTemplate: Template = {
-  id: "foundry-agent-ts",
+  id: "foundry-agent-to-m365-ts",
   name: TemplateNames.FoundryAgent,
   language: "typescript",
   displayName: "Foundry Agent",

--- a/templates/src/metadata/teams.ts
+++ b/templates/src/metadata/teams.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { TemplateNames } from "../templateNames";
+import { TemplateAlias, TemplateNames } from "../templateNames";
 import { getString } from "../ui/helper";
 import { Template } from "./interface";
 
@@ -9,6 +9,7 @@ export const generalTeamsAgentTemplates: Template[] = [
   {
     id: "custom-copilot-basic-ts",
     name: TemplateNames.CustomCopilotBasic,
+    alias: TemplateAlias.CustomCopilotBasic,
     language: "typescript",
     displayName: getString("template.teams.general.label"),
     description: getString("template.teams.general.detail"),
@@ -16,6 +17,7 @@ export const generalTeamsAgentTemplates: Template[] = [
   {
     id: "custom-copilot-basic-js",
     name: TemplateNames.CustomCopilotBasic,
+    alias: TemplateAlias.CustomCopilotBasic,
     language: "javascript",
     displayName: getString("template.teams.general.label"),
     description: getString("template.teams.general.detail"),
@@ -23,6 +25,7 @@ export const generalTeamsAgentTemplates: Template[] = [
   {
     id: "custom-copilot-basic-csharp",
     name: TemplateNames.CustomCopilotBasic,
+    alias: TemplateAlias.CustomCopilotBasic,
     language: "csharp",
     displayName: getString("template.teams.general.label"),
     description: getString("template.teams.general.detail"),
@@ -30,6 +33,7 @@ export const generalTeamsAgentTemplates: Template[] = [
   {
     id: "custom-copilot-basic-python",
     name: TemplateNames.CustomCopilotBasic,
+    alias: TemplateAlias.CustomCopilotBasic,
     language: "python",
     displayName: getString("template.teams.general.label"),
     description: getString("template.teams.general.detail"),
@@ -40,6 +44,7 @@ export const chatWithYourDataTemplates: Template[] = [
   {
     id: "custom-copilot-rag-customize-ts",
     name: TemplateNames.CustomCopilotRagCustomize,
+    alias: TemplateAlias.CustomCopilotRagCustomize,
     language: "typescript",
     displayName: "Teams Agent with Data from Customized Source",
     description: getString("template.teams.rag.detail"),
@@ -47,6 +52,7 @@ export const chatWithYourDataTemplates: Template[] = [
   {
     id: "custom-copilot-rag-customize-js",
     name: TemplateNames.CustomCopilotRagCustomize,
+    alias: TemplateAlias.CustomCopilotRagCustomize,
     language: "javascript",
     displayName: "Teams Agent with Data from Customized Source",
     description: getString("template.teams.rag.detail"),
@@ -54,6 +60,7 @@ export const chatWithYourDataTemplates: Template[] = [
   {
     id: "custom-copilot-rag-customize-csharp",
     name: TemplateNames.CustomCopilotRagCustomize,
+    alias: TemplateAlias.CustomCopilotRagCustomize,
     language: "csharp",
     displayName: "Teams Agent with Data from Customized Source",
     description: getString("template.teams.rag.detail"),
@@ -61,6 +68,7 @@ export const chatWithYourDataTemplates: Template[] = [
   {
     id: "custom-copilot-rag-customize-python",
     name: TemplateNames.CustomCopilotRagCustomize,
+    alias: TemplateAlias.CustomCopilotRagCustomize,
     language: "python",
     displayName: "Teams Agent with Data from Customized Source",
     description: getString("template.teams.rag.detail"),
@@ -68,6 +76,7 @@ export const chatWithYourDataTemplates: Template[] = [
   {
     id: "custom-copilot-rag-azure-ai-search-ts",
     name: TemplateNames.CustomCopilotRagAzureAISearch,
+    alias: TemplateAlias.CustomCopilotRagAzureAISearch,
     language: "typescript",
     displayName: "Teams Agent with Data from Azure AI Search",
     description: getString("template.teams.rag.detail"),
@@ -75,6 +84,7 @@ export const chatWithYourDataTemplates: Template[] = [
   {
     id: "custom-copilot-rag-azure-ai-search-js",
     name: TemplateNames.CustomCopilotRagAzureAISearch,
+    alias: TemplateAlias.CustomCopilotRagAzureAISearch,
     language: "javascript",
     displayName: "Teams Agent with Data from Azure AI Search",
     description: getString("template.teams.rag.detail"),
@@ -82,6 +92,7 @@ export const chatWithYourDataTemplates: Template[] = [
   {
     id: "custom-copilot-rag-azure-ai-search-csharp",
     name: TemplateNames.CustomCopilotRagAzureAISearch,
+    alias: TemplateAlias.CustomCopilotRagAzureAISearch,
     language: "csharp",
     displayName: "Teams Agent with Data from Azure AI Search",
     description: getString("template.teams.rag.detail"),
@@ -89,6 +100,7 @@ export const chatWithYourDataTemplates: Template[] = [
   {
     id: "custom-copilot-rag-azure-ai-search-python",
     name: TemplateNames.CustomCopilotRagAzureAISearch,
+    alias: TemplateAlias.CustomCopilotRagAzureAISearch,
     language: "python",
     displayName: "Teams Agent with Data from Azure AI Search",
     description: getString("template.teams.rag.detail"),
@@ -162,6 +174,7 @@ export const customApiFromOpenApiSpecTemplates: Template[] = [
   {
     id: "custom-copilot-rag-custom-api-ts",
     name: TemplateNames.CustomCopilotRagCustomApi,
+    alias: TemplateAlias.CustomCopilotRagCustomApi,
     language: "typescript",
     displayName: "Teams Agent with Data from Custom API using OpenAPI Spec",
     description: getString("template.teams.rag.detail"),
@@ -169,6 +182,7 @@ export const customApiFromOpenApiSpecTemplates: Template[] = [
   {
     id: "custom-copilot-rag-custom-api-js",
     name: TemplateNames.CustomCopilotRagCustomApi,
+    alias: TemplateAlias.CustomCopilotRagCustomApi,
     language: "javascript",
     displayName: "Teams Agent with Data from Custom API using OpenAPI Spec",
     description: getString("template.teams.rag.detail"),
@@ -176,6 +190,7 @@ export const customApiFromOpenApiSpecTemplates: Template[] = [
   {
     id: "teams-agent-with-data-custom-api-v2-csharp",
     name: TemplateNames.CustomCopilotRagCustomApi,
+    alias: TemplateAlias.CustomCopilotRagCustomApi,
     language: "csharp",
     displayName: "Teams Agent with Data from Custom API using OpenAPI Spec",
     description: getString("template.teams.rag.detail"),
@@ -183,6 +198,7 @@ export const customApiFromOpenApiSpecTemplates: Template[] = [
   {
     id: "teams-agent-with-data-custom-api-v2-python",
     name: TemplateNames.CustomCopilotRagCustomApi,
+    alias: TemplateAlias.CustomCopilotRagCustomApi,
     language: "python",
     displayName: "Teams Agent with Data from Custom API using OpenAPI Spec",
     description: getString("template.teams.rag.detail"),
@@ -210,6 +226,7 @@ export const teamsOtherTemplates: Template[] = [
   {
     id: "basic-tab-ts",
     name: TemplateNames.Tab,
+    alias: TemplateAlias.Tab,
     language: "typescript",
     displayName: getString("template.teams.others.tab.label"),
     description: getString("template.teams.others.tab.detail"),
@@ -217,6 +234,7 @@ export const teamsOtherTemplates: Template[] = [
   {
     id: "default-bot-ts",
     name: TemplateNames.DefaultBot,
+    alias: TemplateAlias.DefaultBot,
     language: "typescript",
     displayName: getString("template.teams.others.bot.label"),
     description: getString("template.teams.others.bot.detail"),
@@ -224,6 +242,7 @@ export const teamsOtherTemplates: Template[] = [
   {
     id: "default-bot-js",
     name: TemplateNames.DefaultBot,
+    alias: TemplateAlias.DefaultBot,
     language: "javascript",
     displayName: getString("template.teams.others.bot.label"),
     description: getString("template.teams.others.bot.detail"),
@@ -231,6 +250,7 @@ export const teamsOtherTemplates: Template[] = [
   {
     id: "default-bot-python",
     name: TemplateNames.DefaultBot,
+    alias: TemplateAlias.DefaultBot,
     language: "python",
     displayName: getString("template.teams.others.bot.label"),
     description: getString("template.teams.others.bot.detail"),
@@ -238,6 +258,7 @@ export const teamsOtherTemplates: Template[] = [
   {
     id: "message-extension-v2-ts",
     name: TemplateNames.DefaultMessageExtension,
+    alias: TemplateAlias.DefaultMessageExtension,
     language: "typescript",
     displayName: getString("template.teams.others.messageExtension.label"),
     description: getString("template.teams.others.messageExtension.detail"),
@@ -245,6 +266,7 @@ export const teamsOtherTemplates: Template[] = [
   {
     id: "message-extension-v2-python",
     name: TemplateNames.DefaultMessageExtension,
+    alias: TemplateAlias.DefaultMessageExtension,
     language: "python",
     displayName: getString("template.teams.others.messageExtension.label"),
     description: getString("template.teams.others.messageExtension.detail"),

--- a/templates/src/templateNames.ts
+++ b/templates/src/templateNames.ts
@@ -74,7 +74,7 @@ export enum TemplateNames {
   Empty = "empty",
   MessageExtensionSearch = "message-extension-search",
 
-  FoundryAgent = "foundry-agent",
+  FoundryAgent = "foundry-agent-to-m365",
 }
 
 export enum TemplateAlias {

--- a/templates/src/templateNames.ts
+++ b/templates/src/templateNames.ts
@@ -76,3 +76,33 @@ export enum TemplateNames {
 
   FoundryAgent = "foundry-agent",
 }
+
+export enum TemplateAlias {
+  // declarative agent
+  DeclarativeAgentBasic = "declarative-agent",
+  DeclarativeAgentWithActionFromScratch = "declarative-agent-action",
+  DeclarativeAgentWithActionFromScratchBearer = "declarative-agent-action-bearer",
+  DeclarativeAgentWithActionFromScratchOAuth = "declarative-agent-action-oauth",
+  DeclarativeAgentWithActionFromExistingApiSpec = "declarative-agent-action-from-existing-api",
+  DeclarativeAgentWithExistingAction = "declarative-agent-existing-action",
+
+  // agent for Teams
+  CustomCopilotBasic = "teams-agent",
+  CustomCopilotRagCustomize = "teams-agent-rag-customize",
+  CustomCopilotRagAzureAISearch = "teams-agent-rag-azure-ai-search",
+  CustomCopilotRagCustomApi = "teams-agent-rag-custom-api",
+
+  // Copilot connector
+  GraphConnector = "copilot-connector",
+
+  // tab
+  Tab = "tab",
+  TabSSR = "tab-ssr", // handled by SsrTabGenerator
+  SsoTabSSR = "sso-tab-ssr", // handled by SsrTabGenerator
+
+  // bot
+  DefaultBot = "bot",
+
+  // messaging extension
+  DefaultMessageExtension = "message-extension",
+}


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/36965071/

Effect:
<img width="1639" height="902" alt="image" src="https://github.com/user-attachments/assets/496b8148-2848-4e2a-b0d1-de47fad975f4" />


This pull request introduces support for template aliases in the TeamsFx CLI, allowing users to refer to templates using more user-friendly or standardized names. The changes update the template metadata, CLI logic, and output formatting to utilize these aliases, improving the developer experience and making the CLI commands more intuitive.

**Template alias support and metadata enhancements:**

* Added an optional `alias` field to the `Template` interface and updated all relevant template entries in `allTemplates.json` to include meaningful aliases (e.g., `declarative-agent`, `bot`, `teams-agent`, etc.), as well as `displayName` where appropriate. This enables referencing templates by alias in CLI commands and outputs. [[1]](diffhunk://#diff-512b13ebd769e3b99f2479e4d5694cfc567775aa7d51c4d75d10f1857da92bc9R7-R8) [[2]](diffhunk://#diff-f197411e58db5c7b98d0801736467bc0375a1c0ebc0e5cca7787122a029005e6R5-R101) [[3]](diffhunk://#diff-f197411e58db5c7b98d0801736467bc0375a1c0ebc0e5cca7787122a029005e6R193-R321) [[4]](diffhunk://#diff-f197411e58db5c7b98d0801736467bc0375a1c0ebc0e5cca7787122a029005e6R343-R383)
* Updated the template listing and selection logic in the CLI to prefer displaying and matching on `alias` when available, falling back to `name` otherwise. This affects template choice lists, table outputs, and command matching. [[1]](diffhunk://#diff-08322dba58ad594fb8b437cca6686f3afcf97af3fd64cd3ca9be5f337fc337fdR9) [[2]](diffhunk://#diff-08322dba58ad594fb8b437cca6686f3afcf97af3fd64cd3ca9be5f337fc337fdR19) [[3]](diffhunk://#diff-08322dba58ad594fb8b437cca6686f3afcf97af3fd64cd3ca9be5f337fc337fdL34-R40) [[4]](diffhunk://#diff-08322dba58ad594fb8b437cca6686f3afcf97af3fd64cd3ca9be5f337fc337fdL74-R79) [[5]](diffhunk://#diff-08322dba58ad594fb8b437cca6686f3afcf97af3fd64cd3ca9be5f337fc337fdL108-R113) [[6]](diffhunk://#diff-2130140e1d728fdc5281195176e6ce75eac9d8b0f1b973b74ae7e83da61d7c5bL34-R34) [[7]](diffhunk://#diff-2130140e1d728fdc5281195176e6ce75eac9d8b0f1b973b74ae7e83da61d7c5bL75-R80)

**CLI command and example improvements:**

* Changed default and example CLI commands to use the new template aliases, such as replacing `copilot-gpt-basic` with `declarative-agent` in help messages and examples. [[1]](diffhunk://#diff-2130140e1d728fdc5281195176e6ce75eac9d8b0f1b973b74ae7e83da61d7c5bL49-R49) [[2]](diffhunk://#diff-c56a5887f3de27c5eba48e134709b33ad2c1e67b31447b7de501f6039b6e15f9L13-R40)

**Other updates:**

* Updated the advanced DA setting URL in the M365 constants to a new endpoint.
* Renamed the `foundry-agent` template to `foundry-agent-to-m365` for clarity and consistency.