### PR TITLE
fix: update vs/csharp/teams-collaborator-agent manifest to v1.25

### DIFF
--- a/templates/vs/csharp/teams-collaborator-agent/appPackage/manifest.json.tpl
+++ b/templates/vs/csharp/teams-collaborator-agent/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.23/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.23",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.25/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.25",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {


### PR DESCRIPTION
## Summary

The `vs/csharp/teams-collaborator-agent` template was originally created in PR #14810 with `manifestVersion: 1.23`.

When PR #15265 upgraded all templates from `1.24` to `1.25`, this file was only **partially updated** - `supportsChannelFeatures: tier1` was added, but the schema URL and `manifestVersion` were not bumped from `1.23` to `1.25`.

## Changes

- `templates/vs/csharp/teams-collaborator-agent/appPackage/manifest.json.tpl`:
  - `manifestVersion`: `1.23` → `1.25`
