### PR TITLE
ci: add vsChannelName input to pass VS channel to ADO build pipeline

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,6 +20,11 @@ on:
         type: boolean
         default: false
         description: "Whether to release vs product"
+      vsChannelName:
+        type: string
+        default: "IntPreview"
+        description: "VS channel to target (IntPreview=main/Canary, IntRelease=rel/insiders, Release=rel/stable)"
+        required: false
       vstemplate:
         type: boolean
         default: false
@@ -507,6 +512,7 @@ jobs:
           echo ${{steps.version-change.outputs.CHANGED}} > changed.txt
           npx lerna ls -all --json > versions.json
           echo ${{ inputs.series }} > series.txt
+          echo ${{ inputs.vsChannelName || 'Release' }} > vschannel.txt
           find ./packages/vscode-extension -type f -name '*.vsix' -exec mv {} . \;
 
       - name: upload release info to artifact
@@ -516,6 +522,7 @@ jobs:
           path: |
             changed.txt
             series.txt
+            vschannel.txt
             versions.json
             *.vsix
             *.exe

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -512,7 +512,7 @@ jobs:
           echo ${{steps.version-change.outputs.CHANGED}} > changed.txt
           npx lerna ls -all --json > versions.json
           echo ${{ inputs.series }} > series.txt
-          echo ${{ inputs.vsChannelName || 'Release' }} > vschannel.txt
+          echo ${{ inputs.vsChannelName || 'IntPreview' }} > vschannel.txt
           find ./packages/vscode-extension -type f -name '*.vsix' -exec mv {} . \;
 
       - name: upload release info to artifact


### PR DESCRIPTION
## Summary

Add \sChannelName\ workflow input to \.github/workflows/cd.yml\ so callers can specify which VS channel the ADO build pipeline should target.

## Changes

- Added \sChannelName\ input (type: string, default: \Release\) to the workflow
- Writes the value to \schannel.txt\ in the \save release info\ step
- Includes \schannel.txt\ in the release artifact upload

## How it works

The ADO \cd.yml\ reads \schannel.txt\ from the downloaded artifact and passes it as \VsChannelName\ to \TriggerBuild@4\, which forwards it to \uild.yml\ where the \MicroBuildBuildVSBootstrapper@3\ task uses it as \channelName\.

Channel name mapping:
| Value | VS Branch | Channel |
|---|---|---|
| \IntPreview\ | main | Canary |
| \IntRelease\ | rel/insiders | Insiders |
| \Release\ | rel/stable | Stable |