### PR TITLE
fix: use local json schemas to validate manifest before falling back to use remote url

### DIFF
--- a/packages/cli/.gitignore
+++ b/packages/cli/.gitignore
@@ -43,4 +43,5 @@ resource
 !src/resource
 !src/cmds/preview/depsChecker/resource/
 templates
+json-schemas
 *.tgz

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -136,6 +136,7 @@
     "lib",
     "resource",
     "templates",
+    "json-schemas",
     "deletePS1.js",
     "cli.js",
     "cli_teamsapp.js"

--- a/packages/cli/webpack.config.js
+++ b/packages/cli/webpack.config.js
@@ -75,6 +75,10 @@ const config = {
           from: "../fx-core/templates/",
           to: "../templates/",
         },
+        {
+          from: "../manifest/src/json-schemas/",
+          to: "../json-schemas/",
+        },
       ],
     }),
     new webpack.ContextReplacementPlugin(/express[\/\\]lib/, false, /$^/),

--- a/packages/fx-core/src/component/driver/teamsApp/appStudio.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/appStudio.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 import {
+  AppManifestUtils,
   AppPackageFolderName,
   BuildFolderName,
   Colors,
@@ -9,7 +10,6 @@ import {
   InputsWithProjectPath,
   LogProvider,
   M365TokenProvider,
-  ManifestUtil,
   Platform,
   Result,
   TeamsAppManifest,
@@ -255,7 +255,7 @@ export async function updateTeamsAppV3ForPublish(
         );
       } else {
         teamsAppId = manifest.id;
-        const validationResult = await ManifestUtil.validateManifest(manifest);
+        const validationResult = await AppManifestUtils.validateAgainstSchema(manifest as any);
         if (validationResult.length > 0) {
           const errMessage = AppStudioError.ValidationFailedError.message(validationResult);
           validationError = AppStudioResultFactory.UserError(

--- a/packages/fx-core/src/component/driver/teamsApp/utils/CopilotGptManifestUtils.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/utils/CopilotGptManifestUtils.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import {
+  AppManifestUtils,
   Colors,
   DeclarativeAgentManifest,
   DeclarativeAgentManifestConverter,
@@ -11,7 +12,6 @@ import {
   err,
   FxError,
   IDeclarativeCopilot,
-  ManifestUtil,
   ok,
   OneDriveAndSharePointCapability,
   Platform,
@@ -186,7 +186,9 @@ export class CopilotGptManifestUtils {
 
     const manifest = manifestRes.value;
     try {
-      const manifestValidationRes = await ManifestUtil.validateManifest(manifestRes.value);
+      const manifestValidationRes = await AppManifestUtils.validateAgainstSchema(
+        manifestRes.value as any
+      );
       const res: DeclarativeCopilotManifestValidationResult = {
         id: declaraitveCopilot.id,
         filePath: manifestPath,

--- a/packages/fx-core/src/component/driver/teamsApp/utils/PluginManifestUtils.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/utils/PluginManifestUtils.ts
@@ -2,12 +2,12 @@
 // Licensed under the MIT license.
 
 import {
+  AppManifestUtils,
   Colors,
   DefaultApiSpecJsonFileName,
   DefaultApiSpecYamlFileName,
   FxError,
   IPlugin,
-  ManifestUtil,
   Platform,
   PluginManifestSchema,
   FunctionObject,
@@ -95,7 +95,7 @@ export class PluginManifestUtils {
     }
 
     try {
-      const schemaErrors = await ManifestUtil.validateManifest(manifestRes.value);
+      const schemaErrors = await AppManifestUtils.validateAgainstSchema(manifestRes.value as any);
       const localMCPPluginErrors = await this.validateLocalMCPPluginRuntimes(manifestRes.value);
       const allErrors = [...schemaErrors, ...localMCPPluginErrors];
 

--- a/packages/fx-core/src/component/driver/teamsApp/validate.ts
+++ b/packages/fx-core/src/component/driver/teamsApp/validate.ts
@@ -3,14 +3,13 @@
 
 import { hooks } from "@feathersjs/hooks/lib";
 import {
+  AppManifestUtils,
   Colors,
   err,
   FxError,
-  ManifestUtil,
   ok,
   Platform,
   Result,
-  TeamsAppManifest,
   TeamsManifest,
   TeamsManifestV1D19,
   TeamsManifestV1D5,
@@ -77,7 +76,7 @@ export class ValidateManifestDriver implements StepDriver {
     const telemetryProperties: Record<string, string> = {};
     if (manifest.$schema) {
       try {
-        manifestValidationResult = await ManifestUtil.validateManifest(manifest);
+        manifestValidationResult = await AppManifestUtils.validateAgainstSchema(manifest);
         telemetryProperties[TelemetryPropertyKey.validationErrors] = manifestValidationResult
           .map((r: string) => r.replace(/\//g, ""))
           .join(";");
@@ -405,9 +404,10 @@ export class ValidateManifestDriver implements StepDriver {
       if (resolvedLocFileRes.isErr()) {
         return err(resolvedLocFileRes.error);
       }
-      const localizationFile = JSON.parse(resolvedLocFileRes.value) as TeamsAppManifest;
+      const localizationFile = JSON.parse(resolvedLocFileRes.value) as TeamsManifest;
       try {
-        const schema = await ManifestUtil.fetchSchema(localizationFile);
+        const schemaUrl = (localizationFile.$schema ?? (localizationFile as any).schema) as string;
+        const schema = await AppManifestUtils.fetchSchema(schemaUrl);
         // the current localization schema has invalid regex sytax, we need to manually fix the properties temporarily
         const activityDespString =
           "^activities.activityTypes\\[\\b([0-9]|[1-8][0-9]|9[0-9]|1[01][0-9]|12[0-7])\\b]\\.description$";
@@ -428,7 +428,7 @@ export class ValidateManifestDriver implements StepDriver {
           delete schema.patternProperties[activityTemplateString];
         }
 
-        const validationRes = await ManifestUtil.validateManifestAgainstSchema(
+        const validationRes = await AppManifestUtils.validateAgainstSchema(
           localizationFile,
           schema
         );

--- a/packages/fx-core/tests/component/driver/teamsApp/copilotGptManifest.test.ts
+++ b/packages/fx-core/tests/component/driver/teamsApp/copilotGptManifest.test.ts
@@ -3,6 +3,7 @@
 
 import { SpecParser } from "@microsoft/m365-spec-parser";
 import {
+  AppManifestUtils,
   Colors,
   DeclarativeAgentManifestConverter,
   DeclarativeCopilotCapabilityName,
@@ -585,7 +586,7 @@ describe("copilotGptManifestUtils", () => {
       });
       sandbox.stub(fs, "pathExists").resolves(true);
       sandbox.stub(fs, "readFile").resolves(JSON.stringify(manifest) as any);
-      sandbox.stub(ManifestUtil, "validateManifest").resolves([]);
+      sandbox.stub(AppManifestUtils, "validateAgainstSchema").resolves([]);
       sandbox.stub(pluginManifestUtils, "validateAgainstSchema").resolves(
         ok({
           id: "1",
@@ -631,7 +632,7 @@ describe("copilotGptManifestUtils", () => {
       });
       sandbox.stub(fs, "pathExists").resolves(true);
       sandbox.stub(fs, "readFile").resolves(JSON.stringify(manifest) as any);
-      sandbox.stub(ManifestUtil, "validateManifest").resolves([]);
+      sandbox.stub(AppManifestUtils, "validateAgainstSchema").resolves([]);
       sandbox
         .stub(pluginManifestUtils, "validateAgainstSchema")
         .resolves(err(new SystemError("error", "error", "error", "error")));
@@ -662,7 +663,7 @@ describe("copilotGptManifestUtils", () => {
       });
       sandbox.stub(fs, "pathExists").resolves(true);
       sandbox.stub(fs, "readFile").resolves(JSON.stringify(gptManifest) as any);
-      sandbox.stub(ManifestUtil, "validateManifest").throws("error");
+      sandbox.stub(AppManifestUtils, "validateAgainstSchema").throws("error");
 
       const res = await copilotGptManifestUtils.validateAgainstSchema(
         { id: "1", file: "file" },

--- a/packages/fx-core/tests/component/driver/teamsApp/pluginManifestUtils.test.ts
+++ b/packages/fx-core/tests/component/driver/teamsApp/pluginManifestUtils.test.ts
@@ -7,8 +7,8 @@ import chai from "chai";
 import fs from "fs-extra";
 import { pluginManifestUtils } from "../../../../src/component/driver/teamsApp/utils/PluginManifestUtils";
 import {
+  AppManifestUtils,
   Colors,
-  ManifestUtil,
   Platform,
   PluginManifestSchema,
   SystemError,
@@ -389,7 +389,7 @@ describe("pluginManifestUtils", () => {
     it("validate success", async () => {
       sandbox.stub(fs, "pathExists").resolves(true);
       sandbox.stub(fs, "readFile").resolves(JSON.stringify(pluginManifest) as any);
-      sandbox.stub(ManifestUtil, "validateManifest").resolves([]);
+      sandbox.stub(AppManifestUtils, "validateAgainstSchema").resolves([]);
       sandbox.stub(pluginManifestUtils, "validateLocalMCPPluginRuntimes").resolves([]);
 
       const res = await pluginManifestUtils.validateAgainstSchema(
@@ -410,7 +410,7 @@ describe("pluginManifestUtils", () => {
     it("validate action error", async () => {
       sandbox.stub(fs, "pathExists").resolves(true);
       sandbox.stub(fs, "readFile").resolves(JSON.stringify(pluginManifest) as any);
-      sandbox.stub(ManifestUtil, "validateManifest").resolves([]);
+      sandbox.stub(AppManifestUtils, "validateAgainstSchema").resolves([]);
       sandbox
         .stub(pluginManifestUtils, "validateAgainstSchema")
         .resolves(err(new SystemError("error", "error", "error", "error")));
@@ -429,7 +429,7 @@ describe("pluginManifestUtils", () => {
     it("validate schema error", async () => {
       sandbox.stub(fs, "pathExists").resolves(true);
       sandbox.stub(fs, "readFile").resolves(JSON.stringify(pluginManifest) as any);
-      sandbox.stub(ManifestUtil, "validateManifest").throws("error");
+      sandbox.stub(AppManifestUtils, "validateAgainstSchema").throws("error");
 
       const res = await pluginManifestUtils.validateAgainstSchema(
         { id: "1", file: "file" },

--- a/packages/fx-core/tests/component/driver/teamsApp/validate.test.ts
+++ b/packages/fx-core/tests/component/driver/teamsApp/validate.test.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import {
+  AppManifestUtils,
   err,
   ManifestUtil,
   ok,
@@ -179,8 +180,12 @@ describe("teamsApp/validateManifest", async () => {
   });
 
   it("validation error - download failed", async () => {
-    sinon.stub(ManifestUtil, "validateManifest").resolves([]);
-    sinon.stub(ManifestUtil, "validateManifestAgainstSchema").throws("error");
+    sinon
+      .stub(AppManifestUtils, "validateAgainstSchema")
+      .onFirstCall()
+      .resolves([])
+      .onSecondCall()
+      .throws(new Error("error"));
     const args: ValidateManifestArgs = {
       manifestPath:
         "./tests/plugins/resource/appstudio/resources-multi-env/templates/appPackage/v3.manifest.template.json",
@@ -197,7 +202,7 @@ describe("teamsApp/validateManifest", async () => {
 
   it("validation error - localization file validation failed", async () => {
     sinon
-      .stub(ManifestUtil, "validateManifest")
+      .stub(AppManifestUtils, "validateAgainstSchema")
       .throws(new Error(`Failed to get manifest at url due to: unknown error`));
     const args: ValidateManifestArgs = {
       manifestPath:
@@ -440,7 +445,7 @@ describe("teamsApp/validateManifest", async () => {
       };
 
       sinon.stub(manifestUtils, "getManifestV3").resolves(ok(teamsManifest));
-      sinon.stub(ManifestUtil, "validateManifest").resolves([]);
+      sinon.stub(AppManifestUtils, "validateAgainstSchema").resolves([]);
       sinon.stub(pluginManifestUtils, "validateAgainstSchema").resolves(
         ok({
           id: "fakeId",
@@ -498,7 +503,7 @@ describe("teamsApp/validateManifest", async () => {
       };
 
       sinon.stub(manifestUtils, "getManifestV3").resolves(ok(teamsManifest));
-      sinon.stub(ManifestUtil, "validateManifest").resolves([]);
+      sinon.stub(AppManifestUtils, "validateAgainstSchema").resolves([]);
       sinon.stub(pluginManifestUtils, "validateAgainstSchema").resolves(
         ok({
           id: "fakeId",
@@ -556,7 +561,7 @@ describe("teamsApp/validateManifest", async () => {
       };
 
       sinon.stub(manifestUtils, "getManifestV3").resolves(ok(teamsManifest));
-      sinon.stub(ManifestUtil, "validateManifest").resolves([]);
+      sinon.stub(AppManifestUtils, "validateAgainstSchema").resolves([]);
       sinon.stub(pluginManifestUtils, "validateAgainstSchema").resolves(
         ok({
           id: "fakeId",
@@ -606,7 +611,7 @@ describe("teamsApp/validateManifest", async () => {
       } as TeamsManifestV1D19.TeamsManifestV1D19;
 
       sinon.stub(manifestUtils, "getManifestV3").resolves(ok(teamsManifest));
-      sinon.stub(ManifestUtil, "validateManifest").resolves([]);
+      sinon.stub(AppManifestUtils, "validateAgainstSchema").resolves([]);
       sinon.stub(pluginManifestUtils, "validateAgainstSchema").resolves(
         ok({
           id: "fakeId",
@@ -661,7 +666,7 @@ describe("teamsApp/validateManifest", async () => {
       };
 
       sinon.stub(manifestUtils, "getManifestV3").resolves(ok(teamsManifest));
-      sinon.stub(ManifestUtil, "validateManifest").resolves([]);
+      sinon.stub(AppManifestUtils, "validateAgainstSchema").resolves([]);
       sinon.stub(pluginManifestUtils, "validateAgainstSchema").resolves(
         ok({
           id: "fakeId",

--- a/packages/fx-core/tests/component/resource/appManifest/appstudio.test.ts
+++ b/packages/fx-core/tests/component/resource/appManifest/appstudio.test.ts
@@ -2,9 +2,9 @@
 // Licensed under the MIT license.
 
 import {
+  AppManifestUtils,
   Context,
   InputsWithProjectPath,
-  ManifestUtil,
   Platform,
   TeamsAppManifest,
   TeamsManifest,
@@ -335,7 +335,7 @@ describe.skip("appStudio", () => {
       };
 
       const errors: string[] = ["error1"];
-      sandbox.stub(ManifestUtil, "validateManifest").resolves(errors);
+      sandbox.stub(AppManifestUtils, "validateAgainstSchema").resolves(errors);
 
       const res = await updateTeamsAppV3ForPublish(ctx, inputs);
       chai.assert.isTrue(res.isErr());
@@ -354,7 +354,7 @@ describe.skip("appStudio", () => {
       const zip = new AdmZip();
       zip.addFile("manifest.json", new Buffer(JSON.stringify(json)));
       const info = zip.toBuffer();
-      sandbox.stub(ManifestUtil, "validateManifest").resolves([]);
+      sandbox.stub(AppManifestUtils, "validateAgainstSchema").resolves([]);
 
       const inputs: InputsWithProjectPath = {
         [QuestionNames.AppPackagePath]: info,
@@ -389,7 +389,7 @@ describe.skip("appStudio", () => {
       const zip = new AdmZip();
       zip.addFile("manifest.json", new Buffer(JSON.stringify(json)));
       const info = zip.toBuffer();
-      sandbox.stub(ManifestUtil, "validateManifest").resolves([]);
+      sandbox.stub(AppManifestUtils, "validateAgainstSchema").resolves([]);
 
       const inputs: InputsWithProjectPath = {
         [QuestionNames.AppPackagePath]: info,
@@ -409,6 +409,74 @@ describe.skip("appStudio", () => {
       const res = await updateTeamsAppV3ForPublish(ctx, inputs);
       chai.assert.isTrue(res.isOk());
     });
+  });
+});
+
+describe("updateTeamsAppV3ForPublish - validateAgainstSchema", () => {
+  const sandbox = sinon.createSandbox();
+
+  beforeEach(() => {
+    setTools(new MockTools());
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("should call AppManifestUtils.validateAgainstSchema and return error when validation fails", async () => {
+    const ctx = createContext();
+    const json = {
+      $schema: "schema",
+      id: "fe58d257-4ce6-427e-a388-496c89633774",
+    };
+    const zip = new AdmZip();
+    zip.addFile("manifest.json", new Buffer(JSON.stringify(json)));
+    const info = zip.toBuffer();
+    const errors: string[] = ["error1"];
+    sandbox.stub(AppManifestUtils, "validateAgainstSchema").resolves(errors);
+
+    const inputs: InputsWithProjectPath = {
+      [QuestionNames.AppPackagePath]: info,
+      platform: Platform.VSCode,
+      projectPath: "projectPath",
+    };
+
+    const res = await updateTeamsAppV3ForPublish(ctx, inputs);
+    chai.assert.isTrue(res.isErr());
+    if (res.isErr()) {
+      chai.assert.equal(res.error.name, "ManifestValidationFailed");
+      chai.assert.isTrue(res.error.message.includes("error1"));
+    }
+  });
+
+  it("should call AppManifestUtils.validateAgainstSchema and succeed when no errors", async () => {
+    const ctx = createContext();
+    const json = {
+      $schema: "schema",
+      id: "fe58d257-4ce6-427e-a388-496c89633774",
+    };
+    const zip = new AdmZip();
+    zip.addFile("manifest.json", new Buffer(JSON.stringify(json)));
+    const info = zip.toBuffer();
+    sandbox.stub(AppManifestUtils, "validateAgainstSchema").resolves([]);
+
+    const inputs: InputsWithProjectPath = {
+      [QuestionNames.AppPackagePath]: info,
+      platform: Platform.VSCode,
+      projectPath: "projectPath",
+    };
+    const updateDriver = new ConfigureTeamsAppDriver();
+    sandbox.stub(Container, "get").callsFake((name) => {
+      if ((name as any) === "teamsApp/update") {
+        return updateDriver;
+      } else {
+        throw new Error("not implemented");
+      }
+    });
+    sandbox.stub(updateDriver, "execute").resolves({ result: ok(new Map([])), summaries: [] });
+
+    const res = await updateTeamsAppV3ForPublish(ctx, inputs);
+    chai.assert.isTrue(res.isOk());
   });
 });
 

--- a/packages/manifest/package.json
+++ b/packages/manifest/package.json
@@ -48,7 +48,7 @@
   "scripts": {
     "build": "tsc -p ./ --incremental",
     "prebuild": "npm run copy-json-schema",
-    "copy-json-schema": "copyfiles -u 1 src/json-schemas/**/* build/",
+    "copy-json-schema": "copyfiles -u 1 \"src/json-schemas/**/*\" build/",
     "test": "npm run test:unit",
     "test:unit": "npx nyc mocha --no-timeouts --require ts-node/register \"test/**/*.test.ts\"",
     "lint": "eslint \"**/*.ts\"",

--- a/packages/manifest/src/generated-types/index.ts
+++ b/packages/manifest/src/generated-types/index.ts
@@ -341,12 +341,19 @@ export class ApiPluginManifestConverter {
 }
 
 export class AppManifestUtils {
-  /**
-   * Fetch the schema from the manifest object, load from local if the schema is in the package
-   * @param manifest
-   * @returns manifest schema object
-   */
-  static async fetchSchema(schemaUrl: string): Promise<JSONSchemaType<AppManifest>> {
+  private static getLocalSchemaSuffix(schemaUrl: string): string | undefined {
+    try {
+      const parsedUrl = new URL(schemaUrl);
+      if (parsedUrl.hostname === "developer.microsoft.com") {
+        const localizedPathMatch = parsedUrl.pathname.match(
+          /^\/[a-z]{2}(?:-[a-z]{2})?(\/json-schemas\/.*)$/i
+        );
+        schemaUrl = `${parsedUrl.origin}${localizedPathMatch?.[1] ?? parsedUrl.pathname}`;
+      }
+    } catch {
+      // Ignore invalid URL input and fall back to remote fetch.
+    }
+
     if (
       schemaUrl.startsWith("https://developer.microsoft.com/json-schemas/teams") ||
       schemaUrl.startsWith(
@@ -354,11 +361,39 @@ export class AppManifestUtils {
       ) ||
       schemaUrl.startsWith("https://developer.microsoft.com/json-schemas/copilot/plugin")
     ) {
-      const suffix = schemaUrl.substring("https://developer.microsoft.com/".length);
-      const schemaFile = path.join(__dirname, "..", suffix);
-      if (await fs.pathExists(schemaFile)) {
-        const json = await fs.readJson(schemaFile);
-        return json as JSONSchemaType<AppManifest>;
+      return schemaUrl.substring("https://developer.microsoft.com/".length);
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Fetch the schema from the manifest object, load from local if the schema is in the package
+   * @param manifest
+   * @returns manifest schema object
+   */
+  private static getLocalSchemaCandidates(suffix: string): string[] {
+    const candidates: string[] = [];
+    // 1. Relative to __dirname (works in both source and bundled exe snapshot)
+    candidates.push(path.join(__dirname, "..", suffix));
+    // 2. Relative to the running executable (pkg exe layout)
+    if (process.execPath) {
+      candidates.push(path.join(path.dirname(process.execPath), suffix));
+    }
+    // 3. Relative to cwd
+    candidates.push(path.join(process.cwd(), suffix));
+    return candidates;
+  }
+
+  static async fetchSchema(schemaUrl: string): Promise<JSONSchemaType<AppManifest>> {
+    const suffix = this.getLocalSchemaSuffix(schemaUrl);
+    if (suffix) {
+      for (const schemaFile of this.getLocalSchemaCandidates(suffix)) {
+        if (await fs.pathExists(schemaFile)) {
+          const raw = await fs.readFile(schemaFile, "utf8");
+          const cleanedText = raw.replace(/\\a/g, "\\u0007").replace(/\\v/g, "\\u000b");
+          return JSON.parse(cleanedText) as JSONSchemaType<AppManifest>;
+        }
       }
     }
     let result: JSONSchemaType<AppManifest>;

--- a/packages/manifest/test/AppManifestUtils.test.ts
+++ b/packages/manifest/test/AppManifestUtils.test.ts
@@ -14,7 +14,10 @@ describe("AppManifestUtils", async () => {
 
   describe("fetchSchema", async () => {
     it("should return local schema", async () => {
-      const readJson = sandbox.stub(fs, "readJson").resolves({});
+      sandbox.stub(fs, "pathExists").resolves(true);
+      const readFile = sandbox
+        .stub(fs, "readFile")
+        .resolves(JSON.stringify({ title: "test" }) as any);
       const fetchStub = sandbox.stub(fetchHelper, "default").resolves({
         ok: true,
         json: async () => ({}),
@@ -22,9 +25,37 @@ describe("AppManifestUtils", async () => {
       const schema = await AppManifestUtils.fetchSchema(
         "https://developer.microsoft.com/json-schemas/teams/v1.17/MicrosoftTeams.schema.json"
       );
-      assert.isTrue(readJson.calledOnce);
+      assert.isTrue(readFile.calledOnce);
       assert.isTrue(fetchStub.notCalled);
-      assert.deepEqual(schema, {} as any);
+      assert.deepEqual(schema, { title: "test" } as any);
+    });
+    it("should return local schema for localized microsoft docs url", async () => {
+      sandbox.stub(fs, "pathExists").resolves(true);
+      const readFile = sandbox
+        .stub(fs, "readFile")
+        .resolves(JSON.stringify({ title: "test" }) as any);
+      const fetchStub = sandbox.stub(fetchHelper, "default").resolves({
+        ok: true,
+        json: async () => ({}),
+      } as any);
+      const schema = await AppManifestUtils.fetchSchema(
+        "https://developer.microsoft.com/en-us/json-schemas/teams/v1.17/MicrosoftTeams.schema.json"
+      );
+      assert.isTrue(readFile.calledOnce);
+      assert.isTrue(fetchStub.notCalled);
+      assert.deepEqual(schema, { title: "test" } as any);
+    });
+    it("should apply regex workaround for \\a and \\v characters when reading local schema", async () => {
+      const rawContent = '{"pattern":"\\\\a test \\\\v pattern"}';
+      sandbox.stub(fs, "pathExists").resolves(true);
+      const readFile = sandbox.stub(fs, "readFile").resolves(rawContent as any);
+      const fetchStub = sandbox.stub(fetchHelper, "default");
+      const schema = await AppManifestUtils.fetchSchema(
+        "https://developer.microsoft.com/json-schemas/teams/v1.25/MicrosoftTeams.schema.json"
+      );
+      assert.isTrue(readFile.calledOnce);
+      assert.isTrue(fetchStub.notCalled);
+      assert.deepEqual((schema as any).pattern, "\\u0007 test \\u000b pattern");
     });
     it("should fetch remote schema", async () => {
       const readJson = sandbox.stub(fs, "readJson").resolves({});
@@ -44,8 +75,7 @@ describe("AppManifestUtils", async () => {
         text: sandbox.stub().resolves(mockResponseText),
       };
       const fetchStub = sandbox.stub(fetchHelper, "default").resolves(mockResponse as any);
-      const readJson = sandbox.stub(fs, "readJson").rejects(new Error("File not found"));
-      const pathExists = sandbox.stub(fs, "pathExists").resolves(false);
+      sandbox.stub(fs, "pathExists").resolves(false);
       const schema = await AppManifestUtils.fetchSchema(
         "https://developer.microsoft.com/json-schemas/teams/v1.24/MicrosoftTeams.schema.json"
       );

--- a/packages/server/.gitignore
+++ b/packages/server/.gitignore
@@ -28,6 +28,8 @@ obj
 # Resx Generated Code
 *.resx.ts
 
+json-schemas/
+
 # Styles Generated Code
 *.scss.ts
 

--- a/packages/server/pkg.json
+++ b/packages/server/pkg.json
@@ -1,5 +1,5 @@
 {
   "pkg": {
-    "assets": ["resource/**/*", "templates/**/*"]
+    "assets": ["resource/**/*", "templates/**/*", "json-schemas/**/*"]
   }
 }

--- a/packages/server/webpack.config.js
+++ b/packages/server/webpack.config.js
@@ -75,6 +75,10 @@ const config = {
           from: "../fx-core/templates/",
           to: "../templates/",
         },
+        {
+          from: "../manifest/src/json-schemas/",
+          to: "../json-schemas/",
+        },
       ],
     }),
     new webpack.ContextReplacementPlugin(/express[\/\\]lib/, false, /$^/),

--- a/packages/vscode-extension/esbuild.mjs
+++ b/packages/vscode-extension/esbuild.mjs
@@ -114,6 +114,10 @@ async function main() {
         dest: path.join(outputDirectory, "templates"),
       }),
       copyStaticFiles({
+        src: "../manifest/src/json-schemas/",
+        dest: path.join(outputDirectory, "json-schemas"),
+      }),
+      copyStaticFiles({
         src: "./src/commonlib/codeFlowResult/index.html",
         dest: path.join(outputDirectory, "src", "codeFlowResult", "index.html"),
       }),


### PR DESCRIPTION
use local json schemas to validate manifest before falling back to use remote url