### PR TITLE
fix: override dependency package to avoid warning during npm install

### DIFF
--- a/templates/vsc/ts/custom-copilot-basic/package.json.tpl
+++ b/templates/vsc/ts/custom-copilot-basic/package.json.tpl
@@ -39,5 +39,8 @@
         "typescript": "~5.8.3",
         "nodemon": "^3.1.7",
         "shx": "^0.4.0"
+    },
+    "overrides": {
+        "formdata-node": "6.0.3"
     }
 }


### PR DESCRIPTION
Fix the non security related warning https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/36931058/?view=edit