### PR TITLE
fix: use colon as PATH separator for Linux in playground tasks

### DIFF
--- a/templates/vsc/ts/default-bot/.vscode/tasks.json
+++ b/templates/vsc/ts/default-bot/.vscode/tasks.json
@@ -153,7 +153,7 @@
       "isBackground": true,
       "options": {
         "env": {
-          "PATH": "${workspaceFolder}/devTools/playground/node_modules/.bin;${env:PATH}"
+          "PATH": "${workspaceFolder}/devTools/playground/node_modules/.bin:${env:PATH}"
         }
       },
       "windows": {

--- a/templates/vsc/ts/message-extension-v2/.vscode/tasks.json
+++ b/templates/vsc/ts/message-extension-v2/.vscode/tasks.json
@@ -70,7 +70,7 @@
       "isBackground": true,
       "options": {
         "env": {
-          "PATH": "${workspaceFolder}/devTools/playground/node_modules/.bin;${env:PATH}"
+          "PATH": "${workspaceFolder}/devTools/playground/node_modules/.bin:${env:PATH}"
         }
       },
       "windows": {


### PR DESCRIPTION
related bug: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/36610041
