### PR TITLE
feat(fx-core): decouple VS/VSC template release with dynamic version lookup

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -348,16 +348,17 @@ jobs:
 
       - name: Release RC VS templates to GitHub
         if: ${{ contains(steps.version-change.outputs.CHANGED, 'templates@') && github.event_name == 'workflow_dispatch' && github.event.inputs.vsrelease == 'true' }}
-        uses: mini-bomba/create-github-release@v1.2.0
+        uses: ncipollo/release-action@v1.10.0
         with:
           token: ${{ steps.generate-token.outputs.token }}
           tag: "templates-vs@0.0.0-rc"
           name: "templates-vs@0.0.0-rc"
           body: "VS Templates RC release for templates-vs@0.0.0-rc"
-          target_commit: ${{ github.sha }}
+          commit: ${{ github.sha }}
           prerelease: true
-          clear_attachments: true
-          files: |
+          allowUpdates: true
+          removeArtifacts: true
+          artifacts: |
             ${{ github.workspace }}/templates/build/fallback/csharp.zip
             ${{ github.workspace }}/templates/build/metadata.zip
       
@@ -369,16 +370,17 @@ jobs:
           echo "VSTAG=templates-vs@$VS_VERSION" >> $GITHUB_OUTPUT
 
       - name: Release stable VS Templates to GitHub
-        uses: mini-bomba/create-github-release@v1.2.0
+        uses: ncipollo/release-action@v1.10.0
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.vsrelease == 'true' && github.event.inputs.vstemplate == 'true' }}
         with:
           token: ${{ steps.generate-token.outputs.token }}
           tag: ${{ steps.vs-template-tag.outputs.VSTAG }}
           name: ${{ steps.vs-template-tag.outputs.VSTAG }}
           body: "VS Templates release for ${{ steps.vs-template-tag.outputs.VSTAG }}"
-          target_commit: ${{ github.sha }}
-          clear_attachments: true
-          files: |
+          commit: ${{ github.sha }}
+          allowUpdates: true
+          removeArtifacts: true
+          artifacts: |
             ${{ github.workspace }}/templates/build/fallback/csharp.zip
             ${{ github.workspace }}/templates/build/metadata.zip
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -359,6 +359,7 @@ jobs:
           clear_attachments: true
           files: |
             ${{ github.workspace }}/templates/build/fallback/csharp.zip
+            ${{ github.workspace }}/templates/build/metadata.zip
       
       - name: Get VS Templates version
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.vsrelease == 'true' && github.event.inputs.vstemplate == 'true' }}
@@ -379,6 +380,22 @@ jobs:
           clear_attachments: true
           files: |
             ${{ github.workspace }}/templates/build/fallback/csharp.zip
+            ${{ github.workspace }}/templates/build/metadata.zip
+
+      - name: Generate Tag List (VS stable release)
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.vsrelease == 'true' && github.event.inputs.vstemplate == 'true' }}
+        run: git tag | grep templates > ${{ runner.temp }}/template-tags.txt
+
+      - name: Update Template Tag list Release (VS stable release)
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.vsrelease == 'true' && github.event.inputs.vstemplate == 'true' }}
+        uses: ncipollo/release-action@v1.10.0
+        with:
+          artifacts: ${{ runner.temp }}/template-tags.txt
+          name: "Template Tag List"
+          body: "Release to maintain template tag list."
+          token: ${{ steps.generate-token.outputs.token }}
+          tag: "template-tag-list"
+          allowUpdates: true
 
       - name: enable prerelease only features
         if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && (github.event.inputs.preid == 'alpha' || github.event.inputs.preid == 'preview')) }}

