### PR TITLE
fix: use apiSpecWithSearchNode for DA OpenAPI spec path

### DIFF
--- a/packages/fx-core/templates/ui/tdpNode.json
+++ b/packages/fx-core/templates/ui/tdpNode.json
@@ -152,7 +152,7 @@
                   }
                 },
                 {
-                  "node": "apiSpecNode",
+                  "node": "apiSpecWithSearchNode",
                   "condition": {
                     "equals": "api-spec"
                   }

--- a/packages/fx-core/templates/ui/wizardNode.json
+++ b/packages/fx-core/templates/ui/wizardNode.json
@@ -174,7 +174,7 @@
                   }
                 },
                 {
-                  "node": "apiSpecNode",
+                  "node": "apiSpecWithSearchNode",
                   "condition": {
                     "equals": "api-spec"
                   }

--- a/templates/src/ui/da.ts
+++ b/templates/src/ui/da.ts
@@ -124,7 +124,7 @@ export const daNode = {
                 ],
               },
             },
-            { node: "apiSpecNode", condition: { equals: "api-spec" } },
+            { node: "apiSpecWithSearchNode", condition: { equals: "api-spec" } },
             { node: "mcpServerTypeNode", condition: { equals: "mcp" } },
           ],
         },


### PR DESCRIPTION
## Problem
The JSON-driven DA wizard (`templates/src/ui/da.ts`) was using `apiSpecNode` instead of `apiSpecWithSearchNode` for the OpenAPI spec action type. This caused the "Search for an API" option to be missing when users selected:

Declarative Agent -> Add an Action -> Start with an OpenAPI Description Document

Since `KiotaNPMIntegration` feature flag defaults to `true`, the old TypeScript code path always used `apiSpecWithSearchNode()`, which provides both:
- Enter URL or open local file
- Search for an API

But the new JSON-driven path only referenced `apiSpecNode`, which skips the search option.

## Fix
Changed `da.ts` to reference `apiSpecWithSearchNode` instead of `apiSpecNode`:
```diff
- { node: "apiSpecNode", condition: { equals: "api-spec" } }
+ { node: "apiSpecWithSearchNode", condition: { equals: "api-spec" } }
```

Also regenerated `wizardNode.json` and `tdpNode.json` to reflect the change.

## Verification
Tested locally via Playwright-driven VS Code with the local dev extension build:
- Both "Enter URL" and "Search API" options appear correctly
- Entering petstore OpenAPI URL loads 13 API operations
- Full scaffold completes successfully

## Audit
Audited all other wizard sub-trees (CEA, Teams, Graph Connector, Office Add-in). Only the DA api-spec path had this issue.

[workitem](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/37300245)
