### PR TITLE
ci: fetch remote tags before generating VS template tag list

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -386,7 +386,9 @@ jobs:
 
       - name: Generate Tag List (VS stable release)
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.vsrelease == 'true' && github.event.inputs.vstemplate == 'true' }}
-        run: git tag | grep templates > ${{ runner.temp }}/template-tags.txt
+        run: |
+          git fetch --tags
+          git tag | grep templates > ${{ runner.temp }}/template-tags.txt
 
       - name: Update Template Tag list Release (VS stable release)
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.vsrelease == 'true' && github.event.inputs.vstemplate == 'true' }}


### PR DESCRIPTION
## Problem

When triggering the CD pipeline with `vsrelease=true` and `vstemplate=true`, the "Generate Tag List (VS stable release)" step uses `git tag | grep templates` to collect all template tags. However, the `templates-vs@x.x.x` tag is created remotely by the preceding `ncipollo/release-action` step, and is **not automatically synced back to the local runner**. As a result, the newly created VS template tag is missing from the generated tag list.

## Fix

Add `git fetch --tags` before reading local tags in the "Generate Tag List (VS stable release)" step. This ensures the runner has the latest remote tags (including the just-created `templates-vs@x.x.x`) before generating the list.

## Root cause note

The VSC `templates@x.x.x` tag (non-VS path) does not have this problem because it is created locally by `lerna version` and pushed to origin in the same job, so `git tag` already has it.
