### PR TITLE
fix: fetch online template metadata on server startup to fix stale cache

### DIFF
--- a/packages/server/src/serverConnection.ts
+++ b/packages/server/src/serverConnection.ts
@@ -104,6 +104,7 @@ export default class ServerConnection implements IServerConnection {
   }
   public listen() {
     this.connection.listen();
+    void this.core.fetchOnlineTemplateMetadata();
   }
 
   public getQuestionsRequest(


### PR DESCRIPTION
## Summary

Fixes the template metadata stale cache bug in VS by calling FetchOnlineTemplateMetadata() from the server's listen() method on startup.

### Root Cause
VS server did not proactively refresh template metadata on startup. Customers with a stale ~/.fx/metadata/ cache (e.g., after installing a new VSIX with new templates like oundry-proxy-agent) would get NoActivatedGeneratorError because the cached defaultGeneratorTemplates.json did not include the new entry.

### Fix
Added oid this.core.fetchOnlineTemplateMetadata() in ServerConnection.listen() so the server triggers an async metadata fetch/refresh on every startup, ensuring the local cache stays in sync with the latest published 	emplates@ tag.

### Change
- packages/server/src/serverConnection.ts — call etchOnlineTemplateMetadata() on server listen