### PR TITLE
fix: message extension template for 2.0.7 SDK

### DIFF
--- a/templates/vsc/ts/message-extension-v2/src/index.ts.tpl
+++ b/templates/vsc/ts/message-extension-v2/src/index.ts.tpl
@@ -33,13 +33,15 @@ const tokenCredentials: TokenCredentials = {
   token: createTokenFactory(),
 };
 
-const credentialOptions =
-  process.env.BOT_TYPE === "UserAssignedMsi" ? { ...tokenCredentials } : undefined;
+// Use managed identity in cloud environment, otherwise use devtools plugin for local development
+const options =
+  process.env.BOT_TYPE === "UserAssignedMsi"
+    ? { ...tokenCredentials }
+    : { plugins: [new DevtoolsPlugin()] };
 
 const app = new App({
-  ...credentialOptions,
+  ...options,
   logger: new ConsoleLogger("{{appName}}", { level: "debug" }),
-  plugins: [new DevtoolsPlugin()],
 });
 
 app.on("install.add", async ({ send }) => {


### PR DESCRIPTION
https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/37467231

Same issue as #15670 (tab template fix) but in the message extension template.

## Problem
`DevtoolsPlugin` is included unconditionally in the message extension template. On Azure App Service, `PORT` is a named pipe (not a number), and `DevtoolsPlugin` calls `parseInt()` on it, causing a crash.

## Fix
Conditionally include `DevtoolsPlugin` only for local development, matching the pattern already used in `teams-collaborator-agent` template:
- When `BOT_TYPE === "UserAssignedMsi"` (cloud): use managed identity credentials, no DevtoolsPlugin
- Otherwise (local dev): include DevtoolsPlugin, no managed identity credentials