--- a/packages/cli/src/commands/engine.ts
+++ b/packages/cli/src/commands/engine.ts
@@ -68,6 +68,9 @@ class CLIEngine {
   async start(rootCmd: CLICommand): Promise<void> {
     Correlator.setId();
 
+    // Fire-and-forget: fetch latest metadata in background, same as VSC extension activation
+    void getFxCore().fetchOnlineTemplateMetadata();
+
     this.debugLogs = [];
 
     const root = cloneDeep(rootCmd);

--- a/packages/fx-core/src/common/templates-config.json
+++ b/packages/fx-core/src/common/templates-config.json
@@ -4,6 +4,7 @@
     "tagPrefix": "templates@",
     "vstagPrefix": "templates-vs@",
     "vsversion": "18.4.2",
+    "vsVersionPattern": "~18.4",
     "tagListURL": "https://github.com/OfficeDev/microsoft-365-agents-toolkit/releases/download/template-tag-list/template-tags.txt",
     "templateDownloadBaseURL": "https://github.com/OfficeDev/microsoft-365-agents-toolkit/releases/download",
     "templateReleaseURL": "https://github.com/OfficeDev/microsoft-365-agents-toolkit/releases/expanded_assets",

--- a/packages/fx-core/src/component/generator/templates/metadata/index.ts
+++ b/packages/fx-core/src/component/generator/templates/metadata/index.ts
@@ -9,13 +9,14 @@ import { getTemplatesFolder } from "../../../../folder";
 import { useLocalTemplate } from "../../templateHelper";
 import { Template } from "./interface";
 
-function getTemplateMetadataConfig(configName: string): Template[] {
+function getTemplateMetadataConfig(configName: string, platform?: Platform): Template[] {
   let jsonPath: string;
 
+  const cacheSubDir = platform === Platform.VS ? "vs-metadata" : "metadata";
   const cachedJsonPath = path.join(
     os.homedir(),
     `.${String(ConfigFolderName)}`,
-    "metadata",
+    cacheSubDir,
     configName
   );
 
@@ -32,7 +33,7 @@ function getTemplateMetadataConfig(configName: string): Template[] {
 
 // used by programming language question options filter
 export function getAllTemplatesOnPlatform(platform: Platform): Template[] {
-  const allTemplates = getTemplateMetadataConfig("allTemplates.json");
+  const allTemplates = getTemplateMetadataConfig("allTemplates.json", platform);
   switch (platform) {
     case Platform.VSCode:
       return allTemplates.filter((t) => t.language !== "csharp");
@@ -47,7 +48,10 @@ export function getAllTemplatesOnPlatform(platform: Platform): Template[] {
 
 // used by default generator
 export function getDefaultTemplatesOnPlatform(platform: Platform): Template[] {
-  const defaultGeneratorTemplates = getTemplateMetadataConfig("defaultGeneratorTemplates.json");
+  const defaultGeneratorTemplates = getTemplateMetadataConfig(
+    "defaultGeneratorTemplates.json",
+    platform
+  );
   switch (platform) {
     case Platform.VSCode:
       return defaultGeneratorTemplates.filter((t) => t.language !== "csharp");

--- a/packages/fx-core/src/component/generator/utils.ts
+++ b/packages/fx-core/src/component/generator/utils.ts
@@ -36,7 +36,7 @@ export async function getTemplateUrl(
   platform?: Platform
 ): Promise<string | undefined> {
   return platform === Platform.VS
-    ? getTemplateVSUrl(programmingLanguage)
+    ? await getTemplateVSUrl(programmingLanguage)
     : await getTemplateVSCUrl(programmingLanguage, getLatestVersion);
 }
 
@@ -76,26 +76,32 @@ async function getTemplateVSCUrl(
   }
 }
 
-function getTemplateVSUrl(name: string): string | undefined {
+async function getTemplateVSUrl(name: string): Promise<string | undefined> {
   // If the template is a daily version, return undefined to use local template.
   if (templateConfig.useLocalTemplate) {
     return;
   }
-  // If the template is a prerelease version, use the "0.0.0-rc" version.
+  // Env override: explicit prerelease flag → use RC version.
   if (process.env.TEAMSFX_TEMPLATE_PRERELEASE === Platform.VS) {
     return getTemplateZipUrlByVersion(name, "0.0.0-rc", templateConfig.vstagPrefix);
   }
-  // If the template is stable version, use the latest stable version.
-  return getTemplateZipUrlByVersion(name, templateConfig.vsversion, templateConfig.vstagPrefix);
+  // VS stable release ships with a beta fx-core (unlike VSC which ships stable).
+  // A beta fx-core therefore indicates a pre-release test build → use RC templates.
+  const version: string = packageJson.version;
+  if (version.includes("beta")) {
+    return getTemplateZipUrlByVersion(name, "0.0.0-rc", templateConfig.vstagPrefix);
+  }
+  // Stable fx-core means an actual VS stable release → look up the latest stable VS templates.
+  const latestVsVersion = await getTemplateVSLatestVersion();
+  return getTemplateZipUrlByVersion(name, latestVsVersion, templateConfig.vstagPrefix);
 }
 
 async function selectTemplateVersion(
-  getTags: () => Promise<string[]>
+  getTags: () => Promise<string[]>,
+  tagPrefix: string = templateConfig.tagPrefix,
+  versionPattern: string = templateConfig.version
 ): Promise<string | undefined> {
-  const templateTagPrefix = templateConfig.tagPrefix;
-  const versionPattern = templateConfig.version;
-
-  const versionList = (await getTags()).map((tag: string) => tag.replace(templateTagPrefix, ""));
+  const versionList = (await getTags()).map((tag: string) => tag.replace(tagPrefix, ""));
   const selectedVersion = semver.maxSatisfying(versionList, versionPattern);
   return selectedVersion ?? undefined;
 }
@@ -123,6 +129,24 @@ export async function getTemplateLatestVersion(
   );
   if (!selectedVersion) {
     throw new Error(`Failed to find valid template`);
+  }
+  return selectedVersion;
+}
+
+export async function getTemplateVSLatestVersion(
+  tryLimits = defaultTryLimits,
+  timeoutInMs = defaultTimeoutInMs
+): Promise<string> {
+  const selectedVersion = await selectTemplateVersion(
+    async () =>
+      (await fetchTagList(templateConfig.tagListURL, tryLimits, timeoutInMs))
+        .replace(/\r/g, "")
+        .split("\n"),
+    templateConfig.vstagPrefix,
+    templateConfig.vsVersionPattern
+  );
+  if (!selectedVersion) {
+    throw new Error("Failed to find valid VS template version");
   }
   return selectedVersion;
 }

--- a/packages/fx-core/src/core/FxCore.ts
+++ b/packages/fx-core/src/core/FxCore.ts
@@ -146,7 +146,12 @@ import {
 } from "../component/generator/openApiSpec/helper";
 import { useLocalTemplate } from "../component/generator/templateHelper";
 import { TemplateNames } from "../component/generator/templates/templateNames";
-import { fetchZipFromUrl, getTemplateLatestVersion, unzip } from "../component/generator/utils";
+import {
+  fetchZipFromUrl,
+  getTemplateLatestVersion,
+  getTemplateVSLatestVersion,
+  unzip,
+} from "../component/generator/utils";
 import { LaunchHelper } from "../component/m365/launchHelper";
 import { PackageService } from "../component/m365/packageService";
 import { MosServiceScope } from "../common/constants";
@@ -2962,6 +2967,63 @@ export class FxCore extends FxCoreDeclarativeAgentPart {
       const message = error?.message || "Unknown error while fetching template metadata";
       const systemErr = new SystemError(
         "FetchOnlineTemplateMetadata",
+        "DownloadFailed",
+        message,
+        message
+      );
+      return err(systemErr);
+    }
+  }
+
+  /**
+   * dynamic VS template metadata download
+   */
+  @hooks([
+    ErrorContextMW({ component: "FxCore", stage: "fetchOnlineTemplateMetadataForVS" }),
+    ErrorHandlerMW,
+  ])
+  async fetchOnlineTemplateMetadataForVS(): Promise<Result<undefined, FxError>> {
+    if (useLocalTemplate()) {
+      return ok(undefined); // Skip if using local templates
+    }
+    try {
+      // VS ships stable templates with a stable fx-core and test/pre-release
+      // templates with a beta fx-core. So beta = pre-stable test build → RC.
+      const coreVersion = require("../../package.json").version as string;
+      const latestVersion = coreVersion.includes("beta")
+        ? "0.0.0-rc"
+        : await getTemplateVSLatestVersion();
+
+      const homedir = os.homedir();
+      const metadataDir = path.join(homedir, `.${String(ConfigFolderName)}`, "vs-metadata");
+      await fs.ensureDir(metadataDir);
+
+      const versionFile = path.join(metadataDir, "template-vs-version.txt");
+      const needDownload = async (): Promise<boolean> => {
+        if (!(await fs.pathExists(versionFile))) return true;
+        try {
+          const cachedVersion = (await fs.readFile(versionFile, "utf-8")).trim();
+          return cachedVersion !== latestVersion;
+        } catch {
+          return true;
+        }
+      };
+
+      if (!(await needDownload())) {
+        return ok(undefined); // Already up-to-date
+      }
+
+      const tag = `${templateConfig.vstagPrefix}${latestVersion}`;
+      const metadataZipUrl = `${templateConfig.templateDownloadBaseURL}/${tag}/metadata.zip`;
+
+      const zip = await fetchZipFromUrl(metadataZipUrl);
+      await unzip(zip, metadataDir);
+      await fs.writeFile(versionFile, latestVersion, { encoding: "utf-8" });
+      return ok(undefined);
+    } catch (error: any) {
+      const message = error?.message || "Unknown error while fetching VS template metadata";
+      const systemErr = new SystemError(
+        "FetchOnlineTemplateMetadataForVS",
         "DownloadFailed",
         message,
         message

--- a/packages/fx-core/tests/component/generator/templates/metadata.test.ts
+++ b/packages/fx-core/tests/component/generator/templates/metadata.test.ts
@@ -1,0 +1,218 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { Platform } from "@microsoft/teamsfx-api";
+import { assert } from "chai";
+import fs from "fs-extra";
+import "mocha";
+import * as path from "path";
+import * as sinon from "sinon";
+import {
+  getAllTemplatesOnPlatform,
+  getDefaultTemplatesOnPlatform,
+} from "../../../../src/component/generator/templates/metadata";
+import * as templateHelper from "../../../../src/component/generator/templateHelper";
+import * as folder from "../../../../src/folder";
+import { Template } from "../../../../src/component/generator/templates/metadata/interface";
+
+const mockTemplates: Template[] = [
+  { id: "t1", name: "TypeScript Bot", language: "typescript", description: "A TS bot" },
+  { id: "t2", name: "CSharp Bot", language: "csharp", description: "A C# bot" },
+  { id: "t3", name: "JavaScript Tab", language: "javascript", description: "A JS tab" },
+];
+
+describe("metadata platform routing", () => {
+  const sandbox = sinon.createSandbox();
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe("getAllTemplatesOnPlatform", () => {
+    it("reads from vs-metadata subdir when cache exists for Platform.VS", () => {
+      sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
+      sandbox.stub(folder, "getTemplatesFolder").returns("/bundled");
+      const pathExistsStub = sandbox.stub(fs, "pathExistsSync").returns(true);
+      sandbox.stub(fs, "readFileSync").returns(JSON.stringify(mockTemplates));
+
+      getAllTemplatesOnPlatform(Platform.VS);
+
+      const checkedPath = pathExistsStub.firstCall.args[0] as string;
+      assert.include(checkedPath, "vs-metadata");
+      assert.include(checkedPath, "allTemplates.json");
+    });
+
+    it("reads from metadata subdir when cache exists for Platform.VSCode", () => {
+      sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
+      sandbox.stub(folder, "getTemplatesFolder").returns("/bundled");
+      const pathExistsStub = sandbox.stub(fs, "pathExistsSync").returns(true);
+      sandbox.stub(fs, "readFileSync").returns(JSON.stringify(mockTemplates));
+
+      getAllTemplatesOnPlatform(Platform.VSCode);
+
+      const checkedPath = pathExistsStub.firstCall.args[0] as string;
+      assert.notInclude(checkedPath, "vs-metadata");
+      assert.include(checkedPath, path.join(".fx", "metadata"));
+      assert.include(checkedPath, "allTemplates.json");
+    });
+
+    it("reads from metadata subdir when cache exists for Platform.CLI", () => {
+      sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
+      sandbox.stub(folder, "getTemplatesFolder").returns("/bundled");
+      const pathExistsStub = sandbox.stub(fs, "pathExistsSync").returns(true);
+      sandbox.stub(fs, "readFileSync").returns(JSON.stringify(mockTemplates));
+
+      getAllTemplatesOnPlatform(Platform.CLI);
+
+      const checkedPath = pathExistsStub.firstCall.args[0] as string;
+      assert.notInclude(checkedPath, "vs-metadata");
+    });
+
+    it("falls back to bundled path when cache does not exist", () => {
+      sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
+      const bundledPath = path.resolve("/bundled");
+      sandbox.stub(folder, "getTemplatesFolder").returns(bundledPath);
+      sandbox.stub(fs, "pathExistsSync").returns(false);
+      const readFileSyncStub = sandbox
+        .stub(fs, "readFileSync")
+        .returns(JSON.stringify(mockTemplates));
+
+      getAllTemplatesOnPlatform(Platform.VS);
+
+      const readPath = readFileSyncStub.firstCall.args[0] as string;
+      assert.include(readPath, bundledPath);
+      assert.notInclude(readPath, "vs-metadata");
+    });
+
+    it("falls back to bundled path when useLocalTemplate is true", () => {
+      sandbox.stub(templateHelper, "useLocalTemplate").returns(true);
+      const bundledPath = path.resolve("/bundled");
+      sandbox.stub(folder, "getTemplatesFolder").returns(bundledPath);
+      sandbox.stub(fs, "pathExistsSync").returns(true);
+      const readFileSyncStub = sandbox
+        .stub(fs, "readFileSync")
+        .returns(JSON.stringify(mockTemplates));
+
+      getAllTemplatesOnPlatform(Platform.VS);
+
+      const readPath = readFileSyncStub.firstCall.args[0] as string;
+      assert.include(readPath, bundledPath);
+    });
+
+    it("returns only csharp templates for Platform.VS", () => {
+      sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
+      sandbox.stub(folder, "getTemplatesFolder").returns("/bundled");
+      sandbox.stub(fs, "pathExistsSync").returns(true);
+      sandbox.stub(fs, "readFileSync").returns(JSON.stringify(mockTemplates));
+
+      const result = getAllTemplatesOnPlatform(Platform.VS);
+
+      assert.deepEqual(result, [mockTemplates[1]]);
+    });
+
+    it("returns only non-csharp templates for Platform.VSCode", () => {
+      sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
+      sandbox.stub(folder, "getTemplatesFolder").returns("/bundled");
+      sandbox.stub(fs, "pathExistsSync").returns(true);
+      sandbox.stub(fs, "readFileSync").returns(JSON.stringify(mockTemplates));
+
+      const result = getAllTemplatesOnPlatform(Platform.VSCode);
+
+      assert.deepEqual(result, [mockTemplates[0], mockTemplates[2]]);
+    });
+
+    it("returns all templates for Platform.CLI", () => {
+      sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
+      sandbox.stub(folder, "getTemplatesFolder").returns("/bundled");
+      sandbox.stub(fs, "pathExistsSync").returns(true);
+      sandbox.stub(fs, "readFileSync").returns(JSON.stringify(mockTemplates));
+
+      const result = getAllTemplatesOnPlatform(Platform.CLI);
+
+      assert.deepEqual(result, mockTemplates);
+    });
+
+    it("returns empty array for unknown platform", () => {
+      sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
+      sandbox.stub(folder, "getTemplatesFolder").returns("/bundled");
+      sandbox.stub(fs, "pathExistsSync").returns(true);
+      sandbox.stub(fs, "readFileSync").returns(JSON.stringify(mockTemplates));
+
+      const result = getAllTemplatesOnPlatform("unknown" as Platform);
+
+      assert.deepEqual(result, []);
+    });
+  });
+
+  describe("getDefaultTemplatesOnPlatform", () => {
+    it("reads from vs-metadata subdir when cache exists for Platform.VS", () => {
+      sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
+      sandbox.stub(folder, "getTemplatesFolder").returns("/bundled");
+      const pathExistsStub = sandbox.stub(fs, "pathExistsSync").returns(true);
+      sandbox.stub(fs, "readFileSync").returns(JSON.stringify(mockTemplates));
+
+      getDefaultTemplatesOnPlatform(Platform.VS);
+
+      const checkedPath = pathExistsStub.firstCall.args[0] as string;
+      assert.include(checkedPath, "vs-metadata");
+      assert.include(checkedPath, "defaultGeneratorTemplates.json");
+    });
+
+    it("reads from metadata subdir when cache exists for Platform.VSCode", () => {
+      sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
+      sandbox.stub(folder, "getTemplatesFolder").returns("/bundled");
+      const pathExistsStub = sandbox.stub(fs, "pathExistsSync").returns(true);
+      sandbox.stub(fs, "readFileSync").returns(JSON.stringify(mockTemplates));
+
+      getDefaultTemplatesOnPlatform(Platform.VSCode);
+
+      const checkedPath = pathExistsStub.firstCall.args[0] as string;
+      assert.notInclude(checkedPath, "vs-metadata");
+      assert.include(checkedPath, "defaultGeneratorTemplates.json");
+    });
+
+    it("returns only csharp templates for Platform.VS", () => {
+      sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
+      sandbox.stub(folder, "getTemplatesFolder").returns("/bundled");
+      sandbox.stub(fs, "pathExistsSync").returns(true);
+      sandbox.stub(fs, "readFileSync").returns(JSON.stringify(mockTemplates));
+
+      const result = getDefaultTemplatesOnPlatform(Platform.VS);
+
+      assert.deepEqual(result, [mockTemplates[1]]);
+    });
+
+    it("returns only non-csharp templates for Platform.VSCode", () => {
+      sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
+      sandbox.stub(folder, "getTemplatesFolder").returns("/bundled");
+      sandbox.stub(fs, "pathExistsSync").returns(true);
+      sandbox.stub(fs, "readFileSync").returns(JSON.stringify(mockTemplates));
+
+      const result = getDefaultTemplatesOnPlatform(Platform.VSCode);
+
+      assert.deepEqual(result, [mockTemplates[0], mockTemplates[2]]);
+    });
+
+    it("returns all templates for Platform.CLI", () => {
+      sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
+      sandbox.stub(folder, "getTemplatesFolder").returns("/bundled");
+      sandbox.stub(fs, "pathExistsSync").returns(true);
+      sandbox.stub(fs, "readFileSync").returns(JSON.stringify(mockTemplates));
+
+      const result = getDefaultTemplatesOnPlatform(Platform.CLI);
+
+      assert.deepEqual(result, mockTemplates);
+    });
+
+    it("returns empty array for unknown platform", () => {
+      sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
+      sandbox.stub(folder, "getTemplatesFolder").returns("/bundled");
+      sandbox.stub(fs, "pathExistsSync").returns(true);
+      sandbox.stub(fs, "readFileSync").returns(JSON.stringify(mockTemplates));
+
+      const result = getDefaultTemplatesOnPlatform("unknown" as Platform);
+
+      assert.deepEqual(result, []);
+    });
+  });
+});

--- a/packages/fx-core/tests/component/generator/utils.test.ts
+++ b/packages/fx-core/tests/component/generator/utils.test.ts
@@ -8,10 +8,12 @@ import proxyquire from "proxyquire";
 import * as sinon from "sinon";
 import { GraphClient } from "../../../src/client/graphClient";
 import { createContext, setTools } from "../../../src/common/globalVars";
+import * as requestUtils from "../../../src/common/requestUtils";
 import { copilotGptManifestUtils } from "../../../src/component/driver/teamsApp/utils/CopilotGptManifestUtils";
 import { useLocalTemplate } from "../../../src/component/generator/templateHelper";
 import {
   getTemplateUrl,
+  getTemplateVSLatestVersion,
   getTemplateZipUrlByVersion,
   setGeneralSensitivityLabel,
 } from "../../../src/component/generator/utils";
@@ -72,12 +74,17 @@ describe("utils unit test cases", () => {
   });
 
   it("should return the stable URL for getTemplateVSUrl", async () => {
+    // Stub HTTP so getTemplateVSLatestVersion() can resolve without network
+    sandbox
+      .stub(requestUtils, "sendRequestWithTimeout")
+      .resolves({ data: "templates-vs@18.0.0\ntemplates@6.0.0\n" } as any);
     const mockSettings = {
       version: "~6.0",
       localVersion: "6.0.0",
       tagPrefix: "templates@",
       vstagPrefix: "templates-vs@",
       vsversion: "18.0.0",
+      vsVersionPattern: "~18.0",
       tagListURL:
         "https://github.com/OfficeDev/microsoft-365-agents-toolkit/releases/download/template-tag-list/template-tags.txt",
       templateDownloadBaseURL:
@@ -90,11 +97,41 @@ describe("utils unit test cases", () => {
     };
     const dUtils = proxyquire("../../../src/component/generator/utils", {
       "../../common/templates-config.json": mockSettings,
+      "../../../package.json": { version: "3.0.0" }, // stable, not beta
     });
     const getLatestVersion = () => Promise.resolve("18.0.0");
     const result = await dUtils.getTemplateUrl("csharp", getLatestVersion, Platform.VS);
     const expectedUrl =
       "https://github.com/OfficeDev/microsoft-365-agents-toolkit/releases/download/templates-vs@18.0.0/csharp.zip";
+    assert.strictEqual(result, expectedUrl);
+  });
+
+  it("should return rc URL for beta fx-core version (VS pre-release test build)", async () => {
+    const mockPackageJson = { version: "3.0.0-beta.1" };
+    const mockSettings = {
+      version: "~6.0",
+      localVersion: "6.0.0",
+      tagPrefix: "templates@",
+      vstagPrefix: "templates-vs@",
+      vsversion: "18.4.2",
+      tagListURL:
+        "https://github.com/OfficeDev/microsoft-365-agents-toolkit/releases/download/template-tag-list/template-tags.txt",
+      templateDownloadBaseURL:
+        "https://github.com/OfficeDev/microsoft-365-agents-toolkit/releases/download",
+      templateReleaseURL:
+        "https://github.com/OfficeDev/microsoft-365-agents-toolkit/releases/expanded_assets",
+      templateDownloadBasePath: "/OfficeDev/microsoft-365-agents-toolkit/releases/download",
+      templateExt: ".zip",
+      useLocalTemplate: false,
+    };
+    const dUtils = proxyquire("../../../src/component/generator/utils", {
+      "../../common/templates-config.json": mockSettings,
+      "../../../package.json": mockPackageJson,
+    });
+    const getLatestVersion = () => Promise.resolve("18.4.1");
+    const result = await dUtils.getTemplateUrl("csharp", getLatestVersion, Platform.VS);
+    const expectedUrl =
+      "https://github.com/OfficeDev/microsoft-365-agents-toolkit/releases/download/templates-vs@0.0.0-rc/csharp.zip";
     assert.strictEqual(result, expectedUrl);
   });
 
@@ -371,5 +408,56 @@ describe("templateHelper unit test cases", () => {
     const result = templateHelper.useLocalTemplate();
     assert.isFalse(result);
     restore();
+  });
+});
+
+describe("getTemplateVSLatestVersion", () => {
+  const sandbox = sinon.createSandbox();
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("should return the max satisfying version matching vsVersionPattern", async () => {
+    // shared tag list contains both VSC and VS tags
+    const tagList =
+      "templates@6.6.0\ntemplates@6.6.1\ntemplates-vs@18.4.0\ntemplates-vs@18.4.1\ntemplates-vs@18.3.0\ntemplates-vs@18.5.0\n";
+    sandbox.stub(requestUtils, "sendRequestWithTimeout").resolves({ data: tagList } as any);
+
+    const result = await getTemplateVSLatestVersion();
+    // ~18.4 matches 18.4.x only, not 18.5.x; VSC tags are ignored
+    assert.strictEqual(result, "18.4.1");
+  });
+
+  it("should handle CRLF line endings in tag list", async () => {
+    const tagList = "templates@6.6.1\r\ntemplates-vs@18.4.0\r\ntemplates-vs@18.4.1\r\n";
+    sandbox.stub(requestUtils, "sendRequestWithTimeout").resolves({ data: tagList } as any);
+
+    const result = await getTemplateVSLatestVersion();
+    assert.strictEqual(result, "18.4.1");
+  });
+
+  it("should throw when no version satisfies vsVersionPattern", async () => {
+    // only non-VS tags and old VS tags — none match ~18.4
+    const tagList = "templates@6.6.1\ntemplates-vs@17.0.0\ntemplates-vs@17.1.0\n";
+    sandbox.stub(requestUtils, "sendRequestWithTimeout").resolves({ data: tagList } as any);
+
+    try {
+      await getTemplateVSLatestVersion();
+      assert.fail("Expected error to be thrown");
+    } catch (e: any) {
+      assert.include(e.message, "Failed to find valid VS template version");
+    }
+  });
+
+  it("should propagate network errors from fetchTagList", async () => {
+    sandbox.stub(requestUtils, "sendRequestWithTimeout").rejects(new Error("Network timeout"));
+
+    try {
+      await getTemplateVSLatestVersion();
+      assert.fail("Expected error to be thrown");
+    } catch (e: any) {
+      assert.include(e.message, "Network timeout");
+    }
   });
 });

--- a/packages/fx-core/tests/core/FxCore.test.ts
+++ b/packages/fx-core/tests/core/FxCore.test.ts
@@ -9353,3 +9353,227 @@ describe("fetchOnlineTemplateMetadata", () => {
     );
   });
 });
+
+describe("fetchOnlineTemplateMetadataForVS", () => {
+  const sandbox = sinon.createSandbox();
+  let core: FxCore;
+  let mockedEnvRestore: RestoreFn | undefined;
+
+  beforeEach(() => {
+    setTools(tools);
+    core = new FxCore(tools);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    if (mockedEnvRestore) {
+      mockedEnvRestore();
+      mockedEnvRestore = undefined;
+    }
+  });
+
+  it("should skip download when using local template", async () => {
+    sandbox.stub(templateHelper, "useLocalTemplate").returns(true);
+
+    const result = await core.fetchOnlineTemplateMetadataForVS();
+
+    assert.isTrue(result.isOk());
+    if (result.isOk()) {
+      assert.isUndefined(result.value);
+    }
+  });
+
+  it("should download metadata when version file does not exist (stable fx-core)", async () => {
+    sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
+    sandbox.stub(packageJson, "version").value("1.0.0"); // stable
+    sandbox.stub(templateConfigModule, "vstagPrefix").value("templates-vs@");
+    sandbox
+      .stub(templateConfigModule, "templateDownloadBaseURL")
+      .value("https://example.com/releases/download");
+    sandbox.stub(generatorUtils, "getTemplateVSLatestVersion").resolves("18.4.1");
+    const mockZip = new AdmZip();
+    const fetchZipStub = sandbox.stub(generatorUtils, "fetchZipFromUrl").resolves(mockZip);
+    const unzipStub = sandbox.stub(generatorUtils, "unzip").resolves();
+
+    sandbox.stub(fs, "pathExists").resolves(false);
+    sandbox.stub(fs, "ensureDir").resolves();
+    const writeFileStub = sandbox.stub(fs, "writeFile").resolves();
+
+    const result = await core.fetchOnlineTemplateMetadataForVS();
+
+    assert.isTrue(result.isOk());
+    assert.isTrue(fetchZipStub.calledOnce);
+    assert.isTrue(
+      fetchZipStub.calledWith(
+        "https://example.com/releases/download/templates-vs@18.4.1/metadata.zip"
+      )
+    );
+    assert.isTrue(unzipStub.calledOnce);
+    assert.isTrue(writeFileStub.calledWith(sinon.match.string, "18.4.1", { encoding: "utf-8" }));
+  });
+
+  it("should use rc templates for beta fx-core (VS pre-release test build)", async () => {
+    sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
+    sandbox.stub(packageJson, "version").value("1.0.0-beta.1"); // beta = pre-stable test
+    sandbox.stub(templateConfigModule, "vstagPrefix").value("templates-vs@");
+    sandbox
+      .stub(templateConfigModule, "templateDownloadBaseURL")
+      .value("https://example.com/releases/download");
+    const getVSLatestStub = sandbox.stub(generatorUtils, "getTemplateVSLatestVersion");
+    const mockZip = new AdmZip();
+    const fetchZipStub = sandbox.stub(generatorUtils, "fetchZipFromUrl").resolves(mockZip);
+    sandbox.stub(generatorUtils, "unzip").resolves();
+
+    sandbox.stub(fs, "pathExists").resolves(false);
+    sandbox.stub(fs, "ensureDir").resolves();
+    sandbox.stub(fs, "writeFile").resolves();
+
+    const result = await core.fetchOnlineTemplateMetadataForVS();
+
+    assert.isTrue(result.isOk());
+    // beta should NOT call getTemplateVSLatestVersion
+    assert.isFalse(getVSLatestStub.called);
+    assert.isTrue(
+      fetchZipStub.calledWith(
+        "https://example.com/releases/download/templates-vs@0.0.0-rc/metadata.zip"
+      )
+    );
+  });
+
+  it("should skip download when cached version matches latest", async () => {
+    sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
+    sandbox.stub(generatorUtils, "getTemplateVSLatestVersion").resolves("18.4.1");
+    const fetchZipStub = sandbox.stub(generatorUtils, "fetchZipFromUrl");
+    const unzipStub = sandbox.stub(generatorUtils, "unzip");
+
+    sandbox.stub(fs, "pathExists").resolves(true);
+    sandbox.stub(fs, "ensureDir").resolves();
+    sandbox.stub(fs, "readFile").resolves("18.4.1" as any);
+    sandbox.stub(fs, "writeFile").resolves();
+
+    const result = await core.fetchOnlineTemplateMetadataForVS();
+
+    assert.isTrue(result.isOk());
+    assert.isFalse(fetchZipStub.called);
+    assert.isFalse(unzipStub.called);
+  });
+
+  it("should download when cached version differs from latest", async () => {
+    sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
+    sandbox.stub(templateConfigModule, "vstagPrefix").value("templates-vs@");
+    sandbox
+      .stub(templateConfigModule, "templateDownloadBaseURL")
+      .value("https://example.com/releases/download");
+    sandbox.stub(generatorUtils, "getTemplateVSLatestVersion").resolves("18.4.1");
+    const mockZip = new AdmZip();
+    const fetchZipStub = sandbox.stub(generatorUtils, "fetchZipFromUrl").resolves(mockZip);
+    const unzipStub = sandbox.stub(generatorUtils, "unzip").resolves();
+
+    sandbox.stub(fs, "pathExists").resolves(true);
+    sandbox.stub(fs, "ensureDir").resolves();
+    sandbox.stub(fs, "readFile").resolves("18.4.0" as any);
+    sandbox.stub(fs, "writeFile").resolves();
+
+    const result = await core.fetchOnlineTemplateMetadataForVS();
+
+    assert.isTrue(result.isOk());
+    assert.isTrue(fetchZipStub.calledOnce);
+    assert.isTrue(unzipStub.calledOnce);
+  });
+
+  it("should re-download when version file read throws", async () => {
+    sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
+    sandbox.stub(templateConfigModule, "vstagPrefix").value("templates-vs@");
+    sandbox
+      .stub(templateConfigModule, "templateDownloadBaseURL")
+      .value("https://example.com/releases/download");
+    sandbox.stub(generatorUtils, "getTemplateVSLatestVersion").resolves("18.4.1");
+    const mockZip = new AdmZip();
+    const fetchZipStub = sandbox.stub(generatorUtils, "fetchZipFromUrl").resolves(mockZip);
+    const unzipStub = sandbox.stub(generatorUtils, "unzip").resolves();
+
+    sandbox.stub(fs, "pathExists").resolves(true);
+    sandbox.stub(fs, "ensureDir").resolves();
+    sandbox.stub(fs, "readFile").rejects(new Error("File read error"));
+    sandbox.stub(fs, "writeFile").resolves();
+
+    const result = await core.fetchOnlineTemplateMetadataForVS();
+
+    assert.isTrue(result.isOk());
+    assert.isTrue(fetchZipStub.calledOnce);
+    assert.isTrue(unzipStub.calledOnce);
+  });
+
+  it("should return error when getTemplateVSLatestVersion fails", async () => {
+    sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
+    sandbox
+      .stub(generatorUtils, "getTemplateVSLatestVersion")
+      .rejects(new Error("Failed to find valid VS template version"));
+
+    sandbox.stub(fs, "ensureDir").resolves();
+
+    const result = await core.fetchOnlineTemplateMetadataForVS();
+
+    assert.isTrue(result.isErr());
+    if (result.isErr()) {
+      assert.equal(result.error.source, "FetchOnlineTemplateMetadataForVS");
+      assert.equal(result.error.name, "DownloadFailed");
+      assert.include(result.error.message, "Failed to find valid VS template version");
+    }
+  });
+
+  it("should return error when fetchZipFromUrl fails", async () => {
+    sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
+    sandbox.stub(templateConfigModule, "vstagPrefix").value("templates-vs@");
+    sandbox
+      .stub(templateConfigModule, "templateDownloadBaseURL")
+      .value("https://example.com/releases/download");
+    sandbox.stub(generatorUtils, "getTemplateVSLatestVersion").resolves("18.4.1");
+    sandbox
+      .stub(generatorUtils, "fetchZipFromUrl")
+      .rejects(new Error("Download failed: 404 Not Found"));
+
+    sandbox.stub(fs, "pathExists").resolves(false);
+    sandbox.stub(fs, "ensureDir").resolves();
+
+    const result = await core.fetchOnlineTemplateMetadataForVS();
+
+    assert.isTrue(result.isErr());
+    if (result.isErr()) {
+      assert.equal(result.error.source, "FetchOnlineTemplateMetadataForVS");
+      assert.equal(result.error.name, "DownloadFailed");
+      assert.include(result.error.message, "Download failed: 404 Not Found");
+    }
+  });
+
+  it("should use vs-metadata directory with correct version file path", async () => {
+    sandbox.stub(templateHelper, "useLocalTemplate").returns(false);
+    sandbox.stub(templateConfigModule, "vstagPrefix").value("templates-vs@");
+    sandbox
+      .stub(templateConfigModule, "templateDownloadBaseURL")
+      .value("https://example.com/releases/download");
+    sandbox.stub(generatorUtils, "getTemplateVSLatestVersion").resolves("18.4.1");
+    const mockZip = new AdmZip();
+    sandbox.stub(generatorUtils, "fetchZipFromUrl").resolves(mockZip);
+    const unzipStub = sandbox.stub(generatorUtils, "unzip").resolves();
+
+    sandbox.stub(fs, "pathExists").resolves(false);
+    const ensureDirStub = sandbox.stub(fs, "ensureDir").resolves();
+    const writeFileStub = sandbox.stub(fs, "writeFile").resolves();
+
+    const expectedMetadataDir = path.join(os.homedir(), ".fx", "vs-metadata");
+
+    const result = await core.fetchOnlineTemplateMetadataForVS();
+
+    assert.isTrue(result.isOk());
+    assert.isTrue(ensureDirStub.calledWith(expectedMetadataDir));
+    assert.isTrue(unzipStub.calledWith(mockZip, expectedMetadataDir));
+    assert.isTrue(
+      writeFileStub.calledWith(
+        path.join(expectedMetadataDir, "template-vs-version.txt"),
+        "18.4.1",
+        { encoding: "utf-8" }
+      )
+    );
+  });
+});

--- a/packages/server/src/serverConnection.ts
+++ b/packages/server/src/serverConnection.ts
@@ -104,7 +104,7 @@ export default class ServerConnection implements IServerConnection {
   }
   public listen() {
     this.connection.listen();
-    void this.core.fetchOnlineTemplateMetadata();
+    void this.core.fetchOnlineTemplateMetadataForVS();
   }
 
   public getQuestionsRequest(


### PR DESCRIPTION
Cherry-pick of #15564 squash commit onto dev.

## Changes
- getTemplateVSUrl: dynamic version lookup via tag list instead of hardcoded vsversion
- getTemplateVSLatestVersion: fetches shared tag list, filters by vsVersionPattern semver range
- fetchOnlineTemplateMetadataForVS: new API - downloads VS metadata zip to ~/.m365agents/vs-metadata/
- metadata/index.ts: platform routing - VS uses vs-metadata/ cache, VSC/CLI uses metadata/ cache
- templates-config.json: removed vsTagListURL, VS now uses shared tagListURL
- cd.yml: RC VS template release step, stable VS template release step, shared tag list update

## Unit Tests
- getTemplateVSLatestVersion: 4 tests (tag list fetch, CRLF handling, version mismatch, network error)
- fetchOnlineTemplateMetadataForVS: 9 tests (skip/download/cache/error paths)
- metadata/index.ts: 15 tests (platform routing for VS, VSCode, CLI)

Related: #15564 (VS184 branch)
Related issue: #15583

## workitem
[link](https://dev.azure.com/msazure/Microsoft%20Teams%20Extensibility/_workitems/edit/37100162)