### PR TITLE
fix: Add repository information to package.json for fx-core

### DIFF
--- a/packages/fx-core/package.json
+++ b/packages/fx-core/package.json
@@ -4,6 +4,11 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/OfficeDev/microsoft-365-agents-toolkit.git",
+    "directory": "packages/fx-core"
+  },
   "scripts": {
     "lint:staged": "lint-staged",
     "lint": "eslint \"src/**/*.ts\" \"tests/**/*.ts\"",


### PR DESCRIPTION
this enables navigation to the repository from the npmjs website and other tools