### PR TITLE
fix: cherry-pick mac os playground cannot be started

### DIFF
--- a/templates/configs/playground/typescript/.vscode/tasks.json
+++ b/templates/configs/playground/typescript/.vscode/tasks.json
@@ -70,7 +70,7 @@
             "isBackground": true,
             "options": {
                 "env": {
-                  "PATH": "${workspaceFolder}/devTools/playground/node_modules/.bin;${env:PATH}"
+                  "PATH": "${workspaceFolder}/devTools/playground/node_modules/.bin:${env:PATH}"
                 }
             },
             "windows": {

--- a/templates/vsc/ts/foundry-agent-to-m365/.vscode/tasks.json
+++ b/templates/vsc/ts/foundry-agent-to-m365/.vscode/tasks.json
@@ -70,7 +70,7 @@
       "isBackground": true,
       "options": {
         "env": {
-          "PATH": "${workspaceFolder}/devTools/playground/node_modules/.bin;${env:PATH}"
+          "PATH": "${workspaceFolder}/devTools/playground/node_modules/.bin:${env:PATH}"
         }
       },
       "windows": {


### PR DESCRIPTION
cherry-pick #15668