### PR TITLE
fix: add --yes flag for deploying task pane template

### DIFF
--- a/templates/vsc/ts/office-addin-wxpo-taskpane/m365agents.yml
+++ b/templates/vsc/ts/office-addin-wxpo-taskpane/m365agents.yml
@@ -46,7 +46,7 @@ deploy:
   # Azure Static Web Apps needs index.html
   - uses: cli/runNpxCommand
     with:
-      args: shx touch dist/index.html
+      args: --yes shx touch dist/index.html
   # Get the deployment token from Azure Static Web Apps
   - uses: azureStaticWebApps/getDeploymentToken
     with:
@@ -55,6 +55,6 @@ deploy:
   - uses: cli/runNpxCommand
     name: deploy to Azure Static Web Apps
     with:
-      args: '@azure/static-web-apps-cli deploy ./dist -d
+      args: '--yes @azure/static-web-apps-cli deploy ./dist -d
         ${{SECRET_TAB_SWA_DEPLOYMENT_TOKEN}} --env production'
 projectId: 47881792-967b-4b57-920c-cb3856631ba3


### PR DESCRIPTION
Symptom:
Currently, deploying task pane template requires manually to input "yes" to continue the deployment. It's unexpected. We expect that it should be deployed without interaction.

Solution:
I added --yes flag for task pane template

The related bug link: https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/35651866