### PR TITLE
fix: prevent garbled output in PowerShell on Windows

### DIFF
--- a/packages/vscode-ui/src/ui.ts
+++ b/packages/vscode-ui/src/ui.ts
@@ -1140,7 +1140,7 @@ export class VSCodeUI implements UserInteraction {
     if (isWindows) {
       // PowerShell script for Windows
       // Capture output to file within the script itself for compatibility
-      scriptContent = `$ErrorActionPreference = 'Continue'\n& {\n${cmd}\n} 2>&1 | ForEach-Object { $_ | Out-File -FilePath "${tempFile}" -Encoding utf8 -Append; $_ }\n`;
+      scriptContent = `[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; $OutputEncoding = [System.Text.Encoding]::UTF8; $ErrorActionPreference = 'Continue'\n& {\n${cmd}\n} 2>&1 | ForEach-Object { $_ | Out-File -FilePath "${tempFile}" -Encoding utf8 -Append; $_ }\n`;
       // Use the shell parameter if provided, otherwise default to powershell for broader compatibility
       const shellCmd = args.shell || "powershell";
       wrappedCmd = `${shellCmd} -NoProfile -ExecutionPolicy Bypass -File "${scriptFile}"`;


### PR DESCRIPTION
[Bug 36950739](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/36950739): [VSC] Sometimes unreadable code may appear during the deployment process in  Tab project