### PR TITLE
fix: replace variable accounName for cli login

### DIFF
--- a/packages/cli/src/commonlib/codeFlowLogin.ts
+++ b/packages/cli/src/commonlib/codeFlowLogin.ts
@@ -303,7 +303,11 @@ export class CodeFlowLogin {
     const loopbackTemplatePath = path.join(__dirname, "codeFlowResult", "index.html");
     let loopbackTemplate = undefined;
     if (fs.pathExistsSync(loopbackTemplatePath)) {
-      loopbackTemplate = await fs.readFile(loopbackTemplatePath, "utf-8");
+      const displayName = this.accountName == "azure" ? "Azure" : "M365";
+      loopbackTemplate = (await fs.readFile(loopbackTemplatePath, "utf-8")).replace(
+        /\${accountName}/g,
+        displayName
+      );
     }
     const interactiveRequest = {
       scopes: scopes,

--- a/packages/cli/tests/unit/commonlib/codeFlowLogin.tests.ts
+++ b/packages/cli/tests/unit/commonlib/codeFlowLogin.tests.ts
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import "mocha";
+import sinon from "sinon";
+import { expect } from "../utils";
+import { CodeFlowLogin } from "../../../src/commonlib/codeFlowLogin";
+import CliTelemetry from "../../../src/telemetry/cliTelemetry";
+
+describe("CodeFlowLogin.loginWithBroker", function () {
+  const sandbox = sinon.createSandbox();
+
+  // A minimal JWT-like token: header.payload.signature
+  // payload = base64({"oid":"fake-oid","upn":"test@test.com"})
+  const fakeAccessToken =
+    "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9." +
+    Buffer.from(JSON.stringify({ oid: "fake-oid", upn: "test@test.com" })).toString("base64") +
+    ".fake-signature";
+
+  const fakeResponse = {
+    account: {
+      homeAccountId: "fake-id",
+      environment: "login.microsoftonline.com",
+      tenantId: "fake-tenant",
+      username: "test@test.com",
+      localAccountId: "fake-local-id",
+    },
+    accessToken: fakeAccessToken,
+  };
+
+  const config = {
+    auth: {
+      clientId: "fake-client-id",
+      authority: "https://login.microsoftonline.com/common",
+    },
+  };
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  function setupLogin(accountName: string) {
+    sandbox.stub(CliTelemetry, "sendTelemetryEvent");
+
+    const codeFlowLogin = new CodeFlowLogin([], config, 0, accountName);
+    let capturedRequest: any;
+    sandbox.stub(codeFlowLogin.pca, "acquireTokenInteractive").callsFake(async (request: any) => {
+      capturedRequest = request;
+      return fakeResponse as any;
+    });
+    sandbox.stub(codeFlowLogin as any, "mutex").value({
+      runExclusive: async (fn: any) => fn(),
+    });
+
+    return { codeFlowLogin, getCapturedRequest: () => capturedRequest };
+  }
+
+  it("should replace accountName placeholder with M365 in loopback template for m365 account", async () => {
+    const { codeFlowLogin, getCapturedRequest } = setupLogin("appStudio");
+
+    await codeFlowLogin.loginWithBroker(["scope1"]);
+    const req = getCapturedRequest();
+
+    expect(req.successTemplate).to.include("M365 - Sign In");
+    expect(req.successTemplate).to.not.include("$" + "{accountName}");
+    expect(req.errorTemplate).to.include("M365 - Sign In");
+    expect(req.errorTemplate).to.not.include("$" + "{accountName}");
+  });
+
+  it("should replace accountName placeholder with Azure in loopback template for azure account", async () => {
+    const { codeFlowLogin, getCapturedRequest } = setupLogin("azure");
+
+    await codeFlowLogin.loginWithBroker(["scope1"]);
+    const req = getCapturedRequest();
+
+    expect(req.successTemplate).to.include("Azure - Sign In");
+    expect(req.successTemplate).to.not.include("$" + "{accountName}");
+    expect(req.errorTemplate).to.include("Azure - Sign In");
+    expect(req.errorTemplate).to.not.include("$" + "{accountName}");
+  });
+});


### PR DESCRIPTION
The ${accountName} placeholders are now replaced with the display name ("M365" or "Azure") before passing the template to MSAL's successTemplate/errorTemplate