### PR TITLE
fix: ensure error logs contain message when displayMessage is empty

### DIFF
--- a/packages/fx-core/src/component/driver/m365/acquire.ts
+++ b/packages/fx-core/src/component/driver/m365/acquire.ts
@@ -115,7 +115,11 @@ export class M365TitleAcquireDriver implements StepDriver {
     } catch (error) {
       if (error instanceof UserError || error instanceof SystemError) {
         context.logProvider?.error(
-          getLocalizedString(logMessageKeys.failExecuteDriver, actionName, error.displayMessage)
+          getLocalizedString(
+            logMessageKeys.failExecuteDriver,
+            actionName,
+            error.displayMessage || error.message
+          )
         );
         throw error;
       }

--- a/packages/fx-core/tests/component/driver/m365/acquire.test.ts
+++ b/packages/fx-core/tests/component/driver/m365/acquire.test.ts
@@ -134,6 +134,28 @@ describe("teamsApp/extendToM365", async () => {
     }
   });
 
+  it("execute: UserError with undefined displayMessage should fallback to message", async () => {
+    const args = {
+      appPackagePath: "fakePath",
+    };
+    const outputEnvVarNames = new Map([
+      ["titleId", "MY_TITLE_ID"],
+      ["appId", "MY_APP_ID"],
+    ]);
+
+    const mockError = new FileNotFoundError("test", "test-file-path");
+    (mockError as any).displayMessage = undefined;
+
+    sinon.stub(PackageService.prototype, "sideLoading").rejects(mockError);
+    sinon.stub(fs, "pathExists").resolves(true);
+
+    const result = await acquireDriver.execute(args, mockedDriverContext, outputEnvVarNames);
+    chai.assert(result.result.isErr());
+    if (result.result.isErr()) {
+      chai.assert.isTrue(result.result.error instanceof FileNotFoundError);
+    }
+  });
+
   it("execute: happy path", async () => {
     const args = {
       appPackagePath: "fakePath",


### PR DESCRIPTION
Add fallback from `displayMessage` to `message` in error logging  to prevent empty error messages in logs.

Related bug: [Bug 35666175](https://msazure.visualstudio.com/Microsoft%20Teams%20Extensibility/_workitems/edit/35666175): [VSC] DA-NoAction, the error message contains 'undefined' in second provision