### PR TITLE
fix: always preserve supportsChannelFeatures when replacing bot IDs in Developer Portal scaffold

### DIFF
--- a/packages/fx-core/src/component/developerPortalScaffoldUtils.ts
+++ b/packages/fx-core/src/component/developerPortalScaffoldUtils.ts
@@ -180,6 +180,7 @@ async function updateManifest(
         manifest.bots = getBotsTplBasedOnVersion(manifest.manifestVersion);
         manifest.bots[0].botId = "${{BOT_ID}}";
       }
+      manifest.supportsChannelFeatures = existingManifestTemplate.supportsChannelFeatures;
     }
 
     if (inputs[QuestionNames.ReplaceBotIds].includes(answerToReplaceMessageExtensionBotId)) {
@@ -205,12 +206,13 @@ async function updateManifest(
     manifest.permissions = existingManifestTemplate.permissions;
     manifest.validDomains = existingManifestTemplate.validDomains;
     manifest.webApplicationInfo = existingManifestTemplate.webApplicationInfo;
-    if (
-      existingManifestTemplate.supportsChannelFeatures &&
-      "supportsChannelFeatures" in appDefinition
-    ) {
-      manifest.supportsChannelFeatures = existingManifestTemplate.supportsChannelFeatures;
-    }
+  }
+
+  if (
+    existingManifestTemplate.supportsChannelFeatures &&
+    "supportsChannelFeatures" in appDefinition
+  ) {
+    manifest.supportsChannelFeatures = existingManifestTemplate.supportsChannelFeatures;
   }
 
   // manifest: developer


### PR DESCRIPTION
## Summary

Cherry-pick of #15507 to release/VS184.

Fix the \supportsChannelFeatures\ field not being preserved when replacing bot IDs during Developer Portal import/scaffold.

### Changes
- Move the \supportsChannelFeatures\ assignment to always apply when replacing bot IDs (not just inside the bots condition block)
- Keep the existing conditional assignment for the general case (outside bot replacement block)

### Root Cause
The \supportsChannelFeatures\ was only being set inside the conditional block for bot ME tab replacement, causing it to be dropped in some code paths.