### PR TITLE
fix: fetch online template metadata on server startup to fix stale cache bug

### DIFF
--- a/packages/server/src/serverConnection.ts
+++ b/packages/server/src/serverConnection.ts
@@ -104,6 +104,7 @@ export default class ServerConnection implements IServerConnection {
   }
   public listen() {
     this.connection.listen();
+    void this.core.fetchOnlineTemplateMetadata();
   }
 
   public getQuestionsRequest(

--- a/templates/vs/csharp/custom-copilot-travel-agent/{{ProjectName}}.csproj.tpl
+++ b/templates/vs/csharp/custom-copilot-travel-agent/{{ProjectName}}.csproj.tpl
@@ -9,13 +9,13 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
-    <PackageReference Include="Azure.Identity" Version="1.17.0" />
     <PackageReference Include="AdaptiveCards" Version="3.1.0" />
+    <PackageReference Include="Azure.Identity" Version="1.19.0" />
     <PackageReference Include="Microsoft.Agents.AI" Version="1.0.0-preview.251028.1" />
     <PackageReference Include="Microsoft.Agents.M365Copilot.Beta" Version="1.0.0-preview.7" />
     <PackageReference Include="Microsoft.Extensions.AI" Version="9.10.1" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="9.10.1-preview.1.25521.4" />
-    <PackageReference Include="Microsoft.Graph" Version="5.95.0" />
+    <PackageReference Include="Microsoft.Graph" Version="5.103.0" />
     <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="1.*" />
     <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="1.*" />
   </ItemGroup>

--- a/templates/vs/csharp/custom-copilot-weather-agent/{{ProjectName}}.csproj.tpl
+++ b/templates/vs/csharp/custom-copilot-weather-agent/{{ProjectName}}.csproj.tpl
@@ -9,10 +9,11 @@
 
   <ItemGroup>
     <PackageReference Include="AdaptiveCards" Version="3.1.0" />
-    <PackageReference Include="Microsoft.SemanticKernel.Agents.AzureAI" Version="1.45.0-preview" />
-    <PackageReference Include="Microsoft.SemanticKernel.Agents.Core" Version="1.45.0" />
-    <PackageReference Include="Microsoft.SemanticKernel.Connectors.AzureOpenAI" Version="1.45.0" />
-    <PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.45.0" />
+    <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.5" />
+    <PackageReference Include="Microsoft.SemanticKernel.Agents.AzureAI" Version="1.73.0-preview" />
+    <PackageReference Include="Microsoft.SemanticKernel.Agents.Core" Version="1.73.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Connectors.AzureOpenAI" Version="1.73.0" />
+    <PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.73.0" />
     <PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="1.*" />
     <PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="1.*" />
   </ItemGroup>

--- a/templates/vs/csharp/foundry-proxy-agent/README.md.tpl
+++ b/templates/vs/csharp/foundry-proxy-agent/README.md.tpl
@@ -215,6 +215,27 @@ Create a Dev Tunnel via **Debug > Dev Tunnels > Create A Tunnel** with Public ac
 ### "Authentication failed"
 Ensure you're signed into Microsoft 365 Agents Toolkit with a work/school account that has access to your Azure subscription.
 
+### "AADSTS650052: Azure Machine Learning Services lacks a service principal"
+
+**Symptom:** The SSO token exchange fails at runtime with:
+```
+AuthenticationFailed / invalid_client
+AADSTS650052: The app is trying to access a service '18a66f5f-dbdf-4c17-9dd7-1634712a9cbe'
+(Azure Machine Learning Services) that your organization lacks a service principal for.
+```
+
+**Root cause:** This proxy agent exchanges the signed-in user's token for an `Azure Machine Learning | user_impersonation` token to call Azure AI Foundry. If your tenant has never provisioned any Azure ML or AI Foundry resources, the **Azure Machine Learning Services** enterprise application doesn't exist in your Entra ID tenant, and the token exchange fails.
+
+**Solution (requires Tenant Admin — one-time):**
+```powershell
+# Option 1 – Azure CLI
+az ad sp create --id 18a66f5f-dbdf-4c17-9dd7-1634712a9cbe
+
+# Option 2 – Azure PowerShell
+New-AzADServicePrincipal -ApplicationId 18a66f5f-dbdf-4c17-9dd7-1634712a9cbe
+```
+After the command completes, retry the agent — no restart is required.
+
 ## Learn More
 
 - [Microsoft 365 Agents Toolkit Documentation](https://aka.ms/teams-toolkit-vs-docs)

--- a/templates/vs/csharp/foundry-proxy-agent/README.md.tpl
+++ b/templates/vs/csharp/foundry-proxy-agent/README.md.tpl
@@ -53,7 +53,7 @@ This proxy pattern allows you to:
 ## Prerequisites
 
 Before you begin, ensure you have:
-- An **Azure AI Foundry** project with a deployed agent
+- An **Azure AI Foundry** project with a deployed agent, ensure the AI Foundry is in the same tenant with your m365 and your azure account. SSO is only available in single tenant.
 - Your **Foundry Project Endpoint** (e.g., `https://your-project.services.ai.azure.com/api/projects/your-project`)
 - Your **Agent ID** (e.g., `asst_xxxxxxxxxxxxx`)
 
@@ -99,6 +99,8 @@ If you need to update these values, edit `env/.env.local.user` directly.
 3. Sign in with a **Microsoft 365 work or school account**
 4. Set **Startup Item** to `Microsoft Teams (browser)` or `Microsoft M365 Copilot (browser)`
 5. Press **F5** to start debugging
+
+> **Having issues?** If you encounter any errors during or after debugging, see the [Troubleshooting](#troubleshooting) section below.
 
 ## What Happens During Local Debug (F5)
 
@@ -234,7 +236,10 @@ az ad sp create --id 18a66f5f-dbdf-4c17-9dd7-1634712a9cbe
 # Option 2 – Azure PowerShell
 New-AzADServicePrincipal -ApplicationId 18a66f5f-dbdf-4c17-9dd7-1634712a9cbe
 ```
-After the command completes, retry the agent — no restart is required.
+
+> **Note:** If the command fails with _"The service principal cannot be created because the service principal name `https://containeragents.ai.azure.com` is already in use"_, this means the **Azure Machine Learning Services** enterprise application is already present in your tenant. You can ignore the error and retry the agent directly — no further action is needed.
+
+After the command completes (or if the SP already exists), retry the agent — no restart is required.
 
 ## Learn More
 

--- a/templates/vs/csharp/teams-collaborator-agent/appPackage/manifest.json.tpl
+++ b/templates/vs/csharp/teams-collaborator-agent/appPackage/manifest.json.tpl
@@ -1,6 +1,6 @@
 {
-    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.23/MicrosoftTeams.schema.json",
-    "manifestVersion": "1.23",
+    "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.25/MicrosoftTeams.schema.json",
+    "manifestVersion": "1.25",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
     "developer": {


### PR DESCRIPTION
## Summary

Fixes the template metadata stale cache bug in VS by calling etchOnlineTemplateMetadata() from the server's listen() method on startup.

### Root Cause
VS server did not proactively refresh template metadata on startup. Customers with a stale ~/.fx/metadata/ cache (e.g., after installing a new VSIX with new templates like oundry-proxy-agent) would get NoActivatedGeneratorError because the cached defaultGeneratorTemplates.json did not include the new entry.

### Fix
Added oid this.core.fetchOnlineTemplateMetadata() in ServerConnection.listen() so the server triggers an async metadata fetch/refresh on every startup, ensuring the local cache stays in sync with the latest published 	emplates@ tag.

### Change
- packages/server/src/serverConnection.ts — call etchOnlineTemplateMetadata() on server listen