### PR TITLE
chore: update vsversion to 18.4.2

### DIFF
--- a/packages/fx-core/src/common/templates-config.json
+++ b/packages/fx-core/src/common/templates-config.json
@@ -3,7 +3,7 @@
     "localVersion": "6.2.4",
     "tagPrefix": "templates@",
     "vstagPrefix": "templates-vs@",
-    "vsversion": "18.3.0",
+    "vsversion": "18.4.2",
     "tagListURL": "https://github.com/OfficeDev/microsoft-365-agents-toolkit/releases/download/template-tag-list/template-tags.txt",
     "templateDownloadBaseURL": "https://github.com/OfficeDev/microsoft-365-agents-toolkit/releases/download",
     "templateReleaseURL": "https://github.com/OfficeDev/microsoft-365-agents-toolkit/releases/expanded_assets",

--- a/packages/fx-core/tests/component/generator/utils.test.ts
+++ b/packages/fx-core/tests/component/generator/utils.test.ts
@@ -49,7 +49,7 @@ describe("utils unit test cases", () => {
       localVersion: "6.0.0",
       tagPrefix: "templates@",
       vstagPrefix: "templates-vs@",
-      vsversion: "18.3.0",
+      vsversion: "18.4.2",
       tagListURL:
         "https://github.com/OfficeDev/microsoft-365-agents-toolkit/releases/download/template-tag-list/template-tags.txt",
       templateDownloadBaseURL:

--- a/templates/package.json
+++ b/templates/package.json
@@ -3,7 +3,7 @@
     "version": "6.2.4",
     "private": "true",
     "license": "MIT",
-    "vsversion": "18.3.0",
+    "vsversion": "18.4.2",
     "scripts": {
         "check-sensitive": "npx eslint --plugin 'no-secrets' --cache --ignore-pattern 'package.json' --ignore-pattern 'package-lock.json'",
         "precommit": "npm run check-sensitive && lint-staged",


### PR DESCRIPTION
## Summary
- Bumps `vsversion` from `18.3.0` to `18.4.2` across three files, following the same pattern as #14922
- Updates `packages/fx-core/src/common/templates-config.json`
- Updates `templates/package.json`
- Updates test fixture in `packages/fx-core/tests/component/generator/utils.test.ts`

## Test plan
- [ ] Verify `vsversion` is `18.4.2` in `templates-config.json`
- [ ] Verify `vsversion` is `18.4.2` in `templates/package.json`
- [ ] Run unit tests: `cd packages/fx-core && npm run test:generator`